### PR TITLE
feat: support storing page-level stats

### DIFF
--- a/docs/format.rst
+++ b/docs/format.rst
@@ -385,6 +385,7 @@ metadata.
 The schema for the statistics is:
 
 .. code-block::
+
     <field_id_1>: struct
         null_count: i64
         min_value: <field_1_data_type>
@@ -394,3 +395,14 @@ The schema for the statistics is:
         null_count: i64
         min_value: <field_N_data_type>
         max_value: <field_N_data_type>
+
+
+Any number of fields may be missing, as statistics for some fields or of some
+kind may be skipped. In addition, readers should expect there may be extra
+fields that are not in this schema. These should be ignored. Future changes to
+the format may add additional fields, but these changes will be backwards
+compatible.
+
+However, writers should not write extra fields that aren't described in this
+document. Until they are defined the specification, there is no guarantee that
+writers will be able to safely interpret new forms of statistics.

--- a/docs/format.rst
+++ b/docs/format.rst
@@ -354,7 +354,8 @@ and timestamps), if the min and max are unknown (all values are null), then the
 minimum/maximum representable values should be used instead.
 
 For float data types, if the min and max are unknown, then use ``-Inf`` and ``+Inf``,
-respectively. ``NaN`` values should be ignored for the purpose of min and max
+respectively. (``-Inf`` and ``+Inf`` may also be used for min and max if those values
+are present in the arrays.) ``NaN`` values should be ignored for the purpose of min and max
 statistics. If the max value is zero (negative or positive), the max value
 should be recorded as ``+0.0``. Likewise, if the min value is zero (positive
 or negative), it should be recorded as ``-0.0``.
@@ -371,16 +372,15 @@ maximum value, then instead use null for the maximum.
     they are simply upper and lower bounds. Two common cases where they are not
     contained in the array is if the min or max original value was deleted and
     when binary data is truncated. Therefore, statistic should not be used to
-    compute queries such as ``SELECT max(col) FROM table``, except to identify
-    which pages and files definitely do not contain the min or max value.
+    compute queries such as ``SELECT max(col) FROM table``.
 
 Page-level statistics format
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Page-level statistics are stored as separate arrays within the Lance file. Each
-array is only one page long. The page offsets are stored in an array just like
-the data page table. The offset to the statistics page offsets is stored in the
-metadata.
+Page-level statistics are stored as arrays within the Lance file. Each array
+contains one page long and is ``num_pages`` long. The page offsets are stored in
+an array just like the data page table. The offset to the statistics page
+table is stored in the metadata.
 
 The schema for the statistics is:
 

--- a/docs/format.rst
+++ b/docs/format.rst
@@ -404,5 +404,5 @@ the format may add additional fields, but these changes will be backwards
 compatible.
 
 However, writers should not write extra fields that aren't described in this
-document. Until they are defined the specification, there is no guarantee that
-writers will be able to safely interpret new forms of statistics.
+document. Until they are defined in the specification, there is no guarantee that
+readers will be able to safely interpret new forms of statistics.

--- a/protos/format.proto
+++ b/protos/format.proto
@@ -258,7 +258,7 @@ message Metadata {
     // is one per column in the stats page table.
     repeated int32 fields = 2;
 
-	  // The file position of the statistics page table
+    // The file position of the statistics page table
     //
     // The page table is a matrix of N x 2, where N = length of stats_fields. This is
     // the same layout as the main page table, except there is always only one

--- a/protos/format.proto
+++ b/protos/format.proto
@@ -243,6 +243,36 @@ message Metadata {
   //   length = page_table[5][4][1];
   // ```
   uint64 page_table_position = 3;
+
+  message StatisticsMetadata {
+    // The schema of the statistics.
+    //
+    // This might be empty, meaning there are no statistics. It also might not 
+    // contain statistics for every field.
+    repeated Field schema = 1;
+
+    // The field ids of the statistics leaf fields.
+    //
+    // This plays a similar role to the `fields` field in the DataFile message.
+    // Each of these field ids corresponds to a field in the stats_schema. There
+    // is one per column in the stats page table.
+    repeated int32 fields = 2;
+
+	  // The file position of the statistics page table
+    //
+    // The page table is a matrix of N x 2, where N = length of stats_fields. This is
+    // the same layout as the main page table, except there is always only one
+    // batch.
+    //
+    // For example, to get the stats column 5, we have:
+    // ```text
+    //   position = stats_page_table[5][0];
+    //   length = stats_page_table[5][1];
+    // ```
+	  uint64 page_table_position = 3;
+  }
+
+  StatisticsMetadata statistics = 4;
 } // Metadata
 
 // Supported encodings.

--- a/rust/lance/src/format.rs
+++ b/rust/lance/src/format.rs
@@ -13,7 +13,7 @@ use crate::{Error, Result};
 pub use fragment::*;
 pub use index::Index;
 pub use manifest::Manifest;
-pub use metadata::Metadata;
+pub use metadata::{Metadata, StatisticsMetadata};
 pub use page_table::{PageInfo, PageTable};
 use snafu::{location, Location};
 /// Protobuf definitions

--- a/rust/lance/src/format/manifest.rs
+++ b/rust/lance/src/format/manifest.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use chrono::prelude::*;
@@ -67,10 +67,20 @@ pub struct Manifest {
 
     /// The path to the transaction file, relative to the root of the dataset
     pub transaction_file: Option<String>,
+
+    /// Index of fragments by id. This only exists in memory and is not persisted.
+    ///
+    /// Keys are fragment ids and values are the index of the fragment in the `fragments` vector.
+    fragment_id_index: BTreeMap<u32, usize>,
 }
 
 impl Manifest {
     pub fn new(schema: &Schema, fragments: Arc<Vec<Fragment>>) -> Self {
+        let fragment_id_index = fragments
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (f.id as u32, i))
+            .collect();
         Self {
             schema: schema.clone(),
             version: 1,
@@ -83,6 +93,7 @@ impl Manifest {
             writer_feature_flags: 0,
             max_fragment_id: 0,
             transaction_file: None,
+            fragment_id_index,
         }
     }
 
@@ -91,6 +102,11 @@ impl Manifest {
         schema: &Schema,
         fragments: Arc<Vec<Fragment>>,
     ) -> Self {
+        let fragment_id_index = fragments
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (f.id as u32, i))
+            .collect();
         Self {
             schema: schema.clone(),
             version: previous.version + 1,
@@ -103,6 +119,7 @@ impl Manifest {
             writer_feature_flags: 0, // These will be set on commit
             max_fragment_id: previous.max_fragment_id,
             transaction_file: None,
+            fragment_id_index,
         }
     }
 
@@ -167,13 +184,17 @@ impl Manifest {
                 location: location!(),
             });
         }
-        let start = since.max_fragment_id();
+        let start = since.max_fragment_id().map(|id| id + 1).unwrap_or_default() as u32;
+
         Ok(self
-            .fragments
-            .iter()
-            .filter(|&f| start.map(|s| f.id > s).unwrap_or(true))
-            .cloned()
+            .fragment_id_index
+            .range(start..)
+            .map(|(_, i)| self.fragments[*i].clone())
             .collect())
+    }
+
+    pub fn fragment_by_id(&self, id: u32) -> Option<&Fragment> {
+        self.fragment_id_index.get(&id).map(|i| &self.fragments[*i])
     }
 }
 
@@ -188,10 +209,17 @@ impl From<pb::Manifest> for Manifest {
             let nanos = ts.nanos as u128;
             sec + nanos
         });
+        let fragments: Arc<Vec<Fragment>> =
+            Arc::new(p.fragments.iter().map(Fragment::from).collect());
+        let fragment_id_index = fragments
+            .iter()
+            .enumerate()
+            .map(|(i, f)| (f.id as u32, i))
+            .collect();
         Self {
             schema: Schema::from((&p.fields, p.metadata)),
             version: p.version,
-            fragments: Arc::new(p.fragments.iter().map(Fragment::from).collect()),
+            fragments,
             version_aux_data: p.version_aux_data as usize,
             index_section: p.index_section.map(|i| i as usize),
             timestamp_nanos: timestamp_nanos.unwrap_or(0),
@@ -204,6 +232,7 @@ impl From<pb::Manifest> for Manifest {
             } else {
                 Some(p.transaction_file)
             },
+            fragment_id_index,
         }
     }
 }

--- a/rust/lance/src/format/metadata.rs
+++ b/rust/lance/src/format/metadata.rs
@@ -198,11 +198,16 @@ impl Metadata {
     }
 }
 
+/// Metadata about the statistics
 #[derive(Debug, PartialEq)]
 pub struct StatisticsMetadata {
-    pub(crate) schema: Schema,
-    pub(crate) leaf_field_ids: Vec<i32>,
-    pub(crate) page_table_position: usize,
+    /// Schema of the page-level statistics.
+    ///
+    /// For a given field with id `i`, the statistics are stored in the field
+    /// `i.null_count`, `i.min_value`, and `i.max_value`.
+    pub schema: Schema,
+    pub leaf_field_ids: Vec<i32>,
+    pub page_table_position: usize,
 }
 
 #[cfg(test)]

--- a/rust/lance/src/io/reader.rs
+++ b/rust/lance/src/io/reader.rs
@@ -238,7 +238,10 @@ impl FileReader {
         // read the fragment metadata so we can handle deletion
         let fragment = if is_dataset {
             let fragment = manifest
-                .fragment_by_id(fragment_id as u32)
+                .fragments
+                .iter()
+                .find(|frag| frag.id == fragment_id)
+                .map(|f| f.to_owned())
                 .ok_or(Error::IO {
                     message: format!("Fragment {} not found in manifest", fragment_id),
                     location: location!(),

--- a/rust/lance/src/io/reader.rs
+++ b/rust/lance/src/io/reader.rs
@@ -177,6 +177,9 @@ pub struct FileReader {
 
     // deletion vector indicating which rows are deleting in the fragment
     deletion_vector: Option<Arc<DeletionVector>>,
+
+    /// Page table for statistics
+    stats_page_table: Arc<Option<PageTable>>,
 }
 
 impl std::fmt::Debug for FileReader {
@@ -214,26 +217,7 @@ impl FileReader {
         let object_reader = object_store.open(path).await?;
         let is_dataset = manifest.is_some();
 
-        let metadata = Self::load_from_cache(session, path, |_| async {
-            let file_size = object_reader.size().await?;
-            let begin = if file_size < object_store.block_size() {
-                0
-            } else {
-                file_size - object_store.block_size()
-            };
-            let tail_bytes = object_reader.get_range(begin..file_size).await?;
-            let metadata_pos = read_metadata_offset(&tail_bytes)?;
-
-            let metadata: Metadata = if metadata_pos < file_size - tail_bytes.len() {
-                // We have not read the metadata bytes yet.
-                read_struct(object_reader.as_ref(), metadata_pos).await?
-            } else {
-                let offset = tail_bytes.len() - (file_size - metadata_pos);
-                read_struct_from_buf(&tail_bytes.slice(offset..))?
-            };
-            Ok(metadata)
-        })
-        .await?;
+        let metadata = Self::read_metadata(object_reader.as_ref(), session).await?;
 
         // m is either
         // a ref if passed in as Some(&manifest), or
@@ -254,10 +238,7 @@ impl FileReader {
         // read the fragment metadata so we can handle deletion
         let fragment = if is_dataset {
             let fragment = manifest
-                .fragments
-                .iter()
-                .find(|frag| frag.id == fragment_id)
-                .map(|f| f.to_owned())
+                .fragment_by_id(fragment_id as u32)
                 .ok_or(Error::IO {
                     message: format!("Fragment {} not found in manifest", fragment_id),
                     location: location!(),
@@ -267,44 +248,57 @@ impl FileReader {
             None
         };
 
-        let page_table = Self::load_from_cache(session, path, |_| async {
-            // TODO: we should have a more efficient way to look up the fields
-            // present in a data file. We might want to include this info in the
-            // data file's metadata.
-            let field_ids = if let Some(fragment) = fragment.as_ref() {
-                Cow::Borrowed(
-                    &fragment
-                        .files
-                        .iter()
-                        .find(|f| path.to_string().ends_with(&f.path))
-                        .ok_or_else(|| Error::Internal {
-                            message: format!("File {} not found in fragment {:?}", path, fragment),
-                        })?
-                        .fields,
-                )
-            } else {
-                let max_id = manifest.schema.max_field_id().unwrap() as i32 + 1;
-                Cow::Owned((0..max_id).collect::<Vec<i32>>())
-            };
+        let page_table = async {
+            Self::load_from_cache(session, path, |_| async {
+                // TODO: we should have a more efficient way to look up the fields
+                // present in a data file. We might want to include this info in the
+                // data file's metadata.
+                let field_ids = if let Some(fragment) = fragment.as_ref() {
+                    Cow::Borrowed(
+                        &fragment
+                            .files
+                            .iter()
+                            .find(|f| path.to_string().ends_with(&f.path))
+                            .ok_or_else(|| Error::Internal {
+                                message: format!(
+                                    "File {} not found in fragment {:?}",
+                                    path, fragment
+                                ),
+                            })?
+                            .fields,
+                    )
+                } else {
+                    let max_id = manifest.schema.max_field_id().unwrap() as i32 + 1;
+                    Cow::Owned((0..max_id).collect::<Vec<i32>>())
+                };
 
-            PageTable::load(
-                object_reader.as_ref(),
-                metadata.page_table_position,
-                field_ids.len() as i32,
-                metadata.num_batches() as i32,
-                field_ids[0],
-            )
+                PageTable::load(
+                    object_reader.as_ref(),
+                    metadata.page_table_position,
+                    field_ids.len() as i32,
+                    metadata.num_batches() as i32,
+                    field_ids[0],
+                )
+                .await
+            })
             .await
-        })
-        .await?;
+        };
 
         let projection = manifest.schema.clone();
 
-        let deletion_vector = if let Some(fragment) = &fragment {
-            Self::load_deletion_vector(object_store, fragment, session).await?
-        } else {
-            None
+        let deletion_vector = async {
+            if let Some(fragment) = &fragment {
+                Self::load_deletion_vector(object_store, fragment, session).await
+            } else {
+                Ok(None)
+            }
         };
+
+        let stats_page_table = Self::read_stats_page_table(object_reader.as_ref(), session);
+
+        // Can concurrently load page tables and deletion vectors
+        let (page_table, deletion_vector, stats_page_table) =
+            futures::try_join!(page_table, deletion_vector, stats_page_table)?;
 
         Ok(Self {
             object_reader: object_reader.into(),
@@ -314,7 +308,63 @@ impl FileReader {
             fragment_id,
             with_row_id: false,
             deletion_vector,
+            stats_page_table,
         })
+    }
+
+    async fn read_metadata(
+        object_reader: &dyn ObjectReader,
+        session: Option<&Session>,
+    ) -> Result<Arc<Metadata>> {
+        Self::load_from_cache(session, object_reader.path(), |_| async {
+            let file_size = object_reader.size().await?;
+            let begin = if file_size < object_reader.block_size() {
+                0
+            } else {
+                file_size - object_reader.block_size()
+            };
+            let tail_bytes = object_reader.get_range(begin..file_size).await?;
+            let metadata_pos = read_metadata_offset(&tail_bytes)?;
+
+            let metadata: Metadata = if metadata_pos < file_size - tail_bytes.len() {
+                // We have not read the metadata bytes yet.
+                read_struct(object_reader, metadata_pos).await?
+            } else {
+                let offset = tail_bytes.len() - (file_size - metadata_pos);
+                read_struct_from_buf(&tail_bytes.slice(offset..))?
+            };
+            Ok(metadata)
+        })
+        .await
+    }
+
+    /// Get the statistics page table. This will read the metadata if it is not cached.
+    ///
+    /// The page table is cached.
+    async fn read_stats_page_table(
+        object_reader: &dyn ObjectReader,
+        session: Option<&Session>,
+    ) -> Result<Arc<Option<PageTable>>> {
+        // To prevent collisions, we cache this at a child path
+        Self::load_from_cache(session, &object_reader.path().child("stats"), |_| async {
+            let metadata = Self::read_metadata(object_reader, session).await?;
+
+            if let Some(stats_meta) = metadata.stats_metadata.as_ref() {
+                Ok(Some(
+                    PageTable::load(
+                        object_reader,
+                        stats_meta.page_table_position,
+                        stats_meta.leaf_field_ids.len() as i32,
+                        metadata.num_batches() as i32,
+                        0,
+                    )
+                    .await?,
+                ))
+            } else {
+                Ok(None)
+            }
+        })
+        .await
     }
 
     /// Load some metadata about the fragment from the cache, if there is one.
@@ -472,6 +522,31 @@ impl FileReader {
 
         Ok(concat_batches(&schema, &batches)?)
     }
+
+    pub async fn read_page_stats(&self, projection: &Schema) -> Result<Option<RecordBatch>> {
+        if let Some(stats_page_table) = self.stats_page_table.as_ref() {
+            let arrays = futures::stream::iter(&projection.fields)
+                .map(|field| async move {
+                    read_array(
+                        self,
+                        field,
+                        0,
+                        stats_page_table,
+                        &ReadBatchParams::RangeFull,
+                    )
+                    .await
+                })
+                .buffered(num_cpus::get())
+                .try_collect::<Vec<_>>()
+                .await?;
+
+            let schema = ArrowSchema::from(projection);
+            let batch = RecordBatch::try_new(Arc::new(schema), arrays)?;
+            Ok(Some(batch))
+        } else {
+            Ok(None)
+        }
+    }
 }
 
 /// Stream desired full batches from the file.
@@ -522,7 +597,7 @@ async fn read_batch(
 ) -> Result<RecordBatch> {
     // We box this because otherwise we get a higher-order lifetime error.
     let arrs = stream::iter(&schema.fields)
-        .map(|f| read_array(reader, f, batch_id, params))
+        .map(|f| async { read_array(reader, f, batch_id, &reader.page_table, params).await })
         .buffered(num_cpus::get() * 4)
         .try_collect::<Vec<_>>()
         .boxed();
@@ -590,6 +665,7 @@ async fn read_array(
     reader: &FileReader,
     field: &Field,
     batch_id: i32,
+    page_table: &PageTable,
     params: &ReadBatchParams,
 ) -> Result<ArrayRef> {
     let data_type = field.data_type();
@@ -597,17 +673,23 @@ async fn read_array(
     use DataType::*;
 
     if data_type.is_fixed_stride() {
-        _read_fixed_stride_array(reader, field, batch_id, params).await
+        _read_fixed_stride_array(reader, field, batch_id, page_table, params).await
     } else {
         match data_type {
-            Null => read_null_array(reader, field, batch_id, params),
+            Null => read_null_array(field, batch_id, page_table, params),
             Utf8 | LargeUtf8 | Binary | LargeBinary => {
-                read_binary_array(reader, field, batch_id, params).await
+                read_binary_array(reader, field, batch_id, page_table, params).await
             }
-            Struct(_) => read_struct_array(reader, field, batch_id, params).await,
-            Dictionary(_, _) => read_dictionary_array(reader, field, batch_id, params).await,
-            List(_) => read_list_array::<Int32Type>(reader, field, batch_id, params).await,
-            LargeList(_) => read_list_array::<Int64Type>(reader, field, batch_id, params).await,
+            Struct(_) => read_struct_array(reader, field, batch_id, page_table, params).await,
+            Dictionary(_, _) => {
+                read_dictionary_array(reader, field, batch_id, page_table, params).await
+            }
+            List(_) => {
+                read_list_array::<Int32Type>(reader, field, batch_id, page_table, params).await
+            }
+            LargeList(_) => {
+                read_list_array::<Int64Type>(reader, field, batch_id, page_table, params).await
+            }
             _ => {
                 unimplemented!("{}", format!("No support for {data_type} yet"));
             }
@@ -634,9 +716,10 @@ async fn _read_fixed_stride_array(
     reader: &FileReader,
     field: &Field,
     batch_id: i32,
+    page_table: &PageTable,
     params: &ReadBatchParams,
 ) -> Result<ArrayRef> {
-    let page_info = get_page_info(&reader.page_table, field, batch_id)?;
+    let page_info = get_page_info(page_table, field, batch_id)?;
 
     read_fixed_stride_array(
         reader.object_reader.as_ref(),
@@ -649,12 +732,12 @@ async fn _read_fixed_stride_array(
 }
 
 fn read_null_array(
-    reader: &FileReader,
     field: &Field,
     batch_id: i32,
+    page_table: &PageTable,
     params: &ReadBatchParams,
 ) -> Result<ArrayRef> {
-    let page_info = get_page_info(&reader.page_table, field, batch_id)?;
+    let page_info = get_page_info(page_table, field, batch_id)?;
 
     let length_output = match params {
         ReadBatchParams::Indices(indices) => {
@@ -702,9 +785,10 @@ async fn read_binary_array(
     reader: &FileReader,
     field: &Field,
     batch_id: i32,
+    page_table: &PageTable,
     params: &ReadBatchParams,
 ) -> Result<ArrayRef> {
-    let page_info = get_page_info(&reader.page_table, field, batch_id)?;
+    let page_info = get_page_info(page_table, field, batch_id)?;
 
     use crate::io::object_reader::read_binary_array;
     read_binary_array(
@@ -722,9 +806,10 @@ async fn read_dictionary_array(
     reader: &FileReader,
     field: &Field,
     batch_id: i32,
+    page_table: &PageTable,
     params: &ReadBatchParams,
 ) -> Result<ArrayRef> {
-    let page_info = get_page_info(&reader.page_table, field, batch_id)?;
+    let page_info = get_page_info(page_table, field, batch_id)?;
     let data_type = field.data_type();
     let decoder = DictionaryDecoder::new(
         reader.object_reader.as_ref(),
@@ -747,12 +832,13 @@ async fn read_struct_array(
     reader: &FileReader,
     field: &Field,
     batch_id: i32,
+    page_table: &PageTable,
     params: &ReadBatchParams,
 ) -> Result<ArrayRef> {
     // TODO: use tokio to make the reads in parallel.
     let mut sub_arrays: Vec<(FieldRef, ArrayRef)> = vec![];
     for child in field.children.as_slice() {
-        let arr = read_array(reader, child, batch_id, params).await?;
+        let arr = read_array(reader, child, batch_id, page_table, params).await?;
         sub_arrays.push((Arc::new(child.into()), arr));
     }
 
@@ -763,6 +849,7 @@ async fn take_list_array<T: ArrowNumericType>(
     reader: &FileReader,
     field: &Field,
     batch_id: i32,
+    page_table: &PageTable,
     positions: &PrimitiveArray<T>,
     indices: &UInt32Array,
 ) -> Result<ArrayRef>
@@ -786,6 +873,7 @@ where
                 reader,
                 &field.children[0],
                 batch_id,
+                page_table,
                 &(range.clone()).into(),
             )
             .await?,
@@ -813,6 +901,7 @@ async fn read_list_array<T: ArrowNumericType>(
     reader: &FileReader,
     field: &Field,
     batch_id: i32,
+    page_table: &PageTable,
     params: &ReadBatchParams,
 ) -> Result<ArrayRef>
 where
@@ -853,13 +942,20 @@ where
             positions.value(0).as_usize()..positions.value(positions.len() - 1).as_usize(),
         ),
         ReadBatchParams::Indices(indices) => {
-            return take_list_array(reader, field, batch_id, positions, indices).await;
+            return take_list_array(reader, field, batch_id, page_table, positions, indices).await;
         }
     };
 
     let start_position = positions.value(0);
     let offset_arr = subtract_scalar(positions, start_position)?;
-    let value_arrs = read_array(reader, &field.children[0], batch_id, &value_params).await?;
+    let value_arrs = read_array(
+        reader,
+        &field.children[0],
+        batch_id,
+        page_table,
+        &value_params,
+    )
+    .await?;
     let arr = try_new_generic_list_array(value_arrs, &offset_arr)?;
     Ok(Arc::new(arr) as ArrayRef)
 }
@@ -1404,7 +1500,7 @@ mod tests {
             field: &Field,
             params: ReadBatchParams,
         ) -> ArrayRef {
-            read_array(reader, field, 0, &params)
+            read_array(reader, field, 0, reader.page_table.as_ref(), &params)
                 .await
                 .expect("Error reading back the null array from file") as _
         }
@@ -1439,12 +1535,24 @@ mod tests {
 
         // raise error if take indices are out of bounds
         let params = ReadBatchParams::Indices(UInt32Array::from(vec![1, 9, 30, 72, 100]));
-        let arr = read_array(&reader, &schema.fields[1], 0, &params);
+        let arr = read_array(
+            &reader,
+            &schema.fields[1],
+            0,
+            reader.page_table.as_ref(),
+            &params,
+        );
         assert!(arr.await.is_err());
 
         // raise error if range indices are out of bounds
         let params = ReadBatchParams::RangeTo(..107);
-        let arr = read_array(&reader, &schema.fields[1], 0, &params);
+        let arr = read_array(
+            &reader,
+            &schema.fields[1],
+            0,
+            reader.page_table.as_ref(),
+            &params,
+        );
         assert!(arr.await.is_err());
     }
 

--- a/rust/lance/src/io/writer.rs
+++ b/rust/lance/src/io/writer.rs
@@ -524,7 +524,8 @@ impl FileWriter {
                     .await?;
                 }
 
-                let page_table_position = stats_page_table.write(&mut self.object_writer, 0).await?;
+                let page_table_position =
+                    stats_page_table.write(&mut self.object_writer, 0).await?;
 
                 Ok(Some(StatisticsMetadata {
                     schema,
@@ -545,18 +546,18 @@ impl FileWriter {
             .await?;
         self.metadata.page_table_position = pos;
 
-        // Step 1.5 Write statistics.
+        // Step 2. Write statistics.
         self.metadata.stats_metadata = self.write_statistics().await?;
 
-        // Step 2. Write manifest and dictionary values.
+        // Step 3. Write manifest and dictionary values.
         let mut manifest = Manifest::new(&self.schema, Arc::new(vec![]));
         let pos = write_manifest(&mut self.object_writer, &mut manifest, None).await?;
 
-        // Step 3. Write metadata.
+        // Step 4. Write metadata.
         self.metadata.manifest_position = Some(pos);
         let pos = self.object_writer.write_struct(&self.metadata).await?;
 
-        // Step 4. Write magics.
+        // Step 5. Write magics.
         self.object_writer.write_magics(pos).await
     }
 }

--- a/rust/lance/src/io/writer.rs
+++ b/rust/lance/src/io/writer.rs
@@ -861,8 +861,8 @@ mod tests {
                 DataType::Struct(
                     vec![
                         ArrowField::new("null_count", DataType::Int64, true),
-                        ArrowField::new("min", DataType::Float32, true),
-                        ArrowField::new("max", DataType::Float32, true),
+                        ArrowField::new("min_value", DataType::Float32, true),
+                        ArrowField::new("max_value", DataType::Float32, true),
                     ]
                     .into(),
                 ),
@@ -873,8 +873,8 @@ mod tests {
                 DataType::Struct(
                     vec![
                         ArrowField::new("null_count", DataType::Int64, true),
-                        ArrowField::new("min", DataType::Utf8, true),
-                        ArrowField::new("max", DataType::Utf8, true),
+                        ArrowField::new("min_value", DataType::Utf8, true),
+                        ArrowField::new("max_value", DataType::Utf8, true),
                     ]
                     .into(),
                 ),
@@ -897,11 +897,11 @@ mod tests {
                         Arc::new(Int64Array::from(vec![3, 0])) as ArrayRef,
                     ),
                     (
-                        Arc::new(ArrowField::new("min", DataType::Float32, true)),
+                        Arc::new(ArrowField::new("min_value", DataType::Float32, true)),
                         Arc::new(Float32Array::from(vec![0.0, -20.0])) as ArrayRef,
                     ),
                     (
-                        Arc::new(ArrowField::new("max", DataType::Float32, true)),
+                        Arc::new(ArrowField::new("max_value", DataType::Float32, true)),
                         Arc::new(Float32Array::from(vec![10.0, 20.0])) as ArrayRef,
                     ),
                 ])),
@@ -911,11 +911,11 @@ mod tests {
                         Arc::new(Int64Array::from(vec![0, 2])) as ArrayRef,
                     ),
                     (
-                        Arc::new(ArrowField::new("min", DataType::Utf8, true)),
+                        Arc::new(ArrowField::new("min_value", DataType::Utf8, true)),
                         Arc::new(StringArray::from(vec!["abcdef", "abbb"])) as ArrayRef,
                     ),
                     (
-                        Arc::new(ArrowField::new("max", DataType::Utf8, true)),
+                        Arc::new(ArrowField::new("max_value", DataType::Utf8, true)),
                         Arc::new(StringArray::from(vec!["yz", "zz"])) as ArrayRef,
                     ),
                 ])),
@@ -929,7 +929,9 @@ mod tests {
         let arrow_projection = Arc::new(ArrowSchema::new(vec![
             ArrowField::new(
                 "0",
-                DataType::Struct(vec![ArrowField::new("min", DataType::Float32, true)].into()),
+                DataType::Struct(
+                    vec![ArrowField::new("min_value", DataType::Float32, true)].into(),
+                ),
                 true,
             ),
             ArrowField::new(
@@ -937,7 +939,7 @@ mod tests {
                 DataType::Struct(
                     vec![
                         ArrowField::new("null_count", DataType::Int64, true),
-                        ArrowField::new("max", DataType::Utf8, true),
+                        ArrowField::new("max_value", DataType::Utf8, true),
                     ]
                     .into(),
                 ),


### PR DESCRIPTION
This PR adds page-level statistics to the Lance format. Computing the statistics and using them in queries is left for a future PR.

Changes:
 * Define the statistics format in the format documentation.
 * Added statistics metadata to the metadata
 * Added reading and writing of the statistic page table. Refactored array read and write functions to take the page table as a parameter.

Closes #1318