### PR TITLE
feat: fused argmin and argmax to avoid unnecessary memory allocation

### DIFF
--- a/rust/lance-linalg/benches/argmin.rs
+++ b/rust/lance-linalg/benches/argmin.rs
@@ -16,7 +16,7 @@ use std::{sync::Arc, time::Duration};
 
 use arrow_array::{Float32Array, UInt32Array};
 use criterion::{criterion_group, criterion_main, Criterion};
-use lance_linalg::kernels::argmin;
+use lance_linalg::kernels::{argmin, argmin_opt};
 use lance_testing::datagen::generate_random_array_with_seed;
 
 #[cfg(target_os = "linux")]
@@ -24,7 +24,7 @@ use pprof::criterion::{Output, PProfProfiler};
 
 #[inline]
 fn argmin_arrow(x: &Float32Array) -> u32 {
-    argmin(x).unwrap()
+    argmin_opt(x.iter()).unwrap()
 }
 
 fn argmin_arrow_batch(x: &Float32Array, dimension: usize) -> Arc<UInt32Array> {

--- a/rust/lance-linalg/src/kernels.rs
+++ b/rust/lance-linalg/src/kernels.rs
@@ -72,15 +72,7 @@ where
 pub fn argmin_value<T: Num + Bounded + PartialOrd + Copy>(
     iter: impl Iterator<Item = T>,
 ) -> Option<(u32, T)> {
-    let mut min_idx: Option<u32> = None;
-    let mut min_value = T::max_value();
-    for (idx, value) in iter.enumerate() {
-        if let Some(Ordering::Less) = value.partial_cmp(&min_value) {
-            min_value = value;
-            min_idx = Some(idx as u32);
-        }
-    }
-    min_idx.map(|idx| (idx, min_value))
+    argmin_value_opt(iter.map(Some))
 }
 
 pub fn argmin_value_opt<T: Num + Bounded + PartialOrd>(

--- a/rust/lance-linalg/src/kernels.rs
+++ b/rust/lance-linalg/src/kernels.rs
@@ -23,20 +23,31 @@ use arrow_array::{
     Array, ArrowNumericType, GenericStringArray, OffsetSizeTrait, PrimitiveArray, UInt64Array,
 };
 use arrow_schema::{ArrowError, DataType};
-use num_traits::bounds::Bounded;
+use num_traits::{bounds::Bounded, Num};
 
 use crate::Result;
 
 /// Argmax on a [PrimitiveArray].
 ///
 /// Returns the index of the max value in the array.
-pub fn argmax<T: ArrowNumericType>(array: &PrimitiveArray<T>) -> Option<u32>
-where
-    T::Native: PartialOrd + Bounded,
-{
+pub fn argmax<T: Num + Bounded + PartialOrd>(iter: impl Iterator<Item = T>) -> Option<u32> {
     let mut max_idx: Option<u32> = None;
-    let mut max_value = T::Native::min_value();
-    for (idx, value) in array.iter().enumerate() {
+    let mut max_value = T::min_value();
+    for (idx, value) in iter.enumerate() {
+        if let Some(Ordering::Greater) = value.partial_cmp(&max_value) {
+            max_value = value;
+            max_idx = Some(idx as u32);
+        }
+    }
+    max_idx
+}
+
+pub fn argmax_opt<T: Num + Bounded + PartialOrd>(
+    iter: impl Iterator<Item = Option<T>>,
+) -> Option<u32> {
+    let mut max_idx: Option<u32> = None;
+    let mut max_value = T::min_value();
+    for (idx, value) in iter.enumerate() {
         if let Some(value) = value {
             if let Some(Ordering::Greater) = value.partial_cmp(&max_value) {
                 max_value = value;
@@ -47,16 +58,37 @@ where
     max_idx
 }
 
-/// Argmin on a [PrimitiveArray].
+/// Argmin on an iterator. Fused the operation in iterator to avoid memory allocation.
 ///
 /// Returns the index of the min value in the array.
-pub fn argmin<T: ArrowNumericType>(array: &PrimitiveArray<T>) -> Option<u32>
+///
+pub fn argmin<T: Num + PartialOrd + Copy>(iter: impl Iterator<Item = T>) -> Option<u32>
 where
-    T::Native: PartialOrd + Bounded,
+    T: Bounded,
 {
+    argmin_value(iter).map(|(idx, _)| idx)
+}
+
+pub fn argmin_value<T: Num + Bounded + PartialOrd + Copy>(
+    iter: impl Iterator<Item = T>,
+) -> Option<(u32, T)> {
     let mut min_idx: Option<u32> = None;
-    let mut min_value = T::Native::max_value();
-    for (idx, value) in array.iter().enumerate() {
+    let mut min_value = T::max_value();
+    for (idx, value) in iter.enumerate() {
+        if let Some(Ordering::Less) = value.partial_cmp(&min_value) {
+            min_value = value;
+            min_idx = Some(idx as u32);
+        }
+    }
+    min_idx.map(|idx| (idx, min_value))
+}
+
+pub fn argmin_value_opt<T: Num + Bounded + PartialOrd>(
+    iter: impl Iterator<Item = Option<T>>,
+) -> Option<(u32, T)> {
+    let mut min_idx: Option<u32> = None;
+    let mut min_value = T::max_value();
+    for (idx, value) in iter.enumerate() {
         if let Some(value) = value {
             if let Some(Ordering::Less) = value.partial_cmp(&min_value) {
                 min_value = value;
@@ -64,7 +96,16 @@ where
             }
         }
     }
-    min_idx
+    min_idx.map(|idx| (idx, min_value))
+}
+
+/// Argmin over an `Option<Float>` iterator.
+///
+#[inline]
+pub fn argmin_opt<T: Num + Bounded + PartialOrd>(
+    iter: impl Iterator<Item = Option<T>>,
+) -> Option<u32> {
+    argmin_value_opt(iter).map(|(idx, _)| idx)
 }
 
 fn hash_numeric_type<T: ArrowNumericType>(array: &PrimitiveArray<T>) -> Result<UInt64Array>
@@ -134,57 +175,57 @@ mod tests {
     #[test]
     fn test_argmax() {
         let f = Float32Array::from(vec![1.0, 5.0, 3.0, 2.0, 20.0, 8.2, 3.5]);
-        assert_eq!(argmax(&f), Some(4));
+        assert_eq!(argmax(f.values().iter().copied()), Some(4));
 
         let f = Float32Array::from(vec![1.0, 5.0, NAN, 3.0, 2.0, 20.0, INFINITY, 3.5]);
-        assert_eq!(argmax(&f), Some(6));
+        assert_eq!(argmax_opt(f.iter()), Some(6));
 
         let f = Float32Array::from_iter(vec![Some(2.0), None, Some(20.0), Some(NAN)]);
-        assert_eq!(argmax(&f), Some(2));
+        assert_eq!(argmax_opt(f.iter()), Some(2));
 
         let f = Float32Array::from(vec![NAN, NAN, NAN]);
-        assert_eq!(argmax(&f), None);
+        assert_eq!(argmax(f.values().iter().copied()), None);
 
         let i = Int16Array::from(vec![1, 5, 3, 2, 20, 8, 16]);
-        assert_eq!(argmax(&i), Some(4));
+        assert_eq!(argmax(i.values().iter().copied()), Some(4));
 
         let u = UInt32Array::from(vec![1, 5, 3, 2, 20, 8, 16]);
-        assert_eq!(argmax(&u), Some(4));
+        assert_eq!(argmax(u.values().iter().copied()), Some(4));
 
         let empty_vec: Vec<i16> = vec![];
-        let emtpy = Int16Array::from(empty_vec);
-        assert_eq!(argmax(&emtpy), None)
+        let empty = Int16Array::from(empty_vec);
+        assert_eq!(argmax_opt(empty.iter()), None)
     }
 
     #[test]
     fn test_argmin() {
         let f = Float32Array::from_iter(vec![5.0, 3.0, 2.0, 20.0, 8.2, 3.5]);
-        assert_eq!(argmin(&f), Some(2));
+        assert_eq!(argmin(f.values().iter().copied()), Some(2));
 
         let f = Float32Array::from_iter(vec![5.0, 3.0, 2.0, 20.0, NAN]);
-        assert_eq!(argmin(&f), Some(2));
+        assert_eq!(argmin_opt(f.iter()), Some(2));
 
         let f = Float32Array::from_iter(vec![Some(2.0), None, Some(NAN)]);
-        assert_eq!(argmin(&f), Some(0));
+        assert_eq!(argmin_opt(f.iter()), Some(0));
 
         let f = Float32Array::from_iter(vec![5.0, 3.0, 2.0, NEG_INFINITY, NAN]);
-        assert_eq!(argmin(&f), Some(3));
+        assert_eq!(argmin(f.values().iter().copied()), Some(3));
 
         let f = Float32Array::from_iter(vec![NAN, NAN, NAN, NAN]);
-        assert_eq!(argmin(&f), None);
+        assert_eq!(argmin(f.values().iter().copied()), None);
 
         let f = Float32Array::from_iter(vec![5.0, 3.0, 2.0, 20.0, 8.2, 3.5]);
-        assert_eq!(argmin(&f), Some(2));
+        assert_eq!(argmin(f.values().iter().copied()), Some(2));
 
         let i = Int16Array::from_iter(vec![5, 3, 2, 20, 8, 16]);
-        assert_eq!(argmin(&i), Some(2));
+        assert_eq!(argmin(i.values().iter().copied()), Some(2));
 
         let u = UInt32Array::from_iter(vec![5, 3, 2, 20, 8, 16]);
-        assert_eq!(argmin(&u), Some(2));
+        assert_eq!(argmin(u.values().iter().copied()), Some(2));
 
         let empty_vec: Vec<i16> = vec![];
         let emtpy = Int16Array::from(empty_vec);
-        assert_eq!(argmin(&emtpy), None)
+        assert_eq!(argmin_opt(emtpy.iter()), None)
     }
 
     #[test]

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -28,8 +28,9 @@ use log::{info, warn};
 use rand::prelude::*;
 use rand::{distributions::WeightedIndex, Rng};
 
+use crate::kernels::argmin_value;
 use crate::{
-    distance::{Cosine, Dot, MetricType, L2},
+    distance::{Cosine, Dot, MetricType, Normalize, L2},
     matrix::MatrixView,
 };
 use crate::{Error, Result};
@@ -446,10 +447,26 @@ impl KMeans {
         let n = data.len() / self.dimension;
         let metric_type = self.metric_type;
         const CHUNK_SIZE: usize = 1024;
+
+        // Normalized centroids for fast cosine.
+        let norm_centroids = if matches!(metric_type, MetricType::Cosine) {
+            Arc::new(Some(
+                self.centroids
+                    .values()
+                    .chunks_exact(dimension)
+                    .map(|centroid| centroid.norm_l2())
+                    .collect::<Vec<f32>>(),
+            ))
+        } else {
+            Arc::new(None)
+        };
+
         let cluster_with_distances = stream::iter((0..n).step_by(CHUNK_SIZE))
             // make tiles of input data to split between threads.
-            .zip(repeat_with(|| (data.clone(), self.centroids.clone())))
-            .map(|(start_idx, (data, centroids))| async move {
+            .zip(repeat_with(|| {
+                (data.clone(), self.centroids.clone(), norm_centroids.clone())
+            }))
+            .map(|(start_idx, (data, centroids, norms))| async move {
                 let data = tokio::task::spawn_blocking(move || {
                     let array = data.values();
                     let centroids_array = centroids.values();
@@ -457,26 +474,17 @@ impl KMeans {
                     (start_idx..min(start_idx + CHUNK_SIZE, n))
                         .map(|idx| {
                             let vector = &array[idx * dimension..(idx + 1) * dimension];
-                            let mut min = std::f32::MAX;
-                            let mut min_idx = 0;
-                            for (idx, other) in centroids_array.chunks_exact(dimension).enumerate()
-                            {
-                                // We've found about 40% performance improvement by using static dispatch instead
-                                // of dynamic dispatch.
-                                //
-                                // NOTE: Please make sure run benchmark when changing the following code.
-                                // `RUSTFLAGS="-C target-cpu=native" cargo bench --bench ivf_pq`
-                                let dist = match metric_type {
-                                    MetricType::L2 => vector.l2(other),
-                                    MetricType::Cosine => vector.cosine(other),
-                                    MetricType::Dot => vector.dot(other),
-                                };
-                                if dist < min {
-                                    min = dist;
-                                    min_idx = idx;
-                                }
-                            }
-                            (min_idx as u32, min)
+                            argmin_value(centroids_array.chunks_exact(dimension).enumerate().map(
+                                |(c_idx, centroid)| match metric_type {
+                                    MetricType::L2 => vector.l2(centroid),
+                                    MetricType::Cosine => centroid.cosine_fast(
+                                        norms.as_ref().as_ref().unwrap()[c_idx],
+                                        vector,
+                                    ),
+                                    MetricType::Dot => vector.dot(centroid),
+                                },
+                            ))
+                            .unwrap()
                         })
                         .collect::<Vec<_>>()
                 })

--- a/rust/lance/src/index/vector/diskann/builder.rs
+++ b/rust/lance/src/index/vector/diskann/builder.rs
@@ -23,7 +23,7 @@ use arrow_array::{
 use arrow_select::concat::concat_batches;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use lance_arrow::*;
-use lance_linalg::{distance::l2_distance, kernels::argmin, matrix::MatrixView};
+use lance_linalg::{distance::l2_distance, kernels::argmin_opt, matrix::MatrixView};
 use ordered_float::OrderedFloat;
 use rand::{distributions::Uniform, prelude::*, Rng, SeedableRng};
 
@@ -261,7 +261,7 @@ async fn find_medoid(vectors: &MatrixView<Float32Type>, metric_type: MetricType)
         vectors.data().values(),
         vectors.num_columns(),
     );
-    let medoid_idx = argmin(dists.as_ref()).unwrap();
+    let medoid_idx = argmin_opt(dists.iter()).unwrap();
     Ok(medoid_idx as usize)
 }
 

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -28,7 +28,7 @@ use async_trait::async_trait;
 use futures::{stream, StreamExt, TryStreamExt};
 use lance_linalg::{
     distance::{l2::l2_distance_batch, norm_l2::norm_l2},
-    kernels::argmin,
+    kernels::argmin_opt,
     matrix::MatrixView,
 };
 use rand::SeedableRng;
@@ -494,8 +494,10 @@ impl ProductQuantizer {
                     let offset = row_offset + sub_idx * sub_dim;
                     let sub_vector = &flatten_values[offset..offset + sub_dim];
                     let centroids = all_centroids[sub_idx].as_ref();
-                    let code = argmin(dist_func(sub_vector, centroids.values(), sub_dim).as_ref())
-                        .unwrap();
+                    // TODO(lei): use kmeans.compute_membership()
+                    let code =
+                        argmin_opt(dist_func(sub_vector, centroids.values(), sub_dim).iter())
+                            .unwrap();
                     builder[i * num_sub_vectors + sub_idx] = code as u8;
                 }
             }


### PR DESCRIPTION
Implement fused argmin / argmax that takes an iterator instead of an array, to avoid memory allocation.