### PR TITLE
Add basic support for cast in expressions

### DIFF
--- a/docs/read_and_write.rst
+++ b/docs/read_and_write.rst
@@ -105,6 +105,7 @@ Currently, Lance supports a growing list of expressions.
 * ``IN``
 * ``LIKE``, ``NOT LIKE``
 * ``regexp_match(column, pattern)``
+* ``CAST``
 
 For example, the following filter string is acceptable:
 
@@ -125,6 +126,70 @@ path must be wrapped in backticks.
 .. warning::
 
   Field names containing periods (``.``) are not supported.
+
+Literals for dates, timestamps, and decimals can be written by writing the string
+value after the type name. For example
+
+  .. code-block:: SQL
+
+    date_col = date '2021-01-01'
+    and timestamp_col = timestamp '2021-01-01 00:00:00'
+    and decimal_col = decimal(8,3) '1.000'
+
+For timestamp columns, the precision can be specified as a number in the type
+parameter. Microsecond precision (6) is the default.
+
+.. list-table::
+    :widths: 30 40
+    :header-rows: 1
+
+    * - SQL
+      - Time unit
+    * - ``timestamp(0)``
+      - Seconds
+    * - ``timestamp(3)``
+      - Milliseconds
+    * - ``timestamp(6)``
+      - Microseconds
+    * - ``timestamp(9)``
+      - Nanoseconds
+
+Lance internally stores data in Arrow format. The mapping from SQL types to Arrow
+is:
+
+.. list-table::
+    :widths: 30 40
+    :header-rows: 1
+
+    * - SQL type
+      - Arrow type
+    * - ``boolean``
+      - ``Boolean``
+    * - ``tinyint`` / ``tinyint unsigned``
+      - ``Int8`` / ``UInt8``
+    * - ``smallint`` / ``smallint unsigned``
+      - ``Int16`` / ``UInt16``
+    * - ``int`` or ``integer`` / ``int unsigned`` or ``integer unsigned``
+      - ``Int32`` / ``UInt32``
+    * - ``bigint`` / ``bigint unsigned``
+      - ``Int64`` / ``UInt64``
+    * - ``float``
+      - ``Float32``
+    * - ``double``
+      - ``Float64``
+    * - ``decimal(precision, scale)``
+      - ``Decimal128``
+    * - ``date``
+      - ``Date32``
+    * - ``timestamp``
+      - ``Timestamp`` (1)
+    * - ``string``
+      - ``Utf8``
+    * - ``binary``
+      - ``Binary``
+
+(1) See precision mapping in previous table.
+
 
 Random read
 ~~~~~~~~~~~

--- a/python/python/tests/test_filter.py
+++ b/python/python/tests/test_filter.py
@@ -17,6 +17,7 @@
 from datetime import date, datetime, timedelta
 import random
 from pathlib import Path
+from decimal import Decimal
 
 import lance
 import numpy as np
@@ -41,10 +42,12 @@ def create_table(nrows=100):
     def gen_str(n):
         return "".join(random.choices("abc", k=n))
 
-    stringcol = pa.array([gen_str(2) for _ in range(nrows)])
+    string_col = pa.array([gen_str(2) for _ in range(nrows)])
+
+    decimal_col = pa.array([Decimal(f"{str(i)}.000") for i in range(nrows)])
 
     tbl = pa.Table.from_arrays(
-        [intcol, floatcol, structcol, stringcol], names=["int", "float", "rec", "str"]
+        [intcol, floatcol, structcol, string_col, decimal_col], names=["int", "float", "rec", "str", "decimal"]
     )
     return tbl
 
@@ -96,6 +99,8 @@ def test_sql_predicates(dataset):
         ("rec.date = DATE '2021-01-01'", 1),
         ("rec.date >= cast('2021-01-31' as date)", 70),
         ("cast(rec.date as string) = '2021-01-01'", 1),
+        ("decimal = DECIMAL(5,3) '12.000'", 1),
+        ("decimal >= DECIMAL(5,3) '50.000'", 50),
     ]
 
     for expr, expected_num_rows in predicates_nrows:

--- a/python/python/tests/test_filter.py
+++ b/python/python/tests/test_filter.py
@@ -86,9 +86,6 @@ def test_sql_predicates(dataset):
         ("str = 'aa'", 16),
         ("str in ('aa', 'bb')", 26),
         ("rec.bool", 50),
-        # TODO: Get dates to work without casting
-        # ("rec.date = '2021-01-01'", 1),
-        # ("rec.dt = '2021-01-01 00:00:00'", 1),
         ("rec.date = cast('2021-01-01' as date)", 1),
         ("rec.dt = cast('2021-01-01 00:00:00' as timestamp(6))", 1),
         ("rec.dt = cast('2021-01-01 00:00:00' as timestamp)", 1),

--- a/python/python/tests/test_filter.py
+++ b/python/python/tests/test_filter.py
@@ -90,8 +90,10 @@ def test_sql_predicates(dataset):
         ("rec.dt = cast('2021-01-01 00:00:00' as timestamp(6))", 1),
         ("rec.dt = cast('2021-01-01 00:00:00' as timestamp)", 1),
         ("rec.dt = cast('2021-01-01 00:00:00' as datetime(6))", 1),
-        # Default is microsecond
         ("rec.dt = cast('2021-01-01 00:00:00' as datetime)", 1),
+        ("rec.dt = TIMESTAMP '2021-01-01 00:00:00'", 1),
+        ("rec.dt = TIMESTAMP(6) '2021-01-01 00:00:00'", 1),
+        ("rec.date = DATE '2021-01-01'", 1),
         ("rec.date >= cast('2021-01-31' as date)", 70),
         ("cast(rec.date as string) = '2021-01-01'", 1),
     ]

--- a/python/python/tests/test_filter.py
+++ b/python/python/tests/test_filter.py
@@ -87,6 +87,8 @@ def test_sql_predicates(dataset):
         # ("rec.date = '2021-01-01'", 1),
         # ("rec.dt = '2021-01-01 00:00:00'", 1),
         ("rec.date = cast('2021-01-01' as date)", 1),
+        ("rec.dt = cast('2021-01-01 00:00:00' as timestamp(6))", 1),
+        ("rec.dt = cast('2021-01-01 00:00:00' as timestamp)", 1),
         ("rec.dt = cast('2021-01-01 00:00:00' as datetime(6))", 1),
         # Default is microsecond
         ("rec.dt = cast('2021-01-01 00:00:00' as datetime)", 1),

--- a/rust/src/io/exec/planner.rs
+++ b/rust/src/io/exec/planner.rs
@@ -179,17 +179,18 @@ impl Planner {
     fn parse_type(&self, data_type: &SQLDataType) -> Result<ArrowDataType> {
         match data_type {
             SQLDataType::String => Ok(ArrowDataType::Utf8),
-            SQLDataType::Float(None) => Ok(ArrowDataType::Float32),
-            SQLDataType::Float(Some(16)) => Ok(ArrowDataType::Float16),
-            SQLDataType::Float(Some(32)) => Ok(ArrowDataType::Float32),
-            SQLDataType::Float(Some(64)) => Ok(ArrowDataType::Float64),
+            SQLDataType::Binary(_) => Ok(ArrowDataType::Binary),
+            SQLDataType::Float(_) => Ok(ArrowDataType::Float32),
             SQLDataType::Double => Ok(ArrowDataType::Float64),
             SQLDataType::Boolean => Ok(ArrowDataType::Boolean),
-            SQLDataType::Int(None) | SQLDataType::Integer(None) => Ok(ArrowDataType::Int32),
-            SQLDataType::Int(Some(32)) | SQLDataType::Integer(Some(32)) => Ok(ArrowDataType::Int32),
-            SQLDataType::Int(Some(8)) | SQLDataType::Integer(Some(8)) => Ok(ArrowDataType::Int8),
-            SQLDataType::Int(Some(16)) | SQLDataType::Integer(Some(16)) => Ok(ArrowDataType::Int16),
-            SQLDataType::Int(Some(64)) | SQLDataType::Integer(Some(64)) => Ok(ArrowDataType::Int64),
+            SQLDataType::TinyInt(_) => Ok(ArrowDataType::Int8),
+            SQLDataType::SmallInt(_) => Ok(ArrowDataType::Int16),
+            SQLDataType::Int(_) | SQLDataType::Integer(_) => Ok(ArrowDataType::Int32),
+            SQLDataType::BigInt(_) => Ok(ArrowDataType::Int64),
+            SQLDataType::UnsignedTinyInt(_) => Ok(ArrowDataType::UInt8),
+            SQLDataType::UnsignedSmallInt(_) => Ok(ArrowDataType::UInt16),
+            SQLDataType::UnsignedInt(_) => Ok(ArrowDataType::UInt32),
+            SQLDataType::UnsignedBigInt(_) => Ok(ArrowDataType::UInt64),
             SQLDataType::Date => Ok(ArrowDataType::Date32),
             SQLDataType::Timestamp(resolution, tz) => {
                 match tz {

--- a/rust/src/io/exec/planner.rs
+++ b/rust/src/io/exec/planner.rs
@@ -250,6 +250,13 @@ impl Planner {
             SQLExpr::BinaryOp { left, op, right } => self.binary_expr(left, op, right),
             SQLExpr::UnaryOp { op, expr } => self.unary_expr(op, expr),
             SQLExpr::Value(value) => self.value(value),
+            // For example, DATE '2020-01-01'
+            SQLExpr::TypedString { data_type, value } => {
+                Ok(Expr::Cast(datafusion::logical_expr::Cast {
+                    expr: Box::new(Expr::Literal(ScalarValue::Utf8(Some(value.clone())))),
+                    data_type: self.parse_type(data_type)?,
+                }))
+            }
             SQLExpr::IsFalse(expr) => Ok(Expr::IsFalse(Box::new(self.parse_sql_expr(expr)?))),
             SQLExpr::IsNotFalse(_) => Ok(Expr::IsNotFalse(Box::new(self.parse_sql_expr(expr)?))),
             SQLExpr::IsTrue(expr) => Ok(Expr::IsTrue(Box::new(self.parse_sql_expr(expr)?))),

--- a/rust/src/io/exec/planner.rs
+++ b/rust/src/io/exec/planner.rs
@@ -31,8 +31,8 @@ use datafusion::{
     scalar::ScalarValue,
 };
 use sqlparser::ast::{
-    BinaryOperator, DataType as SQLDataType, Expr as SQLExpr, Function, FunctionArg,
-    FunctionArgExpr, Ident, TimezoneInfo, UnaryOperator, Value,
+    BinaryOperator, DataType as SQLDataType, ExactNumberInfo, Expr as SQLExpr, Function,
+    FunctionArg, FunctionArgExpr, Ident, TimezoneInfo, UnaryOperator, Value,
 };
 
 use crate::datafusion::logical_expr::coerce_filter_type_to_boolean;
@@ -177,6 +177,21 @@ impl Planner {
     }
 
     fn parse_type(&self, data_type: &SQLDataType) -> Result<ArrowDataType> {
+        const SUPPORTED_TYPES: [&str; 13] = [
+            "int [unsigned]",
+            "tinyint [unsigned]",
+            "smallint [unsigned]",
+            "bigint [unsigned]",
+            "float",
+            "double",
+            "string",
+            "binary",
+            "date",
+            "timestamp(precision)",
+            "datetime(precision)",
+            "decimal(precision,scale)",
+            "boolean",
+        ];
         match data_type {
             SQLDataType::String => Ok(ArrowDataType::Utf8),
             SQLDataType::Binary(_) => Ok(ArrowDataType::Binary),
@@ -189,12 +204,14 @@ impl Planner {
             SQLDataType::BigInt(_) => Ok(ArrowDataType::Int64),
             SQLDataType::UnsignedTinyInt(_) => Ok(ArrowDataType::UInt8),
             SQLDataType::UnsignedSmallInt(_) => Ok(ArrowDataType::UInt16),
-            SQLDataType::UnsignedInt(_) => Ok(ArrowDataType::UInt32),
+            SQLDataType::UnsignedInt(_) | SQLDataType::UnsignedInteger(_) => {
+                Ok(ArrowDataType::UInt32)
+            }
             SQLDataType::UnsignedBigInt(_) => Ok(ArrowDataType::UInt64),
             SQLDataType::Date => Ok(ArrowDataType::Date32),
             SQLDataType::Timestamp(resolution, tz) => {
                 match tz {
-                    TimezoneInfo::None => {},
+                    TimezoneInfo::None => {}
                     _ => {
                         return Err(Error::IO {
                             message: format!("Timezone not supported in timestamp"),
@@ -231,8 +248,24 @@ impl Planner {
                 };
                 Ok(ArrowDataType::Timestamp(time_unit, None))
             }
+            SQLDataType::Decimal(number_info) => match number_info {
+                ExactNumberInfo::PrecisionAndScale(precision, scale) => {
+                    Ok(ArrowDataType::Decimal128(*precision as u8, *scale as i8))
+                }
+                _ => {
+                    return Err(Error::IO {
+                        message: format!(
+                            "Must provide precision and scale for decimal: {:?}",
+                            number_info
+                        ),
+                    })
+                }
+            },
             _ => Err(Error::IO {
-                message: format!("Unsupported data type: {:?}. Supports: float, double, boolean, int, integer, date, datetime", data_type),
+                message: format!(
+                    "Unsupported data type: {:?}. Supported types: {:?}",
+                    data_type, SUPPORTED_TYPES
+                ),
             }),
         }
     }
@@ -402,7 +435,7 @@ mod tests {
         ArrayRef, BooleanArray, Float32Array, Int32Array, RecordBatch, StringArray, StructArray,
     };
     use arrow_schema::{DataType, Field, Fields, Schema};
-    use datafusion::logical_expr::{col, lit};
+    use datafusion::logical_expr::{col, lit, Cast};
 
     #[test]
     fn test_parse_filter_simple() {
@@ -624,5 +657,136 @@ mod tests {
                 false, true, true, false, true, true, false, true, true, false
             ])
         );
+    }
+
+    #[test]
+    fn test_sql_cast() {
+        let cases = &[
+            (
+                "x = cast('2021-01-01 00:00:00' as timestamp)",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+            ),
+            (
+                "x = cast('2021-01-01 00:00:00' as timestamp(0))",
+                ArrowDataType::Timestamp(TimeUnit::Second, None),
+            ),
+            (
+                "x = cast('2021-01-01 00:00:00.123' as timestamp(9))",
+                ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
+            ),
+            (
+                "x = cast('2021-01-01 00:00:00.123' as datetime(9))",
+                ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
+            ),
+            ("x = cast('2021-01-01' as date)", ArrowDataType::Date32),
+            (
+                "x = cast('1.238' as decimal(9,3))",
+                ArrowDataType::Decimal128(9, 3),
+            ),
+            ("x = cast(1 as float)", ArrowDataType::Float32),
+            ("x = cast(1 as double)", ArrowDataType::Float64),
+            ("x = cast(1 as tinyint)", ArrowDataType::Int8),
+            ("x = cast(1 as smallint)", ArrowDataType::Int16),
+            ("x = cast(1 as int)", ArrowDataType::Int32),
+            ("x = cast(1 as integer)", ArrowDataType::Int32),
+            ("x = cast(1 as bigint)", ArrowDataType::Int64),
+            ("x = cast(1 as tinyint unsigned)", ArrowDataType::UInt8),
+            ("x = cast(1 as smallint unsigned)", ArrowDataType::UInt16),
+            ("x = cast(1 as int unsigned)", ArrowDataType::UInt32),
+            ("x = cast(1 as integer unsigned)", ArrowDataType::UInt32),
+            ("x = cast(1 as bigint unsigned)", ArrowDataType::UInt64),
+            ("x = cast(1 as boolean)", ArrowDataType::Boolean),
+            ("x = cast(1 as string)", ArrowDataType::Utf8),
+            ("x = cast(1 as binary)", ArrowDataType::Binary),
+        ];
+
+        for (sql, expected_data_type) in cases {
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                "x",
+                expected_data_type.clone(),
+                true,
+            )]));
+            let planner = Planner::new(schema.clone());
+            let expr = planner.parse_filter(sql).unwrap();
+
+            // Get the thing after 'cast(` but before ' as'.
+            let expected_value_str = sql
+                .split("cast(")
+                .skip(1)
+                .next()
+                .unwrap()
+                .split(" as")
+                .next()
+                .unwrap();
+            // Remove any quote marks
+            let expected_value_str = expected_value_str.trim_matches('\'');
+
+            match expr {
+                Expr::BinaryExpr(BinaryExpr { right, .. }) => match right.as_ref() {
+                    Expr::Cast(Cast { expr, data_type }) => {
+                        match expr.as_ref() {
+                            Expr::Literal(ScalarValue::Utf8(Some(value_str))) => {
+                                assert_eq!(value_str, expected_value_str);
+                            }
+                            Expr::Literal(ScalarValue::Int64(Some(value))) => {
+                                assert_eq!(*value, 1);
+                            }
+                            _ => panic!("Expected cast to be applied to literal"),
+                        }
+                        assert_eq!(data_type, expected_data_type);
+                    }
+                    _ => panic!("Expected right to be a cast"),
+                },
+                _ => panic!("Expected binary expression"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_sql_literals() {
+        let cases = &[
+            (
+                "x = timestamp '2021-01-01 00:00:00'",
+                ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+            ),
+            (
+                "x = timestamp(0) '2021-01-01 00:00:00'",
+                ArrowDataType::Timestamp(TimeUnit::Second, None),
+            ),
+            (
+                "x = timestamp(9) '2021-01-01 00:00:00.123'",
+                ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
+            ),
+            ("x = date '2021-01-01'", ArrowDataType::Date32),
+            ("x = decimal(9,3) '1.238'", ArrowDataType::Decimal128(9, 3)),
+        ];
+
+        for (sql, expected_data_type) in cases {
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                "x",
+                expected_data_type.clone(),
+                true,
+            )]));
+            let planner = Planner::new(schema.clone());
+            let expr = planner.parse_filter(sql).unwrap();
+
+            let expected_value_str = sql.split('\'').skip(1).next().unwrap();
+
+            match expr {
+                Expr::BinaryExpr(BinaryExpr { right, .. }) => match right.as_ref() {
+                    Expr::Cast(Cast { expr, data_type }) => {
+                        match expr.as_ref() {
+                            Expr::Literal(ScalarValue::Utf8(Some(value_str))) => {
+                                assert_eq!(value_str, expected_value_str);
+                            }
+                            _ => panic!("Expected cast to be applied to literal"),
+                        }
+                        assert_eq!(data_type, expected_data_type);
+                    }
+                    _ => panic!("Expected right to be a cast"),
+                },
+                _ => panic!("Expected binary expression"),
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixed #956. Allows casting, but also "typed literals" where you just put the type you want in front of the string.