### PR TITLE
feat: add function to cleanup partial writes

### DIFF
--- a/python/python/lance/cleanup.py
+++ b/python/python/lance/cleanup.py
@@ -1,0 +1,31 @@
+#  Copyright (c) 2023. Lance Developers
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from typing import List, Tuple
+
+from .lance import _cleanup_partial_writes
+
+
+def cleanup_partial_writes(objects: List[Tuple[str, str]]):
+    """Cleans up partial writes from a list of objects.
+
+    These writes can be discovered using the
+    :class:`lance.progress.FragmentWriteProgress` class.
+
+    Parameters
+    ----------
+    objects : List[Tuple[str, str]]
+        A list of tuples of (fragment_id, multipart_id) to clean up.
+    """
+    _cleanup_partial_writes(objects)

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -72,6 +72,10 @@ class FragmentMetadata:
         """Return the deletion file, if any"""
         return self._metadata.deletion_file()
 
+    @property
+    def id(self) -> int:
+        return self._metadata.id
+
 
 class LanceFragment(pa.dataset.Fragment):
     def __init__(

--- a/python/python/lance/progress.py
+++ b/python/python/lance/progress.py
@@ -200,5 +200,7 @@ class FileSystemFragmentWriteProgress(FragmentWriteProgress):
 
         for path in marker_paths:
             self._fs.delete_file(path)
+            json_path = path.rstrip(".in_progress") + ".json"
+            self._fs.delete_file(json_path)
 
         return len(objects)

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -83,10 +83,6 @@ def test_dataset_progress(tmp_path: Path):
     # In-progress file should be deleted
     assert not (tmp_path / "fragment_0.in_progress").exists()
 
-    import os
-
-    print(os.listdir(tmp_path))
-
     # Metadata should be written
     with open(tmp_path / "fragment_0.json") as f:
         metadata = json.load(f)

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -95,22 +95,29 @@ def test_dataset_progress(tmp_path: Path):
 
     assert fragment == FragmentMetadata.from_json(json.dumps(metadata))
 
+    mock_fragment = {
+        "id": 0,
+        "files": [
+            {
+                "path": "fragment_0.parquet",
+                "fields": [0],
+            }
+        ],
+    }
+
     mock_in_progress = {
         "fragment_id": 1,
         "multipart_id": "whatever",
-        "metadata": {
-            "id": 0,
-            "files": [
-                {
-                    "path": "fragment_0.parquet",
-                    "fields": [0],
-                }
-            ],
-        },
+        "metadata": mock_fragment,
     }
+
+    with open(tmp_path / "fragment_1.json", "w") as f:
+        json.dump(mock_fragment, f)
+
     with open(tmp_path / "fragment_1.in_progress", "w") as f:
         json.dump(mock_in_progress, f)
 
     progress.cleanup_partial_writes()
 
+    assert not (tmp_path / "fragment_1.json").exists()
     assert not (tmp_path / "fragment_1.in_progress").exists()

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -59,7 +59,7 @@ const DEFAULT_METADATA_CACHE_SIZE: usize = 256;
 pub struct Dataset {
     #[pyo3(get)]
     uri: String,
-    pub(crate) ds: Arc<LanceDataset>,
+    ds: Arc<LanceDataset>,
 }
 
 #[pymethods]

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -59,7 +59,7 @@ const DEFAULT_METADATA_CACHE_SIZE: usize = 256;
 pub struct Dataset {
     #[pyo3(get)]
     uri: String,
-    ds: Arc<LanceDataset>,
+    pub(crate) ds: Arc<LanceDataset>,
 }
 
 #[pymethods]

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -474,6 +474,11 @@ impl FragmentMetadata {
                 .map(|d| deletion_file_path(&Default::default(), self.inner.id, &d).to_string()),
         )
     }
+
+    #[getter]
+    fn id(&self) -> PyResult<u64> {
+        Ok(self.inner.id)
+    }
 }
 
 #[pyfunction(name = "_cleanup_partial_writes")]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -64,7 +64,7 @@ lazy_static! {
 #[pymodule]
 fn lance(_py: Python, m: &PyModule) -> PyResult<()> {
     let env = Env::new()
-        .filter("LANCE_LOG")
+        .filter_or("LANCE_LOG", "warn")
         .write_style("LANCE_LOG_STYLE");
     env_logger::init_from_env(env);
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -46,6 +46,7 @@ pub(crate) mod scanner;
 pub(crate) mod updater;
 
 pub use crate::arrow::{bfloat16_array, BFloat16};
+use crate::fragment::cleanup_partial_writes;
 pub use dataset::write_dataset;
 pub use dataset::Dataset;
 pub use fragment::FragmentMetadata;
@@ -79,6 +80,7 @@ fn lance(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(json_to_schema))?;
     m.add_wrapped(wrap_pyfunction!(infer_tfrecord_schema))?;
     m.add_wrapped(wrap_pyfunction!(read_tfrecord))?;
+    m.add_wrapped(wrap_pyfunction!(cleanup_partial_writes))?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
 }

--- a/rust/src/dataset/cleanup.rs
+++ b/rust/src/dataset/cleanup.rs
@@ -957,9 +957,7 @@ mod tests {
             (&path2, &non_existent_multipart_id),
         ];
 
-        cleanup_partial_writes(&dataset, objects.into_iter())
-            .await
-            .unwrap();
+        cleanup_partial_writes(&dataset, objects).await.unwrap();
 
         // Assert directly calling abort returns not found on first one.
         assert!(store

--- a/rust/src/dataset/cleanup.rs
+++ b/rust/src/dataset/cleanup.rs
@@ -321,7 +321,7 @@ pub async fn cleanup_old_versions(
 /// have been started but never finished.
 pub async fn cleanup_partial_writes(
     dataset: &Dataset,
-    objects: impl Iterator<Item = (&Path, &String)>,
+    objects: impl IntoIterator<Item = (&Path, &String)>,
 ) -> Result<()> {
     let store = dataset.object_store();
     futures::stream::iter(objects)
@@ -329,7 +329,10 @@ pub async fn cleanup_partial_writes(
             match store.inner.abort_multipart(path, multipart_id).await {
                 Ok(_) => Ok(()),
                 // We don't care if it's not there.
-                Err(object_store::Error::NotFound { .. }) => {
+                // TODO: once this issue is addressed, we should just use teh error
+                // variant. https://github.com/apache/arrow-rs/issues/4749
+                // Err(object_store::Error::NotFound { .. }) => {
+                Err(e) if e.to_string().contains("No such file or directory") => {
                     log::warn!("Partial write not found: {} {}", path, multipart_id);
                     Ok(())
                 }
@@ -349,8 +352,10 @@ mod tests {
         sync::{Arc, Mutex},
     };
 
-    use arrow_array::RecordBatchReader;
+    use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+    use arrow_array::{RecordBatchIterator, RecordBatchReader};
     use chrono::Duration;
+    use tokio::io::AsyncWriteExt;
 
     use crate::{
         dataset::{ReadParams, WriteMode, WriteParams},
@@ -924,5 +929,43 @@ mod tests {
         let after_count = fixture.count_files().await.unwrap();
         assert_eq!(after_count.num_data_files, 1);
         assert_eq!(after_count.num_manifest_files, 2);
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_partial_writes() {
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let schema = ArrowSchema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let reader = RecordBatchIterator::new(vec![], Arc::new(schema));
+        let dataset = Dataset::write(reader, test_uri, Default::default())
+            .await
+            .unwrap();
+        let store = dataset.object_store();
+
+        // Create a partial write
+        let path1 = dataset.base.child("test");
+        let (multipart_id, mut writer) = store.inner.put_multipart(&path1).await.unwrap();
+        writer.write_all(b"test").await.unwrap();
+
+        // Add a non-existant path and id
+        let path2 = dataset.base.child("test2");
+        let non_existent_multipart_id = "non-existant-id".to_string();
+
+        let objects = vec![
+            (&path1, &multipart_id),
+            (&path2, &non_existent_multipart_id),
+        ];
+
+        cleanup_partial_writes(&dataset, objects.into_iter())
+            .await
+            .unwrap();
+
+        // Assert directly calling abort returns not found on first one.
+        assert!(store
+            .inner
+            .abort_multipart(&path1, &multipart_id)
+            .await
+            .is_err());
     }
 }

--- a/rust/src/io/object_store.rs
+++ b/rust/src/io/object_store.rs
@@ -20,9 +20,10 @@ use std::path::Path as StdPath;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
+pub use ::object_store::path::Path;
 use ::object_store::{
     aws::AmazonS3Builder, azure::MicrosoftAzureBuilder, gcp::GoogleCloudStorageBuilder,
-    local::LocalFileSystem, memory::InMemory, path::Path, ClientOptions, CredentialProvider,
+    local::LocalFileSystem, memory::InMemory, ClientOptions, CredentialProvider,
     Error as ObjectStoreError, ObjectStore as OSObjectStore, Result as ObjectStoreResult,
 };
 use async_trait::async_trait;


### PR DESCRIPTION
In #1146 we added a way to detect partial writes but no way to clean them up. This PR exposes a function that can be used to perform cleanup.

Also there were several bugs in #1146, so this PR also fixes those.