### PR TITLE
refactor: generalize shardable index concept

### DIFF
--- a/rust/lance/src/index/vector/diskann/search.rs
+++ b/rust/lance/src/index/vector/diskann/search.rs
@@ -27,6 +27,13 @@ use ordered_float::OrderedFloat;
 use serde::Serialize;
 
 use super::row_vertex::{RowVertex, RowVertexSerDe};
+use crate::index::{
+    vector::VectorIndex,
+    vector::{
+        graph::{Graph, VertexWithDistance},
+        Query,
+    },
+};
 use crate::{
     dataset::{Dataset, ROW_ID},
     index::{
@@ -38,17 +45,6 @@ use crate::{
         Index,
     },
     Result,
-};
-use crate::{
-    index::{
-        vector::VectorIndex,
-        vector::{
-            graph::{Graph, VertexWithDistance},
-            Query,
-        },
-    },
-    io::object_reader::ObjectReader,
-    Error,
 };
 
 /// DiskANN search state.
@@ -258,17 +254,6 @@ impl VectorIndex for DiskANNIndex {
 
     fn is_loadable(&self) -> bool {
         false
-    }
-
-    async fn load(
-        &self,
-        _reader: &dyn ObjectReader,
-        _offset: usize,
-        _length: usize,
-    ) -> Result<Arc<dyn VectorIndex>> {
-        Err(Error::Index {
-            message: "DiskANNIndex is not loadable".to_string(),
-        })
     }
 }
 

--- a/rust/lance/src/index/vector/io.rs
+++ b/rust/lance/src/index/vector/io.rs
@@ -1,0 +1,75 @@
+use std::sync::Arc;
+
+use object_store::path::Path;
+use prost::Message;
+
+use crate::{
+    io::{
+        object_reader::{read_message, ObjectReader},
+        read_message_from_buf, read_metadata_offset,
+    },
+    session::Session,
+    Result,
+};
+
+use super::{IndexShardLoader, VectorIndex};
+
+/// A helper with some common I/O operations that indexes need to perform
+pub(crate) struct IndexReader {
+    reader: Arc<dyn ObjectReader>,
+    session: Option<Arc<Session>>,
+    block_size: usize,
+}
+
+impl IndexReader {
+    pub fn new(reader: Arc<dyn ObjectReader>, session: Arc<Session>, block_size: usize) -> Self {
+        Self {
+            reader,
+            session: Some(session),
+            block_size,
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        self.reader.path()
+    }
+
+    /// Loads a sub index by first checking the session cache
+    pub async fn load_sub_index(
+        &self,
+        loader: &dyn IndexShardLoader,
+        key: &str,
+        shard_index: usize,
+    ) -> Result<Arc<dyn VectorIndex>> {
+        if let Some(session) = &self.session {
+            if let Some(index) = session.index_cache.get(key) {
+                return Ok(index);
+            }
+        }
+        let index: Arc<dyn VectorIndex> =
+            loader.load(self.reader.as_ref(), shard_index).await?.into();
+        if let Some(session) = &self.session {
+            session.index_cache.insert(key, index.clone());
+        }
+        Ok(index)
+    }
+
+    /// Reads a protobuf message from the end of a file
+    pub async fn read_tail_proto<M: Message + Default>(&self) -> Result<M> {
+        let file_size = self.reader.size().await?;
+        let begin = if file_size < self.block_size {
+            0
+        } else {
+            file_size - self.block_size
+        };
+        let tail_bytes = self.reader.get_range(begin..file_size).await?;
+        let metadata_pos = read_metadata_offset(&tail_bytes)?;
+        if metadata_pos < file_size - tail_bytes.len() {
+            // We have not read the metadata bytes yet.
+            read_message(self.reader.as_ref(), metadata_pos).await
+        } else {
+            let offset = tail_bytes.len() - (file_size - metadata_pos);
+            Ok(read_message_from_buf(&tail_bytes.slice(offset..))?)
+        }
+    }
+}

--- a/rust/lance/src/index/vector/io.rs
+++ b/rust/lance/src/index/vector/io.rs
@@ -15,7 +15,7 @@ use crate::{
 use super::{IndexShardLoader, VectorIndex};
 
 /// A helper with some common I/O operations that indexes need to perform
-pub(crate) struct IndexReader {
+pub struct IndexReader {
     reader: Arc<dyn ObjectReader>,
     session: Option<Arc<Session>>,
     block_size: usize,

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -92,7 +92,7 @@ impl PQIndex {
             nbits: pq.num_bits,
             num_sub_vectors: pq.num_sub_vectors,
             dimension: pq.dimension,
-            pq: pq,
+            pq,
             code,
             row_ids,
             metric_type,
@@ -282,7 +282,7 @@ impl IndexShardLoader for PQShardLoader {
         shard_index: usize,
     ) -> Result<Box<dyn VectorIndex>> {
         if shard_index >= self.lengths.len() {
-            return Err(Error::invalid_input(&format!("PQ index metadata only had information for {} partitions but was asked to load partition at index {}", self.lengths.len(), shard_index)));
+            return Err(Error::invalid_input(format!("PQ index metadata only had information for {} partitions but was asked to load partition at index {}", self.lengths.len(), shard_index)));
         }
         let length = self.lengths[shard_index];
         let offset = self.offsets[shard_index];

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -94,8 +94,19 @@ mod tests {
 
     use std::sync::Arc;
 
-    use crate::index::vector::pq::{PQIndex, ProductQuantizer};
+    use crate::index::vector::{
+        pq::{PQIndex, ProductQuantizer},
+        VectorIndex,
+    };
+    use arrow_array::{UInt64Array, UInt8Array};
     use lance_linalg::distance::MetricType;
+
+    fn dummy_index(num_sub_vectors: usize) -> Arc<dyn VectorIndex> {
+        let pq = Arc::new(ProductQuantizer::new(num_sub_vectors, 8, 1));
+        let empty_code = Arc::new(UInt8Array::from_value(0, 0));
+        let empty_row_ids = Arc::new(UInt64Array::from_value(0, 0));
+        Arc::new(PQIndex::new(pq, MetricType::L2, empty_code, empty_row_ids))
+    }
 
     #[test]
     fn test_disable_index_cache() {
@@ -103,9 +114,7 @@ mod tests {
         assert!(no_cache.index_cache.get("abc").is_none());
         let no_cache = Arc::new(no_cache);
 
-        let pq = Arc::new(ProductQuantizer::new(1, 8, 1));
-        let idx = Arc::new(PQIndex::new(pq, MetricType::L2));
-        no_cache.index_cache.insert("abc", idx);
+        no_cache.index_cache.insert("abc", dummy_index(1));
 
         assert!(no_cache.index_cache.get("abc").is_none());
         assert_eq!(no_cache.index_cache.len(), 0);
@@ -116,22 +125,21 @@ mod tests {
         let session = Session::new(10, 1);
         let session = Arc::new(session);
 
-        let pq = Arc::new(ProductQuantizer::new(1, 8, 1));
-        let idx = Arc::new(PQIndex::new(pq, MetricType::L2));
-        session.index_cache.insert("abc", idx.clone());
+        session.index_cache.insert("abc", dummy_index(1));
 
         let found = session.index_cache.get("abc");
         assert!(found.is_some());
-        assert_eq!(format!("{:?}", found.unwrap()), format!("{:?}", idx));
+        assert_eq!(
+            format!("{:?}", found.unwrap()),
+            format!("{:?}", dummy_index(1))
+        );
         assert!(session.index_cache.get("abc").is_some());
         assert_eq!(session.index_cache.len(), 1);
 
         for iter_idx in 0..100 {
-            let pq_other = Arc::new(ProductQuantizer::new(16, 8, 1));
-            let idx_other = Arc::new(PQIndex::new(pq_other, MetricType::L2));
             session
                 .index_cache
-                .insert(format!("{iter_idx}").as_str(), idx_other.clone());
+                .insert(format!("{iter_idx}").as_str(), dummy_index(16));
         }
 
         // Capacity is 10 so there should be at most 10 items


### PR DESCRIPTION
The IVF index can, in theory, support any index embedded inside of it.  However, the protobuf and the I/O routines are somewhat hard-wired for embedding PQ inside of IVF.  This PR is a start at changing that.  It adds a new trait (IndexShardLoader) which can be serialized to/from protobuf.  It contains the metadata needed to load individual shards.  This new trait is used in the read path of IVF but this PR does not yet introduce changes to the protobuf or modify the write path.