### PR TITLE
ci: fix the release commit script

### DIFF
--- a/.github/workflows/make-release-commit.yml
+++ b/.github/workflows/make-release-commit.yml
@@ -43,6 +43,8 @@ jobs:
     - name: Create tag
       working-directory: rust
       run: |
+        git add -u
+        git commit -m "Bump version"
         export TAG="v$(cargo metadata --no-deps --format-version 1 | jq '.packages[0].version' | xargs echo)"
         git tag $TAG
     - name: Push new version and tag


### PR DESCRIPTION
Pushing a new tag isn't useful if it doesn't contain the changes we want.