### PR TITLE
[Rust] Convert between json / arrow schema

### DIFF
--- a/rust/.vscode/settings.json
+++ b/rust/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "Cargo.toml"
+    ],
+    "rust-analyzer.cargo.features": [
+        "clap", "json"
+    ]
+}

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -72,6 +72,8 @@ num-traits = "0.2"
 ordered-float = "3.6.0"
 snafu = "0.7.4"
 log = "0"
+serde_json = { version = "1", optional = true }
+serde = { version = "^1", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accelerate-src = { version = "0.3.2", optional = true }
@@ -102,6 +104,7 @@ dirs = "5.0.0"
 [features]
 cli = ["clap"]
 opq = ["cblas", "lapack", "openblas-src", "accelerate-src"]
+json = ["serde_json", "serde"]
 
 [[bin]]
 name = "lq"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -65,7 +65,6 @@ arrow = { version = "42.0.0", features = ["prettyprint"] }
 num_cpus = "1.0"
 # TODO: use datafusion sub-modules to reduce build size?
 datafusion = { version = "27.0.0", default-features = false, features = ["regex_expressions"] }
-faiss = { version = "0.11.0", features = ["gpu"], optional = true }
 lapack = { version = "0.19.0", optional = true }
 cblas =  { version = "0.4.0", optional = true }
 lru_time_cache = "0.11"

--- a/rust/src/arrow.rs
+++ b/rust/src/arrow.rs
@@ -32,6 +32,8 @@ use crate::error::{Error, Result};
 pub use kernels::*;
 pub mod schema;
 pub use schema::*;
+#[cfg(feature = "json")]
+pub mod json;
 
 pub trait DataTypeExt {
     /// Returns true if the data type is binary-like, such as (Large)Utf8 and (Large)Binary.

--- a/rust/src/arrow/json.rs
+++ b/rust/src/arrow/json.rs
@@ -296,7 +296,7 @@ mod test {
     }
 
     fn assert_primitive_types(dt: DataType, type_name: &str) {
-        assert_type_json_str(dt, json!({"type": type_name}));
+        assert_type_json_str(dt, json!({ "type": type_name }));
     }
 
     #[test]

--- a/rust/src/arrow/json.rs
+++ b/rust/src/arrow/json.rs
@@ -152,24 +152,24 @@ impl TryFrom<&JsonDataType> for DataType {
                     .collect::<Result<Vec<_>>>()?;
 
                 match type_name {
-                    "list" => Ok(DataType::List(Arc::new(fields[0].clone()))),
-                    "large_list" => Ok(DataType::LargeList(Arc::new(fields[0].clone()))),
+                    "list" => Ok(Self::List(Arc::new(fields[0].clone()))),
+                    "large_list" => Ok(Self::LargeList(Arc::new(fields[0].clone()))),
                     "fixed_size_list" => {
                         let length = value.length.ok_or_else(|| Error::Arrow {
                             message: "Json conversion: FixedSizeList type requires a length"
                                 .to_string(),
                         })?;
-                        Ok(DataType::FixedSizeList(
+                        Ok(Self::FixedSizeList(
                             Arc::new(fields[0].clone()),
                             length as i32,
                         ))
                     }
-                    "struct" => Ok(DataType::Struct(fields.into())),
+                    "struct" => Ok(Self::Struct(fields.into())),
                     _ => unreachable!(),
                 }
             }
             _ => {
-                return Err(Error::Arrow {
+                Err(Error::Arrow {
                     message: format!("Json conversion: Unsupported type: {value:?}"),
                 })
             }
@@ -204,7 +204,7 @@ impl TryFrom<&JsonField> for Field {
 
     fn try_from(value: &JsonField) -> Result<Self> {
         let data_type = DataType::try_from(&value.type_)?;
-        Ok(Field::new(&value.name, data_type, value.nullable))
+        Ok(Self::new(&value.name, data_type, value.nullable))
     }
 }
 

--- a/rust/src/arrow/json.rs
+++ b/rust/src/arrow/json.rs
@@ -128,7 +128,7 @@ impl TryFrom<&JsonDataType> for DataType {
             "null" | "bool" | "int8" | "int16" | "int32" | "int64" | "uint8" | "uint16"
             | "uint32" | "halffloat" | "float" | "double" | "string" | "binary"
             | "large_string" | "large_binary" | "date32:day" | "date64:ms" => {
-                let logical_type: LogicalType = value.type_.as_str().into();
+                let logical_type: LogicalType = type_name.into();
                 (&logical_type).try_into()
             }
             dt if dt.starts_with("time32:")

--- a/rust/src/arrow/json.rs
+++ b/rust/src/arrow/json.rs
@@ -57,9 +57,9 @@ impl TryFrom<DataType> for JsonDataType {
             DataType::UInt16 => Self::new("uint16"),
             DataType::UInt32 => Self::new("uint32"),
             DataType::UInt64 => Self::new("uint64"),
-            DataType::Float16 => todo!(),
-            DataType::Float32 => todo!(),
-            DataType::Float64 => todo!(),
+            DataType::Float16 => Self::new("float16"),
+            DataType::Float32 => Self::new("float32"),
+            DataType::Float64 => Self::new("float64"),
             DataType::Timestamp(_, _) => todo!(),
             DataType::Date32 => todo!(),
             DataType::Date64 => todo!(),
@@ -128,6 +128,10 @@ mod test {
         assert_eq!(
             serde_json::to_string(&JsonDataType::try_new(DataType::Int32).unwrap()).unwrap(),
             r#"{"type":"int32"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&JsonDataType::try_new(DataType::UInt64).unwrap()).unwrap(),
+            r#"{"type":"uint64"}"#
         );
         assert_eq!(
             serde_json::to_string(&JsonDataType::try_new(DataType::Boolean).unwrap()).unwrap(),

--- a/rust/src/arrow/json.rs
+++ b/rust/src/arrow/json.rs
@@ -1,0 +1,135 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Serialization and deserialization of Arrow Schema to JSON.
+
+use std::collections::HashMap;
+
+use arrow_schema::{Schema, Field, DataType};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct JsonDataType {
+    #[serde(rename = "type")]
+    type_: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fields: Option<Vec<JsonField>>,
+}
+
+impl JsonDataType {
+    fn try_new(dt: DataType) -> Result<Self> {
+        dt.try_into()
+    }
+
+    fn new(type_name: &str) -> Self {
+        Self {
+            type_: type_name.to_string(),
+            fields: None,
+        }
+    }
+}
+
+impl TryFrom<DataType> for JsonDataType {
+    type Error = Error;
+
+    fn try_from(dt: DataType) -> Result<Self> {
+        let json_type = match dt {
+            DataType::Null => Self::new("null"),
+            DataType::Boolean => Self::new("boolean"),
+            DataType::Int8 => Self::new("int8"),
+            DataType::Int16 => Self::new("int16"),
+            DataType::Int32 => Self::new("int32"),
+            DataType::Int64 => Self::new("int64"),
+            DataType::UInt8 => todo!(),
+            DataType::UInt16 => todo!(),
+            DataType::UInt32 => todo!(),
+            DataType::UInt64 => todo!(),
+            DataType::Float16 => todo!(),
+            DataType::Float32 => todo!(),
+            DataType::Float64 => todo!(),
+            DataType::Timestamp(_, _) => todo!(),
+            DataType::Date32 => todo!(),
+            DataType::Date64 => todo!(),
+            DataType::Time32(_) => todo!(),
+            DataType::Time64(_) => todo!(),
+            DataType::Duration(_) => todo!(),
+            DataType::Interval(_) => todo!(),
+            DataType::Binary => todo!(),
+            DataType::FixedSizeBinary(_) => todo!(),
+            DataType::LargeBinary => todo!(),
+            DataType::Utf8 => todo!(),
+            DataType::LargeUtf8 => todo!(),
+            DataType::List(_) => todo!(),
+            DataType::FixedSizeList(_, _) => todo!(),
+            DataType::LargeList(_) => todo!(),
+            DataType::Struct(_) => todo!(),
+            DataType::Union(_, _) => todo!(),
+            DataType::Dictionary(_, _) => todo!(),
+            DataType::Decimal128(_, _) => todo!(),
+            DataType::Decimal256(_, _) => todo!(),
+            DataType::Map(_, _) => todo!(),
+            DataType::RunEndEncoded(_, _) => todo!(),
+        };
+        Ok(json_type)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct JsonField {
+    name: String,
+    nullable: bool,
+    data_type: JsonDataType,
+    children: Option<Vec<JsonField>>,
+    metadata: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct JsonSchema {
+    fields: Vec<JsonField>,
+    metadata: Option<HashMap<String, String>>,
+}
+
+pub trait ArrowJsonExt {
+    fn to_json(&self) -> String;
+
+    fn from_json(json: &str) -> Self;
+}
+
+impl ArrowJsonExt for Schema {
+    fn to_json(&self) -> String {
+        todo!()
+    }
+
+    fn from_json(json: &str) -> Self {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use serde_json;
+
+    #[test]
+    fn test_data_type_to_json() {
+        assert_eq!(serde_json::to_string(&JsonDataType::try_new(DataType::Int32).unwrap()).unwrap(), r#"{"type":"int32"}"#)
+    }
+
+    #[test]
+    fn test_schema_to_json() {
+
+    }
+}

--- a/rust/src/arrow/json.rs
+++ b/rust/src/arrow/json.rs
@@ -168,11 +168,9 @@ impl TryFrom<&JsonDataType> for DataType {
                     _ => unreachable!(),
                 }
             }
-            _ => {
-                Err(Error::Arrow {
-                    message: format!("Json conversion: Unsupported type: {value:?}"),
-                })
-            }
+            _ => Err(Error::Arrow {
+                message: format!("Json conversion: Unsupported type: {value:?}"),
+            }),
         }
     }
 }

--- a/rust/src/arrow/json.rs
+++ b/rust/src/arrow/json.rs
@@ -16,7 +16,7 @@
 
 use std::collections::HashMap;
 
-use arrow_schema::{Schema, Field, DataType};
+use arrow_schema::{DataType, Field, Schema};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
@@ -53,10 +53,10 @@ impl TryFrom<DataType> for JsonDataType {
             DataType::Int16 => Self::new("int16"),
             DataType::Int32 => Self::new("int32"),
             DataType::Int64 => Self::new("int64"),
-            DataType::UInt8 => todo!(),
-            DataType::UInt16 => todo!(),
-            DataType::UInt32 => todo!(),
-            DataType::UInt64 => todo!(),
+            DataType::UInt8 => Self::new("uint8"),
+            DataType::UInt16 => Self::new("uint16"),
+            DataType::UInt32 => Self::new("uint32"),
+            DataType::UInt64 => Self::new("uint64"),
             DataType::Float16 => todo!(),
             DataType::Float32 => todo!(),
             DataType::Float64 => todo!(),
@@ -70,8 +70,8 @@ impl TryFrom<DataType> for JsonDataType {
             DataType::Binary => todo!(),
             DataType::FixedSizeBinary(_) => todo!(),
             DataType::LargeBinary => todo!(),
-            DataType::Utf8 => todo!(),
-            DataType::LargeUtf8 => todo!(),
+            DataType::Utf8 => Self::new("string"),
+            DataType::LargeUtf8 => Self::new("large_string"),
             DataType::List(_) => todo!(),
             DataType::FixedSizeList(_, _) => todo!(),
             DataType::LargeList(_) => todo!(),
@@ -125,11 +125,16 @@ mod test {
 
     #[test]
     fn test_data_type_to_json() {
-        assert_eq!(serde_json::to_string(&JsonDataType::try_new(DataType::Int32).unwrap()).unwrap(), r#"{"type":"int32"}"#)
+        assert_eq!(
+            serde_json::to_string(&JsonDataType::try_new(DataType::Int32).unwrap()).unwrap(),
+            r#"{"type":"int32"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&JsonDataType::try_new(DataType::Boolean).unwrap()).unwrap(),
+            r#"{"type":"boolean"}"#
+        );
     }
 
     #[test]
-    fn test_schema_to_json() {
-
-    }
+    fn test_schema_to_json() {}
 }


### PR DESCRIPTION
Implement Round trip of json / arrow schema conversion. 
Use this as source of truth between rust/javascript/python.