### PR TITLE
feat: add prefilter to the to_table method

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -228,6 +228,8 @@ class LanceDataset(pa.dataset.Dataset):
         batch_readahead: Optional[int] = None,
         fragment_readahead: Optional[int] = None,
         scan_in_order: bool = True,
+        *,
+        prefilter: bool = False,
     ) -> pa.Table:
         """Read the data into memory as a pyarrow Table.
 
@@ -285,6 +287,7 @@ class LanceDataset(pa.dataset.Dataset):
             batch_readahead=batch_readahead,
             fragment_readahead=fragment_readahead,
             scan_in_order=scan_in_order,
+            prefilter=prefilter,
         ).to_table()
 
     @property

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -336,6 +336,8 @@ class LanceDataset(pa.dataset.Dataset):
         batch_readahead: Optional[int] = None,
         fragment_readahead: Optional[int] = None,
         scan_in_order: bool = True,
+        *,
+        prefilter: bool = False,
         **kwargs,
     ) -> Iterator[pa.RecordBatch]:
         """Read the dataset as materialized record batches.
@@ -359,6 +361,7 @@ class LanceDataset(pa.dataset.Dataset):
             batch_readahead=batch_readahead,
             fragment_readahead=fragment_readahead,
             scan_in_order=scan_in_order,
+            prefilter=prefilter,
         ).to_batches()
 
     def take(

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -713,6 +713,9 @@ def test_scan_prefilter(tmp_path: Path):
     table = dataset.to_table(**args)
     assert table.column("index") == expected.column("index")
 
+    table = pa.Table.from_batches(dataset.to_batches(**args))
+    assert table.column("index") == expected.column("index")
+
 
 def test_scan_count_rows(tmp_path: Path):
     base_dir = tmp_path / "dataset"

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -710,6 +710,9 @@ def test_scan_prefilter(tmp_path: Path):
 
     assert table.column("index") == expected.column("index")
 
+    table = dataset.to_table(**args)
+    assert table.column("index") == expected.column("index")
+
 
 def test_scan_count_rows(tmp_path: Path):
     base_dir = tmp_path / "dataset"


### PR DESCRIPTION
Naive prefiltering was added to the scanner in https://github.com/lancedb/lance/pull/1276

I did not realize there was also a `to_table` method which is what lancedb uses.

This PR adds the prefilter option to `to_table` as well.