### PR TITLE
feat: parse TFRecords as Arrow data

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -20,10 +20,10 @@ chrono = "0.4.23"
 env_logger = "0.10"
 futures = "0.3"
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
-lance = { path = "../rust" }
+lance = { path = "../rust", features = ["tensorflow"] }
 lazy_static = "1"
 log = "0.4"
-prost = "0.11"
+prost = "0.10"
 pyo3 = { version = "0.19", features = ["extension-module", "abi3-py38"] }
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 uuid = "1.3.0"

--- a/python/python/lance/lance.pyi
+++ b/python/python/lance/lance.pyi
@@ -1,0 +1,10 @@
+from typing import List, Optional
+
+import pyarrow as pa
+
+def infer_tfrecord_schema(
+    uri: str,
+    tensor_features: Optional[List[str]] = None,
+    string_features: Optional[List[str]] = None,
+) -> pa.Schema: ...
+def read_tfrecord(uri: str, schema: pa.Schema) -> pa.RecordBatchReader: ...

--- a/python/python/lance/tf/tfrecord.py
+++ b/python/python/lance/tf/tfrecord.py
@@ -1,0 +1,15 @@
+#  Copyright (c) 2023. Lance Developers
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from lance.lance import infer_tfrecord_schema as infer_tfrecord_schema, read_tfrecord as read_tfrecord

--- a/python/python/lance/tf/tfrecord.py
+++ b/python/python/lance/tf/tfrecord.py
@@ -12,4 +12,5 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from lance.lance import infer_tfrecord_schema as infer_tfrecord_schema, read_tfrecord as read_tfrecord
+from lance.lance import infer_tfrecord_schema as infer_tfrecord_schema
+from lance.lance import read_tfrecord as read_tfrecord

--- a/python/python/tests/test_tf.py
+++ b/python/python/tests/test_tf.py
@@ -266,6 +266,12 @@ def test_tfrecord_parsing(tmp_path):
 
     assert table == expected_data
 
+    # Can roundtrip to lance
+    dataset_uri = tmp_path / "dataset"
+    dataset = lance.write_dataset(table, dataset_uri)
+    assert dataset.schema == expected_data.schema
+    assert dataset.to_table() == expected_data
+
 
 def test_tfrecord_parsing_nulls(tmp_path):
     # Make sure we don't trip up on missing values

--- a/python/python/tests/test_tf.py
+++ b/python/python/tests/test_tf.py
@@ -236,7 +236,9 @@ def test_tfrecord_parsing(tmp_path):
         }
     )
 
-    batch = read_tfrecord(str(path), inferred_schema)
+    reader = read_tfrecord(str(path), inferred_schema)
+    assert reader.schema == inferred_schema
+    batch = pa.Table.from_batches(reader).to_batches()[0]
     assert batch.num_rows == 1
     assert batch.num_columns == 3
     assert batch.column_names == ["bytes", "string", "tensor"]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -188,16 +188,18 @@ fn read_tfrecord(
 
     let schema_ref = schema.clone();
     RT.spawn_background(None, async move {
-        let mut stream = match ::lance::utils::tfrecord::read_tfrecord(&uri, schema_ref, Some(batch_size)).await {
-            Ok(stream) => {
-                init_sender.send(Ok(())).unwrap();
-                stream
-            }
-            Err(err) => {
-                init_sender.send(Err(err)).unwrap();
-                return;
-            }
-        };
+        let mut stream =
+            match ::lance::utils::tfrecord::read_tfrecord(&uri, schema_ref, Some(batch_size)).await
+            {
+                Ok(stream) => {
+                    init_sender.send(Ok(())).unwrap();
+                    stream
+                }
+                Err(err) => {
+                    init_sender.send(Err(err)).unwrap();
+                    return;
+                }
+            };
 
         while let Some(batch) = stream.next().await {
             let batch = batch.map_err(|err| ArrowError::ExternalError(Box::new(err)));

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -102,6 +102,25 @@ fn json_to_schema(py: Python<'_>, json: &str) -> PyResult<PyObject> {
     schema.to_pyarrow(py)
 }
 
+/// Infer schema from tfrecord file
+///
+/// Parameters
+/// ----------
+/// uri: str
+///     URI of the tfrecord file
+/// tensor_features: Optional[List[str]]
+///     Names of features that should be treated as tensors. Currently only
+///     fixed-shape tensors are supported.
+/// string_features: Optional[List[str]]
+///     Names of features that should be treated as strings. Otherwise they
+///     will be treated as binary.
+///
+/// Returns
+/// -------
+/// pyarrow.Schema
+///     An Arrow schema inferred from the tfrecord file. The schema is
+///     alphabetically sorted by field names, since TFRecord doesn't have
+///     a concept of field order.
 #[pyfunction]
 #[pyo3(signature = (uri, *, tensor_features = None, string_features = None))]
 fn infer_tfrecord_schema(
@@ -130,6 +149,23 @@ fn infer_tfrecord_schema(
     Ok(PyArrowType(schema))
 }
 
+/// Read tfrecord file as an Arrow stream
+///
+/// Parameters
+/// ----------
+/// uri: str
+///     URI of the tfrecord file
+/// schema: pyarrow.Schema
+///     Arrow schema of the tfrecord file. Use :py:func:`infer_tfrecord_schema`
+///     to infer the schema. The schema is allowed to be a subset of fields; the
+///     reader will only parse the fields that are present in the schema.
+///
+/// Returns
+/// -------
+/// pyarrow.RecordBatchReader
+///     An Arrow reader, which can be passed directly to
+///     :py:func:`lance.write_dataset`. The output schema will match the schema
+///     provided, including field order.
 #[pyfunction]
 fn read_tfrecord(
     uri: String,

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -76,6 +76,7 @@ log = "0"
 serde_json = { version = "1" }
 serde = { version = "^1" }
 moka = "0.11.3"
+tfrecord = { version = "0.14.0", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accelerate-src = { version = "0.3.2", optional = true }
@@ -103,8 +104,11 @@ all_asserts = "2.3.1"
 mock_instant = { version = "0.3.1", features = ["sync"] }
 
 [features]
+# TODO: remove this
+default = ["tensorflow"]
 cli = ["clap"]
 opq = ["cblas", "lapack", "openblas-src", "accelerate-src"]
+tensorflow = ["tfrecord"]
 
 [[bin]]
 name = "lq"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -52,8 +52,8 @@ object_store = { version = "0.6.1", features = ["aws", "gcp", "azure"] }
 aws-config = "0.54"
 aws-credential-types = "0.54.1"
 pin-project = "1.0"
-prost = "0.11"
-prost-types = "0.11"
+prost = "0.10"
+prost-types = "0.10"
 roaring = "0.10.1"
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 url = "2.3"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -104,8 +104,6 @@ all_asserts = "2.3.1"
 mock_instant = { version = "0.3.1", features = ["sync"] }
 
 [features]
-# TODO: remove this
-default = ["tensorflow"]
 cli = ["clap"]
 opq = ["cblas", "lapack", "openblas-src", "accelerate-src"]
 tensorflow = ["tfrecord"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -76,7 +76,7 @@ log = "0"
 serde_json = { version = "1" }
 serde = { version = "^1" }
 moka = "0.11.3"
-tfrecord = { version = "0.14.0", optional = true }
+tfrecord = { version = "0.14.0", optional = true, features = ["async"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accelerate-src = { version = "0.3.2", optional = true }

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -299,12 +299,7 @@ impl ObjectStore {
         if !expanded_path.try_exists()? {
             std::fs::create_dir_all(expanded_path)?;
         }
-        // TODO: do we really need this? It is leaky.
-        // else if !expanded_path.is_dir() {
-        //     return Err(Error::IO {
-        //         message: format!("{} is not a lance directory", str_path),
-        //     });
-        // }
+
         let expanded_path = expanded_path.canonicalize()?;
 
         Ok((

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -298,7 +298,7 @@ impl ObjectStore {
 
         if !expanded_path.try_exists()? {
             std::fs::create_dir_all(expanded_path)?;
-        } 
+        }
         // TODO: do we really need this? It is leaky.
         // else if !expanded_path.is_dir() {
         //     return Err(Error::IO {

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -298,11 +298,13 @@ impl ObjectStore {
 
         if !expanded_path.try_exists()? {
             std::fs::create_dir_all(expanded_path)?;
-        } else if !expanded_path.is_dir() {
-            return Err(Error::IO {
-                message: format!("{} is not a lance directory", str_path),
-            });
-        }
+        } 
+        // TODO: do we really need this? It is leaky.
+        // else if !expanded_path.is_dir() {
+        //     return Err(Error::IO {
+        //         message: format!("{} is not a lance directory", str_path),
+        //     });
+        // }
         let expanded_path = expanded_path.canonicalize()?;
 
         Ok((

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -23,3 +23,5 @@ pub mod sql;
 pub mod temporal;
 #[cfg(test)]
 pub mod testing;
+#[cfg(feature = "tfrecord")]
+pub mod tfrecord;

--- a/rust/src/utils/tfrecord.rs
+++ b/rust/src/utils/tfrecord.rs
@@ -612,6 +612,8 @@ fn convert_fixedshape_tensor(
         None
     };
 
+    let list_size = type_info.fsl_size.unwrap() as usize;
+
     let values: ArrayRef = match type_info.leaf_type {
         DataType::Float16 => {
             let mut values = Float16Builder::with_capacity(features.len());
@@ -634,7 +636,7 @@ fn convert_fixedshape_tensor(
                         }
                     }
                 } else {
-                    values.append_null();
+                    values.append_nulls(list_size);
                 }
             }
             Arc::new(values.finish())
@@ -662,7 +664,9 @@ fn convert_fixedshape_tensor(
                         }
                     }
                 } else {
-                    values.append_null();
+                    for _ in 0..list_size {
+                        values.append_null();
+                    }
                 }
             }
             Arc::new(values.finish())
@@ -684,7 +688,7 @@ fn convert_fixedshape_tensor(
                         }
                     }
                 } else {
-                    values.append_null();
+                    values.append_nulls(list_size);
                 }
             }
             Arc::new(values.finish())
@@ -706,7 +710,7 @@ fn convert_fixedshape_tensor(
                         };
                     }
                 } else {
-                    values.append_null();
+                    values.append_nulls(list_size);
                 }
             }
             Arc::new(values.finish())

--- a/rust/src/utils/tfrecord.rs
+++ b/rust/src/utils/tfrecord.rs
@@ -1,0 +1,79 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Reading TFRecord files into Arrow data
+
+use crate::error::{Error, Result};
+use crate::io::ObjectStore;
+use arrow::record_batch::RecordBatch;
+use arrow_array::builder::ArrayBuilder;
+use arrow_schema::Schema as ArrowSchema;
+use object_store::path::Path;
+use tfrecord::protobuf::TensorProto;
+use tfrecord::record_reader::RecordIter;
+use tfrecord::Example;
+
+pub async fn read_tfrecord(uri: &str, schema: ArrowSchema) -> Result<RecordBatch> {
+    // TODO: Use schema to create builders
+
+    let (store, path) = ObjectStore::from_uri(uri).await?;
+    // TODO: should we avoid reading the entire file into memory?
+    let data = store.inner.get(&path).await?.bytes().await?;
+    let records = RecordIter::<Example, _>::from_reader(data.as_ref(), Default::default());
+
+    for record in records {
+        let record = record.map_err(|err| Error::IO {
+            message: err.to_string(),
+        })?;
+        if let Some(features) = record.features {
+            for field in &schema.fields {
+                if let Some(feature) = features.feature.get(field.name()) {
+                    todo!("append feature to appropriate builder")
+                }
+            }
+        }
+    }
+
+    // TODO: support reading:
+    // Binary
+    // Binary list
+    // int64
+    // int64 list
+    // float32
+    // float32 list
+    // Then also tensors based on https://github.com/tensorflow/tensorboard/blob/master/tensorboard/compat/proto/tensor.proto
+
+    todo!()
+}
+
+/// Infer the Arrow schema from a TFRecord file.
+///
+/// The featured named by `tensor_features` will be assumed to be binary fields
+/// containing serialized tensors (TensorProto messages). Currently only
+/// fixed-shape tensors are supported.
+pub async fn infer_tfrecord_schema(uri: &str, tensor_features: &[&str]) -> Result<ArrowSchema> {
+    todo!()
+}
+
+/// Convert TensorProto message into an element of a FixedShapeTensor array and
+/// append it to the builder.
+///
+/// TensorProto definition:
+/// https://github.com/tensorflow/tensorboard/blob/master/tensorboard/compat/proto/tensor.proto
+///
+/// FixedShapeTensor definition:
+/// https://arrow.apache.org/docs/format/CanonicalExtensions.html#fixed-shape-tensor
+pub fn append_fixedshape_tensor(builder: &dyn ArrayBuilder, tensor: &TensorProto) -> Result<()> {
+    todo!()
+}

--- a/rust/src/utils/tfrecord.rs
+++ b/rust/src/utils/tfrecord.rs
@@ -764,6 +764,10 @@ fn append_primitive_from_slice<T>(
 ) where
     T: arrow::datatypes::ArrowPrimitiveType,
 {
+    // Safety: we are trusting that the data in the buffer are valid for the
+    // datatype T::Native, as claimed by the file. There isn't anywhere for
+    // TensorProto to tell us the original endianness, so it's possible there
+    // could be a mismatch here.
     let (prefix, middle, suffix) = unsafe { slice.align_to::<T::Native>() };
     for val in prefix.chunks_exact(T::get_byte_width()) {
         builder.append_value(parse_val(val));


### PR DESCRIPTION
Adds utility functions for reading TFRecords files:

```python
import pyarrow as pa

def infer_tfrecord_schema(
    uri: str, 
    tensor_features: Optional[List[str]],
    string_features: Optional[List[str]]
) -> pa.Schema:
    """Infer the schema for a TFRecord dataset"""
    ...

def read_tfrecord(uri: str, schema: pa.Schema) -> pa.RecordBatchReader:
    """
    Read a TFRecord file as a stream of record batches. This can be fed directly
    into lance.write_dataset().
    """
    ...
```

Closes: #1165