### PR TITLE
fix: search should not panic on empty table

### DIFF
--- a/rust/lance/src/datatypes.rs
+++ b/rust/lance/src/datatypes.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 
 use arrow_array::ArrayRef;
 use arrow_schema::{DataType, Field as ArrowField, TimeUnit};
+use snafu::{location, Location};
 
 mod field;
 mod schema;
@@ -144,6 +145,7 @@ impl TryFrom<&DataType> for LogicalType {
             _ => {
                 return Err(Error::Schema {
                     message: format!("Unsupported data type: {:?}", dt),
+                    location: location!(),
                 })
             }
         };
@@ -195,11 +197,13 @@ impl TryFrom<&LogicalType> for DataType {
                     if splits.len() != 3 {
                         Err(Error::Schema {
                             message: format!("Unsupported logical type: {}", lt),
+                            location: location!(),
                         })
                     } else {
                         let elem_type = (&LogicalType(splits[1].to_string())).try_into()?;
                         let size: i32 = splits[2].parse::<i32>().map_err(|e: _| Error::Schema {
                             message: e.to_string(),
+                            location: location!(),
                         })?;
                         Ok(FixedSizeList(
                             Arc::new(ArrowField::new("item", elem_type, true)),
@@ -211,10 +215,12 @@ impl TryFrom<&LogicalType> for DataType {
                     if splits.len() != 2 {
                         Err(Error::Schema {
                             message: format!("Unsupported logical type: {}", lt),
+                            location: location!(),
                         })
                     } else {
                         let size: i32 = splits[1].parse::<i32>().map_err(|e: _| Error::Schema {
                             message: e.to_string(),
+                            location: location!(),
                         })?;
                         Ok(FixedSizeBinary(size))
                     }
@@ -223,6 +229,7 @@ impl TryFrom<&LogicalType> for DataType {
                     if splits.len() != 4 {
                         Err(Error::Schema {
                             message: format!("Unsupport dictionary type: {}", lt),
+                            location: location!(),
                         })
                     } else {
                         let value_type: Self = (&LogicalType::from(splits[1])).try_into()?;
@@ -234,17 +241,21 @@ impl TryFrom<&LogicalType> for DataType {
                     if splits.len() != 4 {
                         Err(Error::Schema {
                             message: format!("Unsupport decimal type: {}", lt),
+                            location: location!(),
                         })
                     } else {
                         let bits: i16 = splits[1].parse::<i16>().map_err(|err| Error::Schema {
                             message: err.to_string(),
+                            location: location!(),
                         })?;
                         let precision: u8 =
                             splits[2].parse::<u8>().map_err(|err| Error::Schema {
                                 message: err.to_string(),
+                                location: location!(),
                             })?;
                         let scale: i8 = splits[3].parse::<i8>().map_err(|err| Error::Schema {
                             message: err.to_string(),
+                            location: location!(),
                         })?;
 
                         if bits == 128 {
@@ -256,6 +267,7 @@ impl TryFrom<&LogicalType> for DataType {
                                 message: format!(
                                     "Only Decimal128 and Decimal256 is supported. Found {bits}"
                                 ),
+                                location: location!(),
                             })
                         }
                     }
@@ -264,6 +276,7 @@ impl TryFrom<&LogicalType> for DataType {
                     if splits.len() != 3 {
                         Err(Error::Schema {
                             message: format!("Unsupported timestamp type: {}", lt),
+                            location: location!(),
                         })
                     } else {
                         let timeunit = parse_timeunit(splits[1])?;
@@ -277,6 +290,7 @@ impl TryFrom<&LogicalType> for DataType {
                 }
                 _ => Err(Error::Schema {
                     message: format!("Unsupported logical type: {}", lt),
+                    location: location!(),
                 }),
             }
         }

--- a/rust/lance/src/datatypes/field.rs
+++ b/rust/lance/src/datatypes/field.rs
@@ -25,6 +25,7 @@ use arrow_array::{
 };
 use arrow_schema::{DataType, Field as ArrowField};
 use async_recursion::async_recursion;
+use snafu::{location, Location};
 
 use super::{Dictionary, LogicalType};
 use crate::{
@@ -200,6 +201,7 @@ impl Field {
                     "Attempt to project field by different names: {} and {}",
                     self.name, other.name,
                 ),
+                location: location!(),
             });
         };
 
@@ -215,6 +217,7 @@ impl Field {
                             "Attempt to project field by different types: {} and {}",
                             dt, other_dt,
                         ),
+                        location: location!(),
                     });
                 }
                 Ok(self.clone())
@@ -228,6 +231,7 @@ impl Field {
                                 "Attempt to project non-existed field: {} on {}",
                                 other_field.name, self,
                             ),
+                            location: location!(),
                         });
                     };
                     fields.push(child.project_by_field(other_field)?);
@@ -263,6 +267,7 @@ impl Field {
                     "Attempt to project incompatible fields: {} and {}",
                     self, other
                 ),
+                location: location!(),
             }),
         }
     }
@@ -387,6 +392,7 @@ impl Field {
                             "Attempt to merge incompatible fields: {} and {}",
                             self, other
                         ),
+                        location: location!(),
                     });
                 }
             }
@@ -471,6 +477,7 @@ impl Field {
                                 "Does not support {} as dictionary value type",
                                 value_type
                             ),
+                            location: location!(),
                         });
                     }
                 }

--- a/rust/lance/src/datatypes/schema.rs
+++ b/rust/lance/src/datatypes/schema.rs
@@ -21,6 +21,7 @@ use std::{
 
 use arrow_array::RecordBatch;
 use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
+use snafu::{location, Location};
 
 use super::field::Field;
 use crate::arrow::*;
@@ -57,6 +58,7 @@ impl Schema {
             } else {
                 return Err(Error::Schema {
                     message: format!("Column {} does not exist", col.as_ref()),
+                    location: location!(),
                 });
             }
         }
@@ -75,7 +77,7 @@ impl Schema {
                 return Err(Error::Schema{message:format!(
                     "Top level field {} cannot contain `.`. Maybe you meant to create a struct field?",
                     field.name.clone()
-                )});
+                ), location: location!(),});
             }
         }
         Ok(true)
@@ -123,6 +125,7 @@ impl Schema {
             } else {
                 return Err(Error::Schema {
                     message: format!("Field {} not found", field.name),
+                    location: location!(),
                 });
             }
         }
@@ -136,6 +139,7 @@ impl Schema {
     pub fn exclude<T: TryInto<Self> + Debug>(&self, schema: T) -> Result<Self> {
         let other = schema.try_into().map_err(|_| Error::Schema {
             message: "The other schema is not compatible with this schema".to_string(),
+            location: location!(),
         })?;
         let mut fields = vec![];
         for field in self.fields.iter() {
@@ -169,6 +173,7 @@ impl Schema {
             .map(|f| f.id)
             .ok_or_else(|| Error::Schema {
                 message: "Vector column not in schema".to_string(),
+                location: location!(),
             })
     }
 
@@ -210,6 +215,7 @@ impl Schema {
                 .column_by_name(&field.name)
                 .ok_or_else(|| Error::Schema {
                     message: format!("column '{}' does not exist in the record batch", field.name),
+                    location: location!(),
                 })?;
             field.set_dictionary(column);
         }

--- a/rust/lance/src/encodings/dictionary.rs
+++ b/rust/lance/src/encodings/dictionary.rs
@@ -29,6 +29,7 @@ use arrow_array::types::{
 use arrow_array::{Array, ArrayRef, DictionaryArray, PrimitiveArray, UInt32Array};
 use arrow_schema::DataType;
 use async_trait::async_trait;
+use snafu::{location, Location};
 
 use super::plain::PlainEncoder;
 use super::AsyncIndex;
@@ -90,6 +91,7 @@ impl<'a> Encoder for DictionaryEncoder<'a> {
                     "DictionaryEncoder: unsupported key type: {:?}",
                     self.key_type
                 ),
+                location: location!(),
             }),
         }
     }

--- a/rust/lance/src/encodings/plain.rs
+++ b/rust/lance/src/encodings/plain.rs
@@ -37,6 +37,7 @@ use arrow_select::take::take;
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 use futures::stream::{self, StreamExt, TryStreamExt};
+use snafu::{location, Location};
 use tokio::io::AsyncWriteExt;
 
 use crate::arrow::*;
@@ -144,6 +145,7 @@ impl<'a> PlainEncoder<'a> {
                 .downcast_ref::<FixedSizeListArray>()
                 .ok_or_else(|| Error::Schema {
                     message: format!("Needed a FixedSizeListArray but got {}", array.data_type()),
+                    location: location!(),
                 })?;
             let offset = list_array.value_offset(0) as usize;
             let length = list_array.len();
@@ -267,6 +269,7 @@ impl<'a> PlainDecoder<'a> {
                     "Items for fixed size list should be primitives but found {}",
                     items.data_type()
                 ),
+                location: location!(),
             });
         };
         let item_decoder = PlainDecoder::new(
@@ -303,6 +306,7 @@ impl<'a> PlainDecoder<'a> {
             .downcast_ref::<UInt8Array>()
             .ok_or_else(|| Error::Schema {
                 message: "Could not cast to UInt8Array for FixedSizeBinary".to_string(),
+                location: location!(),
             })?;
         Ok(Arc::new(FixedSizeBinaryArray::try_new_from_values(values, stride)?) as ArrayRef)
     }

--- a/rust/lance/src/error.rs
+++ b/rust/lance/src/error.rs
@@ -51,8 +51,8 @@ pub enum Error {
     Internal { message: String },
     #[snafu(display("LanceError(Arrow): {message}"))]
     Arrow { message: String },
-    #[snafu(display("LanceError(Schema): {message}"))]
-    Schema { message: String },
+    #[snafu(display("LanceError(Schema): {message}, {location}"))]
+    Schema { message: String, location: Location },
     #[snafu(display("Not found: {uri}, {location}"))]
     NotFound { uri: String, location: Location },
     #[snafu(display("LanceError(IO): {message}"))]
@@ -151,7 +151,7 @@ impl From<Error> for ArrowError {
         match value {
             Error::Arrow { message: err } => Self::IoError(err), // we lose the error type converting to LanceError
             Error::IO { message: err } => Self::IoError(err),
-            Error::Schema { message: err } => Self::SchemaError(err),
+            Error::Schema { message: err, .. } => Self::SchemaError(err),
             Error::Index { message: err } => Self::IoError(err),
             Error::Stop => Self::IoError("early stop".to_string()),
             e => Self::IoError(e.to_string()), // Find a more scalable way of doing this

--- a/rust/lance/src/io/object_reader.rs
+++ b/rust/lance/src/io/object_reader.rs
@@ -29,6 +29,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use bytes::Bytes;
 use object_store::path::Path;
 use prost::Message;
+use snafu::{location, Location};
 
 use super::ReadBatchParams;
 use crate::arrow::*;
@@ -149,6 +150,7 @@ pub(crate) async fn read_fixed_stride_array(
     if !data_type.is_fixed_stride() {
         return Err(Error::Schema {
             message: format!("{data_type} is not a fixed stride type"),
+            location: location!(),
         });
     }
     // TODO: support more than plain encoding here.

--- a/rust/lance/src/io/writer.rs
+++ b/rust/lance/src/io/writer.rs
@@ -22,6 +22,7 @@ use arrow_buffer::ArrowNativeType;
 use arrow_schema::DataType;
 use async_recursion::async_recursion;
 use object_store::path::Path;
+use snafu::{location, Location};
 
 use crate::arrow::*;
 use crate::datatypes::{Field, Schema};
@@ -200,6 +201,7 @@ impl FileWriter {
             }
             _ => Err(Error::Schema {
                 message: format!("FileWriter::write: unsupported data type: {data_type}"),
+                location: location!(),
             }),
         }
     }
@@ -270,6 +272,7 @@ impl FileWriter {
                             child.name,
                             struct_array.data_type()
                         ),
+                        location: location!(),
                     })?;
                 arrs.push(arr);
             }


### PR DESCRIPTION
This PR add a test for KNN search on an empty table. Our code previously returns error because `KNNFlat` returned an empty record batch without `_distance` column. This PR makes `KNNFlat` return a schema with `_distance` column.

This PR also adds a test for KNN search on an empty table that was previously non-empty. This also seems to fail, but is not fixed in this PR. I created a new issue [here](https://github.com/lancedb/lance/issues/1288)

This PR sneaks in `location: Location` field to `crate::Error::Schema`. I needed this for debugging.