### PR TITLE
bump windows-build storage to 1gb

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,6 +73,8 @@ jobs:
           vcpkg_token: ${{ secrets.VCPKG_GITHUB_PACKAGES }}
           update_vcpkg: true
       - name: Run tests
+        with:
+          root-reserve-mb: 1024
         run: |
           $env:VCPKG_ROOT = $env:VCPKG_INSTALLATION_ROOT
           $env:PATH = $env:VCPKG_INSTALLATION_ROOT + '\installed\x64-windows\bin;' + $env:PATH


### PR DESCRIPTION
windows build started to fail after #899 
error:
```
windows-msvc\\lib\\rustlib\\etc\\libstd.natvis"
  = note: D:\a\lance\lance\rust\target\debug\deps\lance-f6d472ae34a42458.exe : fatal error LNK1180: insufficient disk space to complete link
```

bumping the action storage space to fix