### PR TITLE
fix: crate config for release

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,6 +11,9 @@ license = "Apache-2.0"
 repository = "https://github.com/lancedb/lance"
 
 [workspace.dependencies]
+lance-arrow = { version = "0.7.4", path = "./lance-arrow" }
+lance-linalg = { version = "0.7.4", path = "./lance-linalg" }
+lance-testing = { version = "0.7.4", path = "./lance-testing" }
 # Note that this one does not include pyarrow
 arrow = { version = "43.0.0", optional = false }
 arrow-arith = "43.0"

--- a/rust/lance-linalg/Cargo.toml
+++ b/rust/lance-linalg/Cargo.toml
@@ -16,13 +16,13 @@ num_cpus = { workspace = true }
 num-traits = { workspace = true }
 rand = { workspace = true }
 tokio = { workspace = true }
+lance-arrow = { workspace = true }
 
 [dev-dependencies]
 approx = { workspace = true }
 arrow-arith = { workspace = true }
 criterion = { workspace = true }
 lance-testing = { path = "../lance-testing" }
-lance-arrow = { path = "../lance-arrow" }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof = { workspace = true }

--- a/rust/lance-testing/Cargo.toml
+++ b/rust/lance-testing/Cargo.toml
@@ -11,4 +11,4 @@ arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
 rand = { workspace = true }
 num-traits = { workspace = true }
-lance-arrow = { path = "../lance-arrow" }
+lance-arrow = { workspace = true }

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -27,8 +27,8 @@ features = []
 no-default-features = true
 
 [dependencies]
-lance-arrow = { version = "0.7.3", path = "../lance-arrow" }
-lance-linalg = { version = "0.7.3", path = "../lance-linalg" }
+lance-arrow = { workspace = true }
+lance-linalg = { workspace = true }
 bytes = "1.3"
 arrow-arith = { workspace = true }
 arrow-array = { workspace = true }
@@ -114,7 +114,7 @@ approx = "0.5.1"
 dirs = "5.0.0"
 all_asserts = "2.3.1"
 mock_instant = { version = "0.3.1", features = ["sync"] }
-lance-testing = { path = "../lance-testing" }
+lance-testing = { workspace = true }
 
 [features]
 cli = ["clap"]


### PR DESCRIPTION
Example dry run here: https://github.com/lancedb/lance/actions/runs/6188966323/job/16802039317?pr=1280

This PR fixes versions in our cargo config so we can release.