### PR TITLE
use commit handler to find the latest version of a dataset

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -48,7 +48,9 @@ build-backend = "maturin"
 
 [project.optional-dependencies]
 tests = [
-    "pandas>=1.4",
+    # Can't use pandas 2.1 in tests until this duckdb bug is fixed:
+    # https://github.com/duckdb/duckdb/issues/8735
+    "pandas>=1.4,<2.1",
     "pytest",
     "duckdb",
     "polars[pyarrow,pandas]",


### PR DESCRIPTION
part of #1183

This PR adds `get_latest_version` to `CommitHandler` and use the commit handler to resolve latest version in `Dataset::open`