### PR TITLE
feat: update the commit function to work with transactions

### DIFF
--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -26,7 +26,13 @@ except ImportError:
     pd = None
     ts_types = Union[datetime, str]
 
-from .dataset import LanceDataset, LanceOperation, LanceScanner, __version__, write_dataset
+from .dataset import (
+    LanceDataset,
+    LanceOperation,
+    LanceScanner,
+    __version__,
+    write_dataset,
+)
 from .fragment import FragmentMetadata, LanceFragment
 from .schema import json_to_schema, schema_to_json
 from .util import sanitize_ts

--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -26,13 +26,14 @@ except ImportError:
     pd = None
     ts_types = Union[datetime, str]
 
-from .dataset import LanceDataset, LanceScanner, __version__, write_dataset
+from .dataset import LanceDataset, LanceOperation, LanceScanner, __version__, write_dataset
 from .fragment import FragmentMetadata, LanceFragment
 from .schema import json_to_schema, schema_to_json
 from .util import sanitize_ts
 
 __all__ = [
     "LanceDataset",
+    "LanceOperation",
     "LanceScanner",
     "__version__",
     "write_dataset",

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -710,7 +710,7 @@ class LanceDataset(pa.dataset.Dataset):
         """
         if isinstance(base_uri, Path):
             base_uri = str(base_uri)
-            
+
         _Dataset.commit(base_uri, operation._to_inner(), read_version, options)
         return LanceDataset(base_uri)
 
@@ -719,7 +719,7 @@ class BaseOperation(ABC):
     @abstractmethod
     def _to_inner(self):
         raise NotImplementedError()
-    
+
     @staticmethod
     def _validate_fragments(fragments):
         if not isinstance(fragments, list):
@@ -731,12 +731,11 @@ class BaseOperation(ABC):
         ):
             raise TypeError(
                 f"fragments must be list[FragmentMetadata], got {type(fragments[0])}"
-            )        
+            )
 
 
 # LanceOperation is a namespace for operations that can be applied to a dataset.
 class LanceOperation:
-
     @dataclass
     class Overwrite(BaseOperation):
         new_schema: pa.Schema
@@ -744,9 +743,11 @@ class LanceOperation:
 
         def __post_init__(self):
             if not isinstance(self.new_schema, pa.Schema):
-                raise TypeError(f"schema must be pyarrow.Schema, got {type(self.new_schema)}")
+                raise TypeError(
+                    f"schema must be pyarrow.Schema, got {type(self.new_schema)}"
+                )
             BaseOperation._validate_fragments(self.fragments)
-            
+
         def _to_inner(self):
             raw_fragments = [f._metadata for f in self.fragments]
             # TODO: make fragments as a generator
@@ -758,11 +759,11 @@ class LanceOperation:
 
         def __post_init__(self):
             BaseOperation._validate_fragments(self.fragments)
-        
+
         def _to_inner(self):
             raw_fragments = [f._metadata for f in self.fragments]
             return _Operation.append(raw_fragments)
-        
+
     @dataclass
     class Delete(BaseOperation):
         updated_fragments: Iterable[FragmentMetadata]
@@ -774,8 +775,9 @@ class LanceOperation:
 
         def _to_inner(self):
             raw_updated_fragments = [f._metadata for f in self.updated_fragments]
-            return _Operation.delete(raw_updated_fragments, self.deleted_fragment_ids, self.predicate)
-
+            return _Operation.delete(
+                raw_updated_fragments, self.deleted_fragment_ids, self.predicate
+            )
 
     @dataclass
     class Rewrite(BaseOperation):
@@ -790,7 +792,7 @@ class LanceOperation:
             raw_old_fragments = [f._metadata for f in self.old_fragments]
             raw_new_fragments = [f._metadata for f in self.new_fragments]
             return _Operation.rewrite(raw_old_fragments, raw_new_fragments)
-        
+
     @dataclass
     class Merge(BaseOperation):
         fragments: Iterable[FragmentMetadata]
@@ -802,7 +804,6 @@ class LanceOperation:
         def _to_inner(self):
             raw_fragments = [f._metadata for f in self.fragments]
             return _Operation.merge(raw_fragments, self.schema)
-
 
     @dataclass
     class Restore(BaseOperation):

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -690,7 +690,8 @@ class LanceDataset(pa.dataset.Dataset):
 
         This method is an advanced method which allows users to describe a change
         that has been made to the data files.  This method is not needed when using
-        lancedb to apply changes (e.g. when using the Dataset class)
+        Lance to apply changes (e.g. when using :py:class:`LanceDataset` or
+        :py:func:`write_dataset`.)
 
         It's current purpose is to allow for changes being made in a distributed
         environment where no single process is doing all of the work.  For example,

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -792,6 +792,19 @@ class LanceOperation:
             return _Operation.rewrite(raw_old_fragments, raw_new_fragments)
         
     @dataclass
+    class Merge(BaseOperation):
+        fragments: Iterable[FragmentMetadata]
+        schema: pa.Schema
+
+        def __post_init__(self):
+            BaseOperation._validate_fragments(self.fragments)
+
+        def _to_inner(self):
+            raw_fragments = [f._metadata for f in self.fragments]
+            return _Operation.merge(raw_fragments, self.schema)
+
+
+    @dataclass
     class Restore(BaseOperation):
         version: int
 

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -347,4 +347,4 @@ class LanceFragment(pa.dataset.Fragment):
         FragmentMetadata
         """
 
-        return FragmentMetadata(self._fragment.metadata())
+        return FragmentMetadata(self._fragment.metadata().json())

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -420,11 +420,9 @@ def test_delete_with_commit(tmp_path: Path):
 
     fragments = lance.dataset(base_dir).get_fragments()
 
-    fragment = lance.fragment.LanceFragment.create(
-        base_dir, half_table, fragment_id=fragments[0].fragment_id
-    )
+    updated_fragment = fragments[0].delete("a >= 50")
     delete = lance.LanceOperation.Delete(
-        [fragment], [fragments[1].fragment_id], "hello"
+        [updated_fragment], [fragments[1].fragment_id], "hello"
     )
 
     dataset = lance.LanceDataset._commit(base_dir, delete, read_version=2)

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -440,7 +440,7 @@ def test_rewrite_with_commit(tmp_path: Path):
     lance.write_dataset(table, base_dir)
     lance.write_dataset(table, base_dir, mode="append")
 
-    combined = expected = pa.Table.from_pydict(
+    combined = pa.Table.from_pydict(
         {
             "a": list(range(100)) + list(range(100)),
             "b": list(range(100)) + list(range(100)),

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -362,7 +362,7 @@ def test_add_columns(tmp_path: Path):
     fragment_metadata = fragment.add_columns(adder, columns=["a"])
     schema = dataset.schema.append(pa.field("c", pa.int64()))
 
-    operation = lance.LanceOperation.overwrite(schema, [fragment_metadata])
+    operation = lance.LanceOperation.Overwrite(schema, [fragment_metadata])
     dataset = lance.LanceDataset._commit(base_dir, operation)
     assert dataset.schema == schema
 
@@ -372,13 +372,91 @@ def test_add_columns(tmp_path: Path):
     )
 
 
-def test_create_from_fragments(tmp_path: Path):
+def test_create_from_commit(tmp_path: Path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
     base_dir = tmp_path / "test"
     fragment = lance.fragment.LanceFragment.create(base_dir, table)
 
-    operation = lance.LanceOperation.overwrite(table.schema, [fragment])
+    operation = lance.LanceOperation.Overwrite(table.schema, [fragment])
     dataset = lance.LanceDataset._commit(base_dir, operation)
+    tbl = dataset.to_table()
+    assert tbl == table
+
+def test_append_with_commit(tmp_path: Path):
+    table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
+    base_dir = tmp_path / "test"
+
+    lance.write_dataset(table, base_dir)
+
+    fragment = lance.fragment.LanceFragment.create(base_dir, table)
+    append = lance.LanceOperation.Append([fragment])
+
+    with pytest.raises(OSError):
+        # Must specify read version
+        dataset = lance.LanceDataset._commit(base_dir, append)
+
+    dataset = lance.LanceDataset._commit(base_dir, append, read_version=1)
+
+    tbl = dataset.to_table()
+
+    expected = pa.Table.from_pydict({
+        "a": list(range(100)) + list(range(100)),
+        "b": list(range(100)) + list(range(100))})
+    assert tbl == expected
+
+
+def test_delete_with_commit(tmp_path: Path):
+    table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
+    base_dir = tmp_path / "test"
+
+    lance.write_dataset(table, base_dir)    
+    lance.write_dataset(table, base_dir, mode="append")
+
+    half_table = pa.Table.from_pydict({"a": range(50), "b": range(50)})
+
+    fragments = lance.dataset(base_dir).get_fragments()
+    
+    fragment = lance.fragment.LanceFragment.create(base_dir, half_table, fragment_id=fragments[0].fragment_id)
+    delete = lance.LanceOperation.Delete([fragment], [fragments[1].fragment_id], "hello")
+
+    dataset = lance.LanceDataset._commit(base_dir, delete, read_version=2)
+
+    tbl = dataset.to_table()
+    assert tbl == half_table
+
+def test_rewrite_with_commit(tmp_path: Path):
+    table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
+    base_dir = tmp_path / "test"
+
+    lance.write_dataset(table, base_dir)
+    lance.write_dataset(table, base_dir, mode="append")
+
+    combined = expected = pa.Table.from_pydict({
+        "a": list(range(100)) + list(range(100)),
+        "b": list(range(100)) + list(range(100))})
+
+    to_be_rewrote = [lf.metadata for lf in lance.dataset(base_dir).get_fragments()]
+
+    fragment = lance.fragment.LanceFragment.create(base_dir, combined)
+    rewrite = lance.LanceOperation.Rewrite(to_be_rewrote, [fragment])
+
+    dataset = lance.LanceDataset._commit(base_dir, rewrite, read_version=1)
+
+    tbl = dataset.to_table()
+    assert tbl == combined
+
+    assert len(lance.dataset(base_dir).get_fragments()) == 1
+
+def test_restore_with_commit(tmp_path: Path):
+    table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
+    base_dir = tmp_path / "test"
+
+    lance.write_dataset(table, base_dir)
+    lance.write_dataset(table, base_dir, mode="append")
+
+    restore = lance.LanceOperation.Restore(1)
+    dataset = lance.LanceDataset._commit(base_dir, restore)
+
     tbl = dataset.to_table()
     assert tbl == table
 
@@ -413,7 +491,7 @@ def test_deletion_file(tmp_path: Path):
     assert new_fragment.deletion_file() is not None
     assert re.match("_deletions/0-1-[0-9]{1,32}.arrow", new_fragment.deletion_file())
     print(type(new_fragment), new_fragment)
-    operation = lance.LanceOperation.overwrite(table.schema, [new_fragment])
+    operation = lance.LanceOperation.Overwrite(table.schema, [new_fragment])
     dataset = lance.LanceDataset._commit(base_dir, operation)
     assert dataset.count_rows() == 90
 
@@ -432,7 +510,7 @@ def test_commit_fragments_via_scanner(tmp_path: Path):
     unpickled = pickle.loads(pickled)
     assert fragment_metadata == unpickled
 
-    operation = lance.LanceOperation.overwrite(table.schema, [fragment_metadata])
+    operation = lance.LanceOperation.Overwrite(table.schema, [fragment_metadata])
     dataset = lance.LanceDataset._commit(base_dir, operation)
     assert dataset.schema == table.schema
 

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -362,7 +362,8 @@ def test_add_columns(tmp_path: Path):
     fragment_metadata = fragment.add_columns(adder, columns=["a"])
     schema = dataset.schema.append(pa.field("c", pa.int64()))
 
-    dataset = lance.LanceDataset._commit(base_dir, schema, [fragment_metadata])
+    operation = lance.LanceOperation.overwrite(schema, [fragment_metadata])
+    dataset = lance.LanceDataset._commit(base_dir, operation)
     assert dataset.schema == schema
 
     tbl = dataset.to_table()
@@ -376,7 +377,8 @@ def test_create_from_fragments(tmp_path: Path):
     base_dir = tmp_path / "test"
     fragment = lance.fragment.LanceFragment.create(base_dir, table)
 
-    dataset = lance.LanceDataset._commit(base_dir, table.schema, [fragment])
+    operation = lance.LanceOperation.overwrite(table.schema, [fragment])
+    dataset = lance.LanceDataset._commit(base_dir, operation)
     tbl = dataset.to_table()
     assert tbl == table
 
@@ -411,7 +413,8 @@ def test_deletion_file(tmp_path: Path):
     assert new_fragment.deletion_file() is not None
     assert re.match("_deletions/0-1-[0-9]{1,32}.arrow", new_fragment.deletion_file())
     print(type(new_fragment), new_fragment)
-    dataset = lance.LanceDataset._commit(base_dir, table.schema, [new_fragment])
+    operation = lance.LanceOperation.overwrite(table.schema, [new_fragment])
+    dataset = lance.LanceDataset._commit(base_dir, operation)
     assert dataset.count_rows() == 90
 
 
@@ -429,7 +432,8 @@ def test_commit_fragments_via_scanner(tmp_path: Path):
     unpickled = pickle.loads(pickled)
     assert fragment_metadata == unpickled
 
-    dataset = lance.LanceDataset._commit(base_dir, table.schema, [fragment_metadata])
+    operation = lance.LanceOperation.overwrite(table.schema, [fragment_metadata])
+    dataset = lance.LanceDataset._commit(base_dir, operation)
     assert dataset.schema == table.schema
 
     tbl = dataset.to_table()

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -382,6 +382,7 @@ def test_create_from_commit(tmp_path: Path):
     tbl = dataset.to_table()
     assert tbl == table
 
+
 def test_append_with_commit(tmp_path: Path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
     base_dir = tmp_path / "test"
@@ -399,9 +400,12 @@ def test_append_with_commit(tmp_path: Path):
 
     tbl = dataset.to_table()
 
-    expected = pa.Table.from_pydict({
-        "a": list(range(100)) + list(range(100)),
-        "b": list(range(100)) + list(range(100))})
+    expected = pa.Table.from_pydict(
+        {
+            "a": list(range(100)) + list(range(100)),
+            "b": list(range(100)) + list(range(100)),
+        }
+    )
     assert tbl == expected
 
 
@@ -409,20 +413,25 @@ def test_delete_with_commit(tmp_path: Path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
     base_dir = tmp_path / "test"
 
-    lance.write_dataset(table, base_dir)    
+    lance.write_dataset(table, base_dir)
     lance.write_dataset(table, base_dir, mode="append")
 
     half_table = pa.Table.from_pydict({"a": range(50), "b": range(50)})
 
     fragments = lance.dataset(base_dir).get_fragments()
-    
-    fragment = lance.fragment.LanceFragment.create(base_dir, half_table, fragment_id=fragments[0].fragment_id)
-    delete = lance.LanceOperation.Delete([fragment], [fragments[1].fragment_id], "hello")
+
+    fragment = lance.fragment.LanceFragment.create(
+        base_dir, half_table, fragment_id=fragments[0].fragment_id
+    )
+    delete = lance.LanceOperation.Delete(
+        [fragment], [fragments[1].fragment_id], "hello"
+    )
 
     dataset = lance.LanceDataset._commit(base_dir, delete, read_version=2)
 
     tbl = dataset.to_table()
     assert tbl == half_table
+
 
 def test_rewrite_with_commit(tmp_path: Path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
@@ -431,9 +440,12 @@ def test_rewrite_with_commit(tmp_path: Path):
     lance.write_dataset(table, base_dir)
     lance.write_dataset(table, base_dir, mode="append")
 
-    combined = expected = pa.Table.from_pydict({
-        "a": list(range(100)) + list(range(100)),
-        "b": list(range(100)) + list(range(100))})
+    combined = expected = pa.Table.from_pydict(
+        {
+            "a": list(range(100)) + list(range(100)),
+            "b": list(range(100)) + list(range(100)),
+        }
+    )
 
     to_be_rewrote = [lf.metadata for lf in lance.dataset(base_dir).get_fragments()]
 
@@ -446,6 +458,7 @@ def test_rewrite_with_commit(tmp_path: Path):
     assert tbl == combined
 
     assert len(lance.dataset(base_dir).get_fragments()) == 1
+
 
 def test_restore_with_commit(tmp_path: Path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
@@ -468,7 +481,9 @@ def test_merge_with_commit(tmp_path: Path):
     lance.write_dataset(table, base_dir)
 
     fragment = lance.dataset(base_dir).get_fragments()[0]
-    merged = fragment.add_columns(lambda _: pa.RecordBatch.from_pydict({"c": range(100)}))
+    merged = fragment.add_columns(
+        lambda _: pa.RecordBatch.from_pydict({"c": range(100)})
+    )
 
     expected = pa.Table.from_pydict({"a": range(100), "b": range(100), "c": range(100)})
 
@@ -477,6 +492,7 @@ def test_merge_with_commit(tmp_path: Path):
 
     tbl = dataset.to_table()
     assert tbl == expected
+
 
 def test_data_files(tmp_path: Path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -20,7 +20,7 @@ from typing import Optional
 import pandas as pd
 import pyarrow as pa
 import pytest
-from lance import FragmentMetadata, LanceDataset, LanceFragment
+from lance import FragmentMetadata, LanceDataset, LanceFragment, LanceOperation
 from lance.progress import FileSystemFragmentWriteProgress, FragmentWriteProgress
 
 
@@ -50,7 +50,9 @@ def test_write_fragment_two_phases(tmp_path: Path):
     fragments = [FragmentMetadata.from_json(j) for j in json_array]
 
     schema = pa.schema([pa.field("a", pa.int64())])
-    dataset = LanceDataset._commit(tmp_path, schema, fragments)
+
+    operation = LanceOperation.overwrite(schema, fragments)
+    dataset = LanceDataset._commit(tmp_path, operation)
 
     df = dataset.to_table().to_pandas()
     pd.testing.assert_frame_equal(

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -51,7 +51,7 @@ def test_write_fragment_two_phases(tmp_path: Path):
 
     schema = pa.schema([pa.field("a", pa.int64())])
 
-    operation = LanceOperation.overwrite(schema, fragments)
+    operation = LanceOperation.Overwrite(schema, fragments)
     dataset = LanceDataset._commit(tmp_path, operation)
 
     df = dataset.to_table().to_pandas()

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -642,15 +642,13 @@ fn parse_write_mode(mode: &str) -> PyResult<WriteMode> {
 pub(crate) fn get_object_store_params(options: &PyDict) -> Option<ObjectStoreParams> {
     if options.is_none() {
         None
+    } else if let Some(commit_handler) = options.get_item("commit_handler") {
+        let py_commit_lock = PyCommitLock::new(commit_handler.to_object(options.py()));
+        let mut object_store_params = ObjectStoreParams::default();
+        object_store_params.set_commit_lock(Arc::new(py_commit_lock));
+        Some(object_store_params)
     } else {
-        if let Some(commit_handler) = options.get_item("commit_handler") {
-            let py_commit_lock = PyCommitLock::new(commit_handler.to_object(options.py()));
-            let mut object_store_params = ObjectStoreParams::default();
-            object_store_params.set_commit_lock(Arc::new(py_commit_lock));
-            Some(object_store_params)
-        } else {
-            None
-        }
+        None
     }
 }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -48,7 +48,7 @@ pub(crate) mod updater;
 pub use crate::arrow::{bfloat16_array, BFloat16};
 use crate::fragment::cleanup_partial_writes;
 pub use dataset::write_dataset;
-pub use dataset::Dataset;
+pub use dataset::{Dataset, Operation};
 pub use fragment::FragmentMetadata;
 use fragment::{DataFile, FileFragment};
 pub use reader::LanceReader;
@@ -70,6 +70,7 @@ fn lance(_py: Python, m: &PyModule) -> PyResult<()> {
 
     m.add_class::<Scanner>()?;
     m.add_class::<Dataset>()?;
+    m.add_class::<Operation>()?;
     m.add_class::<FileFragment>()?;
     m.add_class::<FragmentMetadata>()?;
     m.add_class::<DataFile>()?;

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -559,45 +559,106 @@ impl Dataset {
         Ok(())
     }
 
-    /// Create a new version of [`Dataset`] from a collection of fragments.
+    /// Commit changes to the dataset
+    ///
+    /// This operation is not needed if you are using append/write/delete to manipulate the dataset.
+    /// It is used to commit changes to the dataset that are made externally.  For example, a bulk
+    /// import tool may import large amounts of new data and write the appropriate lance files
+    /// directly instead of using the write function.
+    ///
+    /// This method can be used to commit this change to the dataset's manifest.  This method will
+    /// not verify that the provided fragments exist and correct, that is the caller's responsibility.
+    ///
+    /// If this commit is a change to an existing dataset then it will often need to be based on an
+    /// existing version of the dataset.  For example, if this change is a `delete` operation then
+    /// the caller will have read in the existing data (at some version) to determine which fragments
+    /// need to be deleted.  The base version that the caller used should be supplied as the `read_version`
+    /// parameter.  Some operations (e.g. Overwrite) do not depend on a previous version and `read_version`
+    /// can be None.  An error will be returned if the `read_version` is needed for an operation and
+    /// it is not specified.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_uri` - The base URI of the dataset
+    /// * `read_version` - The version of the dataset that this change is based on
+    /// * `operation` - A description of the change to commit
+    /// * `write_params` Parameters controlling how the manifest is written
     pub async fn commit(
         base_uri: &str,
-        schema: &Schema,
-        fragments: &[Fragment],
-        mode: WriteMode,
+        read_version: Option<u64>,
+        operation: Operation,
+        write_params: Option<WriteParams>,
     ) -> Result<Self> {
-        let (object_store, base) = ObjectStore::from_uri(base_uri).await?;
+        let read_version = read_version.map_or_else(
+            || match operation {
+                Operation::Append { .. }
+                | Operation::CreateIndex { .. }
+                | Operation::Delete { .. }
+                | Operation::Rewrite { .. }
+                | Operation::Merge { .. } => Err(Error::invalid_input(
+                    "read_version must be specified for this operation",
+                )),
+                _ => Ok(0),
+            },
+            Ok,
+        )?;
+
+        let (object_store, base) = ObjectStore::from_uri_and_params(
+            base_uri,
+            &write_params
+                .clone()
+                .map(|params| params.store_params.unwrap_or_default())
+                .unwrap_or_default(),
+        )
+        .await?;
+
+        // Test if the dataset exists
         let latest_manifest = object_store
             .commit_handler
             .resolve_latest_version(&base, &object_store)
             .await?;
-        let mut indices = vec![];
-        let mut manifest = if object_store.exists(&latest_manifest).await? {
-            let dataset = Self::open(base_uri).await?;
+        let flag_dataset_exists = object_store.exists(&latest_manifest).await?;
 
-            if matches!(mode, WriteMode::Append) {
-                // Append mode: inherit indices from previous version.
-                indices = dataset.load_indices().await?;
-            }
+        // Running checks for the different write modes
+        // create + dataset already exists = error
+        if !flag_dataset_exists && !matches!(operation, Operation::Overwrite { .. }) {
+            return Err(Error::DatasetNotFound {
+                path: base.to_string(),
+                source: "The dataset must already exist unless the operation is Overwrite".into(),
+            });
+        }
 
-            let dataset_schema = dataset.schema();
-            let added_on_schema = schema.exclude(dataset_schema)?;
-            let schema = dataset_schema.merge(&added_on_schema)?;
-
-            Manifest::new_from_previous(&dataset.manifest, &schema, Arc::new(fragments.to_vec()))
+        let dataset = if flag_dataset_exists {
+            // pull the store params from write params because there might be creds in there
+            Some(
+                Self::open_with_params(
+                    base_uri,
+                    &ReadParams {
+                        store_options: write_params.unwrap_or_default().store_params.clone(),
+                        ..Default::default()
+                    },
+                )
+                .await?,
+            )
         } else {
-            Manifest::new(schema, Arc::new(fragments.to_vec()))
+            None
         };
 
-        // Preserve indices.
-        write_manifest_file(
-            &object_store,
-            &base,
-            &mut manifest,
-            Some(indices),
-            &Default::default(),
-        )
-        .await?;
+        let transaction = Transaction::new(read_version, operation, None);
+
+        let manifest = if let Some(dataset) = &dataset {
+            commit_transaction(
+                dataset,
+                &object_store,
+                &transaction,
+                &Default::default(),
+                &Default::default(),
+            )
+            .await?
+        } else {
+            commit_new_dataset(&object_store, &base, &transaction, &Default::default()).await?
+        };
+
         Ok(Self {
             object_store: Arc::new(object_store),
             base,

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -851,7 +851,7 @@ mod tests {
             fragments,
         };
 
-        let new_dataset = Dataset::commit(test_uri, None, op, None).await.unwrap();
+        let new_dataset = Dataset::commit(test_uri, op, None, None).await.unwrap();
 
         assert_eq!(new_dataset.count_rows().await.unwrap(), dataset_rows);
     }
@@ -923,7 +923,7 @@ mod tests {
                 schema: full_schema.clone(),
             };
 
-            let dataset = Dataset::commit(test_uri, None, op, None).await.unwrap();
+            let dataset = Dataset::commit(test_uri, op, None, None).await.unwrap();
 
             // We only kept the first fragment of 40 rows
             assert_eq!(


### PR DESCRIPTION
Previously the commit function did not use the new transactions feature.  This meant that a commit running concurrently with another operation could lead to bad behavior.  The commit operation was also limited mostly to overwrites.

Now commits can apply any kind of transaction operation.