### PR TITLE
feat: add naive prefiltering

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -164,6 +164,8 @@ class LanceDataset(pa.dataset.Dataset):
             If True then the filter will be applied before the vector query is run.
             This will generate more correct results but it may be a more costly
             query.  It's generally good when the filter is highly selective.
+            Right now, this must be used with ``use_index=False`` in the
+            ``nearest`` parameters.
 
             If False then the filter will be applied after the vector query is run.
             This will perform well but the results may have fewer than the requested

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -117,6 +117,8 @@ class LanceDataset(pa.dataset.Dataset):
         fragment_readahead: Optional[int] = None,
         scan_in_order: bool = True,
         fragments: Optional[Iterable[LanceFragment]] = None,
+        *,
+        prefilter: bool = False,
     ) -> LanceScanner:
         """Return a Scanner that can support various pushdowns.
 
@@ -158,7 +160,16 @@ class LanceDataset(pa.dataset.Dataset):
         fragments: iterable of LanceFragment, default None
             If specified, only scan these fragments. If scan_in_order is True, then
             the fragments will be scanned in the order given.
+        prefilter: bool, default False
+            If True then the filter will be applied before the vector query is run.
+            This will generate more correct results but it may be a more costly
+            query.  It's generally good when the filter is highly selective.
 
+            If False then the filter will be applied after the vector query is run.
+            This will perform well but the results may have fewer than the requested
+            number of rows (or be empty) if the rows closest to the query do not
+            match the filter.  It's generally good when the filter is not very
+            selective.
         Notes
         -----
 
@@ -184,6 +195,7 @@ class LanceDataset(pa.dataset.Dataset):
             ScannerBuilder(self)
             .columns(columns)
             .filter(filter)
+            .prefilter(prefilter)
             .limit(limit)
             .offset(offset)
             .nearest(**(nearest or {}))
@@ -875,6 +887,7 @@ class ScannerBuilder:
         self.ds = ds
         self._limit = 0
         self._filter = None
+        self._prefilter = None
         self._offset = None
         self._columns = None
         self._nearest = None
@@ -934,6 +947,10 @@ class ScannerBuilder:
         if isinstance(filter, pa.compute.Expression):
             filter = str(filter)
         self._filter = filter
+        return self
+
+    def prefilter(self, prefilter: bool) -> ScannerBuilder:
+        self._prefilter = prefilter
         return self
 
     def with_fragments(
@@ -996,6 +1013,7 @@ class ScannerBuilder:
         scanner = self.ds._ds.scanner(
             self._columns,
             self._filter,
+            self._prefilter,
             self._limit,
             self._offset,
             self._nearest,

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -679,6 +679,37 @@ def test_scan_with_batch_size(tmp_path: Path):
         assert df["a"].iloc[0] == idx * 16
 
 
+def test_scan_prefilter(tmp_path: Path):
+    base_dir = tmp_path / "dataset"
+    vecs = pa.array(
+        [[1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 6]], type=pa.list_(pa.float32(), 2)
+    )
+    df = pa.Table.from_pydict(
+        {
+            "index": [1, 2, 3, 4, 5, 6],
+            "type": ["a", "a", "a", "b", "b", "b"],
+            "vecs": vecs,
+        }
+    )
+    dataset = lance.write_dataset(df, base_dir)
+    query = pa.array([1, 1], pa.float32())
+    args = {
+        "columns": ["index"],
+        "filter": "type = 'b'",
+        "nearest": {"column": "vecs", "q": pa.array(query), "k": 2, "use_index": False},
+    }
+
+    # With post-filter no results are returned because all the closest results don't match the filter
+    assert dataset.scanner(**args).to_table().num_rows == 0
+
+    args["prefilter"] = True
+    table = dataset.scanner(**args).to_table()
+
+    expected = pa.Table.from_pydict({"index": [4, 5]})
+
+    assert table.column("index") == expected.column("index")
+
+
 def test_scan_count_rows(tmp_path: Path):
     base_dir = tmp_path / "dataset"
     df = pd.DataFrame({"a": range(42), "b": range(42)})

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -699,7 +699,8 @@ def test_scan_prefilter(tmp_path: Path):
         "nearest": {"column": "vecs", "q": pa.array(query), "k": 2, "use_index": False},
     }
 
-    # With post-filter no results are returned because all the closest results don't match the filter
+    # With post-filter no results are returned because all
+    # the closest results don't match the filter
     assert dataset.scanner(**args).to_table().num_rows == 0
 
     args["prefilter"] = True

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -252,6 +252,7 @@ impl Dataset {
         self_: PyRef<'_, Self>,
         columns: Option<Vec<String>>,
         filter: Option<String>,
+        prefilter: Option<bool>,
         limit: Option<i64>,
         offset: Option<i64>,
         nearest: Option<&PyDict>,
@@ -271,6 +272,9 @@ impl Dataset {
             scanner
                 .filter(f.as_str())
                 .map_err(|err| PyValueError::new_err(err.to_string()))?;
+        }
+        if let Some(prefilter) = prefilter {
+            scanner.prefilter(prefilter);
         }
 
         scanner


### PR DESCRIPTION
This adds a prefilter option to the list of scan options.  If prefilter is true then the filter is applied before the index (instead of after the index).  Currently this only works when using a flat KNN scan (e.g. when use_index is false) and so it may be very expensive on large datasets if the filter is not very selective.

Closes #1032 