### PR TITLE
fix s3 get_range issues: 416, range not satisfiable

### DIFF
--- a/rust/src/encodings/binary.rs
+++ b/rust/src/encodings/binary.rs
@@ -206,7 +206,7 @@ impl<'a, T: ByteArrayType> BinaryDecoder<'a, T> {
         };
 
         let bytes: Bytes;
-        if start == end {
+        if start >= end {
             bytes = Bytes::new();
         } else {
             bytes = self.reader.get_range(start as usize..end as usize).await?;

--- a/rust/src/encodings/binary.rs
+++ b/rust/src/encodings/binary.rs
@@ -34,6 +34,7 @@ use arrow_data::ArrayDataBuilder;
 use arrow_schema::DataType;
 use arrow_select::{concat::concat, take::take};
 use async_trait::async_trait;
+use bytes::Bytes;
 use futures::stream::{self, repeat_with, StreamExt, TryStreamExt};
 use tokio::io::AsyncWriteExt;
 
@@ -204,7 +205,12 @@ impl<'a, T: ByteArrayType> BinaryDecoder<'a, T> {
             .into_data()
         };
 
-        let bytes = self.reader.get_range(start as usize..end as usize).await?;
+        let bytes: Bytes;
+        if start == end {
+            bytes = Bytes::new();
+        } else {
+            bytes = self.reader.get_range(start as usize..end as usize).await?;
+        }
 
         let mut data_builder = ArrayDataBuilder::new(T::DATA_TYPE)
             .len(range.len())


### PR DESCRIPTION
fix #739 

Currently, when get data from cloud storage, the input range is specified as a half-open interval (left-closed and right-open). 
However, in actual HTTP requests, the range is interpreted as a closed interval(the byte positions specified are inclusive). This means that when the range size is 0, the generated HTTP request range can result in the end being smaller than the start, leading to an HTTP error code of [416](https://httpwg.org/specs/rfc7233.html#status.416) ("Range Not Satisfiable").
```
"api":{"name":"GetObject","bucket":"xxx","object":"xxx","status":"Requested Range Not Satisfiable","statusCode":416,...},
"requestHeader":{"Accept":"*/*","Range":"bytes=308827096-308827095","User-Agent":"object_store/0.5.6", ...}
```

To fix this, add a check before calling get_range to verify if the range length is non-zero. Only if the length is greater than 0, then the get_range function will be called.

