### PR TITLE
upgrade to arrow 40 and datafusion 26

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -11,10 +11,10 @@ name = "lance"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow = { version = "37.0.0", features = ["pyarrow"] }
-arrow-array = "37.0"
-arrow-data = "37.0"
-arrow-schema = "37.0"
+arrow = { version = "40.0.0", features = ["pyarrow"] }
+arrow-array = "40.0"
+arrow-data = "40.0"
+arrow-schema = "40.0"
 chrono = "0.4.23"
 env_logger = "0.10"
 futures = "0.3"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,16 +28,16 @@ no-default-features = true
 
 [dependencies]
 bytes = "1.3"
-arrow-arith = "37.0"
-arrow-array = "37.0"
-arrow-buffer = "37.0"
-arrow-cast = "37.0.0"
-arrow-data = "37.0"
-arrow-ipc = { version = "37.0", features = ["zstd"] }
-arrow-ord = "37.0"
-arrow-row = "37.0"
-arrow-schema = "37.0"
-arrow-select = "37.0"
+arrow-arith = "40.0"
+arrow-array = "40.0"
+arrow-buffer = "40.0"
+arrow-cast = "40.0.0"
+arrow-data = "40.0"
+arrow-ipc = { version = "40.0", features = ["zstd"] }
+arrow-ord = "40.0"
+arrow-row = "40.0"
+arrow-schema = "40.0"
+arrow-select = "40.0"
 async-recursion = "1.0"
 async-trait = "0.1.60"
 byteorder = "1.4.3"
@@ -60,11 +60,11 @@ futures = "0.3.27"
 uuid = { version = "1.2", features = ["v4"] }
 path-absolutize = "3.0.14"
 shellexpand = "3.0.0"
-arrow = { version = "37.0.0", features = ["prettyprint"] }
+arrow = { version = "40.0.0", features = ["prettyprint"] }
 num_cpus = "1.0"
 sqlparser-lance = "0.32.0"
 # TODO: use datafusion sub-modules to reduce build size?
-datafusion = { version = "23.0.0", default-features = false, features = ["regex_expressions"] }
+datafusion = { version = "26.0.0", default-features = false, features = ["regex_expressions"] }
 faiss = { version = "0.11.0", features = ["gpu"], optional = true }
 lapack = { version = "0.19.0", optional = true }
 cblas =  { version = "0.4.0", optional = true }

--- a/rust/src/arrow.rs
+++ b/rust/src/arrow.rs
@@ -136,59 +136,50 @@ impl DataTypeExt for DataType {
     }
 }
 
-pub trait GenericListArrayExt<Offset: ArrowNumericType>
+/// Create an [`GenericListArray`] from values and offsets.
+///
+/// ```
+/// use arrow_array::{Int32Array, Int64Array, ListArray};
+/// use arrow_array::types::Int64Type;
+/// use lance::arrow::try_new_generic_list_array;
+///
+/// let offsets = Int32Array::from_iter([0, 2, 7, 10]);
+/// let int_values = Int64Array::from_iter(0..10);
+/// let list_arr = try_new_generic_list_array(int_values, &offsets).unwrap();
+/// assert_eq!(list_arr,
+///     ListArray::from_iter_primitive::<Int64Type, _, _>(vec![
+///         Some(vec![Some(0), Some(1)]),
+///         Some(vec![Some(2), Some(3), Some(4), Some(5), Some(6)]),
+///         Some(vec![Some(7), Some(8), Some(9)]),
+/// ]))
+/// ```
+pub fn try_new_generic_list_array<T: Array, Offset: ArrowNumericType>(
+    values: T,
+    offsets: &PrimitiveArray<Offset>,
+) -> Result<GenericListArray<Offset::Native>>
 where
     Offset::Native: OffsetSizeTrait,
 {
-    /// Create an [`GenericListArray`] from values and offsets.
-    ///
-    /// ```
-    /// use arrow_array::{Int32Array, Int64Array, ListArray};
-    /// use arrow_array::types::Int64Type;
-    /// use lance::arrow::GenericListArrayExt;
-    ///
-    /// let offsets = Int32Array::from_iter([0, 2, 7, 10]);
-    /// let int_values = Int64Array::from_iter(0..10);
-    /// let list_arr = ListArray::try_new(int_values, &offsets).unwrap();
-    /// assert_eq!(list_arr,
-    ///     ListArray::from_iter_primitive::<Int64Type, _, _>(vec![
-    ///         Some(vec![Some(0), Some(1)]),
-    ///         Some(vec![Some(2), Some(3), Some(4), Some(5), Some(6)]),
-    ///         Some(vec![Some(7), Some(8), Some(9)]),
-    /// ]))
-    /// ```
-    fn try_new<T: Array>(
-        values: T,
-        offsets: &PrimitiveArray<Offset>,
-    ) -> Result<GenericListArray<Offset::Native>>;
-}
+    let data_type = if Offset::Native::IS_LARGE {
+        DataType::LargeList(Arc::new(Field::new(
+            "item",
+            values.data_type().clone(),
+            true,
+        )))
+    } else {
+        DataType::List(Arc::new(Field::new(
+            "item",
+            values.data_type().clone(),
+            true,
+        )))
+    };
+    let data = ArrayDataBuilder::new(data_type)
+        .len(offsets.len() - 1)
+        .add_buffer(offsets.into_data().buffers()[0].clone())
+        .add_child_data(values.into_data())
+        .build()?;
 
-impl<Offset: ArrowNumericType> GenericListArrayExt<Offset> for GenericListArray<Offset::Native>
-where
-    Offset::Native: OffsetSizeTrait,
-{
-    fn try_new<T: Array>(values: T, offsets: &PrimitiveArray<Offset>) -> Result<Self> {
-        let data_type = if Offset::Native::IS_LARGE {
-            DataType::LargeList(Arc::new(Field::new(
-                "item",
-                values.data_type().clone(),
-                true,
-            )))
-        } else {
-            DataType::List(Arc::new(Field::new(
-                "item",
-                values.data_type().clone(),
-                true,
-            )))
-        };
-        let data = ArrayDataBuilder::new(data_type)
-            .len(offsets.len() - 1)
-            .add_buffer(offsets.into_data().buffers()[0].clone())
-            .add_child_data(values.into_data())
-            .build()?;
-
-        Ok(Self::from(data))
-    }
+    Ok(GenericListArray::from(data))
 }
 
 pub trait FixedSizeListArrayExt {
@@ -434,11 +425,7 @@ fn project(struct_array: &StructArray, fields: &Fields) -> Result<StructArray> {
         }
     }
     Ok(StructArray::from(
-        fields
-            .iter()
-            .map(|f| f.as_ref().clone())
-            .zip(columns)
-            .collect::<Vec<_>>(),
+        fields.iter().cloned().zip(columns).collect::<Vec<_>>(),
     ))
 }
 
@@ -507,9 +494,10 @@ fn merge(left_struct_array: &StructArray, right_struct_array: &StructArray) -> R
             }
         });
 
-    let zipped: Vec<(Field, ArrayRef)> = fields
+    let zipped: Vec<(FieldRef, ArrayRef)> = fields
         .iter()
         .cloned()
+        .map(Arc::new)
         .zip(columns.iter().cloned())
         .collect::<Vec<_>>();
     StructArray::try_from(zipped).map_err(|e| Error::Arrow {
@@ -556,7 +544,7 @@ mod tests {
             vec![
                 Arc::new(a_array.clone()),
                 Arc::new(StructArray::from(vec![(
-                    Field::new("c", DataType::Int32, true),
+                    Arc::new(Field::new("c", DataType::Int32, true)),
                     Arc::new(c_array.clone()) as ArrayRef,
                 )])),
             ],
@@ -576,7 +564,7 @@ mod tests {
             vec![
                 Arc::new(e_array.clone()),
                 Arc::new(StructArray::from(vec![(
-                    Field::new("d", DataType::Utf8, true),
+                    Arc::new(Field::new("d", DataType::Utf8, true)),
                     Arc::new(d_array.clone()) as ArrayRef,
                 )])) as ArrayRef,
             ],
@@ -604,11 +592,11 @@ mod tests {
                 Arc::new(a_array) as ArrayRef,
                 Arc::new(StructArray::from(vec![
                     (
-                        Field::new("c", DataType::Int32, true),
+                        Arc::new(Field::new("c", DataType::Int32, true)),
                         Arc::new(c_array) as ArrayRef,
                     ),
                     (
-                        Field::new("d", DataType::Utf8, true),
+                        Arc::new(Field::new("d", DataType::Utf8, true)),
                         Arc::new(d_array) as ArrayRef,
                     ),
                 ])) as ArrayRef,

--- a/rust/src/arrow/linalg/matrix.rs
+++ b/rust/src/arrow/linalg/matrix.rs
@@ -289,6 +289,7 @@ impl TryFrom<&FixedSizeListArray> for MatrixView {
 mod tests {
     use std::collections::HashSet;
 
+    #[cfg(feature = "opq")]
     use approx::assert_relative_eq;
 
     use super::*;

--- a/rust/src/datafusion/logical_expr.rs
+++ b/rust/src/datafusion/logical_expr.rs
@@ -15,6 +15,7 @@
 //! Extends logical expression.
 
 use arrow_schema::DataType;
+use datafusion::logical_expr::expr::ScalarFunction;
 use datafusion::logical_expr::{BuiltinScalarFunction, Operator};
 use datafusion::scalar::ScalarValue;
 use datafusion::{logical_expr::BinaryExpr, prelude::*};
@@ -153,10 +154,10 @@ pub fn coerce_filter_type_to_boolean(expr: Expr) -> Result<Expr> {
     match expr {
         // TODO: consider making this dispatch more generic, i.e. fun.output_type -> coerce
         // instead of hardcoding coerce method for each function
-        Expr::ScalarFunction {
+        Expr::ScalarFunction(ScalarFunction {
             fun: BuiltinScalarFunction::RegexpMatch,
             args: _,
-        } => Ok(Expr::IsNotNull(Box::new(expr))),
+        }) => Ok(Expr::IsNotNull(Box::new(expr))),
 
         _ => Ok(expr),
     }

--- a/rust/src/datafusion/physical_expr.rs
+++ b/rust/src/datafusion/physical_expr.rs
@@ -186,12 +186,12 @@ mod tests {
                 )),
                 Arc::new(StructArray::from(vec![
                     (
-                        Field::new("x", DataType::Float32, false),
+                        Arc::new(Field::new("x", DataType::Float32, false)),
                         Arc::new(Float32Array::from_iter_values((0..10).map(|v| v as f32)))
                             as ArrayRef,
                     ),
                     (
-                        Field::new("y", DataType::Float32, false),
+                        Arc::new(Field::new("y", DataType::Float32, false)),
                         Arc::new(Float32Array::from_iter_values(
                             (0..10).map(|v| (v * 10) as f32),
                         )),

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -967,8 +967,8 @@ mod tests {
                             Arc::new(Int32Array::from_iter_values(i * 20..(i + 1) * 20)),
                             Arc::new(
                                 DictionaryArray::try_new(
-                                    &UInt16Array::from_iter_values((0_u16..20_u16).map(|v| v % 5)),
-                                    &dict_values,
+                                    UInt16Array::from_iter_values((0_u16..20_u16).map(|v| v % 5)),
+                                    Arc::new(dict_values.clone()),
                                 )
                                 .unwrap(),
                             ),

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -1652,8 +1652,8 @@ mod test {
                     schema.clone(),
                     vec![
                         Arc::new(StructArray::from(vec![
-                            (struct_i_field.clone(), struct_i_arr as ArrayRef),
-                            (struct_o_field.clone(), struct_o_arr as ArrayRef),
+                            (Arc::new(struct_i_field.clone()), struct_i_arr as ArrayRef),
+                            (Arc::new(struct_o_field.clone()), struct_o_arr as ArrayRef),
                         ])),
                         Arc::new(StringArray::from_iter_values(
                             (i * 20..(i + 1) * 20).map(|v| format!("s-{}", v)),

--- a/rust/src/encodings/dictionary.rs
+++ b/rust/src/encodings/dictionary.rs
@@ -169,8 +169,11 @@ impl<'a> DictionaryDecoder<'a> {
         &self,
         index_array: ArrayRef,
     ) -> Result<ArrayRef> {
-        let keys: &PrimitiveArray<T> = as_primitive_array(index_array.as_ref());
-        Ok(Arc::new(DictionaryArray::try_new(keys, &self.value_arr)?))
+        let keys: PrimitiveArray<T> = as_primitive_array(index_array.as_ref()).clone();
+        Ok(Arc::new(DictionaryArray::try_new(
+            keys,
+            self.value_arr.clone(),
+        )?))
     }
 }
 
@@ -219,16 +222,19 @@ mod tests {
         let value_array: StringArray = vec![Some("a"), Some("b"), Some("c"), Some("d")]
             .into_iter()
             .collect();
+        let value_array_ref = Arc::new(value_array) as ArrayRef;
 
         let keys1: PrimitiveArray<T> = vec![T::Native::from_usize(0), T::Native::from_usize(1)]
             .into_iter()
             .collect();
-        let arr1: DictionaryArray<T> = DictionaryArray::try_new(&keys1, &value_array).unwrap();
+        let arr1: DictionaryArray<T> =
+            DictionaryArray::try_new(keys1, value_array_ref.clone()).unwrap();
 
         let keys2: PrimitiveArray<T> = vec![T::Native::from_usize(1), T::Native::from_usize(3)]
             .into_iter()
             .collect();
-        let arr2: DictionaryArray<T> = DictionaryArray::try_new(&keys2, &value_array).unwrap();
+        let arr2: DictionaryArray<T> =
+            DictionaryArray::try_new(keys2, value_array_ref.clone()).unwrap();
 
         let keys1_ref = arr1.keys() as &dyn Array;
         let keys2_ref = arr2.keys() as &dyn Array;
@@ -251,7 +257,7 @@ mod tests {
             pos,
             arr1.len() + arr2.len(),
             arr1.data_type(),
-            Arc::new(value_array),
+            value_array_ref.clone(),
         );
 
         let decoded_data = decoder.decode().await.unwrap();

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -756,7 +756,7 @@ mod tests {
         for i in 0..10 {
             let data = array.slice(i * 12, 12); // one and half byte
             file_writer
-                .write(&[RecordBatch::try_new(arrow_schema.clone(), vec![data]).unwrap()])
+                .write(&[RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(data)]).unwrap()])
                 .await
                 .unwrap();
         }

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -591,7 +591,7 @@ pub async fn build_ivf_pq_index(
         if pq_params.use_opq {
             #[cfg(not(feature = "opq"))]
             return Err(Error::Index {
-                message: format!("Feature 'opq' is not installed."),
+                message: "Feature 'opq' is not installed.".to_string(),
             });
             #[cfg(feature = "opq")]
             {

--- a/rust/src/io/exec/planner.rs
+++ b/rust/src/io/exec/planner.rs
@@ -16,10 +16,13 @@
 
 use std::sync::Arc;
 
-use arrow_cast::DEFAULT_CAST_OPTIONS;
 use arrow_schema::{DataType as ArrowDataType, SchemaRef, TimeUnit};
 use datafusion::{
-    logical_expr::{col, BinaryExpr, BuiltinScalarFunction, Like, Operator},
+    logical_expr::{
+        col,
+        expr::{InList, ScalarFunction},
+        BinaryExpr, BuiltinScalarFunction, Like, Operator,
+    },
     physical_expr::execution_props::ExecutionProps,
     physical_plan::{
         expressions::{
@@ -186,10 +189,10 @@ impl Planner {
                 .map(|arg| self.parse_function_args(arg).unwrap())
                 .collect::<Vec<_>>();
 
-            return Ok(Expr::ScalarFunction {
+            return Ok(Expr::ScalarFunction(ScalarFunction {
                 fun: BuiltinScalarFunction::RegexpMatch,
                 args: args_vec,
-            });
+            }));
         }
         Err(Error::IO {
             message: format!("function '{}' is not supported", func.name),
@@ -380,17 +383,17 @@ impl Planner {
             Expr::IsNull(expr) => Arc::new(IsNullExpr::new(self.create_physical_expr(expr)?)),
             Expr::IsTrue(expr) => self.create_physical_expr(expr)?,
             Expr::IsFalse(expr) => Arc::new(NotExpr::new(self.create_physical_expr(expr)?)),
-            Expr::InList {
+            Expr::InList(InList {
                 expr,
                 list,
                 negated,
-            } => Arc::new(InListExpr::new(
+            }) => Arc::new(InListExpr::new(
                 self.create_physical_expr(expr)?,
                 list.iter()
                     .map(|e| self.create_physical_expr(e))
                     .collect::<Result<Vec<_>>>()?,
                 *negated,
-                self.schema.as_ref(),
+                None,
             )),
             Expr::Like(expr) => Arc::new(LikeExpr::new(
                 expr.negated,
@@ -401,9 +404,9 @@ impl Planner {
             Expr::Not(expr) => Arc::new(NotExpr::new(self.create_physical_expr(expr)?)),
             Expr::Cast(datafusion::logical_expr::Cast { expr, data_type }) => {
                 let expr = self.create_physical_expr(expr.as_ref())?;
-                Arc::new(CastExpr::new(expr, data_type.clone(), DEFAULT_CAST_OPTIONS))
+                Arc::new(CastExpr::new(expr, data_type.clone(), None))
             }
-            Expr::ScalarFunction { fun, args } => {
+            Expr::ScalarFunction(ScalarFunction { fun, args }) => {
                 if fun != &BuiltinScalarFunction::RegexpMatch {
                     return Err(Error::IO {
                         message: format!("Scalar function '{:?}' is not supported", fun),
@@ -506,12 +509,12 @@ mod tests {
                 )),
                 Arc::new(StructArray::from(vec![
                     (
-                        Field::new("x", DataType::Float32, false),
+                        Arc::new(Field::new("x", DataType::Float32, false)),
                         Arc::new(Float32Array::from_iter_values((0..10).map(|v| v as f32)))
                             as ArrayRef,
                     ),
                     (
-                        Field::new("y", DataType::Float32, false),
+                        Arc::new(Field::new("y", DataType::Float32, false)),
                         Arc::new(Float32Array::from_iter_values(
                             (0..10).map(|v| (v * 10) as f32),
                         )),

--- a/rust/src/io/writer.rs
+++ b/rust/src/io/writer.rs
@@ -370,8 +370,7 @@ mod tests {
         types::UInt32Type, BooleanArray, Decimal128Array, Decimal256Array, DictionaryArray,
         DurationMicrosecondArray, DurationMillisecondArray, DurationNanosecondArray,
         DurationSecondArray, FixedSizeBinaryArray, FixedSizeListArray, Float32Array, Int64Array,
-        LargeListArray, ListArray, NullArray, StringArray, TimestampMicrosecondArray,
-        TimestampSecondArray, UInt8Array,
+        NullArray, StringArray, TimestampMicrosecondArray, TimestampSecondArray, UInt8Array,
     };
     use arrow_buffer::i256;
     use arrow_schema::{
@@ -476,25 +475,27 @@ mod tests {
         let list_offsets = (0..202).step_by(2).collect();
         let list_values =
             StringArray::from((0..200).map(|n| format!("str-{}", n)).collect::<Vec<_>>());
-        let list_arr = ListArray::try_new(list_values, &list_offsets).unwrap();
+        let list_arr: arrow_array::GenericListArray<i32> =
+            try_new_generic_list_array(list_values, &list_offsets).unwrap();
 
         let large_list_offsets: Int64Array = (0..202).step_by(2).collect();
         let large_list_values =
             StringArray::from((0..200).map(|n| format!("str-{}", n)).collect::<Vec<_>>());
-        let large_list_arr =
-            LargeListArray::try_new(large_list_values, &large_list_offsets).unwrap();
+        let large_list_arr: arrow_array::GenericListArray<i64> =
+            try_new_generic_list_array(large_list_values, &large_list_offsets).unwrap();
 
         let list_dict_offsets = (0..202).step_by(2).collect();
         let list_dict_vec = (0..200).map(|n| ["a", "b", "c"][n % 3]).collect::<Vec<_>>();
         let list_dict_arr: DictionaryArray<UInt32Type> = list_dict_vec.into_iter().collect();
-        let list_dict_arr = ListArray::try_new(list_dict_arr, &list_dict_offsets).unwrap();
+        let list_dict_arr: arrow_array::GenericListArray<i32> =
+            try_new_generic_list_array(list_dict_arr, &list_dict_offsets).unwrap();
 
         let large_list_dict_offsets: Int64Array = (0..202).step_by(2).collect();
         let large_list_dict_vec = (0..200).map(|n| ["a", "b", "c"][n % 3]).collect::<Vec<_>>();
         let large_list_dict_arr: DictionaryArray<UInt32Type> =
             large_list_dict_vec.into_iter().collect();
-        let large_list_dict_arr =
-            LargeListArray::try_new(large_list_dict_arr, &large_list_dict_offsets).unwrap();
+        let large_list_dict_arr: arrow_array::GenericListArray<i64> =
+            try_new_generic_list_array(large_list_dict_arr, &large_list_dict_offsets).unwrap();
 
         let columns: Vec<ArrayRef> = vec![
             Arc::new(NullArray::new(100)),
@@ -531,11 +532,11 @@ mod tests {
             Arc::new(large_list_dict_arr),
             Arc::new(StructArray::from(vec![
                 (
-                    ArrowField::new("si", DataType::Int64, true),
+                    Arc::new(ArrowField::new("si", DataType::Int64, true)),
                     Arc::new(Int64Array::from_iter((100..200).collect::<Vec<_>>())) as ArrayRef,
                 ),
                 (
-                    ArrowField::new("sb", DataType::Utf8, true),
+                    Arc::new(ArrowField::new("sb", DataType::Utf8, true)),
                     Arc::new(StringArray::from(
                         (0..100).map(|n| n.to_string()).collect::<Vec<_>>(),
                     )) as ArrayRef,


### PR DESCRIPTION
update to arrow 40 and datafusion 26

arrow changes are a bunch of constructor, e.g. we now pass `Arc` instead of `&` for ArrayField.
