### PR TITLE
feat: add support for field metdata

### DIFF
--- a/protos/format.proto
+++ b/protos/format.proto
@@ -304,6 +304,9 @@ message Field {
   /// The logic type presents the value type of the column, i.e., string value.
   Dictionary dictionary = 8;
 
-  // optional extension type name
+  // Deprecated: optional extension type name, use metadata field ARROW:extension:name
   string extension_name = 9;
+
+  // optional field metadata (e.g. extension type name/parameters)
+  map<string, bytes> metadata = 10;
 }

--- a/python/python/tests/test_lance.py
+++ b/python/python/tests/test_lance.py
@@ -197,6 +197,12 @@ def test_schema_to_json():
 @pytest.fixture
 def sample_data_all_types():
     nrows = 10
+
+    tensor_type = pa.fixed_shape_tensor(pa.float32(), [2, 3])
+    inner = pa.array([float(x) for x in range(60)], pa.float32())
+    storage = pa.FixedSizeListArray.from_arrays(inner, 6)
+    tensor_array = pa.ExtensionArray.from_storage(tensor_type, storage)
+
     return pa.table(
         {
             # TODO: add remaining types
@@ -207,6 +213,7 @@ def sample_data_all_types():
             "bfloat16": lance.arrow.bfloat16_array(
                 [1.0 + i / 10 for i in range(nrows)]
             ),
+            "tensor": tensor_array,
         }
     )
 

--- a/rust/src/datatypes/field.rs
+++ b/rust/src/datatypes/field.rs
@@ -14,7 +14,7 @@
 
 //! Lance Schema Field
 
-use std::{cmp::max, fmt, sync::Arc};
+use std::{cmp::max, collections::HashMap, fmt, sync::Arc};
 
 use arrow_array::{
     cast::AsArray,
@@ -43,7 +43,7 @@ pub struct Field {
     pub id: i32,
     parent_id: i32,
     logical_type: LogicalType,
-    extension_name: String,
+    metadata: HashMap<String, String>,
     pub(crate) encoding: Option<Encoding>,
     pub nullable: bool,
 
@@ -66,6 +66,12 @@ impl Field {
             }
             lt => DataType::try_from(lt).unwrap(),
         }
+    }
+
+    pub fn extension_name(&self) -> Option<&str> {
+        self.metadata
+            .get("ARROW:extension:name")
+            .map(String::as_str)
     }
 
     pub fn child(&self, name: &str) -> Option<&Self> {
@@ -163,7 +169,7 @@ impl Field {
             id: self.id,
             parent_id: self.parent_id,
             logical_type: self.logical_type.clone(),
-            extension_name: self.extension_name.clone(),
+            metadata: self.metadata.clone(),
             encoding: self.encoding.clone(),
             nullable: self.nullable,
             children: vec![],
@@ -292,7 +298,7 @@ impl Field {
                 id: self.id,
                 parent_id: self.parent_id,
                 logical_type: self.logical_type.clone(),
-                extension_name: self.extension_name.clone(),
+                metadata: self.metadata.clone(),
                 encoding: self.encoding.clone(),
                 nullable: self.nullable,
                 children,
@@ -338,7 +344,7 @@ impl Field {
                 id: self.id,
                 parent_id: self.parent_id,
                 logical_type: self.logical_type.clone(),
-                extension_name: self.extension_name.clone(),
+                metadata: self.metadata.clone(),
                 encoding: self.encoding.clone(),
                 nullable: self.nullable,
                 children,
@@ -523,11 +529,7 @@ impl TryFrom<&ArrowField> for Field {
                 DataType::List(_) | DataType::LargeList(_) => Some(Encoding::Plain),
                 _ => None,
             },
-            extension_name: field
-                .metadata()
-                .get("ARROW:extension:name")
-                .map(|name| name.to_owned())
-                .unwrap_or_else(|| "".to_string()),
+            metadata: field.metadata().clone(),
             nullable: field.is_nullable(),
             children,
             dictionary: None,
@@ -546,30 +548,33 @@ impl TryFrom<ArrowField> for Field {
 impl From<&Field> for ArrowField {
     fn from(field: &Field) -> Self {
         let out = Self::new(&field.name, field.data_type(), field.nullable);
-
-        if !field.extension_name.is_empty() {
-            out.with_metadata(
-                vec![(
-                    "ARROW:extension:name".to_string(),
-                    field.extension_name.clone(),
-                )]
-                .into_iter()
-                .collect(),
-            )
-        } else {
-            out
-        }
+        out.with_metadata(field.metadata.clone())
     }
 }
 
 impl From<&pb::Field> for Field {
     fn from(field: &pb::Field) -> Self {
+        let mut lance_metadata: HashMap<String, String> = field
+            .metadata
+            .iter()
+            .map(|(key, value)| {
+                let string_value = String::from_utf8_lossy(value).to_string();
+                (key.clone(), string_value)
+            })
+            .collect();
+        if !field.extension_name.is_empty() {
+            lance_metadata.insert(
+                "ARROW:extension:name".to_string(),
+                field.extension_name.clone(),
+            );
+        }
+        // TODO (check extension_name)
         Self {
             name: field.name.clone(),
             id: field.id,
             parent_id: field.parent_id,
             logical_type: LogicalType(field.logical_type.clone()),
-            extension_name: field.extension_name.clone(),
+            metadata: lance_metadata,
             encoding: match field.encoding {
                 1 => Some(Encoding::Plain),
                 2 => Some(Encoding::VarBinary),
@@ -586,6 +591,12 @@ impl From<&pb::Field> for Field {
 
 impl From<&Field> for pb::Field {
     fn from(field: &Field) -> Self {
+        let pb_metadata = field
+            .metadata
+            .clone()
+            .into_iter()
+            .map(|(key, value)| (key, value.into_bytes()))
+            .collect();
         Self {
             id: field.id,
             parent_id: field.parent_id,
@@ -600,7 +611,11 @@ impl From<&Field> for pb::Field {
             },
             nullable: field.nullable,
             dictionary: field.dictionary.as_ref().map(pb::Dictionary::from),
-            extension_name: field.extension_name.clone(),
+            metadata: pb_metadata,
+            extension_name: field
+                .extension_name()
+                .map(|name| name.to_owned())
+                .unwrap_or(String::new()),
             r#type: 0,
         }
     }

--- a/rust/src/datatypes/field.rs
+++ b/rust/src/datatypes/field.rs
@@ -568,7 +568,6 @@ impl From<&pb::Field> for Field {
                 field.extension_name.clone(),
             );
         }
-        // TODO (check extension_name)
         Self {
             name: field.name.clone(),
             id: field.id,


### PR DESCRIPTION
Previously we had just extracted the extension name from the field and discarded the rest of the metadata.  Unfortunately, these fields are used to parameterize extension types.  For example:

```
// A fixed shape tensor extension type for tensors with shape (2, 3)
metadata: {
    "ARROW:extension:name": "arrow.fixed_shape_tensor",
    "ARROW:extension:metadata": "{\"shape\":[2,3]}",
},
```

This PR keeps all of the metadata information.  This also allows for a lossless transformation when users have their own custom field metadata.