### PR TITLE
refactor: pass params by reference in from_uri_and_params method

### DIFF
--- a/rust/src/dataset.rs
+++ b/rust/src/dataset.rs
@@ -180,7 +180,7 @@ impl Dataset {
 
     /// Open a dataset with read params.
     pub async fn open_with_params(uri: &str, params: &ReadParams) -> Result<Self> {
-        let (mut object_store, base_path) = match params.store_options.clone() {
+        let (mut object_store, base_path) = match params.store_options.as_ref() {
             Some(store_options) => ObjectStore::from_uri_and_params(uri, store_options).await?,
             None => ObjectStore::from_uri(uri).await?,
         };
@@ -321,7 +321,7 @@ impl Dataset {
         let mut params = params.unwrap_or_default();
 
         let (object_store, base) =
-            ObjectStore::from_uri_and_params(uri, params.store_params.clone().unwrap_or_default())
+            ObjectStore::from_uri_and_params(uri, &params.store_params.clone().unwrap_or_default())
                 .await?;
 
         // Read expected manifest path for the dataset

--- a/rust/src/dataset/cleanup.rs
+++ b/rust/src/dataset/cleanup.rs
@@ -603,7 +603,7 @@ mod tests {
 
         async fn count_files(&self) -> Result<FileCounts> {
             let (os, path) =
-                ObjectStore::from_uri_and_params(&self.dataset_path, self.os_params()).await?;
+                ObjectStore::from_uri_and_params(&self.dataset_path, &self.os_params()).await?;
             let mut file_stream = os.read_dir_all(&path, None).await?;
             let mut file_count = FileCounts {
                 num_data_files: 0,


### PR DESCRIPTION
This is just a small nit I came across while working on #1091 and I figured it would be easier to put these changes in their own PR.