### PR TITLE
feat: upgrade to datafusion 28.0.0 and arrow 43.0

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -11,10 +11,10 @@ name = "lance"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow = { version = "42.0.0", features = ["pyarrow"] }
-arrow-array = "42.0"
-arrow-data = "42.0"
-arrow-schema = "42.0"
+arrow = { version = "43.0.0", features = ["pyarrow"] }
+arrow-array = "43.0"
+arrow-data = "43.0"
+arrow-schema = "43.0"
 async-trait = "0.1"
 chrono = "0.4.23"
 env_logger = "0.10"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -28,16 +28,16 @@ no-default-features = true
 
 [dependencies]
 bytes = "1.3"
-arrow-arith = "42.0"
-arrow-array = "42.0"
-arrow-buffer = "42.0"
-arrow-cast = "42.0"
-arrow-data = "42.0"
-arrow-ipc = { version = "42.0", features = ["zstd"] }
-arrow-ord = "42.0"
-arrow-row = "42.0"
-arrow-schema = "42.0"
-arrow-select = "42.0"
+arrow-arith = "43.0"
+arrow-array = "43.0"
+arrow-buffer = "43.0"
+arrow-cast = "43.0"
+arrow-data = "43.0"
+arrow-ipc = { version = "43.0", features = ["zstd"] }
+arrow-ord = "43.0"
+arrow-row = "43.0"
+arrow-schema = "43.0"
+arrow-select = "43.0"
 async-recursion = "1.0"
 async-trait = "0.1.60"
 byteorder = "1.4.3"
@@ -62,10 +62,10 @@ futures = "0.3.27"
 uuid = { version = "1.2", features = ["v4"] }
 path-absolutize = "3.0.14"
 shellexpand = "3.0.0"
-arrow = { version = "42.0.0", features = ["prettyprint"] }
+arrow = { version = "43.0.0", features = ["prettyprint"] }
 num_cpus = "1.0"
 # TODO: use datafusion sub-modules to reduce build size?
-datafusion = { version = "27.0.0", default-features = false, features = ["regex_expressions"] }
+datafusion = { version = "28.0.0", default-features = false, features = ["regex_expressions"] }
 lapack = { version = "0.19.0", optional = true }
 cblas =  { version = "0.4.0", optional = true }
 lru_time_cache = "0.11"

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -149,7 +149,11 @@ impl DisplayAs for KNNFlatExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                std::fmt::Debug::fmt(&self, f)
+                write!(
+                    f,
+                    "KNNFlat: k={} metric={}",
+                    self.query.k, self.query.metric_type
+                )
             }
         }
     }
@@ -358,7 +362,7 @@ impl DisplayAs for KNNIndexExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                std::fmt::Debug::fmt(&self, f)
+                write!(f, "KNNIndex: name={}, k={}", self.index_name, self.query.k)
             }
         }
     }
@@ -570,6 +574,7 @@ mod tests {
 
         let input: Arc<dyn ExecutionPlan> = Arc::new(TestingExec::new(vec![batch]));
         let idx = KNNFlatExec::try_new(input, query).unwrap();
+        println!("{:?}", idx);
         assert_eq!(
             idx.schema().as_ref(),
             &ArrowSchema::new(vec![

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -21,8 +21,8 @@ use arrow_array::RecordBatch;
 use arrow_schema::{DataType, Field, Schema};
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::physical_plan::{
-    ExecutionPlan, Partitioning, RecordBatchStream as DFRecordBatchStream,
-    SendableRecordBatchStream, Statistics,
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
+    RecordBatchStream as DFRecordBatchStream, SendableRecordBatchStream, Statistics,
 };
 use futures::stream::Stream;
 use futures::FutureExt;
@@ -142,6 +142,16 @@ impl std::fmt::Debug for KNNFlatExec {
             "KNN(flat, k={}, metric={}, child={:?})",
             self.query.k, self.query.metric_type, self.input
         )
+    }
+}
+
+impl DisplayAs for KNNFlatExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                std::fmt::Debug::fmt(&self, f)
+            }
+        }
     }
 }
 
@@ -341,6 +351,16 @@ impl std::fmt::Debug for KNNIndexExec {
             "KNN(index, name={}, k={})",
             self.index_name, self.query.k
         )
+    }
+}
+
+impl DisplayAs for KNNIndexExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                std::fmt::Debug::fmt(&self, f)
+            }
+        }
     }
 }
 

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -127,22 +127,13 @@ impl DFRecordBatchStream for KNNFlatStream {
 /// - `input` schema must contains `query.column`,
 /// - The column must be a vector.
 /// - `input` schema does not have "_distance" column.
+#[derive(Debug)]
 pub struct KNNFlatExec {
     /// Input node.
     input: Arc<dyn ExecutionPlan>,
 
     /// The query to execute.
     query: Query,
-}
-
-impl std::fmt::Debug for KNNFlatExec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "KNN(flat, k={}, metric={}, child={:?})",
-            self.query.k, self.query.metric_type, self.input
-        )
-    }
 }
 
 impl DisplayAs for KNNFlatExec {
@@ -339,6 +330,7 @@ impl Stream for KNNIndexStream {
 }
 
 /// [ExecutionPlan] for KNNIndex node.
+#[derive(Debug)]
 pub struct KNNIndexExec {
     /// Dataset to read from.
     dataset: Arc<Dataset>,
@@ -346,16 +338,6 @@ pub struct KNNIndexExec {
     index_name: String,
     /// The vector query to execute.
     query: Query,
-}
-
-impl std::fmt::Debug for KNNIndexExec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "KNN(index, name={}, k={})",
-            self.index_name, self.query.k
-        )
-    }
 }
 
 impl DisplayAs for KNNIndexExec {

--- a/rust/src/io/exec/planner.rs
+++ b/rust/src/io/exec/planner.rs
@@ -332,6 +332,18 @@ impl Planner {
             }
             SQLExpr::Nested(inner) => self.parse_sql_expr(inner.as_ref()),
             SQLExpr::Function(func) => self.parse_function(func),
+            SQLExpr::ILike {
+                negated,
+                expr,
+                pattern,
+                escape_char,
+            } => Ok(Expr::Like(Like::new(
+                *negated,
+                Box::new(self.parse_sql_expr(expr)?),
+                Box::new(self.parse_sql_expr(pattern)?),
+                *escape_char,
+                true,
+            ))),
             SQLExpr::Like {
                 negated,
                 expr,
@@ -342,6 +354,7 @@ impl Planner {
                 Box::new(self.parse_sql_expr(expr)?),
                 Box::new(self.parse_sql_expr(pattern)?),
                 *escape_char,
+                false,
             ))),
             SQLExpr::Cast { expr, data_type } => Ok(Expr::Cast(datafusion::logical_expr::Cast {
                 expr: Box::new(self.parse_sql_expr(expr)?),

--- a/rust/src/io/exec/projection.rs
+++ b/rust/src/io/exec/projection.rs
@@ -122,25 +122,10 @@ impl RecordBatchStream for ProjectionStream {
     }
 }
 
+#[derive(Debug)]
 pub struct ProjectionExec {
     input: Arc<dyn ExecutionPlan>,
     project: Arc<Schema>,
-}
-
-impl std::fmt::Debug for ProjectionExec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let columns = self
-            .project
-            .fields
-            .iter()
-            .map(|f| f.name.clone())
-            .collect::<Vec<_>>();
-        write!(
-            f,
-            "Projection(schema={:?},\n\tchild={:?})",
-            columns, self.input
-        )
-    }
 }
 
 impl DisplayAs for ProjectionExec {

--- a/rust/src/io/exec/projection.rs
+++ b/rust/src/io/exec/projection.rs
@@ -22,7 +22,9 @@ use std::task::{Context, Poll};
 use arrow_array::RecordBatch;
 use arrow_schema::{Schema as ArrowSchema, SchemaRef};
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
-use datafusion::physical_plan::{ExecutionPlan, RecordBatchStream, SendableRecordBatchStream};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, RecordBatchStream, SendableRecordBatchStream,
+};
 use futures::{stream, FutureExt, Stream, StreamExt, TryStreamExt};
 use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinHandle;
@@ -138,6 +140,16 @@ impl std::fmt::Debug for ProjectionExec {
             "Projection(schema={:?},\n\tchild={:?})",
             columns, self.input
         )
+    }
+}
+
+impl DisplayAs for ProjectionExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                std::fmt::Debug::fmt(&self, f)
+            }
+        }
     }
 }
 

--- a/rust/src/io/exec/projection.rs
+++ b/rust/src/io/exec/projection.rs
@@ -147,7 +147,14 @@ impl DisplayAs for ProjectionExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                std::fmt::Debug::fmt(&self, f)
+                let columns = self
+                    .project
+                    .fields
+                    .iter()
+                    .map(|f| f.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "Projection: fields=[{}]", columns)
             }
         }
     }

--- a/rust/src/io/exec/scan.rs
+++ b/rust/src/io/exec/scan.rs
@@ -22,7 +22,8 @@ use arrow_array::RecordBatch;
 use arrow_schema::{DataType, Field, Schema as ArrowSchema, SchemaRef};
 use datafusion::error::{DataFusionError, Result};
 use datafusion::physical_plan::{
-    ExecutionPlan, Partitioning, RecordBatchStream, SendableRecordBatchStream,
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
+    SendableRecordBatchStream,
 };
 use futures::stream::Stream;
 use futures::{stream, Future};
@@ -207,6 +208,16 @@ impl std::fmt::Debug for LanceScanExec {
             self.with_row_id,
             self.ordered_output
         )
+    }
+}
+
+impl DisplayAs for LanceScanExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                std::fmt::Debug::fmt(&self, f)
+            }
+        }
     }
 }
 

--- a/rust/src/io/exec/scan.rs
+++ b/rust/src/io/exec/scan.rs
@@ -181,6 +181,7 @@ impl Stream for LanceStream {
 }
 
 /// DataFusion [ExecutionPlan] for scanning one Lance dataset
+#[derive(Debug)]
 pub struct LanceScanExec {
     dataset: Arc<Dataset>,
     fragments: Arc<Vec<Fragment>>,
@@ -190,25 +191,6 @@ pub struct LanceScanExec {
     fragment_readahead: usize,
     with_row_id: bool,
     ordered_output: bool,
-}
-
-impl std::fmt::Debug for LanceScanExec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let columns = self
-            .projection
-            .fields
-            .iter()
-            .map(|f| f.name.as_str())
-            .collect::<Vec<_>>();
-        write!(
-            f,
-            "LanceScan(uri={}, projection={:#?}, row_id={}, ordered={})",
-            self.dataset.data_dir(),
-            columns,
-            self.with_row_id,
-            self.ordered_output
-        )
-    }
 }
 
 impl DisplayAs for LanceScanExec {

--- a/rust/src/io/exec/scan.rs
+++ b/rust/src/io/exec/scan.rs
@@ -215,7 +215,21 @@ impl DisplayAs for LanceScanExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                std::fmt::Debug::fmt(&self, f)
+                let columns = self
+                    .projection
+                    .fields
+                    .iter()
+                    .map(|f| f.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(
+                    f,
+                    "LanceScan: uri={}, projection=[{}], row_id={}, ordered={}",
+                    self.dataset.data_dir(),
+                    columns,
+                    self.with_row_id,
+                    self.ordered_output
+                )
             }
         }
     }

--- a/rust/src/io/exec/take.rs
+++ b/rust/src/io/exec/take.rs
@@ -178,7 +178,14 @@ impl DisplayAs for TakeExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match t {
             DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                std::fmt::Debug::fmt(&self, f)
+                let columns = self
+                    .output_schema
+                    .fields
+                    .iter()
+                    .map(|f| f.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "Take: columns={:?}", columns)
             }
         }
     }

--- a/rust/src/io/exec/take.rs
+++ b/rust/src/io/exec/take.rs
@@ -150,6 +150,7 @@ impl RecordBatchStream for Take {
 /// The rows are identified by the inexplicit row IDs from `input` plan.
 ///
 /// The output schema will be the input schema, merged with extra schemas from the dataset.
+#[derive(Debug)]
 pub struct TakeExec {
     /// Dataset to read from.
     dataset: Arc<Dataset>,
@@ -160,18 +161,6 @@ pub struct TakeExec {
 
     /// Output schema is the merged schema between input schema and extra schema.
     output_schema: Schema,
-}
-
-impl std::fmt::Debug for TakeExec {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let columns = self
-            .output_schema
-            .fields
-            .iter()
-            .map(|f| f.name.as_str())
-            .collect::<Vec<_>>();
-        write!(f, "Take(columns={:?}, \n\tchild={:?})", columns, self.input)
-    }
 }
 
 impl DisplayAs for TakeExec {

--- a/rust/src/io/exec/take.rs
+++ b/rust/src/io/exec/take.rs
@@ -19,7 +19,9 @@ use std::task::{Context, Poll};
 use arrow_array::{cast::as_primitive_array, RecordBatch, UInt64Array};
 use arrow_schema::{Schema as ArrowSchema, SchemaRef};
 use datafusion::error::{DataFusionError, Result};
-use datafusion::physical_plan::{ExecutionPlan, RecordBatchStream, SendableRecordBatchStream};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, RecordBatchStream, SendableRecordBatchStream,
+};
 use futures::stream::{self, Stream, StreamExt, TryStreamExt};
 use futures::FutureExt;
 use tokio::sync::mpsc::{self, Receiver};
@@ -169,6 +171,16 @@ impl std::fmt::Debug for TakeExec {
             .map(|f| f.name.as_str())
             .collect::<Vec<_>>();
         write!(f, "Take(columns={:?}, \n\tchild={:?})", columns, self.input)
+    }
+}
+
+impl DisplayAs for TakeExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                std::fmt::Debug::fmt(&self, f)
+            }
+        }
     }
 }
 

--- a/rust/src/io/exec/testing.rs
+++ b/rust/src/io/exec/testing.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use arrow_array::RecordBatch;
 use datafusion::{
     execution::context::TaskContext,
-    physical_plan::{ExecutionPlan, SendableRecordBatchStream},
+    physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, SendableRecordBatchStream},
 };
 
 #[derive(Debug)]
@@ -32,6 +32,14 @@ pub struct TestingExec {
 impl TestingExec {
     pub(crate) fn new(batches: Vec<RecordBatch>) -> Self {
         Self { batches }
+    }
+}
+
+impl DisplayAs for TestingExec {
+    fn fmt_as(&self, t: DisplayFormatType, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => todo!(),
+        }
     }
 }
 


### PR DESCRIPTION
Datafusion added a new `DisplayAs` trait (with method `fmt_as` that can be parameterized by a `verbose`/`default` style) which is inherited by `ExecutionPlan` and thus must be implemented on all our custom nodes.  Currently, I am just defaulting to existing `fmt` implementation regardless of the requested style (this seems to be the pattern used in most datafusion nodes as well).

Datafusion added a new parameter to the `like` function for `case_insensitive` which maps, in SQL, to `LIKE` vs. `ILIKE`.