### PR TITLE
Use backtick to escape column names

### DIFF
--- a/docs/read_and_write.rst
+++ b/docs/read_and_write.rst
@@ -103,6 +103,8 @@ Currently, Lance supports a growing list of expressions.
 * ``IS NULL``, ``IS NOT NULL``
 * ``IS TRUE``, ``IS NOT TRUE``, ``IS FALSE``, ``IS NOT FALSE``
 * ``IN``
+* ``LIKE``, ``NOT LIKE``
+* ``regexp_match(column, pattern)``
 
 For example, the following filter string is acceptable:
 
@@ -111,11 +113,18 @@ For example, the following filter string is acceptable:
     ((label IN [10, 20]) AND (note.email IS NOT NULL))
         OR NOT note.created
 
- .. warning::
+If your column name contains special characters or is a `SQL Keyword <https://docs.rs/sqlparser/latest/sqlparser/keywords/index.html>`_,
+you can use backtick (`````) to escape it. For nested fields, each segment of the
+path must be wrapped in backticks. 
 
-    Currently limitation: it does not support filter on columns that are
-    `SQL Keywords <https://docs.rs/sqlparser/latest/sqlparser/keywords/index.html>_`.
-    We are working on a resolution. For now please rename the column for filter predicates to work
+  .. code-block:: SQL
+
+    `CUBE` = 10 AND `column name with space` IS NOT NULL
+      AND `nested with space`.`inner with space` < 2
+
+.. warning::
+
+  Field names containing periods (``.``) are not supported.
 
 Random read
 ~~~~~~~~~~~

--- a/python/python/tests/test_filter.py
+++ b/python/python/tests/test_filter.py
@@ -93,18 +93,31 @@ def test_match(tmp_path: Path):
     table = pa.Table.from_arrays([array], names=["str"])
     dataset = lance.write_dataset(table, tmp_path / "test_match")
 
-    dataset = lance.dataset(tmp_path / "test_match")
     result = dataset.to_table(filter="str LIKE 'a%'").to_pandas()
     pd.testing.assert_frame_equal(result, pd.DataFrame({"str": ["aaa", "abc"]}))
 
+    result = dataset.to_table(filter="str NOT LIKE 'a%'").to_pandas()
+    pd.testing.assert_frame_equal(result, pd.DataFrame({"str": ["bbb", "bca", "cab", "cba"]}))
+
+    result = dataset.to_table(filter="regexp_match(str, 'c.+')").to_pandas()
+    pd.testing.assert_frame_equal(result, pd.DataFrame({"str": ["bca", "cab", "cba"]}))
+
 
 def test_escaped_name(tmp_path: Path):
-    table = pa.table({"silly :name": pa.array([1, 2, 3])})
+    table = pa.table({"silly :name": pa.array([0, 1, 2])})
     dataset = lance.write_dataset(table, tmp_path / "test_escaped_name")
 
     dataset = lance.dataset(tmp_path / "test_escaped_name")
-    result = dataset.to_table(filter='`silly :name` > 2').to_pandas()
-    pd.testing.assert_frame_equal(result, pd.DataFrame({"silly :name": [3]}))
+    result = dataset.to_table(filter='`silly :name` > 1').to_pandas()
+    pd.testing.assert_frame_equal(result, pd.DataFrame({"silly :name": [2]}))
+
+    # nested case
+    table = pa.table({"outer field": pa.array([{"inner field": i} for i in range(3)])})
+    dataset = lance.write_dataset(table, tmp_path / "test_escaped_name_nested")
+
+    dataset = lance.dataset(tmp_path / "test_escaped_name_nested")
+    result = dataset.to_table(filter='`outer field`.`inner field` > 1').to_pandas()
+    pd.testing.assert_frame_equal(result, pd.DataFrame({"outer field": [{"inner field": 2}]}))
 
 
 def create_table_for_duckdb(nvec=10000, ndim=768):

--- a/rust/src/utils/sql.rs
+++ b/rust/src/utils/sql.rs
@@ -123,12 +123,26 @@ mod tests {
 
     #[test]
     fn test_quoted_ident() {
-        let expr = parse_sql_filter("`a:Test_Something` == `test'STR`").unwrap();
+        // CUBE is a SQL keyword, so it must be quoted.
+        let expr = parse_sql_filter("`a:Test_Something` == `CUBE`").unwrap();
         assert_eq!(
             Expr::BinaryOp {
                 left: Box::new(Expr::Identifier(Ident::with_quote('`', "a:Test_Something"))),
                 op: BinaryOperator::Eq,
-                right: Box::new(Expr::Identifier(Ident::with_quote('`', "test'STR")))
+                right: Box::new(Expr::Identifier(Ident::with_quote('`', "CUBE")))
+            },
+            expr
+        );
+
+        let expr = parse_sql_filter("`outer field`.`inner field` == 1").unwrap();
+        assert_eq!(
+            Expr::BinaryOp {
+                left: Box::new(Expr::CompoundIdentifier(vec![
+                    Ident::with_quote('`', "outer field"),
+                    Ident::with_quote('`', "inner field")
+                ])),
+                op: BinaryOperator::Eq,
+                right: Box::new(Expr::Value(Value::Number("1".to_string(), false))),
             },
             expr
         );


### PR DESCRIPTION
Closes #839

Adds support for any column name, as long as it doesn't contain a `.`. Users can now escape with backtick. This even works with nested columns.