### PR TITLE
chore: convenience methods for reading and writing local files

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,7 +97,7 @@ jobs:
         run: cargo clippy --all-features --tests -- -D warnings
   mac-build:
     runs-on: macos-12
-    timeout-minutes: 30
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: ./rust/lance

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -836,9 +836,13 @@ async fn write_index_file(
         if parted_batch.num_rows() > 0 {
             // Write one partition.
             let pq_code = &parted_batch[PQ_CODE_COLUMN];
-            writer.write_plain_encoded_array(pq_code.as_ref()).await?;
+            writer
+                .write_plain_encoded_array(&[pq_code.as_ref()])
+                .await?;
             let row_ids = &parted_batch[ROW_ID];
-            writer.write_plain_encoded_array(row_ids.as_ref()).await?;
+            writer
+                .write_plain_encoded_array(&[row_ids.as_ref()])
+                .await?;
         }
     }
 

--- a/rust/lance/src/io/object_writer.rs
+++ b/rust/lance/src/io/object_writer.rs
@@ -87,12 +87,16 @@ impl ObjectWriter {
         self.write_protobuf(&msg).await
     }
 
-    /// Write an array using plain encoding.
+    /// Write arrays, as single array, using plain encoding
     ///
     /// Returns the file position if success.
-    pub async fn write_plain_encoded_array(&mut self, array: &dyn Array) -> Result<usize> {
-        let mut encoder = PlainEncoder::new(self, array.data_type());
-        encoder.encode(&[array]).await
+    pub async fn write_plain_encoded_array(&mut self, array: &[&dyn Array]) -> Result<usize> {
+        if array.is_empty() {
+            return Ok(self.tell());
+        }
+        let data_type = array[0].data_type();
+        let mut encoder = PlainEncoder::new(self, data_type);
+        encoder.encode(array).await
     }
 
     /// Write magics to the tail of a file before closing the file.

--- a/rust/lance/src/io/object_writer.rs
+++ b/rust/lance/src/io/object_writer.rs
@@ -90,13 +90,13 @@ impl ObjectWriter {
     /// Write arrays, as single array, using plain encoding
     ///
     /// Returns the file position if success.
-    pub async fn write_plain_encoded_array(&mut self, array: &[&dyn Array]) -> Result<usize> {
-        if array.is_empty() {
+    pub async fn write_plain_encoded_array(&mut self, arrays: &[&dyn Array]) -> Result<usize> {
+        if arrays.is_empty() {
             return Ok(self.tell());
         }
-        let data_type = array[0].data_type();
+        let data_type = arrays[0].data_type();
         let mut encoder = PlainEncoder::new(self, data_type);
-        encoder.encode(array).await
+        encoder.encode(arrays).await
     }
 
     /// Write magics to the tail of a file before closing the file.


### PR DESCRIPTION
Provide `ObjectStore::create_local(std::path::Path)` and `open_local(std::path::Path)` 