### PR TITLE
Track writing fragment progress

### DIFF
--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -26,7 +26,8 @@ except ImportError:
     pd = None
 import pyarrow as pa
 
-from .lance import _Fragment, _FragmentMetadata as _FragmentMetadata
+from .lance import _Fragment
+from .lance import _FragmentMetadata as _FragmentMetadata
 from .progress import FragmentWriteProgress, NoopFragmentWriteProgress
 
 if TYPE_CHECKING:

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -26,8 +26,7 @@ except ImportError:
     pd = None
 import pyarrow as pa
 
-from .lance import _Fragment
-from .lance import _FragmentMetadata as _FragmentMetadata
+from .lance import _Fragment, _FragmentMetadata as _FragmentMetadata
 from .progress import FragmentWriteProgress, NoopFragmentWriteProgress
 
 if TYPE_CHECKING:
@@ -154,6 +153,12 @@ class LanceFragment(pa.dataset.Fragment):
             from the data.
         max_rows_per_group: int, default 1024
             The maximum number of rows per group in the data file.
+        progress: FragmentWriteProgress, optional
+            *Experimental API*. Progress tracking for writing the fragment.
+
+        Returns
+        -------
+        FragmentMetadata
         """
         if pd and isinstance(data, pd.DataFrame):
             reader = pa.Table.from_pandas(data, schema=schema).to_reader()

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -28,6 +28,7 @@ import pyarrow as pa
 
 from .lance import _Fragment
 from .lance import _FragmentMetadata as _FragmentMetadata
+from .progress import WriteProgressTracker
 
 if TYPE_CHECKING:
     from .dataset import LanceDataset, LanceScanner
@@ -130,6 +131,7 @@ class LanceFragment(pa.dataset.Fragment):
         fragment_id: Optional[int] = None,
         schema: Optional[pa.Schema] = None,
         max_rows_per_group: int = 1024,
+        progress_tracker: Optional[WriteProgressTracker] = None,
     ) -> FragmentMetadata:
         """Create a :class:`FragmentMetadata` from the given data.
 

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -28,7 +28,7 @@ import pyarrow as pa
 
 from .lance import _Fragment
 from .lance import _FragmentMetadata as _FragmentMetadata
-from .progress import WriteProgressTracker
+from .progress import FragmentWriteProgress, NoopFragmentWriteProgress
 
 if TYPE_CHECKING:
     from .dataset import LanceDataset, LanceScanner
@@ -131,7 +131,7 @@ class LanceFragment(pa.dataset.Fragment):
         fragment_id: Optional[int] = None,
         schema: Optional[pa.Schema] = None,
         max_rows_per_group: int = 1024,
-        progress_tracker: Optional[WriteProgressTracker] = None,
+        progress: Optional[FragmentWriteProgress] = None,
     ) -> FragmentMetadata:
         """Create a :class:`FragmentMetadata` from the given data.
 
@@ -168,8 +168,15 @@ class LanceFragment(pa.dataset.Fragment):
 
         if isinstance(dataset_uri, Path):
             dataset_uri = str(dataset_uri)
+        if progress is None:
+            progress = NoopFragmentWriteProgress()
+
         inner_meta = _Fragment.create(
-            dataset_uri, fragment_id, reader, max_rows_per_group=max_rows_per_group
+            dataset_uri,
+            fragment_id,
+            reader,
+            max_rows_per_group=max_rows_per_group,
+            progress=progress,
         )
         return FragmentMetadata(inner_meta.json())
 

--- a/python/python/lance/progress.py
+++ b/python/python/lance/progress.py
@@ -16,9 +16,9 @@
 
 from __future__ import annotations
 
-from typing import Optional, Dict
-from abc import ABC, abstractmethod
 import json
+from abc import ABC, abstractmethod
+from typing import Dict, Optional
 
 
 class FragmentWriteProgress(ABC):
@@ -29,12 +29,14 @@ class FragmentWriteProgress(ABC):
     This tracking class is experimental and may change in the future.
     """
 
-    def _do_begin(self, fragment_json: str, **kwargs):
+    def _do_begin(
+        self, fragment_json: str, multipart_id: Optional[str] = None, **kwargs
+    ):
         """Called when a new fragment is created"""
         from .fragment import FragmentMetadata
 
         fragment = FragmentMetadata.from_json(fragment_json)
-        return self.begin(fragment, **kwargs)
+        return self.begin(fragment, multipart_id, **kwargs)
 
     @abstractmethod
     def begin(
@@ -84,7 +86,9 @@ class NoopFragmentWriteProgress(FragmentWriteProgress):
     This is the default implementation.
     """
 
-    def begin(self, fragment: "FragmentMetadata", **kargs):
+    def begin(
+        self, fragment: "FragmentMetadata", multipart_id: Optional[str] = None, **kargs
+    ):
         pass
 
     def complete(self, fragment: "FragmentMetadata", **kwargs):

--- a/python/python/lance/progress.py
+++ b/python/python/lance/progress.py
@@ -42,7 +42,7 @@ class FragmentWriteProgress(ABC):
     def begin(
         self, fragment: "FragmentMetadata", multipart_id: Optional[str] = None, **kwargs
     ) -> None:
-        """Called when a new fragment is created.
+        """Called when a new fragment is about to be written.
 
         Parameters
         ----------

--- a/python/python/lance/progress.py
+++ b/python/python/lance/progress.py
@@ -1,0 +1,85 @@
+#  Copyright (c) 2023. Lance Developers
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from abc import ABC, abstractmethod
+
+
+class FragmentWriteProgress(ABC):
+    """Progress tracking for Writing a Dataset or Fragment"""
+
+    def _do_begin(self, fragment_json: str):
+        """Called when a new fragment is created"""
+        from .fragment import FragmentMetadata
+
+        fragment = FragmentMetadata.from_json(fragment_json)
+        return self.begin(fragment)
+
+    @abstractmethod
+    def begin(self, fragment: "FragmentMetadata"):
+        """Called when a new fragment is created"""
+        pass
+
+    def _do_complete(self, fragment_json: str):
+        """Called when a fragment is completed"""
+        from .fragment import FragmentMetadata
+
+        fragment = FragmentMetadata.from_json(fragment_json)
+        return self.complete(fragment)
+
+    @abstractmethod
+    def complete(self, fragment: "FragmentMetadata"):
+        """Called when a fragment is completed"""
+        pass
+
+
+class NoopFragmentWriteProgress(FragmentWriteProgress):
+    """No-op implementation of WriteProgressTracker"""
+
+    def begin(self, fragment: "FragmentMetadata"):
+        pass
+
+    def complete(self, fragment: "FragmentMetadata"):
+        pass
+
+
+class FileSystemFragmentWriteProgress(FragmentWriteProgress):
+    """Progress tracking for Writing a Dataset or Fragment.
+
+    This implementation writes a JSON file to the filesystem for each fragment.
+    """
+
+    def __init__(self, base_uri: str):
+        from pyarrow.fs import FileSystem
+        fs, path = FileSystem.from_uri(base_uri)
+        self._fs = fs
+        self._base_path = path
+
+    def _in_progress_path(self, fragment: "FragmentMetadata"):
+        return self._base_path / f"fragment_{fragment.id}.in_progress"
+
+    def _fragment_file(self, fragment: "FragmentMetadata"):
+        return self._base_path / f"fragment_{fragment.id}.json"
+
+    def begin(self, fragment: "FragmentMetadata"):
+        """Called when a new fragment is created"""
+
+        self._fs.create_dir(self._base_path)
+        with self._fs.open_output_stream(self._in_progress_path(fragment)) as out:
+            out.write(str(fragment.id).encode("utf-8"))
+        with self._fs.open_input_stream(self._fragment_file(fragment)) as out:
+            out.write(fragment.to_json()).encode("utf-8")
+
+    def complete(self, fragment: "FragmentMetadata"):
+        """Called when a fragment is completed"""
+        self._fs.delete(self._in_progress_path(fragment))

--- a/python/python/lance/progress.py
+++ b/python/python/lance/progress.py
@@ -61,6 +61,7 @@ class FileSystemFragmentWriteProgress(FragmentWriteProgress):
 
     def __init__(self, base_uri: str):
         from pyarrow.fs import FileSystem
+
         fs, path = FileSystem.from_uri(base_uri)
         self._fs = fs
         self._base_path = path

--- a/python/python/lance/progress.py
+++ b/python/python/lance/progress.py
@@ -69,7 +69,7 @@ class FragmentWriteProgress(ABC):
 
     @abstractmethod
     def complete(self, fragment: "FragmentMetadata", **kwargs) -> None:
-        """Callback when a fragment is completed written.
+        """Callback when a fragment is completely written.
 
         Parameters
         ----------

--- a/python/python/lance/progress.py
+++ b/python/python/lance/progress.py
@@ -47,7 +47,8 @@ class FragmentWriteProgress(ABC):
         Parameters
         ----------
         fragment : FragmentMetadata
-            The fragment that is open to write to.
+            The fragment that is open to write to. The fragment id might not
+            yet be assigned at this point.
         multipart_id : str, optional
             The multipart id to upload this fragment to cloud storage.
         kwargs: dict, optional

--- a/python/python/lance/progress.py
+++ b/python/python/lance/progress.py
@@ -50,7 +50,8 @@ class FragmentWriteProgress(ABC):
             The fragment that is open to write to. The fragment id might not
             yet be assigned at this point.
         multipart_id : str, optional
-            The multipart id to upload this fragment to cloud storage.
+            The multipart id that will be uploaded to cloud storage. This may be
+            used later to abort incomplete uploads if this fragment write fails.
         kwargs: dict, optional
             Extra keyword arguments to pass to the implementation.
 

--- a/python/python/lance/progress.py
+++ b/python/python/lance/progress.py
@@ -12,6 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+# ruff: noqa: F821
+
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 
 

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pandas as pd
 import pyarrow as pa
 from lance import FragmentMetadata, LanceDataset, LanceFragment
+from lance.progress import FragmentWriteProgress
 
 
 def test_write_fragment(tmp_path: Path):
@@ -47,3 +48,16 @@ def test_write_fragment_two_phases(tmp_path: Path):
     pd.testing.assert_frame_equal(
         df, pd.DataFrame({"a": [i * 10 for i in range(num_files)]})
     )
+
+
+class ProgressTracker(FragmentWriteProgress):
+    def begin(self, fragment: FragmentMetadata):
+        print("Call form rust: ", fragment)
+
+    def complete(self, fragment: FragmentMetadata):
+        print(fragment)
+
+
+def test_write_fragment_with_progress(tmp_path: Path):
+    df = pd.DataFrame({"a": [10 * 10]})
+    frag = LanceFragment.create(tmp_path, df, progress=ProgressTracker())

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -50,14 +50,22 @@ def test_write_fragment_two_phases(tmp_path: Path):
     )
 
 
-class ProgressTracker(FragmentWriteProgress):
+class ProgressForTest(FragmentWriteProgress):
+    def __init__(self):
+        super().__init__()
+        self.begin_called = 0
+        self.complete_called = 0
+
     def begin(self, fragment: FragmentMetadata):
-        print("Call form rust: ", fragment)
+        self.begin_called += 1
 
     def complete(self, fragment: FragmentMetadata):
-        print(fragment)
+        self.complete_called += 1
 
 
 def test_write_fragment_with_progress(tmp_path: Path):
     df = pd.DataFrame({"a": [10 * 10]})
-    frag = LanceFragment.create(tmp_path, df, progress=ProgressTracker())
+    progress = ProgressForTest()
+    frag = LanceFragment.create(tmp_path, df, progress=progress)
+    assert progress.begin_called == 1
+    assert progress.complete_called == 1

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -66,6 +66,6 @@ class ProgressForTest(FragmentWriteProgress):
 def test_write_fragment_with_progress(tmp_path: Path):
     df = pd.DataFrame({"a": [10 * 10]})
     progress = ProgressForTest()
-    frag = LanceFragment.create(tmp_path, df, progress=progress)
+    LanceFragment.create(tmp_path, df, progress=progress)
     assert progress.begin_called == 1
     assert progress.complete_called == 1

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -14,6 +14,7 @@
 
 import json
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 import pyarrow as pa
@@ -56,7 +57,9 @@ class ProgressForTest(FragmentWriteProgress):
         self.begin_called = 0
         self.complete_called = 0
 
-    def begin(self, fragment: FragmentMetadata):
+    def begin(
+        self, fragment: FragmentMetadata, multipart_id: Optional[str] = None, **kwargs
+    ):
         self.begin_called += 1
 
     def complete(self, fragment: FragmentMetadata):

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -61,13 +61,8 @@ impl WriteFragmentProgress for PyWriteProgress {
                 .call_method(py, "_do_begin", (json_str,), None)?;
             Ok(())
         })
-        .map_err(|e| {
-            return lance::Error::IO {
-                message: format!(
-                    "Failed to call begin() on WriteFragmentProgress: {}",
-                    e.to_string()
-                ),
-            };
+        .map_err(|e| lance::Error::IO {
+            message: format!("Failed to call begin() on WriteFragmentProgress: {}", e),
         })?;
         Ok(())
     }
@@ -80,13 +75,8 @@ impl WriteFragmentProgress for PyWriteProgress {
                 .call_method(py, "_do_complete", (json_str,), None)?;
             Ok(())
         })
-        .map_err(|e| {
-            return lance::Error::IO {
-                message: format!(
-                    "Failed to call begin() on WriteFragmentProgress: {}",
-                    e.to_string()
-                ),
-            };
+        .map_err(|e| lance::Error::IO {
+            message: format!("Failed to call complete() on WriteFragmentProgress: {}", e),
         })?;
         Ok(())
     }

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -175,19 +175,29 @@ impl FileFragment {
                     .await
                     .map_err(|err| PyValueError::new_err(err.to_string()))?;
                 let schema = batches.schema().clone();
-                let metadata =
-                    LanceFragment::create(dataset_uri, fragment_id.unwrap_or(0), batches, params,                 progress_wrapper.as_mut())
-                        .await
-                        .map_err(|err| PyIOError::new_err(err.to_string()))?;
+                let metadata = LanceFragment::create(
+                    dataset_uri,
+                    fragment_id.unwrap_or(0),
+                    batches,
+                    params,
+                    progress_wrapper.as_mut(),
+                )
+                .await
+                .map_err(|err| PyIOError::new_err(err.to_string()))?;
                 (metadata, schema)
             } else {
                 let batches = ArrowArrayStreamReader::from_pyarrow(reader)?;
                 let schema = batches.schema().clone();
 
-                let metadata =
-                    LanceFragment::create(dataset_uri, fragment_id.unwrap_or(0), batches, params,                 progress_wrapper.as_mut())
-                        .await
-                        .map_err(|err| PyIOError::new_err(err.to_string()))?;
+                let metadata = LanceFragment::create(
+                    dataset_uri,
+                    fragment_id.unwrap_or(0),
+                    batches,
+                    params,
+                    progress_wrapper.as_mut(),
+                )
+                .await
+                .map_err(|err| PyIOError::new_err(err.to_string()))?;
                 (metadata, schema)
             };
             let schema = Schema::try_from(schema.as_ref())

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -35,6 +35,7 @@ mod chunker;
 mod feature_flags;
 pub mod fragment;
 mod hash_joiner;
+pub mod progress;
 pub mod scanner;
 pub mod transaction;
 pub mod updater;

--- a/rust/src/dataset/fragment.rs
+++ b/rust/src/dataset/fragment.rs
@@ -638,6 +638,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+    use crate::dataset::progress::NoopFragmentWriteProgress;
     use crate::dataset::{WriteParams, ROW_ID};
 
     async fn create_dataset(test_uri: &str) -> Dataset {
@@ -1057,6 +1058,7 @@ mod tests {
                 max_rows_per_group: 100,
                 ..Default::default()
             }),
+            &mut NoopFragmentWriteProgress::new(),
         )
         .await
         .unwrap();

--- a/rust/src/dataset/fragment.rs
+++ b/rust/src/dataset/fragment.rs
@@ -81,12 +81,10 @@ impl FileFragment {
         let (object_store, base_path) = ObjectStore::from_uri(dataset_uri).await?;
         let filename = format!("{}.lance", Uuid::new_v4());
         let fragment = Fragment::with_file(id as u64, &filename, &schema);
-
-        progress.begin(&fragment).await?;
-
         let full_path = base_path.child(DATA_DIR).child(filename.clone());
-
         let mut writer = FileWriter::try_new(&object_store, &full_path, schema.clone()).await?;
+
+        progress.begin(&fragment, writer.multipart_id()).await?;
 
         let mut buffered_reader = chunk_stream(stream, params.max_rows_per_group);
         while let Some(batched_chunk) = buffered_reader.next().await {

--- a/rust/src/dataset/fragment.rs
+++ b/rust/src/dataset/fragment.rs
@@ -82,7 +82,7 @@ impl FileFragment {
         let filename = format!("{}.lance", Uuid::new_v4());
         let fragment = Fragment::with_file(id as u64, &filename, &schema);
 
-        progress.begin(&fragment)?;
+        progress.begin(&fragment).await?;
 
         let full_path = base_path.child(DATA_DIR).child(filename.clone());
 
@@ -97,7 +97,7 @@ impl FileFragment {
         // Params.max_rows_per_file is ignored in this case.
         writer.finish().await?;
 
-        progress.complete(&fragment)?;
+        progress.complete(&fragment).await?;
 
         Ok(fragment)
     }

--- a/rust/src/dataset/progress.rs
+++ b/rust/src/dataset/progress.rs
@@ -23,15 +23,18 @@ use crate::Result;
 /// writing any data.
 ///
 /// When stop writing a [`Fragment`], WriteProgress::complete() will be called after.
+///
+/// This is an experimental API and may change in the future.
 #[async_trait]
 pub trait WriteFragmentProgress: std::fmt::Debug + Sync + Send {
-    /// Indicate the beginning of writing a [Fragment].
-    async fn begin(&mut self, fragment: &Fragment) -> Result<()>;
+    /// Indicate the beginning of writing a [Fragment], with the in-flight multipart ID.
+    async fn begin(&mut self, fragment: &Fragment, multipart_id: &str) -> Result<()>;
 
     /// Complete writing a [Fragment].
     async fn complete(&mut self, fragment: &Fragment) -> Result<()>;
 }
 
+/// By default, Progress tracker is Noop.
 #[derive(Debug, Clone, Default)]
 pub struct NoopFragmentWriteProgress {}
 
@@ -44,7 +47,7 @@ impl NoopFragmentWriteProgress {
 #[async_trait]
 impl WriteFragmentProgress for NoopFragmentWriteProgress {
     #[inline]
-    async fn begin(&mut self, _fragment: &Fragment) -> Result<()> {
+    async fn begin(&mut self, _fragment: &Fragment, _multipart_id: &str) -> Result<()> {
         Ok(())
     }
 

--- a/rust/src/dataset/progress.rs
+++ b/rust/src/dataset/progress.rs
@@ -18,6 +18,11 @@ use crate::format::Fragment;
 use crate::Result;
 
 /// Progress of writing a [Fragment].
+///
+/// When start writing a [`Fragment`], WriteProgress::begin() will be called before
+/// writing any data.
+///
+/// When stop writing a [`Fragment`], WriteProgress::complete() will be called after.
 #[async_trait]
 pub trait WriteFragmentProgress: std::fmt::Debug + Sync + Send {
     /// Indicate the beginning of writing a [Fragment].

--- a/rust/src/dataset/progress.rs
+++ b/rust/src/dataset/progress.rs
@@ -27,7 +27,7 @@ pub trait WriteFragmentProgress: std::fmt::Debug + Sync + Send {
     async fn complete(&mut self, fragment: &Fragment) -> Result<()>;
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct NoopFragmentWriteProgress {}
 
 impl NoopFragmentWriteProgress {

--- a/rust/src/dataset/progress.rs
+++ b/rust/src/dataset/progress.rs
@@ -16,7 +16,7 @@ use crate::format::Fragment;
 use crate::Result;
 
 /// Progress of writing a [Fragment].
-pub trait WriteFragmentProgress {
+pub trait WriteFragmentProgress: std::fmt::Debug + Sync + Send {
     /// Indicate the beginning of writing a [Fragment].
     fn begin(&mut self, fragment: &Fragment) -> Result<()>;
 
@@ -24,6 +24,7 @@ pub trait WriteFragmentProgress {
     fn complete(&mut self, fragment: &Fragment) -> Result<()>;
 }
 
+#[derive(Debug, Clone)]
 pub struct NoopFragmentWriteProgress {}
 
 impl NoopFragmentWriteProgress {

--- a/rust/src/dataset/progress.rs
+++ b/rust/src/dataset/progress.rs
@@ -1,0 +1,43 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::format::Fragment;
+use crate::Result;
+
+/// Progress of writing a [Fragment].
+pub trait WriteFragmentProgress {
+    /// Indicate the beginning of writing a [Fragment].
+    fn begin(&mut self, fragment: &Fragment) -> Result<()>;
+
+    /// Complete writing a [Fragment].
+    fn complete(&mut self, fragment: &Fragment) -> Result<()>;
+}
+
+pub struct NoopFragmentWriteProgress {}
+
+impl NoopFragmentWriteProgress {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl WriteFragmentProgress for NoopFragmentWriteProgress {
+    fn begin(&mut self, _fragment: &Fragment) -> Result<()> {
+        Ok(())
+    }
+
+    fn complete(&mut self, _fragment: &Fragment) -> Result<()> {
+        Ok(())
+    }
+}

--- a/rust/src/dataset/write.rs
+++ b/rust/src/dataset/write.rs
@@ -25,6 +25,7 @@ use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
 use uuid::Uuid;
 
+use super::progress::WriteFragmentProgress;
 use super::{chunker::chunk_stream, DATA_DIR};
 use crate::error::Result;
 use crate::Error;
@@ -58,6 +59,8 @@ pub struct WriteParams {
     pub mode: WriteMode,
 
     pub store_params: Option<ObjectStoreParams>,
+
+    pub progress: Option<Arc<dyn WriteFragmentProgress>>,
 }
 
 impl Default for WriteParams {
@@ -67,6 +70,7 @@ impl Default for WriteParams {
             max_rows_per_group: 1024,
             mode: WriteMode::Create,
             store_params: None,
+            progress: None,
         }
     }
 }

--- a/rust/src/io/object_writer.rs
+++ b/rust/src/io/object_writer.rs
@@ -35,7 +35,9 @@ pub struct ObjectWriter {
     // TODO: wrap writer with a BufWriter.
     #[pin]
     writer: Box<dyn AsyncWrite + Unpin + Send>,
-    multipart_id: MultipartId,
+
+    pub(crate) multipart_id: MultipartId,
+
     cursor: usize,
 }
 

--- a/rust/src/io/object_writer.rs
+++ b/rust/src/io/object_writer.rs
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2023 Lance Developers.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/rust/src/io/writer.rs
+++ b/rust/src/io/writer.rs
@@ -158,6 +158,11 @@ impl FileWriter {
         self.metadata.len()
     }
 
+    /// Returns the in-flight multipart ID.
+    pub fn multipart_id(&self) -> &str {
+        &self.object_writer.multipart_id
+    }
+
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }


### PR DESCRIPTION
This is used for case where there is no coordination between distributed writers. It keeps track the start / finish / incomplete of each fragment writes, in case of the writer crashes in the middle. 