### PR TITLE
cache aws credentials until 30s before expiry

### DIFF
--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -14,8 +14,10 @@
 
 //! Wraps [ObjectStore](object_store::ObjectStore)
 
+use std::collections::HashMap;
 use std::path::Path as StdPath;
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
 use ::object_store::{
     aws::AmazonS3Builder, azure::MicrosoftAzureBuilder, gcp::GoogleCloudStorageBuilder,
@@ -29,6 +31,7 @@ use futures::{StreamExt, TryStreamExt};
 use object_store::aws::AwsCredential as ObjectStoreAwsCredential;
 use reqwest::header::{HeaderMap, CACHE_CONTROL};
 use shellexpand::tilde;
+use tokio::sync::RwLock;
 use url::Url;
 
 use crate::error::{Error, Result};
@@ -54,26 +57,84 @@ impl std::fmt::Display for ObjectStore {
     }
 }
 
+const AWS_CREDS_CACHE_KEY: &str = "aws_credentials";
 #[derive(Debug)]
 struct AwsCredentialAdapter {
-    pub inner: DefaultCredentialsChain,
+    pub inner: Arc<dyn ProvideCredentials>,
+
+    // RefCell can't be shared accross threads, so we use HashMap
+    cache: Arc<RwLock<HashMap<String, Arc<aws_credential_types::Credentials>>>>,
+
+    // The amount of time before expiry to refresh credentials
+    credentials_refresh_offset: Duration,
+}
+
+impl AwsCredentialAdapter {
+    fn new(provider: Arc<dyn ProvideCredentials>, credentials_refresh_offset: Duration) -> Self {
+        Self {
+            inner: provider,
+            cache: Arc::new(RwLock::new(HashMap::new())),
+            credentials_refresh_offset,
+        }
+    }
 }
 
 #[async_trait]
 impl CredentialProvider for AwsCredentialAdapter {
     type Credential = ObjectStoreAwsCredential;
+
     async fn get_credential(&self) -> ObjectStoreResult<Arc<Self::Credential>> {
-        let creds = self.inner.provide_credentials().await.unwrap();
-        Ok(Arc::new(Self::Credential {
-            key_id: creds.access_key_id().to_string(),
-            secret_key: creds.secret_access_key().to_string(),
-            token: creds.session_token().map(|s| s.to_string()),
-        }))
+        let cached_creds = {
+            let cache_value = self.cache.read().await.get(AWS_CREDS_CACHE_KEY).cloned();
+            let expired = cache_value
+                .clone()
+                .map(|cred| {
+                    cred.expiry()
+                        .map(|exp| {
+                            exp.checked_sub(self.credentials_refresh_offset)
+                                .expect("this time should always be valid")
+                                < SystemTime::now()
+                        })
+                        // no expiry is never expire
+                        .unwrap_or(false)
+                })
+                .unwrap_or(true); // no cred is the same as expired;
+            if expired {
+                None
+            } else {
+                cache_value.clone()
+            }
+        };
+
+        if let Some(creds) = cached_creds {
+            Ok(Arc::new(Self::Credential {
+                key_id: creds.access_key_id().to_string(),
+                secret_key: creds.secret_access_key().to_string(),
+                token: creds.session_token().map(|s| s.to_string()),
+            }))
+        } else {
+            let refreshed_creds = Arc::new(self.inner.provide_credentials().await.unwrap());
+
+            self.cache
+                .write()
+                .await
+                .insert(AWS_CREDS_CACHE_KEY.to_string(), refreshed_creds.clone());
+
+            Ok(Arc::new(Self::Credential {
+                key_id: refreshed_creds.access_key_id().to_string(),
+                secret_key: refreshed_creds.secret_access_key().to_string(),
+                token: refreshed_creds.session_token().map(|s| s.to_string()),
+            }))
+        }
     }
 }
 
-/// BUild S3 ObjectStore using default credential chain.
-async fn build_s3_object_store(uri: &str) -> Result<Arc<dyn OSObjectStore>> {
+/// Build S3 ObjectStore using default credential chain.
+/// `credentials_refresh_offset` is the amount of time before expiry to refresh credentials.
+async fn build_s3_object_store(
+    uri: &str,
+    credentials_refresh_offset: Duration,
+) -> Result<Arc<dyn OSObjectStore>> {
     use aws_config::meta::region::RegionProviderChain;
 
     const DEFAULT_REGION: &str = "us-west-2";
@@ -88,9 +149,10 @@ async fn build_s3_object_store(uri: &str) -> Result<Arc<dyn OSObjectStore>> {
     Ok(Arc::new(
         AmazonS3Builder::new()
             .with_url(uri)
-            .with_credentials(Arc::new(AwsCredentialAdapter {
-                inner: credentials_provider,
-            }))
+            .with_credentials(Arc::new(AwsCredentialAdapter::new(
+                Arc::new(credentials_provider),
+                credentials_refresh_offset,
+            )))
             .with_region(
                 region_provider
                     .region()
@@ -124,9 +186,21 @@ pub trait WrappingObjectStore: Send + Sync {
     fn wrap(&self, original: Arc<dyn OSObjectStore>) -> Arc<dyn OSObjectStore>;
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct ObjectStoreParams {
     pub object_store_wrapper: Option<Arc<dyn WrappingObjectStore>>,
+
+    pub s3_credentials_refresh_offset: Duration,
+}
+
+// Need this for setting a non-zero default duration
+impl Default for ObjectStoreParams {
+    fn default() -> Self {
+        Self {
+            object_store_wrapper: None,
+            s3_credentials_refresh_offset: Duration::from_secs(60),
+        }
+    }
 }
 
 impl ObjectStore {
@@ -147,7 +221,8 @@ impl ObjectStore {
                 Self::new_from_path(uri)
             }
             Ok(url) => {
-                let store = Self::new_from_url(url.clone()).await?;
+                let store =
+                    Self::new_from_url(url.clone(), params.s3_credentials_refresh_offset).await?;
                 let path = Path::from(url.path());
                 Ok((store, path))
             }
@@ -190,10 +265,14 @@ impl ObjectStore {
         ))
     }
 
-    async fn new_from_url(url: Url) -> Result<Self> {
+    async fn new_from_url(url: Url, s3_credential_refresh_offset: Duration) -> Result<Self> {
         match url.scheme() {
             "s3" => Ok(Self {
-                inner: build_s3_object_store(url.to_string().as_str()).await?,
+                inner: build_s3_object_store(
+                    url.to_string().as_str(),
+                    s3_credential_refresh_offset,
+                )
+                .await?,
                 scheme: String::from("s3"),
                 base_path: Path::from(url.path()),
                 block_size: 64 * 1024,
@@ -473,6 +552,7 @@ mod tests {
 
         let params = ObjectStoreParams {
             object_store_wrapper: Some(wrapper.clone()),
+            ..ObjectStoreParams::default()
         };
 
         // not called yet


### PR DESCRIPTION
We are hammering EC2/ECS metadata services over and over because we are calling the metadata service we to get creds on each request to AWS. The metadata service is returning 429 as we are making too many requests.

Caching AWS creds is a common practice to avoid throttles. 

TODO:
- [x] test with integration test