### PR TITLE
bugfix: remove extra character from jq filter in GHA

### DIFF
--- a/.github/workflows/make-release-commit.yml
+++ b/.github/workflows/make-release-commit.yml
@@ -42,7 +42,7 @@ jobs:
         part: ${{ inputs.part }}
     - name: Create tag
       run: |
-        export TAG="$(cargo metadata --no-deps --format-version 1 | jq '.packages[0].version')"
+        export TAG="v$(cargo metadata --no-deps --format-version 1 | jq '.packages[0].version')"
         git tag $TAG
     - name: Push new version and tag
       if: ${{ inputs.dry_run }} == "false"


### PR DESCRIPTION
```
% cargo metadata --no-deps --format-version 1 | jq '{.packages[0].version}'
jq: error: syntax error, unexpected FIELD (Unix shell quoting issues?) at <top-level>, line 1:
{.packages[0].version}
jq: 1 compile error
cargo metadata --no-deps --format-version 1 | jq '.packages[0].version'
"0.4.18"
```