### PR TITLE
fix: knn search works after compaction

### DIFF
--- a/python/python/lance/optimize.py
+++ b/python/python/lance/optimize.py
@@ -20,6 +20,8 @@ from .lance import CompactionMetrics as CompactionMetrics
 from .lance import CompactionTask as CompactionTask
 from .lance import RewriteResult as RewriteResult
 
+# from .lance import CompactionPlan as CompactionPlan
+
 
 class CompactionOptions(TypedDict):
     """Options for compaction."""

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -29,6 +29,7 @@ import pandas as pd
 import pandas.testing as tm
 import polars as pl
 import pyarrow as pa
+import pyarrow.compute as pc
 import pyarrow.dataset as pa_ds
 import pyarrow.parquet as pq
 import pytest
@@ -785,11 +786,22 @@ def test_metadata(tmp_path: Path):
 
 def test_dataset_optimize(tmp_path: Path):
     base_dir = tmp_path / "dataset"
-    data = pa.table({"a": range(1000), "b": range(1000)})
+    ndim = 128
+    vec = pc.random(1000 * ndim).cast("float32")
+    vec = pa.FixedSizeListArray.from_arrays(vec, ndim)
+    data = pa.table({"a": range(1000), "b": range(1000), "vector": vec})
 
-    dataset = lance.write_dataset(data, base_dir, max_rows_per_file=100)
-    assert dataset.version == 1
-    assert len(dataset.get_fragments()) == 10
+    # One fragment with 1k rows
+    dataset = lance.write_dataset(data, base_dir, max_rows_per_file=1000)
+    # 10 fragments with 100 rows each
+    dataset = lance.write_dataset(data, base_dir, max_rows_per_file=100, mode="append")
+    # One fragment with 1k rows
+    dataset = lance.write_dataset(data, base_dir, max_rows_per_file=1000, mode="append")
+
+    fragment_ids = [f.fragment_id for f in dataset.get_fragments()]
+    assert fragment_ids == list(range(12))
+
+    assert dataset.version == 3
 
     metrics = dataset.optimize.compact_files(
         target_rows_per_fragment=1000,
@@ -802,7 +814,15 @@ def test_dataset_optimize(tmp_path: Path):
     assert metrics.files_removed == 10
     assert metrics.files_added == 1
 
-    assert dataset.version == 2
+    assert dataset.version == 4
+
+    fragment_ids = [f.fragment_id for f in dataset.get_fragments()]
+    # Note that fragment_ids are out of order. Fragments 1 - 10 are replaced
+    # by a new compacted fragment, fragment 12.
+    assert fragment_ids == [0, 12, 11]
+
+    # Make sure we can query successfully.
+    dataset.to_table(nearest=dict(column="vector", q=[0] * ndim))
 
 
 def test_dataset_distributed_optimize(tmp_path: Path):

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -878,8 +878,15 @@ impl Dataset {
 
         let remapping_index: UInt64Array = row_ids
             .iter()
-            .filter_map(|o| returned_row_ids.binary_search(o).ok().map(|pos| pos as u64))
+            .filter_map(|o| {
+                returned_row_ids
+                    .iter()
+                    .position(|id| id == o)
+                    .map(|pos| pos as u64)
+            })
             .collect();
+
+        debug_assert_eq!(remapping_index.len(), one_batch.num_rows());
 
         // Remove the row id column.
         let keep_indices = (0..one_batch.num_columns() - 1).collect::<Vec<_>>();


### PR DESCRIPTION
Fixes #1303 

After compaction, the fragment ids may not be in sequential order. We were using 
`binary_search` to re-order results received from parallel `Fragment::take_rows()` calls, 
which requires sorted data. This PR switches to just doing linear search for now, which 
doesn't require sorting.

We should optimize this code path better in the future, but the batches are small enough for 
linear search is likely not too slow.
