### PR TITLE
move python test entrypoint to makefile

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,6 +22,7 @@ env:
   # "1" means line tables only, which is useful for panic tracebacks.
   RUSTFLAGS: "-C debuginfo=1"
   RUST_BACKTRACE: "1"
+  CI: "true"
 
 jobs:
   lint:

--- a/.github/workflows/run_integtests/action.yml
+++ b/.github/workflows/run_integtests/action.yml
@@ -12,5 +12,4 @@ runs:
   - name: Run python tests
     shell: bash
     working-directory: python
-    run: |
-      pytest -x -v --durations=30 -m "integration" python/tests
+    run: make integtest

--- a/.github/workflows/run_tests/action.yml
+++ b/.github/workflows/run_tests/action.yml
@@ -16,5 +16,4 @@ runs:
   - name: Run python tests
     shell: bash
     working-directory: python
-    run: |
-      pytest -x -v --durations=30 -m "not integration" python/tests
+    run: make test

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,0 +1,13 @@
+ifeq ($(CI), true)
+    PYTEST_ARGS = -v --durations=30
+else
+    PYTEST_ARGS = -v
+endif
+
+test:
+	pytest -m 'not integration' $(PYTEST_ARGS) python/tests
+.PHONY: test
+
+integtest:
+	pytest -m 'integration' $(PYTEST_ARGS) python/tests
+.PHONY: integtest

--- a/python/README.md
+++ b/python/README.md
@@ -125,6 +125,8 @@ rs = [dataset.to_table(nearest={"column": "vector", "k": 10, "q": q})
 
 Install from PyPI: `pip install pylance`  # >=0.3.0 is the new rust-based implementation
 Install from source: `maturin develop` (under the `/python` directory)
+Run unit tests: `make test`
+Run integration tests: `make integtest`
 
 Import via: `import lance`
 


### PR DESCRIPTION
move python test entrypoint to makefile so we can manage pytest marks easily.