### PR TITLE
feat: expose query plan as a debug string

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1104,6 +1104,21 @@ class LanceScanner(pa.dataset.Scanner):
         """
         return self._scanner.count_rows()
 
+    def explain_plan(self, verbose=False) -> str:
+        """Return the execution plan for this scanner.
+
+        Parameters
+        ----------
+        verbose : bool, default False
+            Use a verbose output format.
+
+        Returns
+        -------
+        plan : str
+        """
+
+        return self._scanner.explain_plan(verbose=verbose)
+
 
 class DatasetOptimizer:
     def __init__(self, dataset: LanceDataset):

--- a/python/src/scanner.rs
+++ b/python/src/scanner.rs
@@ -58,6 +58,18 @@ impl Scanner {
             .map_err(|err| PyValueError::new_err(err.to_string()))?
     }
 
+    #[pyo3(signature = (*, verbose = false))]
+    fn explain_plan(self_: PyRef<'_, Self>, verbose: bool) -> PyResult<String> {
+        let scanner = self_.scanner.clone();
+        let res = RT
+            .spawn(Some(self_.py()), async move {
+                scanner.explain_plan(verbose).await
+            })
+            .map_err(|err| PyValueError::new_err(err.to_string()))?;
+
+        Ok(res)
+    }
+
     fn count_rows(self_: PyRef<'_, Self>) -> PyResult<u64> {
         let scanner = self_.scanner.clone();
         RT.spawn(Some(self_.py()), async move { scanner.count_rows().await })

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -25,6 +25,7 @@ use datafusion::execution::{
 };
 use datafusion::logical_expr::AggregateFunction;
 use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
+use datafusion::physical_plan::display::DisplayableExecutionPlan;
 use datafusion::physical_plan::expressions::{create_aggregate_expr, Literal};
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::{
@@ -681,6 +682,13 @@ impl Scanner {
             *self.offset.as_ref().unwrap_or(&0) as usize,
             self.limit.map(|l| l as usize),
         ))
+    }
+
+    pub async fn explain_plan(&self, verbose: bool) -> Result<String> {
+        let plan = self.create_plan().await?;
+        let display = DisplayableExecutionPlan::new(plan.as_ref());
+
+        Ok(format!("{}", display.indent(verbose)))
     }
 }
 


### PR DESCRIPTION
This PR add `explain_plan` to the scanner and exposes the API to python. This is handy to get a visual understanding of what's going on in the query. e.g.
```
In [8]: plan = ds.scanner(nearest={
   ...:                     "column": "vector",
   ...:                     "k": 10,
   ...:                     "q": [0.0 for _ in range(128)],
   ...:                     "use_index": True,
   ...:                     "metric": "L2",
   ...:                     "nprobes": 10,
   ...:                 }).explain_plan(False)

In [9]: print(plan)
Projection: fields=[id, vector, _distance]
  Take: columns="_distance, _rowid, vector, id"
    Take: columns="_distance, _rowid, vector"
      KNNIndex: name=6b86192c-699f-405e-9e72-d2d84a84da84, k=10
```
^^^ Two take nodes could be merged into one