### PR TITLE
feat: add new operation to reserve fragment ids

### DIFF
--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -131,6 +131,12 @@ message Transaction {
     uint64 version = 1;
   }
 
+  // An operation that reserves fragment ids for future use in
+  // a rewrite operation.
+  message ReserveFragments {
+    uint32 num_fragments = 1;
+  }
+
   // The operation of this transaction.
   oneof operation {
     Append append = 100;
@@ -140,5 +146,6 @@ message Transaction {
     Rewrite rewrite = 104;
     Merge merge = 105;
     Restore restore = 106;
+    ReserveFragments reserve_fragments = 107;
   }
 }

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -45,7 +45,7 @@
 //! (1) Delete and rewrite are compatible with each other and themselves only if
 //! they affect distinct fragments. Otherwise, they conflict.
 
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, ops::Range, sync::Arc};
 
 use object_store::path::Path;
 
@@ -112,6 +112,11 @@ pub enum Operation {
     },
     /// Restore an old version of the database
     Restore { version: u64 },
+    /// Reserves fragment ids for future use
+    /// This can be used when row ids need to be known before a transaction
+    /// has been committed.  It is used during a rewrite operation to allow
+    /// indices to be remapped to the new row ids as part of the operation.
+    ReserveFragments { num_fragments: u32 },
 }
 
 #[derive(Debug, Clone)]
@@ -130,6 +135,7 @@ impl Operation {
             Self::Append { .. }
             | Self::Overwrite { .. }
             | Self::CreateIndex { .. }
+            | Self::ReserveFragments { .. }
             | Self::Restore { .. } => Box::new(std::iter::empty()),
             Self::Delete {
                 updated_fragments,
@@ -165,6 +171,7 @@ impl Operation {
             Self::CreateIndex { .. } => "CreateIndex",
             Self::Rewrite { .. } => "Rewrite",
             Self::Merge { .. } => "Merge",
+            Self::ReserveFragments { .. } => "ReserveFragments",
             Self::Restore { .. } => "Restore",
         }
     }
@@ -195,6 +202,7 @@ impl Transaction {
                 Operation::Rewrite { .. } => false,
                 Operation::CreateIndex { .. } => false,
                 Operation::Delete { .. } => false,
+                Operation::ReserveFragments { .. } => false,
                 _ => true,
             },
             Operation::Rewrite { .. } => match &other.operation {
@@ -203,6 +211,7 @@ impl Transaction {
                 // TODO: it could also be compatible with operations that update
                 // fragments we don't touch.
                 Operation::Append { .. } => false,
+                Operation::ReserveFragments { .. } => false,
                 Operation::Delete { .. } => {
                     // If we rewrote any fragments that were modified by delete,
                     // we conflict.
@@ -217,6 +226,13 @@ impl Transaction {
             // Overwrite and Restore always succeed
             Operation::Overwrite { .. } => false,
             Operation::Restore { .. } => false,
+            // ReserveFragments is compatible with anything that doesn't reset the
+            // max fragment id.
+            Operation::ReserveFragments { .. } => match &other.operation {
+                Operation::Overwrite { .. } => true,
+                Operation::Restore { .. } => true,
+                _ => false,
+            },
             Operation::CreateIndex { .. } => match &other.operation {
                 Operation::Append { .. } => false,
                 // Indices are identified by UUIDs, so they shouldn't conflict.
@@ -224,8 +240,9 @@ impl Transaction {
                 // Although some of the rows we indexed may have been deleted,
                 // row ids are still valid, so we allow this optimistically.
                 Operation::Delete { .. } => false,
-                // Merge doesn't change row ids, so this should be fine.
+                // Merge & reserve don't change row ids, so this should be fine.
                 Operation::Merge { .. } => false,
+                Operation::ReserveFragments { .. } => false,
                 // Rewrite likely changed many of the row ids, so our index is
                 // likely useless. It should be rebuilt.
                 // TODO: we could be smarter here and only invalidate the index
@@ -235,6 +252,7 @@ impl Transaction {
             },
             Operation::Delete { .. } => match &other.operation {
                 Operation::CreateIndex { .. } => false,
+                Operation::ReserveFragments { .. } => false,
                 Operation::Delete { .. } => {
                     // If we update the same fragments, we conflict.
                     self.operation.modifies_same_ids(&other.operation)
@@ -247,20 +265,27 @@ impl Transaction {
             },
             // Merge changes the schema, but preserves row ids, so the only operation
             // it's compatible with is CreateIndex.
-            Operation::Merge { .. } => !matches!(&other.operation, Operation::CreateIndex { .. }),
+            Operation::Merge { .. } => match &other.operation {
+                Operation::CreateIndex { .. } => false,
+                Operation::ReserveFragments { .. } => false,
+                _ => true,
+            },
         }
     }
 
     fn fragments_with_ids<'a, T>(
         new_fragments: T,
         fragment_id: &'a mut u64,
+        reserved_fragment_ids: Range<u64>,
     ) -> impl Iterator<Item = Fragment> + 'a
     where
         T: IntoIterator<Item = Fragment> + 'a,
     {
-        new_fragments.into_iter().map(|mut f| {
-            f.id = *fragment_id;
-            *fragment_id += 1;
+        new_fragments.into_iter().map(move |mut f| {
+            if !reserved_fragment_ids.contains(&f.id) {
+                f.id = *fragment_id;
+                *fragment_id += 1;
+            }
             f
         })
     }
@@ -292,6 +317,7 @@ impl Transaction {
         current_indices: Vec<Index>,
         transaction_file_path: &str,
         config: &ManifestWriteConfig,
+        reserved_fragment_ids: Range<u64>,
     ) -> Result<(Manifest, Vec<Index>)> {
         // Get the schema and the final fragment list
         let schema = match self.operation {
@@ -335,6 +361,7 @@ impl Transaction {
                 final_fragments.extend(Self::fragments_with_ids(
                     fragments.clone(),
                     &mut fragment_id,
+                    reserved_fragment_ids,
                 ));
             }
             Operation::Delete {
@@ -357,6 +384,7 @@ impl Transaction {
                 final_fragments.extend(Self::fragments_with_ids(
                     fragments.clone(),
                     &mut fragment_id,
+                    reserved_fragment_ids,
                 ));
                 final_indices = Vec::new();
             }
@@ -368,6 +396,7 @@ impl Transaction {
                     groups,
                     &mut fragment_id,
                     current_version,
+                    reserved_fragment_ids,
                 )?;
             }
             Operation::CreateIndex { new_indices } => {
@@ -378,6 +407,9 @@ impl Transaction {
                         .any(|new_index| new_index.name == existing_index.name)
                 });
                 final_indices.extend(new_indices.clone());
+            }
+            Operation::ReserveFragments { .. } => {
+                final_fragments.extend(maybe_existing_fragments?.clone());
             }
             Operation::Merge { ref fragments, .. } => {
                 final_fragments.extend(fragments.clone());
@@ -402,6 +434,10 @@ impl Transaction {
 
         manifest.update_max_fragment_id();
 
+        if let Operation::ReserveFragments { num_fragments } = self.operation {
+            manifest.max_fragment_id += num_fragments;
+        }
+
         manifest.transaction_file = Some(transaction_file_path.to_string());
 
         Ok((manifest, final_indices))
@@ -412,6 +448,7 @@ impl Transaction {
         groups: &[RewriteGroup],
         fragment_id: &mut u64,
         version: u64,
+        reserved_fragment_ids: Range<u64>,
     ) -> Result<()> {
         for group in groups {
             // If the old fragments are contiguous, find the range
@@ -433,7 +470,11 @@ impl Transaction {
                 }
             };
 
-            let new_fragments = Self::fragments_with_ids(group.new_fragments.clone(), fragment_id);
+            let new_fragments = Self::fragments_with_ids(
+                group.new_fragments.clone(),
+                fragment_id,
+                reserved_fragment_ids.clone(),
+            );
             if let Some(replace_range) = replace_range {
                 // Efficiently path using slice
                 final_fragments.splice(replace_range, new_fragments);
@@ -475,6 +516,11 @@ impl TryFrom<&pb::Transaction> for Transaction {
             })) => Operation::Overwrite {
                 fragments: fragments.iter().map(Fragment::from).collect(),
                 schema: Schema::from(schema),
+            },
+            Some(pb::transaction::Operation::ReserveFragments(
+                pb::transaction::ReserveFragments { num_fragments },
+            )) => Operation::ReserveFragments {
+                num_fragments: *num_fragments,
             },
             Some(pb::transaction::Operation::Rewrite(pb::transaction::Rewrite {
                 old_fragments,
@@ -568,6 +614,11 @@ impl From<&Transaction> for pb::Transaction {
                     fragments: fragments.iter().map(pb::DataFragment::from).collect(),
                     schema: schema.into(),
                     schema_metadata: Default::default(), // TODO: handle metadata
+                })
+            }
+            Operation::ReserveFragments { num_fragments } => {
+                pb::transaction::Operation::ReserveFragments(pb::transaction::ReserveFragments {
+                    num_fragments: *num_fragments,
                 })
             }
             Operation::Rewrite { groups } => {
@@ -665,6 +716,7 @@ mod tests {
                     new_fragments: vec![fragment1.clone()],
                 }],
             },
+            Operation::ReserveFragments { num_fragments: 3 },
         ];
         let other_transactions = other_operations
             .iter()
@@ -678,7 +730,7 @@ mod tests {
                 Operation::Append {
                     fragments: vec![fragment0.clone()],
                 },
-                [false, false, false, true, true, false],
+                [false, false, false, true, true, false, false],
             ),
             (
                 Operation::Delete {
@@ -687,7 +739,7 @@ mod tests {
                     deleted_fragment_ids: vec![],
                     predicate: "x > 2".to_string(),
                 },
-                [true, false, false, true, true, false],
+                [true, false, false, true, true, false, false],
             ),
             (
                 Operation::Delete {
@@ -696,7 +748,7 @@ mod tests {
                     deleted_fragment_ids: vec![],
                     predicate: "x > 2".to_string(),
                 },
-                [true, false, true, true, true, true],
+                [true, false, true, true, true, true, false],
             ),
             (
                 Operation::Overwrite {
@@ -705,14 +757,14 @@ mod tests {
                 },
                 // No conflicts: overwrite can always happen since it doesn't
                 // depend on previous state of the table.
-                [false, false, false, false, false, false],
+                [false, false, false, false, false, false, false],
             ),
             (
                 Operation::CreateIndex {
                     new_indices: vec![index0],
                 },
                 // Will only conflict with operations that modify row ids.
-                [false, false, false, false, true, true],
+                [false, false, false, false, true, true, false],
             ),
             (
                 // Rewrite that affects different fragments
@@ -722,7 +774,7 @@ mod tests {
                         new_fragments: vec![fragment0.clone()],
                     }],
                 },
-                [false, true, false, true, true, false],
+                [false, true, false, true, true, false, false],
             ),
             (
                 // Rewrite that affects the same fragments
@@ -732,15 +784,20 @@ mod tests {
                         new_fragments: vec![fragment0.clone()],
                     }],
                 },
-                [false, true, true, true, true, true],
+                [false, true, true, true, true, true, false],
             ),
             (
                 Operation::Merge {
                     fragments: vec![fragment0.clone(), fragment2.clone()],
                     schema: Schema::default(),
                 },
-                // Merge conflicts with everything except CreateIndex.
-                [true, false, true, true, true, true],
+                // Merge conflicts with everything except CreateIndex and ReserveFragments.
+                [true, false, true, true, true, true, false],
+            ),
+            (
+                Operation::ReserveFragments { num_fragments: 2 },
+                // ReserveFragments only conflicts with Overwrite and Restore.
+                [false, false, false, false, true, false, false],
             ),
         ];
 
@@ -773,16 +830,19 @@ mod tests {
             // as 1 and 2.
             RewriteGroup {
                 old_fragments: vec![Fragment::new(1), Fragment::new(2)],
-                new_fragments: vec![Fragment::new(0), Fragment::new(0)],
+                // These two fragments were previously reserved
+                new_fragments: vec![Fragment::new(15), Fragment::new(16)],
             },
             // These are not contiguous, so they will be inserted at the end.
             RewriteGroup {
                 old_fragments: vec![Fragment::new(5), Fragment::new(8)],
+                // We pretend this id was not reserved.  Does not happen in practice today
+                // but we want to leave the door open.
                 new_fragments: vec![Fragment::new(0)],
             },
         ];
 
-        let mut fragment_id = 10;
+        let mut fragment_id = 20;
         let version = 0;
 
         Transaction::handle_rewrite_fragments(
@@ -790,21 +850,22 @@ mod tests {
             &rewrite_groups,
             &mut fragment_id,
             version,
+            15..17,
         )
         .unwrap();
 
-        assert_eq!(fragment_id, 13);
+        assert_eq!(fragment_id, 21);
 
         let expected_fragments: Vec<Fragment> = vec![
             Fragment::new(0),
-            Fragment::new(10),
-            Fragment::new(11),
+            Fragment::new(15),
+            Fragment::new(16),
             Fragment::new(3),
             Fragment::new(4),
             Fragment::new(6),
             Fragment::new(7),
             Fragment::new(9),
-            Fragment::new(12),
+            Fragment::new(20),
         ];
 
         assert_eq!(final_fragments, expected_fragments);

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -34,6 +34,7 @@
 //! alternative to [CommitHandler].
 
 use std::future;
+use std::ops::Range;
 use std::sync::Arc;
 use std::{fmt::Debug, sync::atomic::AtomicBool};
 
@@ -406,15 +407,24 @@ impl<T: CommitLock + Send + Sync> CommitHandler for Arc<T> {
     }
 }
 
+pub const NO_RESERVED_FRAGMENTS: Range<u64> = 0..0;
+
 #[derive(Debug, Clone)]
 pub struct CommitConfig {
     pub num_retries: u32,
+    // Fragment ids that have been previously reserved.  This is
+    // currently only used for rewrite operations but may be used
+    // for other operations in the future.
+    pub reserved_fragment_ids: Range<u64>,
     // TODO: add isolation_level
 }
 
 impl Default for CommitConfig {
     fn default() -> Self {
-        Self { num_retries: 5 }
+        Self {
+            num_retries: 5,
+            reserved_fragment_ids: NO_RESERVED_FRAGMENTS,
+        }
     }
 }
 
@@ -486,8 +496,13 @@ pub(crate) async fn commit_new_dataset(
 ) -> Result<Manifest> {
     let transaction_file = write_transaction_file(object_store, base_path, transaction).await?;
 
-    let (mut manifest, indices) =
-        transaction.build_manifest(None, vec![], &transaction_file, write_config)?;
+    let (mut manifest, indices) = transaction.build_manifest(
+        None,
+        vec![],
+        &transaction_file,
+        write_config,
+        NO_RESERVED_FRAGMENTS,
+    )?;
 
     write_manifest_file(
         object_store,
@@ -668,6 +683,7 @@ pub(crate) async fn commit_transaction(
                 dataset.load_indices().await?,
                 &transaction_file,
                 write_config,
+                commit_config.reserved_fragment_ids.clone(),
             )?,
         };
 


### PR DESCRIPTION
This will eventually be used to remap indices during a rewrite.  It allows us to know what the destination row ids will be during the rewrite operation.