### PR TITLE
fix: take and search now work properly with deletions

### DIFF
--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -706,14 +706,12 @@ impl Dataset {
             .iter()
             .filter_map(|o| returned_row_ids.binary_search(o).ok().map(|pos| pos as u64))
             .collect();
-        let num_rows = one_batch.num_rows();
 
         // Remove the row id column.
         let keep_indices = (0..one_batch.num_columns() - 1).collect::<Vec<_>>();
         let one_batch = one_batch.project(&keep_indices)?;
         let struct_arr: StructArray = one_batch.into();
         let reordered = take(&struct_arr, &remapping_index, None)?;
-        assert_eq!(reordered.len(), num_rows);
         Ok(as_struct_array(&reordered).into())
     }
 

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -23,7 +23,7 @@ use std::time::SystemTime;
 use arrow_array::{
     cast::as_struct_array, RecordBatch, RecordBatchReader, StructArray, UInt64Array,
 };
-use arrow_schema::Schema as ArrowSchema;
+use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
 use arrow_select::{concat::concat_batches, take::take};
 use chrono::prelude::*;
 use futures::stream::{self, StreamExt, TryStreamExt};
@@ -41,6 +41,7 @@ use self::feature_flags::{apply_feature_flags, can_read_dataset, can_write_datas
 use self::fragment::FileFragment;
 use self::scanner::Scanner;
 use self::write::{reader_to_stream, write_fragments};
+use crate::arrow::SchemaExt;
 use crate::datatypes::Schema;
 use crate::error::box_error;
 use crate::format::{pb, Fragment, Index, Manifest};
@@ -652,6 +653,8 @@ impl Dataset {
         let mut sorted_row_ids = Vec::from(row_ids);
         sorted_row_ids.sort();
 
+        assert_eq!(row_ids.len(), sorted_row_ids.len());
+
         // Group ROW Ids by the fragment
         let mut row_ids_per_fragment: BTreeMap<u64, Vec<u32>> = BTreeMap::new();
         sorted_row_ids.iter().for_each(|row_id| {
@@ -662,35 +665,71 @@ impl Dataset {
                 .and_modify(|v| v.push(offset))
                 .or_insert_with(|| vec![offset]);
         });
+
+        assert_eq!(
+            row_ids.len(),
+            row_ids_per_fragment.values().flatten().count()
+        );
+
         let schema = Arc::new(ArrowSchema::from(projection));
         let fragments = self.get_fragments();
-        let fragment_and_indices = fragments
-            .iter()
-            .map(|f| {
-                (
-                    f,
-                    row_ids_per_fragment.get(&(f.id() as u64)),
-                    schema.clone(),
-                )
-            })
-            .collect::<Vec<_>>();
+        dbg!(row_ids.len());
+        dbg!(row_ids_per_fragment.keys().collect::<Vec<_>>());
+        dbg!(fragments.iter().map(|f| f.metadata.id).collect::<Vec<_>>());
+        let fragment_and_indices = fragments.iter().filter_map(|f| {
+            let local_row_ids = row_ids_per_fragment.get(&(f.id() as u64))?;
+            Some((f, local_row_ids))
+        });
+
+        let projection_with_row_id = Schema::merge(
+            projection,
+            &ArrowSchema::new(vec![ArrowField::new(
+                ROW_ID,
+                arrow::datatypes::DataType::UInt64,
+                false,
+            )]),
+        )?;
+        let schema_with_row_id = Arc::new(ArrowSchema::from(&projection_with_row_id));
+
+        let schema_ref = &projection_with_row_id;
         let batches = stream::iter(fragment_and_indices)
-            .then(|(fragment, indices_opt, schema)| async move {
-                let Some(indices) = indices_opt else {
-                    return Ok(RecordBatch::new_empty(schema));
-                };
-                fragment.take(indices.as_slice(), projection).await
+            .then(|(fragment, indices)| {
+                async move {
+                    let mut reader = fragment.open(schema_ref).await?;
+                    // We need row id to reconstruct the requested order of rows
+                    reader.with_row_id();
+                    reader.take(indices.as_slice()).await
+                }
             })
             .try_collect::<Vec<_>>()
             .await?;
-        let one_batch = concat_batches(&schema, &batches)?;
+
+        dbg!(batches.len());
+        let one_batch = concat_batches(&schema_with_row_id, &batches)?;
+        dbg!(one_batch.num_rows());
+        // Note: one_batch may contains fewer rows than the number of requested
+        // row ids because some rows may have been deleted.
+
+        let returned_row_ids = one_batch
+            .column_by_name(ROW_ID)
+            .ok_or_else(|| Error::Internal {
+                message: "ROW_ID column not found".into(),
+            })?
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| Error::Internal {
+                message: "ROW_ID column is not UInt64Array".into(),
+            })?
+            .values();
 
         let remapping_index: UInt64Array = row_ids
             .iter()
-            .map(|o| sorted_row_ids.binary_search(o).unwrap() as u64)
+            .filter_map(|o| returned_row_ids.binary_search(o).ok().map(|pos| pos as u64))
             .collect();
+        let num_rows = one_batch.num_rows();
         let struct_arr: StructArray = one_batch.into();
         let reordered = take(&struct_arr, &remapping_index, None)?;
+        assert_eq!(reordered.len(), num_rows);
         Ok(as_struct_array(&reordered).into())
     }
 
@@ -1581,26 +1620,20 @@ mod tests {
             ..Default::default()
         };
         let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        Dataset::write(batches, test_uri, Some(write_params))
+        let mut dataset = Dataset::write(batches, test_uri, Some(write_params))
             .await
             .unwrap();
 
-        let dataset = Dataset::open(test_uri).await.unwrap();
         assert_eq!(dataset.count_rows().await.unwrap(), 400);
         let projection = Schema::try_from(schema.as_ref()).unwrap();
-        let values = dataset
-            .take_rows(
-                &[
-                    5_u64 << 32,        // 200
-                    (4_u64 << 32) + 39, // 199
-                    39,                 // 39
-                    1_u64 << 32,        // 40
-                    (2_u64 << 32) + 20, // 100
-                ],
-                &projection,
-            )
-            .await
-            .unwrap();
+        let indices = &[
+            5_u64 << 32,        // 200
+            (4_u64 << 32) + 39, // 199
+            39,                 // 39
+            1_u64 << 32,        // 40
+            (2_u64 << 32) + 20, // 100
+        ];
+        let values = dataset.take_rows(indices, &projection).await.unwrap();
         assert_eq!(
             RecordBatch::try_new(
                 schema.clone(),
@@ -1614,6 +1647,28 @@ mod tests {
             .unwrap(),
             values
         );
+
+        // Delete some rows from a fragment
+        dataset.delete("i in (199, 100)").await.unwrap();
+        dataset.validate().await.unwrap();
+        let values = dataset.take_rows(indices, &projection).await.unwrap();
+        assert_eq!(
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from_iter_values([200, 39, 40])),
+                    Arc::new(StringArray::from_iter_values(
+                        [200, 39, 40].iter().map(|v| format!("str-{v}"))
+                    )),
+                ],
+            )
+            .unwrap(),
+            values
+        );
+
+        // Take an empty selection.
+        let values = dataset.take_rows(&[], &projection).await.unwrap();
+        assert_eq!(RecordBatch::new_empty(schema.clone()), values);
     }
 
     #[tokio::test]

--- a/rust/src/dataset/fragment.rs
+++ b/rust/src/dataset/fragment.rs
@@ -14,15 +14,15 @@
 
 //! Wraps a Fragment of the dataset.
 
+use std::borrow::Cow;
 use std::ops::Range;
 use std::sync::Arc;
 
 use arrow_array::cast::as_primitive_array;
 use arrow_array::{RecordBatch, RecordBatchReader, UInt64Array};
-use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use futures::future::try_join_all;
 use futures::stream::BoxStream;
-use futures::{join, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
+use futures::{join, StreamExt, TryFutureExt, TryStreamExt};
 use object_store::path::Path;
 use uuid::Uuid;
 
@@ -33,11 +33,13 @@ use crate::arrow::*;
 use crate::dataset::{Dataset, DATA_DIR};
 use crate::datatypes::Schema;
 use crate::format::Fragment;
-use crate::io::deletion::{deletion_file_path, read_deletion_file, write_deletion_file};
+use crate::io::deletion::{
+    deletion_file_path, read_deletion_file, write_deletion_file, DeletionVector,
+};
 use crate::io::{FileReader, FileWriter, ObjectStore, ReadBatchParams};
 use crate::{Error, Result};
 
-use super::{WriteParams, ROW_ID};
+use super::WriteParams;
 
 /// A Fragment of a Lance [`Dataset`].
 ///
@@ -281,10 +283,111 @@ impl FileFragment {
         Ok(())
     }
 
-    /// Take rows from this fragment.
+    /// Take rows from this fragment based on the offset in the file.
+    ///
+    /// This will always return the same number of rows as the input indices.
+    /// If indices are out-of-bounds, this will return an error.
     pub async fn take(&self, indices: &[u32], projection: &Schema) -> Result<RecordBatch> {
-        let reader = self.open(projection).await?;
-        reader.take(indices).await
+        // Re-map the indices to row ids using the deletion vector
+        let deletion_vector = self.get_deletion_vector().await?;
+        let row_ids = if let Some(deletion_vector) = deletion_vector {
+            // Naive case is O(N*M), where N = indices.len() and M = deletion_vector.len()
+            // We can do better by sorting the deletion vector and using binary search
+            // This is O(N * log M + M log M).
+            let mut sorted_deleted_ids = deletion_vector
+                .as_ref()
+                .clone()
+                .into_iter()
+                .collect::<Vec<_>>();
+            sorted_deleted_ids.sort();
+
+            let mut row_ids = indices.to_vec();
+            for row_id in row_ids.iter_mut() {
+                // We find the number of deleted rows that are less than each row
+                // index, and that becomes the initial offset. We increment the
+                // index by that amount, plus the number of deleted row ids we
+                // encounter along the way. So for example, if deleted rows are
+                // [2, 3, 5] and we want row 4, we need to advanced by 2 (since
+                // 2 and 3 are less than 4). That puts us at row 6, but since
+                // we passed row 5, we need to advance by 1 more, giving a final
+                // row id of 7.
+                let mut new_row_id = *row_id;
+                let offset = sorted_deleted_ids.partition_point(|v| *v <= new_row_id);
+
+                let mut deletion_i = offset;
+                let mut i = 0;
+                while i < offset {
+                    // Advance the row id
+                    new_row_id += 1;
+                    while deletion_i < sorted_deleted_ids.len()
+                        && sorted_deleted_ids[deletion_i] == new_row_id
+                    {
+                        // If we encounter a deleted row, we need to advance
+                        // again.
+                        deletion_i += 1;
+                        new_row_id += 1;
+                    }
+                    i += 1;
+                }
+
+                *row_id = new_row_id;
+            }
+
+            Cow::Owned(row_ids)
+        } else {
+            Cow::Borrowed(indices)
+        };
+
+        // Then call take rows
+        self.take_rows(&row_ids, projection, false).await
+    }
+
+    /// Get the deletion vector for this fragment, using the cache if available.
+    pub(crate) async fn get_deletion_vector(&self) -> Result<Option<Arc<DeletionVector>>> {
+        let Some(deletion_file) =  self.metadata.deletion_file.as_ref() else { return Ok(None) };
+
+        let cache = &self.dataset.session.file_metadata_cache;
+        let path = deletion_file_path(&self.dataset.base, self.metadata.id, deletion_file);
+        if let Some(deletion_vector) = cache.get::<DeletionVector>(&path) {
+            Ok(Some(deletion_vector))
+        } else {
+            let deletion_vector = read_deletion_file(
+                &self.dataset.base,
+                &self.metadata,
+                self.dataset.object_store(),
+            )
+            .await?;
+            match deletion_vector {
+                Some(deletion_vector) => {
+                    let deletion_vector = Arc::new(deletion_vector);
+                    cache.insert(path, deletion_vector.clone());
+                    Ok(Some(deletion_vector))
+                }
+                None => Ok(None),
+            }
+        }
+    }
+
+    /// Take rows based on internal local row ids
+    ///
+    /// If the row ids are out-of-bounds, this will return an error. But if the
+    /// row id is marked deleted, it will be ignored. Thus, the number of rows
+    /// returned may be less than the number of row ids provided.
+    ///
+    /// To recover the original row ids from the returned RecordBatch, set the
+    /// `with_row_id` parameter to true. This will add a column named `_row_id`
+    /// to the RecordBatch at the end.
+    pub(crate) async fn take_rows(
+        &self,
+        row_ids: &[u32],
+        projection: &Schema,
+        with_row_id: bool,
+    ) -> Result<RecordBatch> {
+        let mut reader = self.open(projection).await?;
+        if with_row_id {
+            reader.with_row_id();
+        }
+        reader.take(row_ids).await
     }
 
     /// Scan this [`FileFragment`].
@@ -472,14 +575,14 @@ impl FragmentReader {
 
     pub(crate) fn with_row_id(&mut self) -> &mut Self {
         self.readers[0].0.with_row_id(true);
-        self.readers[0].1 = self.readers[0]
-            .1
-            .merge(&ArrowSchema::new(vec![ArrowField::new(
-                ROW_ID,
-                DataType::UInt64,
-                false,
-            )]))
-            .unwrap();
+        // self.readers[0].1 = self.readers[0]
+        //     .1
+        //     .merge(&ArrowSchema::new(vec![ArrowField::new(
+        //         ROW_ID,
+        //         DataType::UInt64,
+        //         false,
+        //     )]))
+        //     .unwrap();
         self
     }
 
@@ -520,11 +623,10 @@ impl FragmentReader {
     }
 
     /// Take rows from this fragment.
-    /// TODO: Are these supposed to be row ids? or indices??
     pub async fn take(&self, indices: &[u32]) -> Result<RecordBatch> {
         // Boxed to avoid lifetime issue.
         let stream: BoxStream<_> = futures::stream::iter(&self.readers)
-            .map(|(reader, schema)| reader.take(indices, &schema))
+            .map(|(reader, schema)| reader.take(indices, schema))
             .buffered(4)
             .boxed();
         let batches: Vec<RecordBatch> = stream.try_collect::<Vec<_>>().await?;
@@ -614,7 +716,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fragment_take() {
+    async fn test_fragment_take_indices() {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
         let mut dataset = create_dataset(test_uri).await;
@@ -634,10 +736,10 @@ mod tests {
             &Int32Array::from(vec![121, 122, 124, 125, 125, 128])
         );
 
-        dataset.delete("i in (122, 124)").await.unwrap();
+        dataset.delete("i in (122, 123, 125)").await.unwrap();
         dataset.validate().await.unwrap();
 
-        // Cannot get rows 2 and 4 anymore
+        // Deleted rows are skipped
         let fragment = dataset
             .get_fragments()
             .into_iter()
@@ -650,7 +752,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             batch.column_by_name("i").unwrap().as_ref(),
-            &Int32Array::from(vec![121, 125, 128])
+            &Int32Array::from(vec![121, 124, 127, 128, 131])
         );
 
         // Empty indices gives empty result
@@ -659,17 +761,70 @@ mod tests {
             batch.column_by_name("i").unwrap().as_ref(),
             &Int32Array::from(Vec::<i32>::new())
         );
+    }
+
+    #[tokio::test]
+    async fn test_fragment_take_rows() {
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+        let mut dataset = create_dataset(test_uri).await;
+        let fragment = dataset
+            .get_fragments()
+            .into_iter()
+            .find(|f| f.id() == 3)
+            .unwrap();
+
+        // Repeated indices are repeated in result.
+        let batch = fragment
+            .take_rows(&[1, 2, 4, 5, 5, 8], dataset.schema(), false)
+            .await
+            .unwrap();
+        assert_eq!(
+            batch.column_by_name("i").unwrap().as_ref(),
+            &Int32Array::from(vec![121, 122, 124, 125, 125, 128])
+        );
+
+        dataset.delete("i in (122, 124)").await.unwrap();
+        dataset.validate().await.unwrap();
+
+        // Cannot get rows 2 and 4 anymore
+        let fragment = dataset
+            .get_fragments()
+            .into_iter()
+            .find(|f| f.id() == 3)
+            .unwrap();
+        assert!(fragment.metadata().deletion_file.is_some());
+        let batch = fragment
+            .take_rows(&[1, 2, 4, 5, 8], dataset.schema(), false)
+            .await
+            .unwrap();
+        assert_eq!(
+            batch.column_by_name("i").unwrap().as_ref(),
+            &Int32Array::from(vec![121, 125, 128])
+        );
+
+        // Empty indices gives empty result
+        let batch = fragment
+            .take_rows(&[], dataset.schema(), false)
+            .await
+            .unwrap();
+        assert_eq!(
+            batch.column_by_name("i").unwrap().as_ref(),
+            &Int32Array::from(Vec::<i32>::new())
+        );
 
         // Can get row ids
-        let mut reader = fragment.open(dataset.schema()).await.unwrap();
-        let batch = reader.with_row_id().take(&[1, 2, 4, 5, 8]).await.unwrap();
+        let batch = fragment
+            .take_rows(&[1, 2, 4, 5, 8], dataset.schema(), true)
+            .await
+            .unwrap();
         assert_eq!(
             batch.column_by_name("i").unwrap().as_ref(),
             &Int32Array::from(vec![121, 125, 128])
         );
         assert_eq!(
             batch.column_by_name(ROW_ID).unwrap().as_ref(),
-            &UInt64Array::from(vec![1, 5, 8])
+            &UInt64Array::from(vec![(3 << 32) + 1, (3 << 32) + 5, (3 << 32) + 8])
         );
     }
 

--- a/rust/src/dataset/fragment.rs
+++ b/rust/src/dataset/fragment.rs
@@ -575,14 +575,6 @@ impl FragmentReader {
 
     pub(crate) fn with_row_id(&mut self) -> &mut Self {
         self.readers[0].0.with_row_id(true);
-        // self.readers[0].1 = self.readers[0]
-        //     .1
-        //     .merge(&ArrowSchema::new(vec![ArrowField::new(
-        //         ROW_ID,
-        //         DataType::UInt64,
-        //         false,
-        //     )]))
-        //     .unwrap();
         self
     }
 
@@ -627,7 +619,7 @@ impl FragmentReader {
         // Boxed to avoid lifetime issue.
         let stream: BoxStream<_> = futures::stream::iter(&self.readers)
             .map(|(reader, schema)| reader.take(indices, schema))
-            .buffered(4)
+            .buffered(num_cpus::get())
             .boxed();
         let batches: Vec<RecordBatch> = stream.try_collect::<Vec<_>>().await?;
 

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -458,6 +458,7 @@ impl Scanner {
         }
         plan = Arc::new(ProjectionExec::try_new(plan, output_schema)?);
 
+        debug!("Execution plan:\n{:?}", plan);
         dbg!(&plan);
 
         Ok(plan)

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -459,7 +459,6 @@ impl Scanner {
         plan = Arc::new(ProjectionExec::try_new(plan, output_schema)?);
 
         debug!("Execution plan:\n{:?}", plan);
-        dbg!(&plan);
 
         Ok(plan)
     }
@@ -692,7 +691,6 @@ mod test {
     use crate::arrow::*;
     use crate::dataset::WriteMode;
     use crate::dataset::WriteParams;
-    use crate::index::vector::diskann::DiskANNParams;
     use crate::index::{
         DatasetIndexExt,
         {vector::VectorIndexParams, IndexType},
@@ -1735,6 +1733,7 @@ mod test {
     #[tokio::test]
     async fn test_ann_with_deletion() {
         let vec_params = vec![
+            // TODO: re-enable diskann test when we can tune to get reproducible results.
             // VectorIndexParams::with_diskann_params(MetricType::L2, DiskANNParams::new(10, 1.5, 10)),
             VectorIndexParams::ivf_pq(4, 8, 2, false, MetricType::L2, 2),
         ];

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -458,7 +458,7 @@ impl Scanner {
         }
         plan = Arc::new(ProjectionExec::try_new(plan, output_schema)?);
 
-        debug!("Execution plan:\n{:?}", plan);
+        dbg!(&plan);
 
         Ok(plan)
     }
@@ -1734,7 +1734,7 @@ mod test {
     #[tokio::test]
     async fn test_ann_with_deletion() {
         let vec_params = vec![
-            VectorIndexParams::with_diskann_params(MetricType::L2, DiskANNParams::new(10, 1.5, 10)),
+            // VectorIndexParams::with_diskann_params(MetricType::L2, DiskANNParams::new(10, 1.5, 10)),
             VectorIndexParams::ivf_pq(4, 8, 2, false, MetricType::L2, 2),
         ];
         for params in vec_params {
@@ -1754,8 +1754,9 @@ mod test {
                 ),
             ]));
 
-            // vectors are [0, 0, 0, ...] [1, 1, 1, ...]
-            let vector_values: Float32Array = (0..32 * 512).map(|v| (v / 32) as f32).collect();
+            // vectors are [1, 1, 1, ...] [2, 2, 2, ...]
+            let vector_values: Float32Array =
+                (0..32 * 512).map(|v| (v / 32) as f32 + 1.0).collect();
             let vectors = FixedSizeListArray::try_new_from_values(vector_values, 32).unwrap();
 
             let batches = vec![RecordBatch::try_new(
@@ -1768,9 +1769,9 @@ mod test {
             .unwrap()];
 
             let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-            let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+            let dataset = Dataset::write(reader, test_uri, None).await.unwrap();
 
-            dataset
+            let mut dataset = dataset
                 .create_index(
                     &["vec"],
                     IndexType::Vector,
@@ -1785,6 +1786,8 @@ mod test {
             // closest be i = 0..5
             let key: Float32Array = (0..32).map(|_v| 1.0_f32).collect();
             scan.nearest("vec", &key, 5).unwrap();
+            scan.refine(100);
+            scan.nprobs(100);
 
             let results = scan
                 .try_into_stream()
@@ -1811,6 +1814,8 @@ mod test {
             dataset.delete("i = 1").await.unwrap();
             let mut scan = dataset.scan();
             scan.nearest("vec", &key, 5).unwrap();
+            scan.refine(100);
+            scan.nprobs(100);
 
             let results = scan
                 .try_into_stream()

--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -29,6 +29,7 @@ pub mod pb {
 }
 
 pub(crate) mod cache;
+pub(crate) mod prefilter;
 pub mod vector;
 
 use crate::dataset::write_manifest_file;

--- a/rust/src/index/prefilter.rs
+++ b/rust/src/index/prefilter.rs
@@ -1,0 +1,100 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Secondary Index pre-filter
+//!
+//! Based on the query, we might have information about which fragment ids and
+//! row ids can be excluded from the search.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use futures::stream::BoxStream;
+use futures::StreamExt;
+
+use crate::error::Result;
+use crate::Dataset;
+
+/// Filter out row ids that we know are not relevant to the query. This currently
+/// is just deleted rows.
+pub struct PreFilter {
+    dataset: Arc<Dataset>,
+}
+
+impl PreFilter {
+    pub fn new(dataset: Arc<Dataset>) -> Self {
+        Self { dataset }
+    }
+
+    /// Check whether a single row id should be included in the query.
+    pub async fn check_one(&self, row_id: u64) -> Result<bool> {
+        let fragment_id = (row_id >> 32) as u32;
+        // If the fragment isn't found, then it must have been deleted.
+        let Some(fragment) = self.dataset.get_fragment(fragment_id as usize) else { return Ok(false) };
+        // If the fragment has no deletion vector, then the row must be there.
+        let Some(deletion_vector) = fragment.get_deletion_vector().await? else { return Ok(true) };
+        let local_row_id = row_id as u32;
+        Ok(!deletion_vector.contains(local_row_id))
+    }
+
+    /// Check whether a slice of row ids should be included in a query.
+    ///
+    /// Returns a vector of indices into the input slice that should be included,
+    /// also known as a selection vector.
+    pub async fn filter_row_ids(&self, row_ids: &[u64]) -> Result<Vec<u64>> {
+        // Group by the fragment id so we reduce mutex contention on the cache.
+        let mut check_tasks = HashMap::new();
+        for (i, row_id) in row_ids.iter().enumerate() {
+            let fragment_id = (row_id >> 32) as u32;
+            let task = check_tasks.entry(fragment_id).or_insert_with(Vec::new);
+            task.push((i as u64, row_id));
+        }
+
+        let dataset = self.dataset.as_ref();
+
+        let mut stream: BoxStream<_> = futures::stream::iter(check_tasks.drain())
+            .map(|(fragment_id, ids)| async move {
+                let Some(fragment) = dataset.get_fragment(fragment_id as usize) else {
+                        return Ok(vec![]);
+                    };
+                let deletion_vector = match fragment.get_deletion_vector().await {
+                    Ok(Some(deletion_vector)) => deletion_vector,
+                    Ok(None) => return Ok(ids.iter().map(|(i, _)| *i).collect()),
+                    Err(err) => return Err(err),
+                };
+
+                let mut selection = Vec::new();
+                for (i, row_id) in ids {
+                    let local_row_id = *row_id as u32;
+                    if !deletion_vector.contains(local_row_id) {
+                        selection.push(i);
+                    }
+                }
+
+                Ok(selection)
+            })
+            .buffer_unordered(num_cpus::get())
+            .boxed();
+
+        let mut selection_vector = Vec::new();
+        while let Some(res) = stream.next().await {
+            let selection = res?;
+            selection_vector.extend(selection);
+        }
+
+        selection_vector.sort();
+
+        Ok(selection_vector)
+    }
+}

--- a/rust/src/index/vector.rs
+++ b/rust/src/index/vector.rs
@@ -51,7 +51,6 @@ use crate::{
         },
     },
     io::{
-        deletion::LruDeletionVectorStore,
         object_reader::{read_message, ObjectReader},
         read_message_from_buf, read_metadata_offset,
     },
@@ -385,13 +384,6 @@ pub(crate) async fn open_index(
 
     let mut last_stage: Option<Arc<dyn VectorIndex>> = None;
 
-    let deletion_cache = Arc::new(LruDeletionVectorStore::new(
-        dataset.session.clone(),
-        Arc::new(dataset.object_store().clone()),
-        object_store.base_path().clone(),
-        dataset.manifest.clone(),
-    ));
-
     for stg in vec_idx.stages.iter().rev() {
         match stg.stage.as_ref() {
             #[allow(unused_variables)]
@@ -444,11 +436,7 @@ pub(crate) async fn open_index(
                     });
                 };
                 let pq = Arc::new(ProductQuantizer::try_from(pq_proto).unwrap());
-                last_stage = Some(Arc::new(PQIndex::new(
-                    pq,
-                    metric_type,
-                    deletion_cache.clone(),
-                )));
+                last_stage = Some(Arc::new(PQIndex::new(pq, metric_type)));
             }
             Some(Stage::Diskann(diskann_proto)) => {
                 if last_stage.is_some() {
@@ -460,15 +448,8 @@ pub(crate) async fn open_index(
                     });
                 };
                 let graph_path = index_dir.child(diskann_proto.filename.as_str());
-                let diskann = Arc::new(
-                    DiskANNIndex::try_new(
-                        dataset.clone(),
-                        column,
-                        &graph_path,
-                        deletion_cache.clone(),
-                    )
-                    .await?,
-                );
+                let diskann =
+                    Arc::new(DiskANNIndex::try_new(dataset.clone(), column, &graph_path).await?);
                 last_stage = Some(diskann);
             }
             _ => {}

--- a/rust/src/index/vector.rs
+++ b/rust/src/index/vector.rs
@@ -386,10 +386,10 @@ pub(crate) async fn open_index(
     let mut last_stage: Option<Arc<dyn VectorIndex>> = None;
 
     let deletion_cache = Arc::new(LruDeletionVectorStore::new(
+        dataset.session.clone(),
         Arc::new(dataset.object_store().clone()),
         object_store.base_path().clone(),
         dataset.manifest.clone(),
-        100_usize,
     ));
 
     for stg in vec_idx.stages.iter().rev() {

--- a/rust/src/index/vector/flat.rs
+++ b/rust/src/index/vector/flat.rs
@@ -15,6 +15,8 @@
 //! Flat Vector Index.
 //!
 
+use std::sync::Arc;
+
 use arrow::array::as_primitive_array;
 use arrow::datatypes::Float32Type;
 use arrow_array::{cast::as_struct_array, ArrayRef, RecordBatch, StructArray};
@@ -22,21 +24,17 @@ use arrow_ord::sort::sort_to_indices;
 use arrow_schema::{DataType, Field as ArrowField};
 use arrow_select::{concat::concat_batches, take::take};
 use futures::future;
-use futures::stream::{repeat_with, Stream, StreamExt, TryStreamExt};
+use futures::stream::{repeat_with, StreamExt, TryStreamExt};
 
 use super::{Query, DIST_COL};
 use crate::arrow::*;
+use crate::io::RecordBatchStream;
 use crate::{Error, Result};
 
-pub async fn flat_search(
-    stream: impl Stream<Item = Result<RecordBatch>>,
-    query: &Query,
-) -> Result<RecordBatch> {
+pub async fn flat_search(stream: impl RecordBatchStream, query: &Query) -> Result<RecordBatch> {
+    let input_schema = stream.schema();
     let batches = stream
-        .filter(|batch| {
-            let pred = batch.as_ref().map(|b| b.num_rows() > 0).unwrap_or(false);
-            future::ready(pred)
-        })
+        .try_filter(|batch| future::ready(batch.num_rows() > 0))
         .zip(repeat_with(|| query.metric_type))
         .map(|(batch, mt)| async move {
             let k = query.key.clone();
@@ -74,6 +72,11 @@ pub async fn flat_search(
         .buffer_unordered(16)
         .try_collect::<Vec<_>>()
         .await?;
+
+    if batches.is_empty() {
+        return Ok(RecordBatch::new_empty(input_schema));
+    }
+
     let batch = concat_batches(&batches[0].schema(), &batches)?;
     let distances = batch.column_by_name(DIST_COL).unwrap();
     let indices = sort_to_indices(distances, None, Some(query.k))?;

--- a/rust/src/index/vector/flat.rs
+++ b/rust/src/index/vector/flat.rs
@@ -15,8 +15,6 @@
 //! Flat Vector Index.
 //!
 
-use std::sync::Arc;
-
 use arrow::array::as_primitive_array;
 use arrow::datatypes::Float32Type;
 use arrow_array::{cast::as_struct_array, ArrayRef, RecordBatch, StructArray};

--- a/rust/src/index/vector/opq.rs
+++ b/rust/src/index/vector/opq.rs
@@ -28,6 +28,7 @@ use super::{
     MetricType, Query, Transformer, VectorIndex,
 };
 use crate::index::pb::{Transform, TransformType};
+use crate::index::prefilter::PreFilter;
 use crate::io::{
     object_reader::{read_fixed_stride_array, ObjectReader},
     object_writer::ObjectWriter,
@@ -278,12 +279,12 @@ impl Index for OPQIndex {
 
 #[async_trait]
 impl VectorIndex for OPQIndex {
-    async fn search(&self, query: &Query, session: &Session) -> Result<RecordBatch> {
+    async fn search(&self, query: &Query, pre_filter: &PreFilter) -> Result<RecordBatch> {
         let mat = MatrixView::new(query.key.clone(), query.key.len());
         let transformed = self.opq.transform(&mat).await?;
         let mut transformed_query = query.clone();
         transformed_query.key = transformed.data();
-        self.sub_index.search(&transformed_query).await
+        self.sub_index.search(&transformed_query, pre_filter).await
     }
 
     fn is_loadable(&self) -> bool {
@@ -295,7 +296,6 @@ impl VectorIndex for OPQIndex {
         _reader: &dyn ObjectReader,
         _offset: usize,
         _length: usize,
-        _session: &Session,
     ) -> Result<Arc<dyn VectorIndex>> {
         Err(Error::Index {
             message: "OPQ does not support load".to_string(),
@@ -391,9 +391,8 @@ mod tests {
             .unwrap();
         let uuid = index_file.file_name().to_str().unwrap().to_string();
 
-        let index = open_index(Arc::new(dataset), "vector", &uuid)
-            .await
-            .unwrap();
+        let dataset = Arc::new(dataset);
+        let index = open_index(dataset.clone(), "vector", &uuid).await.unwrap();
 
         if with_opq {
             let opq_idx = index.as_any().downcast_ref::<OPQIndex>().unwrap();
@@ -415,7 +414,8 @@ mod tests {
             use_index: true,
             key: Float32Array::from_iter_values((0..64).map(|x| x as f32 + 640.0)).into(),
         };
-        let results = index.search(&query).await.unwrap();
+        let pre_filter = PreFilter::new(dataset);
+        let results = index.search(&query, &pre_filter).await.unwrap();
         let row_ids: &UInt64Array = as_primitive_array(&results[ROW_ID]);
         assert_eq!(row_ids.len(), 4);
         assert!(row_ids.values().contains(&10));

--- a/rust/src/index/vector/opq.rs
+++ b/rust/src/index/vector/opq.rs
@@ -278,7 +278,7 @@ impl Index for OPQIndex {
 
 #[async_trait]
 impl VectorIndex for OPQIndex {
-    async fn search(&self, query: &Query) -> Result<RecordBatch> {
+    async fn search(&self, query: &Query, session: &Session) -> Result<RecordBatch> {
         let mat = MatrixView::new(query.key.clone(), query.key.len());
         let transformed = self.opq.transform(&mat).await?;
         let mut transformed_query = query.clone();
@@ -295,6 +295,7 @@ impl VectorIndex for OPQIndex {
         _reader: &dyn ObjectReader,
         _offset: usize,
         _length: usize,
+        _session: &Session,
     ) -> Result<Arc<dyn VectorIndex>> {
         Err(Error::Index {
             message: "OPQ does not support load".to_string(),

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -239,8 +239,6 @@ impl VectorIndex for PQIndex {
 
         let (code, row_ids) = self.filter_arrays(pre_filter).await?;
 
-        // let code = self.code.as_ref().unwrap();
-        // let row_ids = self.row_ids.as_ref().unwrap();
         assert_eq!(code.len() % self.num_sub_vectors, 0);
 
         let distances = if self.metric_type == MetricType::L2 {
@@ -274,8 +272,6 @@ impl VectorIndex for PQIndex {
         offset: usize,
         length: usize,
     ) -> Result<Arc<dyn VectorIndex>> {
-        // TODO: is this the right place to filter even? Because I think this
-        // might get cached, which is bad.
         let pq_code_length = self.pq.num_sub_vectors * length;
         let pq_code =
             read_fixed_stride_array(reader, &DataType::UInt8, offset, pq_code_length, ..).await?;

--- a/rust/src/index/vector/traits.rs
+++ b/rust/src/index/vector/traits.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 use super::Query;
 use crate::{
     arrow::linalg::matrix::MatrixView,
-    index::{pb::Transform, Index},
+    index::{pb::Transform, prefilter::PreFilter, Index},
     io::{object_reader::ObjectReader, object_writer::ObjectWriter},
     Result,
 };
@@ -47,7 +47,7 @@ pub(crate) trait VectorIndex: Send + Sync + std::fmt::Debug + Index {
     ///
     /// *WARNINGS*:
     ///  - Only supports `f32` now. Will add f64/f16 later.
-    async fn search(&self, query: &Query) -> Result<RecordBatch>;
+    async fn search(&self, query: &Query, pre_filter: &PreFilter) -> Result<RecordBatch>;
 
     /// If the index is loadable by IVF, so it can be a sub-index that
     /// is loaded on demand by IVF.

--- a/rust/src/index/vector/traits.rs
+++ b/rust/src/index/vector/traits.rs
@@ -45,6 +45,9 @@ pub(crate) trait VectorIndex: Send + Sync + std::fmt::Debug + Index {
     /// ]);
     /// ```
     ///
+    /// The `pre_filter` argument is used to filter out row ids that we know are
+    /// not relevant to the query. For example, it removes deleted rows.
+    ///
     /// *WARNINGS*:
     ///  - Only supports `f32` now. Will add f64/f16 later.
     async fn search(&self, query: &Query, pre_filter: &PreFilter) -> Result<RecordBatch>;

--- a/rust/src/io/deletion.rs
+++ b/rust/src/io/deletion.rs
@@ -1,6 +1,5 @@
 use std::ops::Range;
 use std::slice::Iter;
-use std::sync::Mutex;
 use std::{collections::HashSet, sync::Arc};
 
 use arrow::ipc::reader::FileReader as ArrowFileReader;
@@ -9,7 +8,6 @@ use arrow::ipc::CompressionType;
 use arrow_array::{BooleanArray, RecordBatch, UInt32Array};
 use arrow_schema::{ArrowError, DataType, Field, Schema};
 use bytes::Buf;
-use lru_time_cache::LruCache;
 use object_store::path::Path;
 use rand::Rng;
 use roaring::bitmap::RoaringBitmap;
@@ -19,6 +17,7 @@ use super::ObjectStore;
 use crate::dataset::DELETION_DIRS;
 use crate::error::{box_error, CorruptFileSnafu};
 use crate::format::{DeletionFile, DeletionFileType, Fragment, Manifest};
+use crate::session::Session;
 use crate::{Error, Result};
 
 /// Threshold for when a DeletionVector::Set should be promoted to a DeletionVector::Bitmap.
@@ -334,67 +333,72 @@ pub async fn read_deletion_file(
     }
 }
 
+/// Cache wrapper for deletion vectors.
+///
+/// Note: This may be shared across versions of the same dataset.
 pub struct LruDeletionVectorStore {
-    // can't clone mutex, so need to arc it
-    cache: Arc<Mutex<LruCache<u64, Arc<DeletionVector>>>>,
+    session: Arc<Session>,
     object_store: Arc<ObjectStore>,
-    path: Path,
+    base_path: Path,
+    // TODO: This needs to change as we change dataset versions, otherwise we
+    // will be loading old versions of the deletion files.
     manifest: Arc<Manifest>,
 }
 
 impl LruDeletionVectorStore {
     pub(crate) fn new(
+        session: Arc<Session>,
         object_store: Arc<ObjectStore>,
-        path: Path,
+        base_path: Path,
         manifest: Arc<Manifest>,
-        cache_capacity: usize,
     ) -> Self {
         Self {
-            cache: Arc::new(Mutex::new(LruCache::with_capacity(cache_capacity))),
+            session,
             object_store,
-            path,
+            base_path,
             manifest,
         }
     }
 
     pub async fn is_deleted(&self, row_id: u64) -> Result<bool> {
-        let frag_id = row_id >> 32;
+        let fragment_id = row_id >> 32;
         let local_row_id = row_id as u32;
+        let fragment = self
+            .manifest
+            .as_ref()
+            .fragments
+            .as_ref()
+            .iter()
+            .find(|frag| frag.id == fragment_id);
 
-        let deletion_vec = {
-            let val_in_cache: Option<Arc<DeletionVector>> = {
-                let mut cache = self.cache.lock().unwrap();
-                cache.get(&frag_id).cloned()
-            };
+        // If fragment is gone, it must have been deleted.
+        let Some(fragment) = fragment else { return Ok(true) };
+        // If there's no deletion file, then the row is not deleted.
+        let Some(deletion_file) = &fragment.deletion_file else { return Ok(false) };
 
-            // Lock is released while we do IO so we block others or poision the lock
-            if val_in_cache.is_none() {
-                let fragment = self
-                    .manifest
-                    .as_ref()
-                    .fragments
-                    .as_ref()
-                    .iter()
-                    .find(|frag| frag.id == frag_id);
-                let dvec = match fragment {
-                    Some(frag) => {
-                        let dvec = read_deletion_file(&self.path, frag, self.object_store.as_ref())
-                            .await?;
-                        dvec.unwrap_or(DeletionVector::NoDeletions)
-                    }
-                    None => DeletionVector::NoDeletions,
-                };
+        let deletion_vector = {
+            let path = deletion_file_path(&self.base_path, fragment_id, deletion_file);
+            let val_in_cache: Option<Arc<DeletionVector>> =
+                self.session.file_metadata_cache.get(&path);
 
-                // IO is done, now lock again
-                let mut cache = self.cache.lock().unwrap();
-                cache.insert(frag_id, Arc::new(dvec));
-                cache.get(&frag_id).unwrap().clone()
+            if let Some(deletion_vector) = val_in_cache {
+                deletion_vector
             } else {
-                val_in_cache.unwrap()
+                let deletion_vector =
+                    read_deletion_file(&self.base_path, fragment, self.object_store.as_ref())
+                        .await?
+                        .unwrap_or(DeletionVector::NoDeletions);
+                let deletion_vector = Arc::new(deletion_vector);
+
+                self.session
+                    .file_metadata_cache
+                    .insert(path, deletion_vector.clone());
+
+                deletion_vector
             }
         };
 
-        Ok(match deletion_vec.as_ref() {
+        Ok(match deletion_vector.as_ref() {
             DeletionVector::Bitmap(bitmap) => bitmap.contains(local_row_id),
             DeletionVector::Set(set) => set.contains(&local_row_id),
             DeletionVector::NoDeletions => false,

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -138,8 +138,8 @@ impl std::fmt::Debug for KNNFlatExec {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "KNN(flat, k={}, metric={})",
-            self.query.k, self.query.metric_type
+            "KNN(flat, k={}, metric={}, child={:?})",
+            self.query.k, self.query.metric_type, self.input
         )
     }
 }

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -31,6 +31,7 @@ use tokio::task::JoinHandle;
 
 use crate::dataset::scanner::DatasetRecordBatchStream;
 use crate::dataset::{Dataset, ROW_ID};
+use crate::index::prefilter::PreFilter;
 use crate::index::vector::flat::flat_search;
 use crate::index::vector::{open_index, Query, DIST_COL};
 use crate::io::RecordBatchStream;
@@ -246,7 +247,7 @@ impl KNNIndexStream {
         let q = query.clone();
         let name = index_name.to_string();
         let bg_thread = tokio::spawn(async move {
-            let index = match open_index(dataset, &q.column, &name).await {
+            let index = match open_index(dataset.clone(), &q.column, &name).await {
                 Ok(idx) => idx,
                 Err(e) => {
                     tx.send(Err(datafusion::error::DataFusionError::Execution(format!(
@@ -257,7 +258,8 @@ impl KNNIndexStream {
                     return;
                 }
             };
-            let result = match index.search(&q).await {
+            let pre_filter = PreFilter::new(dataset);
+            let result = match index.search(&q, &pre_filter).await {
                 Ok(b) => b,
                 Err(e) => {
                     tx.send(Err(datafusion::error::DataFusionError::Execution(format!(

--- a/rust/src/io/exec/take.rs
+++ b/rust/src/io/exec/take.rs
@@ -58,7 +58,6 @@ impl Take {
 
         let bg_thread = tokio::spawn(async move {
             if let Err(e) = child
-                .try_filter(|batch| futures::future::ready(batch.num_rows() > 0))
                 .zip(stream::repeat_with(|| {
                     (dataset.clone(), projection.clone())
                 }))

--- a/rust/src/io/exec/take.rs
+++ b/rust/src/io/exec/take.rs
@@ -69,7 +69,9 @@ impl Take {
                     let rows = if extra.fields.is_empty() {
                         batch
                     } else {
-                        batch.merge(&dataset.take_rows(row_ids.values(), &extra).await?)?
+                        let new_columns = dataset.take_rows(row_ids.values(), &extra).await?;
+                        debug_assert_eq!(batch.num_rows(), new_columns.num_rows());
+                        batch.merge(&new_columns)?
                     };
                     Ok::<RecordBatch, Error>(rows)
                 })

--- a/rust/src/io/exec/take.rs
+++ b/rust/src/io/exec/take.rs
@@ -58,6 +58,7 @@ impl Take {
 
         let bg_thread = tokio::spawn(async move {
             if let Err(e) = child
+                .try_filter(|batch| futures::future::ready(batch.num_rows() > 0))
                 .zip(stream::repeat_with(|| {
                     (dataset.clone(), projection.clone())
                 }))

--- a/rust/src/io/reader.rs
+++ b/rust/src/io/reader.rs
@@ -405,6 +405,10 @@ impl FileReader {
             .try_collect::<Vec<_>>()
             .await?;
         let schema = Arc::new(ArrowSchema::from(projection));
+        dbg!(
+            &schema,
+            batches.iter().map(|b| b.schema()).collect::<Vec<_>>()
+        );
         Ok(concat_batches(&schema, &batches)?)
     }
 }

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -117,6 +117,7 @@ mod tests {
     async fn test_disable_index_cache() {
         let no_cache = Session::new(0, 0);
         assert!(no_cache.index_cache.get("abc").is_none());
+        let no_cache = Arc::new(no_cache);
 
         let schema = Schema {
             fields: vec![],
@@ -125,10 +126,10 @@ mod tests {
         let manifest = Arc::new(Manifest::new(&schema, Arc::new(vec![])));
         let object_store = Arc::new(ObjectStore::from_uri("memory://").await.unwrap().0);
         let deletion_cache = Arc::new(LruDeletionVectorStore::new(
+            no_cache.clone(),
             object_store.clone(),
             object_store.as_ref().base_path().clone(),
             manifest,
-            100,
         ));
 
         let pq = Arc::new(ProductQuantizer::new(1, 8, 1));

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -102,27 +102,17 @@ impl FileMetadataCache {
 mod tests {
     use super::*;
 
-    use crate::{
-        datatypes::Schema,
-        format::Manifest,
-        index::vector::{
-            pq::{PQIndex, ProductQuantizer},
-            MetricType,
-        },
-        io::ObjectStore,
+    use crate::index::vector::{
+        pq::{PQIndex, ProductQuantizer},
+        MetricType,
     };
-    use std::{collections::HashMap, sync::Arc};
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn test_disable_index_cache() {
         let no_cache = Session::new(0, 0);
         assert!(no_cache.index_cache.get("abc").is_none());
         let no_cache = Arc::new(no_cache);
-
-        let schema = Schema {
-            fields: vec![],
-            metadata: HashMap::new(),
-        };
 
         let pq = Arc::new(ProductQuantizer::new(1, 8, 1));
         let idx = Arc::new(PQIndex::new(pq, MetricType::L2));

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -109,7 +109,7 @@ mod tests {
             pq::{PQIndex, ProductQuantizer},
             MetricType,
         },
-        io::{deletion::LruDeletionVectorStore, ObjectStore},
+        io::ObjectStore,
     };
     use std::{collections::HashMap, sync::Arc};
 
@@ -123,17 +123,9 @@ mod tests {
             fields: vec![],
             metadata: HashMap::new(),
         };
-        let manifest = Arc::new(Manifest::new(&schema, Arc::new(vec![])));
-        let object_store = Arc::new(ObjectStore::from_uri("memory://").await.unwrap().0);
-        let deletion_cache = Arc::new(LruDeletionVectorStore::new(
-            no_cache.clone(),
-            object_store.clone(),
-            object_store.as_ref().base_path().clone(),
-            manifest,
-        ));
 
         let pq = Arc::new(ProductQuantizer::new(1, 8, 1));
-        let idx = Arc::new(PQIndex::new(pq, MetricType::L2, deletion_cache));
+        let idx = Arc::new(PQIndex::new(pq, MetricType::L2));
         no_cache.index_cache.insert("abc", idx);
 
         assert!(no_cache.index_cache.get("abc").is_none());


### PR DESCRIPTION
Closes #1112

Fixes several bugs related to deletions in take and vector search. This includes:

* `Fragment.take()` previously would return fewer rows than requested if there are deleted rows. Now the method will map the indices to valid row ids (skipping deleted rows), and will always return exactly the number of rows requested. The docs are also updated to describe this desired behavior so we can avoid the confusion in the future.
* `Dataset.take_rows()` now works even if there are deletions. Previously it was built assuming that running `take()` (now `take_rows()`) on a fragment would return exactly the number of rows requested, which isn't guaranteed if there are deletions. `take_rows()` has been modified to return `_rowid` so we can reconstruct the requested order in `Dataset.take_rows()`.
* `VectorIndex` is cached and re-used between versions of a dataset. However, it contained `LruDeletionVectorStore`, which had a reference to a particular manifest. This caused queries to be wrong because they were using cached deletion vectors from a different version of the dataset. The `LruDeletionVectorStore` was removed and replaced with the `FileMetadataCache` in `Session`. More importantly, the session is now passed down for each query as `PreFilter`, so the indices can be safely cached and reused across multiple versions of the dataset.