### PR TITLE
implement object caching interface

### DIFF
--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -45,6 +45,7 @@ use crate::arrow::*;
 use crate::datatypes::Schema;
 use crate::error::box_error;
 use crate::format::{pb, Fragment, Index, Manifest};
+use crate::io::object_cache::ObjectCache;
 use crate::io::{
     object_reader::{read_message, read_struct},
     read_manifest, read_metadata_offset, write_manifest, FileWriter, ObjectStore,
@@ -212,6 +213,15 @@ impl Dataset {
             Arc::new(Session::new(params.index_cache_size))
         };
         Self::checkout_manifest(Arc::new(object_store), base_path, &manifest_file, session).await
+    }
+
+    pub fn with_object_cache(&self, object_cache: Arc<dyn ObjectCache>) -> Self {
+        let new_store = self.object_store.with_cache(object_cache);
+        let object_store = Arc::new(new_store);
+        Self {
+            object_store,
+            ..self.clone()
+        }
     }
 
     /// Check out the specified version of this dataset

--- a/rust/src/io.rs
+++ b/rust/src/io.rs
@@ -27,6 +27,7 @@ use tokio::io::{AsyncWrite, AsyncWriteExt};
 pub(crate) mod deletion;
 pub(crate) mod exec;
 pub mod local;
+pub mod object_cache;
 pub mod object_reader;
 pub mod object_store;
 pub mod object_writer;

--- a/rust/src/io/object_cache.rs
+++ b/rust/src/io/object_cache.rs
@@ -1,0 +1,29 @@
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use super::object_reader::ObjectReader;
+
+#[async_trait]
+pub trait ObjectCache: Send + Sync + Debug + 'static {
+    async fn to_cached_reader(&self, reader: Box<dyn ObjectReader>) -> Box<dyn ObjectReader>;
+}
+
+#[derive(Debug)]
+struct NoOpCache;
+
+#[async_trait]
+impl ObjectCache for NoOpCache {
+    async fn to_cached_reader(&self, reader: Box<dyn ObjectReader>) -> Box<dyn ObjectReader> {
+        reader
+    }
+}
+
+pub struct ObjectCaches;
+
+impl ObjectCaches {
+    pub fn no_op() -> Arc<dyn ObjectCache> {
+        Arc::new(NoOpCache)
+    }
+}


### PR DESCRIPTION
add a caching interface for object store. Only effective when the backend storage type is cloud.