### PR TITLE
feat: run pq portion of ivf_pq in parallel

### DIFF
--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -77,7 +77,6 @@ aws-sdk-dynamodb = { version = "0.30.0", optional = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }
 lazy_static = "1"
-rayon = "1.8.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accelerate-src = { version = "0.3.2", optional = true }

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -77,6 +77,7 @@ aws-sdk-dynamodb = { version = "0.30.0", optional = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }
 lazy_static = "1"
+rayon = "1.8.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accelerate-src = { version = "0.3.2", optional = true }

--- a/rust/lance/src/utils.rs
+++ b/rust/lance/src/utils.rs
@@ -23,6 +23,7 @@ pub mod temporal;
 pub mod testing;
 #[cfg(feature = "tfrecord")]
 pub mod tfrecord;
+pub(crate) mod tokio;
 
 // Re-export
 pub use lance_linalg::kmeans;

--- a/rust/lance/src/utils/tokio.rs
+++ b/rust/lance/src/utils/tokio.rs
@@ -1,19 +1,31 @@
 use crate::Result;
 
 use futures::{Future, FutureExt};
+use tokio::runtime::{Builder, Runtime};
+
+lazy_static::lazy_static! {
+    static ref CPU_RUNTIME: Runtime = Builder::new_multi_thread()
+        .thread_name("lance-cpu")
+        .max_blocking_threads(num_cpus::get())
+        .build()
+        .unwrap();
+}
 
 /// Spawn a CPU intensive task
 ///
-/// This task will be put onto the rayon thread pool dedicated for CPU-intensive work
+/// This task will be put onto a thread pool dedicated for CPU-intensive work
+/// This keeps the tokio thread pool free so that we can always be ready to service
+/// cheap I/O & control requests.
+///
+/// This can also be used to convert a big chunk of synchronous work into a future
+/// so that it can be run in parallel with something like StreamExt::buffered()
 pub fn spawn_cpu<F: FnOnce() -> Result<R> + Send + 'static, R: Send + 'static>(
     func: F,
 ) -> impl Future<Output = Result<R>> {
     let (send, recv) = tokio::sync::oneshot::channel();
-    rayon::spawn(|| {
+    CPU_RUNTIME.spawn_blocking(|| {
         let result = func();
         let _ = send.send(result);
     });
-    // res will be an error if func() panic'd.  We propagate that panic via unwrap
-    // in the same way we do with a mutex
     recv.map(|res| res.unwrap())
 }

--- a/rust/lance/src/utils/tokio.rs
+++ b/rust/lance/src/utils/tokio.rs
@@ -1,0 +1,19 @@
+use crate::Result;
+
+use futures::{Future, FutureExt};
+
+/// Spawn a CPU intensive task
+///
+/// This task will be put onto the rayon thread pool dedicated for CPU-intensive work
+pub fn spawn_cpu<F: FnOnce() -> Result<R> + Send + 'static, R: Send + 'static>(
+    func: F,
+) -> impl Future<Output = Result<R>> {
+    let (send, recv) = tokio::sync::oneshot::channel();
+    rayon::spawn(|| {
+        let result = func();
+        let _ = send.send(result);
+    });
+    // res will be an error if func() panic'd.  We propagate that panic via unwrap
+    // in the same way we do with a mutex
+    recv.map(|res| res.unwrap())
+}


### PR DESCRIPTION
The IVF search launches its sub-vector search in parallel:

```
let batches = stream::iter(part_ids)
    .map(|part_id| async move {
        self.search_in_partition(part_id as usize, query, pre_filter)
            .await
    })
    .buffer_unordered(num_cpus::get())
    .try_collect::<Vec<_>>()
    .await?;
```

However, if the subvector is PQ (which it always is today) then the only part that is actually run in parallel is the load of the deletion file.  This is because an async function, without any awaits, is not actually asynchronous at all.  Or, phrased another way, don't create asynchronous functions that run a long time without an await.

This PR demonstrates a simple fix to this problem using rayon.  An alternative would be for `spawn_cpu` to use tokio's `spawn_blocking` but tokio themselves suggest this is not a preferred solution for CPU intensive tasks.  Another alternative would be to use a dedicated tokio runtime (as suggested in [Andrew Lamb (datafusion)'s blog](https://thenewstack.io/using-rustlangs-async-tokio-runtime-for-cpu-bound-tasks/)).  The bigger challenge her is to figure out a good balance of threads to dedicate for intensive CPU work and threads to dedicate for control plane / IO work.

However, this fix is pretty effective at the moment.  The vector_index benchmark shows a 3-4x speedup.  My profiling with end-to-end ANN search shows a 2-3x speedup (assuming a simple "pure ann" with no refinement, combined knn, etc.)

One downside of this approach is that we end up cloning the PQ & query.  This isn't particularly expensive but both of these clones can probably be avoided since the clone already happens at the IVF layer.  Since it would require mucking around with the vector index traits I've left it alone for now.