### PR TITLE
fix: cargo toml to follow crates.io convenetion

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -13,6 +13,9 @@ rustflags = [
     "-Wclippy::string_lit_as_bytes",
     "-Wclippy::string_to_string",
     "-Wclippy::use_self",
+    "-Dclippy::cargo",
+    # not too much we can do to avoid multiple crate versions
+    "-Aclippy::multiple-crate-versions",
 ]
 
 [target.x86_64-unknown-linux-gnu]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,21 @@ edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 license = "Apache-2.0"
 repository = "https://github.com/lancedb/lance"
+readme = "README.md"
+description = "A columnar data format that is 100x faster than Parquet for random access."
+keywords = [
+    "data-format",
+    "data-science",
+    "machine-learning",
+    "apache-arrow",
+    "data-analytics"
+]
+categories = [
+    "database-implementations",
+    "data-structures",
+    "development-tools",
+    "science"
+]
 
 [workspace.dependencies]
 lance-arrow = { version = "0.7.4", path = "./lance-arrow" }

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,2 @@
+# Lance Rust Workspace
+Where core rust code lance lives

--- a/rust/lance-arrow/Cargo.toml
+++ b/rust/lance-arrow/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+readme.workspace = true
+description.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 arrow-array = { workspace = true }

--- a/rust/lance-linalg/Cargo.toml
+++ b/rust/lance-linalg/Cargo.toml
@@ -4,6 +4,10 @@ version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+description = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 
 [dependencies]
 arrow-array = { workspace = true }

--- a/rust/lance-testing/Cargo.toml
+++ b/rust/lance-testing/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+readme.workspace = true
+description.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 arrow-array = { workspace = true }

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -5,22 +5,11 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "A columnar data format that is 100x faster than Parquet for random access."
+description.workspace = true
 readme = "README.md"
 rust-version = "1.65"
-keywords = [
-    "data-format",
-    "data-science",
-    "machine-learning",
-    "apache-arrow",
-    "data-analytics"
-]
-categories = [
-    "database-implementations",
-    "data-structures",
-    "development-tools",
-    "science"
-]
+keywords.workspace = true
+categories.workspace = true
 
 [package.metadata.docs.rs]
 features = []


### PR DESCRIPTION
This PR fixes cargo config conventions.

So we can publish to crates.io