### PR TITLE
allow object store wrapper as part of dataset construction param

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -71,6 +71,7 @@ impl Dataset {
             block_size,
             index_cache_size: index_cache_size.unwrap_or(DEFAULT_INDEX_CACHE_SIZE),
             session: None,
+            store_options: None,
         };
         let dataset = rt.block_on(async {
             if let Some(ver) = version {


### PR DESCRIPTION
## Why?

We need a way to inject a customized `object_store::ObjectStore` into `lance::io::object_store::ObjectStore`.

We could go full java-style dependency injection and take a pre-constructed `object_store::ObjectStore`. But that seems to be way too big of a refactor. The refactor would probably break the assumptions built into `base_path` easily. This PR add a way to hook into `lance::io::object_store::ObjectStore` construction and allow callers to wrap the inner `object_store::ObjectStore` with custom logic.

## What?

* added a `WrappingObjectStore` trait which is a hook called after we construct `object_store::ObjectStore` from the uri provided.
* added `ObjectStoreParams` and `from_uri_and_params`