### PR TITLE
feat: remove tombstones from the IVF remapping process by shrinking the index

### DIFF
--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -114,6 +114,7 @@ async fn remap_index(
         &field.name,
         index_id,
         &new_id,
+        matched,
         row_id_map,
     )
     .await?;

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -274,6 +274,7 @@ pub(crate) async fn remap_vector_index(
     column: &str,
     old_uuid: &Uuid,
     new_uuid: &Uuid,
+    old_metadata: &crate::format::Index,
     mapping: &HashMap<u64, Option<u64>>,
 ) -> Result<()> {
     let old_index = open_index(dataset.clone(), column, &old_uuid.to_string()).await?;
@@ -290,8 +291,15 @@ pub(crate) async fn remap_vector_index(
         dataset.as_ref(),
         &old_uuid.to_string(),
         &new_uuid.to_string(),
+        old_metadata.dataset_version,
         ivf_index,
         mapping,
+        old_metadata.name.clone(),
+        column.to_string(),
+        // We can safely assume there are no transforms today.  We assert above that the
+        // top stage is IVF and IVF does not support transforms between IVF and PQ.  This
+        // will be fixed in the future.
+        vec![],
     )
     .await?;
     Ok(())


### PR DESCRIPTION
I also simplify the remap tasks a bit by removing some unnecessary traits.