### PR TITLE
[Python] Support creating index over tensor type and allow Dataset::take() with projection

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -363,7 +363,6 @@ class LanceDataset(pa.dataset.Dataset):
         -------
         table : Table
         """
-        # kwargs['take'] = indices
         return pa.Table.from_batches([self._ds.take(indices, columns)])
 
     def head(self, num_rows, **kwargs):

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -341,14 +341,21 @@ class LanceDataset(pa.dataset.Dataset):
             scan_in_order=scan_in_order,
         ).to_batches()
 
-    def take(self, indices, **kwargs):
-        """
-        Select rows of data by index.
+    def take(
+        self,
+        indices: Union[List[int], pa.Array],
+        columns: Optional[List[str]] = None,
+        **kwargs,
+    ) -> pa.Table:
+        """Select rows of data by index.
 
         Parameters
         ----------
         indices : Array or array-like
             indices of rows to select in the dataset.
+        columns: list of strings, optional
+            List of column names to be fetched. All columns are fetched
+            if not specified.
         **kwargs : dict, optional
             See scanner() method for full parameter description.
 
@@ -357,7 +364,7 @@ class LanceDataset(pa.dataset.Dataset):
         table : Table
         """
         # kwargs['take'] = indices
-        return pa.Table.from_batches([self._ds.take(indices)])
+        return pa.Table.from_batches([self._ds.take(indices, columns)])
 
     def head(self, num_rows, **kwargs):
         """
@@ -629,7 +636,8 @@ class LanceDataset(pa.dataset.Dataset):
                 )
             ):
                 raise TypeError(
-                    f"Vector column {c} must be FixedSizeListArray or TensorArray, got {field.type}"
+                    f"Vector column {c} must be FixedSizeListArray or TensorArray,"
+                    f"got {field.type}"
                 )
             if not pa.types.is_float32(field.type.value_type):
                 raise TypeError(

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -621,9 +621,15 @@ class LanceDataset(pa.dataset.Dataset):
             if c not in self.schema.names:
                 raise KeyError(f"{c} not found in schema")
             field = self.schema.field(c)
-            if not pa.types.is_fixed_size_list(field.type):
+            if not (
+                pa.types.is_fixed_size_list(field.type)
+                or (
+                    isinstance(field.type, pa.FixedShapeTensorType)
+                    and len(field.type.shape) == 1
+                )
+            ):
                 raise TypeError(
-                    f"Vector column {c} must be FixedSizeListArray, got {field.type}"
+                    f"Vector column {c} must be FixedSizeListArray or TensorArray, got {field.type}"
                 )
             if not pa.types.is_float32(field.type.value_type):
                 raise TypeError(

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -636,8 +636,8 @@ class LanceDataset(pa.dataset.Dataset):
                 )
             ):
                 raise TypeError(
-                    f"Vector column {c} must be FixedSizeListArray or TensorArray,"
-                    f"got {field.type}"
+                    f"Vector column {c} must be FixedSizeListArray "
+                    f"1-dimensional FixedShapeTensorArray, got {field.type}"
                 )
             if not pa.types.is_float32(field.type.value_type):
                 raise TypeError(

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -200,6 +200,17 @@ def test_take(tmp_path: Path):
     assert table2 == table1
 
 
+def test_take_with_columns(tmp_path: Path):
+    table1 = pa.Table.from_pylist([{"a": 1, "b": 2}, {"a": 10, "b": 20}])
+    base_dir = tmp_path / "test"
+    lance.write_dataset(table1, base_dir)
+
+    dataset = lance.dataset(base_dir)
+    table2 = dataset.take([0], columns=["b"])
+
+    assert table2 == pa.Table.from_pylist([{"b": 2}])
+
+
 def test_filter(tmp_path: Path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
     base_dir = tmp_path / "test"

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -400,7 +400,8 @@ impl Dataset {
             self_.ds.schema().project(&columns)
         } else {
             Ok(self_.ds.schema().clone())
-        }.map_err(|err| PyIOError::new_err(err.to_string()))?;
+        }
+        .map_err(|err| PyIOError::new_err(err.to_string()))?;
         let batch = RT
             .block_on(Some(self_.py()), self_.ds.take(&row_indices, &projection))
             .map_err(|err| PyIOError::new_err(err.to_string()))?;


### PR DESCRIPTION
* Create vector index over `pyarrow.FixedShapeTensorType`
* `Dataset::take(indices, column)` to allow projection over Dataset::take() operation.