### PR TITLE
fix: stop reading latest manifest

### DIFF
--- a/rust/lance/src/io/commit/external_manifest.rs
+++ b/rust/lance/src/io/commit/external_manifest.rs
@@ -30,7 +30,7 @@ use crate::io::ObjectStore;
 use crate::{Error, Result};
 
 use super::{
-    latest_manifest_path, make_staging_manifest_path, manifest_path, write_latest_manifest,
+    current_manifest_path, make_staging_manifest_path, manifest_path, write_latest_manifest,
     MANIFEST_EXTENSION,
 };
 
@@ -119,8 +119,8 @@ impl CommitHandler for ExternalManifestCommitHandler {
                 Ok(object_store_manifest_path)
             }
             // Dataset not found in the external store, this could be because the dataset did not
-            // use external store for commit before. In this case, we use the _latest.manifest file
-            None => Ok(latest_manifest_path(base_path)),
+            // use external store for commit before. In this case, we search for the latest manifest
+            None => current_manifest_path(object_store, base_path).await,
         }
     }
 
@@ -251,7 +251,7 @@ mod test {
 
     use crate::{
         dataset::{ReadParams, WriteMode, WriteParams},
-        io::object_store::ObjectStoreParams,
+        io::{commit::latest_manifest_path, object_store::ObjectStoreParams},
         Dataset,
     };
 


### PR DESCRIPTION
As a quick fix to address safety/consistency issues, we will find the latest manifest by scanning the `_versions` directory.

We continue to write the `_latest.manifest` file, so older readers are still compatible.

Performance considerations: in object stores like S3, we can get 1,000 objects listed with 1 request. So right now this adds 1 IO for those tables. Tables with more versions should probably have `cleanup_old_versions` applied.

Fixes: #1356

We will optimize this in follow ups, as described in #1362