### PR TITLE
feat: add feature flags to the dataset manifest

### DIFF
--- a/protos/format.proto
+++ b/protos/format.proto
@@ -72,6 +72,26 @@ message Manifest {
 
   // Optional version tag
   string tag = 8;
+
+  // Feature flags for readers.
+  //
+  // A bitmap of flags that indicate which features are required to be able to
+  // read the table. If a reader does not recognize a flag that is set, it
+  // should not attempt to read the dataset.
+  //
+  // Known flags:
+  // * 1: deletion files are present
+  uint64 reader_feature_flags = 9;
+
+  // Feature flags for writers.
+  //
+  // A bitmap of flags that indicate which features are required to be able to
+  // write to the dataset. if a writer does not recognize a flag that is set, it
+  // should not attempt to write to the dataset.
+  //
+  // The flags are the same as for reader_feature_flags, although they will not
+  // always apply to both.
+  uint64 writer_feature_flags = 10;
 }
 
 // Auxiliary Data attached to a version.

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -261,7 +261,7 @@ impl Dataset {
         if !can_read_dataset(manifest.reader_feature_flags) {
             let message = format!(
                 "This dataset cannot be read by this version of Lance. \
-                                           Please upgrade Lance to read this dataset.\n Flags: {}",
+                 Please upgrade Lance to read this dataset.\n Flags: {}",
                 manifest.reader_feature_flags
             );
             return Err(Error::NotSupported {
@@ -353,9 +353,11 @@ impl Dataset {
 
         if let Some(d) = dataset.as_ref() {
             if !can_write_dataset(d.manifest.writer_feature_flags) {
-                let message = format!("This dataset cannot be written by this version of Lance. \
-                                               Please upgrade Lance to write to this dataset.\n Flags: {}",
-                                               d.manifest.writer_feature_flags);
+                let message = format!(
+                    "This dataset cannot be written by this version of Lance. \
+                    Please upgrade Lance to write to this dataset.\n Flags: {}",
+                    d.manifest.writer_feature_flags
+                );
                 return Err(Error::NotSupported {
                     source: message.into(),
                 });

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -870,10 +870,19 @@ impl Dataset {
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub(crate) struct ManifestWriteConfig {
-    auto_set_feature_flags: bool,  // default false
+    auto_set_feature_flags: bool,  // default true
     timestamp: Option<SystemTime>, // default None
+}
+
+impl Default for ManifestWriteConfig {
+    fn default() -> Self {
+        Self {
+            auto_set_feature_flags: true,
+            timestamp: None,
+        }
+    }
 }
 
 /// Finish writing the manifest file, and commit the changes by linking the latest manifest file
@@ -1102,7 +1111,16 @@ mod tests {
         )
         .unwrap()]);
         let mut batches: Box<dyn RecordBatchReader> = Box::new(batches);
-        let write_result = Dataset::write(&mut batches, test_uri, None).await;
+        let write_result = Dataset::write(
+            &mut batches,
+            test_uri,
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            }),
+        )
+        .await;
+
         assert!(matches!(write_result, Err(Error::NotSupported { .. })));
     }
 

--- a/rust/src/dataset/feature_flags.rs
+++ b/rust/src/dataset/feature_flags.rs
@@ -1,0 +1,62 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Feature flags
+use crate::format::Manifest;
+
+pub const FLAG_DELETION_FILES: u64 = 1;
+
+/// Set the reader and writer feature flags in the manifest based on the contents of the manifest.
+pub(crate) fn apply_feature_flags(manifest: &mut Manifest) {
+    // Reset flags
+    manifest.reader_feature_flags = 0;
+    manifest.writer_feature_flags = 0;
+
+    let has_deletion_files = manifest
+        .fragments
+        .iter()
+        .any(|frag| frag.deletion_file.is_some());
+    if has_deletion_files {
+        // Both readers and writers need to be able to read deletion files
+        manifest.reader_feature_flags |= FLAG_DELETION_FILES;
+        manifest.writer_feature_flags |= FLAG_DELETION_FILES;
+    }
+}
+
+pub(crate) fn can_read_dataset(reader_flags: u64) -> bool {
+    reader_flags <= 1
+}
+
+pub(crate) fn can_write_dataset(writer_flags: u64) -> bool {
+    writer_flags <= 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_read_check() {
+        assert!(can_read_dataset(0));
+        assert!(can_read_dataset(super::FLAG_DELETION_FILES));
+        assert!(!can_read_dataset(super::FLAG_DELETION_FILES + 1));
+    }
+
+    #[test]
+    fn test_write_check() {
+        assert!(can_write_dataset(0));
+        assert!(can_write_dataset(super::FLAG_DELETION_FILES));
+        assert!(!can_write_dataset(super::FLAG_DELETION_FILES + 1));
+    }
+}

--- a/rust/src/error.rs
+++ b/rust/src/error.rs
@@ -45,6 +45,8 @@ pub enum Error {
         source: BoxedError,
         // TODO: add backtrace?
     },
+    #[snafu(display("Not supported: {source}"))]
+    NotSupported { source: BoxedError },
     #[snafu(display("Encountered internal error. Please file a bug report at https://github.com/lancedb/lance/issues. {message}"))]
     Internal { message: String },
     #[snafu(display("LanceError(Arrow): {message}"))]

--- a/rust/src/format/manifest.rs
+++ b/rust/src/format/manifest.rs
@@ -55,6 +55,12 @@ pub struct Manifest {
 
     /// An optional string tag for this version
     pub tag: Option<String>,
+
+    /// The reader flags
+    pub reader_feature_flags: u64,
+
+    /// The writer flags
+    pub writer_feature_flags: u64,
 }
 
 impl Manifest {
@@ -67,6 +73,8 @@ impl Manifest {
             index_section: None,
             timestamp_nanos: 0,
             tag: None,
+            reader_feature_flags: 0,
+            writer_feature_flags: 0,
         }
     }
 
@@ -136,6 +144,8 @@ impl From<pb::Manifest> for Manifest {
             index_section: p.index_section.map(|i| i as usize),
             timestamp_nanos: timestamp_nanos.unwrap_or(0),
             tag: if p.tag.is_empty() { None } else { Some(p.tag) },
+            reader_feature_flags: p.reader_feature_flags,
+            writer_feature_flags: p.writer_feature_flags,
         }
     }
 }
@@ -161,6 +171,8 @@ impl From<&Manifest> for pb::Manifest {
             index_section: m.index_section.map(|i| i as u64),
             timestamp: timestamp_nanos,
             tag: m.tag.clone().unwrap_or("".to_string()),
+            reader_feature_flags: m.reader_feature_flags,
+            writer_feature_flags: m.writer_feature_flags,
         }
     }
 }

--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -184,6 +184,7 @@ impl DatasetIndexExt for Dataset {
             &self.base,
             &mut new_manifest,
             Some(indices),
+            Default::default(),
         )
         .await?;
 


### PR DESCRIPTION
As we add new features, we need to be sure our readers and writers aren't trying to access data they don't know how to interpret. This PRs adds feature flags to so they can detect if a table uses features it doesn't know about.

This is preferable to versions because:

1. It makes it easy to granularly see what features are unsupported
2. In a future where there are independent readers / writers, they don't have to implement features in a linear order.

Closes #973