### PR TITLE
Write path for deletion files

### DIFF
--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -688,8 +688,7 @@ impl Dataset {
     pub(crate) async fn delete(&mut self, predicate: &str) -> Result<()> {
         let updated_fragments = stream::iter(self.get_fragments())
             .map(|f| async move { f.delete(predicate).await.map(|f| f.map(|f| f.metadata)) })
-            // Handle up to 16 fragments concurrently
-            .buffer_unordered(16)
+            .buffer_unordered(num_cpus::get())
             // Drop the fragments that were deleted.
             .try_filter_map(|f| futures::future::ready(Ok(f)))
             .try_collect::<Vec<_>>()

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -1509,6 +1509,14 @@ mod tests {
         let mut batches: Box<dyn RecordBatchReader> = Box::new(RecordBatchBuffer::new(vec![data]));
         let mut dataset = Dataset::write(&mut batches, test_uri, None).await.unwrap();
 
+        // Delete nothing
+        dataset.delete("i < 0").await.unwrap();
+
+        // We should not have any deletion file still
+        let fragments = dataset.get_fragments();
+        assert_eq!(fragments.len(), 1);
+        assert!(fragments[0].metadata.deletion_file.is_none());
+
         // Delete rows
         dataset.delete("i < 10 OR i >= 90").await.unwrap();
 

--- a/rust/src/dataset/fragment.rs
+++ b/rust/src/dataset/fragment.rs
@@ -544,9 +544,14 @@ mod tests {
 
         // Scan again
         let full_schema = dataset.schema().merge(new_schema.as_ref()).unwrap();
-        let dataset = Dataset::commit(test_uri, &full_schema, &[new_fragment], false)
-            .await
-            .unwrap();
+        let dataset = Dataset::commit(
+            test_uri,
+            &full_schema,
+            &[new_fragment],
+            crate::dataset::WriteMode::Create,
+        )
+        .await
+        .unwrap();
         assert_eq!(dataset.version().version, 2);
         let new_projection = full_schema.project(&["i", "double_i"]).unwrap();
 

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -45,6 +45,8 @@ pub enum Error {
         source: BoxedError,
         // TODO: add backtrace?
     },
+    #[snafu(display("Encountered internal error. Please file a bug report at https://github.com/lancedb/lance/issues. {message}"))]
+    Internal { message: String },
     #[snafu(display("LanceError(Arrow): {message}"))]
     Arrow { message: String },
     #[snafu(display("LanceError(Schema): {message}"))]

--- a/rust/src/format/manifest.rs
+++ b/rust/src/format/manifest.rs
@@ -17,10 +17,10 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use chrono::prelude::*;
 use prost_types::Timestamp;
-use std::time::SystemTime;
 
 use super::Fragment;
 use crate::datatypes::Schema;

--- a/rust/src/io/deletion.rs
+++ b/rust/src/io/deletion.rs
@@ -30,6 +30,16 @@ pub(crate) enum DeletionVector {
     Bitmap(RoaringBitmap),
 }
 
+impl DeletionVector {
+    pub fn len(&self) -> usize {
+        match self {
+            DeletionVector::NoDeletions => 0,
+            DeletionVector::Set(set) => set.len(),
+            DeletionVector::Bitmap(bitmap) => bitmap.len() as usize,
+        }
+    }
+}
+
 impl Default for DeletionVector {
     fn default() -> Self {
         DeletionVector::NoDeletions
@@ -141,8 +151,12 @@ fn deletion_file_path(
     id: u64,
     suffix: &str,
 ) -> Path {
-    base_path.child(format!(
-        "_deletions/{fragment_id}-{read_version}-{id}.{suffix}"
+    // base_path.child("_deletions").child(format!(
+    //     "{fragment_id}-{read_version}-{id}.{suffix}"
+    // ))
+    Path::from(format!(
+        "_deletions/{}-{}-{}.{}",
+        fragment_id, read_version, id, suffix
     ))
 }
 

--- a/rust/src/io/deletion.rs
+++ b/rust/src/io/deletion.rs
@@ -32,6 +32,7 @@ pub(crate) enum DeletionVector {
 }
 
 impl DeletionVector {
+    #[allow(dead_code)] // Used in tests
     pub fn len(&self) -> usize {
         match self {
             Self::NoDeletions => 0,
@@ -155,8 +156,7 @@ fn deletion_arrow_schema() -> Arc<Schema> {
 /// Get the file path for a deletion file. This is relative to the dataset root.
 fn deletion_file_path(fragment_id: u64, read_version: u64, id: u64, suffix: &str) -> Path {
     Path::from(format!(
-        "_deletions/{}-{}-{}.{}",
-        fragment_id, read_version, id, suffix
+        "_deletions/{fragment_id}-{read_version}-{id}.{suffix}"
     ))
 }
 


### PR DESCRIPTION
Closes #915.

Adds `delete()` methods to both `Dataset` and `FileFragment`.