### PR TITLE
fix window test and sleep longer on asof test

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -157,17 +157,19 @@ def test_asof_checkout(tmp_path: Path):
 
     lance.write_dataset(table, base_dir)
     assert len(lance.dataset(base_dir).versions()) == 1
-    time.sleep(0.01)
+    time.sleep(0.1)
     ts_1 = datetime.now()
-    time.sleep(0.01)
+    time.sleep(0.1)
 
     lance.write_dataset(table, base_dir, mode="append")
     assert len(lance.dataset(base_dir).versions()) == 2
+    time.sleep(0.1)
     ts_2 = datetime.now()
-    time.sleep(0.01)
+    time.sleep(0.1)
 
     lance.write_dataset(table, base_dir, mode="append")
     assert len(lance.dataset(base_dir).versions()) == 3
+    time.sleep(0.1)
     ts_3 = datetime.now()
 
     # check that only the first batch is present

--- a/rust/src/io/commit/external_manifest.rs
+++ b/rust/src/io/commit/external_manifest.rs
@@ -335,6 +335,7 @@ mod test {
         assert_eq!(ds.count_rows().await.unwrap(), 100);
     }
 
+    #[cfg(not(windows))]
     #[tokio::test]
     async fn test_concurrent_commits_are_okay() {
         let sleepy_store = SleepyExternalManifestStore::new();


### PR DESCRIPTION
two tests are a little flaky
https://github.com/lancedb/lance/actions/runs/6053727633/job/16429797785 <-- rust `test_concurrent_commits_are_okay`
https://github.com/lancedb/lance/actions/runs/6052938492/job/16427381322 <-- python `test_asof_checkout`

I disabled `test_concurrent_commits_are_okay` for window because we won't use an external store on a local file system outside of test. It is okay to ignore window.
