### PR TITLE
relax minimum pandas version to 1.4

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylance"
-dependencies = ["pyarrow>=10", "pandas>=1.4", "numpy"]
+dependencies = ["pyarrow>=10", "pandas>=1.4", "numpy>=1.22"]
 description = "python wrapper for lance-rs"
 authors = [
     { name = "Lance Devs", email = "dev@eto.ai" },

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylance"
-dependencies = ["pyarrow>=10", "pandas>=1.5", "numpy"]
+dependencies = ["pyarrow>=10", "pandas>=1.4", "numpy"]
 description = "python wrapper for lance-rs"
 authors = [
     { name = "Lance Devs", email = "dev@eto.ai" },


### PR DESCRIPTION
user wants to install lancedb in an environment with pandas 1.4 and cannot upgrade. This causes version incompatibility issues.