### PR TITLE
Pin vcpkg version to speed up windows builds (fixed hash)

### DIFF
--- a/.github/workflows/install_windows_dependencies/action.yml
+++ b/.github/workflows/install_windows_dependencies/action.yml
@@ -34,7 +34,7 @@ runs:
       run: |
         cd $env:VCPKG_INSTALLATION_ROOT
         git fetch
-        git checkout eb597bb2f157c30f0c74e02177cfc30ac6102d8d
+        git checkout 259762c386bc8cdfa26509ecbb0bf82bdb752c56
         .\bootstrap-vcpkg.bat  -disableMetrics
     - name: Setup Dependencies with vcpkg
       shell: powershell


### PR DESCRIPTION
Should match [the vcpkg repo](https://github.com/microsoft/vcpkg)

```
eto@gian-air dev % cd vcpkg
eto@gian-air vcpkg % git checkout 259762c386bc8cdfa26509ecbb0bf82bdb752c56
HEAD is now at 259762c38 nghttp3: update to 0.12.0 (#31829)
```