### PR TITLE
fix: make sure we are always running with a single partition

### DIFF
--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -77,7 +77,6 @@ def run(ds, q=None, assert_func=None):
 
         for filter_ in filters:
             for rf in refine:
-                print(rf)
                 start = time.time()
                 rs = ds.to_table(
                     columns=columns,

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -77,13 +77,14 @@ def run(ds, q=None, assert_func=None):
 
         for filter_ in filters:
             for rf in refine:
+                print(rf)
                 start = time.time()
                 rs = ds.to_table(
                     columns=columns,
                     nearest={
                         "column": "vector",
                         "q": q,
-                        "k": 10,
+                        "k": 15,
                         "nprobes": 1,
                         "refine_factor": rf,
                     },
@@ -96,7 +97,7 @@ def run(ds, q=None, assert_func=None):
                     inmem = pa.dataset.dataset(rs)
                     assert len(inmem.to_table(filter=filter_)) == len(rs)
                 else:
-                    assert len(rs) == 10
+                    assert len(rs) == 15
                     scores = rs["score"].to_numpy()
                     assert (scores.max() - scores.min()) > 1e-6
                     if assert_func is not None:
@@ -118,7 +119,7 @@ def test_ann_append(tmp_path):
     dataset = dataset.create_index(
         "vector", index_type="IVF_PQ", num_partitions=4, num_sub_vectors=16
     )
-    new_data = create_table(nvec=100)
+    new_data = create_table(nvec=10)
     dataset = lance.write_dataset(new_data, dataset.uri, mode="append")
     q = new_data["vector"][0].as_py()
 

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -23,6 +23,7 @@ use datafusion::execution::{
     context::SessionState,
     runtime_env::{RuntimeConfig, RuntimeEnv},
 };
+use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::{
     filter::FilterExec, limit::GlobalLimitExec, union::UnionExec, ExecutionPlan,
     SendableRecordBatchStream,
@@ -348,6 +349,9 @@ impl Scanner {
         let runtime_config = RuntimeConfig::new();
         let runtime_env = Arc::new(RuntimeEnv::new(runtime_config)?);
         let session_state = SessionState::with_config_rt(session_config, runtime_env);
+        // NOTE: we are only executing the first partition here. Therefore, if
+        // the plan has more than one partition, we will be missing data.
+        assert_eq!(plan.output_partitioning().partition_count(), 1);
         Ok(DatasetRecordBatchStream::new(
             plan.execute(0, session_state.task_ctx())?,
         ))
@@ -398,6 +402,8 @@ impl Scanner {
     /// 3. Limit / Offset
     /// 4. Take remaining columns / Projection
     async fn create_plan(&self) -> Result<Arc<dyn ExecutionPlan>> {
+        // NOTE: we only support node that have one partition. So any nodes that
+        // produce multiple need to be repartitioned to 1.
         let filter_expr = if let Some(filter) = self.filter.as_ref() {
             let planner = Planner::new(Arc::new(self.dataset.schema().into()));
             let logical_expr = planner.parse_filter(filter)?;
@@ -526,8 +532,20 @@ impl Scanner {
                 );
                 // first we do flat search on just the new data
                 let topk_appended = self.flat_knn(scan_node, q)?;
+
+                // To do a union, we need to make the schemas match. Right now
+                // knn_node: score, _rowid, vector
+                // topk_appended: vector, _rowid, score
+                let new_schema = Schema::try_from(&topk_appended.schema().project(&[2, 1, 0])?)?;
+                let topk_appended = ProjectionExec::try_new(topk_appended, Arc::new(new_schema))?;
+                assert_eq!(topk_appended.schema(), knn_node.schema());
                 // union
-                let unioned = UnionExec::new(vec![topk_appended, knn_node]);
+                let unioned = UnionExec::new(vec![Arc::new(topk_appended), knn_node]);
+                // Enforce only 1 partition.
+                let unioned = RepartitionExec::try_new(
+                    Arc::new(unioned),
+                    datafusion::physical_plan::Partitioning::RoundRobinBatch(1),
+                )?;
                 // then we do a flat search on KNN(new data) + ANN(indexed data)
                 return self.flat_knn(Arc::new(unioned), q);
             }
@@ -933,6 +951,111 @@ mod test {
                 .copied()
                 .collect();
             assert_eq!(expected_i, actual_i);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_knn_with_new_data() {
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+        let dataset = create_vector_dataset(test_uri, true).await;
+
+        // Insert more data
+        // (0, 0, ...), (1, 1, ...), (2, 2, ...)
+        let vector_values: Float32Array =
+            (0..10).flat_map(|i| [i as f32; 32].into_iter()).collect();
+        let new_vectors = FixedSizeListArray::try_new(&vector_values, 32).unwrap();
+        let new_data: Vec<ArrayRef> = vec![
+            Arc::new(Int32Array::from_iter_values(400..410)), // 5 * 80
+            Arc::new(StringArray::from_iter_values(
+                (400..410).map(|v| format!("s-{}", v)),
+            )),
+            Arc::new(new_vectors),
+        ];
+        let schema: Arc<ArrowSchema> = Arc::new(dataset.schema().try_into().unwrap());
+        let new_data =
+            RecordBatchBuffer::new(vec![RecordBatch::try_new(schema, new_data).unwrap()]);
+        let mut new_data_reader: Box<dyn RecordBatchReader> = Box::new(new_data);
+        let dataset = Dataset::write(
+            &mut new_data_reader,
+            test_uri,
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        // Create a bunch of queries
+        let key: Float32Array = [0f32; 32].into_iter().collect();
+        // Set as larger than the number of new rows that aren't in the index to
+        // force result sets to be combined between index and flat scan.
+        let k = 20;
+
+        #[derive(Debug)]
+        struct TestCase {
+            filter: Option<&'static str>,
+            limit: Option<i64>,
+            use_index: bool,
+        }
+
+        let mut cases = vec![];
+        for filter in [Some("i > 100"), None] {
+            for limit in [None, Some(10)] {
+                for use_index in [true, false] {
+                    cases.push(TestCase {
+                        filter,
+                        limit,
+                        use_index,
+                    });
+                }
+            }
+        }
+
+        // Validate them all.
+        for case in cases {
+            let mut scanner = dataset.scan();
+            scanner
+                .nearest("vec", &key, k)
+                .unwrap()
+                .limit(case.limit, None)
+                .unwrap()
+                .refine(3)
+                .use_index(case.use_index);
+            if let Some(filter) = case.filter {
+                scanner.filter(filter).unwrap();
+            }
+
+            let result = scanner
+                .try_into_stream()
+                .await
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            assert!(result.len() > 0);
+            let result = concat_batches(&result[0].schema(), result.iter()).unwrap();
+
+            if case.filter.is_some() {
+                let result_rows = result.num_rows();
+                let expected_rows = case.limit.unwrap_or(k as i64) as usize;
+                assert!(
+                    result_rows <= expected_rows,
+                    "Expected less than {} rows, got {}",
+                    expected_rows,
+                    result_rows
+                );
+            } else {
+                // Exactly equal count
+                assert_eq!(result.num_rows(), case.limit.unwrap_or(k as i64) as usize);
+            }
+
+            // Top one should be the first value of new data
+            assert_eq!(
+                as_primitive_array::<Int32Type>(result.column(0).as_ref()).value(0),
+                400
+            );
         }
     }
 

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -93,7 +93,7 @@ impl DFRecordBatchStream for KNNFlatStream {
     fn schema(&self) -> arrow_schema::SchemaRef {
         Arc::new(Schema::new(vec![
             Field::new("score", DataType::Float32, false),
-            Field::new(ROW_ID, DataType::UInt16, false),
+            Field::new(ROW_ID, DataType::UInt64, false),
         ]))
     }
 }
@@ -266,7 +266,7 @@ impl DFRecordBatchStream for KNNIndexStream {
     fn schema(&self) -> arrow_schema::SchemaRef {
         Arc::new(Schema::new(vec![
             Field::new(SCORE_COL, DataType::Float32, false),
-            Field::new(ROW_ID, DataType::UInt16, false),
+            Field::new(ROW_ID, DataType::UInt64, false),
         ]))
     }
 }
@@ -328,7 +328,7 @@ impl ExecutionPlan for KNNIndexExec {
     fn schema(&self) -> arrow_schema::SchemaRef {
         Arc::new(Schema::new(vec![
             Field::new(SCORE_COL, DataType::Float32, false),
-            Field::new(ROW_ID, DataType::UInt16, false),
+            Field::new(ROW_ID, DataType::UInt64, false),
         ]))
     }
 


### PR DESCRIPTION
When we have an index and some unindexed data, we read from both and use a union node to combine the results. However, at the end of the plan, we only read from the first partition. This meant we only ever would read from the flat scan, and not from the index scan.

The test cases have been adjusted so that we try to retrieve more vector results than there was added data, so we can confirm that we are actually getting results from both parts.

I also enforce with an assertion that we only use 1 partition in the final plan. In the future, we might consider splitting things out into multiple partitions, once we have a better understanding of the performance impact in DataFusion.