### PR TITLE
fix: make PageTable handle multiple files

### DIFF
--- a/protos/format.proto
+++ b/protos/format.proto
@@ -181,6 +181,8 @@ message DataFile {
   // field id in the table (if any already). So when a fragment is first created
   // with one file of N columns, the field ids will be 1, 2, ..., N. If a second,
   // fragment is created with M columns, the field ids will be N+1, N+2, ..., N+M.
+  //
+  // These ids must be sorted and contiguous.
   repeated int32 fields = 2;
 } // DataFile
 
@@ -230,6 +232,10 @@ message Metadata {
   // length:int64> of the page. Both position and length are int64 values. The
   // <position, length> of all the pages in the same column are then
   // contiguously stored.
+  //
+  // Every field that is a part of the file will have a run in the page table.
+  // This includes struct columns, which will have a run of length 0 since 
+  // they don't store any actual data.
   //
   // For example, for the column 5 and batch 4, we have:
   // ```text

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -639,7 +639,7 @@ def test_merge_data(tmp_path: Path):
     new_tab = pa.table({"a2": range(5), "d": ["a", "b", "c", "d", "e"]})
     dataset.merge(new_tab, left_on="a", right_on="a2")
     assert dataset.version == 3
-    assert dataset.to_table() == pa.table(
+    expected = pa.table(
         {
             "a": range(100),
             "b": range(100),
@@ -647,6 +647,10 @@ def test_merge_data(tmp_path: Path):
             "d": ["a", "b", "c", "d", "e"] + [None] * 95,
         }
     )
+    assert dataset.to_table() == expected
+    # Verify we can also load from fresh instance
+    dataset = lance.dataset(tmp_path / "dataset")
+    assert dataset.to_table() == expected
 
 
 def test_delete_data(tmp_path: Path):

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2383,6 +2383,20 @@ mod tests {
         .unwrap();
 
         assert_eq!(actual, expected);
+
+        // Validate we can still read after re-instantiating dataset, which
+        // clears the cache.
+        let dataset = Dataset::open(test_uri).await.unwrap();
+        let actual_batches = dataset
+            .scan()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let actual = concat_batches(&actual_batches[0].schema(), &actual_batches).unwrap();
+        assert_eq!(actual, expected);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -251,7 +251,7 @@ impl FileFragment {
                 &self.dataset.object_store,
                 path,
                 self.id() as u64,
-                None,
+                Some(self.dataset.manifest.as_ref()),
                 Some(self.dataset.session.as_ref()),
             );
             reader.map_ok(|r| r.len())

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -79,6 +79,10 @@ impl FileFragment {
         let reader = Box::new(reader);
         let (stream, schema) = reader_to_stream(reader)?;
 
+        if schema.fields.is_empty() {
+            return Err(Error::invalid_input("Cannot write with an empty schema."));
+        }
+
         let (object_store, base_path) = ObjectStore::from_uri(dataset_uri).await?;
         let filename = format!("{}.lance", Uuid::new_v4());
         let mut fragment = Fragment::with_file(id as u64, &filename, &schema, 0);

--- a/rust/lance/src/format/page_table.rs
+++ b/rust/lance/src/format/page_table.rs
@@ -42,7 +42,7 @@ impl PageInfo {
 
 /// Page lookup table.
 ///
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct PageTable {
     /// map[field-id,  map[batch-id, PageInfo]]
     pages: BTreeMap<i32, BTreeMap<i32, PageInfo>>,
@@ -50,11 +50,17 @@ pub struct PageTable {
 
 impl PageTable {
     /// Load [PageTable] from disk.
+    ///
+    /// The field_ids that are loaded are `field_id_offset` to `field_id_offset + num_columns`.
+    /// `field_id_offset` should be the smallest field_id in the schema. `num_columns` should
+    /// be the total unique number of field ids, including struct fields despite the fact
+    /// they have no data pages.
     pub async fn load<'a>(
         reader: &dyn ObjectReader,
         position: usize,
         num_columns: i32,
         num_batches: i32,
+        field_id_offset: i32,
     ) -> Result<Self> {
         let length = num_columns * num_batches * 2;
         let decoder = PlainDecoder::new(reader, &DataType::Int64, position, length as usize)?;
@@ -63,12 +69,13 @@ impl PageTable {
 
         let mut pages = BTreeMap::default();
         for col in 0..num_columns {
-            pages.insert(col, BTreeMap::default());
+            let field_id = col + field_id_offset;
+            pages.insert(field_id, BTreeMap::default());
             for batch in 0..num_batches {
                 let idx = col * num_batches + batch;
                 let batch_position = &arr.value((idx * 2) as usize);
                 let batch_length = &arr.value((idx * 2 + 1) as usize);
-                pages.get_mut(&col).unwrap().insert(
+                pages.get_mut(&field_id).unwrap().insert(
                     batch,
                     PageInfo {
                         position: *batch_position as usize,
@@ -81,7 +88,15 @@ impl PageTable {
         Ok(Self { pages })
     }
 
-    pub async fn write(&self, writer: &mut ObjectWriter) -> Result<usize> {
+    /// Write [PageTable] to disk.
+    ///
+    /// `field_id_offset` is the smallest field_id that is present in the schema.
+    /// This might be a struct field, which has no data pages, but it still must
+    /// be serialized to the page table per the format spec.
+    ///
+    /// Any (field_id, batch_id) combinations that are not present in the page table
+    /// will be written as (0, 0) to indicate an empty page.
+    pub async fn write(&self, writer: &mut ObjectWriter, field_id_offset: i32) -> Result<usize> {
         if self.pages.is_empty() {
             return Err(Error::InvalidInput {
                 source: "empty page table".into(),
@@ -89,7 +104,7 @@ impl PageTable {
         }
 
         let pos = writer.tell();
-        let num_columns = self.pages.keys().max().unwrap() + 1;
+        let num_columns = self.pages.keys().max().unwrap() + 1 - field_id_offset;
         let num_batches = self
             .pages
             .values()
@@ -101,7 +116,8 @@ impl PageTable {
         let mut builder = Int64Builder::with_capacity((num_columns * num_batches) as usize);
         for col in 0..num_columns {
             for batch in 0..num_batches {
-                if let Some(page_info) = self.get(col, batch) {
+                let field_id = col + field_id_offset;
+                if let Some(page_info) = self.get(field_id, batch) {
                     builder.append_value(page_info.position as i64);
                     builder.append_value(page_info.length as i64);
                 } else {
@@ -118,20 +134,26 @@ impl PageTable {
     }
 
     /// Set page lookup info for a page identified by `(column, batch)` pair.
-    pub fn set(&mut self, column: i32, batch: i32, page_info: PageInfo) {
+    pub fn set(&mut self, field_id: i32, batch: i32, page_info: PageInfo) {
         self.pages
-            .entry(column)
+            .entry(field_id)
             .or_insert_with(BTreeMap::default)
             .insert(batch, page_info);
     }
 
-    pub fn get(&self, column: i32, batch: i32) -> Option<&PageInfo> {
-        self.pages.get(&column).and_then(|c_map| c_map.get(&batch))
+    pub fn get(&self, field_id: i32, batch: i32) -> Option<&PageInfo> {
+        self.pages
+            .get(&field_id)
+            .and_then(|c_map| c_map.get(&batch))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use object_store::path::Path;
+
+    use crate::io::ObjectStore;
+
     use super::*;
 
     #[test]
@@ -142,5 +164,61 @@ mod tests {
 
         let actual = page_table.get(10, 20).unwrap();
         assert_eq!(actual, &page_info);
+    }
+
+    #[tokio::test]
+    async fn test_roundtrip_page_info() {
+        let mut page_table = PageTable::default();
+        let page_info = PageInfo::new(1, 2);
+
+        // Add fields 10..13, 4 batches with some missing
+        page_table.set(10, 2, page_info.clone());
+        page_table.set(11, 1, page_info.clone());
+        page_table.set(12, 0, page_info.clone());
+        page_table.set(12, 1, page_info.clone());
+        page_table.set(12, 2, page_info.clone());
+        page_table.set(12, 3, page_info.clone());
+
+        let path = Path::from("test");
+        let object_store = ObjectStore::memory();
+
+        // The first field_id with entries is 10, but if it's inside of a struct
+        // the struct itself needs to be included in the page table. We use 9
+        // here to represent the struct.
+        let starting_field_id = 9;
+
+        let mut writer = ObjectWriter::new(&object_store, &path).await.unwrap();
+        let pos = page_table
+            .write(&mut writer, starting_field_id)
+            .await
+            .unwrap();
+        writer.shutdown().await.unwrap();
+
+        let reader = object_store.open(&path).await.unwrap();
+        let actual = PageTable::load(
+            reader.as_ref(),
+            pos,
+            3,                 // There are three columns
+            4,                 // 4 batches
+            starting_field_id, // First field id is 10, but we want to start at 9
+        )
+        .await
+        .unwrap();
+
+        // Output should have filled in the empty pages.
+        let mut expected = actual.clone();
+        let default_page_info = PageInfo::new(0, 0);
+        expected.set(9, 0, default_page_info.clone());
+        expected.set(9, 1, default_page_info.clone());
+        expected.set(9, 2, default_page_info.clone());
+        expected.set(9, 3, default_page_info.clone());
+        expected.set(10, 0, default_page_info.clone());
+        expected.set(10, 1, default_page_info.clone());
+        expected.set(10, 3, default_page_info.clone());
+        expected.set(11, 0, default_page_info.clone());
+        expected.set(11, 2, default_page_info.clone());
+        expected.set(11, 3, default_page_info);
+
+        assert_eq!(expected, actual);
     }
 }

--- a/rust/lance/src/io/local.rs
+++ b/rust/lance/src/io/local.rs
@@ -110,20 +110,8 @@ impl ObjectReader for LocalObjectReader {
             // Safety: `buf` is set with appropriate capacity above. It is
             // written to below and we check all data is initialized at that point.
             unsafe { buf.set_len(range.len()) };
-            #[cfg(unix)]
-            let bytes_read = file.read_at(buf.as_mut(), range.start as u64)?;
-            #[cfg(windows)]
-            let bytes_read = file.seek_read(buf.as_mut(), range.start as u64)?;
-            if bytes_read != range.len() {
-                return Err(Error::IO {
-                    message: format!(
-                        "failed to read all bytes from file: expected {}, got {}",
-                        range.len(),
-                        bytes_read
-                    ),
-                    location: location!(),
-                });
-            }
+            file.read_exact_at(buf.as_mut(), range.start as u64)?;
+
             Ok(buf.freeze())
         })
         .await?

--- a/rust/lance/src/io/local.rs
+++ b/rust/lance/src/io/local.rs
@@ -122,7 +122,7 @@ impl ObjectReader for LocalObjectReader {
 }
 
 #[cfg(windows)]
-fn read_exact_at(file: Arc<File>, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+fn read_exact_at(file: Arc<File>, mut buf: &mut [u8], mut offset: u64) -> std::io::Result<()> {
     while !buf.is_empty() {
         match file.seek_read(buf, offset) {
             Ok(0) => break,

--- a/rust/lance/src/io/local.rs
+++ b/rust/lance/src/io/local.rs
@@ -123,6 +123,7 @@ impl ObjectReader for LocalObjectReader {
 
 #[cfg(windows)]
 fn read_exact_at(file: Arc<File>, mut buf: &mut [u8], mut offset: u64) -> std::io::Result<()> {
+    let expected_len = buf.len();
     while !buf.is_empty() {
         match file.seek_read(buf, offset) {
             Ok(0) => break,
@@ -138,7 +139,10 @@ fn read_exact_at(file: Arc<File>, mut buf: &mut [u8], mut offset: u64) -> std::i
     if !buf.is_empty() {
         Err(std::io::Error::new(
             std::io::ErrorKind::UnexpectedEof,
-            "failed to fill whole buffer",
+            format!(
+                "failed to fill whole buffer. Expected {} bytes, got {}",
+                expected_len, offset
+            ),
         ))
     } else {
         Ok(())

--- a/rust/lance/src/io/writer.rs
+++ b/rust/lance/src/io/writer.rs
@@ -372,7 +372,11 @@ impl FileWriter {
 
     async fn write_footer(&mut self) -> Result<()> {
         // Step 1. Write page table.
-        let pos = self.page_table.write(&mut self.object_writer).await?;
+        let field_id_offset = *self.schema.field_ids().iter().min().unwrap();
+        let pos = self
+            .page_table
+            .write(&mut self.object_writer, field_id_offset)
+            .await?;
         self.metadata.page_table_position = pos;
 
         // Step 2. Write manifest and dictionary values.


### PR DESCRIPTION
Currently, `PageTable` assumes there are fields `0..num_columns`, where `num_columns` is the total number of columns in the dataset. This works for new files added, because we always write `0..(max_field_id + 1)` entries in the page table, but it breaks for old data files who have fewer fields. This is why after merge we can read the new columns (in the new files), but not the old columns. Also, because the PageTable is cached, we could read while using the same instance of `LanceDataset`, but as soon as we loaded in a new session, the PageTables would be re-read and break.

This PR modifies the `PageTable` format slightly so that the fields start at the minimum field id in that file's schema. This is backwards compatible for all tables that only have one data file per fragment, but breaks tables that have more than one file. However, seeing as the latter case is broken already, I think this breaking change is fine.

Closes #1331.
