### PR TITLE
add a benchmark for cosine distance and unroll ARM Neon simd

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -122,6 +122,10 @@ harness = false
 name = "argmin"
 harness = false
 
+[[bench]]
+name = "cosine"
+harness = false
+
 [profile.release]
 strip = true
 opt-level = "s"

--- a/rust/benches/argmin.rs
+++ b/rust/benches/argmin.rs
@@ -65,4 +65,13 @@ criterion_group!(
         .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = bench_argmin);
 
+// Non-linux version does not support pprof.
+#[cfg(not(target_os = "linux"))]
+criterion_group!(
+    name=benches;
+    config = Criterion::default()
+        .measurement_time(Duration::from_secs(10))
+        .sample_size(32);
+    targets = bench_argmin);
+
 criterion_main!(benches);

--- a/rust/benches/cosine.rs
+++ b/rust/benches/cosine.rs
@@ -1,0 +1,61 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use lance::linalg::cosine::cosine_distance_batch;
+#[cfg(target_os = "linux")]
+use pprof::criterion::{Output, PProfProfiler};
+
+use lance::utils::testing::generate_random_array_with_seed;
+
+fn bench_distance(c: &mut Criterion) {
+    const DIMENSION: usize = 1024;
+    const TOTAL: usize = 1024 * 1024; // 1M vectors
+
+    let key = generate_random_array_with_seed(DIMENSION, [0; 32]);
+    // 1M of 1024 D vectors. 4GB in memory.
+    let target = generate_random_array_with_seed(TOTAL * DIMENSION, [42; 32]);
+
+    c.bench_function("Cosine(simd)", |b| {
+        b.iter(|| {
+            cosine_distance_batch(key.values(), target.values(), DIMENSION);
+        })
+    });
+
+    let key = generate_random_array_with_seed(DIMENSION, [5; 32]);
+    // 1M of 1024 D vectors. 4GB in memory.
+    let target = generate_random_array_with_seed(TOTAL * DIMENSION, [7; 32]);
+
+    c.bench_function("Cosine(simd) second rng seed", |b| {
+        b.iter(|| {
+            cosine_distance_batch(key.values(), target.values(), DIMENSION);
+        })
+    });
+}
+
+#[cfg(target_os = "linux")]
+criterion_group!(
+    name=benches;
+    config = Criterion::default().significance_level(0.1).sample_size(10)
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench_distance);
+
+// Non-linux version does not support pprof.
+#[cfg(not(target_os = "linux"))]
+criterion_group!(
+    name=benches;
+    config = Criterion::default().significance_level(0.1).sample_size(10);
+    targets = bench_distance);
+criterion_main!(benches);


### PR DESCRIPTION
similar to #937 this one optimizes cosine distance.

before
```
[300.01 ms 302.41 ms 305.41 ms] Cosine(simd)
[302.51 ms 306.08 ms 311.26 ms] Cosine(simd) second rng seed
```

after
```
[86.878 ms 87.004 ms 87.263 ms] Cosine(simd)
[87.301 ms 102.65 ms 131.89 ms] Cosine(simd) second rng seed
```

Will add AVX unroll later today