### PR TITLE
Dataset.write_dataset enforcing thread safety

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -433,7 +433,7 @@ impl Dataset {
 pub fn write_dataset(reader: &PyAny, uri: &str, options: &PyDict) -> PyResult<bool> {
     let params = get_write_params(options)?;
     Runtime::new()?.block_on(async move {
-        let mut batches: Box<dyn RecordBatchReader> = if reader.is_instance_of::<Scanner>()? {
+        let mut batches: Box<dyn RecordBatchReader + Send> = if reader.is_instance_of::<Scanner>()? {
             let scanner: Scanner = reader.extract()?;
             Box::new(
                 scanner

--- a/rust/README.md
+++ b/rust/README.md
@@ -29,7 +29,7 @@ use ::lance::dataset::WriteParams;
 use ::lance::dataset::Dataset;
 
 let mut write_params = WriteParams::default();
-let mut reader: Box<dyn RecordBatchReader> = Box::new(batches);
+let mut reader: Box<dyn RecordBatchReader + Send> = Box::new(batches);
 Dataset::write(&mut reader, test_uri, Some(write_params)).await?;
 ```
 

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -250,7 +250,7 @@ impl Dataset {
     ///
     /// Returns the newly created [`Dataset`]. Returns [Error] if the dataset already exists.
     pub async fn write(
-        batches: &mut Box<dyn RecordBatchReader>,
+        batches: &mut Box<dyn RecordBatchReader + Send>,
         uri: &str,
         params: Option<WriteParams>,
     ) -> Result<Self> {
@@ -783,7 +783,7 @@ mod tests {
         write_params.max_rows_per_file = 40;
         write_params.max_rows_per_group = 10;
         write_params.mode = mode;
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut reader: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut reader, test_uri, Some(write_params))
             .await
             .unwrap();
@@ -851,7 +851,7 @@ mod tests {
         let mut write_params = WriteParams::default();
         write_params.max_rows_per_file = 40;
         write_params.max_rows_per_group = 10;
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut batches: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut batches, test_uri, Some(write_params))
             .await
             .unwrap();
@@ -862,7 +862,7 @@ mod tests {
         )
         .unwrap()]);
         write_params.mode = WriteMode::Append;
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut batches: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut batches, test_uri, Some(write_params))
             .await
             .unwrap();
@@ -926,7 +926,7 @@ mod tests {
         let mut write_params = WriteParams::default();
         write_params.max_rows_per_file = 40;
         write_params.max_rows_per_group = 10;
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut batches: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut batches, test_uri, Some(write_params))
             .await
             .unwrap();
@@ -944,7 +944,7 @@ mod tests {
         )
         .unwrap()]);
         write_params.mode = WriteMode::Overwrite;
-        let mut new_batch_reader: Box<dyn RecordBatchReader> = Box::new(new_batches);
+        let mut new_batch_reader: Box<dyn RecordBatchReader + Send> = Box::new(new_batches);
         Dataset::write(&mut new_batch_reader, test_uri, Some(write_params))
             .await
             .unwrap();
@@ -1006,7 +1006,7 @@ mod tests {
         let mut write_params = WriteParams::default();
         write_params.max_rows_per_file = 40;
         write_params.max_rows_per_group = 10;
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut batches: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut batches, test_uri, Some(write_params))
             .await
             .unwrap();
@@ -1070,7 +1070,7 @@ mod tests {
         let mut write_params = WriteParams::default();
         write_params.max_rows_per_file = 40;
         write_params.max_rows_per_group = 10;
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut batches: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut batches, test_uri, Some(write_params))
             .await
             .unwrap();
@@ -1132,7 +1132,7 @@ mod tests {
         let mut write_params = WriteParams::default();
         write_params.max_rows_per_file = 40;
         write_params.max_rows_per_group = 10;
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut batches: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut batches, test_uri, Some(write_params))
             .await
             .unwrap();
@@ -1166,7 +1166,7 @@ mod tests {
 
         let test_uri = test_dir.path().to_str().unwrap();
 
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut reader: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         let dataset = Dataset::write(&mut reader, test_uri, None).await.unwrap();
 
         // Make sure valid arguments should create index successfully
@@ -1190,7 +1190,7 @@ mod tests {
             vec![vectors.clone()],
         )
         .unwrap()]);
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut reader: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         let dataset = Dataset::write(&mut reader, test_uri, Some(write_params))
             .await
             .unwrap();
@@ -1206,7 +1206,7 @@ mod tests {
             RecordBatchBuffer::new(vec![
                 RecordBatch::try_new(schema.clone(), vec![vectors]).unwrap()
             ]);
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut reader: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         let dataset = Dataset::write(&mut reader, test_uri, Some(write_params))
             .await
             .unwrap();
@@ -1235,7 +1235,7 @@ mod tests {
                 .collect(),
         );
         let test_uri = test_dir.path().to_str().unwrap();
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut reader: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut reader, test_uri, None).await
     }
 

--- a/rust/src/dataset/fragment.rs
+++ b/rust/src/dataset/fragment.rs
@@ -345,7 +345,7 @@ mod tests {
         let mut write_params = WriteParams::default();
         write_params.max_rows_per_file = 40;
         write_params.max_rows_per_group = 2;
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut batches: Box<dyn RecordBatchReader + Send> = Box::new(batches);
 
         Dataset::write(&mut batches, test_uri, Some(write_params))
             .await

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -624,7 +624,7 @@ mod test {
         let mut write_params = WriteParams::default();
         write_params.max_rows_per_file = 40;
         write_params.max_rows_per_group = 10;
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut batches: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut batches, test_uri, Some(write_params))
             .await
             .unwrap();
@@ -662,7 +662,7 @@ mod test {
         )
         .unwrap()]);
 
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut batches: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
         Dataset::write(&mut batches, test_uri, None).await.unwrap();
@@ -746,7 +746,7 @@ mod test {
         let batches = RecordBatchBuffer::new(expected_batches.clone());
         let mut params = WriteParams::default();
         params.max_rows_per_group = 10;
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut reader: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut reader, path, Some(params))
             .await
             .unwrap();
@@ -789,7 +789,7 @@ mod test {
 
         let mut params = WriteParams::default();
         params.max_rows_per_group = 10;
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut reader: Box<dyn RecordBatchReader + Send> = Box::new(batches);
 
         let dataset = Dataset::write(&mut reader, path, Some(params))
             .await
@@ -1233,7 +1233,7 @@ mod test {
         .unwrap()]);
 
         let write_params = WriteParams::default();
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut batches: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut batches, test_uri, Some(write_params))
             .await
             .unwrap();
@@ -1304,7 +1304,7 @@ mod test {
         let mut write_params = WriteParams::default();
         write_params.max_rows_per_file = 40;
         write_params.max_rows_per_group = 10;
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(reader);
+        let mut batches: Box<dyn RecordBatchReader + Send> = Box::new(reader);
         Dataset::write(&mut batches, test_uri, Some(write_params))
             .await
             .unwrap();

--- a/rust/src/index/vector/diskann.rs
+++ b/rust/src/index/vector/diskann.rs
@@ -148,7 +148,7 @@ mod tests {
 
         let test_uri = test_dir.path().to_str().unwrap();
 
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut reader: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         let dataset = Dataset::write(&mut reader, test_uri, None).await.unwrap();
 
         // Make sure valid arguments should create index successfully

--- a/rust/src/index/vector/diskann/builder.rs
+++ b/rust/src/index/vector/diskann/builder.rs
@@ -405,7 +405,7 @@ mod tests {
         let mut write_params = WriteParams::default();
         write_params.max_rows_per_file = 40;
         write_params.max_rows_per_group = 10;
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut batches: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut batches, uri, Some(write_params))
             .await
             .unwrap();

--- a/rust/src/index/vector/opq.rs
+++ b/rust/src/index/vector/opq.rs
@@ -367,7 +367,7 @@ mod tests {
         )
         .unwrap()
         .into()]);
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(batch);
+        let mut reader: Box<dyn RecordBatchReader + Send> = Box::new(batch);
         Dataset::write(&mut reader, tmp_dir.path().to_str().unwrap(), None)
             .await
             .unwrap();

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -430,7 +430,7 @@ mod tests {
         let vector_arr = batches.batches[0].column_by_name("vector").unwrap();
         let q = as_fixed_size_list_array(&vector_arr).value(5);
 
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut reader: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut reader, test_uri, Some(write_params))
             .await
             .unwrap();

--- a/rust/src/io/exec/take.rs
+++ b/rust/src/io/exec/take.rs
@@ -270,7 +270,7 @@ mod tests {
         let test_uri = test_dir.path().to_str().unwrap();
         let mut params = WriteParams::default();
         params.max_rows_per_group = 10;
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(batches);
+        let mut reader: Box<dyn RecordBatchReader + Send> = Box::new(batches);
         Dataset::write(&mut reader, test_uri, Some(params))
             .await
             .unwrap();

--- a/rust/src/io/reader.rs
+++ b/rust/src/io/reader.rs
@@ -931,7 +931,7 @@ mod tests {
         let test_uri = test_dir.path().to_str().unwrap();
 
         let batch_buffer = crate::arrow::RecordBatchBuffer::new(batches.clone());
-        let mut batch_reader: Box<dyn RecordBatchReader> = Box::new(batch_buffer);
+        let mut batch_reader: Box<dyn RecordBatchReader + Send> = Box::new(batch_buffer);
         Dataset::write(&mut batch_reader, test_uri, Some(WriteParams::default()))
             .await
             .unwrap();


### PR DESCRIPTION
Making sure we only allow thread safe RecordBatchReader in `Dataset.write_dataset`. **This is a breaking change.**