### PR TITLE
chore: add pr title check

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -30,9 +30,7 @@ jobs:
           script: |
             const message = `**ACTION NEEDED**
               
-              Lance follows the [Conventional Commits
-              specification](https://www.conventionalcommits.org/en/v1.0.0/) for
-              release automation.
+              Lance follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) for release automation.
 
               The PR title and description are used as the merge commit message.\
               Please update your PR title and description to match the specification.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -16,6 +16,10 @@ jobs:
       - run: npm install @commitlint/config-conventional
       - run: >
           echo 'module.exports = {
+            "rules": {
+              "body-max-line-length": [0, "always", Infinity],
+              "body-leading-blank": [0, "always"]
+            }
             "ignores": [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)]
           }' > .commitlintrc.js
       - run: npx commitlint --extends @commitlint/config-conventional --verbose <<< $COMMIT_MSG
@@ -34,6 +38,8 @@ jobs:
 
               The PR title and description are used as the merge commit message.\
               Please update your PR title and description to match the specification.
+
+              For details on the error please inspect the "PR Title Check" action.
               `
             // Get list of current comments
             const comments = await github.paginate(github.rest.issues.listComments, {

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -20,7 +20,6 @@ jobs:
               "body-max-line-length": [0, "always", Infinity],
               "body-leading-blank": [0, "always"]
             }
-            "ignores": [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)]
           }' > .commitlintrc.js
       - run: npx commitlint --extends @commitlint/config-conventional --verbose <<< $COMMIT_MSG
         env:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: "18"
+      # These rules are disabled because Github will always ensure there
+      # is a blank line between the title and the body and Github will
+      # word wrap the description field to ensure a reasonable max line
+      # length.
       - run: npm install @commitlint/config-conventional
       - run: >
           echo 'module.exports = {

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, edited, synchronize, reopened]
 jobs:
   commitlint:
+    permissions:
+      pull-requests: write
     name: Verify PR title / description conforms to semantic-release
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,57 @@
+name: PR Title Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+jobs:
+  commitlint:
+    name: Verify PR title / description conforms to semantic-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - run: npm install @commitlint/config-conventional
+      - run: >
+          echo 'module.exports = {
+            "ignores": [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)]
+          }' > .commitlintrc.js
+      - run: npx commitlint --extends @commitlint/config-conventional --verbose <<< $COMMIT_MSG
+        env:
+          COMMIT_MSG: >
+            ${{ github.event.pull_request.title }}
+
+            ${{ github.event.pull_request.body }}
+      - if: failure()
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const message = `**ACTION NEEDED**
+              
+              Lance follows the [Conventional Commits
+              specification](https://www.conventionalcommits.org/en/v1.0.0/) for
+              release automation.
+
+              The PR title and description are used as the merge commit message.\
+              Please update your PR title and description to match the specification.
+              `
+            // Get list of current comments
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            // Check if this job already commented
+            for (const comment of comments) {
+              if (comment.body === message) {
+                return // Already commented
+              }
+            }
+            // Post the comment about Conventional Commits
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: message
+            })
+            core.setFailed(message)


### PR DESCRIPTION
When we squash merge PRs from Github it will use the PR title and the description as the commit comment.  This adds a job that checks these fields are correctly formatted according to the conventional commits specification.