### PR TITLE
feat: add a cache for dynamodb schema validation

### DIFF
--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -75,6 +75,7 @@ tfrecord = { version = "0.14.0", optional = true, features = ["async"] }
 aws-sdk-dynamodb = { version = "0.30.0", optional = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }
+lazy_static = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accelerate-src = { version = "0.3.2", optional = true }


### PR DESCRIPTION
Prior to this PR we describe dynamo db table everytime opening a dataset. This is okay when the number of calls to opening a table with dynamodb store is low. As `DescribeTable` has a account level limit of 2,500 RPS, we should avoid repeatedly calling the API.

This PR also fixes error formatting for aws sdk errors. AWS sdk error doesn't include the underlaying error unless asked for.