### PR TITLE
feat: upgrade arrow, make write Send

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -11,17 +11,17 @@ name = "lance"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow = { version = "40.0.0", features = ["pyarrow"] }
-arrow-array = "40.0"
-arrow-data = "40.0"
-arrow-schema = "40.0"
+arrow = { version = "42.0.0", features = ["pyarrow"] }
+arrow-array = "42.0"
+arrow-data = "42.0"
+arrow-schema = "42.0"
 chrono = "0.4.23"
 env_logger = "0.10"
 futures = "0.3"
 lance = { path = "../rust" }
 log = "0.4"
 prost = "0.11"
-pyo3 = { version = "0.18.1", features = ["extension-module", "abi3-py38"] }
+pyo3 = { version = "0.19", features = ["extension-module", "abi3-py38"] }
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 uuid = "1.3.0"
 

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -15,8 +15,8 @@
 use std::sync::Arc;
 
 use arrow::ffi_stream::ArrowArrayStreamReader;
-use arrow::pyarrow::PyArrowConvert;
 use arrow::pyarrow::PyArrowType;
+use arrow::pyarrow::{FromPyArrow, ToPyArrow};
 use arrow_array::RecordBatchReader;
 use arrow_schema::Schema as ArrowSchema;
 use lance::dataset::fragment::FileFragment as LanceFragment;
@@ -108,7 +108,7 @@ impl FileFragment {
     ) -> PyResult<FragmentMetadata> {
         let rt = tokio::runtime::Runtime::new()?;
         rt.block_on(async {
-            let mut batches: Box<dyn RecordBatchReader> = if reader.is_instance_of::<Scanner>()? {
+            let mut batches: Box<dyn RecordBatchReader> = if reader.is_instance_of::<Scanner>() {
                 let scanner: Scanner = reader.extract()?;
                 Box::new(
                     scanner

--- a/python/src/scanner.rs
+++ b/python/src/scanner.rs
@@ -71,7 +71,7 @@ impl Scanner {
             unsafe {
                 export_reader_into_raw(Box::new(reader), stream_ptr);
                 match ArrowArrayStreamReader::from_raw(stream_ptr) {
-                    Ok(reader) => reader.to_pyarrow(self_.py()),
+                    Ok(reader) => reader.into_pyarrow(self_.py()),
                     Err(err) => Err(ioerror(self_.py(), err.to_string())),
                 }
             }

--- a/python/src/updater.rs
+++ b/python/src/updater.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use arrow::pyarrow::PyArrowConvert;
+use arrow::pyarrow::{FromPyArrow, ToPyArrow};
 use arrow_array::RecordBatch;
 use pyo3::{exceptions::*, prelude::*};
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,16 +28,16 @@ no-default-features = true
 
 [dependencies]
 bytes = "1.3"
-arrow-arith = "40.0"
-arrow-array = "40.0"
-arrow-buffer = "40.0"
-arrow-cast = "40.0.0"
-arrow-data = "40.0"
-arrow-ipc = { version = "40.0", features = ["zstd"] }
-arrow-ord = "40.0"
-arrow-row = "40.0"
-arrow-schema = "40.0"
-arrow-select = "40.0"
+arrow-arith = "42.0"
+arrow-array = "42.0"
+arrow-buffer = "42.0"
+arrow-cast = "42.0"
+arrow-data = "42.0"
+arrow-ipc = { version = "42.0", features = ["zstd"] }
+arrow-ord = "42.0"
+arrow-row = "42.0"
+arrow-schema = "42.0"
+arrow-select = "42.0"
 async-recursion = "1.0"
 async-trait = "0.1.60"
 byteorder = "1.4.3"
@@ -60,10 +60,10 @@ futures = "0.3.27"
 uuid = { version = "1.2", features = ["v4"] }
 path-absolutize = "3.0.14"
 shellexpand = "3.0.0"
-arrow = { version = "40.0.0", features = ["prettyprint"] }
+arrow = { version = "42.0.0", features = ["prettyprint"] }
 num_cpus = "1.0"
 # TODO: use datafusion sub-modules to reduce build size?
-datafusion = { version = "26.0.0", default-features = false, features = ["regex_expressions"] }
+datafusion = { version = "27.0.0", default-features = false, features = ["regex_expressions"] }
 faiss = { version = "0.11.0", features = ["gpu"], optional = true }
 lapack = { version = "0.19.0", optional = true }
 cblas =  { version = "0.4.0", optional = true }

--- a/rust/README.md
+++ b/rust/README.md
@@ -29,10 +29,10 @@ use ::lance::dataset::WriteParams;
 use ::lance::dataset::Dataset;
 
 let mut write_params = WriteParams::default();
-let mut reader: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
+let mut reader = RecordBatchIterator::new(
     batches.into_iter().map(Ok),
     schema,
-));
+);
 Dataset::write(&mut reader, test_uri, Some(write_params)).await?;
 ```
 

--- a/rust/benches/ivf_pq.rs
+++ b/rust/benches/ivf_pq.rs
@@ -46,7 +46,7 @@ async fn create_dataset(path: &std::path::Path, dim: usize, mode: WriteMode) {
             RecordBatch::try_new(
                 schema.clone(),
                 vec![Arc::new(
-                    FixedSizeListArray::try_new(
+                    FixedSizeListArray::try_new_from_values(
                         generate_random_array(batch_size * dim),
                         dim as i32,
                     )

--- a/rust/benches/ivf_pq.rs
+++ b/rust/benches/ivf_pq.rs
@@ -61,11 +61,8 @@ async fn create_dataset(path: &std::path::Path, dim: usize, mode: WriteMode) {
     write_params.max_rows_per_file = num_rows as usize;
     write_params.max_rows_per_group = batch_size as usize;
     write_params.mode = mode;
-    let mut reader: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
-        batches.into_iter().map(Ok),
-        schema.clone(),
-    ));
-    Dataset::write(&mut reader, path.to_str().unwrap(), Some(write_params))
+    let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+    Dataset::write(reader, path.to_str().unwrap(), Some(write_params))
         .await
         .unwrap();
 }

--- a/rust/benches/scan.rs
+++ b/rust/benches/scan.rs
@@ -124,11 +124,8 @@ async fn create_file(path: &std::path::Path, mode: WriteMode) {
     write_params.max_rows_per_file = num_rows as usize;
     write_params.max_rows_per_group = batch_size as usize;
     write_params.mode = mode;
-    let mut reader: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
-        batches.into_iter().map(Ok),
-        schema.clone(),
-    ));
-    Dataset::write(&mut reader, test_uri, Some(write_params))
+    let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+    Dataset::write(reader, test_uri, Some(write_params))
         .await
         .unwrap();
 }

--- a/rust/benches/scan.rs
+++ b/rust/benches/scan.rs
@@ -99,7 +99,7 @@ async fn create_file(path: &std::path::Path, mode: WriteMode) {
                             .collect::<Vec<_>>(),
                     )),
                     Arc::new(
-                        FixedSizeListArray::try_new(
+                        FixedSizeListArray::try_new_from_values(
                             Float32Array::from_iter_values(
                                 (i * batch_size..(i + 2) * batch_size)
                                     .map(|x| (batch_size + (x - batch_size) / 2) as f32),

--- a/rust/benches/vector_index.rs
+++ b/rust/benches/vector_index.rs
@@ -132,11 +132,8 @@ async fn create_file(path: &std::path::Path, mode: WriteMode) {
     write_params.max_rows_per_file = num_rows as usize;
     write_params.max_rows_per_group = batch_size as usize;
     write_params.mode = mode;
-    let mut reader: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
-        batches.into_iter().map(Ok),
-        schema.clone(),
-    ));
-    let dataset = Dataset::write(&mut reader, test_uri, Some(write_params))
+    let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+    let dataset = Dataset::write(reader, test_uri, Some(write_params))
         .await
         .unwrap();
     let mut ivf_params = IvfBuildParams::default();

--- a/rust/benches/vector_index.rs
+++ b/rust/benches/vector_index.rs
@@ -119,7 +119,11 @@ async fn create_file(path: &std::path::Path, mode: WriteMode) {
             RecordBatch::try_new(
                 schema.clone(),
                 vec![Arc::new(
-                    FixedSizeListArray::try_new(create_float32_array(num_rows * 128), 128).unwrap(),
+                    FixedSizeListArray::try_new_from_values(
+                        create_float32_array(num_rows * 128),
+                        128,
+                    )
+                    .unwrap(),
                 )],
             )
             .unwrap()

--- a/rust/src/arrow.rs
+++ b/rust/src/arrow.rs
@@ -189,7 +189,7 @@ pub trait FixedSizeListArrayExt {
     /// use lance::arrow::FixedSizeListArrayExt;
     ///
     /// let int_values = Int64Array::from_iter(0..10);
-    /// let fixed_size_list_arr = FixedSizeListArray::try_new(int_values, 2).unwrap();
+    /// let fixed_size_list_arr = FixedSizeListArray::try_new_from_values(int_values, 2).unwrap();
     /// assert_eq!(fixed_size_list_arr,
     ///     FixedSizeListArray::from_iter_primitive::<Int64Type, _, _>(vec![
     ///         Some(vec![Some(0), Some(1)]),
@@ -199,11 +199,11 @@ pub trait FixedSizeListArrayExt {
     ///         Some(vec![Some(8), Some(9)])
     /// ], 2))
     /// ```
-    fn try_new<T: Array>(values: T, list_size: i32) -> Result<FixedSizeListArray>;
+    fn try_new_from_values<T: Array>(values: T, list_size: i32) -> Result<FixedSizeListArray>;
 }
 
 impl FixedSizeListArrayExt for FixedSizeListArray {
-    fn try_new<T: Array>(values: T, list_size: i32) -> Result<Self> {
+    fn try_new_from_values<T: Array>(values: T, list_size: i32) -> Result<Self> {
         let list_type = DataType::FixedSizeList(
             Arc::new(Field::new("item", values.data_type().clone(), true)),
             list_size,
@@ -232,7 +232,7 @@ pub trait FixedSizeBinaryArrayExt {
     /// use lance::arrow::FixedSizeBinaryArrayExt;
     ///
     /// let int_values = UInt8Array::from_iter(0..10);
-    /// let fixed_size_list_arr = FixedSizeBinaryArray::try_new(&int_values, 2).unwrap();
+    /// let fixed_size_list_arr = FixedSizeBinaryArray::try_new_from_values(&int_values, 2).unwrap();
     /// assert_eq!(fixed_size_list_arr,
     ///     FixedSizeBinaryArray::from(vec![
     ///         Some(vec![0, 1].as_slice()),
@@ -242,11 +242,11 @@ pub trait FixedSizeBinaryArrayExt {
     ///         Some(vec![8, 9].as_slice())
     /// ]))
     /// ```
-    fn try_new(values: &UInt8Array, stride: i32) -> Result<FixedSizeBinaryArray>;
+    fn try_new_from_values(values: &UInt8Array, stride: i32) -> Result<FixedSizeBinaryArray>;
 }
 
 impl FixedSizeBinaryArrayExt for FixedSizeBinaryArray {
-    fn try_new(values: &UInt8Array, stride: i32) -> Result<Self> {
+    fn try_new_from_values(values: &UInt8Array, stride: i32) -> Result<Self> {
         let data_type = DataType::FixedSizeBinary(stride);
         let data = ArrayDataBuilder::new(data_type)
             .len(values.len() / stride as usize)

--- a/rust/src/arrow.rs
+++ b/rust/src/arrow.rs
@@ -199,21 +199,18 @@ pub trait FixedSizeListArrayExt {
     ///         Some(vec![Some(8), Some(9)])
     /// ], 2))
     /// ```
-    fn try_new_from_values<T: Array>(values: T, list_size: i32) -> Result<FixedSizeListArray>;
+    fn try_new_from_values<T: Array + 'static>(
+        values: T,
+        list_size: i32,
+    ) -> Result<FixedSizeListArray>;
 }
 
 impl FixedSizeListArrayExt for FixedSizeListArray {
-    fn try_new_from_values<T: Array>(values: T, list_size: i32) -> Result<Self> {
-        let list_type = DataType::FixedSizeList(
-            Arc::new(Field::new("item", values.data_type().clone(), true)),
-            list_size,
-        );
-        let data = ArrayDataBuilder::new(list_type)
-            .len(values.len() / list_size as usize)
-            .add_child_data(values.into_data())
-            .build()?;
+    fn try_new_from_values<T: Array + 'static>(values: T, list_size: i32) -> Result<Self> {
+        let field = Arc::new(Field::new("item", values.data_type().clone(), true));
+        let values = Arc::new(values);
 
-        Ok(Self::from(data))
+        Ok(Self::try_new(field, list_size, values, None)?)
     }
 }
 

--- a/rust/src/datafusion/physical_expr.rs
+++ b/rust/src/datafusion/physical_expr.rs
@@ -96,6 +96,12 @@ impl PhysicalExpr for Column {
     ) -> Result<Arc<dyn PhysicalExpr>> {
         todo!()
     }
+
+    fn dyn_hash(&self, state: &mut dyn std::hash::Hasher) {
+        use std::hash::Hash;
+        let mut s = state;
+        self.hash(&mut s);
+    }
 }
 
 struct ColumnVisitor {

--- a/rust/src/dataset/fragment.rs
+++ b/rust/src/dataset/fragment.rs
@@ -520,9 +520,7 @@ impl FragmentReader {
 mod tests {
 
     use arrow_arith::arithmetic::multiply_scalar;
-    use arrow_array::{
-        cast::AsArray, ArrayRef, Int32Array, RecordBatchIterator, RecordBatchReader, StringArray,
-    };
+    use arrow_array::{cast::AsArray, ArrayRef, Int32Array, RecordBatchIterator, StringArray};
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
     use arrow_select::concat::concat_batches;
     use futures::TryStreamExt;
@@ -557,11 +555,8 @@ mod tests {
             max_rows_per_group: 2,
             ..Default::default()
         };
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
-            batches.into_iter().map(Ok),
-            schema.clone(),
-        ));
-        Dataset::write(&mut batches, test_uri, Some(write_params))
+        let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+        Dataset::write(batches, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -807,9 +802,8 @@ mod tests {
         )
         .unwrap();
 
-        let mut stream: Box<dyn RecordBatchReader> =
-            Box::new(RecordBatchIterator::new(vec![Ok(to_merge)], schema.clone()));
-        dataset.merge(&mut stream, "i", "i").await.unwrap();
+        let stream = RecordBatchIterator::new(vec![Ok(to_merge)], schema.clone());
+        dataset.merge(stream, "i", "i").await.unwrap();
         dataset.validate().await.unwrap();
 
         // Validate the resulting data

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -861,7 +861,7 @@ mod test {
         let batches: Vec<RecordBatch> = (0..5)
             .map(|i| {
                 let vector_values: Float32Array = (0..32 * 80).map(|v| v as f32).collect();
-                let vectors = FixedSizeListArray::try_new(&vector_values, 32).unwrap();
+                let vectors = FixedSizeListArray::try_new_from_values(&vector_values, 32).unwrap();
                 RecordBatch::try_new(
                     schema.clone(),
                     vec![
@@ -962,7 +962,7 @@ mod test {
         // (0, 0, ...), (1, 1, ...), (2, 2, ...)
         let vector_values: Float32Array =
             (0..10).flat_map(|i| [i as f32; 32].into_iter()).collect();
-        let new_vectors = FixedSizeListArray::try_new(&vector_values, 32).unwrap();
+        let new_vectors = FixedSizeListArray::try_new_from_values(&vector_values, 32).unwrap();
         let new_data: Vec<ArrayRef> = vec![
             Arc::new(Int32Array::from_iter_values(400..410)), // 5 * 80
             Arc::new(StringArray::from_iter_values(
@@ -1739,7 +1739,7 @@ mod test {
 
             // vectors are [0, 0, 0, ...] [1, 1, 1, ...]
             let vector_values: Float32Array = (0..32 * 512).map(|v| (v / 32) as f32).collect();
-            let vectors = FixedSizeListArray::try_new(&vector_values, 32).unwrap();
+            let vectors = FixedSizeListArray::try_new_from_values(&vector_values, 32).unwrap();
 
             let batches = vec![RecordBatch::try_new(
                 schema.clone(),

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -861,7 +861,7 @@ mod test {
         let batches: Vec<RecordBatch> = (0..5)
             .map(|i| {
                 let vector_values: Float32Array = (0..32 * 80).map(|v| v as f32).collect();
-                let vectors = FixedSizeListArray::try_new_from_values(&vector_values, 32).unwrap();
+                let vectors = FixedSizeListArray::try_new_from_values(vector_values, 32).unwrap();
                 RecordBatch::try_new(
                     schema.clone(),
                     vec![
@@ -962,7 +962,7 @@ mod test {
         // (0, 0, ...), (1, 1, ...), (2, 2, ...)
         let vector_values: Float32Array =
             (0..10).flat_map(|i| [i as f32; 32].into_iter()).collect();
-        let new_vectors = FixedSizeListArray::try_new_from_values(&vector_values, 32).unwrap();
+        let new_vectors = FixedSizeListArray::try_new_from_values(vector_values, 32).unwrap();
         let new_data: Vec<ArrayRef> = vec![
             Arc::new(Int32Array::from_iter_values(400..410)), // 5 * 80
             Arc::new(StringArray::from_iter_values(
@@ -1739,7 +1739,7 @@ mod test {
 
             // vectors are [0, 0, 0, ...] [1, 1, 1, ...]
             let vector_values: Float32Array = (0..32 * 512).map(|v| (v / 32) as f32).collect();
-            let vectors = FixedSizeListArray::try_new_from_values(&vector_values, 32).unwrap();
+            let vectors = FixedSizeListArray::try_new_from_values(vector_values, 32).unwrap();
 
             let batches = vec![RecordBatch::try_new(
                 schema.clone(),

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -806,7 +806,7 @@ mod tests {
         let path = Path::from("/shared_slice");
 
         let array = Int32Array::from_iter_values(0..1600);
-        let fixed_size_list = FixedSizeListArray::try_new_from_values(&array, 16).unwrap();
+        let fixed_size_list = FixedSizeListArray::try_new_from_values(array, 16).unwrap();
         let arrow_schema = Arc::new(ArrowSchema::new(vec![Field::new(
             "fl",
             fixed_size_list.data_type().clone(),

--- a/rust/src/encodings/plain.rs
+++ b/rust/src/encodings/plain.rs
@@ -216,8 +216,18 @@ impl<'a> PlainDecoder<'a> {
 
         let data = self.reader.get_range(range).await?;
         let buf: Buffer = data.into();
+
+        // booleans are bitpacked, so we need an offset to provide the exact
+        // requested range.
+        let offset = if self.data_type == &DataType::Boolean {
+            start % 8
+        } else {
+            0
+        };
+
         let array_data = ArrayDataBuilder::new(self.data_type.clone())
             .len(end - start)
+            .offset(offset)
             .null_count(0)
             .add_buffer(buf)
             .build()?;
@@ -248,7 +258,9 @@ impl<'a> PlainDecoder<'a> {
         let item_array = item_decoder
             .get(start * list_size as usize..end * list_size as usize)
             .await?;
-        Ok(Arc::new(FixedSizeListArray::try_new(item_array, list_size)?) as ArrayRef)
+        Ok(Arc::new(FixedSizeListArray::try_new_from_values(
+            item_array, list_size,
+        )?) as ArrayRef)
     }
 
     async fn decode_fixed_size_binary(
@@ -272,7 +284,7 @@ impl<'a> PlainDecoder<'a> {
             .ok_or_else(|| Error::Schema {
                 message: "Could not cast to UInt8Array for FixedSizeBinary".to_string(),
             })?;
-        Ok(Arc::new(FixedSizeBinaryArray::try_new(values, stride)?) as ArrayRef)
+        Ok(Arc::new(FixedSizeBinaryArray::try_new_from_values(values, stride)?) as ArrayRef)
     }
 
     async fn take_boolean(&self, indices: &UInt32Array) -> Result<ArrayRef> {
@@ -296,13 +308,16 @@ impl<'a> PlainDecoder<'a> {
         let arrays = stream::iter(chunk_ranges)
             .map(|cr| async move {
                 let index_chunk = indices.slice(cr.start as usize, cr.len());
+                // request contains the array indices we are retrieving in this chunk.
                 let request: &UInt32Array = as_primitive_array(&index_chunk);
 
+                // Get the starting index
                 let start = request.value(0);
+                // Final index is the last value
                 let end = request.value(request.len() - 1);
                 let array = self.get(start as usize..end as usize + 1).await?;
-                let array_byte_boundray = start / 8 * 8_u32;
-                let shifted_indices = subtract_scalar(request, array_byte_boundray)?;
+
+                let shifted_indices = subtract_scalar(request, start)?;
                 Ok::<ArrayRef, Error>(take(&array, &shifted_indices, None)?)
             })
             .buffered(num_cpus::get())
@@ -563,7 +578,7 @@ mod tests {
 
             for _ in 0..10 {
                 let items = make_array_(&t.clone(), &buffer).await;
-                let arr = FixedSizeListArray::try_new(items, 3).unwrap();
+                let arr = FixedSizeListArray::try_new_from_values(items, 3).unwrap();
                 arrs.push(Arc::new(arr) as ArrayRef);
             }
             test_round_trip(arrs.as_slice(), list_type).await;
@@ -577,7 +592,7 @@ mod tests {
 
         for _ in 0..10 {
             let values = UInt8Array::from(Vec::from_iter(1..127_u8));
-            let arr = FixedSizeBinaryArray::try_new(&values, 3).unwrap();
+            let arr = FixedSizeBinaryArray::try_new_from_values(&values, 3).unwrap();
             arrs.push(Arc::new(arr) as ArrayRef);
         }
         test_round_trip(arrs.as_slice(), t).await;
@@ -592,9 +607,11 @@ mod tests {
 
         for _ in 0..10 {
             let values = Int64Array::from_iter_values(1..=120_i64);
-            let arr =
-                FixedSizeListArray::try_new(FixedSizeListArray::try_new(values, 2).unwrap(), 2)
-                    .unwrap();
+            let arr = FixedSizeListArray::try_new_from_values(
+                FixedSizeListArray::try_new_from_values(values, 2).unwrap(),
+                2,
+            )
+            .unwrap();
             arrs.push(Arc::new(arr) as ArrayRef);
         }
         test_round_trip(arrs.as_slice(), t).await;
@@ -606,9 +623,11 @@ mod tests {
 
         for _ in 0..10 {
             let values = UInt8Array::from_iter_values(1..=120_u8);
-            let arr =
-                FixedSizeListArray::try_new(FixedSizeBinaryArray::try_new(&values, 2).unwrap(), 2)
-                    .unwrap();
+            let arr = FixedSizeListArray::try_new_from_values(
+                FixedSizeBinaryArray::try_new_from_values(&values, 2).unwrap(),
+                2,
+            )
+            .unwrap();
             arrs.push(Arc::new(arr) as ArrayRef);
         }
         test_round_trip(arrs.as_slice(), t).await;
@@ -787,7 +806,7 @@ mod tests {
         let path = Path::from("/shared_slice");
 
         let array = Int32Array::from_iter_values(0..1600);
-        let fixed_size_list = FixedSizeListArray::try_new(&array, 16).unwrap();
+        let fixed_size_list = FixedSizeListArray::try_new_from_values(&array, 16).unwrap();
         let arrow_schema = Arc::new(ArrowSchema::new(vec![Field::new(
             "fl",
             fixed_size_list.data_type().clone(),
@@ -832,15 +851,19 @@ mod tests {
         let array = BooleanArray::from((0..120).map(|v| v % 5 == 0).collect::<Vec<_>>());
         let batch =
             RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(array.clone())]).unwrap();
+        dbg!(&batch);
         file_writer.write(&[batch]).await.unwrap();
         file_writer.finish().await.unwrap();
 
         let reader = FileReader::try_new(&store, &path).await.unwrap();
-        let actual = reader.take(&[2, 4, 5, 8, 20], &schema).await.unwrap();
+        let actual = reader
+            .take(&[2, 4, 5, 8, 63, 64, 65], &schema)
+            .await
+            .unwrap();
 
         assert_eq!(
             actual.column_by_name("b").unwrap().as_ref(),
-            &BooleanArray::from(vec![false, false, true, false, true])
+            &BooleanArray::from(vec![false, false, true, false, false, false, true])
         );
     }
 

--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -220,8 +220,8 @@ mod tests {
         let batches: Vec<RecordBatch> = vec![RecordBatch::try_new(
             schema.clone(),
             vec![
-                Arc::new(FixedSizeListArray::try_new(&data, DIM).unwrap()),
-                Arc::new(FixedSizeListArray::try_new(&data, DIM).unwrap()),
+                Arc::new(FixedSizeListArray::try_new_from_values(&data, DIM).unwrap()),
+                Arc::new(FixedSizeListArray::try_new_from_values(&data, DIM).unwrap()),
             ],
         )
         .unwrap()];

--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -220,8 +220,8 @@ mod tests {
         let batches: Vec<RecordBatch> = vec![RecordBatch::try_new(
             schema.clone(),
             vec![
-                Arc::new(FixedSizeListArray::try_new_from_values(&data, DIM).unwrap()),
-                Arc::new(FixedSizeListArray::try_new_from_values(&data, DIM).unwrap()),
+                Arc::new(FixedSizeListArray::try_new_from_values(data.clone(), DIM).unwrap()),
+                Arc::new(FixedSizeListArray::try_new_from_values(data, DIM).unwrap()),
             ],
         )
         .unwrap()];

--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -195,7 +195,7 @@ impl DatasetIndexExt for Dataset {
 mod tests {
     use super::*;
 
-    use arrow_array::{FixedSizeListArray, RecordBatch, RecordBatchIterator, RecordBatchReader};
+    use arrow_array::{FixedSizeListArray, RecordBatch, RecordBatchIterator};
     use arrow_schema::{DataType, Field, Schema};
     use tempfile::tempdir;
 
@@ -228,11 +228,8 @@ mod tests {
 
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
-            batches.into_iter().map(Ok),
-            schema.clone(),
-        ));
-        let dataset = Dataset::write(&mut reader, test_uri, None).await.unwrap();
+        let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+        let dataset = Dataset::write(reader, test_uri, None).await.unwrap();
 
         let params = VectorIndexParams::ivf_pq(2, 8, 2, false, MetricType::L2, 2);
         let dataset = dataset

--- a/rust/src/index/vector/diskann.rs
+++ b/rust/src/index/vector/diskann.rs
@@ -111,7 +111,7 @@ impl DiskANNParams {
 mod tests {
     use std::sync::Arc;
 
-    use arrow_array::{FixedSizeListArray, RecordBatch, RecordBatchIterator, RecordBatchReader};
+    use arrow_array::{FixedSizeListArray, RecordBatch, RecordBatchIterator};
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
     use tempfile::tempdir;
 
@@ -146,11 +146,8 @@ mod tests {
 
         let test_uri = test_dir.path().to_str().unwrap();
 
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
-            batches.into_iter().map(Ok),
-            schema.clone(),
-        ));
-        let dataset = Dataset::write(&mut reader, test_uri, None).await.unwrap();
+        let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+        let dataset = Dataset::write(reader, test_uri, None).await.unwrap();
 
         // Make sure valid arguments should create index successfully
         let params =

--- a/rust/src/index/vector/diskann.rs
+++ b/rust/src/index/vector/diskann.rs
@@ -141,7 +141,8 @@ mod tests {
         )]));
 
         let float_arr = generate_random_array(512 * dimension as usize);
-        let vectors = Arc::new(FixedSizeListArray::try_new(float_arr, dimension).unwrap());
+        let vectors =
+            Arc::new(FixedSizeListArray::try_new_from_values(float_arr, dimension).unwrap());
         let batches = vec![RecordBatch::try_new(schema.clone(), vec![vectors.clone()]).unwrap()];
 
         let test_uri = test_dir.path().to_str().unwrap();

--- a/rust/src/index/vector/diskann/builder.rs
+++ b/rust/src/index/vector/diskann/builder.rs
@@ -395,7 +395,7 @@ mod tests {
         let batches = vec![RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(
-                FixedSizeListArray::try_new(&data, dim as i32).unwrap(),
+                FixedSizeListArray::try_new_from_values(&data, dim as i32).unwrap(),
             )],
         )
         .unwrap()];

--- a/rust/src/index/vector/diskann/builder.rs
+++ b/rust/src/index/vector/diskann/builder.rs
@@ -375,7 +375,7 @@ mod tests {
 
     use std::sync::Arc;
 
-    use arrow_array::{FixedSizeListArray, RecordBatch, RecordBatchIterator, RecordBatchReader};
+    use arrow_array::{FixedSizeListArray, RecordBatch, RecordBatchIterator};
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
     use tempfile;
 
@@ -405,11 +405,8 @@ mod tests {
             max_rows_per_group: 10,
             ..Default::default()
         };
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
-            batches.into_iter().map(Ok),
-            schema.clone(),
-        ));
-        Dataset::write(&mut batches, uri, Some(write_params))
+        let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+        Dataset::write(batches, uri, Some(write_params))
             .await
             .unwrap();
 

--- a/rust/src/index/vector/diskann/builder.rs
+++ b/rust/src/index/vector/diskann/builder.rs
@@ -395,7 +395,7 @@ mod tests {
         let batches = vec![RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(
-                FixedSizeListArray::try_new_from_values(&data, dim as i32).unwrap(),
+                FixedSizeListArray::try_new_from_values(data, dim as i32).unwrap(),
             )],
         )
         .unwrap()];

--- a/rust/src/index/vector/graph/persisted.rs
+++ b/rust/src/index/vector/graph/persisted.rs
@@ -409,7 +409,7 @@ mod tests {
         let batches = vec![RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(
-                FixedSizeListArray::try_new_from_values(&data, dim as i32).unwrap(),
+                FixedSizeListArray::try_new_from_values(data, dim as i32).unwrap(),
             )],
         )
         .unwrap()];

--- a/rust/src/index/vector/graph/persisted.rs
+++ b/rust/src/index/vector/graph/persisted.rs
@@ -409,7 +409,7 @@ mod tests {
         let batches = vec![RecordBatch::try_new(
             schema.clone(),
             vec![Arc::new(
-                FixedSizeListArray::try_new(&data, dim as i32).unwrap(),
+                FixedSizeListArray::try_new_from_values(&data, dim as i32).unwrap(),
             )],
         )
         .unwrap()];

--- a/rust/src/index/vector/graph/persisted.rs
+++ b/rust/src/index/vector/graph/persisted.rs
@@ -335,7 +335,7 @@ pub async fn write_graph<V: Vertex + Clone + Sync + Send>(
 
 #[cfg(test)]
 mod tests {
-    use arrow_array::{FixedSizeListArray, RecordBatchIterator, RecordBatchReader};
+    use arrow_array::{FixedSizeListArray, RecordBatchIterator};
 
     use super::*;
     use crate::{
@@ -419,11 +419,8 @@ mod tests {
             max_rows_per_group: 10,
             ..Default::default()
         };
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
-            batches.into_iter().map(Ok),
-            schema.clone(),
-        ));
-        let dataset = Dataset::write(&mut batches, test_uri, Some(write_params))
+        let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+        let dataset = Dataset::write(batches, test_uri, Some(write_params))
             .await
             .unwrap();
 

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -812,7 +812,7 @@ async fn train_ivf_model(
 mod tests {
     use super::*;
 
-    use arrow_array::{cast::AsArray, RecordBatchIterator, RecordBatchReader};
+    use arrow_array::{cast::AsArray, RecordBatchIterator};
     use arrow_schema::{DataType, Field, Schema};
     use tempfile::tempdir;
 
@@ -840,11 +840,8 @@ mod tests {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
 
-        let mut batches: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
-            vec![batch].into_iter().map(Ok),
-            schema.clone(),
-        ));
-        let dataset = Dataset::write(&mut batches, test_uri, None).await.unwrap();
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
+        let dataset = Dataset::write(batches, test_uri, None).await.unwrap();
 
         let centroids = generate_random_array(2 * DIM);
         let ivf_centroids = FixedSizeListArray::try_new(&centroids, DIM as i32).unwrap();

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -361,7 +361,8 @@ impl Ivf {
         }
 
         let part_ids = part_id_builder.finish();
-        let residuals = FixedSizeListArray::try_new(residual_builder.finish(), dim as i32)?;
+        let residuals =
+            FixedSizeListArray::try_new_from_values(residual_builder.finish(), dim as i32)?;
         let schema = Arc::new(ArrowSchema::new(vec![
             ArrowField::new(PARTITION_ID_COLUMN, DataType::UInt32, false),
             ArrowField::new(
@@ -405,7 +406,7 @@ impl TryFrom<&pb::Ivf> for Ivf {
     fn try_from(proto: &pb::Ivf) -> Result<Self> {
         let f32_centroids = Float32Array::from(proto.centroids.clone());
         let dimension = f32_centroids.len() / proto.offsets.len();
-        let centroids = Arc::new(FixedSizeListArray::try_new(
+        let centroids = Arc::new(FixedSizeListArray::try_new_from_values(
             f32_centroids,
             dimension as i32,
         )?);
@@ -802,7 +803,7 @@ async fn train_ivf_model(
         metric_type,
     )
     .await?;
-    Ok(Ivf::new(Arc::new(FixedSizeListArray::try_new(
+    Ok(Ivf::new(Arc::new(FixedSizeListArray::try_new_from_values(
         centroids,
         data.num_columns() as i32,
     )?)))
@@ -834,7 +835,8 @@ mod tests {
             ),
             true,
         )]));
-        let array = Arc::new(FixedSizeListArray::try_new(&vectors, DIM as i32).unwrap());
+        let array =
+            Arc::new(FixedSizeListArray::try_new_from_values(&vectors, DIM as i32).unwrap());
         let batch = RecordBatch::try_new(schema.clone(), vec![array.clone()]).unwrap();
 
         let test_dir = tempdir().unwrap();
@@ -844,7 +846,8 @@ mod tests {
         let dataset = Dataset::write(batches, test_uri, None).await.unwrap();
 
         let centroids = generate_random_array(2 * DIM);
-        let ivf_centroids = FixedSizeListArray::try_new(&centroids, DIM as i32).unwrap();
+        let ivf_centroids =
+            FixedSizeListArray::try_new_from_values(&centroids, DIM as i32).unwrap();
         let ivf_params = IvfBuildParams::try_with_centroids(2, Arc::new(ivf_centroids)).unwrap();
 
         let codebook = Arc::new(generate_random_array(256 * DIM));

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -835,8 +835,7 @@ mod tests {
             ),
             true,
         )]));
-        let array =
-            Arc::new(FixedSizeListArray::try_new_from_values(&vectors, DIM as i32).unwrap());
+        let array = Arc::new(FixedSizeListArray::try_new_from_values(vectors, DIM as i32).unwrap());
         let batch = RecordBatch::try_new(schema.clone(), vec![array.clone()]).unwrap();
 
         let test_dir = tempdir().unwrap();
@@ -846,8 +845,7 @@ mod tests {
         let dataset = Dataset::write(batches, test_uri, None).await.unwrap();
 
         let centroids = generate_random_array(2 * DIM);
-        let ivf_centroids =
-            FixedSizeListArray::try_new_from_values(&centroids, DIM as i32).unwrap();
+        let ivf_centroids = FixedSizeListArray::try_new_from_values(centroids, DIM as i32).unwrap();
         let ivf_params = IvfBuildParams::try_with_centroids(2, Arc::new(ivf_centroids)).unwrap();
 
         let codebook = Arc::new(generate_random_array(256 * DIM));

--- a/rust/src/index/vector/opq.rs
+++ b/rust/src/index/vector/opq.rs
@@ -329,7 +329,7 @@ mod tests {
     use approx::assert_relative_eq;
     use arrow::compute::{max, min};
     use arrow_array::{
-        FixedSizeListArray, Float32Array, RecordBatchIterator, RecordBatchReader, UInt64Array,
+        FixedSizeListArray, Float32Array, RecordBatchIterator, UInt64Array,
     };
     use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
 
@@ -367,13 +367,13 @@ mod tests {
         )]));
 
         let vectors = Float32Array::from_iter_values((0..32000).map(|x| x as f32));
-        let vectors = FixedSizeListArray::try_new(vectors, 64).unwrap();
+        let vectors = FixedSizeListArray::try_new_from_values(vectors, 64).unwrap();
         let batches = vec![RecordBatch::try_new(schema.clone(), vec![Arc::new(vectors)]).unwrap()];
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
+        let reader = RecordBatchIterator::new(
             batches.into_iter().map(Ok),
             schema.clone(),
-        ));
-        Dataset::write(&mut reader, tmp_dir.path().to_str().unwrap(), None)
+        );
+        Dataset::write(reader, tmp_dir.path().to_str().unwrap(), None)
             .await
             .unwrap();
 

--- a/rust/src/index/vector/opq.rs
+++ b/rust/src/index/vector/opq.rs
@@ -328,9 +328,7 @@ mod tests {
 
     use approx::assert_relative_eq;
     use arrow::compute::{max, min};
-    use arrow_array::{
-        FixedSizeListArray, Float32Array, RecordBatchIterator, UInt64Array,
-    };
+    use arrow_array::{FixedSizeListArray, Float32Array, RecordBatchIterator, UInt64Array};
     use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
 
     use crate::arrow::{linalg::matrix::MatrixView, *};
@@ -369,10 +367,7 @@ mod tests {
         let vectors = Float32Array::from_iter_values((0..32000).map(|x| x as f32));
         let vectors = FixedSizeListArray::try_new_from_values(vectors, 64).unwrap();
         let batches = vec![RecordBatch::try_new(schema.clone(), vec![Arc::new(vectors)]).unwrap()];
-        let reader = RecordBatchIterator::new(
-            batches.into_iter().map(Ok),
-            schema.clone(),
-        );
+        let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
         Dataset::write(reader, tmp_dir.path().to_str().unwrap(), None)
             .await
             .unwrap();

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -471,7 +471,7 @@ impl ProductQuantizer {
         })
         .await??;
 
-        FixedSizeListArray::try_new(values, self.num_sub_vectors as i32)
+        FixedSizeListArray::try_new_from_values(values, self.num_sub_vectors as i32)
     }
 
     /// Train [`ProductQuantizer`] using vectors.
@@ -620,8 +620,9 @@ fn divide_to_subvectors(data: &MatrixView, m: usize) -> Vec<Arc<FixedSizeListArr
             builder.append_slice(&row[start..start + sub_vector_length]);
         }
         let values = builder.finish();
-        let sub_array =
-            Arc::new(FixedSizeListArray::try_new(values, sub_vector_length as i32).unwrap());
+        let sub_array = Arc::new(
+            FixedSizeListArray::try_new_from_values(values, sub_vector_length as i32).unwrap(),
+        );
         subarrays.push(sub_array);
     }
     subarrays

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -422,9 +422,7 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_array::RecordBatchIterator;
-    use arrow_array::{
-        cast::as_primitive_array, FixedSizeListArray, Int32Array, RecordBatchReader, StringArray,
-    };
+    use arrow_array::{cast::as_primitive_array, FixedSizeListArray, Int32Array, StringArray};
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
     use futures::TryStreamExt;
     use tempfile::tempdir;
@@ -480,11 +478,8 @@ mod tests {
         let vector_arr = batches[0].column_by_name("vector").unwrap();
         let q = as_fixed_size_list_array(&vector_arr).value(5);
 
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
-            batches.into_iter().map(Ok),
-            schema.clone(),
-        ));
-        Dataset::write(&mut reader, test_uri, Some(write_params))
+        let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+        Dataset::write(reader, test_uri, Some(write_params))
             .await
             .unwrap();
 

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -455,7 +455,7 @@ mod tests {
                     vec![
                         Arc::new(Int32Array::from_iter_values(i * 20..(i + 1) * 20)),
                         Arc::new(
-                            FixedSizeListArray::try_new(generate_random_array(128 * 20), 128)
+                            FixedSizeListArray::try_new_from_values(generate_random_array(128 * 20), 128)
                                 .unwrap(),
                         ),
                         Arc::new(StringArray::from_iter_values(

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -455,8 +455,11 @@ mod tests {
                     vec![
                         Arc::new(Int32Array::from_iter_values(i * 20..(i + 1) * 20)),
                         Arc::new(
-                            FixedSizeListArray::try_new_from_values(generate_random_array(128 * 20), 128)
-                                .unwrap(),
+                            FixedSizeListArray::try_new_from_values(
+                                generate_random_array(128 * 20),
+                                128,
+                            )
+                            .unwrap(),
                         ),
                         Arc::new(StringArray::from_iter_values(
                             (i * 20..(i + 1) * 20).map(|i| format!("s3://bucket/file-{}", i)),

--- a/rust/src/io/exec/take.rs
+++ b/rust/src/io/exec/take.rs
@@ -257,9 +257,7 @@ impl ExecutionPlan for TakeExec {
 mod tests {
     use super::*;
 
-    use arrow_array::{
-        ArrayRef, Float32Array, Int32Array, RecordBatchIterator, RecordBatchReader, StringArray,
-    };
+    use arrow_array::{ArrayRef, Float32Array, Int32Array, RecordBatchIterator, StringArray};
     use arrow_schema::{DataType, Field};
     use tempfile::tempdir;
 
@@ -295,11 +293,9 @@ mod tests {
             max_rows_per_group: 10,
             ..Default::default()
         };
-        let mut reader: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
-            expected_batches.clone().into_iter().map(Ok),
-            schema.clone(),
-        ));
-        Dataset::write(&mut reader, test_uri, Some(params))
+        let reader =
+            RecordBatchIterator::new(expected_batches.clone().into_iter().map(Ok), schema.clone());
+        Dataset::write(reader, test_uri, Some(params))
             .await
             .unwrap();
 

--- a/rust/src/io/reader.rs
+++ b/rust/src/io/reader.rs
@@ -689,7 +689,7 @@ mod tests {
         cast::{as_primitive_array, as_string_array, as_struct_array},
         types::UInt8Type,
         Array, DictionaryArray, Float32Array, Int64Array, LargeListArray, ListArray, NullArray,
-        RecordBatchReader, StringArray, StructArray, UInt32Array, UInt8Array,
+        StringArray, StructArray, UInt32Array, UInt8Array,
     };
     use arrow_schema::{Field as ArrowField, Fields as ArrowFields, Schema as ArrowSchema};
     use rand::{distributions::Alphanumeric, Rng};
@@ -1154,11 +1154,9 @@ mod tests {
 
         let test_uri = test_dir.path().to_str().unwrap();
 
-        let mut batch_reader: Box<dyn RecordBatchReader> = Box::new(RecordBatchIterator::new(
-            batches.clone().into_iter().map(Ok),
-            arrow_schema.clone(),
-        ));
-        Dataset::write(&mut batch_reader, test_uri, Some(WriteParams::default()))
+        let batch_reader =
+            RecordBatchIterator::new(batches.clone().into_iter().map(Ok), arrow_schema.clone());
+        Dataset::write(batch_reader, test_uri, Some(WriteParams::default()))
             .await
             .unwrap();
 

--- a/rust/src/io/writer.rs
+++ b/rust/src/io/writer.rs
@@ -462,7 +462,7 @@ mod tests {
         let dict_vec = (0..100).map(|n| ["a", "b", "c"][n % 3]).collect::<Vec<_>>();
         let dict_arr: DictionaryArray<UInt32Type> = dict_vec.into_iter().collect();
 
-        let fixed_size_list_arr = FixedSizeListArray::try_new(
+        let fixed_size_list_arr = FixedSizeListArray::try_new_from_values(
             Float32Array::from_iter((0..1600).map(|n| n as f32).collect::<Vec<_>>()),
             16,
         )
@@ -470,7 +470,8 @@ mod tests {
 
         let binary_data: [u8; 800] = [123; 800];
         let fixed_size_binary_arr =
-            FixedSizeBinaryArray::try_new(&UInt8Array::from_iter(binary_data), 8).unwrap();
+            FixedSizeBinaryArray::try_new_from_values(&UInt8Array::from_iter(binary_data), 8)
+                .unwrap();
 
         let list_offsets = (0..202).step_by(2).collect();
         let list_values =


### PR DESCRIPTION
This PR upgrades Arrow and DataFusion.

It changes the signature of writing methods so that:

1. It takes owned boxes of RecordBatchReader instead of mutable reference. I think this makes more sense given readers are one-shot.
2. It adds a `Send` bound to the input reader argument. This makes the full method Send allowing write tasks to be sent to other threads.

fixes #1031