### PR TITLE
fix GHA build

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -15,8 +15,5 @@ rustflags = [
     "-Wclippy::use_self",
 ]
 
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=haswell", "-C", "target-feature=+avx2"]
-
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "target-cpu=apple-m1", "-C", "target-feature=+neon"]


### PR DESCRIPTION
https://github.com/lancedb/lance/actions/runs/5352836458/jobs/9717791491

GHA failing with
```
Caused by:
  process didn't exit successfully: `/home/runner/work/lance/lance/rust/target/debug/deps/lance-d[65](https://github.com/lancedb/lance/actions/runs/5352836458/jobs/9717791491#step:7:66)c2e0e1171b1df` (signal: 4, SIGILL: illegal instruction)
```

Possibly due to target cpu settings. Pending CI to confirm