### PR TITLE
fix: make field name consistent

### DIFF
--- a/rust/src/utils/tfrecord.rs
+++ b/rust/src/utils/tfrecord.rs
@@ -287,7 +287,7 @@ fn make_field(name: &str, feature_meta: &FeatureMeta) -> Result<ArrowField> {
                 ),
                 _ => None,
             };
-            let mut inner_field = ArrowField::new("value", inner_type, false);
+            let mut inner_field = ArrowField::new("item", inner_type, true);
             if let Some(metadata) = inner_meta {
                 inner_field.set_metadata(metadata);
             }


### PR DESCRIPTION
I haven't been able to repro this in the tests, but on some private sample data this fixes an error. The other fields are named "item" and marked as nullable, so it's possible to get a schema mismatch currently.