### PR TITLE
add deletion file handling to scanner

### DIFF
--- a/rust/src/format/fragment.rs
+++ b/rust/src/format/fragment.rs
@@ -19,6 +19,8 @@ use std::collections::BTreeSet;
 
 use crate::datatypes::Schema;
 use crate::format::pb;
+use crate::io::deletion::{read_deletion_file, DeletionVector};
+use crate::io::ObjectStore;
 
 /// Lance Data File
 ///
@@ -134,6 +136,13 @@ impl Fragment {
         BTreeSet::from_iter(self.files.iter().flat_map(|f| f.fields.clone()))
             .into_iter()
             .collect()
+    }
+
+    pub(crate) async fn deletion_vector(
+        &self,
+        object_store: &ObjectStore,
+    ) -> Option<DeletionVector> {
+        read_deletion_file(self, object_store).await.unwrap()
     }
 }
 

--- a/rust/src/io/deletion.rs
+++ b/rust/src/io/deletion.rs
@@ -1,10 +1,11 @@
 use std::ops::Range;
+use std::slice::Iter;
 use std::{collections::HashSet, sync::Arc};
 
 use arrow::ipc::reader::FileReader as ArrowFileReader;
 use arrow::ipc::writer::{FileWriter as ArrowFileWriter, IpcWriteOptions};
 use arrow::ipc::CompressionType;
-use arrow_array::{RecordBatch, UInt32Array};
+use arrow_array::{BooleanArray, RecordBatch, UInt32Array};
 use arrow_schema::{ArrowError, DataType, Field, Schema};
 use bytes::Buf;
 use object_store::path::Path;
@@ -47,6 +48,23 @@ impl DeletionVector {
             Self::Set(set) => range.all(|i| set.contains(&i)),
             Self::Bitmap(bitmap) => bitmap.contains_range(range),
         }
+    }
+
+    pub fn build_predicate(&self, row_ids: Iter<u64>) -> Option<BooleanArray> {
+        match self {
+            Self::Bitmap(bitmap) => Some(
+                row_ids
+                    .map(|&id| !bitmap.contains(id as u32))
+                    .collect::<Vec<_>>(),
+            ),
+            Self::Set(set) => Some(
+                row_ids
+                    .map(|&id| !set.contains(&(id as u32)))
+                    .collect::<Vec<_>>(),
+            ),
+            Self::NoDeletions => None,
+        }
+        .map(|v| BooleanArray::from(v))
     }
 }
 

--- a/rust/src/io/reader.rs
+++ b/rust/src/io/reader.rs
@@ -29,6 +29,7 @@ use arrow_array::{
 use arrow_buffer::ArrowNativeType;
 use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use arrow_select::concat::{concat, concat_batches};
+use arrow_select::filter::filter_record_batch;
 use async_recursion::async_recursion;
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::{Bytes, BytesMut};
@@ -37,6 +38,7 @@ use futures::StreamExt;
 use object_store::path::Path;
 use prost::Message;
 
+use super::deletion::DeletionVector;
 use super::ReadBatchParams;
 use crate::arrow::*;
 use crate::encodings::{dictionary::DictionaryDecoder, AsyncIndex};
@@ -138,6 +140,9 @@ pub struct FileReader {
     /// If set true, returns the row ID from the dataset alongside with the
     /// actual data.
     with_row_id: bool,
+
+    // deletion vector indicating which rows are deleting in the fragment
+    deletion_vector: Option<DeletionVector>,
 }
 
 impl std::fmt::Debug for FileReader {
@@ -178,15 +183,24 @@ impl FileReader {
             read_struct_from_buf(&tail_bytes.slice(offset..))?
         };
 
-        let (projection, num_columns) = if let Some(m) = manifest {
-            (m.schema.clone(), m.schema.max_field_id().unwrap() + 1)
+        // m is either
+        // a ref if passed in as Some(&manifest), or
+        // a value we read in the else block
+        // since we don't want to clone the manifest and force everything into a value
+        // we need this m variable here so the else block has a place to store the read
+        // manifest value. If we declare this var in the else block, it won't live long
+        // enough and the returned ref will be invalid.
+        let mut m: Manifest;
+        let manifest = if let Some(m) = manifest {
+            m
         } else {
-            let mut m: Manifest =
-                read_struct(object_reader.as_ref(), metadata.manifest_position.unwrap()).await?;
+            m = read_struct(object_reader.as_ref(), metadata.manifest_position.unwrap()).await?;
             m.schema.load_dictionary(object_reader.as_ref()).await?;
-
-            (m.schema.clone(), m.schema.max_field_id().unwrap() + 1)
+            &m
         };
+
+        let projection = manifest.schema.clone();
+        let num_columns = manifest.schema.max_field_id().unwrap() + 1;
         let page_table = PageTable::load(
             object_reader.as_ref(),
             metadata.page_table_position,
@@ -195,6 +209,18 @@ impl FileReader {
         )
         .await?;
 
+        // read the fragment metadata so we can handle deletion
+        let fragment = manifest
+            .fragments
+            .iter()
+            .find(|frag| frag.id == fragment_id)
+            .map(|f| f.to_owned());
+
+        let deletion_vector = match &fragment {
+            Some(frag) => frag.deletion_vector(object_store).await,
+            None => None,
+        };
+
         Ok(Self {
             object_reader: object_reader.into(),
             metadata,
@@ -202,6 +228,7 @@ impl FileReader {
             page_table,
             fragment_id,
             with_row_id: false,
+            deletion_vector: deletion_vector,
         })
     }
 
@@ -248,7 +275,15 @@ impl FileReader {
         params: impl Into<ReadBatchParams>,
         projection: &Schema,
     ) -> Result<RecordBatch> {
-        read_batch(self, &params.into(), projection, batch_id, self.with_row_id).await
+        read_batch(
+            self,
+            &params.into(),
+            projection,
+            batch_id,
+            self.with_row_id,
+            self.deletion_vector.as_ref(),
+        )
+        .await
     }
 
     /// Read a range of records into one batch.
@@ -301,13 +336,19 @@ async fn read_batch(
     schema: &Schema,
     batch_id: i32,
     with_row_id: bool,
+    deletion_vector: Option<&DeletionVector>,
 ) -> Result<RecordBatch> {
     let arrs = stream::iter(&schema.fields)
         .then(|f| async move { read_array(reader, f, batch_id, params).await })
         .try_collect::<Vec<_>>()
         .await?;
+
+    let should_fetch_row_id =
+        with_row_id || !matches!(deletion_vector, None | Some(DeletionVector::NoDeletions));
+
     let mut batch = RecordBatch::try_new(Arc::new(schema.into()), arrs)?;
-    if with_row_id {
+
+    let row_ids = if should_fetch_row_id {
         let ids_in_batch: Vec<i32> = match params {
             ReadBatchParams::Indices(indices) => {
                 indices.values().iter().map(|v| *v as i32).collect()
@@ -325,17 +366,36 @@ async fn read_batch(
             .ok_or_else(|| Error::IO {
                 message: format!("batch {batch_id} does not exist"),
             })?;
-        let row_id_arr = Arc::new(UInt64Array::from_iter_values(
-            ids_in_batch
-                .iter()
-                .map(|o| compute_row_id(reader.fragment_id, *o + batch_offset)),
-        ));
+        let row_ids: Vec<u64> = ids_in_batch
+            .iter()
+            .map(|o| compute_row_id(reader.fragment_id, *o + batch_offset))
+            .collect();
+
+        Some(row_ids)
+    } else {
+        None
+    };
+
+    if with_row_id {
+        let row_id_arr = Arc::new(UInt64Array::from(row_ids.clone().unwrap()));
         batch = batch.try_with_column(
             ArrowField::new("_rowid", DataType::UInt64, false),
             row_id_arr,
         )?;
     }
-    Ok(batch)
+
+    // TODO: This is a minor cop out. Pushing deletion vector in to the decoders is hard
+    // so I'm going to just leave deletion filter at this layer for now.
+    // We should push this down futurther when we get to statistics-based predicate pushdown
+    let deletion_mask = deletion_vector
+        .clone()
+        .map(|v| v.build_predicate(row_ids.unwrap().iter()))
+        .flatten();
+
+    match deletion_mask {
+        None => Ok(batch),
+        Some(mask) => Ok(filter_record_batch(&batch, &mask)?),
+    }
 }
 
 #[async_recursion]
@@ -617,6 +677,10 @@ mod tests {
     use super::*;
 
     use crate::dataset::{Dataset, WriteParams};
+    use crate::format::Fragment;
+    use crate::io::deletion::write_deletion_file;
+    use crate::io::deletion::DeletionVector;
+    use crate::io::ObjectStore;
     use arrow::array::LargeListBuilder;
     use arrow_array::builder::StringDictionaryBuilder;
     use arrow_array::types::Int32Type;
@@ -629,6 +693,7 @@ mod tests {
     };
     use arrow_schema::{Field as ArrowField, Fields as ArrowFields, Schema as ArrowSchema};
     use rand::{distributions::Alphanumeric, Rng};
+    use roaring::RoaringBitmap;
     use tempfile::tempdir;
     use tokio::io::AsyncWriteExt;
 
@@ -752,6 +817,118 @@ mod tests {
             )
             .unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn read_with_delete() {
+        let arrow_schema = ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int64, true),
+            ArrowField::new("f", DataType::Float32, false),
+        ]);
+        let schema = Schema::try_from(&arrow_schema).unwrap();
+
+        let store = ObjectStore::memory();
+        let path = Path::from("/foo");
+
+        // Write 10 batches.
+        let mut file_writer = FileWriter::try_new(&store, &path, schema.clone())
+            .await
+            .unwrap();
+        for batch_id in 0..10 {
+            let value_range = batch_id * 10..batch_id * 10 + 10;
+            let columns: Vec<ArrayRef> = vec![
+                Arc::new(Int64Array::from_iter(value_range.clone())),
+                Arc::new(Float32Array::from_iter(value_range.map(|n| n as f32))),
+            ];
+            let batch = RecordBatch::try_new(Arc::new(arrow_schema.clone()), columns).unwrap();
+            file_writer.write(&[batch]).await.unwrap();
+        }
+        file_writer.finish().await.unwrap();
+
+        let fragment = 123;
+
+        // delete even rows
+        let dv = DeletionVector::Bitmap(RoaringBitmap::from_iter((0..100).filter(|x| x % 2 == 0)));
+        let deletion_file = write_deletion_file(fragment, 0, &dv, &store).await.unwrap();
+
+        let mut frag_struct = Fragment::new(fragment);
+        frag_struct.deletion_file = deletion_file;
+
+        let manifest = Manifest::new(&schema, Arc::new(vec![frag_struct]));
+
+        let mut reader =
+            FileReader::try_new_with_fragment(&store, &path, fragment, Some(&manifest))
+                .await
+                .unwrap();
+        reader.with_row_id(true);
+
+        for b in 0..10 {
+            let batch = reader.read_batch(b, .., reader.schema()).await.unwrap();
+            let row_ids_col = &batch["_rowid"];
+            // Do the same computation as `compute_row_id`.
+            let start_pos = (fragment << 32) as u64 + 10 * b as u64;
+
+            assert_eq!(
+                &UInt64Array::from_iter_values((start_pos..start_pos + 10).filter(|i| i % 2 == 1)),
+                as_primitive_array(row_ids_col)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn read_with_delete_without_row_id() {
+        let arrow_schema = ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int64, true),
+            ArrowField::new("f", DataType::Float32, false),
+        ]);
+        let schema = Schema::try_from(&arrow_schema).unwrap();
+
+        let store = ObjectStore::memory();
+        let path = Path::from("/foo");
+
+        // Write 10 batches.
+        let mut file_writer = FileWriter::try_new(&store, &path, schema.clone())
+            .await
+            .unwrap();
+        for batch_id in 0..10 {
+            let value_range = batch_id * 10..batch_id * 10 + 10;
+            let columns: Vec<ArrayRef> = vec![
+                Arc::new(Int64Array::from_iter(value_range.clone())),
+                Arc::new(Float32Array::from_iter(value_range.map(|n| n as f32))),
+            ];
+            let batch = RecordBatch::try_new(Arc::new(arrow_schema.clone()), columns).unwrap();
+            file_writer.write(&[batch]).await.unwrap();
+        }
+        file_writer.finish().await.unwrap();
+
+        let fragment = 123;
+
+        // delete even rows
+        let dv = DeletionVector::Bitmap(RoaringBitmap::from_iter((0..100).filter(|x| x % 2 == 0)));
+        let deletion_file = write_deletion_file(fragment, 0, &dv, &store).await.unwrap();
+
+        let mut frag_struct = Fragment::new(fragment);
+        frag_struct.deletion_file = deletion_file;
+
+        let manifest = Manifest::new(&schema, Arc::new(vec![frag_struct]));
+
+        let mut reader =
+            FileReader::try_new_with_fragment(&store, &path, fragment, Some(&manifest))
+                .await
+                .unwrap();
+        reader.with_row_id(false);
+
+        for b in 0..10 {
+            let batch = reader.read_batch(b, .., reader.schema()).await.unwrap();
+            // if we didn't request rowid we should not get it back
+            assert!(batch
+                .schema()
+                .fields()
+                .iter()
+                .map(|f| f.name().as_str())
+                .find(|&name| name == "_rowid")
+                .is_none())
+        }
     }
 
     async fn test_write_null_string_in_struct(field_nullable: bool) {


### PR DESCRIPTION
NOTE: Only supports `Scan` right now. Still need to add support for index scans.

TODOs:
- [x] pull in #931 and test
- [x] write some unit tests
- [x] test e2e from scanner