### PR TITLE
feat: add count_rows to scanner

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -375,10 +375,9 @@ class LanceDataset(pa.dataset.Dataset):
         kwargs["limit"] = num_rows
         return self.scanner(**kwargs).to_table()
 
-    def count_rows(self,
-        filter: Optional[Union[str, pa.compute.Expression]] = None,
-        **kwargs) -> int:
-
+    def count_rows(
+        self, filter: Optional[Union[str, pa.compute.Expression]] = None, **kwargs
+    ) -> int:
         """Count rows matching the scanner filter.
 
         Parameters

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -375,7 +375,10 @@ class LanceDataset(pa.dataset.Dataset):
         kwargs["limit"] = num_rows
         return self.scanner(**kwargs).to_table()
 
-    def count_rows(self, **kwargs):
+    def count_rows(self,
+        filter: Optional[Union[str, pa.compute.Expression]] = None,
+        **kwargs) -> int:
+
         """Count rows matching the scanner filter.
 
         Parameters
@@ -389,7 +392,10 @@ class LanceDataset(pa.dataset.Dataset):
             The total number of rows in the dataset.
 
         """
-        return self._ds.count_rows()
+        if filter is None:
+            return self._ds.count_rows()
+        else:
+            return self.scanner(filter=filter).count_rows()
 
     def join(
         self,
@@ -953,7 +959,7 @@ class LanceScanner(pa.dataset.Scanner):
         count : int
 
         """
-        return self._ds.count_rows()
+        return self._scanner.count_rows()
 
 
 def write_dataset(

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -549,6 +549,15 @@ def test_scan_with_batch_size(tmp_path: Path):
         df = batch.to_pandas()
         assert df["a"].iloc[0] == idx * 16
 
+def test_scan_count_rows(tmp_path: Path):
+    base_dir = tmp_path / "dataset"
+    df = pd.DataFrame({"a": range(42), "b": range(42)})
+    dataset = lance.write_dataset(df, base_dir)
+
+    assert dataset.scanner().count_rows() == 42
+    assert dataset.count_rows(filter="a < 10") == 10
+    assert dataset.count_rows(filter=pa_ds.field("a") < 20) == 20
+
 
 def test_scanner_schemas(tmp_path: Path):
     base_dir = tmp_path / "dataset"

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -549,6 +549,7 @@ def test_scan_with_batch_size(tmp_path: Path):
         df = batch.to_pandas()
         assert df["a"].iloc[0] == idx * 16
 
+
 def test_scan_count_rows(tmp_path: Path):
     base_dir = tmp_path / "dataset"
     df = pd.DataFrame({"a": range(42), "b": range(42)})

--- a/python/src/scanner.rs
+++ b/python/src/scanner.rs
@@ -58,6 +58,12 @@ impl Scanner {
             .map_err(|err| PyValueError::new_err(err.to_string()))?
     }
 
+    fn count_rows(self_: PyRef<'_, Self>) -> PyResult<u64> {
+        let scanner = self_.scanner.clone();
+        RT.spawn(Some(self_.py()), async move { scanner.count_rows().await })
+            .map_err(|err| PyValueError::new_err(err.to_string()))
+    }
+
     fn to_pyarrow(self_: PyRef<'_, Self>) -> PyResult<PyObject> {
         let scanner = self_.scanner.clone();
         let reader = RT

--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -372,7 +372,7 @@ impl Scanner {
     }
 
     /// Scan and return the number of matching rows
-    pub async fn count_rows(&self) -> Result<usize> {
+    pub async fn count_rows(&self) -> Result<u64> {
         let plan = self.create_plan().await?;
         // Datafusion interprets COUNT(*) as COUNT(1)
         let one = Arc::new(Literal::new(ScalarValue::UInt8(Some(1))));
@@ -399,7 +399,6 @@ impl Scanner {
         // A count plan will always return a single batch with a single row.
         if let Some(first_batch) = stream.next().await {
             let batch = first_batch?;
-            dbg!(&batch);
             let array = batch
                 .column(0)
                 .as_any()
@@ -407,7 +406,7 @@ impl Scanner {
                 .ok_or(Error::IO {
                     message: "Count plan did not return a UInt64Array".to_string(),
                 })?;
-            Ok(array.value(0) as usize)
+            Ok(array.value(0) as u64)
         } else {
             Ok(0)
         }


### PR DESCRIPTION
Adds a `count_rows` method to the scanner which will take any existing scanner filter into account.

Closes #841 
