### PR TITLE
feat: switch session caches to use moka cache instead of LruCache

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -75,6 +75,7 @@ snafu = "0.7.4"
 log = "0"
 serde_json = { version = "1" }
 serde = { version = "^1" }
+moka = "0.11.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accelerate-src = { version = "0.3.2", optional = true }

--- a/rust/src/index/cache.rs
+++ b/rust/src/index/cache.rs
@@ -12,48 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use lru_time_cache::LruCache;
+use moka::sync::{Cache, ConcurrentCacheExt};
 
 use super::vector::VectorIndex;
 
 #[derive(Clone)]
 pub struct IndexCache {
-    /// The maximum number of indices to cache.
-    capacity: usize,
-
-    cache: Arc<Mutex<LruCache<String, Arc<dyn VectorIndex>>>>,
+    cache: Arc<Cache<String, Arc<dyn VectorIndex>>>,
 }
 
 impl IndexCache {
     pub(crate) fn new(capacity: usize) -> Self {
         Self {
-            capacity,
-            cache: Arc::new(Mutex::new(LruCache::with_capacity(capacity))),
+            cache: Arc::new(Cache::new(capacity as u64)),
         }
     }
 
     #[allow(dead_code)]
     pub(crate) fn len(&self) -> usize {
-        let cache = self.cache.lock().unwrap();
-        cache.len()
+        self.cache.sync();
+        self.cache.entry_count() as usize
     }
 
     /// Get an Index if present. Otherwise returns [None].
     pub(crate) fn get(&self, key: &str) -> Option<Arc<dyn VectorIndex>> {
-        let mut cache = self.cache.lock().unwrap();
-        let idx = cache.get(key);
-        idx.cloned()
+        self.cache.get(key)
     }
 
     /// Insert a new entry into the cache.
     pub(crate) fn insert(&self, key: &str, index: Arc<dyn VectorIndex>) {
-        if self.capacity == 0 {
-            // Work-around. lru_time_cache panics if capacity is 0.
-            return;
-        }
-        let mut cache = self.cache.lock().unwrap();
-        cache.insert(key.to_string(), index);
+        self.cache.insert(key.to_string(), index);
     }
 }

--- a/rust/src/session.rs
+++ b/rust/src/session.rs
@@ -28,7 +28,7 @@ pub struct Session {
     pub(crate) index_cache: IndexCache,
 
     /// Cache for file metadata
-    pub file_metadata_cache: FileMetadataCache,
+    pub(crate) file_metadata_cache: FileMetadataCache,
 }
 
 impl std::fmt::Debug for Session {
@@ -71,19 +71,19 @@ pub struct FileMetadataCache {
 }
 
 impl FileMetadataCache {
-    pub fn new(capacity: usize) -> Self {
+    pub(crate) fn new(capacity: usize) -> Self {
         Self {
             cache: Arc::new(Cache::new(capacity as u64)),
         }
     }
 
-    pub fn get<T: Send + Sync + 'static>(&self, path: &Path) -> Option<Arc<T>> {
+    pub(crate) fn get<T: Send + Sync + 'static>(&self, path: &Path) -> Option<Arc<T>> {
         self.cache
             .get(&(path.to_owned(), TypeId::of::<T>()))
             .map(|metadata| metadata.clone().downcast::<T>().unwrap())
     }
 
-    pub fn insert<T: Send + Sync + 'static>(&self, path: Path, metadata: Arc<T>) {
+    pub(crate) fn insert<T: Send + Sync + 'static>(&self, path: Path, metadata: Arc<T>) {
         self.cache.insert((path, TypeId::of::<T>()), metadata);
     }
 }


### PR DESCRIPTION
Closes #1130 

Moka cache should be more performant when accessed from multiple threads concurrently.