### PR TITLE
feat: optimized pushdown scanner

### DIFF
--- a/python/python/benchmarks/test_scan.py
+++ b/python/python/benchmarks/test_scan.py
@@ -125,3 +125,35 @@ def test_scan_table_filter_full(benchmark, sample_dataset, keep_percent):
     )
 
     assert result.schema.names == ["i", "f", "s", "fsl", "blob"]
+
+
+@pytest.mark.benchmark(group="filter_table")
+def test_filter_for_range(benchmark, sample_dataset):
+    result = benchmark(
+        sample_dataset.to_table,
+        filter="i > 1000 and i < 5000",
+    )
+
+    assert result.schema.names == ["i", "f", "s", "fsl", "blob"]
+
+
+@pytest.mark.benchmark(group="filter_table")
+def test_filter_for_row(benchmark, sample_dataset):
+    result = benchmark(
+        sample_dataset.to_table,
+        filter="i = 4200",
+    )
+
+    assert result.num_rows == 1
+    assert result.schema.names == ["i", "f", "s", "fsl", "blob"]
+
+
+@pytest.mark.benchmark(group="filter_table")
+def test_filter_multiple(benchmark, sample_dataset):
+    result = benchmark(
+        sample_dataset.to_table,
+        filter="i > 1000 and i < 5000 and s in ('hello', 'world')",
+    )
+
+    assert result.num_rows == 1
+    assert result.schema.names == ["i", "f", "s", "fsl", "blob"]

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -147,6 +147,7 @@ class LanceDataset(pa.dataset.Dataset):
         *,
         prefilter: bool = False,
         with_row_id: bool = False,
+        use_stats: bool = True,
     ) -> LanceScanner:
         """Return a Scanner that can support various pushdowns.
 
@@ -233,6 +234,7 @@ class LanceDataset(pa.dataset.Dataset):
             .scan_in_order(scan_in_order)
             .with_fragments(fragments)
             .with_row_id(with_row_id)
+            .use_stats(use_stats)
         )
         if nearest is not None:
             builder = builder.nearest(**nearest)
@@ -259,6 +261,7 @@ class LanceDataset(pa.dataset.Dataset):
         *,
         prefilter: bool = False,
         with_row_id: bool = False,
+        use_stats: bool = True,
     ) -> pa.Table:
         """Read the data into memory as a pyarrow Table.
 
@@ -318,6 +321,7 @@ class LanceDataset(pa.dataset.Dataset):
             scan_in_order=scan_in_order,
             prefilter=prefilter,
             with_row_id=with_row_id,
+            use_stats=use_stats,
         ).to_table()
 
     @property
@@ -369,6 +373,7 @@ class LanceDataset(pa.dataset.Dataset):
         *,
         prefilter: bool = False,
         with_row_id: bool = False,
+        use_stats: bool = True,
         **kwargs,
     ) -> Iterator[pa.RecordBatch]:
         """Read the dataset as materialized record batches.
@@ -394,6 +399,7 @@ class LanceDataset(pa.dataset.Dataset):
             scan_in_order=scan_in_order,
             prefilter=prefilter,
             with_row_id=with_row_id,
+            use_stats=use_stats,
         ).to_batches()
 
     def sample(
@@ -1473,6 +1479,7 @@ class ScannerBuilder:
         self._scan_in_order = True
         self._fragments = None
         self._with_row_id = False
+        self._use_stats = True
 
     def batch_size(self, batch_size: int) -> ScannerBuilder:
         """Set batch size for Scanner"""
@@ -1533,6 +1540,11 @@ class ScannerBuilder:
     def with_row_id(self, with_row_id: bool = True) -> ScannerBuilder:
         """Enable returns with physical row IDs."""
         self._with_row_id = with_row_id
+        return self
+
+    def use_stats(self, use_stats: bool = True) -> ScannerBuilder:
+        """Enable use of statistics for query planning."""
+        self._use_stats = use_stats
         return self
 
     def with_fragments(
@@ -1618,6 +1630,7 @@ class ScannerBuilder:
             self._scan_in_order,
             self._fragments,
             self._with_row_id,
+            self._use_stats,
         )
         return LanceScanner(scanner, self.ds)
 

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1543,7 +1543,12 @@ class ScannerBuilder:
         return self
 
     def use_stats(self, use_stats: bool = True) -> ScannerBuilder:
-        """Enable use of statistics for query planning."""
+        """
+        Enable use of statistics for query planning.
+
+        Disabling statistics is used for debugging and benchmarking purposes.
+        This should be left on for normal use.
+        """
         self._use_stats = use_stats
         return self
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -276,6 +276,7 @@ impl Dataset {
         scan_in_order: Option<bool>,
         fragments: Option<Vec<FileFragment>>,
         with_row_id: Option<bool>,
+        use_stats: Option<bool>,
     ) -> PyResult<Scanner> {
         let mut scanner: LanceScanner = self_.ds.scan();
         if let Some(c) = columns {
@@ -311,6 +312,10 @@ impl Dataset {
 
         if with_row_id.unwrap_or(false) {
             scanner.with_row_id();
+        }
+
+        if let Some(use_stats) = use_stats {
+            scanner.use_stats(use_stats);
         }
 
         if let Some(fragments) = fragments {

--- a/rust/lance-arrow/src/schema.rs
+++ b/rust/lance-arrow/src/schema.rs
@@ -51,7 +51,7 @@ impl SchemaExt for Schema {
     ) -> std::result::Result<Schema, ArrowError> {
         if self.column_with_name(field.name()).is_some() {
             return Err(ArrowError::SchemaError(format!(
-                "Can not append column {} on schema: {:?}",
+                "Failed to modify schema: Inserting column {} would create a duplicate column in schema: {:?}",
                 field.name(),
                 self
             )));

--- a/rust/lance-arrow/src/schema.rs
+++ b/rust/lance-arrow/src/schema.rs
@@ -21,6 +21,12 @@ pub trait SchemaExt {
     /// Create a new [`Schema`] with one extra field.
     fn try_with_column(&self, field: Field) -> std::result::Result<Schema, ArrowError>;
 
+    fn try_with_column_at(
+        &self,
+        index: usize,
+        field: Field,
+    ) -> std::result::Result<Schema, ArrowError>;
+
     fn field_names(&self) -> Vec<&String>;
 }
 
@@ -35,6 +41,23 @@ impl SchemaExt for Schema {
         };
         let mut fields: Vec<FieldRef> = self.fields().iter().cloned().collect();
         fields.push(FieldRef::new(field));
+        Ok(Self::new_with_metadata(fields, self.metadata.clone()))
+    }
+
+    fn try_with_column_at(
+        &self,
+        index: usize,
+        field: Field,
+    ) -> std::result::Result<Schema, ArrowError> {
+        if self.column_with_name(field.name()).is_some() {
+            return Err(ArrowError::SchemaError(format!(
+                "Can not append column {} on schema: {:?}",
+                field.name(),
+                self
+            )));
+        };
+        let mut fields: Vec<FieldRef> = self.fields().iter().cloned().collect();
+        fields.insert(index, FieldRef::new(field));
         Ok(Self::new_with_metadata(fields, self.metadata.clone()))
     }
 

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -551,6 +551,14 @@ impl fmt::Display for Field {
             write!(f, ", dictionary={:?}", dictionary)?;
         }
 
+        if !self.children.is_empty() {
+            write!(f, ", children=[")?;
+            for child in self.children.iter() {
+                write!(f, "{}, ", child)?;
+            }
+            write!(f, "]")?;
+        }
+
         write!(f, ")")
     }
 }

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -37,7 +37,7 @@ pub struct Schema {
 }
 
 /// State for a pre-order DFS iterator over the fields of a schema.
-pub struct SchemaFieldIterPreOrder<'a> {
+struct SchemaFieldIterPreOrder<'a> {
     field_stack: Vec<&'a Field>,
 }
 
@@ -135,7 +135,7 @@ impl Schema {
     ///
     /// This is a DFS traversal where the parent is visited
     /// before its children
-    pub fn fields_pre_order(&self) -> SchemaFieldIterPreOrder {
+    pub fn fields_pre_order(&self) -> impl Iterator<Item = &Field> {
         SchemaFieldIterPreOrder::new(self)
     }
 

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -37,7 +37,7 @@ pub struct Schema {
 }
 
 /// State for a pre-order DFS iterator over the fields of a schema.
-struct SchemaFieldIterPreOrder<'a> {
+pub struct SchemaFieldIterPreOrder<'a> {
     field_stack: Vec<&'a Field>,
 }
 
@@ -135,7 +135,7 @@ impl Schema {
     ///
     /// This is a DFS traversal where the parent is visited
     /// before its children
-    fn fields_pre_order(&self) -> SchemaFieldIterPreOrder {
+    pub fn fields_pre_order(&self) -> SchemaFieldIterPreOrder {
         SchemaFieldIterPreOrder::new(self)
     }
 
@@ -244,8 +244,24 @@ impl Schema {
         None
     }
 
-    // TODO: pub(crate)
-    pub fn mut_field_by_id(&mut self, id: impl Into<i32>) -> Option<&mut Field> {
+    /// Get the sequence of fields from the root to the field with the given id.
+    pub(crate) fn field_ancestry_by_id(&self, id: i32) -> Option<Vec<&Field>> {
+        let mut to_visit = self.fields.iter().map(|f| vec![f]).collect::<Vec<_>>();
+        while let Some(path) = to_visit.pop() {
+            let field = path.last().unwrap();
+            if field.id == id {
+                return Some(path);
+            }
+            for child in field.children.iter() {
+                let mut new_path = path.clone();
+                new_path.push(child);
+                to_visit.push(new_path);
+            }
+        }
+        None
+    }
+
+    pub(crate) fn mut_field_by_id(&mut self, id: impl Into<i32>) -> Option<&mut Field> {
         let id = id.into();
         for field in self.fields.as_mut_slice() {
             if field.id == id {

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -245,7 +245,7 @@ impl Schema {
     }
 
     /// Get the sequence of fields from the root to the field with the given id.
-    pub(crate) fn field_ancestry_by_id(&self, id: i32) -> Option<Vec<&Field>> {
+    pub fn field_ancestry_by_id(&self, id: i32) -> Option<Vec<&Field>> {
         let mut to_visit = self.fields.iter().map(|f| vec![f]).collect::<Vec<_>>();
         while let Some(path) = to_visit.pop() {
             let field = path.last().unwrap();
@@ -261,7 +261,7 @@ impl Schema {
         None
     }
 
-    pub(crate) fn mut_field_by_id(&mut self, id: impl Into<i32>) -> Option<&mut Field> {
+    pub fn mut_field_by_id(&mut self, id: impl Into<i32>) -> Option<&mut Field> {
         let id = id.into();
         for field in self.fields.as_mut_slice() {
             if field.id == id {

--- a/rust/lance-core/src/io/reader.rs
+++ b/rust/lance-core/src/io/reader.rs
@@ -556,6 +556,7 @@ impl FileReader {
         })
     }
 
+    /// Get the page statistics for the given data field ids.
     pub async fn read_page_stats(&self, field_ids: &[i32]) -> Result<Option<RecordBatch>> {
         if let Some(stats_page_table) = self.stats_page_table.as_ref() {
             let projection = self.page_stats_schema(field_ids).unwrap();

--- a/rust/lance-core/src/io/reader.rs
+++ b/rust/lance-core/src/io/reader.rs
@@ -361,8 +361,8 @@ impl FileReader {
                         reader,
                         stats_meta.page_table_position,
                         stats_meta.leaf_field_ids.len() as i32,
-                        1,
-                        0,
+                        /*num_batches=*/ 1,
+                        /*field_id_offset=*/ 0,
                     )
                     .await?,
                 ))

--- a/rust/lance-core/src/io/reader.rs
+++ b/rust/lance-core/src/io/reader.rs
@@ -559,6 +559,10 @@ impl FileReader {
     pub async fn read_page_stats(&self, field_ids: &[i32]) -> Result<Option<RecordBatch>> {
         if let Some(stats_page_table) = self.stats_page_table.as_ref() {
             let projection = self.page_stats_schema(field_ids).unwrap();
+            // It's possible none of the requested fields have stats.
+            if projection.fields.is_empty() {
+                return Ok(None);
+            }
             let arrays = futures::stream::iter(projection.fields.iter().cloned())
                 .map(|field| async move {
                     read_array(
@@ -621,6 +625,9 @@ pub fn batches_stream(
 }
 
 /// Read a batch.
+///
+/// `schema` may only be empty if `with_row_id` is also true. This function
+/// panics otherwise.
 async fn read_batch(
     reader: &FileReader,
     params: &ReadBatchParams,
@@ -629,13 +636,20 @@ async fn read_batch(
     with_row_id: bool,
     deletion_vector: Option<Arc<DeletionVector>>,
 ) -> Result<RecordBatch> {
-    // We box this because otherwise we get a higher-order lifetime error.
-    let arrs = stream::iter(&schema.fields)
-        .map(|f| async { read_array(reader, f, batch_id, &reader.page_table, params).await })
-        .buffered(num_cpus::get() * 4)
-        .try_collect::<Vec<_>>()
-        .boxed();
-    let arrs = arrs.await?;
+    let batch = if !schema.fields.is_empty() {
+        // We box this because otherwise we get a higher-order lifetime error.
+        let arrs = stream::iter(&schema.fields)
+            .map(|f| async { read_array(reader, f, batch_id, &reader.page_table, params).await })
+            .buffered(num_cpus::get() * 4)
+            .try_collect::<Vec<_>>()
+            .boxed();
+        let arrs = arrs.await?;
+        Some(RecordBatch::try_new(Arc::new(schema.into()), arrs)?)
+    } else {
+        // If the schema is empty, we are just fetching row ids.
+        assert!(with_row_id);
+        None
+    };
 
     let should_fetch_row_id = with_row_id
         || !matches!(
@@ -643,7 +657,18 @@ async fn read_batch(
             None | Some(DeletionVector::NoDeletions)
         );
 
-    let mut batch = RecordBatch::try_new(Arc::new(schema.into()), arrs)?;
+    let num_rows = if let Some(batch) = &batch {
+        batch.num_rows()
+    } else {
+        let total_rows = reader.num_rows_in_batch(batch_id);
+        match params {
+            ReadBatchParams::Indices(indices) => indices.len(),
+            ReadBatchParams::Range(r) => r.len(),
+            ReadBatchParams::RangeFull => total_rows,
+            ReadBatchParams::RangeTo(r) => r.end,
+            ReadBatchParams::RangeFrom(r) => total_rows - r.start,
+        }
+    };
 
     let row_ids = if should_fetch_row_id {
         let ids_in_batch: Vec<i32> = match params {
@@ -651,11 +676,11 @@ async fn read_batch(
                 indices.values().iter().map(|v| *v as i32).collect()
             }
             ReadBatchParams::Range(r) => r.clone().map(|v| v as i32).collect(),
-            ReadBatchParams::RangeFull => (0..batch.num_rows() as i32).collect(),
+            ReadBatchParams::RangeFull => (0..num_rows as i32).collect(),
             ReadBatchParams::RangeTo(r) => (0..r.end).map(|v| v as i32).collect(),
-            ReadBatchParams::RangeFrom(r) => (r.start..r.start + batch.num_rows())
-                .map(|v| v as i32)
-                .collect(),
+            ReadBatchParams::RangeFrom(r) => {
+                (r.start..r.start + num_rows).map(|v| v as i32).collect()
+            }
         };
         let batch_offset = reader
             .metadata
@@ -685,10 +710,24 @@ async fn read_batch(
     let deletion_mask =
         deletion_vector.and_then(|v| v.build_predicate(row_ids.as_ref().unwrap().iter()));
 
-    if with_row_id {
-        let row_id_arr = Arc::new(UInt64Array::from(row_ids.unwrap()));
-        batch = batch.try_with_column(ROW_ID_FIELD.clone(), row_id_arr)?;
-    }
+    let batch = match batch {
+        Some(batch) => {
+            if with_row_id {
+                let row_id_arr = Arc::new(UInt64Array::from(row_ids.unwrap()));
+                batch.try_with_column(ROW_ID_FIELD.clone(), row_id_arr)?
+            } else {
+                batch
+            }
+        }
+        None if with_row_id => {
+            let row_id_arr = Arc::new(UInt64Array::from(row_ids.unwrap()));
+            RecordBatch::try_new(
+                Arc::new(ArrowSchema::new(vec![ROW_ID_FIELD.clone()])),
+                vec![row_id_arr as ArrayRef],
+            )?
+        }
+        _ => unreachable!(),
+    };
 
     match (deletion_mask, reader.make_deletions_null) {
         (None, _) => Ok(batch),

--- a/rust/lance-core/src/io/writer.rs
+++ b/rust/lance-core/src/io/writer.rs
@@ -60,16 +60,16 @@ pub struct FileWriter {
     batch_id: i32,
     page_table: PageTable,
     metadata: Metadata,
-    // Just for testing purposes.
-    // TODO: replace this with stats collection logic.
-    stats: Option<RecordBatch>,
     stats_collector: Option<statistics::StatisticsCollector>,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct FileWriterOptions {
     /// The field ids to collect statistics for.
-    pub collect_stats_for_fields: Vec<i32>,
+    ///
+    /// If None, will collect for all fields in the schema (that support stats).
+    /// If an empty vector, will not collect any statistics.
+    pub collect_stats_for_fields: Option<Vec<i32>>,
 }
 
 impl FileWriter {
@@ -88,9 +88,16 @@ impl FileWriter {
         schema: Schema,
         options: &FileWriterOptions,
     ) -> Result<Self> {
-        let stats_collector = if !options.collect_stats_for_fields.is_empty() {
-            let stats_schema = schema.project_by_ids(&options.collect_stats_for_fields);
-            let stats_collector = statistics::StatisticsCollector::new(&stats_schema.fields);
+        let collect_stats_for_fields = if let Some(stats_fields) = &options.collect_stats_for_fields
+        {
+            stats_fields.clone()
+        } else {
+            schema.field_ids()
+        };
+
+        let stats_collector = if !collect_stats_for_fields.is_empty() {
+            let stats_schema = schema.project_by_ids(&collect_stats_for_fields);
+            let stats_collector = statistics::StatisticsCollector::new(&stats_schema);
             Some(stats_collector)
         } else {
             None
@@ -108,7 +115,6 @@ impl FileWriter {
             page_table: PageTable::default(),
             metadata: Metadata::default(),
             stats_collector,
-            stats: None,
         })
     }
 
@@ -135,6 +141,18 @@ impl FileWriter {
             }
         }
 
+        // If we are collecting stats for this column, collect them.
+        // Statistics need to traverse nested arrays, so it's a separate loop
+        // from writing which is done on top-level arrays.
+        if let Some(stats_collector) = &mut self.stats_collector {
+            for (field, arrays) in fields_in_batches(batches, &self.schema) {
+                if let Some(stats_builder) = stats_collector.get_builder(field.id) {
+                    let stats_row = statistics::collect_statistics(&arrays);
+                    stats_builder.append(stats_row);
+                }
+            }
+        }
+
         // Copy a list of fields to avoid borrow checker error.
         let fields = self.schema.fields.clone();
         for field in fields.iter() {
@@ -147,14 +165,6 @@ impl FileWriter {
                     })
                 })
                 .collect::<Result<Vec<_>>>()?;
-
-            // If we are collecting stats for this column, collect them
-            if let Some(stats_collector) = &mut self.stats_collector {
-                if let Some(stats_builder) = stats_collector.get_builder(field.id) {
-                    let stats_row = statistics::collect_statistics(&arrs);
-                    stats_builder.append(stats_row);
-                }
-            }
 
             Self::write_array(
                 &mut self.object_writer,
@@ -173,13 +183,6 @@ impl FileWriter {
     }
 
     pub async fn finish(&mut self) -> Result<usize> {
-        // Finish the statistics
-        let _statistics = self
-            .stats_collector
-            .as_mut()
-            .map(|collector| collector.finish());
-
-        // TODO: write the statistics to the file
         self.write_footer().await?;
         self.object_writer.shutdown().await?;
         let num_rows = self
@@ -515,16 +518,15 @@ impl FileWriter {
         .await
     }
 
-    // For testing purposes, set statistics
-    // TODO: remove this once we have stats collection logic.
-    #[allow(dead_code)]
-    fn set_statistics(&mut self, stats: RecordBatch) {
-        self.stats = Some(stats);
-    }
-
     async fn write_statistics(&mut self) -> Result<Option<StatisticsMetadata>> {
-        match &self.stats {
-            Some(stats_batch) if stats_batch.num_rows() > 0 => {
+        let statistics = self
+            .stats_collector
+            .as_mut()
+            .map(|collector| collector.finish());
+
+        match statistics {
+            Some(Ok(stats_batch)) if stats_batch.num_rows() > 0 => {
+                debug_assert_eq!(self.next_batch_id() as usize, stats_batch.num_rows());
                 let schema = Schema::try_from(stats_batch.schema().as_ref())?;
                 let leaf_field_ids = schema.field_ids();
 
@@ -549,6 +551,7 @@ impl FileWriter {
                     page_table_position,
                 }))
             }
+            Some(Err(e)) => Err(e),
             _ => Ok(None),
         }
     }
@@ -576,6 +579,46 @@ impl FileWriter {
         // Step 5. Write magics.
         self.object_writer.write_magics(pos).await
     }
+}
+
+/// Walk through the schema and return arrays with their Lance field.
+///
+/// This skips over nested arrays and fields within list arrays. It does walk
+/// over the children of structs.
+fn fields_in_batches<'a>(
+    batches: &'a [RecordBatch],
+    schema: &'a Schema,
+) -> impl Iterator<Item = (&'a Field, Vec<&'a ArrayRef>)> {
+    let num_columns = batches[0].num_columns();
+    let array_iters = (0..num_columns).map(|col_i| {
+        batches
+            .iter()
+            .map(|batch| batch.column(col_i))
+            .collect::<Vec<_>>()
+    });
+    let mut to_visit: Vec<(&'a Field, Vec<&'a ArrayRef>)> =
+        schema.fields.iter().zip(array_iters).collect();
+
+    std::iter::from_fn(move || {
+        loop {
+            let (field, arrays): (_, Vec<&'a ArrayRef>) = to_visit.pop()?;
+            match field.data_type() {
+                DataType::Struct(_) => {
+                    for (i, child_field) in field.children.iter().enumerate() {
+                        let child_arrays = arrays
+                            .iter()
+                            .map(|arr| as_struct_array(*arr).column(i))
+                            .collect::<Vec<&'a ArrayRef>>();
+                        to_visit.push((child_field, child_arrays));
+                    }
+                    continue;
+                }
+                // We only walk structs right now.
+                _ if field.data_type().is_nested() => continue,
+                _ => return Some((field, arrays)),
+            }
+        }
+    })
 }
 
 #[cfg(test)]
@@ -870,11 +913,13 @@ mod tests {
                 .await
                 .unwrap();
         file_writer.write(&[data_batch.clone()]).await.unwrap();
-        file_writer.set_statistics(stats_batch);
         file_writer.finish().await.unwrap();
 
         let reader = FileReader::try_new(&store, &path).await.unwrap();
-        reader.read_page_stats(projection).await.unwrap()
+        reader
+            .read_page_stats(&projection.field_ids())
+            .await
+            .unwrap()
     }
 
     #[tokio::test]
@@ -1007,9 +1052,9 @@ mod tests {
         let store = ObjectStore::memory();
         let path = Path::from("/foo");
 
-        // TODO: collect_stats_for_fields: vec![0,1,3] once structs are supported
+        // TODO: add 6 once strings are supported
         let options = FileWriterOptions {
-            collect_stats_for_fields: vec![0, 1],
+            collect_stats_for_fields: Some(vec![0, 1, 5]),
         };
         let mut file_writer = FileWriter::try_new(&store, &path, schema, &options)
             .await
@@ -1066,7 +1111,99 @@ mod tests {
 
         file_writer.finish().await.unwrap();
 
-        // TODO: read and test statistics
+        let reader = FileReader::try_new(&store, &path).await.unwrap();
+
+        let read_stats = reader.read_page_stats(&[0, 1, 5, 6]).await.unwrap();
+        assert!(read_stats.is_some());
+        let read_stats = read_stats.unwrap();
+
+        let expected_stats_schema = stats_schema([
+            (0, DataType::Int64),
+            (1, DataType::Int64),
+            (5, DataType::Int64),
+            // (6, DataType::Utf8),
+        ]);
+
+        assert_eq!(read_stats.schema().as_ref(), &expected_stats_schema);
+
+        let expected_stats = stats_batch(&[
+            Stats {
+                field_id: 0,
+                null_counts: vec![0, 0],
+                min_values: Arc::new(Int64Array::from(vec![1, 5])),
+                max_values: Arc::new(Int64Array::from(vec![3, 6])),
+            },
+            Stats {
+                field_id: 1,
+                null_counts: vec![0, 0],
+                min_values: Arc::new(Int64Array::from(vec![4, 10])),
+                max_values: Arc::new(Int64Array::from(vec![6, 11])),
+            },
+            Stats {
+                field_id: 5,
+                null_counts: vec![0, 0],
+                min_values: Arc::new(Int64Array::from(vec![1, 4])),
+                max_values: Arc::new(Int64Array::from(vec![3, 5])),
+            },
+        ]);
+
+        assert_eq!(read_stats, expected_stats);
+    }
+
+    fn stats_schema(data_fields: impl IntoIterator<Item = (i32, DataType)>) -> ArrowSchema {
+        let fields = data_fields
+            .into_iter()
+            .map(|(field_id, data_type)| {
+                Arc::new(ArrowField::new(
+                    format!("{}", field_id),
+                    DataType::Struct(
+                        vec![
+                            Arc::new(ArrowField::new("null_count", DataType::Int64, false)),
+                            Arc::new(ArrowField::new("min_value", data_type.clone(), true)),
+                            Arc::new(ArrowField::new("max_value", data_type, true)),
+                        ]
+                        .into(),
+                    ),
+                    false,
+                ))
+            })
+            .collect::<Vec<_>>();
+        ArrowSchema::new(fields)
+    }
+
+    struct Stats {
+        field_id: i32,
+        null_counts: Vec<i64>,
+        min_values: ArrayRef,
+        max_values: ArrayRef,
+    }
+
+    fn stats_batch(stats: &[Stats]) -> RecordBatch {
+        let schema = stats_schema(
+            stats
+                .iter()
+                .map(|s| (s.field_id, s.min_values.data_type().clone())),
+        );
+
+        let columns = stats
+            .iter()
+            .map(|s| {
+                let data_type = s.min_values.data_type().clone();
+                let fields = vec![
+                    Arc::new(ArrowField::new("null_count", DataType::Int64, false)),
+                    Arc::new(ArrowField::new("min_value", data_type.clone(), true)),
+                    Arc::new(ArrowField::new("max_value", data_type, true)),
+                ];
+                let arrays = vec![
+                    Arc::new(Int64Array::from(s.null_counts.clone())),
+                    s.min_values.clone(),
+                    s.max_values.clone(),
+                ];
+                Arc::new(StructArray::new(fields.into(), arrays, None)) as ArrayRef
+            })
+            .collect();
+
+        RecordBatch::try_new(Arc::new(schema), columns).unwrap()
     }
 
     async fn read_file_as_one_batch(object_store: &ObjectStore, path: &Path) -> RecordBatch {

--- a/rust/lance-core/src/io/writer/statistics.rs
+++ b/rust/lance-core/src/io/writer/statistics.rs
@@ -593,13 +593,7 @@ pub fn collect_statistics(arrays: &[&ArrayRef]) -> StatisticsRow {
         DataType::Dictionary(_, _) => get_dictionary_statistics(arrays),
         // DataType::List(_) => get_list_statistics(arrays),
         // DataType::LargeList(_) => get_list_statistics(arrays),
-        _ => {
-            println!(
-                "Stats collection for {} is not supported yet",
-                arrays[0].data_type()
-            );
-            unreachable!()
-        }
+        _ => unreachable!(),
     }
 }
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2755,6 +2755,24 @@ mod tests {
         assert_eq!(dataset.count_fragments(), 2);
         assert!(fragments[0].metadata.deletion_file.is_some());
         assert!(fragments[1].metadata.deletion_file.is_some());
+        assert_eq!(
+            fragments[0]
+                .metadata
+                .deletion_file
+                .as_ref()
+                .unwrap()
+                .num_deleted_rows,
+            Some(10)
+        );
+        assert_eq!(
+            fragments[1]
+                .metadata
+                .deletion_file
+                .as_ref()
+                .unwrap()
+                .num_deleted_rows,
+            Some(10)
+        );
 
         // The deletion file should contain 20 rows
         assert_eq!(dataset.count_deleted_rows().await.unwrap(), 20);

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -665,7 +665,7 @@ impl From<FileFragment> for Fragment {
 ///
 /// It opens the data files that contains the columns of the projection schema, and
 /// reconstruct the RecordBatch from columns read from each data file.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FragmentReader {
     /// Readers and schema of each opened data file.
     readers: Vec<(FileReader, Schema)>,
@@ -747,9 +747,16 @@ impl FragmentReader {
     }
 
     /// Read the page statistics of the fragment for the specified fields.
-    pub(crate) async fn read_page_stats(&self) -> Result<Option<RecordBatch>> {
+    pub(crate) async fn read_page_stats(
+        &self,
+        projection: Option<&Schema>,
+    ) -> Result<Option<RecordBatch>> {
         let mut stats_batches = vec![];
         for (reader, schema) in self.readers.iter() {
+            let schema = match projection {
+                Some(projection) => schema.intersection(projection)?,
+                None => schema.clone(),
+            };
             if let Some(stats_batch) = reader.read_page_stats(&schema.field_ids()).await? {
                 stats_batches.push(stats_batch);
             }
@@ -776,6 +783,32 @@ impl FragmentReader {
             batches.push(batch);
         }
         merge_batches(&batches)
+    }
+
+    /// Read a batch of rows from the fragment, with a subset of columns.
+    ///
+    /// Note: the projection must be a subset of the schema the reader was created with.
+    /// Otherwise incorrect data will be returned.
+    pub(crate) async fn read_batch_projected(
+        &self,
+        batch_id: usize,
+        params: impl Into<ReadBatchParams> + Clone,
+        projection: &Schema,
+    ) -> Result<RecordBatch> {
+        let read_tasks = self.readers.iter().map(|(reader, schema)| {
+            let projection = schema.intersection(projection);
+            let params = params.clone();
+
+            async move {
+                reader
+                    .read_batch(batch_id as i32, params, &projection?)
+                    .await
+            }
+        });
+        let batches = try_join_all(read_tasks).await?;
+        let result = merge_batches(&batches)?;
+
+        Ok(result)
     }
 
     pub async fn read_range(&self, range: Range<usize>) -> Result<RecordBatch> {

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -61,10 +61,10 @@ use snafu::{location, Location};
 pub const DEFAULT_BATCH_SIZE: usize = 8192;
 
 // Same as pyarrow Dataset::scanner()
-const DEFAULT_BATCH_READAHEAD: usize = 16;
+pub const DEFAULT_BATCH_READAHEAD: usize = 16;
 
 // Same as pyarrow Dataset::scanner()
-const DEFAULT_FRAGMENT_READAHEAD: usize = 4;
+pub const DEFAULT_FRAGMENT_READAHEAD: usize = 4;
 
 /// Defines an ordering for a single column
 ///

--- a/rust/lance/src/io/exec.rs
+++ b/rust/lance/src/io/exec.rs
@@ -25,6 +25,7 @@ pub mod testing;
 pub use knn::*;
 pub use planner::{FilterPlan, Planner};
 pub use projection::ProjectionExec;
+pub use pushdown_scan::{LancePushdownScanExec, ScanConfig};
 pub use scalar_index::{MaterializeIndexExec, ScalarIndexExec};
 pub use scan::LanceScanExec;
 pub use take::TakeExec;

--- a/rust/lance/src/io/exec.rs
+++ b/rust/lance/src/io/exec.rs
@@ -15,6 +15,7 @@
 mod knn;
 mod planner;
 mod projection;
+mod pushdown_scan;
 mod scalar_index;
 mod scan;
 mod take;

--- a/rust/lance/src/io/exec/planner.rs
+++ b/rust/lance/src/io/exec/planner.rs
@@ -77,12 +77,12 @@ impl Planner {
         Self { schema }
     }
 
-    fn column(&self, idents: &[Ident]) -> Result<Expr> {
+    fn column(idents: &[Ident]) -> Expr {
         let mut column = col(&idents[0].value);
         for ident in &idents[1..] {
             column = column.field(&ident.value);
         }
-        Ok(column)
+        column
     }
 
     fn binary_op(&self, op: &BinaryOperator) -> Result<Operator> {
@@ -340,10 +340,10 @@ impl Planner {
                 } else if id.quote_style == Some('`') {
                     Ok(Expr::Column(Column::from_name(id.value.clone())))
                 } else {
-                    self.column(vec![id.clone()].as_slice())
+                    Ok(Self::column(vec![id.clone()].as_slice()))
                 }
             }
-            SQLExpr::CompoundIdentifier(ids) => self.column(ids.as_slice()),
+            SQLExpr::CompoundIdentifier(ids) => Ok(Self::column(ids.as_slice())),
             SQLExpr::BinaryOp { left, op, right } => self.binary_expr(left, op, right),
             SQLExpr::UnaryOp { op, expr } => self.unary_expr(op, expr),
             SQLExpr::Value(value) => self.value(value),

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -1,0 +1,885 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::{any::Any, sync::Arc};
+
+use arrow_array::cast::AsArray;
+use arrow_array::types::Int64Type;
+use arrow_array::{Array, Int64Array, PrimitiveArray, RecordBatch, UInt32Array};
+use arrow_schema::{DataType, Field, Schema as ArrowSchema, SchemaRef};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::optimizer::simplify_expressions::{ExprSimplifier, SimplifyContext};
+use datafusion::physical_expr::execution_props::ExecutionProps;
+use datafusion::physical_expr::intervals::{Interval, IntervalBound, NullableInterval};
+use datafusion::physical_plan::ColumnarValue;
+use datafusion::prelude::Column;
+use datafusion::scalar::ScalarValue;
+use datafusion::{
+    physical_plan::{
+        stream::RecordBatchStreamAdapter, DisplayAs, DisplayFormatType, ExecutionPlan,
+        Partitioning, SendableRecordBatchStream,
+    },
+    prelude::Expr,
+};
+use futures::{Stream, StreamExt, TryStreamExt};
+use lance_arrow::RecordBatchExt;
+use snafu::{location, Location};
+
+use crate::dataset::scanner::{DEFAULT_BATCH_READAHEAD, DEFAULT_FRAGMENT_READAHEAD};
+use crate::io::ReadBatchParams;
+use crate::Error;
+use crate::{
+    dataset::{
+        fragment::{FileFragment, FragmentReader},
+        ROW_ID,
+    },
+    datatypes::Schema,
+    format::Fragment,
+    Dataset,
+};
+
+// TODO:
+// [ ] Test with row_id
+// [ ] Handle scanning out-of-order
+// [ ] Test interval creation
+// [ ] Test predicate simplification
+// [ ] Hook up into planner
+// [ ] Benchmark various scenarios
+
+use super::Planner;
+
+#[derive(Debug, Clone)]
+pub struct ScanConfig {
+    batch_readahead: usize,
+    fragment_readahead: usize,
+    with_row_id: bool,
+    ordered_output: bool,
+}
+
+impl Default for ScanConfig {
+    fn default() -> Self {
+        Self {
+            batch_readahead: DEFAULT_BATCH_READAHEAD,
+            fragment_readahead: DEFAULT_FRAGMENT_READAHEAD,
+            with_row_id: false,
+            ordered_output: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LancePushdownScanExec {
+    dataset: Arc<Dataset>,
+    fragments: Arc<Vec<Fragment>>,
+    projection: Arc<Schema>,
+    predicate_projection: Arc<Schema>,
+    predicate: Expr,
+    config: ScanConfig,
+}
+
+impl LancePushdownScanExec {
+    pub fn try_new(
+        dataset: Arc<Dataset>,
+        fragments: Arc<Vec<Fragment>>,
+        projection: Arc<Schema>,
+        predicate: Expr,
+        config: ScanConfig,
+    ) -> Result<Self> {
+        // This should be infallible.
+        let columns: Vec<_> = predicate
+            .to_columns()
+            .unwrap()
+            .into_iter()
+            .map(|col| col.name)
+            .collect();
+        let dataset_schema = dataset.schema();
+        let predicate_projection = Arc::new(dataset_schema.project(&columns)
+            .map_err(|err| Error::invalid_input(format!("Filter predicate '{:?}' references columns {:?}, but some of them were not found in the dataset schema: {}\nInner error: {:?}", predicate, columns, dataset_schema, err), location!()))?);
+
+        Ok(Self {
+            dataset,
+            fragments,
+            projection,
+            predicate,
+            predicate_projection,
+            config,
+        })
+    }
+}
+
+impl ExecutionPlan for LancePushdownScanExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        let schema: ArrowSchema = self.projection.as_ref().into();
+        if self.config.with_row_id {
+            let mut fields: Vec<Arc<Field>> = schema.fields.to_vec();
+            fields.push(Arc::new(Field::new(ROW_ID, DataType::UInt64, false)));
+            Arc::new(ArrowSchema::new(fields))
+        } else {
+            Arc::new(schema)
+        }
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn output_ordering(&self) -> Option<&[datafusion::physical_expr::PhysicalSortExpr]> {
+        None
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
+        todo!()
+    }
+
+    fn statistics(&self) -> datafusion::physical_plan::Statistics {
+        todo!()
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<datafusion::execution::context::TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        // To get a stream with a static lifetime, we clone self put it into
+        // a stream.
+        let state = (self.clone(), 0);
+        let fragment_stream = futures::stream::unfold(state, |(exec, fragment_i)| async move {
+            if fragment_i == exec.fragments.len() {
+                None
+            } else {
+                let fragment = exec.fragments[fragment_i].clone();
+                let exec_ref = exec.clone();
+                let res = (exec_ref, fragment);
+                let new_state = (exec, fragment_i + 1);
+                Some((res, new_state))
+            }
+        });
+
+        let batch_stream = fragment_stream.map(|(exec, fragment)| async move {
+            let frag_scanner = FragmentScanner::open(
+                fragment,
+                exec.dataset,
+                exec.projection,
+                exec.predicate_projection,
+                exec.predicate,
+                exec.config.batch_readahead,
+                exec.config.with_row_id,
+                exec.config.ordered_output,
+            )
+            .await?;
+
+            frag_scanner.scan().await
+        });
+
+        let batch_stream = batch_stream
+            .buffered(self.config.fragment_readahead)
+            .try_flatten();
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            batch_stream,
+        )))
+    }
+}
+
+impl DisplayAs for LancePushdownScanExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                let columns = self
+                    .projection
+                    .fields
+                    .iter()
+                    .map(|f| f.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(
+                    f,
+                    "LancePushdownScan: uri={}, projection=[{}], predicate={}, row_id=[{}], ordered={}",
+                    self.dataset.data_dir(),
+                    columns,
+                    self.predicate,
+                    self.config.with_row_id,
+                    self.config.ordered_output
+                )
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FragmentScanner {
+    fragment: FileFragment,
+    projection: Arc<Schema>,
+    predicate_projection: Arc<Schema>,
+    predicate: Expr,
+    batch_readahead: usize,
+    ordered_output: bool,
+    /// Cache of readers for each projection. For each batch, we scan the
+    /// minimum number of columns needed to evaluate the predicate, so which
+    /// columns are relevant change from batch to batch. To reduce the cost
+    /// of opening readers, we cache them here.
+    ///
+    /// It's worth noting that the [FileFragment::open()] method caches it's IO
+    /// calls, so there shouldn't be a meaningful cost to each additional reader
+    /// we open beyond the CPU time required to instantiate them.
+    ///
+    /// We don't intend to hold this across await points, so we just use the std
+    /// Mutex instead of the tokio one.
+    reader_cache: Arc<std::sync::Mutex<HashMap<Vec<i32>, Arc<FragmentReader>>>>,
+    stats: Option<RecordBatch>,
+}
+
+impl FragmentScanner {
+    pub async fn open(
+        fragment: Fragment,
+        dataset: Arc<Dataset>,
+        projection: Arc<Schema>,
+        predicate_projection: Arc<Schema>,
+        predicate: Expr,
+        batch_readahead: usize,
+        with_row_id: bool,
+        ordered_output: bool,
+    ) -> Result<Self> {
+        let fragment = FileFragment::new(dataset.clone(), fragment);
+        let mut filter_reader = fragment.open(&predicate_projection).await?;
+        if with_row_id {
+            filter_reader.with_row_id();
+        }
+        // We read the stats off of the filter column reader, since that contains
+        // the statistics we need to simplify the predicate.
+        let stats = filter_reader.read_page_stats().await?;
+
+        let mut reader_cache = HashMap::new();
+        reader_cache.insert(predicate_projection.field_ids(), Arc::new(filter_reader));
+
+        let projection_reader = fragment.open(&projection).await?;
+        reader_cache.insert(projection.field_ids(), Arc::new(projection_reader));
+
+        Ok(Self {
+            fragment,
+            projection,
+            predicate_projection,
+            predicate,
+            batch_readahead,
+            ordered_output,
+            reader_cache: Arc::new(std::sync::Mutex::new(reader_cache)),
+            stats,
+        })
+    }
+
+    pub async fn scan(self) -> Result<impl Stream<Item = Result<RecordBatch>> + 'static + Send> {
+        // This reader was inserted on initialization, so it's guaranteed to be there.
+        let num_batches = self
+            .reader_cache
+            .lock()
+            .unwrap()
+            .get(&self.predicate_projection.field_ids())
+            .unwrap()
+            .num_batches();
+        let batch_readahead = self.batch_readahead;
+        let simplified_predicates = self.simplified_predicates()?;
+
+        let scanner = Arc::new(self);
+
+        Ok(
+            futures::stream::iter((0..num_batches).zip(simplified_predicates.into_iter()))
+                .map(move |(batch_id, predicate)| {
+                    let scanner_ref = scanner.clone();
+                    async move { scanner_ref.read_batch(batch_id, predicate).await }
+                })
+                .buffered(batch_readahead)
+                .try_filter_map(|res| futures::future::ready(Ok(res)))
+                .boxed(),
+        )
+    }
+
+    async fn read_batch(&self, batch_id: usize, predicate: Expr) -> Result<Option<RecordBatch>> {
+        match predicate {
+            Expr::Literal(ScalarValue::Boolean(Some(true))) => {
+                // Predicate is always true, we just need to load the projection.
+
+                // TODO: what about the row id column?
+                let projection_reader = self
+                    .reader_cache
+                    .lock()
+                    .unwrap()
+                    .get(&self.projection.field_ids())
+                    .unwrap()
+                    .clone();
+                let batch = projection_reader.read_batch(batch_id, ..).await?;
+                Ok(Some(batch))
+            }
+            Expr::Literal(ScalarValue::Boolean(Some(false))) => {
+                // Predicate is always false, we can skip this batch.
+                Ok(None)
+            }
+            _ => {
+                // Predicate is not always true or always false, we need to load
+                // the filter columns to evaluate it.
+
+                // 1. Load needed filter columns, which might be a subset of all filter
+                //    columns if statistics obviated the need for some columns.
+                let columns: Vec<_> = predicate
+                    .to_columns()
+                    .unwrap()
+                    .into_iter()
+                    .map(|col| col.name)
+                    .collect();
+                let predicate_projection =
+                    Arc::new(self.fragment.dataset().schema().project(&columns).unwrap());
+                let field_ids = predicate_projection.field_ids();
+                let maybe_reader = self.reader_cache.lock().unwrap().get(&field_ids).cloned();
+                let filter_reader = match maybe_reader {
+                    Some(reader) => reader,
+                    None => {
+                        let filter_reader =
+                            Arc::new(self.fragment.open(&predicate_projection).await?);
+                        self.reader_cache
+                            .lock()
+                            .unwrap()
+                            .insert(field_ids.clone(), filter_reader.clone());
+                        filter_reader
+                    }
+                };
+
+                let batch = filter_reader.read_batch(batch_id, ..).await?;
+
+                // 2. Evaluate predicate
+                let planner = Planner::new(batch.schema());
+                let physical_expr = planner.create_physical_expr(&predicate)?;
+                let result = physical_expr.evaluate(&batch)?;
+                let selection = match result {
+                    ColumnarValue::Scalar(ScalarValue::Boolean(Some(true))) => {
+                        ReadBatchParams::RangeFull
+                    }
+                    ColumnarValue::Scalar(ScalarValue::Boolean(Some(false))) => {
+                        // Nothing matched
+                        return Ok(None);
+                    }
+                    ColumnarValue::Array(array) => {
+                        let array = array
+                            .as_any()
+                            .downcast_ref::<arrow_array::BooleanArray>()
+                            .unwrap();
+                        let selection: UInt32Array = array
+                            .iter()
+                            .enumerate()
+                            .filter_map(|(i, value)| {
+                                if value.unwrap_or_default() {
+                                    Some(i as u32)
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect();
+
+                        if selection.is_empty() {
+                            // Nothing matched the predicate, so the result is empty.
+                            return Ok(None);
+                        }
+
+                        ReadBatchParams::Indices(selection)
+                    }
+                    _ => {
+                        return Err(DataFusionError::Internal(format!(
+                            "Unexpected result from predicate evaluation: {:?}",
+                            result
+                        )))
+                    }
+                };
+
+                // 3. Take the subset of rows that pass the predicate. Some of the
+                //    columns in the projection may have already been loaded as a
+                //    filter column, so we just load the remaining columns.
+                let projection_field_ids = self.projection.field_ids();
+                let remaining_fields: Vec<i32> = projection_field_ids
+                    .iter()
+                    .cloned()
+                    .filter(|i| !field_ids.contains(i))
+                    .collect();
+                let remainder_batch = if !remaining_fields.is_empty() {
+                    let maybe_reader = self
+                        .reader_cache
+                        .lock()
+                        .unwrap()
+                        .get(&remaining_fields)
+                        .cloned();
+                    let remainder_reader = match maybe_reader {
+                        Some(reader) => reader,
+                        None => {
+                            let remainder_reader = Arc::new(
+                                self.fragment
+                                    .open(&self.projection.project_by_ids(&remaining_fields))
+                                    .await?,
+                            );
+                            self.reader_cache
+                                .lock()
+                                .unwrap()
+                                .insert(field_ids.clone(), remainder_reader.clone());
+                            remainder_reader
+                        }
+                    };
+                    Some(
+                        remainder_reader
+                            .read_batch(batch_id, selection.clone())
+                            .await?,
+                    )
+                } else {
+                    None
+                };
+
+                // 4. If filter columns are in the projection, merge them in
+                //    and project the final schema.
+                let batch = if let ReadBatchParams::Indices(indices) = selection {
+                    batch.take(&indices)?
+                } else {
+                    batch
+                };
+                let batch = if let Some(remainder_batch) = remainder_batch {
+                    batch.merge(&remainder_batch)?
+                } else {
+                    batch
+                };
+                let batch = batch.project_by_schema(&self.projection.as_ref().into())
+                    .map_err(|err| Error::Internal {
+                        message: format!("Failed to to select schema {} from batch with schema {}\nInner error: {}", self.projection, batch.schema(), err),
+                        location: location!()
+                    })?;
+
+                Ok(Some(batch))
+            }
+        }
+    }
+
+    /// Parse the statistics into a set of guarantees for each batch.
+    fn extract_guarantees<'a>(
+        predicate_projection: &'a Schema,
+        batch_sizes: &'a [usize],
+        stats: &RecordBatch,
+    ) -> impl Iterator<Item = Vec<(Expr, NullableInterval)>> + 'a {
+        let mut null_counts: HashMap<i32, PrimitiveArray<Int64Type>> = HashMap::new();
+        let mut min_values: HashMap<i32, Arc<dyn Array>> = HashMap::new();
+        let mut max_values: HashMap<i32, Arc<dyn Array>> = HashMap::new();
+
+        for field_id in predicate_projection.field_ids() {
+            let field_stats = stats.column_by_name(&format!("{field_id}"));
+            if let Some(field_stats) = field_stats {
+                if !matches!(field_stats.data_type(), DataType::Struct(_)) {
+                    log::error!(
+                        "Invalid statistics: Field stats for field {} is not a struct, but a {}",
+                        field_id,
+                        field_stats.data_type()
+                    );
+                    continue;
+                }
+                let field_stats_ref = field_stats.as_struct();
+
+                if let Some(null_count_col) = field_stats_ref.column_by_name("null_count") {
+                    let null_count_col = null_count_col
+                        .as_any()
+                        .downcast_ref::<Int64Array>()
+                        .unwrap();
+                    null_counts.insert(field_id, null_count_col.clone());
+                }
+
+                if let Some(min_col) = field_stats_ref.column_by_name("min_value") {
+                    min_values.insert(field_id, min_col.clone());
+                }
+
+                if let Some(max_col) = field_stats_ref.column_by_name("max_value") {
+                    max_values.insert(field_id, max_col.clone());
+                }
+            }
+        }
+
+        (0..stats.num_rows())
+            .map(move |batch_id| {
+                let mut guarantees = Vec::new();
+                for field in predicate_projection.fields_pre_order() {
+                    let null_count = if field.nullable {
+                        let maybe_null_count = null_counts.get(&field.id).map(|arr| arr.value(batch_id));
+                        if let Some(null_count) = maybe_null_count {
+                            null_count
+                        } else {
+                            continue
+                        }
+                    } else {
+                        0
+                    };
+
+                    let min_value = {
+                        let maybe_min_value = min_values.get(&field.id)
+                            .map(|arr| ScalarValue::try_from_array(arr, batch_id));
+                        match maybe_min_value {
+                            Some(Ok(min_value)) => min_value,
+                            Some(Err(err)) => {
+                                log::error!("Invalid statistics: Failed to convert min_value for field {} to ScalarValue: {}", field.id, err);
+                                continue
+                            }
+                            None => continue
+                        }
+                    };
+
+                    let max_value = {
+                        let maybe_max_value = max_values.get(&field.id)
+                            .map(|arr| ScalarValue::try_from_array(arr, batch_id));
+                        match maybe_max_value {
+                            Some(Ok(max_value)) => max_value,
+                            Some(Err(err)) => {
+                                log::error!("Invalid statistics: Failed to convert max_value for field {} to ScalarValue: {}", field.id, err);
+                                continue
+                            }
+                            None => continue
+                        }
+                    };
+
+                    let values = Interval::new(
+                        IntervalBound::new_closed(min_value),
+                        IntervalBound::new_closed(max_value)
+                    );
+                    let batch_size = batch_sizes[batch_id];
+                    let interval = match (null_count, batch_size) {
+                        (0, _) => NullableInterval::NotNull { values },
+                        (null_count, batch_size) if null_count == batch_size as i64 => NullableInterval::Null { datatype: field.data_type() },
+                        _ => NullableInterval::MaybeNull { values }
+                    };
+                    let fully_qualified_name = predicate_projection.field_ancestry_by_id(field.id).unwrap()
+                        .into_iter()
+                        .map(|field| field.name.as_str())
+                        .collect::<Vec<&str>>()
+                        .join(".");
+                    let expr = Expr::Column(Column::from_name(fully_qualified_name));
+                    guarantees.push((expr, interval));
+                }
+                guarantees
+            })
+    }
+
+    fn simplified_predicates(&self) -> Result<Vec<Expr>> {
+        let reader = {
+            let cache = self.reader_cache.lock().unwrap();
+            cache
+                .get(&self.predicate_projection.field_ids())
+                .unwrap()
+                .clone()
+        };
+        let num_batches = reader.num_batches();
+
+        if let Some(stats) = &self.stats {
+            let batch_sizes: Vec<usize> = (0..num_batches)
+                .map(|batch_id| reader.num_rows_in_batch(batch_id))
+                .collect();
+            let schema =
+                Arc::new(ArrowSchema::from(self.predicate_projection.as_ref()).try_into()?);
+            let props = ExecutionProps::new();
+            let context = SimplifyContext::new(&props).with_schema(schema);
+            let mut simplifier = ExprSimplifier::new(context);
+
+            let mut predicates = Vec::with_capacity(num_batches);
+            for guarantees in
+                Self::extract_guarantees(&self.predicate_projection, &batch_sizes, &stats)
+            {
+                dbg!(&guarantees);
+                simplifier = simplifier.with_guarantees(guarantees);
+                predicates.push(simplifier.simplify(self.predicate.clone())?);
+            }
+            Ok(predicates)
+        } else {
+            Ok(vec![self.predicate.clone(); num_batches])
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use arrow_array::{ArrayRef, Int32Array, RecordBatchIterator, StructArray, UInt64Array};
+    use datafusion::prelude::{col, lit, Column, SessionContext};
+    use tempfile::tempdir;
+
+    use crate::dataset::WriteParams;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_empty_result() {
+        // Test we can get no results
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "i",
+            DataType::Int32,
+            false,
+        )]));
+        let num_rows: usize = 10;
+        let batches = vec![RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from_iter_values(0..num_rows as i32))],
+        )
+        .unwrap()];
+        let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+
+        let dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+
+        let fragments = dataset.fragments().clone();
+        let projection = Arc::new(dataset.schema().clone());
+
+        let predicate = col("i").eq(lit(42));
+
+        let exec = LancePushdownScanExec::try_new(
+            Arc::new(dataset),
+            fragments,
+            projection,
+            predicate,
+            ScanConfig::default(),
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+
+        let results = exec.execute(0, ctx.task_ctx()).unwrap();
+        let results = results.try_collect::<Vec<_>>().await.unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_nested_filter() {
+        // Validate we can filter and project nested columns and they will be
+        // merged correctly.
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let field_a = Arc::new(Field::new("a", DataType::Int32, false));
+        let field_b = Arc::new(Field::new("b", DataType::Int32, false));
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new(
+                "x",
+                DataType::Struct(vec![field_a.clone(), field_b.clone()].into()),
+                false,
+            ),
+            Field::new(
+                "y",
+                DataType::Struct(vec![field_a.clone(), field_b.clone()].into()),
+                false,
+            ),
+        ]));
+
+        let array = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StructArray::from(vec![
+                    (field_a.clone(), array.clone() as ArrayRef),
+                    (field_b.clone(), array.clone() as ArrayRef),
+                ])),
+                Arc::new(StructArray::from(vec![
+                    (field_a.clone(), array.clone() as ArrayRef),
+                    (field_b.clone(), array.clone() as ArrayRef),
+                ])),
+            ],
+        )
+        .unwrap();
+
+        let batches = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+
+        let dataset = Arc::new(Dataset::write(batches, test_uri, None).await.unwrap());
+
+        let fragments = dataset.fragments().clone();
+        // [x.b, y.a]
+        let projection = Arc::new(dataset.schema().clone().project_by_ids(&[2, 4]));
+
+        let predicate = col(Column::from_name("x.a"))
+            .lt(lit(8))
+            .and(col(Column::from_name("y.b")).gt(lit(3)));
+
+        let exec = LancePushdownScanExec::try_new(
+            dataset.clone(),
+            fragments.clone(),
+            projection,
+            predicate.clone(),
+            ScanConfig::default(),
+        )
+        .unwrap();
+
+        let ctx = SessionContext::new();
+
+        let results = exec.execute(0, ctx.task_ctx()).unwrap();
+        let results = results.try_collect::<Vec<_>>().await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].num_rows(), 4);
+
+        let expected_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("x", DataType::Struct(vec![field_b.clone()].into()), false),
+            Field::new("y", DataType::Struct(vec![field_a.clone()].into()), false),
+        ]));
+        assert_eq!(results[0].schema().as_ref(), expected_schema.as_ref());
+
+        // Also try where projection is same as filter columns
+        let projection = Arc::new(dataset.schema().clone().project_by_ids(&[1, 5]));
+        let exec = LancePushdownScanExec::try_new(
+            dataset.clone(),
+            fragments,
+            projection,
+            predicate,
+            ScanConfig::default(),
+        )
+        .unwrap();
+        let results = exec.execute(0, ctx.task_ctx()).unwrap();
+        let results = results.try_collect::<Vec<_>>().await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].num_rows(), 4);
+
+        let expected_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("x", DataType::Struct(vec![field_a.clone()].into()), false),
+            Field::new("y", DataType::Struct(vec![field_b.clone()].into()), false),
+        ]));
+        assert_eq!(results[0].schema().as_ref(), expected_schema.as_ref());
+    }
+
+    #[tokio::test]
+    async fn test_with_row_id() {
+        // Want to hit all three code paths:
+        // Batches: [0..100], [100..200], [200..300]
+        // Predicate: s.x >= 150
+        // Expected simplification: false, s.x > 150, true
+        // Expected result: [150..300]
+
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let field = Arc::new(Field::new("x", DataType::Int32, false));
+        let field_outer = Field::new("s", DataType::Struct(vec![field.clone()].into()), false);
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![field_outer]));
+
+        let batches = [0..100, 100..200, 200..300].map(|range| {
+            RecordBatch::try_new(
+                arrow_schema.clone(),
+                vec![Arc::new(StructArray::from(vec![(
+                    field.clone(),
+                    Arc::new(Int32Array::from_iter_values(range)) as ArrayRef,
+                )]))],
+            )
+        });
+
+        let batches = RecordBatchIterator::new(batches, arrow_schema.clone());
+
+        let write_params = WriteParams {
+            max_rows_per_group: 100,
+            ..Default::default()
+        };
+        let dataset = Arc::new(
+            Dataset::write(batches, test_uri, Some(write_params))
+                .await
+                .unwrap(),
+        );
+
+        let fragments = dataset.fragments().clone();
+        assert_eq!(fragments.len(), 1);
+        let fragment = fragments[0].clone();
+
+        let predicate = col(Column::from_name("s.x")).gt_eq(lit(150));
+
+        let schema = Arc::new(dataset.schema().clone());
+
+        let fragment_scanner = FragmentScanner::open(
+            fragment,
+            dataset.clone(),
+            schema.clone(),
+            schema.clone(),
+            predicate.clone(),
+            1,
+            true,
+            true,
+        )
+        .await
+        .unwrap();
+
+        dbg!(&fragment_scanner);
+
+        let predicates = fragment_scanner.simplified_predicates().unwrap();
+        assert_eq!(predicates.len(), 3);
+        assert_eq!(&predicates[0], &lit(false));
+        assert_eq!(&predicates[1], &predicate);
+        assert_eq!(&predicates[2], &lit(true));
+
+        let batch0 = fragment_scanner
+            .read_batch(0, predicates[0].clone())
+            .await
+            .unwrap();
+        assert!(batch0.is_none());
+
+        let batch1 = fragment_scanner
+            .read_batch(1, predicates[1].clone())
+            .await
+            .unwrap();
+        assert!(batch1.is_some());
+        let batch1 = batch1.unwrap();
+        let expected_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("s", DataType::Struct(vec![field.clone()].into()), false),
+            Field::new(ROW_ID, DataType::UInt64, false),
+        ]));
+        let expected = RecordBatch::try_new(
+            expected_schema.clone(),
+            vec![
+                Arc::new(StructArray::from(vec![(
+                    field.clone(),
+                    Arc::new(Int32Array::from_iter_values(150..200)) as ArrayRef,
+                )])),
+                Arc::new(UInt64Array::from_iter_values(150..200)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(batch1, expected);
+
+        let batch2 = fragment_scanner
+            .read_batch(2, predicates[2].clone())
+            .await
+            .unwrap();
+        assert!(batch2.is_some());
+        let batch2 = batch2.unwrap();
+        let expected = RecordBatch::try_new(
+            expected_schema.clone(),
+            vec![
+                Arc::new(StructArray::from(vec![(
+                    field.clone(),
+                    Arc::new(Int32Array::from_iter_values(200..300)) as ArrayRef,
+                )])),
+                Arc::new(UInt64Array::from_iter_values(200..300)),
+            ],
+        )
+        .unwrap();
+        assert_eq!(batch2, expected);
+    }
+
+    // property based testing
+    // All column types
+    // choose random subset to project
+    // random range to filter for
+    // random over with or without rowid
+}

--- a/rust/lance/src/utils/tfrecord.rs
+++ b/rust/lance/src/utils/tfrecord.rs
@@ -18,7 +18,6 @@
 //! [read_tfrecord] to read the file into an Arrow record batch stream.
 
 use arrow::buffer::OffsetBuffer;
-use arrow::datatypes::ArrowPrimitiveType;
 use arrow_array::builder::PrimitiveBuilder;
 use arrow_array::{ArrayRef, FixedSizeListArray, ListArray};
 use arrow_buffer::ScalarBuffer;

--- a/rust/lance/src/utils/tfrecord.rs
+++ b/rust/lance/src/utils/tfrecord.rs
@@ -18,6 +18,7 @@
 //! [read_tfrecord] to read the file into an Arrow record batch stream.
 
 use arrow::buffer::OffsetBuffer;
+use arrow::datatypes::ArrowPrimitiveType;
 use arrow_array::builder::PrimitiveBuilder;
 use arrow_array::{ArrayRef, FixedSizeListArray, ListArray};
 use arrow_buffer::ScalarBuffer;


### PR DESCRIPTION
This PR introduces a new scan node that uses page-level statistics to decide which columns must be read to evaluate the predicate for each batch.

This is only hooked up for scans that don't use an index (scalar or ANN). Adding to other scans will be done in a future PR.

Closes #1264

