### PR TITLE
[Rust] Compute dot distance as negative dot product

### DIFF
--- a/rust/src/linalg/dot.rs
+++ b/rust/src/linalg/dot.rs
@@ -74,19 +74,24 @@ impl Dot for [f64] {
     }
 }
 
+/// Negative dot product, to present the relative order of dot distance.
 pub fn dot_distance_batch(from: &[f32], to: &[f32], dimension: usize) -> Arc<Float32Array> {
     debug_assert_eq!(from.len(), dimension);
     debug_assert_eq!(to.len() % dimension, 0);
 
     let dists = unsafe {
-        Float32Array::from_trusted_len_iter(to.chunks_exact(dimension).map(|v| Some(1.0 - from.dot(v))))
+        Float32Array::from_trusted_len_iter(
+            to.chunks_exact(dimension)
+                .map(|v| Some(dot_distance(from, v))),
+        )
     };
     Arc::new(dists)
 }
 
+/// Negative dot distance.
 #[inline]
 pub fn dot_distance(from: &[f32], to: &[f32]) -> f32 {
-    1.0 - from.dot(to)
+    - from.dot(to)
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/rust/src/linalg/dot.rs
+++ b/rust/src/linalg/dot.rs
@@ -79,13 +79,14 @@ pub fn dot_distance_batch(from: &[f32], to: &[f32], dimension: usize) -> Arc<Flo
     debug_assert_eq!(to.len() % dimension, 0);
 
     let dists = unsafe {
-        Float32Array::from_trusted_len_iter(to.chunks_exact(dimension).map(|v| Some(from.dot(v))))
+        Float32Array::from_trusted_len_iter(to.chunks_exact(dimension).map(|v| Some(1.0 - from.dot(v))))
     };
     Arc::new(dists)
 }
 
+#[inline]
 pub fn dot_distance(from: &[f32], to: &[f32]) -> f32 {
-    from.dot(to)
+    1.0 - from.dot(to)
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/rust/src/linalg/dot.rs
+++ b/rust/src/linalg/dot.rs
@@ -91,7 +91,7 @@ pub fn dot_distance_batch(from: &[f32], to: &[f32], dimension: usize) -> Arc<Flo
 /// Negative dot distance.
 #[inline]
 pub fn dot_distance(from: &[f32], to: &[f32]) -> f32 {
-    - from.dot(to)
+    -from.dot(to)
 }
 
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
To make the sorting of dot distance mathematically correct. The bigger the dot product is, the closer two vectors are.