### PR TITLE
[Rust] Fix typo during ObjectStore construction

### DIFF
--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -106,11 +106,6 @@ fn manifest_path(base: &Path, version: u64) -> Path {
 
 /// Get the latest manifest path
 pub(crate) fn latest_manifest_path(base: &Path) -> Path {
-    println!(
-        "Latest manifest path: base={}, path={}",
-        base,
-        base.child(LATEST_MANIFEST_NAME)
-    );
     base.child(LATEST_MANIFEST_NAME)
 }
 
@@ -1371,7 +1366,6 @@ mod tests {
     #[tokio::test]
     async fn test_open_dataset_not_found() {
         let result = Dataset::open(".").await;
-        println!("{:?}", result);
         assert!(matches!(result.unwrap_err(), Error::DatasetNotFound { .. }));
     }
 

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -106,7 +106,11 @@ fn manifest_path(base: &Path, version: u64) -> Path {
 
 /// Get the latest manifest path
 pub(crate) fn latest_manifest_path(base: &Path) -> Path {
-    println!("Latest manifest path: base={}, path={}", base, base.child(LATEST_MANIFEST_NAME));
+    println!(
+        "Latest manifest path: base={}, path={}",
+        base,
+        base.child(LATEST_MANIFEST_NAME)
+    );
     base.child(LATEST_MANIFEST_NAME)
 }
 
@@ -229,7 +233,10 @@ impl Dataset {
         session: Arc<Session>,
     ) -> Result<Self> {
         println!("Checkout manifest: {}", manifest_path);
-        println!("List dataset dir: {:?}", object_store.read_dir(base_path.clone()).await);
+        println!(
+            "List dataset dir: {:?}",
+            object_store.read_dir(base_path.clone()).await
+        );
         let object_reader = object_store.open(manifest_path).await?;
         println!("XXXX: Manifest reader opened");
         let get_result = object_store

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -232,11 +232,12 @@ impl Dataset {
         manifest_path: &Path,
         session: Arc<Session>,
     ) -> Result<Self> {
-        let object_reader = object_store.open(&manifest_path.to_string()).await.
-            map_err(|e| match e {
-                object_store::Error::NotFound { path: _, source } => Error::DatasetNotFound {
+        let object_reader = object_store
+            .open(&manifest_path.to_string())
+            .await
+            .map_err(|e| match e {
+                Error::NotFound { .. } => Error::DatasetNotFound {
                     path: base_path.to_string(),
-                    source,
                 },
                 _ => e.into(),
             })?;
@@ -246,9 +247,8 @@ impl Dataset {
             .get(manifest_path)
             .await
             .map_err(|e| match e {
-                object_store::Error::NotFound { path: _, source } => Error::DatasetNotFound {
+                object_store::Error::NotFound { path: _, .. } => Error::DatasetNotFound {
                     path: base_path.to_string(),
-                    source,
                 },
                 _ => e.into(),
             })?;

--- a/rust/src/dataset/fragment.rs
+++ b/rust/src/dataset/fragment.rs
@@ -460,9 +460,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_fragment_count() {
-        // let test_dir = tempdir().unwrap();
-        // let test_uri = test_dir.path().to_str().unwrap();
-        let test_uri = "/Users/lei/tmp/test_dataset";
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
         let dataset = create_dataset(test_uri).await;
         let fragment = &dataset.get_fragments()[3];
 

--- a/rust/src/dataset/fragment.rs
+++ b/rust/src/dataset/fragment.rs
@@ -166,7 +166,11 @@ impl FileFragment {
             .dataset
             .data_dir()
             .child(self.metadata.files[0].path.as_str());
-        println!("Opening file: data_dir: {} {:?}", self.dataset.data_dir(), path);
+        println!(
+            "Opening file: data_dir: {} {:?}",
+            self.dataset.data_dir(),
+            path
+        );
         let reader = FileReader::try_new_with_fragment(
             &self.dataset.object_store,
             &path,

--- a/rust/src/dataset/fragment.rs
+++ b/rust/src/dataset/fragment.rs
@@ -126,7 +126,6 @@ impl FileFragment {
             let schema_per_file = data_file_schema.intersection(projection)?;
             if !schema_per_file.fields.is_empty() {
                 let path = self.dataset.data_dir().child(data_file.path.as_str());
-                println!("Opening file: {:?}", path);
                 let reader = FileReader::try_new_with_fragment(
                     &self.dataset.object_store,
                     &path,
@@ -166,11 +165,6 @@ impl FileFragment {
             .dataset
             .data_dir()
             .child(self.metadata.files[0].path.as_str());
-        println!(
-            "Opening file: data_dir: {} {:?}",
-            self.dataset.data_dir(),
-            path
-        );
         let reader = FileReader::try_new_with_fragment(
             &self.dataset.object_store,
             &path,

--- a/rust/src/dataset/updater.rs
+++ b/rust/src/dataset/updater.rs
@@ -16,7 +16,7 @@ use arrow_array::RecordBatch;
 use uuid::Uuid;
 
 use super::fragment::FragmentReader;
-use super::{Dataset, DATA_DIR};
+use super::Dataset;
 use crate::dataset::FileFragment;
 use crate::datatypes::Schema;
 use crate::format::Fragment;
@@ -99,13 +99,7 @@ impl Updater {
         let file_name = format!("{}.lance", Uuid::new_v4());
         self.fragment.metadata.add_file(&file_name, &schema);
 
-        let full_path = self
-            .fragment
-            .dataset()
-            .object_store
-            .base_path()
-            .child(DATA_DIR)
-            .child(file_name.as_str());
+        let full_path = self.fragment.dataset().data_dir().child(file_name.as_str());
 
         FileWriter::try_new(
             self.fragment.dataset().object_store.as_ref(),

--- a/rust/src/encodings/binary.rs
+++ b/rust/src/encodings/binary.rs
@@ -149,8 +149,7 @@ impl<'a, T: ByteArrayType> BinaryDecoder<'a, T> {
     ///
     /// async {
     ///     let object_store = ObjectStore::new(":memory:").await.unwrap();
-    ///     let path = Path::from("/data.lance");
-    ///     let reader = object_store.open(&path).await.unwrap();
+    ///     let reader = object_store.open("/data.lance").await.unwrap();
     ///     let string_decoder = BinaryDecoder::<Utf8Type>::new(reader.as_ref(), 100, 1024, true);
     /// };
     /// ```

--- a/rust/src/encodings/binary.rs
+++ b/rust/src/encodings/binary.rs
@@ -420,7 +420,7 @@ mod tests {
         let store = ObjectStore::memory();
         let path = Path::from("/foo");
         let pos = write_test_data(&store, &path, arrs).await.unwrap();
-        let reader = store.open(&path).await.unwrap();
+        let reader = store.open("/foo").await.unwrap();
         let read_len = arrs.iter().map(|a| a.len()).sum();
         let decoder =
             BinaryDecoder::<GenericStringType<O>>::new(reader.as_ref(), pos, read_len, true);
@@ -476,8 +476,9 @@ mod tests {
     async fn test_range_query() {
         let data = StringArray::from_iter_values(["a", "b", "c", "d", "e", "f", "g"]);
 
+        let path_str = "/foo";
         let store = ObjectStore::memory();
-        let path = Path::from("/foo");
+        let path = Path::from(path_str);
         let mut object_writer = ObjectWriter::new(&store, &path).await.unwrap();
         // Write some gabage to reset "tell()".
         object_writer.write_all(b"1234").await.unwrap();
@@ -485,7 +486,7 @@ mod tests {
         let pos = encoder.encode(&[&data]).await.unwrap();
         object_writer.shutdown().await.unwrap();
 
-        let reader = store.open(&path).await.unwrap();
+        let reader = store.open(path_str).await.unwrap();
         let decoder = BinaryDecoder::<Utf8Type>::new(reader.as_ref(), pos, data.len(), false);
         assert_eq!(
             decoder.decode().await.unwrap().as_ref(),
@@ -526,7 +527,7 @@ mod tests {
         let path = Path::from("/foo");
         let pos = write_test_data(&store, &path, &[&data]).await.unwrap();
 
-        let reader = store.open(&path).await.unwrap();
+        let reader = store.open("/foo").await.unwrap();
         let decoder = BinaryDecoder::<Utf8Type>::new(reader.as_ref(), pos, data.len(), false);
 
         let actual = decoder
@@ -547,7 +548,7 @@ mod tests {
         let path = Path::from("/foo");
         let pos = write_test_data(&store, &path, &[&data]).await.unwrap();
 
-        let reader = store.open(&path).await.unwrap();
+        let reader = store.open("/foo").await.unwrap();
         let decoder = BinaryDecoder::<Utf8Type>::new(reader.as_ref(), pos, data.len(), false);
 
         let positions = decoder.get_positions(1..999998).await.unwrap();
@@ -607,7 +608,7 @@ mod tests {
         let pos = encoder.encode(&[&data]).await.unwrap();
         object_writer.shutdown().await.unwrap();
 
-        let reader = store.open(&path).await.unwrap();
+        let reader = store.open("/slices").await.unwrap();
         let decoder = BinaryDecoder::<BinaryType>::new(reader.as_ref(), pos, data.len(), true);
         let idx = UInt32Array::from(vec![0_u32, 5_u32, 59996_u32]);
         let actual = decoder.take(&idx).await.unwrap();

--- a/rust/src/encodings/dictionary.rs
+++ b/rust/src/encodings/dictionary.rs
@@ -245,7 +245,7 @@ mod tests {
             object_writer.shutdown().await.unwrap();
         }
 
-        let reader = store.open(&path).await.unwrap();
+        let reader = store.open("/foo").await.unwrap();
         let decoder = DictionaryDecoder::new(
             reader.as_ref(),
             pos,

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -519,7 +519,7 @@ mod tests {
         );
         object_writer.shutdown().await.unwrap();
 
-        let reader = store.open(&path).await.unwrap();
+        let reader = store.open("/foo").await.unwrap();
         assert!(reader.size().await.unwrap() > 0);
         // Expected size is the total of all arrays
         let expected_size = expected.iter().map(|e| e.len()).sum();
@@ -634,7 +634,7 @@ mod tests {
         assert_eq!(encoder.encode(&[&array]).await.unwrap(), 0);
         writer.shutdown().await.unwrap();
 
-        let reader = store.open(&path).await.unwrap();
+        let reader = store.open("/scalar").await.unwrap();
         assert!(reader.size().await.unwrap() > 0);
         let decoder =
             PlainDecoder::new(reader.as_ref(), array.data_type(), 0, array.len()).unwrap();
@@ -677,7 +677,7 @@ mod tests {
         assert_eq!(encoder.encode(&[&array]).await.unwrap(), 0);
         writer.shutdown().await.unwrap();
 
-        let reader = store.open(&path).await.unwrap();
+        let reader = store.open("/takes").await.unwrap();
         assert!(reader.size().await.unwrap() > 0);
         let decoder =
             PlainDecoder::new(reader.as_ref(), array.data_type(), 0, array.len()).unwrap();

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -37,8 +37,8 @@ pub enum Error {
     DatasetAlreadyExists { uri: String },
     #[snafu(display("Append with different schema: original={original} new={new}"))]
     SchemaMismatch { original: Schema, new: Schema },
-    #[snafu(display("Dataset at path {path} was not found: {source}"))]
-    DatasetNotFound { path: String, source: BoxedError },
+    #[snafu(display("Dataset at path {path} was not found"))]
+    DatasetNotFound { path: String },
     #[snafu(display("Encountered corrupt file {path}: {source}"))]
     CorruptFile {
         path: object_store::path::Path,
@@ -49,6 +49,8 @@ pub enum Error {
     Arrow { message: String },
     #[snafu(display("LanceError(Schema): {message}"))]
     Schema { message: String },
+    #[snafu(display("LanceError(I/O): File not found {uri}"))]
+    NotFound { uri: String },
     #[snafu(display("LanceError(IO): {message}"))]
     IO { message: String },
     #[snafu(display("LanceError(Index): {message}"))]

--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -179,7 +179,13 @@ impl DatasetIndexExt for Dataset {
             .collect::<Vec<_>>();
         indices.push(new_idx);
 
-        write_manifest_file(&self.object_store, &mut new_manifest, Some(indices)).await?;
+        write_manifest_file(
+            &self.object_store,
+            &self.base,
+            &mut new_manifest,
+            Some(indices),
+        )
+        .await?;
 
         Ok(Self {
             object_store: self.object_store.clone(),

--- a/rust/src/index/vector.rs
+++ b/rust/src/index/vector.rs
@@ -330,7 +330,7 @@ pub(crate) async fn open_index(
     let index_file = index_dir.child(INDEX_FILE_NAME);
 
     let object_store = dataset.object_store();
-    let reader: Arc<dyn ObjectReader> = object_store.open(&index_file).await?.into();
+    let reader: Arc<dyn ObjectReader> = object_store.open(&index_file.to_string()).await?.into();
 
     let file_size = reader.size().await?;
     let block_size = object_store.block_size();

--- a/rust/src/index/vector/opq.rs
+++ b/rust/src/index/vector/opq.rs
@@ -388,8 +388,6 @@ mod tests {
             .await
             .unwrap();
 
-        println!("Open index file: {:?}", tmp_dir.path());
-
         let index_file = std::fs::read_dir(tmp_dir.path().join("_indices"))
             .unwrap()
             .next()

--- a/rust/src/index/vector/opq.rs
+++ b/rust/src/index/vector/opq.rs
@@ -388,6 +388,8 @@ mod tests {
             .await
             .unwrap();
 
+        println!("Open index file: {:?}", tmp_dir.path());
+
         let index_file = std::fs::read_dir(tmp_dir.path().join("_indices"))
             .unwrap()
             .next()

--- a/rust/src/io/local.rs
+++ b/rust/src/io/local.rs
@@ -15,8 +15,8 @@
 //! Optimized local I/Os
 
 use std::fs::File;
-use std::path::Path as StdPath;
 use std::ops::Range;
+use std::path::Path as StdPath;
 use std::sync::Arc;
 
 // TODO: Clean up windows/unix stuff
@@ -47,23 +47,15 @@ pub struct LocalObjectReader {
 
 impl LocalObjectReader {
     /// Open a local object reader, with default prefetch size.
-    pub fn open(path: &Path, block_size: usize) -> Result<Box<dyn ObjectReader>> {
-        let expanded = tilde(&path.to_string()).to_string();
+    pub fn open(path: &str, block_size: usize) -> Result<Box<dyn ObjectReader>> {
+        let expanded = tilde(path).to_string();
         let expanded_path = StdPath::new(&expanded);
 
         let local_path = format!("/{}", expanded_path.to_str().unwrap());
-        println!(
-            "Local object path path: {},
-            local_path: {}, {:?}",
-            path,
-            local_path,
-            File::open(&local_path)
-        );
-
         Ok(Box::new(Self {
+            path: local_path.clone().into(),
             file: File::open(local_path)?.into(),
             block_size,
-            path: path.clone(),
         }))
     }
 }

--- a/rust/src/io/local.rs
+++ b/rust/src/io/local.rs
@@ -15,6 +15,7 @@
 //! Optimized local I/Os
 
 use std::fs::File;
+use std::path::Path as StdPath;
 use std::ops::Range;
 use std::sync::Arc;
 
@@ -27,6 +28,7 @@ use std::os::windows::fs::FileExt;
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use object_store::path::Path;
+use shellexpand::tilde;
 
 use super::object_reader::ObjectReader;
 use crate::Result;
@@ -46,11 +48,15 @@ pub struct LocalObjectReader {
 impl LocalObjectReader {
     /// Open a local object reader, with default prefetch size.
     pub fn open(path: &Path, block_size: usize) -> Result<Box<dyn ObjectReader>> {
-        let local_path = format!("/{path}");
+        let expanded = tilde(&path.to_string()).to_string();
+        let expanded_path = StdPath::new(&expanded);
+
+        let local_path = format!("/{}", expanded_path.to_str().unwrap());
         println!(
             "Local object path path: {},
             local_path: {}, {:?}",
-            path, local_path,
+            path,
+            local_path,
             File::open(&local_path)
         );
 

--- a/rust/src/io/local.rs
+++ b/rust/src/io/local.rs
@@ -51,11 +51,10 @@ impl LocalObjectReader {
         let expanded = tilde(path).to_string();
         let expanded_path = StdPath::new(&expanded);
 
-        let local_path = {
-            #[cfg(unix)]
+        let local_path = if cfg!(windows) {
+            expanded
+        } else {
             format!("/{}", expanded_path.to_str().unwrap())
-            #[cfg(windows)]
-            expanded.to_str().unwrap().to_string()
         };
         let file = File::open(&local_path).map_err(|e| match e.kind() {
             std::io::ErrorKind::NotFound => Error::NotFound {

--- a/rust/src/io/local.rs
+++ b/rust/src/io/local.rs
@@ -51,7 +51,12 @@ impl LocalObjectReader {
         let expanded = tilde(path).to_string();
         let expanded_path = StdPath::new(&expanded);
 
-        let local_path = format!("/{}", expanded_path.to_str().unwrap());
+        let local_path = {
+            #[cfg(unix)]
+            format!("/{}", expanded_path.to_str().unwrap())
+            #[cfg(windows)]
+            expanded.to_str().unwrap().to_string()
+        };
         let file = File::open(&local_path).map_err(|e| match e.kind() {
             std::io::ErrorKind::NotFound => Error::NotFound {
                 uri: local_path.clone(),

--- a/rust/src/io/local.rs
+++ b/rust/src/io/local.rs
@@ -47,6 +47,13 @@ impl LocalObjectReader {
     /// Open a local object reader, with default prefetch size.
     pub fn open(path: &Path, block_size: usize) -> Result<Box<dyn ObjectReader>> {
         let local_path = format!("/{path}");
+        println!(
+            "Local object path path: {},
+            local_path: {}, {:?}",
+            path, local_path,
+            File::open(&local_path)
+        );
+
         Ok(Box::new(Self {
             file: File::open(local_path)?.into(),
             block_size,
@@ -73,7 +80,6 @@ impl ObjectReader for LocalObjectReader {
     /// Reads a range of data.
     ///
     /// TODO: return [arrow_buffer::Buffer] to avoid one memory copy from Bytes to Buffer.
-
     async fn get_range(&self, range: Range<usize>) -> Result<Bytes> {
         let file = self.file.clone();
         tokio::task::spawn_blocking(move || {

--- a/rust/src/io/object_reader.rs
+++ b/rust/src/io/object_reader.rs
@@ -16,7 +16,6 @@
 // under the License.
 
 use std::cmp::min;
-
 use std::ops::Range;
 
 use arrow_array::{
@@ -62,12 +61,13 @@ pub struct CloudObjectReader {
     // File path
     pub path: Path,
 
+    // Preferred I/O size per request.
     block_size: usize,
 }
 
-impl<'a> CloudObjectReader {
+impl CloudObjectReader {
     /// Create an ObjectReader from URI
-    pub fn new(object_store: &'a ObjectStore, path: Path, block_size: usize) -> Result<Self> {
+    pub fn new(object_store: &ObjectStore, path: Path, block_size: usize) -> Result<Self> {
         Ok(Self {
             object_store: object_store.clone(),
             path,

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -160,6 +160,7 @@ impl ObjectStore {
 
     /// Open a file for path
     pub async fn open(&self, path: &str) -> Result<Box<dyn ObjectReader>> {
+        println!("Rust: ObjectStore::open: path: {}, schema: {}", path, self.scheme);
         match self.scheme.as_str() {
             "file" => LocalObjectReader::open(&path, self.block_size),
             _ => Ok(Box::new(CloudObjectReader::new(
@@ -172,6 +173,7 @@ impl ObjectStore {
 
     /// Create a new file.
     pub async fn create(&self, path: &Path) -> Result<ObjectWriter> {
+        println!("Rust: ObjectStore::create: path: {}, schema: {}", path, self.scheme);
         ObjectWriter::new(self, path).await
     }
 

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -217,8 +217,8 @@ mod tests {
         write(path, contents)
     }
 
-    async fn read_from_store(store: ObjectStore, path: &Path) -> Result<String> {
-        let test_file_store = store.open(&path).await.unwrap();
+    async fn read_from_store(store: ObjectStore, path: &str) -> Result<String> {
+        let test_file_store = store.open(path).await.unwrap();
         let size = test_file_store.size().await.unwrap();
         let bytes = test_file_store.get_range(0..size).await.unwrap();
         let contents = String::from_utf8(bytes.to_vec()).unwrap();
@@ -273,7 +273,7 @@ mod tests {
         let uri = "~/foo.lance";
         write_to_file(&(uri.to_string() + "/test_file"), "TILDE").unwrap();
         let store = ObjectStore::new(uri).await.unwrap();
-        let contents = read_from_store(store, &Path::from("test_file"))
+        let contents = read_from_store(store, &Path::from("~/foo.lance/test_file"))
             .await
             .unwrap();
         assert_eq!(contents, "TILDE");
@@ -293,7 +293,10 @@ mod tests {
         .unwrap();
         let store = ObjectStore::new(path.to_str().unwrap()).await.unwrap();
 
-        let sub_dirs = store.read_dir("foo").await.unwrap();
+        let sub_dirs = store
+            .read_dir(path.join("foo").as_path().to_str().unwrap())
+            .await
+            .unwrap();
         assert_eq!(sub_dirs, vec!["bar", "zoo", "test_file"]);
     }
 

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -230,11 +230,7 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
         let tmp_path = tmp_dir.path().to_str().unwrap().to_owned();
         let file_path = tmp_path.clone() + "/bar/foo.lance/test_file";
-        write_to_file(
-            &file_path,
-            "TEST_CONTENT",
-        )
-        .unwrap();
+        write_to_file(&file_path, "TEST_CONTENT").unwrap();
 
         // test a few variations of the same path
         for uri in &[
@@ -253,17 +249,12 @@ mod tests {
         let tmp_dir = tempfile::tempdir().unwrap();
         let tmp_path = tmp_dir.path().to_str().unwrap().to_owned();
         let file_path = tmp_path.clone() + "/bar/foo.lance/test_file";
-        write_to_file(&file_path,
-            "RELATIVE_URL",
-        )
-        .unwrap();
+        write_to_file(&file_path, "RELATIVE_URL").unwrap();
 
         set_current_dir(StdPath::new(&tmp_path)).expect("Error changing current dir");
         let store = ObjectStore::new("./bar/foo.lance").await.unwrap();
 
-        let contents = read_from_store(store, &file_path)
-            .await
-            .unwrap();
+        let contents = read_from_store(store, &file_path).await.unwrap();
         assert_eq!(contents, "RELATIVE_URL");
     }
 
@@ -336,9 +327,7 @@ mod tests {
             format!("{drive_letter}:\\test_folder\\test.lance"),
         ] {
             let store = ObjectStore::new(uri).await.unwrap();
-            let contents = read_from_store(store, "test_file")
-                .await
-                .unwrap();
+            let contents = read_from_store(store, "test_file").await.unwrap();
             assert_eq!(contents, "WINDOWS");
         }
     }

--- a/rust/src/io/object_writer.rs
+++ b/rust/src/io/object_writer.rs
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2023 Lance Developers.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -44,7 +41,6 @@ pub struct ObjectWriter {
 
 impl ObjectWriter {
     pub async fn new(object_store: &ObjectStore, path: &Path) -> Result<Self> {
-        println!("Object Writer::new: path={:?}", path);
         let (multipart_id, writer) = object_store.inner.put_multipart(path).await?;
 
         Ok(Self {

--- a/rust/src/io/object_writer.rs
+++ b/rust/src/io/object_writer.rs
@@ -44,6 +44,7 @@ pub struct ObjectWriter {
 
 impl ObjectWriter {
     pub async fn new(object_store: &ObjectStore, path: &Path) -> Result<Self> {
+        println!("Object Writer::new: path={:?}", path);
         let (multipart_id, writer) = object_store.inner.put_multipart(path).await?;
 
         Ok(Self {

--- a/rust/src/io/reader.rs
+++ b/rust/src/io/reader.rs
@@ -159,6 +159,7 @@ impl FileReader {
         fragment_id: u64,
         manifest: Option<&Manifest>,
     ) -> Result<FileReader> {
+        println!("FileReader open: {}", path);
         let object_reader = object_store.open(path).await?;
 
         let file_size = object_reader.size().await?;
@@ -207,6 +208,7 @@ impl FileReader {
 
     /// Open one Lance data file for read.
     pub async fn try_new(object_store: &ObjectStore, path: &Path) -> Result<FileReader> {
+        println!("FileReader::try_new: path={:?}", path);
         Self::try_new_with_fragment(object_store, path, 0, None).await
     }
 

--- a/rust/src/io/reader.rs
+++ b/rust/src/io/reader.rs
@@ -159,8 +159,7 @@ impl FileReader {
         fragment_id: u64,
         manifest: Option<&Manifest>,
     ) -> Result<FileReader> {
-        println!("FileReader open: {}", path);
-        let object_reader = object_store.open(path).await?;
+        let object_reader = object_store.open(&path.to_string()).await?;
 
         let file_size = object_reader.size().await?;
         let begin = if file_size < object_store.block_size() {


### PR DESCRIPTION
* Change contract that an `ObjectStore` does not hold `base path`, so an object store can be shared by multiple datasets.

Closes #919