### PR TITLE
Implement L2/norm/cosine/dot for bf16/f16/f64

### DIFF
--- a/rust/src/linalg/cosine.rs
+++ b/rust/src/linalg/cosine.rs
@@ -17,7 +17,6 @@ use std::sync::Arc;
 
 use arrow_array::Float32Array;
 use num_traits::real::Real;
-use half::f16;
 
 use super::dot::dot;
 use super::norm_l2::norm_l2;
@@ -31,18 +30,6 @@ pub trait Cosine {
 
     /// Fast cosine function, that assumes that the norm of the first vector is already known.
     fn cosine_fast(&self, x_norm: Self::Output, other: &Self) -> Self::Output;
-}
-
-impl Cosine for [f16] {
-    type Output = f16;
-
-    fn cosine(&self, other: &Self) -> Self::Output {
-        todo!()
-    }
-
-    fn cosine_fast(&self, x_norm: Self::Output, other: &Self) -> Self::Output {
-        todo!()
-    }
 }
 
 impl Cosine for [f32] {
@@ -91,7 +78,7 @@ pub fn cosine_distance(from: &[f32], to: &[f32]) -> f32 {
 /// Cosine Distance
 ///
 /// <https://en.wikipedia.org/wiki/Cosine_similarity>
-pub fn cosine_distance_batch<T: Cosine>(from: &T, to: &T, dimension: usize) -> Arc<> {
+pub fn cosine_distance_batch(from: &[f32], to: &[f32], dimension: usize) -> Arc<Float32Array> {
     let x_norm = norm_l2(from);
 
     let dists = unsafe {
@@ -203,9 +190,6 @@ mod tests {
     use super::*;
 
     use approx::assert_relative_eq;
-    use arrow_array::Float16Array;
-    use half::f16;
-    use num_traits::{AsPrimitive, FromPrimitive};
 
     #[test]
     fn test_cosine() {
@@ -229,12 +213,5 @@ mod tests {
         let d = cosine_distance_batch(x.values(), y.values(), 2);
         assert_relative_eq!(d.value(0), 0.0);
         assert_relative_eq!(d.value(1), 0.0);
-    }
-
-    #[test]
-    fn test_cosine_f16() {
-        let x: Float16Array = (1..9).map(|v| f16::from_i32(v)).collect();
-        let y: Float16Array = (100..108).map(|v| f16::from_i32(v)).collect();
-        let d = cosine_distance_batch(x.values(), y.values(), 8);
     }
 }

--- a/rust/src/linalg/dot.rs
+++ b/rust/src/linalg/dot.rs
@@ -18,6 +18,7 @@ use std::iter::Sum;
 use std::sync::Arc;
 
 use arrow_array::Float32Array;
+use half::{bf16, f16};
 use num_traits::real::Real;
 
 #[inline]
@@ -32,10 +33,34 @@ pub trait Dot {
     fn dot(&self, other: &Self) -> Self::Output;
 }
 
+impl Dot for [bf16] {
+    type Output = bf16;
+
+    fn dot(&self, other: &[bf16]) -> bf16 {
+        dot(self, other)
+    }
+}
+
+impl Dot for [f16] {
+    type Output = f16;
+
+    fn dot(&self, other: &[f16]) -> f16 {
+        dot(self, other)
+    }
+}
+
 impl Dot for [f32] {
     type Output = f32;
 
     fn dot(&self, other: &[f32]) -> f32 {
+        dot(self, other)
+    }
+}
+
+impl Dot for [f64] {
+    type Output = f64;
+
+    fn dot(&self, other: &[f64]) -> f64 {
         dot(self, other)
     }
 }

--- a/rust/src/linalg/l2.rs
+++ b/rust/src/linalg/l2.rs
@@ -19,8 +19,8 @@ use std::iter::Sum;
 use std::sync::Arc;
 
 use arrow_array::Float32Array;
-use num_traits::real::Real;
 use half::{bf16, f16};
+use num_traits::real::Real;
 
 /// Calculate the L2 distance between two vectors.
 ///

--- a/rust/src/linalg/l2.rs
+++ b/rust/src/linalg/l2.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use arrow_array::Float32Array;
 use num_traits::real::Real;
+use half::{bf16, f16};
 
 /// Calculate the L2 distance between two vectors.
 ///
@@ -39,6 +40,26 @@ fn l2_scalar<T: Real + Sum>(from: &[T], to: &[T]) -> T {
         .zip(to.iter())
         .map(|(a, b)| (a.sub(*b).powi(2)))
         .sum::<T>()
+}
+
+impl L2 for [bf16] {
+    type Output = bf16;
+
+    #[inline]
+    fn l2(&self, other: &[bf16]) -> bf16 {
+        // TODO: add SIMD support
+        l2_scalar(self, other)
+    }
+}
+
+impl L2 for [f16] {
+    type Output = f16;
+
+    #[inline]
+    fn l2(&self, other: &[f16]) -> f16 {
+        // TODO: add SIMD support
+        l2_scalar(self, other)
+    }
 }
 
 impl L2 for [f32] {
@@ -76,6 +97,16 @@ impl L2 for Float32Array {
     #[inline]
     fn l2(&self, other: &Self) -> f32 {
         self.values().l2(other.values())
+    }
+}
+
+impl L2 for [f64] {
+    type Output = f64;
+
+    #[inline]
+    fn l2(&self, other: &[f64]) -> f64 {
+        // TODO: add SIMD support
+        l2_scalar(self, other)
     }
 }
 

--- a/rust/src/linalg/norm_l2.rs
+++ b/rust/src/linalg/norm_l2.rs
@@ -12,6 +12,68 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use half::{bf16, f16};
+use num_traits::Float;
+
+/// L2 normalization
+pub trait Normalize<T: Float> {
+    type Output;
+
+    /// L2 Normalization over a Vector.
+    fn norm_l2(&self) -> Self::Output;
+}
+
+impl Normalize<f16> for &[f16] {
+    type Output = f16;
+
+    #[inline]
+    fn norm_l2(&self) -> Self::Output {
+        // Aarch64 does not have SIMD for f16
+        self.iter().map(|v| v * v).sum::<f16>().sqrt()
+    }
+}
+
+impl Normalize<bf16> for &[bf16] {
+    type Output = bf16;
+
+    #[inline]
+    fn norm_l2(&self) -> Self::Output {
+        // Aarch64 does not have SIMD for bf16
+        self.iter().map(|v| v * v).sum::<bf16>().sqrt()
+    }
+}
+
+impl Normalize<f32> for &[f32] {
+    type Output = f32;
+
+    #[inline]
+    fn norm_l2(&self) -> Self::Output {
+        #[cfg(target_arch = "aarch64")]
+        {
+            aarch64::neon::norm_l2(self)
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("fma") {
+                return x86_64::avx::norm_l2_f32(self);
+            }
+        }
+
+        #[cfg(not(target_arch = "aarch64"))]
+        self.iter().map(|v| v * v).sum::<f32>().sqrt()
+    }
+}
+
+impl Normalize<f64> for &[f64] {
+    type Output = f64;
+
+    #[inline]
+    fn norm_l2(&self) -> Self::Output {
+        self.iter().map(|v| v * v).sum::<f64>().sqrt()
+    }
+}
+
 /// Normalize a vector.
 ///
 /// The parameters must be cache line aligned. For example, from
@@ -83,19 +145,41 @@ mod aarch64 {
 
 #[cfg(test)]
 mod tests {
+    use num_traits::{Float, FromPrimitive};
+
     use super::*;
+
+    macro_rules! do_norm_l2_test {
+        ($t: ty) => {
+            let data = (1..=8)
+                .map(|v| <$t>::from_i32(v).unwrap())
+                .collect::<Vec<$t>>();
+
+            let result = data.as_slice().norm_l2();
+            assert_eq!(
+                result,
+                (1..=8)
+                    .map(|v| <$t>::from_i32(v * v).unwrap())
+                    .sum::<$t>()
+                    .sqrt()
+            );
+
+            let not_aligned = (&data[2..]).norm_l2();
+            assert_eq!(
+                not_aligned,
+                (3..=8)
+                    .map(|v| <$t>::from_i32(v * v).unwrap())
+                    .sum::<$t>()
+                    .sqrt()
+            );
+        };
+    }
 
     #[test]
     fn test_norm_l2() {
-        let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
-
-        let result = norm_l2(&data);
-        assert_eq!(result, (1..=8).map(|v| (v * v) as f32).sum::<f32>().sqrt());
-
-        let not_aligned = norm_l2(&data[2..]);
-        assert_eq!(
-            not_aligned,
-            (3..=8).map(|v| (v * v) as f32).sum::<f32>().sqrt()
-        );
+        do_norm_l2_test!(bf16);
+        do_norm_l2_test!(f16);
+        do_norm_l2_test!(f32);
+        do_norm_l2_test!(f64);
     }
 }


### PR DESCRIPTION
Implement L2 normalization for f16/bf16/f64. No SIMD yet. 

Aarch64 neon instructions do not have f16/bf16 instructions. 