### PR TITLE
feat: add a fast path for pq index if there are no missing fragments/rows

### DIFF
--- a/rust/src/dataset/scanner.rs
+++ b/rust/src/dataset/scanner.rs
@@ -1831,8 +1831,7 @@ mod test {
             )
             .unwrap()];
 
-            let reader =
-                RecordBatchIterator::new(batches.clone().into_iter().map(Ok), schema.clone());
+            let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
             let dataset = Dataset::write(reader, test_uri, None).await.unwrap();
 
             let mut dataset = dataset
@@ -1913,8 +1912,7 @@ mod test {
             )
             .unwrap()];
 
-            let reader =
-                RecordBatchIterator::new(batches.clone().into_iter().map(Ok), schema.clone());
+            let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
             let dataset = Dataset::write(
                 reader,
                 test_uri,

--- a/rust/src/index/vector/pq.rs
+++ b/rust/src/index/vector/pq.rs
@@ -257,9 +257,14 @@ impl VectorIndex for PQIndex {
             });
         }
 
-        let (code, row_ids) = self.filter_arrays(pre_filter).await?;
-
-        assert_eq!(code.len() % self.num_sub_vectors, 0);
+        let (code, row_ids) = if pre_filter.is_empty() {
+            (
+                self.code.as_ref().unwrap().clone(),
+                self.row_ids.as_ref().unwrap().clone(),
+            )
+        } else {
+            self.filter_arrays(pre_filter).await?
+        };
 
         let distances = if self.metric_type == MetricType::L2 {
             self.fast_l2_distances(&query.key, code.as_ref())?


### PR DESCRIPTION
This restores the performance of the pq benchmark.  It does not truly fix the underlying problem yet since one would still get poor performance if there are missing fragments / rows.