### PR TITLE
allow filter with regex expression on columns

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -55,7 +55,7 @@ arrow = { version = "37.0.0", features = ["prettyprint"] }
 num_cpus = "1.0"
 sqlparser-lance = "0.32.0"
 # TODO: use datafusion sub-modules to reduce build size?
-datafusion = { version = "23.0.0", default-features = false }
+datafusion = { version = "23.0.0", default-features = false, features = ["regex_expressions"] }
 faiss = { version = "0.11.0", features = ["gpu"], optional = true }
 lapack = "0.19.0"
 cblas = "0.4.0"

--- a/rust/src/datafusion/logical_expr.rs
+++ b/rust/src/datafusion/logical_expr.rs
@@ -15,7 +15,7 @@
 //! Extends logical expression.
 
 use arrow_schema::DataType;
-use datafusion::logical_expr::Operator;
+use datafusion::logical_expr::{BuiltinScalarFunction, Operator};
 use datafusion::scalar::ScalarValue;
 use datafusion::{logical_expr::BinaryExpr, prelude::*};
 
@@ -113,6 +113,24 @@ pub fn resolve_expr(expr: &Expr, schema: &Schema) -> Result<Expr> {
             // Passthrough
             Ok(expr.clone())
         }
+    }
+}
+
+/// Coerce logical expression for filters to bollean.
+///
+/// Parameters
+///
+/// - *expr*: a datafusion logical expression
+pub fn coerce_filter_type_to_boolean(expr: Expr) -> Result<Expr> {
+    match expr {
+        // TODO: consider making this dispatch more generic, i.e. fun.output_type -> coerce
+        // instead of hardcoding coerce method for each function
+        Expr::ScalarFunction {
+            fun: BuiltinScalarFunction::RegexpMatch,
+            args: _,
+        } => Ok(Expr::IsNotNull(Box::new(expr.to_owned()))),
+
+        _ => Ok(expr),
     }
 }
 


### PR DESCRIPTION
closes #896

NOTE: if the column is `LargeUtf8` query currently panics. We need to do at least one of:
* Support `arrow_cast` in filter -- which might be hard I couldn't find a builtin function for this
* Support implicit conversion of `pattern` argument from `Utf8` to `LargeUtf8`

## What changed:
* make `parse_function` understand `regexp_match`
* add a coercing mechanism in `parse_filter`, where we convert non-boolean types to boolean implicitly -- `coerce_filter_type_to_boolean`
* add function dispatch in `create_physical_expr`

TODO:
* [ ] ~~support `LargeUtf8` -- since there is no SQL type mapped to this, we need to support dispatching `arrow_cast` and `arrow_typeof`.~~
* [ ] ~~test withLargeStringArray~~
* [x] make issue for supporting LargeUtf8