### PR TITLE
fix: Copying schema metadata in the Scanner

### DIFF
--- a/rust/src/datatypes/schema.rs
+++ b/rust/src/datatypes/schema.rs
@@ -151,7 +151,7 @@ impl Schema {
         }
         Ok(Self {
             fields,
-            metadata: HashMap::default(),
+            metadata: self.metadata.clone(),
         })
     }
 

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -828,6 +828,8 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use tempfile::tempdir;
 
+    use std::collections::HashMap;
+
     use crate::{
         index::{vector::VectorIndexParams, DatasetIndexExt, IndexType},
         utils::testing::generate_random_array,
@@ -837,15 +839,21 @@ mod tests {
     async fn test_create_ivf_pq_with_centroids() {
         const DIM: usize = 32;
         let vectors = generate_random_array(1000 * DIM);
+        let metadata: HashMap<String, String> = vec![("test".to_string(), "ivf_pq".to_string())]
+            .into_iter()
+            .collect();
 
-        let schema = Arc::new(Schema::new(vec![Field::new(
-            "vector",
-            DataType::FixedSizeList(
-                Arc::new(Field::new("item", DataType::Float32, true)),
-                DIM as i32,
-            ),
-            true,
-        )]));
+        let schema = Arc::new(
+            Schema::new(vec![Field::new(
+                "vector",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    DIM as i32,
+                ),
+                true,
+            )])
+            .with_metadata(metadata),
+        );
         let array = Arc::new(FixedSizeListArray::try_new_from_values(vectors, DIM as i32).unwrap());
         let batch = RecordBatch::try_new(schema.clone(), vec![array.clone()]).unwrap();
 


### PR DESCRIPTION
- The root cause of the issue is that the scanner re-creates the `RecordBatch` schema in a couple of different places without copying the original metadata
- When `concat_batches` sees a different schema between `RecordBatches` it throws an exception
- Overall this process is a little brittle - there are a lot of different places creating schemas, and not all of them need the metadata
- I opted to change the existing test cases instead of creating new ones so they could cover a variety of use cases

Close #1152