### PR TITLE
feat: add target cpu to python dir

### DIFF
--- a/python/.cargo/config.toml
+++ b/python/.cargo/config.toml
@@ -1,0 +1,22 @@
+[profile.release]
+lto = "thin"
+codegen-units = 1
+
+[target.'cfg(all())']
+rustflags = [
+    # "-Wclippy::all",
+    # "-Wclippy::fallible_impl_from",
+    # "-Wclippy::manual_let_else",
+    # "-Wclippy::redundant_pub_crate",
+    # "-Wclippy::string_add_assign",
+    # "-Wclippy::string_add",
+    # "-Wclippy::string_lit_as_bytes",
+    # "-Wclippy::string_to_string",
+    # "-Wclippy::use_self",
+]
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=haswell", "-C", "target-feature=+avx2"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "target-cpu=apple-m1", "-C", "target-feature=+neon"]

--- a/python/python/benchmarks/test_kmeans.py
+++ b/python/python/benchmarks/test_kmeans.py
@@ -1,0 +1,28 @@
+#  Copyright (c) 2023. Lance Developers
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import numpy as np
+import pytest
+from lance.util import KMeans
+
+
+@pytest.mark.benchmark(group="kmeans")
+def test_kmeans(benchmark):
+    data = np.random.random((65535, 16)).astype("f")
+
+    def _f():
+        kmeans = KMeans(256, "l2")
+        kmeans.fit(data)
+
+    benchmark(_f)


### PR DESCRIPTION
This PR adds `target-cpu` profile to `python` folder. This should help with kmeans performance by targeting newers hardware.

Standard release build (before this PR)
```
-------------------------------------- benchmark 'kmeans': 1 tests --------------------------------------
Name (time in s)        Min     Max    Mean  StdDev  Median     IQR  Outliers     OPS  Rounds  Iterations
---------------------------------------------------------------------------------------------------------
test_kmeans          1.7364  2.1359  1.9208  0.1639  1.8873  0.2711       2;0  0.5206       5           1
---------------------------------------------------------------------------------------------------------
```

Haswell w/ fat LTO
```
------------------------------------------- benchmark 'kmeans': 1 tests --------------------------------------------
Name (time in ms)          Min       Max      Mean   StdDev    Median      IQR  Outliers     OPS  Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------
test_kmeans           158.2566  200.0213  176.1580  17.7226  176.0652  33.6837       3;0  5.6767       7           1
--------------------------------------------------------------------------------------------------------------------
```

Haswell w/ thin LTO
```
------------------------------------------ benchmark 'kmeans': 1 tests -------------------------------------------
Name (time in ms)          Min       Max      Mean  StdDev    Median     IQR  Outliers     OPS  Rounds  Iterations
------------------------------------------------------------------------------------------------------------------
test_kmeans           149.2077  170.8400  157.7188  7.3838  156.3246  9.4076       2;0  6.3404       7           1
------------------------------------------------------------------------------------------------------------------
```

Skylake w/ thin LTO
```
------------------------------------------- benchmark 'kmeans': 1 tests --------------------------------------------
Name (time in ms)          Min       Max      Mean   StdDev    Median      IQR  Outliers     OPS  Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------
test_kmeans           146.3734  188.9286  171.8634  17.6650  176.2131  29.4973       1;0  5.8186       6           1
--------------------------------------------------------------------------------------------------------------------
```
