### PR TITLE
chore: improve kmean training performance on CUDA

### DIFF
--- a/python/python/lance/torch/__init__.py
+++ b/python/python/lance/torch/__init__.py
@@ -35,6 +35,8 @@ def preferred_device(device: Optional[str] = None):
         Device to use for computation.
     """
     if device is not None:
+        if isinstance(device, str):
+            device = torch.device(device)
         return device
     if torch.cuda.is_available():
         return torch.device("cuda")

--- a/python/python/lance/torch/kmeans.py
+++ b/python/python/lance/torch/kmeans.py
@@ -146,16 +146,23 @@ class KMeans:
 
     @staticmethod
     def _split_centroids(
-        centroids: List[torch.Tensor], counts: List[int]
+        centroids: torch.Tensor, counts: torch.Tensor
     ) -> torch.Tensor:
-        for idx, cnt in enumerate(counts):
+        for idx, cnt in enumerate(counts.cpu()):
             if cnt == 0:
-                max_idx = np.argmax(counts)
+                max_idx = torch.argmax(counts).item()
                 half_cnt = counts[max_idx] // 2
                 counts[idx], counts[max_idx] = half_cnt, half_cnt
                 centroids[idx] = centroids[max_idx] * 1.05
                 centroids[max_idx] = centroids[max_idx] / 1.05
-        return torch.stack(centroids)
+        return centroids
+
+    @staticmethod
+    def _count_rows_in_clusters(part_ids: torch.Tensor, k: int) -> torch.Tensor:
+        ones = torch.ones(part_ids.shape[0]).to(part_ids.device)
+        num_rows = torch.zeros(k).to(part_ids.device)
+        num_rows.scatter_add_(0, part_ids, ones)
+        return num_rows
 
     def _fit_once(self, data: torch.Tensor) -> float:
         """Train KMean once and return the total distance."""
@@ -163,13 +170,21 @@ class KMeans:
         part_ids = self.transform(data)
         # compute new centroids
         new_centroids = []
-        num_rows = []
-        for i in range(self.k):
-            parted_idx = part_ids == i
-            parted_data = data[parted_idx]
-            new_cent = parted_data.mean(dim=0)
-            new_centroids.append(new_cent)
-            num_rows.append(parted_idx.sum().item())
+
+        num_rows = self._count_rows_in_clusters(part_ids, self.k)
+        if self.device.type == "cuda":
+            new_centroids = torch.empty_like(self.centroids).to(self.device)
+            new_centroids[:] = torch.nan
+            new_centroids.index_reduce_(0, part_ids, data, reduce="mean", include_self=False)
+        else:
+            # MPS does not have Torch.index_reduce_()
+            # See https://github.com/pytorch/pytorch/issues/77764
+            for i in range(self.k):
+                parted_idx = part_ids == i
+                parted_data = data[parted_idx]
+                new_cent = parted_data.mean(dim=0)
+                new_centroids.append(new_cent)
+            new_centroids = torch.stack(new_centroids)
 
         self.centroids = self._split_centroids(new_centroids, num_rows)
 


### PR DESCRIPTION
Push more work to torch / CUDA instead of python for-loop, leads to about 2x speed up on CUDA

```
------------------------------------------------------------------------------------- benchmark 'kmeans': 2 tests -------------------------------------------------------------------------------------
Name (time in ms)                         Min                 Max                Mean            StdDev              Median               IQR            Outliers     OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_kmeans_torch (NOW)              121.7700 (1.0)      131.6143 (1.0)      124.7490 (1.0)      4.3262 (1.0)      121.9373 (1.0)      5.8774 (1.52)          1;0  8.0161 (1.0)           5           1
test_kmeans_torch (0001_baselin)     235.0811 (1.93)     245.2052 (1.86)     237.5965 (1.90)     4.3268 (1.00)     235.3565 (1.93)     3.8629 (1.0)           1;1  4.2088 (0.53)          5           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```