### PR TITLE
fix record batch writing to dataset

### DIFF
--- a/docs/read_and_write.rst
+++ b/docs/read_and_write.rst
@@ -33,7 +33,7 @@ also supports writing a dataset in iterator of :py:class:`pyarrow.RecordBatch` e
 
     schema = pa.schema([
             pa.field("name", pa.string()),
-            pa.field("age", pa.int32()),
+            pa.field("age", pa.int64()),
         ])
 
     lance.write_dataset(reader, "./alice_and_bob.lance", schema)

--- a/docs/read_and_write.rst
+++ b/docs/read_and_write.rst
@@ -31,14 +31,12 @@ also supports writing a dataset in iterator of :py:class:`pyarrow.RecordBatch` e
         yield pa.RecordBatch.from_pylist([{"name": "Alice", "age": 20}])
         yield pa.RecordBatch.from_pylist([{"name": "Blob", "age": 30}])
 
-
     schema = pa.schema([
-                pa.field("name", pa.string()),
-                pa.field("age", pa.int32()),
-            ])
+            pa.field("name", pa.string()),
+            pa.field("age", pa.int32()),
+        ])
 
-    reader = pa.RecordBatchReader.from_batches(schema, producer())
-    lance.write_dataset(reader, "./alice_and_bob.lance")
+    lance.write_dataset(reader, "./alice_and_bob.lance", schema)
 
 :py:meth:`lance.write_dataset` supports writing :py:class:`pyarrow.Table`, :py:class:`pandas.DataFrame`,
 :py:class:`pyarrow.Dataset`, and ``Iterator[pyarrow.RecordBatch]``. Check its doc for more details.

--- a/docs/read_and_write.rst
+++ b/docs/read_and_write.rst
@@ -31,7 +31,14 @@ also supports writing a dataset in iterator of :py:class:`pyarrow.RecordBatch` e
         yield pa.RecordBatch.from_pylist([{"name": "Alice", "age": 20}])
         yield pa.RecordBatch.from_pylist([{"name": "Blob", "age": 30}])
 
-    lance.write_dataset(producer, "./alice_and_bob.lance")
+
+    schema = pa.schema([
+                pa.field("name", pa.string()),
+                pa.field("age", pa.int32()),
+            ])
+
+    reader = pa.RecordBatchReader.from_batches(schema, producer())
+    lance.write_dataset(reader, "./alice_and_bob.lance")
 
 :py:meth:`lance.write_dataset` supports writing :py:class:`pyarrow.Table`, :py:class:`pandas.DataFrame`,
 :py:class:`pyarrow.Dataset`, and ``Iterator[pyarrow.RecordBatch]``. Check its doc for more details.

--- a/integration/duckdb_lance/Cargo.toml
+++ b/integration/duckdb_lance/Cargo.toml
@@ -8,8 +8,8 @@ lance = { path = "../../rust" }
 duckdb-ext = { path = "./duckdb-ext" }
 lazy_static = "1.4.0"
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
-arrow-schema = "37.0.0"
-arrow-array = "37.0.0"
+arrow-schema = "40.0.0"
+arrow-array = "40.0.0"
 futures = "0.3"
 num-traits = "0.2"
 

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -912,10 +912,12 @@ def _coerce_reader(
     elif isinstance(data_obj, pa.dataset.Scanner):
         return data_obj.to_reader()
     elif isinstance(data_obj, Iterator):
-        if schema != None:
+        if schema is not None:
             return pa.RecordBatchReader.from_batches(schema, data_obj)
         else:
-            raise ValueError("Must provide schema to write dataset from RecordBatch iterator")
+            raise ValueError(
+                "Must provide schema to write dataset from RecordBatch iterator"
+            )
     elif isinstance(data_obj, pa.RecordBatchReader):
         return data_obj
     else:

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -851,7 +851,7 @@ ReaderLike = Union[
     pa.Table,
     pa.dataset.Dataset,
     pa.dataset.Scanner,
-    Iterator[RecordBatch],
+    Iterable[RecordBatch],
     pa.RecordBatchReader,
 ]
 
@@ -912,14 +912,15 @@ def _coerce_reader(
         return pa.dataset.Scanner.from_dataset(data_obj).to_reader()
     elif isinstance(data_obj, pa.dataset.Scanner):
         return data_obj.to_reader()
-    elif isinstance(data_obj, Iterator):
+    elif isinstance(data_obj, pa.RecordBatchReader):
+        return data_obj
+    # for other iterables, assume they are of type Iterable[RecordBatch]
+    elif isinstance(data_obj, Iterable):
         if schema is not None:
             return pa.RecordBatchReader.from_batches(schema, data_obj)
         else:
             raise ValueError(
-                "Must provide schema to write dataset from RecordBatch iterator"
+                "Must provide schema to write dataset from RecordBatch iterable"
             )
-    elif isinstance(data_obj, pa.RecordBatchReader):
-        return data_obj
     else:
-        raise TypeError(f"Unknown data_obj type {type(data_obj)}")
+        raise TypeError(f"Unknown data type {type(data_obj)}. Please check https://lancedb.github.io/lance/read_and_write.html to see a list of supported types.")

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -376,7 +376,7 @@ class LanceDataset(pa.dataset.Dataset):
         ----------
         data_obj: Reader-like
             The data to be merged. Acceptable types are:
-            - Pandas DataFrame, Pyarrow Table, Dataset, Scanner, 
+            - Pandas DataFrame, Pyarrow Table, Dataset, Scanner,
             Iterator[RecordBatch], or RecordBatchReader
         left_on: str
             The name of the column in the dataset to join on.

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -20,7 +20,6 @@ from datetime import datetime, timedelta
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
-from typing import get_args
 
 import numpy as np
 import pandas as pd

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -376,7 +376,8 @@ class LanceDataset(pa.dataset.Dataset):
         ----------
         data_obj: Reader-like
             The data to be merged. Acceptable types are:
-            - Pandas DataFrame, Pyarrow Table, Dataset, Scanner, Iterator[RecordBatch], or RecordBatchReader
+            - Pandas DataFrame, Pyarrow Table, Dataset, Scanner, 
+            Iterator[RecordBatch], or RecordBatchReader
         left_on: str
             The name of the column in the dataset to join on.
         right_on: str or None

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -956,4 +956,9 @@ def _coerce_reader(
                 "Must provide schema to write dataset from RecordBatch iterable"
             )
     else:
-        raise TypeError(f"Unknown data type {type(data_obj)}. Please check https://lancedb.github.io/lance/read_and_write.html to see a list of supported types.")
+        raise TypeError(
+            f"Unknown data type {type(data_obj)}. "
+            "Please check "
+            "https://lancedb.github.io/lance/read_and_write.html "
+            "to see supported types."
+        )

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -20,6 +20,7 @@ from datetime import datetime, timedelta
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional, Union
+from typing import get_args
 
 import numpy as np
 import pandas as pd
@@ -362,6 +363,7 @@ class LanceDataset(pa.dataset.Dataset):
         data_obj: ReaderLike,
         left_on: str,
         right_on: Optional[str] = None,
+        schema=None,
     ):
         """
         Merge another dataset into this one.
@@ -375,7 +377,7 @@ class LanceDataset(pa.dataset.Dataset):
         ----------
         data_obj: Reader-like
             The data to be merged. Acceptable types are:
-            - Pandas DataFrame, Pyarrow Table, Dataset, Scanner, or RecordBatchReader
+            - Pandas DataFrame, Pyarrow Table, Dataset, Scanner, Iterator[RecordBatch], or RecordBatchReader
         left_on: str
             The name of the column in the dataset to join on.
         right_on: str or None
@@ -405,7 +407,7 @@ class LanceDataset(pa.dataset.Dataset):
         if right_on is None:
             right_on = left_on
 
-        reader = _coerce_reader(data_obj)
+        reader = _coerce_reader(data_obj, schema)
 
         self._ds.merge(reader, left_on, right_on)
 
@@ -849,6 +851,7 @@ ReaderLike = Union[
     pa.Table,
     pa.dataset.Dataset,
     pa.dataset.Scanner,
+    Iterator[RecordBatch],
     pa.RecordBatchReader,
 ]
 
@@ -884,7 +887,7 @@ def write_dataset(
         The max number of rows before starting a new group (in the same file)
 
     """
-    reader = _coerce_reader(data_obj)
+    reader = _coerce_reader(data_obj, schema)
     # TODO add support for passing in LanceDataset and LanceScanner here
 
     params = {
@@ -909,6 +912,11 @@ def _coerce_reader(
         return pa.dataset.Scanner.from_dataset(data_obj).to_reader()
     elif isinstance(data_obj, pa.dataset.Scanner):
         return data_obj.to_reader()
+    elif isinstance(data_obj, Iterator):
+        if schema != None:
+            return pa.RecordBatchReader.from_batches(schema, data_obj)
+        else:
+            raise ValueError("Must provide schema to write dataset from RecordBatch iterator")
     elif isinstance(data_obj, pa.RecordBatchReader):
         return data_obj
     else:

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -62,7 +62,7 @@ def test_dataset_append(tmp_path: Path):
         lance.write_dataset(table2, base_dir, mode="append")
 
 
-def test_dataset_from_record_batch_iterator(tmp_path: Path):
+def test_dataset_from_record_batch_iterable(tmp_path: Path):
     base_dir = tmp_path / "test"
 
     test_pylist = [{"colA": "Alice", "colB": 20}, {"colA": "Blob", "colB": 30}]
@@ -88,29 +88,8 @@ def test_dataset_from_record_batch_iterator(tmp_path: Path):
     # After combined into one batch, make sure it is the same as original pylist
     assert list(dataset.to_batches())[0].to_pylist() == test_pylist
 
-
-def test_dataset_from_record_batch_list(tmp_path: Path):
-    base_dir = tmp_path / "test"
-
-    test_pylist = [{"colA": "Alice", "colB": 20}, {"colA": "Blob", "colB": 30}]
-
-    # split into two batches
-    batches = [
-        pa.RecordBatch.from_pylist([test_pylist[0]]),
-        pa.RecordBatch.from_pylist([test_pylist[1]]),
-    ]
-
-    # define schema
-    schema = pa.schema(
-        [
-            pa.field("colA", pa.string()),
-            pa.field("colB", pa.int64()),
-        ]
-    )
-
     # write dataset with list
-    lance.write_dataset(batches, base_dir, schema)
-    dataset = lance.dataset(base_dir)
+    lance.write_dataset(batches, base_dir, schema, mode="overwrite")
 
     # After combined into one batch, make sure it is the same as original pylist
     assert list(dataset.to_batches())[0].to_pylist() == test_pylist

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -61,20 +61,26 @@ def test_dataset_append(tmp_path: Path):
     with pytest.raises(OSError):
         lance.write_dataset(table2, base_dir, mode="append")
 
+
 def test_dataset_from_record_batch_iterator(tmp_path: Path):
     base_dir = tmp_path / "test"
-    
+
     test_pylist = [{"colA": "Alice", "colB": 20}, {"colA": "Blob", "colB": 30}]
 
     # split into two batches
-    batches = [pa.RecordBatch.from_pylist([test_pylist[0]]), pa.RecordBatch.from_pylist([test_pylist[1]])]
+    batches = [
+        pa.RecordBatch.from_pylist([test_pylist[0]]),
+        pa.RecordBatch.from_pylist([test_pylist[1]]),
+    ]
 
     # define schema
-    schema = pa.schema([
+    schema = pa.schema(
+        [
             pa.field("colA", pa.string()),
             pa.field("colB", pa.int64()),
-        ])
-    
+        ]
+    )
+
     # write dataset with iterator
     lance.write_dataset(iter(batches), base_dir, schema)
     dataset = lance.dataset(base_dir)
@@ -82,26 +88,33 @@ def test_dataset_from_record_batch_iterator(tmp_path: Path):
     # After combined into one batch, make sure it is the same as original pylist
     assert list(dataset.to_batches())[0].to_pylist() == test_pylist
 
+
 def test_dataset_from_record_batch_list(tmp_path: Path):
     base_dir = tmp_path / "test"
-    
+
     test_pylist = [{"colA": "Alice", "colB": 20}, {"colA": "Blob", "colB": 30}]
 
     # split into two batches
-    batches = [pa.RecordBatch.from_pylist([test_pylist[0]]), pa.RecordBatch.from_pylist([test_pylist[1]])]
+    batches = [
+        pa.RecordBatch.from_pylist([test_pylist[0]]),
+        pa.RecordBatch.from_pylist([test_pylist[1]]),
+    ]
 
     # define schema
-    schema = pa.schema([
+    schema = pa.schema(
+        [
             pa.field("colA", pa.string()),
             pa.field("colB", pa.int64()),
-        ])
-    
+        ]
+    )
+
     # write dataset with list
     lance.write_dataset(batches, base_dir, schema)
     dataset = lance.dataset(base_dir)
 
     # After combined into one batch, make sure it is the same as original pylist
     assert list(dataset.to_batches())[0].to_pylist() == test_pylist
+
 
 def test_versions(tmp_path: Path):
     table1 = pa.Table.from_pylist([{"a": 1, "b": 2}, {"a": 10, "b": 20}])


### PR DESCRIPTION
Implement writing dataset with `Iterator[RecordBatch]`, like mentioned in the docs. This requires an argument of schema, so we throw a ValueError if it doesn't exist.

Minor ugliness: I check for `Iterator` type, not `Iterator[RecordBatch]`. Let me know if this causes some concerns.

Closes #1019 