### PR TITLE
add parsing in object store for s3+ddb scheme

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -167,3 +167,61 @@ jobs:
           workspaces: python
       - uses: ./.github/workflows/build_windows_wheel
       - uses: ./.github/workflows/run_tests
+  aws-integtest:
+    timeout-minutes: 45
+    runs-on: "ubuntu-22.04"
+    defaults:
+      run:
+        shell: bash
+        working-directory: python
+    services:
+      minio:
+        image: lazybit/minio
+        ports:
+          - 9000:9000
+        env:
+          MINIO_ACCESS_KEY: ACCESSKEY
+          MINIO_SECRET_KEY: SECRETKEY
+        options: --name=minio --health-cmd "curl http://localhost:9000/minio/health/live"
+      dynamodb-local:
+        image: amazon/dynamodb-local
+        ports:
+          - 8000:8000
+        env:
+          AWS_ACCESS_KEY_ID: ACCESSKEY
+          AWS_SECRET_ACCESS_KEY: SECRETKEY
+    env:
+      AWS_ACCESS_KEY_ID: ACCESSKEY
+      AWS_SECRET_ACCESS_KEY: SECRETKEY
+      AWS_REGION: us-west-2
+      # this one is for s3
+      AWS_ENDPOINT: http://localhost:9000
+      # this one is for dynamodb
+      DYNAMODB_ENDPOINT: http://localhost:8000
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        lfs: true
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: create s3
+      run: aws s3 mb s3://lance-integtest --endpoint http://localhost:9000
+    - name: create ddb
+      run: |
+        aws dynamodb create-table \
+          --table-name lance-integtest \
+          --attribute-definitions '[{"AttributeName": "base_uri", "AttributeType": "S"}, {"AttributeName": "version", "AttributeType": "N"}]' \
+          --key-schema '[{"AttributeName": "base_uri", "KeyType": "HASH"}, {"AttributeName": "version", "KeyType": "RANGE"}]' \
+          --provisioned-throughput '{"ReadCapacityUnits": 10, "WriteCapacityUnits": 10}' \
+          --endpoint-url http://localhost:8000
+    - uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: python
+    - uses: ./.github/workflows/build_linux_wheel
+    - uses: ./.github/workflows/run_integtests
+    # Make sure wheels are not included in the Rust cache
+    - name: Delete wheels
+      run: sudo rm -rf target/wheels

--- a/.github/workflows/run_integtests/action.yml
+++ b/.github/workflows/run_integtests/action.yml
@@ -1,10 +1,6 @@
 name: run-tests
 
-description: "Install lance wheel and run unit tests"
-inputs:
-  python-minor-version:
-    required: true
-    description: "8 9 10 11"
+description: "Install lance wheel and run integ tests"
 runs:
   using: "composite"
   steps:
@@ -17,4 +13,4 @@ runs:
     shell: bash
     working-directory: python
     run: |
-      pytest -x -v --durations=30 -m "not integration" python/tests
+      pytest -x -v --durations=30 -m "integration" python/tests

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -20,7 +20,7 @@ chrono = "0.4.23"
 env_logger = "0.10"
 futures = "0.3"
 half = { version = "2.1", default-features = false, features = ["num-traits"] }
-lance = { path = "../rust", features = ["tensorflow"] }
+lance = { path = "../rust", features = ["tensorflow", "dynamodb"] }
 lazy_static = "1"
 log = "0.4"
 prost = "0.10"

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 import pytest
@@ -8,3 +9,13 @@ def provide_pandas(request, monkeypatch):
     if not request.param:
         monkeypatch.setitem(sys.modules, "pd", None)
     return request.param
+
+
+@pytest.fixture
+def s3_bucket() -> str:
+    return os.environ.get("TEST_S3_BUCKET", "lance-integtest")
+
+
+@pytest.fixture
+def ddb_table() -> str:
+    return os.environ.get("TEST_DDB_TABLE", "lance-integtest")

--- a/python/python/tests/test_s3_ddb.py
+++ b/python/python/tests/test_s3_ddb.py
@@ -1,0 +1,102 @@
+import uuid
+from concurrent import futures
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
+import lance
+import pyarrow as pa
+import pytest
+
+
+@pytest.mark.integration
+def test_s3_ddb_create_and_append(s3_bucket: str, ddb_table: str):
+    table1 = pa.Table.from_pylist([{"a": 1, "b": 2}, {"a": 10, "b": 20}])
+    table_name = uuid.uuid4().hex
+    table_dir = f"s3+ddb://{s3_bucket}/{table_name}?ddbTableName={ddb_table}"
+    lance.write_dataset(table1, table_dir)
+    assert len(lance.dataset(table_dir).versions()) == 1
+
+    table2 = pa.Table.from_pylist([{"a": 100, "b": 2000}])
+
+    # can detect existing dataset
+    with pytest.raises(OSError, match="Dataset already exists"):
+        lance.write_dataset(table2, table_dir)
+
+    lance.write_dataset(table2, table_dir, mode="append")
+
+    assert len(lance.dataset(table_dir).versions()) == 2
+    assert lance.dataset(table_dir).count_rows() == 3
+
+    # can checkout
+    assert lance.dataset(table_dir, version=1).count_rows() == 2
+    assert lance.dataset(table_dir, version=2).count_rows() == 3
+
+    with pytest.raises(ValueError, match="Not found"):
+        lance.dataset(table_dir, version=3)
+
+
+@pytest.mark.integration
+def test_s3_ddb_concurrent_commit(
+    s3_bucket: str,
+    ddb_table: str,
+):
+    table = pa.Table.from_pylist([{"a": -1}])
+    table_name = uuid.uuid4().hex
+    table_dir = f"s3+ddb://{s3_bucket}/{table_name}?ddbTableName={ddb_table}"
+    lance.write_dataset(table, table_dir)
+
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        futs = [
+            executor.submit(
+                lance.write_dataset,
+                pa.Table.from_pylist([{"a": i}]),
+                table_dir,
+                mode="append",
+            )
+            for i in range(5)
+        ]
+        # surface any errors -- shouldn't be any
+        [result.result() for result in futures.as_completed(futs)]
+
+    assert len(lance.dataset(table_dir).versions()) == 6
+    assert lance.dataset(table_dir).count_rows() == 6
+
+    assert sorted(
+        [item["a"] for item in lance.dataset(table_dir).to_table().to_pylist()]
+    ) == [-1, 0, 1, 2, 3, 4]
+
+
+@pytest.mark.integration
+def test_s3_ddb_concurrent_commit_more_than_five(s3_bucket: str, ddb_table: str):
+    table = pa.Table.from_pylist([{"a": 1, "b": 2}, {"a": 10, "b": 20}])
+    table_name = uuid.uuid4().hex
+    table_dir = f"s3+ddb://{s3_bucket}/{table_name}?ddbTableName={ddb_table}"
+    lance.write_dataset(table, table_dir)
+
+    failures = 0
+    total_futures = 10
+
+    # force the tests to start at the same time
+    barrier = Barrier(10, timeout=5)
+
+    def writh_dataset_with_start_barrier():
+        barrier.wait()
+        lance.write_dataset(table, table_dir, mode="append")
+
+    with ThreadPoolExecutor(max_workers=6) as executor:
+        futs = [
+            executor.submit(writh_dataset_with_start_barrier)
+            for _ in range(total_futures)
+        ]
+        for result in futures.as_completed(futs):
+            try:
+                result.result()
+            except:  # noqa: E722
+                failures += 1
+
+    assert failures > 0
+
+    expected_version = total_futures - failures + 1
+
+    assert len(lance.dataset(table_dir).versions()) == expected_version
+    assert lance.dataset(table_dir).count_rows() == expected_version * 2

--- a/rust/src/io/commit/dynamodb.rs
+++ b/rust/src/io/commit/dynamodb.rs
@@ -56,7 +56,7 @@ impl<E> From<SdkError<E>> for Error {
 /// Transaction Safty: This store uses DynamoDB conditional write to ensure
 /// only one writer can win per version.
 #[derive(Debug)]
-struct DynamoDBExternalManifestStore {
+pub struct DynamoDBExternalManifestStore {
     client: Arc<Client>,
     table_name: String,
     commiter_name: String,
@@ -85,7 +85,6 @@ macro_rules! commiter {
 }
 
 impl DynamoDBExternalManifestStore {
-    #[allow(dead_code)]
     pub async fn new_external_store(
         client: Arc<Client>,
         table_name: &str,


### PR DESCRIPTION
last functional piece for #1183 

This PR adds parsing for `s3+ddb://` scheme to uri parsing when opening a lance dataset

This PR also sets up AWS integration testing by using `minio` for s3 mocking and `dynamodb-local` for dynamodb mocking

## TODO
- [x] add tests
- [ ] ~~add documentation for `s3+ddb://` scheme~~ going to add docs in the next pr