### PR TITLE
feat: typecheck arrow objects before sending to Rust

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -531,6 +531,8 @@ class LanceDataset(pa.dataset.Dataset):
         """
         if isinstance(base_uri, Path):
             base_uri = str(base_uri)
+        if not isinstance(new_schema, pa.Schema):
+            raise TypeError(f"schema must be pyarrow.Schema, got {type(new_schema)}")
         _Dataset.commit(base_uri, new_schema, fragments)
         return LanceDataset(base_uri)
 

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -169,7 +169,7 @@ class LanceFragment(pa.dataset.Fragment):
         return updater.finish()
 
     @property
-    def schema(self):
+    def schema(self) -> pa.Schema:
         """Return the schema of this fragment."""
 
         return self._fragment.schema()


### PR DESCRIPTION
This avoids confusing errors like 

```
AttributeError: 'XXX' object has no attribute '_export_to_c'
```

We can also address this upstream in https://github.com/apache/arrow-rs/issues/4312
