### PR TITLE
[bench] Fix up rust benchmarks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,8 @@ jobs:
       - name: Run tests
         run: |
           cargo test --all-features
+      - name: Build benchmarks
+          cargo build --benches
   linux-arm:
     runs-on: buildjet-4vcpu-ubuntu-2204-arm
     timeout-minutes: 30

--- a/rust/benches/argmin.rs
+++ b/rust/benches/argmin.rs
@@ -17,7 +17,7 @@ use std::{sync::Arc, time::Duration};
 use arrow_array::{Float32Array, UInt32Array};
 use criterion::{criterion_group, criterion_main, Criterion};
 
-use lance::utils::testing::generate_random_array_with_seed;
+use lance::utils::datagen::generate_random_array_with_seed;
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
 

--- a/rust/benches/cosine.rs
+++ b/rust/benches/cosine.rs
@@ -19,7 +19,7 @@ use lance::linalg::cosine::cosine_distance_batch;
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
 
-use lance::utils::testing::generate_random_array_with_seed;
+use lance::utils::datagen::generate_random_array_with_seed;
 
 fn bench_distance(c: &mut Criterion) {
     const DIMENSION: usize = 1024;

--- a/rust/benches/dot.rs
+++ b/rust/benches/dot.rs
@@ -26,7 +26,7 @@ use num_traits::{real::Real, FromPrimitive};
 use pprof::criterion::{Output, PProfProfiler};
 
 use lance::linalg::dot::{dot, Dot};
-use lance::utils::testing::generate_random_array_with_seed;
+use lance::utils::datagen::generate_random_array_with_seed;
 
 #[inline]
 fn dot_arrow_artiy<T: ArrowNumericType>(x: &PrimitiveArray<T>, y: &PrimitiveArray<T>) -> T::Native {
@@ -53,17 +53,17 @@ where
             PrimitiveArray::<T>::from_trusted_len_iter((0..target.len() / DIMENSION).map(|idx| {
                 let arr = target.slice(idx * DIMENSION, DIMENSION);
                 Some(dot_arrow_artiy(&key, &arr))
-            }))
+            }));
         });
     });
 
     c.bench_function(format!("Dot({type_name})").as_str(), |b| {
         let x = key.values();
         b.iter(|| unsafe {
-            PrimitiveArray::<T>::from_trusted_len_iter((0..target.len() / DIMENSION).map(|idx| {
+            PrimitiveArray::<T>::from_trusted_len_iter((0..target.len() / 1024).map(|idx| {
                 let y = target.values()[idx * DIMENSION..(idx + 1) * DIMENSION].as_ref();
                 Some(dot(x, y))
-            }))
+            }));
         });
     });
 

--- a/rust/benches/ivf_pq.rs
+++ b/rust/benches/ivf_pq.rs
@@ -24,7 +24,7 @@ use lance::{
         vector::{MetricType, VectorIndexParams},
         DatasetIndexExt, IndexType,
     },
-    utils::testing::generate_random_array,
+    utils::datagen::generate_random_array,
     Dataset,
 };
 #[cfg(target_os = "linux")]

--- a/rust/benches/kmeans.rs
+++ b/rust/benches/kmeans.rs
@@ -20,8 +20,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
 
+use lance::utils::datagen::generate_random_array;
 use lance::utils::kmeans::KMeans;
-use lance::utils::testing::generate_random_array;
 
 fn bench_train(c: &mut Criterion) {
     // default tokio runtime

--- a/rust/benches/l2.rs
+++ b/rust/benches/l2.rs
@@ -23,7 +23,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
 
 use lance::linalg::l2::l2_distance_batch;
-use lance::utils::testing::generate_random_array_with_seed;
+use lance::utils::datagen::generate_random_array_with_seed;
 
 #[inline]
 fn l2_arrow(x: &Float32Array, y: &Float32Array) -> f32 {

--- a/rust/benches/scan.rs
+++ b/rust/benches/scan.rs
@@ -120,7 +120,7 @@ async fn create_file(path: &std::path::Path, mode: WriteMode) {
 
     let test_uri = path.to_str().unwrap();
     std::fs::remove_dir_all(test_uri).map_or_else(|_| println!("{} not exists", test_uri), |_| {});
-    let mut write_params = WriteParams {
+    let write_params = WriteParams {
         max_rows_per_file: num_rows as usize,
         max_rows_per_group: batch_size as usize,
         mode: mode,

--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -1092,7 +1092,7 @@ mod tests {
     use crate::index::IndexType;
     use crate::index::{vector::VectorIndexParams, DatasetIndexExt};
     use crate::io::deletion::read_deletion_file;
-    use crate::{datatypes::Schema, utils::testing::generate_random_array};
+    use crate::{datatypes::Schema, utils::datagen::generate_random_array};
 
     use crate::dataset::WriteMode::Overwrite;
     use arrow_array::{

--- a/rust/src/index.rs
+++ b/rust/src/index.rs
@@ -199,7 +199,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use tempfile::tempdir;
 
-    use crate::{arrow::*, index::vector::MetricType, utils::testing::generate_random_array};
+    use crate::{arrow::*, index::vector::MetricType, utils::datagen::generate_random_array};
 
     #[tokio::test]
     async fn test_recreate_index() {

--- a/rust/src/index/vector/diskann.rs
+++ b/rust/src/index/vector/diskann.rs
@@ -123,7 +123,7 @@ mod tests {
             DatasetIndexExt,
             {vector::VectorIndexParams, IndexType},
         },
-        utils::testing::generate_random_array,
+        utils::datagen::generate_random_array,
     };
 
     #[tokio::test]

--- a/rust/src/index/vector/diskann/builder.rs
+++ b/rust/src/index/vector/diskann/builder.rs
@@ -380,7 +380,7 @@ mod tests {
     use tempfile;
 
     use crate::dataset::WriteParams;
-    use crate::utils::testing::generate_random_array;
+    use crate::utils::datagen::generate_random_array;
 
     async fn create_dataset(uri: &str, n: usize, dim: usize) -> Arc<Dataset> {
         let schema = Arc::new(ArrowSchema::new(vec![Field::new(

--- a/rust/src/index/vector/graph/persisted.rs
+++ b/rust/src/index/vector/graph/persisted.rs
@@ -343,7 +343,7 @@ mod tests {
         dataset::WriteParams,
         index::vector::diskann::row_vertex::RowVertexSerDe,
         index::vector::MetricType,
-        utils::testing::generate_random_array,
+        utils::datagen::generate_random_array,
     };
 
     #[derive(Clone, Debug)]

--- a/rust/src/index/vector/ivf.rs
+++ b/rust/src/index/vector/ivf.rs
@@ -886,7 +886,7 @@ mod tests {
 
     use crate::{
         index::{vector::VectorIndexParams, DatasetIndexExt, IndexType},
-        utils::testing::generate_random_array,
+        utils::datagen::generate_random_array,
     };
 
     #[tokio::test]

--- a/rust/src/io/commit.rs
+++ b/rust/src/io/commit.rs
@@ -501,7 +501,7 @@ mod tests {
     use crate::index::vector::{MetricType, VectorIndexParams};
     use crate::index::{DatasetIndexExt, IndexType};
     use crate::io::object_store::ObjectStoreParams;
-    use crate::utils::testing::generate_random_array;
+    use crate::utils::datagen::generate_random_array;
     use crate::Dataset;
 
     async fn test_commit_handler(handler: Arc<dyn CommitHandler>, should_succeed: bool) {

--- a/rust/src/io/exec/knn.rs
+++ b/rust/src/io/exec/knn.rs
@@ -439,7 +439,7 @@ mod tests {
     use crate::dataset::{Dataset, WriteParams};
     use crate::index::vector::MetricType;
     use crate::io::exec::testing::TestingExec;
-    use crate::utils::testing::generate_random_array;
+    use crate::utils::datagen::generate_random_array;
 
     #[tokio::test]
     async fn knn_flat_search() {

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -17,7 +17,6 @@
 
 //! Various utilities
 
-#[cfg(test)]
 pub mod datagen;
 pub mod kmeans;
 pub mod sql;

--- a/rust/src/utils/testing.rs
+++ b/rust/src/utils/testing.rs
@@ -20,48 +20,17 @@ use bytes::Bytes;
 use chrono::Duration;
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
-use num_traits::real::Real;
-use num_traits::FromPrimitive;
 use object_store::path::Path;
 use object_store::{
     Error as OSError, GetOptions, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore,
     Result as OSResult,
 };
-use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::future;
-use std::iter::repeat_with;
 use std::ops::Range;
 use std::sync::{Arc, Mutex, MutexGuard};
 use tokio::io::AsyncWrite;
-
-use arrow_array::{ArrowNumericType, Float32Array, NativeAdapter, PrimitiveArray};
-
-/// Create a random float32 array.
-pub fn generate_random_array_with_seed<T: ArrowNumericType>(
-    n: usize,
-    seed: [u8; 32],
-) -> PrimitiveArray<T>
-where
-    T::Native: Real + FromPrimitive,
-    NativeAdapter<T>: From<T::Native>,
-{
-    let mut rng = StdRng::from_seed(seed);
-
-    PrimitiveArray::<T>::from_iter(repeat_with(|| T::Native::from_f32(rng.gen::<f32>())).take(n))
-}
-
-/// Create a random float32 array.
-pub fn generate_random_array(n: usize) -> Float32Array {
-    let mut rng = rand::thread_rng();
-    Float32Array::from(
-        repeat_with(|| rng.gen::<f32>())
-            .take(n)
-            .collect::<Vec<f32>>(),
-    )
-}
 
 /// Asserts that the expression returns an error and the error, when converted to
 /// a string, contains the given substring.


### PR DESCRIPTION
- Move `generate_random_array` and `generate_random_array_with_seed` to datagen.rs
- Limit utils::testing to cfg[test] but include utils::datagen without the `#cfg[test]` predicate
- Add a CI step to build the benchmark code (without running them).
- Changed references from utils::testing::generate_random_array* to utils::datagen::generate_random_array* in a bunch of places.