### PR TITLE
write_impl accepts object store

### DIFF
--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -341,6 +341,10 @@ impl ObjectStore {
         &self.base_path
     }
 
+    pub fn uri(&self) -> String {
+        format!("{}://{}", self.scheme, self.base_path)
+    }
+
     /// Open a file for path.
     ///
     /// The [path] is absolute path.


### PR DESCRIPTION
We're trying to enable future flexibility for write_impl by passing an object_store directly from the outside instead of creating one from a string uri.