### PR TITLE
fix: bump version workflow

### DIFF
--- a/.github/workflows/bump-version/action.yml
+++ b/.github/workflows/bump-version/action.yml
@@ -24,4 +24,4 @@ runs:
     shell: bash
     run: |
       cargo install cargo-workspaces
-      cargo ws version --no-git-commit --no-git-push --no-git-tag ${{ inputs.part }}
+      cargo ws version --no-git-commit -y --exact --force 'lance*' ${{ inputs.part }}


### PR DESCRIPTION
The action didn't update intra-workspace dependencies before because we didn't use exact versioning matching.

This PR forces update on all crates with pattern `lance*` and uses exact version matching