### PR TITLE
chore: speed up kmean training for cosine

### DIFF
--- a/python/src/utils.rs
+++ b/python/src/utils.rs
@@ -99,7 +99,7 @@ impl KMeans {
             return Err(PyValueError::new_err("Must be a FixedSizeList of Float32"));
         };
         let values: Arc<Float32Array> = fixed_size_arr.values().as_primitive().clone().into();
-        let membership = RT.block_on(Some(py), kmeans.compute_membership(values));
+        let membership = RT.block_on(Some(py), kmeans.compute_membership(values, None));
         let cluster_ids: UInt32Array = membership.cluster_ids.into();
         cluster_ids.into_data().to_pyarrow(py)
     }

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -37,6 +37,14 @@ pub trait Cosine {
 
     /// Fast cosine function, that assumes that the norm of the first vector is already known.
     fn cosine_fast(&self, x_norm: Self::Output, other: &Self) -> Self::Output;
+
+    /// Cosine between two vectors, with the L2 norms of both vectors already known.
+    fn cosine_with_norms(
+        &self,
+        x_norm: Self::Output,
+        y_norm: Self::Output,
+        y: &Self,
+    ) -> Self::Output;
 }
 
 impl Cosine for [bf16] {
@@ -53,6 +61,16 @@ impl Cosine for [bf16] {
         // TODO: Implement SIMD
         cosine_scalar(self, x_norm, other)
     }
+
+    #[inline]
+    fn cosine_with_norms(
+        &self,
+        x_norm: Self::Output,
+        y_norm: Self::Output,
+        y: &Self,
+    ) -> Self::Output {
+        cosine_scalar_fast(self, x_norm, y, y_norm)
+    }
 }
 
 impl Cosine for [f16] {
@@ -68,6 +86,16 @@ impl Cosine for [f16] {
     fn cosine_fast(&self, x_norm: Self::Output, other: &Self) -> Self::Output {
         // TODO: Implement SIMD
         cosine_scalar(self, x_norm, other)
+    }
+
+    #[inline]
+    fn cosine_with_norms(
+        &self,
+        x_norm: Self::Output,
+        y_norm: Self::Output,
+        y: &Self,
+    ) -> Self::Output {
+        cosine_scalar_fast(self, x_norm, y, y_norm)
     }
 }
 
@@ -97,6 +125,30 @@ impl Cosine for [f32] {
         #[cfg(not(target_arch = "aarch64"))]
         cosine_scalar(self, x_norm, other)
     }
+
+    #[inline]
+    fn cosine_with_norms(
+        &self,
+        x_norm: Self::Output,
+        y_norm: Self::Output,
+        y: &Self,
+    ) -> Self::Output {
+        #[cfg(target_arch = "aarch64")]
+        {
+            aarch64::neon::cosine_f32(self, other, x_norm)
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("fma") {
+                return x86_64::avx::cosine_f32_norms(self, y, x_norm, y_norm);
+            }
+        }
+
+        // Slow path
+        #[cfg(not(target_arch = "aarch64"))]
+        cosine_scalar_fast(self, x_norm, y, y_norm)
+    }
 }
 
 impl Cosine for [f64] {
@@ -113,6 +165,16 @@ impl Cosine for [f64] {
         // TODO: Implement SIMD
         cosine_scalar(self, x_norm, other)
     }
+
+    #[inline]
+    fn cosine_with_norms(
+        &self,
+        x_norm: Self::Output,
+        y_norm: Self::Output,
+        y: &Self,
+    ) -> Self::Output {
+        cosine_scalar_fast(self, x_norm, y, y_norm)
+    }
 }
 
 /// Fallback non-SIMD implementation
@@ -123,6 +185,13 @@ fn cosine_scalar<T: Real + Sum>(x: &[T], x_norm: T, y: &[T]) -> T {
     let xy = dot(x, y);
     // 1 - xy / (sqrt(x_sq) * sqrt(y_sq))
     T::one().sub(xy.div(x_norm.mul(y_sq.sqrt())))
+}
+
+#[inline]
+fn cosine_scalar_fast<T: Real + Sum>(x: &[T], x_norm: T, y: &[T], y_norm: T) -> T {
+    let xy = dot(x, y);
+    // 1 - xy / (sqrt(x_sq) * sqrt(y_sq))
+    T::one().sub(xy.div(x_norm.mul(y_norm)))
 }
 
 /// Cosine distance function between two vectors.
@@ -175,6 +244,35 @@ mod x86_64 {
                 let mut y_sq_sum = add_f32_register(y_sq);
                 y_sq_sum += norm_l2(&y_vector[len..]).powi(2);
                 let div = x_norm * y_sq_sum.sqrt();
+                if div == 0.0 {
+                    1.0
+                } else {
+                    1.0 - dotprod / div
+                }
+            }
+        }
+
+        #[inline]
+        pub fn cosine_f32_norms(
+            x_vector: &[f32],
+            y_vector: &[f32],
+            x_norm: f32,
+            y_norm: f32,
+        ) -> f32 {
+            unsafe {
+                use crate::distance::x86_64::avx::add_f32_register;
+
+                let len = x_vector.len() / 8 * 8;
+                let mut xy = _mm256_setzero_ps();
+                for i in (0..len).step_by(8) {
+                    let x = _mm256_loadu_ps(x_vector.as_ptr().add(i));
+                    let y = _mm256_loadu_ps(y_vector.as_ptr().add(i));
+                    xy = _mm256_fmadd_ps(x, y, xy);
+                }
+                // handle remaining elements
+                let mut dotprod = add_f32_register(xy);
+                dotprod += dot(&x_vector[len..], &y_vector[len..]);
+                let div = x_norm * y_norm;
                 if div == 0.0 {
                     1.0
                 } else {

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -174,7 +174,12 @@ mod x86_64 {
                 dotprod += dot(&x_vector[len..], &y_vector[len..]);
                 let mut y_sq_sum = add_f32_register(y_sq);
                 y_sq_sum += norm_l2(&y_vector[len..]).powi(2);
-                1.0 - dotprod / (x_norm * y_sq_sum.sqrt())
+                let div = x_norm * y_sq_sum.sqrt();
+                if div == 0.0 {
+                    1.0
+                } else {
+                    1.0 - dotprod / div
+                }
             }
         }
     }

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -135,7 +135,9 @@ impl Cosine for [f32] {
     ) -> Self::Output {
         #[cfg(target_arch = "aarch64")]
         {
-            aarch64::neon::cosine_f32(self, other, x_norm)
+            // TODO: SIMD with normalized X and Y.
+            let _ = y_norm; // Make compiler happy.
+            aarch64::neon::cosine_f32(self, y, x_norm)
         }
 
         #[cfg(target_arch = "x86_64")]

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -468,11 +468,6 @@ impl KMeans {
                             .chunks_exact(dimension)
                             .enumerate()
                             .map(|(idx, vector)| {
-                                let norm_vec = if matches!(metric_type, MetricType::Cosine) {
-                                    norm_data.as_ref().unwrap().values()[idx]
-                                } else {
-                                    0.0
-                                };
                                 let centroid_stream = centroids_array.chunks_exact(dimension);
                                 match metric_type {
                                     MetricType::L2 => {
@@ -480,6 +475,7 @@ impl KMeans {
                                     }
                                     MetricType::Cosine => {
                                         let centroid_norms = norms.as_ref().as_ref().unwrap();
+                                        let norm_vec = norm_data.as_ref().unwrap().values()[idx];
                                         argmin_value(
                                             centroid_stream.zip(centroid_norms.iter()).map(
                                                 |(cent, &cent_norm)| {

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -489,17 +489,13 @@ impl KMeans {
                                             )
                                         } else {
                                             argmin_value(
-                                                centroid_stream
-                                                    .zip(centroid_norms.iter())
-                                                    .map(|(cent, &cent_norm)| {
-                                                        cent.cosine_fast(
-                                                            cent_norm,
-                                                            vector,
-                                                        )
-                                                    }),
+                                                centroid_stream.zip(centroid_norms.iter()).map(
+                                                    |(cent, &cent_norm)| {
+                                                        cent.cosine_fast(cent_norm, vector)
+                                                    },
+                                                ),
                                             )
                                         }
-
                                     }
                                     crate::distance::DistanceType::Dot => {
                                         argmin_value(centroid_stream.map(|cent| vector.dot(cent)))

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -480,15 +480,15 @@ impl KMeans {
                                     }
                                     MetricType::Cosine => {
                                         let centroid_norms = norms.as_ref().as_ref().unwrap();
-                                        argmin_value(centroid_stream.enumerate().map(
-                                            |(c_idx, cent)| {
-                                                cent.cosine_with_norms(
-                                                    centroid_norms[c_idx],
-                                                    norm_vec,
-                                                    vector,
-                                                )
-                                            },
-                                        ))
+                                        argmin_value(
+                                            centroid_stream.zip(centroid_norms.iter()).map(
+                                                |(cent, &cent_norm)| {
+                                                    cent.cosine_with_norms(
+                                                        cent_norm, norm_vec, vector,
+                                                    )
+                                                },
+                                            ),
+                                        )
                                     }
                                     crate::distance::DistanceType::Dot => {
                                         argmin_value(centroid_stream.map(|cent| vector.dot(cent)))

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -464,7 +464,7 @@ impl KMeans {
                         let centroids_array = centroids.values();
 
                         let last_idx = min(start_idx + CHUNK_SIZE, n);
-                        (&array[start_idx * dimension..last_idx * dimension])
+                        array[start_idx * dimension..last_idx * dimension]
                             .chunks_exact(dimension)
                             .enumerate()
                             .map(|(idx, vector)| {
@@ -473,20 +473,22 @@ impl KMeans {
                                 } else {
                                     0.0
                                 };
-                                argmin_value(centroids_array.chunks_exact(dimension).enumerate().map(
-                                    |(c_idx, centroid)| match metric_type {
-                                        MetricType::L2 => vector.l2(centroid),
-                                        MetricType::Cosine => centroid.cosine_with_norms(
-                                            norms.as_ref().as_ref().unwrap()[c_idx],
-                                            norm_vec,
-                                            vector,
-                                        ),
-                                        MetricType::Dot => vector.dot(centroid),
-                                    },
-                                ))
+                                argmin_value(
+                                    centroids_array.chunks_exact(dimension).enumerate().map(
+                                        |(c_idx, centroid)| match metric_type {
+                                            MetricType::L2 => vector.l2(centroid),
+                                            MetricType::Cosine => centroid.cosine_with_norms(
+                                                norms.as_ref().as_ref().unwrap()[c_idx],
+                                                norm_vec,
+                                                vector,
+                                            ),
+                                            MetricType::Dot => vector.dot(centroid),
+                                        },
+                                    ),
+                                )
                                 .unwrap()
                             })
-                        .collect::<Vec<_>>()
+                            .collect::<Vec<_>>()
                     })
                     .await
                     .map_err(|e| {

--- a/rust/lance/benches/ivf_pq.rs
+++ b/rust/lance/benches/ivf_pq.rs
@@ -86,7 +86,33 @@ fn bench_ivf_pq_index(c: &mut Criterion) {
     let pq = 96;
 
     c.bench_function(
-        format!("CreateIVF{},PQ{}(d={})", ivf_partition, pq, DIM).as_str(),
+        format!(
+            "CreateIVF{},PQ{}(d={},metric=cosine)",
+            ivf_partition, pq, DIM
+        )
+        .as_str(),
+        |b| {
+            b.to_async(&rt).iter(|| async {
+                let params =
+                    VectorIndexParams::ivf_pq(ivf_partition, 8, pq, false, MetricType::Cosine, 50);
+
+                dataset
+                    .clone()
+                    .create_index(
+                        vec!["vector"].as_slice(),
+                        IndexType::Vector,
+                        None,
+                        &params,
+                        true,
+                    )
+                    .await
+                    .unwrap();
+            });
+        },
+    );
+
+    c.bench_function(
+        format!("CreateIVF{},PQ{}(d={},metric=l2)", ivf_partition, pq, DIM).as_str(),
         |b| {
             b.to_async(&rt).iter(|| async {
                 let params =


### PR DESCRIPTION
`cargo bench --bench ivf_pq` resulted about 20% speed up over `cosine`