### PR TITLE
move manifest path logic into commit handler

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -83,10 +83,8 @@ impl Dataset {
 
         if let Some(commit_handler) = commit_handler {
             let py_commit_lock = PyCommitLock::new(commit_handler);
-            let object_store_params = ObjectStoreParams {
-                commit_handler: Some(Arc::new(py_commit_lock)),
-                ..Default::default()
-            };
+            let mut object_store_params = ObjectStoreParams::default();
+            object_store_params.set_commit_lock(Arc::new(py_commit_lock));
             params.store_options = Some(object_store_params);
         }
         let dataset = if let Some(ver) = version {
@@ -584,10 +582,8 @@ pub(crate) fn get_write_params(options: &PyDict) -> PyResult<Option<WriteParams>
 
         if let Some(commit_handler) = options.get_item("commit_handler") {
             let py_commit_lock = PyCommitLock::new(commit_handler.to_object(options.py()));
-            let object_store_params = ObjectStoreParams {
-                commit_handler: Some(Arc::new(py_commit_lock)),
-                ..Default::default()
-            };
+            let mut object_store_params = ObjectStoreParams::default();
+            object_store_params.set_commit_lock(Arc::new(py_commit_lock));
             p.store_params = Some(object_store_params);
         }
 

--- a/rust/src/dataset/cleanup.rs
+++ b/rust/src/dataset/cleanup.rs
@@ -124,9 +124,9 @@ impl<'a> CleanupTask<'a> {
     async fn process_manifests(&self) -> Result<()> {
         self.dataset
             .object_store
-            .read_dir_all(&self.dataset.versions_dir(), None)
+            .commit_handler
+            .list_manifests(&self.dataset.base, &self.dataset.object_store)
             .await?
-            .try_filter(|path| future::ready(path.extension() == Some("manifest")))
             .try_for_each_concurrent(num_cpus::get(), |path| async move {
                 self.process_manifest_file(&path).await
             })

--- a/rust/src/dataset/transaction.rs
+++ b/rust/src/dataset/transaction.rs
@@ -59,7 +59,7 @@ use crate::{
     io::{read_manifest, reader::read_manifest_indexes, ObjectStore},
 };
 
-use super::{feature_flags::apply_feature_flags, manifest_path, ManifestWriteConfig};
+use super::{feature_flags::apply_feature_flags, ManifestWriteConfig};
 use crate::{Error, Result};
 
 /// A change to a dataset that can be retried
@@ -265,7 +265,10 @@ impl Transaction {
         config: &ManifestWriteConfig,
         tx_path: &str,
     ) -> Result<(Manifest, Vec<Index>)> {
-        let path = manifest_path(base_path, version);
+        let path = object_store
+            .commit_handler
+            .resolve_version(base_path, version, object_store)
+            .await?;
         let mut manifest = read_manifest(object_store, &path).await?;
         manifest.set_timestamp(config.timestamp);
         manifest.transaction_file = Some(tx_path.to_string());


### PR DESCRIPTION
This PR moves two hard coded functions `manifest_path` and `latest_manifest_path` into `CommitHandler` trait.

`CommitHandler` is now where we define logic for "here is a uri to a dataset, I want to get a version/put a version"

## Why this PR?
In #1190 a major problem I ran into is the tight coupling of logic for determining where a manifest is. We used to use `manifest_path` and `latest_manifest_path` in many places of the code base. However, hardcoded function makes customizing manifest commit logic tricky as we frequently would need to change all callsites. With this PR, we can customize manifest path resolving logic with IoC, where we can change the behavior by "injecting" a new `CommitHandler` implementation.