### PR TITLE
feat: handle NaN values in argmin

### DIFF
--- a/rust/src/arrow/kernels.rs
+++ b/rust/src/arrow/kernels.rs
@@ -40,19 +40,11 @@ where
         .max_by(|(_, x), (_, y)| match (x, y) {
             (None, _) => Ordering::Less,
             (Some(_), None) => Ordering::Greater,
-            (Some(vx), Some(vy)) => {
-                if let Some(ordering) = vx.partial_cmp(vy) {
-                    ordering
-                } else {
-                    Ordering::Greater
-                }
-            }
+            (Some(vx), Some(vy)) => vx.partial_cmp(vy).unwrap_or(Ordering::Greater),
         })
         .and_then(|(idx, val)| {
-            // If the value is NaN, return None
-            if let Some(val) = val {
-                val.partial_cmp(&val)?;
-            }
+            // If the value is None or NaN, return None
+            val.and_then(|val| val.partial_cmp(&val))?;
             Some(idx as u32)
         })
 }
@@ -70,19 +62,11 @@ where
         .max_by(|(_, x), (_, y)| match (x, y) {
             (None, _) => Ordering::Greater,
             (Some(_), None) => Ordering::Greater,
-            (Some(vx), Some(vy)) => {
-                if let Some(ordering) = vy.partial_cmp(vx) {
-                    ordering
-                } else {
-                    Ordering::Greater
-                }
-            }
+            (Some(vx), Some(vy)) => vy.partial_cmp(vx).unwrap_or(Ordering::Greater),
         })
         .and_then(|(idx, val)| {
-            // If the value is NaN, return None
-            if let Some(val) = val {
-                val.partial_cmp(&val)?;
-            }
+            // If the value is None or NaN, return None
+            val.and_then(|val| val.partial_cmp(&val))?;
             Some(idx as u32)
         })
 }

--- a/rust/src/arrow/kernels.rs
+++ b/rust/src/arrow/kernels.rs
@@ -24,38 +24,16 @@ use arrow_array::{
     Array, ArrowNumericType, GenericStringArray, OffsetSizeTrait, PrimitiveArray, UInt64Array,
 };
 use arrow_schema::DataType;
+use num_traits::bounds::Bounded;
 
 use crate::{Error, Result};
-
-pub trait NumericMaxMin {
-    fn max_value() -> Self;
-    fn min_value() -> Self;
-}
-
-macro_rules! impl_numeric_max_min {
-    ($ty:ty) => {
-        impl NumericMaxMin for $ty {
-            fn max_value() -> Self {
-                Self::MAX
-            }
-            fn min_value() -> Self {
-                Self::MIN
-            }
-        }
-    };
-}
-
-impl_numeric_max_min!(f32);
-impl_numeric_max_min!(f64);
-impl_numeric_max_min!(i16);
-impl_numeric_max_min!(u32);
 
 /// Argmax on a [PrimitiveArray].
 ///
 /// Returns the index of the max value in the array.
 pub fn argmax<T: ArrowNumericType>(array: &PrimitiveArray<T>) -> Option<u32>
 where
-    T::Native: PartialOrd + NumericMaxMin,
+    T::Native: PartialOrd + Bounded,
 {
     let mut max_idx: Option<u32> = None;
     let mut max_value = T::Native::min_value();
@@ -75,7 +53,7 @@ where
 /// Returns the index of the min value in the array.
 pub fn argmin<T: ArrowNumericType>(array: &PrimitiveArray<T>) -> Option<u32>
 where
-    T::Native: PartialOrd + NumericMaxMin,
+    T::Native: PartialOrd + Bounded,
 {
     let mut min_idx: Option<u32> = None;
     let mut min_value = T::Native::max_value();

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -514,7 +514,13 @@ fn compute_residual_matrix(
     let mut builder = Float32Builder::with_capacity(data.data().len());
     for i in 0..data.num_rows() {
         let row = data.row(i).unwrap();
-        let part_id = argmin(dist_func(row, centroids.data().values(), dim).as_ref()).unwrap();
+        let dist_array = dist_func(row, centroids.data().values(), dim);
+        let part_id = argmin(dist_array.as_ref()).ok_or_else(|| Error::Index {
+            message: format!(
+                "Ivf::compute_residual: argmin failed. Failed to find minimum of {:?}",
+                dist_array
+            ),
+        })?;
         let centroid = centroids.row(part_id as usize).unwrap();
         if row.len() != centroid.len() {
             return Err(Error::IO {


### PR DESCRIPTION
Currently, we panic if NaN is found in the array argmin or argmax operate on.

Example where we can hit this:

```python
import lance
import pyarrow as pa
import pyarrow.compute as pc
import shutil


dims = 375
nrows = 18836
# all zeros
inner_vector = pc.cast(pa.array([0] * (nrows * dims)), pa.float32())
vector = pa.FixedSizeListArray.from_arrays(inner_vector, dims)
table = pa.Table.from_arrays([vector], ["vector"])

shutil.rmtree("test", ignore_errors=True)
dataset = lance.write_dataset(table, "test")

dataset.create_index(
    "vector",
    index_type="IVF_PQ",
    metric="cosine",
    num_partitions=4,
    num_sub_vectors=125,
)
```