### PR TITLE
feat: remap indices on compaction

### DIFF
--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -98,6 +98,15 @@ message Transaction {
     // These fragments IDs are not yet assigned.
     repeated DataFragment new_fragments = 2;
 
+    // During a rewrite an index may be rewritten.  We only serialize the UUID
+    // since a rewrite should not change the other index parameters.
+    message RewrittenIndex {
+      // The id of the index that will be replaced
+      UUID old_id = 1;
+      // the id of the new index
+      UUID new_id = 2;
+    }
+
     // A group of rewrite files that are all part of the same rewrite.
     message RewriteGroup {
       // The old fragment that is being replaced
@@ -106,11 +115,15 @@ message Transaction {
       repeated DataFragment old_fragments = 1;
       // The new fragment
       //
-      // This fragment ID is not yet assigned.
+      // The ID should have been reserved by an earlier
+      // reserve operation
       repeated DataFragment new_fragments = 2;
     }
 
+    // Groups of files that have been rewritten
     repeated RewriteGroup groups = 3;
+    // Indices that have been rewritten
+    repeated RewrittenIndex rewritten_indices = 4;
   }
 
   // An operation that merges in a new column, altering the schema.

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -131,6 +131,12 @@ message Transaction {
     uint64 version = 1;
   }
 
+  // An operation that reserves fragment ids for future use in
+  // a rewrite operation.
+  message ReserveFragments {
+    uint32 num_fragments = 1;
+  }
+
   // The operation of this transaction.
   oneof operation {
     Append append = 100;
@@ -140,5 +146,6 @@ message Transaction {
     Rewrite rewrite = 104;
     Merge merge = 105;
     Restore restore = 106;
+    ReserveFragments reserve_fragments = 107;
   }
 }

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1130,38 +1130,6 @@ class LanceOperation:
             )
 
     @dataclass
-    class Rewrite(BaseOperation):
-        """
-        Operation that rewrites fragments but does not change the data within them.
-
-        This is for rearranging the data.
-
-        The data are grouped, such that each group contains the old fragments
-        and the new fragments those are rewritten into.
-        """
-
-        groups: Iterable[RewriteGroup]
-
-        @dataclass
-        class RewriteGroup:
-            old_fragments: Iterable[FragmentMetadata]
-            new_fragments: Iterable[FragmentMetadata]
-
-            def __post_init__(self):
-                LanceOperation._validate_fragments(self.old_fragments)
-                LanceOperation._validate_fragments(self.new_fragments)
-
-        def _to_inner(self):
-            groups = [
-                (
-                    [f._metadata for f in g.old_fragments],
-                    [f._metadata for f in g.new_fragments],
-                )
-                for g in self.groups
-            ]
-            return _Operation.rewrite(groups)
-
-    @dataclass
     class Merge(BaseOperation):
         """
         Operation that adds columns. Unlike Overwrite, this should not change

--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -12,13 +12,16 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import pickle
+import random
 import re
 from pathlib import Path
 
 import lance
+import numpy as np
 import pyarrow as pa
 from lance.lance import Compaction
 from lance.optimize import RewriteResult
+from lance.vector import vec_to_table
 
 
 def test_dataset_optimize(tmp_path: Path):
@@ -40,7 +43,84 @@ def test_dataset_optimize(tmp_path: Path):
     assert metrics.files_removed == 10
     assert metrics.files_added == 1
 
-    assert dataset.version == 2
+    assert dataset.version == 3
+
+
+def create_table(min, max, nvec, ndim=8):
+    mat = np.random.uniform(min, max, (nvec, ndim))
+    tbl = vec_to_table(data=mat)
+    print(tbl)
+    return tbl
+
+
+def test_index_remapping(tmp_path: Path):
+    base_dir = tmp_path / "dataset"
+    data = create_table(min=0, max=1, nvec=300)
+
+    dataset = lance.write_dataset(data, base_dir, max_rows_per_file=150)
+    dataset.create_index(
+        "vector", index_type="IVF_PQ", num_partitions=2, num_sub_vectors=2
+    )
+    assert len(dataset.get_fragments()) == 2
+
+    sample_query_indices = random.sample(range(300), 50)
+    vecs = data.column("vector").chunk(0)
+    sample_queries = [
+        {"column": "vector", "q": vecs[i].values, "k": 5} for i in sample_query_indices
+    ]
+
+    first = sample_queries[0]
+
+    def has_target(target, results):
+        for item in results:
+            if item.values == target:
+                return True
+        return False
+
+    def check_index(has_knn_combined):
+        print(dataset.scanner(nearest=first).explain_plan())
+        for query in sample_queries:
+            results = dataset.to_table(nearest=query).column("vector")
+            assert has_target(query["q"], results)
+            plan = dataset.scanner(nearest=query).explain_plan()
+            assert ("KNNFlat" in plan) == has_knn_combined
+
+    # Original state is 2 indexed fragments of size 150.  This should not require
+    # a combined scan
+    check_index(has_knn_combined=False)
+
+    # Compact the 2 fragments into 1.  Combined scan still not needed.
+    dataset.optimize.compact_files()
+    assert len(dataset.get_fragments()) == 1
+    print(dataset.get_fragments())
+    check_index(has_knn_combined=False)
+
+    # Add a new fragment and recalculate the index
+    extra_data = create_table(min=1000, max=1001, nvec=100)
+    dataset = lance.write_dataset(
+        extra_data, base_dir, mode="append", max_rows_per_file=100
+    )
+    dataset.create_index(
+        "vector", index_type="IVF_PQ", num_partitions=2, num_sub_vectors=2, replace=True
+    )
+
+    # Combined scan should not be needed
+    assert len(dataset.get_fragments()) == 2
+    check_index(has_knn_combined=False)
+
+    # Add a new unindexed fragment
+    extra_data = create_table(min=1000, max=1001, nvec=100)
+    dataset = lance.write_dataset(
+        extra_data, base_dir, mode="append", max_rows_per_file=100
+    )
+    assert len(dataset.get_fragments()) == 3
+
+    # Compaction should not combine the unindexed fragment with the indexed fragment
+    dataset.optimize.compact_files()
+    assert len(dataset.get_fragments()) == 2
+
+    # Now a combined scan is required
+    check_index(has_knn_combined=True)
 
 
 def test_dataset_distributed_optimize(tmp_path: Path):
@@ -82,4 +162,5 @@ def test_dataset_distributed_optimize(tmp_path: Path):
     metrics = Compaction.commit(dataset, [result1])
     assert metrics.fragments_removed == 2
     assert metrics.fragments_added == 1
-    assert dataset.version == 2
+    # Compaction occurs in two transactions so it increments the version by 2.
+    assert dataset.version == 3

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -21,10 +21,11 @@ use arrow_array::{Float32Array, RecordBatch};
 use arrow_data::ArrayData;
 use arrow_schema::Schema as ArrowSchema;
 use chrono::Duration;
+use lance::arrow::as_fixed_size_list_array;
 use lance::dataset::{
     fragment::FileFragment as LanceFileFragment, scanner::Scanner as LanceScanner,
-    transaction::Operation as LanceOperation, transaction::RewriteGroup, Dataset as LanceDataset,
-    ReadParams, Version, WriteMode, WriteParams,
+    transaction::Operation as LanceOperation, Dataset as LanceDataset, ReadParams, Version,
+    WriteMode, WriteParams,
 };
 use lance::datatypes::Schema;
 use lance::format::Fragment;
@@ -33,7 +34,6 @@ use lance::index::{
     DatasetIndexExt, IndexType,
 };
 use lance::io::object_store::ObjectStoreParams;
-use lance_arrow::as_fixed_size_list_array;
 use lance_index::vector::pq::PQBuildParams;
 use lance_linalg::distance::MetricType;
 use pyo3::prelude::*;
@@ -116,19 +116,6 @@ impl Operation {
             deleted_fragment_ids,
             predicate,
         };
-        Ok(Self(op))
-    }
-
-    #[staticmethod]
-    fn rewrite(groups: Vec<(Vec<FragmentMetadata>, Vec<FragmentMetadata>)>) -> PyResult<Self> {
-        let groups = groups
-            .into_iter()
-            .map(|(old_fragments, new_fragments)| RewriteGroup {
-                old_fragments: into_fragments(old_fragments),
-                new_fragments: into_fragments(new_fragments),
-            })
-            .collect::<Vec<_>>();
-        let op = LanceOperation::Rewrite { groups };
         Ok(Self(op))
     }
 

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -54,7 +54,7 @@ tokio = { workspace = true }
 url = "2.3"
 rand = { version = "0.8.3", features = ["small_rng"] }
 futures = { workspace = true }
-uuid = { version = "1.2", features = ["v4"] }
+uuid = { version = "1.2", features = ["v4", "serde"] }
 shellexpand = "3.0.0"
 arrow = { version = "43.0.0", features = ["prettyprint"] }
 num_cpus = "1.0"
@@ -77,6 +77,7 @@ aws-sdk-dynamodb = { version = "0.30.0", optional = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }
 lazy_static = "1"
+base64 = "0.21.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accelerate-src = { version = "0.3.2", optional = true }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -43,6 +43,7 @@ pub mod cleanup;
 mod feature_flags;
 pub mod fragment;
 mod hash_joiner;
+pub mod index;
 pub mod optimize;
 pub mod progress;
 pub mod scanner;

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -1,0 +1,66 @@
+use std::collections::HashSet;
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::format::Index;
+use crate::index::remap_index;
+use crate::Dataset;
+use crate::Result;
+
+use super::optimize::{IndexRemapper, IndexRemapperOptions, RemappedIndex};
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DatasetIndexRemapperOptions {}
+
+impl IndexRemapperOptions for DatasetIndexRemapperOptions {
+    fn create_remapper(
+        &self,
+        dataset: &Dataset,
+    ) -> crate::Result<Box<dyn super::optimize::IndexRemapper>> {
+        Ok(Box::new(DatasetIndexRemapper {
+            dataset: Arc::new(dataset.clone()),
+        }))
+    }
+}
+
+struct DatasetIndexRemapper {
+    dataset: Arc<Dataset>,
+}
+
+impl DatasetIndexRemapper {
+    async fn remap_index(
+        &self,
+        index: &Index,
+        mapping: &HashMap<u64, Option<u64>>,
+    ) -> Result<RemappedIndex> {
+        let new_uuid = remap_index(&self.dataset, &index.uuid, mapping).await?;
+        Ok(RemappedIndex::new(index.uuid, new_uuid))
+    }
+}
+
+#[async_trait]
+impl IndexRemapper for DatasetIndexRemapper {
+    async fn remap_indices(
+        &self,
+        mapping: HashMap<u64, Option<u64>>,
+        affected_fragment_ids: &[u64],
+    ) -> Result<Vec<RemappedIndex>> {
+        let affected_frag_ids = HashSet::<u64>::from_iter(affected_fragment_ids.iter().copied());
+        let indices = self.dataset.load_indices().await?;
+        let mut remapped = Vec::with_capacity(indices.len());
+        for index in indices {
+            let needs_remapped = match &index.fragment_bitmap {
+                None => true,
+                Some(fragment_bitmap) => fragment_bitmap
+                    .iter()
+                    .any(|frag_idx| affected_frag_ids.contains(&(frag_idx as u64))),
+            };
+            if needs_remapped {
+                remapped.push(self.remap_index(&index, &mapping).await?);
+            }
+        }
+        Ok(remapped)
+    }
+}

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -890,14 +890,6 @@ pub async fn commit_compaction(
         let rewrite_group = RewriteGroup {
             old_fragments: task.original_fragments,
             new_fragments: task.new_fragments,
-            // rewritten_indices: task
-            //     .remapped_indices
-            //     .iter()
-            //     .map(|rewritten| RewrittenIndex {
-            //         old_id: rewritten.original,
-            //         new_id: rewritten.new,
-            //     })
-            //     .collect(),
         };
         row_id_map.extend(task.row_id_map);
         rewrite_groups.push(rewrite_group);

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -29,12 +29,19 @@
 //! 2. If a fragment has a higher percentage of deleted rows than the provided
 //!    threshold.
 //!
+//! In addition to the rules above there may be restrictions due to indexes.
+//! When a fragment is compacted its row ids change and any index that contained
+//! that fragment will be remapped.  However, we cannot combine indexed fragments
+//! with unindexed fragments.
+//!
 //! ```rust
 //! # use std::sync::Arc;
 //! # use tokio::runtime::Runtime;
 //! # use arrow_array::{RecordBatch, RecordBatchIterator, Int64Array};
 //! # use arrow_schema::{Schema, Field, DataType};
 //! use lance::{dataset::WriteParams, Dataset, dataset::optimize::compact_files};
+//! // Remapping indices is ignored in this example.
+//! use lance::dataset::optimize::IgnoreRemap;
 //!
 //! # let mut rt = Runtime::new().unwrap();
 //! # rt.block_on(async {
@@ -54,7 +61,7 @@
 //! assert_eq!(dataset.get_fragments().len(), 100);
 //!
 //! // Use compact_files() to consolidate the data to 1 fragment
-//! let metrics = compact_files(&mut dataset, Default::default()).await.unwrap();
+//! let metrics = compact_files(&mut dataset, Default::default(), None).await.unwrap();
 //! assert_eq!(metrics.fragments_removed, 100);
 //! assert_eq!(metrics.fragments_added, 1);
 //! assert_eq!(dataset.get_fragments().len(), 1);
@@ -85,20 +92,63 @@
 //! you wish. As long as the tasks don't rewrite any of the same fragments,
 //! they can be committed in any order.
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::ops::{AddAssign, Range};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
+use arrow_array::{RecordBatch, UInt64Array};
+use async_trait::async_trait;
+use datafusion::error::Result as DFResult;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{StreamExt, TryStreamExt};
+use roaring::{RoaringBitmap, RoaringTreemap};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
+use crate::dataset::ROW_ID;
+use crate::format::RowAddress;
 use crate::io::commit::commit_transaction;
 use crate::Result;
 use crate::{format::Fragment, Dataset};
 
 use super::fragment::FileFragment;
-use super::transaction::{Operation, RewriteGroup, Transaction};
+use super::index::DatasetIndexRemapperOptions;
+use super::transaction::{Operation, RewriteGroup, RewrittenIndex, Transaction};
 use super::{write_fragments, WriteMode, WriteParams};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RemappedIndex {
+    original: Uuid,
+    new: Uuid,
+}
+
+impl RemappedIndex {
+    pub fn new(original: Uuid, new: Uuid) -> Self {
+        Self { original, new }
+    }
+}
+
+/// When compaction runs the row ids will change.  This typically means that
+/// indices will need to be remapped.  The details of how this happens are not
+/// a part of the compaction process and so a trait is defined here to allow
+/// for inversion of control.
+#[async_trait]
+pub trait IndexRemapper: Send + Sync {
+    async fn remap_indices(
+        &self,
+        index_map: HashMap<u64, Option<u64>>,
+        affected_fragment_ids: &[u64],
+    ) -> Result<Vec<RemappedIndex>>;
+}
+
+/// Options for creating an [IndexRemapper]
+///
+/// Currently we don't have any options but we may need options in the future and so we
+/// want to keep a placeholder
+pub trait IndexRemapperOptions: Send + Sync {
+    fn create_remapper(&self, dataset: &Dataset) -> Result<Box<dyn IndexRemapper>>;
+}
 
 /// Options to be passed to [compact_files].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -136,6 +186,26 @@ impl Default for CompactionOptions {
             materialize_deletions_threshold: 0.1,
             num_threads: num_cpus::get(),
         }
+    }
+}
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IgnoreRemap {}
+
+#[async_trait]
+impl IndexRemapper for IgnoreRemap {
+    async fn remap_indices(
+        &self,
+        _: HashMap<u64, Option<u64>>,
+        _: &[u64],
+    ) -> Result<Vec<RemappedIndex>> {
+        Ok(Vec::new())
+    }
+}
+
+impl IndexRemapperOptions for IgnoreRemap {
+    fn create_remapper(&self, _: &Dataset) -> Result<Box<dyn IndexRemapper>> {
+        Ok(Box::new(Self {}))
     }
 }
 
@@ -184,6 +254,7 @@ impl AddAssign for CompactionMetrics {
 pub async fn compact_files(
     dataset: &mut Dataset,
     mut options: CompactionOptions,
+    remap_options: Option<Arc<dyn IndexRemapperOptions>>,
 ) -> Result<CompactionMetrics> {
     options.validate();
 
@@ -201,7 +272,8 @@ pub async fn compact_files(
         .buffer_unordered(options.num_threads);
 
     let completed_tasks: Vec<RewriteResult> = result_stream.try_collect().await?;
-    let metrics = commit_compaction(dataset, completed_tasks).await?;
+    let remap_options = remap_options.unwrap_or(Arc::new(DatasetIndexRemapperOptions::default()));
+    let metrics = commit_compaction(dataset, completed_tasks, remap_options).await?;
 
     Ok(metrics)
 }
@@ -349,6 +421,7 @@ struct CandidateBin {
     pub pos_range: Range<usize>,
     pub candidacy: Vec<CompactionCandidacy>,
     pub row_counts: Vec<usize>,
+    pub indices: Vec<usize>,
 }
 
 impl CandidateBin {
@@ -385,6 +458,8 @@ impl CandidateBin {
                     pos_range: self.pos_range.start..(self.pos_range.start + bin_len),
                     candidacy: self.candidacy.drain(0..bin_len).collect(),
                     row_counts: self.row_counts.drain(0..bin_len).collect(),
+                    // By the time we are splitting for size we are done considering indices
+                    indices: Vec::new(),
                 });
                 self.pos_range.start += bin_len;
             } else {
@@ -396,6 +471,21 @@ impl CandidateBin {
 
         bins
     }
+}
+
+async fn load_index_fragmaps(dataset: &Dataset) -> Result<Vec<RoaringBitmap>> {
+    let indices = dataset.load_indices().await?;
+    let mut index_fragmaps = Vec::with_capacity(indices.len());
+    for index in indices {
+        if let Some(fragment_bitmap) = index.fragment_bitmap {
+            index_fragmaps.push(fragment_bitmap.clone());
+        } else {
+            let dataset_at_index = dataset.checkout_version(index.dataset_version).await?;
+            let frags = 0..dataset_at_index.manifest.max_fragment_id;
+            index_fragmaps.push(RoaringBitmap::from_sorted_iter(frags).unwrap());
+        }
+    }
+    Ok(index_fragmaps)
 }
 
 /// Formulate a plan to compact the files in a dataset
@@ -421,6 +511,16 @@ pub async fn plan_compaction(
         })
         .buffered(num_cpus::get() * 2);
 
+    let index_fragmaps = load_index_fragmaps(dataset).await?;
+    let indices_containing_frag = |frag_id: u32| {
+        index_fragmaps
+            .iter()
+            .enumerate()
+            .filter(|(_, bitmap)| bitmap.contains(frag_id))
+            .map(|(pos, _)| pos)
+            .collect::<Vec<_>>()
+    };
+
     let mut candidate_bins: Vec<CandidateBin> = Vec::new();
     let mut current_bin: Option<CandidateBin> = None;
     let mut i = 0;
@@ -441,6 +541,8 @@ pub async fn plan_compaction(
             None
         };
 
+        let indices = indices_containing_frag(fragment.id as u32);
+
         match (candidacy, &mut current_bin) {
             (None, None) => {} // keep searching
             (Some(candidacy), None) => {
@@ -450,14 +552,29 @@ pub async fn plan_compaction(
                     pos_range: i..(i + 1),
                     candidacy: vec![candidacy],
                     row_counts: vec![metrics.num_rows()],
+                    indices,
                 });
             }
             (Some(candidacy), Some(bin)) => {
-                // Add to current bin
-                bin.fragments.push(fragment);
-                bin.pos_range.end += 1;
-                bin.candidacy.push(candidacy);
-                bin.row_counts.push(metrics.num_rows());
+                // We cannot mix "indexed" and "non-indexed" fragments and so we only consider
+                // the existing bin if it contains the same indices
+                if bin.indices == indices {
+                    // Add to current bin
+                    bin.fragments.push(fragment);
+                    bin.pos_range.end += 1;
+                    bin.candidacy.push(candidacy);
+                    bin.row_counts.push(metrics.num_rows());
+                } else {
+                    // Index set is different.  Complete previous bin and start new one
+                    candidate_bins.push(current_bin.take().unwrap());
+                    current_bin = Some(CandidateBin {
+                        fragments: vec![fragment],
+                        pos_range: i..(i + 1),
+                        candidacy: vec![candidacy],
+                        row_counts: vec![metrics.num_rows()],
+                        indices,
+                    });
+                }
             }
             (None, Some(_)) => {
                 // Bin is complete
@@ -490,7 +607,7 @@ pub async fn plan_compaction(
 /// The result of a single compaction task.
 ///
 /// This should be passed to [commit_compaction()] to commit the operation.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RewriteResult {
     pub metrics: CompactionMetrics,
     pub new_fragments: Vec<Fragment>,
@@ -498,6 +615,180 @@ pub struct RewriteResult {
     pub read_version: u64,
     /// The original fragments being replaced
     pub original_fragments: Vec<Fragment>,
+    pub row_id_map: HashMap<u64, Option<u64>>,
+}
+
+fn extract_row_ids(
+    row_ids: &mut RoaringTreemap,
+    batch: DFResult<RecordBatch>,
+) -> DFResult<RecordBatch> {
+    let batch = batch?;
+
+    let (row_id_idx, _) = batch
+        .schema()
+        .column_with_name(ROW_ID)
+        .expect("Received a batch without row ids");
+    let row_ids_arr = batch.column(row_id_idx);
+    let row_ids_itr = row_ids_arr
+        .as_any()
+        .downcast_ref::<UInt64Array>()
+        .unwrap_or_else(|| {
+            panic!(
+                "Row ids had an unexpected type: {}",
+                row_ids_arr.data_type()
+            )
+        })
+        .values()
+        .iter()
+        .copied();
+    row_ids.append(row_ids_itr).map_err(|err| {
+        datafusion::error::DataFusionError::Execution(format!(
+            "Row ids did not arrive in sorted order: {}",
+            err
+        ))
+    })?;
+    let non_row_ids_cols = (0..batch.num_columns())
+        .filter(|col| *col != row_id_idx)
+        .collect::<Vec<_>>();
+    Ok(batch.project(&non_row_ids_cols)?)
+}
+
+fn make_rowid_capture_stream(
+    row_ids: Arc<RwLock<RoaringTreemap>>,
+    target: SendableRecordBatchStream,
+) -> Result<SendableRecordBatchStream> {
+    let schema = target.schema();
+    let stream = target.map(move |batch| {
+        let mut row_ids = row_ids.write().unwrap();
+        extract_row_ids(&mut row_ids, batch)
+    });
+
+    let (row_id_idx, _) = schema
+        .column_with_name(ROW_ID)
+        .expect("Received a batch without row ids");
+
+    let non_row_ids_cols = (0..schema.fields.len())
+        .filter(|col| *col != row_id_idx)
+        .collect::<Vec<_>>();
+
+    let schema = Arc::new(schema.project(&non_row_ids_cols)?);
+
+    let stream = RecordBatchStreamAdapter::new(schema, stream);
+    Ok(Box::pin(stream))
+}
+
+struct MissingIds<'a, I: Iterator<Item = u64>> {
+    row_ids: I,
+    expected_row_id: u64,
+    current_fragment_idx: usize,
+    last: Option<u64>,
+    fragments: &'a Vec<Fragment>,
+}
+
+impl<'a, I: Iterator<Item = u64>> MissingIds<'a, I> {
+    fn new(row_ids: I, fragments: &'a Vec<Fragment>) -> Self {
+        assert!(!fragments.is_empty());
+        let first_frag = &fragments[0];
+        Self {
+            row_ids,
+            expected_row_id: first_frag.id * RowAddress::FRAGMENT_SIZE,
+            current_fragment_idx: 0,
+            last: None,
+            fragments,
+        }
+    }
+}
+
+impl<'a, I: Iterator<Item = u64>> Iterator for MissingIds<'a, I> {
+    type Item = u64;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.current_fragment_idx >= self.fragments.len() {
+                return None;
+            }
+            let val = if let Some(last) = self.last {
+                self.last = None;
+                last
+            } else {
+                // If we've exhausted row_ids but we aren't done then use 0 which
+                // is guaranteed to not match because that would mean that row_ids
+                // was empty and we check for that earlier.
+                self.row_ids.next().unwrap_or(0)
+            };
+
+            let current_fragment = &self.fragments[self.current_fragment_idx];
+            let frag = val / RowAddress::FRAGMENT_SIZE;
+            let expected_row_id = self.expected_row_id;
+            self.expected_row_id += 1;
+            if (self.expected_row_id % RowAddress::FRAGMENT_SIZE)
+                == current_fragment.physical_rows as u64
+            {
+                self.current_fragment_idx += 1;
+                if self.current_fragment_idx < self.fragments.len() {
+                    self.expected_row_id =
+                        self.fragments[self.current_fragment_idx].id * RowAddress::FRAGMENT_SIZE;
+                }
+            }
+            if frag != current_fragment.id {
+                self.last = Some(val);
+                return Some(expected_row_id);
+            }
+            if val != expected_row_id {
+                self.last = Some(val);
+                return Some(expected_row_id);
+            }
+        }
+    }
+}
+
+fn transpose_row_ids(
+    row_ids: RoaringTreemap,
+    old_fragments: &Vec<Fragment>,
+    new_fragments: &[Fragment],
+) -> HashMap<u64, Option<u64>> {
+    let new_ids = new_fragments.iter().flat_map(|frag| {
+        (0..frag.physical_rows as u32).map(|offset| {
+            Some(u64::from(RowAddress::new_from_parts(
+                frag.id as u32,
+                offset,
+            )))
+        })
+    });
+    let mut mapping = row_ids.iter().zip(new_ids).collect::<HashMap<_, _>>();
+    MissingIds::new(row_ids.into_iter(), old_fragments).for_each(|id| {
+        mapping.insert(id, None);
+    });
+    mapping
+}
+
+async fn reserve_fragment_ids(dataset: &Dataset, fragments: &mut Vec<Fragment>) -> Result<()> {
+    let transaction = Transaction::new(
+        dataset.manifest.version,
+        Operation::ReserveFragments {
+            num_fragments: fragments.len() as u32,
+        },
+        None,
+    );
+
+    let manifest = commit_transaction(
+        dataset,
+        dataset.object_store(),
+        &transaction,
+        &Default::default(),
+        &Default::default(),
+    )
+    .await?;
+
+    // Need +1 since max_fragment_id is inclusive in this case and ranges are exclusive
+    let new_max_exclusive = manifest.max_fragment_id + 1;
+    let reserved_ids = (new_max_exclusive - fragments.len() as u32)..(new_max_exclusive);
+
+    for (fragment, new_id) in fragments.iter_mut().zip(reserved_ids) {
+        fragment.id = new_id as u64;
+    }
+
+    Ok(())
 }
 
 /// Rewrite the files in a single task.
@@ -516,14 +807,17 @@ async fn rewrite_files(
             new_fragments: Vec::new(),
             read_version: dataset.manifest.version,
             original_fragments: task.fragments,
+            row_id_map: HashMap::new(),
         });
     }
 
     let fragments = task.fragments.to_vec();
     let mut scanner = dataset.scan();
-    scanner.with_fragments(fragments);
+    scanner.with_fragments(fragments.clone()).with_row_id();
 
     let data = SendableRecordBatchStream::from(scanner.try_into_stream().await?);
+    let row_ids = Arc::new(RwLock::new(RoaringTreemap::new()));
+    let data_no_row_ids = make_rowid_capture_stream(row_ids.clone(), data)?;
 
     let params = WriteParams {
         max_rows_per_file: options.target_rows_per_fragment,
@@ -531,14 +825,24 @@ async fn rewrite_files(
         mode: WriteMode::Append,
         ..Default::default()
     };
-    let new_fragments = write_fragments(
+    let mut new_fragments = write_fragments(
         dataset.object_store.clone(),
         &dataset.base,
         dataset.schema(),
-        data,
+        data_no_row_ids,
         params,
     )
     .await?;
+
+    let row_ids = Arc::try_unwrap(row_ids)
+        .expect("Row ids lock still owned")
+        .into_inner()
+        .expect("Row ids mutex still locked");
+
+    reserve_fragment_ids(&dataset, &mut new_fragments).await?;
+
+    let row_id_map: HashMap<u64, Option<u64>> =
+        transpose_row_ids(row_ids, &fragments, &new_fragments);
 
     metrics.files_removed = task
         .fragments
@@ -557,6 +861,7 @@ async fn rewrite_files(
         new_fragments,
         read_version: dataset.manifest.version,
         original_fragments: task.fragments,
+        row_id_map,
     })
 }
 
@@ -569,6 +874,7 @@ async fn rewrite_files(
 pub async fn commit_compaction(
     dataset: &mut Dataset,
     completed_tasks: Vec<RewriteResult>,
+    options: Arc<dyn IndexRemapperOptions>,
 ) -> Result<CompactionMetrics> {
     if completed_tasks.is_empty() {
         return Ok(CompactionMetrics::default());
@@ -577,19 +883,48 @@ pub async fn commit_compaction(
     let mut rewrite_groups = Vec::with_capacity(completed_tasks.len());
     let mut metrics = CompactionMetrics::default();
 
+    let mut row_id_map: HashMap<u64, Option<u64>> = HashMap::new();
+
     for task in completed_tasks {
         metrics += task.metrics;
         let rewrite_group = RewriteGroup {
             old_fragments: task.original_fragments,
             new_fragments: task.new_fragments,
+            // rewritten_indices: task
+            //     .remapped_indices
+            //     .iter()
+            //     .map(|rewritten| RewrittenIndex {
+            //         old_id: rewritten.original,
+            //         new_id: rewritten.new,
+            //     })
+            //     .collect(),
         };
+        row_id_map.extend(task.row_id_map);
         rewrite_groups.push(rewrite_group);
     }
+
+    let index_remapper = options.create_remapper(dataset)?;
+    let affected_ids = rewrite_groups
+        .iter()
+        .flat_map(|group| group.old_fragments.iter().map(|frag| frag.id))
+        .collect::<Vec<_>>();
+
+    let remapped_indices = index_remapper
+        .remap_indices(row_id_map, &affected_ids)
+        .await?;
+    let rewritten_indices = remapped_indices
+        .iter()
+        .map(|rewritten| RewrittenIndex {
+            old_id: rewritten.original,
+            new_id: rewritten.new,
+        })
+        .collect();
 
     let transaction = Transaction::new(
         dataset.manifest.version,
         Operation::Rewrite {
             groups: rewrite_groups,
+            rewritten_indices,
         },
         None,
     );
@@ -620,12 +955,138 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_missing_indices() {
+        // Sanity test to make sure MissingIds works.  Does not test actual functionality so
+        // feel free to remove if it becomes inconvenient
+        let frags = vec![
+            Fragment {
+                id: 0,
+                files: Vec::new(),
+                deletion_file: None,
+                physical_rows: 5,
+            },
+            Fragment {
+                id: 3,
+                files: Vec::new(),
+                deletion_file: None,
+                physical_rows: 3,
+            },
+        ];
+        let rows = [(0, 1), (0, 3), (0, 4), (3, 0), (3, 2)]
+            .into_iter()
+            .map(|(frag, offset)| RowAddress::new_from_parts(frag, offset).into());
+
+        let missing = MissingIds::new(rows, &frags).collect::<Vec<_>>();
+        let expected_missing = [(0, 0), (0, 2), (3, 1)]
+            .into_iter()
+            .map(|(frag, offset)| RowAddress::new_from_parts(frag, offset).into())
+            .collect::<Vec<u64>>();
+        assert_eq!(missing, expected_missing);
+    }
+
+    #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+    struct IgnoreRemap {}
+
+    #[async_trait]
+    impl IndexRemapper for IgnoreRemap {
+        async fn remap_indices(
+            &self,
+            _: HashMap<u64, Option<u64>>,
+            _: &[u64],
+        ) -> Result<Vec<RemappedIndex>> {
+            Ok(Vec::new())
+        }
+    }
+
+    impl IndexRemapperOptions for IgnoreRemap {
+        fn create_remapper(&self, _: &Dataset) -> Result<Box<dyn IndexRemapper>> {
+            Ok(Box::new(Self {}))
+        }
+    }
+
+    #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+    struct MockIndexRemapperExpectation {
+        expected: HashMap<u64, Option<u64>>,
+        answer: Vec<RemappedIndex>,
+    }
+
+    #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+    struct MockIndexRemapper {
+        expectations: Vec<MockIndexRemapperExpectation>,
+    }
+
+    impl MockIndexRemapper {
+        fn stringify_map(map: &HashMap<u64, Option<u64>>) -> String {
+            let mut sorted_keys = map.keys().collect::<Vec<_>>();
+            sorted_keys.sort();
+            let mut first_keys = sorted_keys
+                .into_iter()
+                .take(10)
+                .map(|key| {
+                    format!(
+                        "{}:{:?}",
+                        RowAddress::new_from_id(*key),
+                        map[key].map(RowAddress::new_from_id)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            if map.len() > 10 {
+                first_keys.push_str(", ...");
+            }
+            let mut result_str = format!("(len={})", map.len());
+            result_str.push_str(&first_keys);
+            result_str
+        }
+
+        fn in_any_order(expectations: &[Self]) -> Self {
+            let expectations = expectations
+                .iter()
+                .flat_map(|item| item.expectations.clone())
+                .collect::<Vec<_>>();
+            Self { expectations }
+        }
+    }
+
+    #[async_trait]
+    impl IndexRemapper for MockIndexRemapper {
+        async fn remap_indices(
+            &self,
+            index_map: HashMap<u64, Option<u64>>,
+            _: &[u64],
+        ) -> Result<Vec<RemappedIndex>> {
+            for expectation in &self.expectations {
+                if expectation.expected == index_map {
+                    return Ok(expectation.answer.clone());
+                }
+            }
+            panic!(
+                "Unexpected index map (len={}): {}\n  Options: {}",
+                index_map.len(),
+                Self::stringify_map(&index_map),
+                self.expectations
+                    .iter()
+                    .map(|expectation| Self::stringify_map(&expectation.expected))
+                    .collect::<Vec<_>>()
+                    .join("\n  ")
+            );
+        }
+    }
+
+    impl IndexRemapperOptions for MockIndexRemapper {
+        fn create_remapper(&self, _: &Dataset) -> Result<Box<dyn IndexRemapper>> {
+            Ok(Box::new(self.clone()))
+        }
+    }
+
+    #[test]
     fn test_candidate_bin() {
         let empty_bin = CandidateBin {
             fragments: vec![],
             pos_range: 0..0,
             candidacy: vec![],
             row_counts: vec![],
+            indices: vec![],
         };
         assert!(empty_bin.is_noop());
 
@@ -640,6 +1101,7 @@ mod tests {
             pos_range: 0..1,
             candidacy: vec![CompactionCandidacy::CompactWithNeighbors],
             row_counts: vec![100],
+            indices: vec![],
         };
         assert!(single_bin.is_noop());
 
@@ -648,6 +1110,7 @@ mod tests {
             pos_range: 0..1,
             candidacy: vec![CompactionCandidacy::CompactItself],
             row_counts: vec![100],
+            indices: vec![],
         };
         // Not a no-op because it's CompactItself
         assert!(!single_bin.is_noop());
@@ -659,6 +1122,7 @@ mod tests {
                 .take(8)
                 .collect(),
             row_counts: vec![100, 400, 200, 200, 400, 300, 300, 100],
+            indices: vec![],
             // Will group into: [[100, 400], [200, 200, 400], [300, 300, 100]]
             // with size = 500
         };
@@ -696,7 +1160,7 @@ mod tests {
             .unwrap();
         assert_eq!(plan.tasks().len(), 0);
 
-        let metrics = compact_files(&mut dataset, CompactionOptions::default())
+        let metrics = compact_files(&mut dataset, CompactionOptions::default(), None)
             .await
             .unwrap();
 
@@ -747,6 +1211,43 @@ mod tests {
         assert_eq!(plan.tasks().len(), 0);
     }
 
+    fn row_ids(frag_idx: u32, offsets: Range<u32>) -> Range<u64> {
+        let start = RowAddress::new_from_parts(frag_idx, offsets.start);
+        let end = RowAddress::new_from_parts(frag_idx, offsets.end);
+        start.into()..end.into()
+    }
+
+    // The outer list has one item per new fragment
+    // The inner list has ranges of old row ids that map to the new fragment, in order
+    fn expect_remap(
+        ranges: &[Vec<(Range<u64>, bool)>],
+        starting_new_frag_idx: u32,
+    ) -> MockIndexRemapper {
+        let mut expected_remap: HashMap<u64, Option<u64>> = HashMap::new();
+        expected_remap.reserve(ranges.iter().map(|r| r.len()).sum());
+        for (new_frag_offset, new_frag_ranges) in ranges.iter().enumerate() {
+            let new_frag_idx = starting_new_frag_idx + new_frag_offset as u32;
+            let mut row_offset = 0;
+            for (old_id_range, is_found) in new_frag_ranges.iter() {
+                for old_id in old_id_range.clone() {
+                    if *is_found {
+                        let new_id = RowAddress::new_from_parts(new_frag_idx, row_offset);
+                        expected_remap.insert(old_id, Some(new_id.into()));
+                        row_offset += 1;
+                    } else {
+                        expected_remap.insert(old_id, None);
+                    }
+                }
+            }
+        }
+        MockIndexRemapper {
+            expectations: vec![MockIndexRemapperExpectation {
+                expected: expected_remap,
+                answer: vec![],
+            }],
+        }
+    }
+
     #[tokio::test]
     async fn test_compact_many() {
         let test_dir = tempdir().unwrap();
@@ -792,6 +1293,54 @@ mod tests {
             .await
             .unwrap();
 
+        let first_new_frag_idx = 7;
+        // Predicting the remap is difficult.  One task will remap to fragments 7/8 and the other
+        // will remap to fragments 9/10 but we don't know which is which and so we just allow ourselves
+        // to expect both possibilities.
+        let remap_a = expect_remap(
+            &[
+                vec![
+                    // 3 small fragments are rewritten to frags 7 & 8
+                    (row_ids(0, 0..400), true),
+                    (row_ids(1, 0..400), true),
+                    (row_ids(2, 0..200), true),
+                ],
+                vec![(row_ids(2, 200..400), true)],
+                // frag 3 is skipped since it does not have enough missing data
+                // Frags 4, 5, and 6 are rewritten to frags 9 & 10
+                vec![
+                    // Only 800 of the 1000 rows taken from frag 4
+                    (row_ids(4, 0..200), true),
+                    (row_ids(4, 200..400), false),
+                    (row_ids(4, 400..1000), true),
+                    // frags 5 compacted with frag 4
+                    (row_ids(5, 0..200), true),
+                ],
+                vec![(row_ids(5, 200..300), true), (row_ids(6, 0..300), true)],
+            ],
+            first_new_frag_idx,
+        );
+        let remap_b = expect_remap(
+            &[
+                // Frags 4, 5, and 6 are rewritten to frags 7 & 8
+                vec![
+                    (row_ids(4, 0..200), true),
+                    (row_ids(4, 200..400), false),
+                    (row_ids(4, 400..1000), true),
+                    (row_ids(5, 0..200), true),
+                ],
+                vec![(row_ids(5, 200..300), true), (row_ids(6, 0..300), true)],
+                // 3 small fragments rewritten to frags 9 & 10
+                vec![
+                    (row_ids(0, 0..400), true),
+                    (row_ids(1, 0..400), true),
+                    (row_ids(2, 0..200), true),
+                ],
+                vec![(row_ids(2, 200..400), true)],
+            ],
+            first_new_frag_idx,
+        );
+
         // Create compaction plan
         let options = CompactionOptions {
             target_rows_per_fragment: 1000,
@@ -819,8 +1368,12 @@ mod tests {
             vec![4, 5, 6]
         );
 
+        let mock_remapper = MockIndexRemapper::in_any_order(&[remap_a, remap_b]);
+
         // Run compaction
-        let metrics = compact_files(&mut dataset, options).await.unwrap();
+        let metrics = compact_files(&mut dataset, options, Some(Arc::new(mock_remapper)))
+            .await
+            .unwrap();
 
         // Assert on metrics
         assert_eq!(metrics.fragments_removed, 6);
@@ -879,13 +1432,27 @@ mod tests {
 
         dataset.merge(reader, "a", "a").await.unwrap();
 
-        let plan = plan_compaction(&dataset, &CompactionOptions::default())
-            .await
-            .unwrap();
+        let expected_remap = expect_remap(
+            &[vec![
+                // 3 small fragments are rewritten entirely
+                (row_ids(0, 0..5000), true),
+                (row_ids(1, 0..5000), true),
+            ]],
+            2,
+        );
+
+        let plan = plan_compaction(
+            &dataset,
+            &CompactionOptions {
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
         assert_eq!(plan.tasks().len(), 1);
         assert_eq!(plan.tasks()[0].fragments.len(), 2);
 
-        let metrics = compact_files(&mut dataset, CompactionOptions::default())
+        let metrics = compact_files(&mut dataset, plan.options, Some(Arc::new(expected_remap)))
             .await
             .unwrap();
 
@@ -949,7 +1516,7 @@ mod tests {
         let plan = plan_compaction(&dataset, &options).await.unwrap();
         assert_eq!(plan.tasks().len(), 1);
 
-        let metrics = compact_files(&mut dataset, options).await.unwrap();
+        let metrics = compact_files(&mut dataset, options, None).await.unwrap();
         assert_eq!(metrics.fragments_removed, 1);
         assert_eq!(metrics.files_removed, 2);
         assert_eq!(metrics.fragments_added, 1);
@@ -1007,13 +1574,23 @@ mod tests {
         assert_eq!(results[0].metrics.files_added, 1);
 
         // Just commit the last task
-        commit_compaction(&mut dataset, vec![results.pop().unwrap()])
-            .await
-            .unwrap();
-        assert_eq!(dataset.manifest.version, 2);
+        commit_compaction(
+            &mut dataset,
+            vec![results.pop().unwrap()],
+            Arc::new(IgnoreRemap::default()),
+        )
+        .await
+        .unwrap();
+        // 1 commit for each task's reserve fragments plus 1 for
+        // the call to commit_compaction
+        assert_eq!(dataset.manifest.version, 5);
 
         // Can commit the remaining tasks
-        commit_compaction(&mut dataset, results).await.unwrap();
-        assert_eq!(dataset.manifest.version, 3);
+        commit_compaction(&mut dataset, results, Arc::new(IgnoreRemap::default()))
+            .await
+            .unwrap();
+        // The reserve fragments call already happened for this task
+        // and so we just see the bump from the commit_compaction
+        assert_eq!(dataset.manifest.version, 6);
     }
 }

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -45,7 +45,7 @@
 //! (1) Delete and rewrite are compatible with each other and themselves only if
 //! they affect distinct fragments. Otherwise, they conflict.
 
-use std::{collections::HashSet, sync::Arc};
+use std::{collections::HashSet, ops::Range, sync::Arc};
 
 use object_store::path::Path;
 
@@ -112,6 +112,11 @@ pub enum Operation {
     },
     /// Restore an old version of the database
     Restore { version: u64 },
+    /// Reserves fragment ids for future use
+    /// This can be used when row ids need to be known before a transaction
+    /// has been committed.  It is used during a rewrite operation to allow
+    /// indices to be remapped to the new row ids as part of the operation.
+    ReserveFragments { num_fragments: u32 },
 }
 
 #[derive(Debug, Clone)]
@@ -130,6 +135,7 @@ impl Operation {
             Self::Append { .. }
             | Self::Overwrite { .. }
             | Self::CreateIndex { .. }
+            | Self::ReserveFragments { .. }
             | Self::Restore { .. } => Box::new(std::iter::empty()),
             Self::Delete {
                 updated_fragments,
@@ -165,6 +171,7 @@ impl Operation {
             Self::CreateIndex { .. } => "CreateIndex",
             Self::Rewrite { .. } => "Rewrite",
             Self::Merge { .. } => "Merge",
+            Self::ReserveFragments { .. } => "ReserveFragments",
             Self::Restore { .. } => "Restore",
         }
     }
@@ -195,6 +202,7 @@ impl Transaction {
                 Operation::Rewrite { .. } => false,
                 Operation::CreateIndex { .. } => false,
                 Operation::Delete { .. } => false,
+                Operation::ReserveFragments { .. } => false,
                 _ => true,
             },
             Operation::Rewrite { .. } => match &other.operation {
@@ -203,6 +211,7 @@ impl Transaction {
                 // TODO: it could also be compatible with operations that update
                 // fragments we don't touch.
                 Operation::Append { .. } => false,
+                Operation::ReserveFragments { .. } => false,
                 Operation::Delete { .. } => {
                     // If we rewrote any fragments that were modified by delete,
                     // we conflict.
@@ -217,6 +226,12 @@ impl Transaction {
             // Overwrite and Restore always succeed
             Operation::Overwrite { .. } => false,
             Operation::Restore { .. } => false,
+            // ReserveFragments is compatible with anything that doesn't reset the
+            // max fragment id.
+            Operation::ReserveFragments { .. } => matches!(
+                &other.operation,
+                Operation::Overwrite { .. } | Operation::Restore { .. }
+            ),
             Operation::CreateIndex { .. } => match &other.operation {
                 Operation::Append { .. } => false,
                 // Indices are identified by UUIDs, so they shouldn't conflict.
@@ -224,8 +239,9 @@ impl Transaction {
                 // Although some of the rows we indexed may have been deleted,
                 // row ids are still valid, so we allow this optimistically.
                 Operation::Delete { .. } => false,
-                // Merge doesn't change row ids, so this should be fine.
+                // Merge & reserve don't change row ids, so this should be fine.
                 Operation::Merge { .. } => false,
+                Operation::ReserveFragments { .. } => false,
                 // Rewrite likely changed many of the row ids, so our index is
                 // likely useless. It should be rebuilt.
                 // TODO: we could be smarter here and only invalidate the index
@@ -235,6 +251,7 @@ impl Transaction {
             },
             Operation::Delete { .. } => match &other.operation {
                 Operation::CreateIndex { .. } => false,
+                Operation::ReserveFragments { .. } => false,
                 Operation::Delete { .. } => {
                     // If we update the same fragments, we conflict.
                     self.operation.modifies_same_ids(&other.operation)
@@ -245,22 +262,28 @@ impl Transaction {
                 }
                 _ => true,
             },
-            // Merge changes the schema, but preserves row ids, so the only operation
-            // it's compatible with is CreateIndex.
-            Operation::Merge { .. } => !matches!(&other.operation, Operation::CreateIndex { .. }),
+            // Merge changes the schema, but preserves row ids, so the only operations
+            // it's compatible with is CreateIndex and ReserveFragments.
+            Operation::Merge { .. } => !matches!(
+                &other.operation,
+                Operation::CreateIndex { .. } | Operation::ReserveFragments { .. }
+            ),
         }
     }
 
     fn fragments_with_ids<'a, T>(
         new_fragments: T,
         fragment_id: &'a mut u64,
+        reserved_fragment_ids: Range<u64>,
     ) -> impl Iterator<Item = Fragment> + 'a
     where
         T: IntoIterator<Item = Fragment> + 'a,
     {
-        new_fragments.into_iter().map(|mut f| {
-            f.id = *fragment_id;
-            *fragment_id += 1;
+        new_fragments.into_iter().map(move |mut f| {
+            if !reserved_fragment_ids.contains(&f.id) {
+                f.id = *fragment_id;
+                *fragment_id += 1;
+            }
             f
         })
     }
@@ -292,6 +315,7 @@ impl Transaction {
         current_indices: Vec<Index>,
         transaction_file_path: &str,
         config: &ManifestWriteConfig,
+        reserved_fragment_ids: Range<u64>,
     ) -> Result<(Manifest, Vec<Index>)> {
         // Get the schema and the final fragment list
         let schema = match self.operation {
@@ -335,6 +359,7 @@ impl Transaction {
                 final_fragments.extend(Self::fragments_with_ids(
                     fragments.clone(),
                     &mut fragment_id,
+                    reserved_fragment_ids,
                 ));
             }
             Operation::Delete {
@@ -357,6 +382,7 @@ impl Transaction {
                 final_fragments.extend(Self::fragments_with_ids(
                     fragments.clone(),
                     &mut fragment_id,
+                    reserved_fragment_ids,
                 ));
                 final_indices = Vec::new();
             }
@@ -368,6 +394,7 @@ impl Transaction {
                     groups,
                     &mut fragment_id,
                     current_version,
+                    reserved_fragment_ids,
                 )?;
             }
             Operation::CreateIndex { new_indices } => {
@@ -378,6 +405,9 @@ impl Transaction {
                         .any(|new_index| new_index.name == existing_index.name)
                 });
                 final_indices.extend(new_indices.clone());
+            }
+            Operation::ReserveFragments { .. } => {
+                final_fragments.extend(maybe_existing_fragments?.clone());
             }
             Operation::Merge { ref fragments, .. } => {
                 final_fragments.extend(fragments.clone());
@@ -402,6 +432,10 @@ impl Transaction {
 
         manifest.update_max_fragment_id();
 
+        if let Operation::ReserveFragments { num_fragments } = self.operation {
+            manifest.max_fragment_id += num_fragments;
+        }
+
         manifest.transaction_file = Some(transaction_file_path.to_string());
 
         Ok((manifest, final_indices))
@@ -412,6 +446,7 @@ impl Transaction {
         groups: &[RewriteGroup],
         fragment_id: &mut u64,
         version: u64,
+        reserved_fragment_ids: Range<u64>,
     ) -> Result<()> {
         for group in groups {
             // If the old fragments are contiguous, find the range
@@ -433,7 +468,11 @@ impl Transaction {
                 }
             };
 
-            let new_fragments = Self::fragments_with_ids(group.new_fragments.clone(), fragment_id);
+            let new_fragments = Self::fragments_with_ids(
+                group.new_fragments.clone(),
+                fragment_id,
+                reserved_fragment_ids.clone(),
+            );
             if let Some(replace_range) = replace_range {
                 // Efficiently path using slice
                 final_fragments.splice(replace_range, new_fragments);
@@ -475,6 +514,11 @@ impl TryFrom<&pb::Transaction> for Transaction {
             })) => Operation::Overwrite {
                 fragments: fragments.iter().map(Fragment::from).collect(),
                 schema: Schema::from(schema),
+            },
+            Some(pb::transaction::Operation::ReserveFragments(
+                pb::transaction::ReserveFragments { num_fragments },
+            )) => Operation::ReserveFragments {
+                num_fragments: *num_fragments,
             },
             Some(pb::transaction::Operation::Rewrite(pb::transaction::Rewrite {
                 old_fragments,
@@ -568,6 +612,11 @@ impl From<&Transaction> for pb::Transaction {
                     fragments: fragments.iter().map(pb::DataFragment::from).collect(),
                     schema: schema.into(),
                     schema_metadata: Default::default(), // TODO: handle metadata
+                })
+            }
+            Operation::ReserveFragments { num_fragments } => {
+                pb::transaction::Operation::ReserveFragments(pb::transaction::ReserveFragments {
+                    num_fragments: *num_fragments,
                 })
             }
             Operation::Rewrite { groups } => {
@@ -665,6 +714,7 @@ mod tests {
                     new_fragments: vec![fragment1.clone()],
                 }],
             },
+            Operation::ReserveFragments { num_fragments: 3 },
         ];
         let other_transactions = other_operations
             .iter()
@@ -678,7 +728,7 @@ mod tests {
                 Operation::Append {
                     fragments: vec![fragment0.clone()],
                 },
-                [false, false, false, true, true, false],
+                [false, false, false, true, true, false, false],
             ),
             (
                 Operation::Delete {
@@ -687,7 +737,7 @@ mod tests {
                     deleted_fragment_ids: vec![],
                     predicate: "x > 2".to_string(),
                 },
-                [true, false, false, true, true, false],
+                [true, false, false, true, true, false, false],
             ),
             (
                 Operation::Delete {
@@ -696,7 +746,7 @@ mod tests {
                     deleted_fragment_ids: vec![],
                     predicate: "x > 2".to_string(),
                 },
-                [true, false, true, true, true, true],
+                [true, false, true, true, true, true, false],
             ),
             (
                 Operation::Overwrite {
@@ -705,14 +755,14 @@ mod tests {
                 },
                 // No conflicts: overwrite can always happen since it doesn't
                 // depend on previous state of the table.
-                [false, false, false, false, false, false],
+                [false, false, false, false, false, false, false],
             ),
             (
                 Operation::CreateIndex {
                     new_indices: vec![index0],
                 },
                 // Will only conflict with operations that modify row ids.
-                [false, false, false, false, true, true],
+                [false, false, false, false, true, true, false],
             ),
             (
                 // Rewrite that affects different fragments
@@ -722,7 +772,7 @@ mod tests {
                         new_fragments: vec![fragment0.clone()],
                     }],
                 },
-                [false, true, false, true, true, false],
+                [false, true, false, true, true, false, false],
             ),
             (
                 // Rewrite that affects the same fragments
@@ -732,15 +782,20 @@ mod tests {
                         new_fragments: vec![fragment0.clone()],
                     }],
                 },
-                [false, true, true, true, true, true],
+                [false, true, true, true, true, true, false],
             ),
             (
                 Operation::Merge {
                     fragments: vec![fragment0.clone(), fragment2.clone()],
                     schema: Schema::default(),
                 },
-                // Merge conflicts with everything except CreateIndex.
-                [true, false, true, true, true, true],
+                // Merge conflicts with everything except CreateIndex and ReserveFragments.
+                [true, false, true, true, true, true, false],
+            ),
+            (
+                Operation::ReserveFragments { num_fragments: 2 },
+                // ReserveFragments only conflicts with Overwrite and Restore.
+                [false, false, false, false, true, false, false],
             ),
         ];
 
@@ -773,16 +828,19 @@ mod tests {
             // as 1 and 2.
             RewriteGroup {
                 old_fragments: vec![Fragment::new(1), Fragment::new(2)],
-                new_fragments: vec![Fragment::new(0), Fragment::new(0)],
+                // These two fragments were previously reserved
+                new_fragments: vec![Fragment::new(15), Fragment::new(16)],
             },
             // These are not contiguous, so they will be inserted at the end.
             RewriteGroup {
                 old_fragments: vec![Fragment::new(5), Fragment::new(8)],
+                // We pretend this id was not reserved.  Does not happen in practice today
+                // but we want to leave the door open.
                 new_fragments: vec![Fragment::new(0)],
             },
         ];
 
-        let mut fragment_id = 10;
+        let mut fragment_id = 20;
         let version = 0;
 
         Transaction::handle_rewrite_fragments(
@@ -790,21 +848,22 @@ mod tests {
             &rewrite_groups,
             &mut fragment_id,
             version,
+            15..17,
         )
         .unwrap();
 
-        assert_eq!(fragment_id, 13);
+        assert_eq!(fragment_id, 21);
 
         let expected_fragments: Vec<Fragment> = vec![
             Fragment::new(0),
-            Fragment::new(10),
-            Fragment::new(11),
+            Fragment::new(15),
+            Fragment::new(16),
             Fragment::new(3),
             Fragment::new(4),
             Fragment::new(6),
             Fragment::new(7),
             Fragment::new(9),
-            Fragment::new(12),
+            Fragment::new(20),
         ];
 
         assert_eq!(final_fragments, expected_fragments);

--- a/rust/lance/src/datatypes/schema.rs
+++ b/rust/lance/src/datatypes/schema.rs
@@ -227,7 +227,6 @@ impl Schema {
     }
 
     /// Get field by its id.
-    #[allow(dead_code)]
     pub(crate) fn field_by_id(&self, id: impl Into<i32>) -> Option<&Field> {
         let id = id.into();
         for field in self.fields.iter() {

--- a/rust/lance/src/format/fragment.rs
+++ b/rust/lance/src/format/fragment.rs
@@ -210,6 +210,54 @@ impl From<&Fragment> for pb::DataFragment {
     }
 }
 
+pub struct RowAddress(u64);
+
+impl RowAddress {
+    pub const FRAGMENT_SIZE: u64 = 1 << 32;
+    // A fragment id that will never be used
+    pub const TOMBSTONE_FRAG: u32 = 0xffffffff;
+    // A row id that will never be used
+    pub const TOMBSTONE_ROW: u64 = 0xffffffffffffffff;
+
+    pub fn new_from_id(row_id: u64) -> Self {
+        Self(row_id)
+    }
+
+    pub fn new_from_parts(fragment_id: u32, row_id: u32) -> Self {
+        Self(((fragment_id as u64) << 32) | row_id as u64)
+    }
+
+    pub fn first_row(fragment_id: u32) -> Self {
+        Self::new_from_parts(fragment_id, 0)
+    }
+
+    pub fn fragment_id(&self) -> u32 {
+        (self.0 >> 32) as u32
+    }
+
+    pub fn row_id(&self) -> u32 {
+        self.0 as u32
+    }
+}
+
+impl From<RowAddress> for u64 {
+    fn from(row_id: RowAddress) -> Self {
+        row_id.0
+    }
+}
+
+impl std::fmt::Debug for RowAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self) // use Display
+    }
+}
+
+impl std::fmt::Display for RowAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({}, {})", self.fragment_id(), self.row_id())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -80,8 +80,7 @@ pub trait IndexParams: Send + Sync {
     fn as_any(&self) -> &dyn Any;
 }
 
-#[allow(dead_code)]
-async fn remap_index(
+pub(crate) async fn remap_index(
     dataset: &Dataset,
     index_id: &Uuid,
     row_id_map: &HashMap<u64, Option<u64>>,

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -16,6 +16,7 @@
 //!
 
 use std::any::Any;
+use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
 
@@ -34,6 +35,7 @@ pub mod vector;
 
 use crate::dataset::transaction::{Operation, Transaction};
 use crate::format::Index as IndexMetadata;
+use crate::index::vector::remap_vector_index;
 use crate::io::commit::commit_transaction;
 use crate::{dataset::Dataset, Error, Result};
 
@@ -76,6 +78,48 @@ pub trait IndexBuilder {
 
 pub trait IndexParams: Send + Sync {
     fn as_any(&self) -> &dyn Any;
+}
+
+#[allow(dead_code)]
+async fn remap_index(
+    dataset: &Dataset,
+    index_id: &Uuid,
+    row_id_map: &HashMap<u64, Option<u64>>,
+) -> Result<Uuid> {
+    // Load indices from the disk.
+    let indices = dataset.load_indices().await?;
+    let matched = indices
+        .iter()
+        .find(|i| i.uuid == *index_id)
+        .ok_or_else(|| Error::Index {
+            message: format!("Index with id {} does not exist", index_id),
+        })?;
+
+    if matched.fields.len() > 1 {
+        return Err(Error::Index {
+            message: "Remapping indices with multiple fields is not supported".to_string(),
+        });
+    }
+    let field = matched
+        .fields
+        .first()
+        .expect("An index existed with no fields");
+
+    let field = dataset.schema().field_by_id(*field).unwrap();
+
+    let new_id = Uuid::new_v4();
+
+    remap_vector_index(
+        Arc::new(dataset.clone()),
+        &field.name,
+        index_id,
+        &new_id,
+        matched,
+        row_id_map,
+    )
+    .await?;
+
+    Ok(new_id)
 }
 
 /// Extends Dataset with secondary index.

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -33,6 +33,7 @@ mod utils;
 
 use lance_index::vector::pq::{PQBuildParams, ProductQuantizer};
 use lance_linalg::distance::*;
+use tracing::instrument;
 use uuid::Uuid;
 
 use self::{
@@ -212,6 +213,7 @@ fn is_diskann(stages: &[StageParams]) -> bool {
 }
 
 /// Build a Vector Index
+#[instrument(skip(dataset))]
 pub(crate) async fn build_vector_index(
     dataset: &Dataset,
     column: &str,
@@ -268,6 +270,7 @@ pub(crate) async fn build_vector_index(
     Ok(())
 }
 
+#[instrument(skip_all, fields(old_uuid = old_uuid.to_string(), new_uuid = new_uuid.to_string(), num_rows = mapping.len()))]
 pub(crate) async fn remap_vector_index(
     dataset: Arc<Dataset>,
     column: &str,

--- a/rust/lance/src/index/vector/diskann/search.rs
+++ b/rust/lance/src/index/vector/diskann/search.rs
@@ -15,7 +15,7 @@
 use std::{
     any::Any,
     cmp::Reverse,
-    collections::{BTreeMap, BinaryHeap, HashSet},
+    collections::{BTreeMap, BinaryHeap, HashMap, HashSet},
     sync::Arc,
 };
 
@@ -265,9 +265,21 @@ impl VectorIndex for DiskANNIndex {
         _reader: &dyn ObjectReader,
         _offset: usize,
         _length: usize,
-    ) -> Result<Arc<dyn VectorIndex>> {
+    ) -> Result<Box<dyn VectorIndex>> {
         Err(Error::Index {
             message: "DiskANNIndex is not loadable".to_string(),
+        })
+    }
+
+    fn check_can_remap(&self) -> Result<()> {
+        Err(Error::NotSupported {
+            source: "DiskANNIndex does not yet support remap".into(),
+        })
+    }
+
+    fn remap(&mut self, _mapping: &HashMap<u64, Option<u64>>) -> Result<()> {
+        Err(Error::NotSupported {
+            source: "DiskANNIndex does not yet support remap".into(),
         })
     }
 }

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -14,7 +14,7 @@
 
 //! IVF - Inverted File index.
 
-use std::{any::Any, sync::Arc};
+use std::{any::Any, collections::HashMap, sync::Arc};
 
 use arrow_arith::arithmetic::subtract_dyn;
 use arrow_array::{
@@ -31,7 +31,7 @@ use futures::{
     TryStreamExt,
 };
 use lance_arrow::*;
-use lance_core::io::WriteExt;
+use lance_core::io::{WriteExt, Writer};
 use lance_index::vector::{
     pq::{PQBuildParams, ProductQuantizer},
     RESIDUAL_COLUMN,
@@ -46,13 +46,16 @@ use tracing::{instrument, span, Level};
 #[cfg(feature = "opq")]
 use super::opq::train_opq;
 use super::{
-    pq::train_pq, utils::maybe_sample_training_data, MetricType, Query, VectorIndex,
-    INDEX_FILE_NAME,
+    pq::{train_pq, PQIndex},
+    utils::maybe_sample_training_data,
+    MetricType, Query, VectorIndex, INDEX_FILE_NAME,
 };
 use crate::{
     dataset::Dataset,
     datatypes::Field,
+    encodings::plain::PlainEncoder,
     index::{pb, prefilter::PreFilter, vector::Transformer, Index},
+    io::object_writer::ObjectWriter,
     io::RecordBatchStream,
 };
 use crate::{
@@ -123,6 +126,7 @@ impl IVFIndex {
                 .sub_index
                 .load(self.reader.as_ref(), offset, length)
                 .await?;
+            let idx: Arc<dyn VectorIndex> = idx.into();
             self.session.index_cache.insert(&cache_key, idx.clone());
             idx
         };
@@ -240,9 +244,25 @@ impl VectorIndex for IVFIndex {
         _reader: &dyn ObjectReader,
         _offset: usize,
         _length: usize,
-    ) -> Result<Arc<dyn VectorIndex>> {
+    ) -> Result<Box<dyn VectorIndex>> {
         Err(Error::Index {
             message: "Flat index does not support load".to_string(),
+        })
+    }
+
+    fn check_can_remap(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn remap(&mut self, _mapping: &HashMap<u64, Option<u64>>) -> Result<()> {
+        // This will be needed if we want to clean up IVF to allow more than just
+        // one layer (e.g. IVF -> IVF -> PQ).  We need to pass on the call to
+        // remap to the lower layers.
+
+        // Currently, remapping for IVF is implemented in remap_index_file which
+        // mirrors some of the other IVF routines like build_ivf_pq_index
+        Err(Error::Index {
+            message: "Remapping IVF in this way not supported".to_string(),
         })
     }
 }
@@ -719,6 +739,124 @@ pub async fn build_ivf_pq_index(
     .await
 }
 
+struct RemapPageTask {
+    offset: usize,
+    length: u32,
+    page: Option<Box<dyn VectorIndex>>,
+}
+
+impl RemapPageTask {
+    fn new(offset: usize, length: u32) -> Self {
+        Self {
+            offset,
+            length,
+            page: None,
+        }
+    }
+}
+
+impl RemapPageTask {
+    async fn load_and_remap(
+        mut self,
+        reader: &dyn ObjectReader,
+        index: &IVFIndex,
+        mapping: &HashMap<u64, Option<u64>>,
+    ) -> Result<Self> {
+        let mut page = index
+            .sub_index
+            .load(reader, self.offset, self.length as usize)
+            .await?;
+        page.remap(mapping)?;
+        self.page = Some(page);
+        Ok(self)
+    }
+
+    async fn write(self, writer: &mut ObjectWriter, ivf: &mut Ivf) -> Result<()> {
+        let page = self.page.as_ref().expect("Load was not called");
+        let page: &PQIndex = page
+            .as_any()
+            .downcast_ref()
+            .expect("Generic index writing not supported yet");
+        ivf.offsets.push(writer.tell());
+        ivf.lengths
+            .push(page.row_ids.as_ref().unwrap().len() as u32);
+        PlainEncoder::write(writer, &[page.code.as_ref().unwrap().as_ref()]).await?;
+        PlainEncoder::write(writer, &[page.row_ids.as_ref().unwrap().as_ref()]).await?;
+        Ok(())
+    }
+}
+
+fn generate_remap_tasks(offsets: &Vec<usize>, lengths: &[u32]) -> Result<Vec<RemapPageTask>> {
+    let mut tasks: Vec<RemapPageTask> = Vec::with_capacity(offsets.len() * 2 + 1);
+
+    for (offset, length) in offsets.iter().zip(lengths.iter()) {
+        tasks.push(RemapPageTask::new(*offset, *length));
+    }
+
+    Ok(tasks)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn remap_index_file(
+    dataset: &Dataset,
+    old_uuid: &str,
+    new_uuid: &str,
+    old_version: u64,
+    index: &IVFIndex,
+    mapping: &HashMap<u64, Option<u64>>,
+    name: String,
+    column: String,
+    transforms: Vec<pb::Transform>,
+) -> Result<()> {
+    let object_store = dataset.object_store();
+    let old_path = dataset.indices_dir().child(old_uuid).child(INDEX_FILE_NAME);
+    let new_path = dataset.indices_dir().child(new_uuid).child(INDEX_FILE_NAME);
+
+    let reader = object_store.open(&old_path).await?;
+    let mut writer = object_store.create(&new_path).await?;
+
+    let tasks = generate_remap_tasks(&index.ivf.offsets, &index.ivf.lengths)?;
+
+    let mut task_stream = stream::iter(tasks.into_iter())
+        .map(|task| task.load_and_remap(reader.as_ref(), index, mapping))
+        .buffered(num_cpus::get());
+
+    let mut ivf = Ivf {
+        centroids: index.ivf.centroids.clone(),
+        offsets: Vec::with_capacity(index.ivf.offsets.len()),
+        lengths: Vec::with_capacity(index.ivf.lengths.len()),
+    };
+    while let Some(write_task) = task_stream.try_next().await? {
+        write_task.write(&mut writer, &mut ivf).await?;
+    }
+
+    let pq_sub_index = index
+        .sub_index
+        .as_any()
+        .downcast_ref::<PQIndex>()
+        .ok_or_else(|| Error::NotSupported {
+            source: "Remapping a non-pq sub-index".into(),
+        })?;
+
+    let metadata = IvfPQIndexMetadata {
+        name,
+        column,
+        dimension: index.ivf.dimension() as u32,
+        dataset_version: old_version,
+        ivf,
+        metric_type: index.metric_type,
+        pq: pq_sub_index.pq.clone(),
+        transforms,
+    };
+
+    let metadata = pb::Index::try_from(&metadata)?;
+    let pos = writer.write_protobuf(&metadata).await?;
+    writer.write_magics(pos).await?;
+    writer.shutdown().await?;
+
+    Ok(())
+}
+
 /// Write the index to the index file.
 ///
 #[allow(clippy::too_many_arguments)]
@@ -807,18 +945,240 @@ async fn train_ivf_model(
 mod tests {
     use super::*;
 
-    use arrow_array::{cast::AsArray, RecordBatchIterator};
+    use arrow_array::{cast::AsArray, RecordBatchIterator, RecordBatchReader, UInt64Array};
     use arrow_schema::{DataType, Field, Schema};
-    use lance_testing::datagen::generate_random_array;
+    use lance_testing::datagen::{
+        generate_random_array, generate_scaled_random_array, sample_without_replacement,
+    };
+    use rand::{seq::SliceRandom, thread_rng};
     use tempfile::tempdir;
+    use uuid::Uuid;
 
     use std::collections::HashMap;
 
-    use crate::index::{vector::VectorIndexParams, DatasetIndexExt, IndexType};
+    use crate::{
+        format::RowAddress,
+        index::{
+            vector::{open_index, VectorIndexParams},
+            DatasetIndexExt, IndexType,
+        },
+    };
 
-    #[tokio::test]
-    async fn test_create_ivf_pq_with_centroids() {
-        const DIM: usize = 32;
+    const DIM: usize = 32;
+
+    /// This goal of this function is to generate data that behaves in a very deterministic way so that
+    /// we can evaluate the correctness of an IVF_PQ implementation.  Currently it is restricted to the
+    /// L2 distance metric.
+    ///
+    /// First, we generate a set of centroids.  These are generated randomly but we ensure that is
+    /// sufficient distance between each of the centroids.
+    ///
+    /// Then, we generate 256 vectors per centroid.  Each vector is generated by making a line by
+    /// adding / subtracting [1,1,1...,1] (with the centroid in the middle)
+    ///
+    /// The trained result should have our generated centroids (without these centroids actually being
+    /// a part of the input data) and the PQ codes for every data point should be identical and, given
+    /// any three data points a, b, and c that are in the same centroid then the distance between a and
+    /// b should be different than the distance between a and c.
+    struct WellKnownIvfPqData {
+        dim: u32,
+        num_centroids: u32,
+        centroids: Option<Float32Array>,
+        vectors: Option<Float32Array>,
+    }
+
+    impl WellKnownIvfPqData {
+        // Right now we are assuming 8-bit codes
+        const VALS_PER_CODE: u32 = 256;
+        const COLUMN: &'static str = "vector";
+
+        fn new(dim: u32, num_centroids: u32) -> Self {
+            Self {
+                dim,
+                num_centroids,
+                centroids: None,
+                vectors: None,
+            }
+        }
+
+        fn distance_between_points(&self) -> f32 {
+            (self.dim as f32).sqrt()
+        }
+
+        fn generate_centroids(&self) -> Float32Array {
+            const MAX_ATTEMPTS: u32 = 10;
+            let distance_needed =
+                self.distance_between_points() * Self::VALS_PER_CODE as f32 * 2_f32;
+            let mut attempts_remaining = MAX_ATTEMPTS;
+            let num_values = self.dim * self.num_centroids;
+            while attempts_remaining > 0 {
+                // Use some biggish numbers to ensure we get the distance we want but make them positive
+                // and not too big for easier debugging.
+                let centroids: Float32Array =
+                    generate_scaled_random_array(num_values as usize, 0_f32, 1000_f32);
+                let mut broken = false;
+                for (index, centroid) in centroids
+                    .values()
+                    .chunks_exact(self.dim as usize)
+                    .enumerate()
+                {
+                    let offset = (index + 1) * self.dim as usize;
+                    let length = centroids.len() - offset;
+                    if length == 0 {
+                        // This will be true for the last item since we ignore comparison with self
+                        continue;
+                    }
+                    let distances = l2_distance_batch(
+                        centroid,
+                        &centroids.values().slice(offset, length),
+                        self.dim as usize,
+                    );
+                    let min_distance = distances
+                        .values()
+                        .iter()
+                        .copied()
+                        .min_by(|a, b| a.total_cmp(b))
+                        .unwrap();
+                    // In theory we could just replace this one vector but, out of laziness, we just retry all of them
+                    if min_distance < distance_needed {
+                        broken = true;
+                        break;
+                    }
+                }
+                if !broken {
+                    return centroids;
+                }
+                attempts_remaining -= 1;
+            }
+            panic!(
+                "Unable to generate centroids with sufficient distance after {} attempts",
+                MAX_ATTEMPTS
+            );
+        }
+
+        fn get_centroids(&mut self) -> &Float32Array {
+            if self.centroids.is_some() {
+                return self.centroids.as_ref().unwrap();
+            }
+            self.centroids = Some(self.generate_centroids());
+            self.centroids.as_ref().unwrap()
+        }
+
+        fn get_centroids_as_list_arr(&mut self) -> Arc<FixedSizeListArray> {
+            Arc::new(
+                FixedSizeListArray::try_new_from_values(
+                    self.get_centroids().clone(),
+                    self.dim as i32,
+                )
+                .unwrap(),
+            )
+        }
+
+        fn generate_vectors(&mut self) -> Float32Array {
+            let dim = self.dim as usize;
+            let num_centroids = self.num_centroids;
+            let centroids = self.get_centroids();
+            let mut vectors: Vec<f32> =
+                vec![0_f32; Self::VALS_PER_CODE as usize * dim * num_centroids as usize];
+            for (centroid, dst_batch) in centroids
+                .values()
+                .chunks_exact(dim)
+                .zip(vectors.chunks_exact_mut(dim * Self::VALS_PER_CODE as usize))
+            {
+                for (offset, dst) in (-128..0).chain(1..129).zip(dst_batch.chunks_exact_mut(dim)) {
+                    for (cent_val, dst_val) in centroid.iter().zip(dst) {
+                        *dst_val = *cent_val + offset as f32;
+                    }
+                }
+            }
+            Float32Array::from(vectors)
+        }
+
+        fn get_vectors(&mut self) -> &Float32Array {
+            if self.vectors.is_some() {
+                return self.vectors.as_ref().unwrap();
+            }
+            self.vectors = Some(self.generate_vectors());
+            self.vectors.as_ref().unwrap()
+        }
+
+        fn get_vector(&mut self, idx: u32) -> Float32Array {
+            let dim = self.dim as usize;
+            let vectors = self.get_vectors();
+            let start = idx as usize * dim;
+            vectors.slice(start, dim)
+        }
+
+        fn generate_batches(&mut self) -> impl RecordBatchReader + Send + 'static {
+            let dim = self.dim as usize;
+            let vectors_array = self.get_vectors();
+
+            let schema = Arc::new(Schema::new(vec![Field::new(
+                Self::COLUMN,
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    dim as i32,
+                ),
+                true,
+            )]));
+            let array = Arc::new(
+                FixedSizeListArray::try_new_from_values(vectors_array.clone(), dim as i32).unwrap(),
+            );
+            let batch = RecordBatch::try_new(schema.clone(), vec![array.clone()]).unwrap();
+            RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone())
+        }
+
+        async fn generate_dataset(&mut self, test_uri: &str) -> Result<Dataset> {
+            let batches = self.generate_batches();
+            Dataset::write(batches, test_uri, None).await
+        }
+
+        async fn check_index<F: Fn(u64) -> Option<u64>>(
+            &mut self,
+            index: &IVFIndex,
+            prefilter: &PreFilter,
+            ids_to_test: &Vec<u64>,
+            row_id_map: F,
+        ) {
+            const ROWS_TO_TEST: u32 = 500;
+            let num_vectors = ids_to_test.len() as u32 / self.dim;
+            let num_tests = ROWS_TO_TEST.min(num_vectors);
+            let row_ids_to_test = sample_without_replacement(ids_to_test, num_tests);
+            for row_id in row_ids_to_test {
+                let row = self.get_vector(row_id as u32);
+                let query = Query {
+                    column: Self::COLUMN.to_string(),
+                    key: Arc::new(row),
+                    k: 5,
+                    nprobes: 1,
+                    refine_factor: None,
+                    metric_type: MetricType::L2,
+                    use_index: true,
+                };
+                let search_result = index.search(&query, prefilter).await.unwrap();
+
+                let found_ids = search_result.column(1);
+                let found_ids = found_ids.as_any().downcast_ref::<UInt64Array>().unwrap();
+                let expected_id = row_id_map(row_id);
+
+                match expected_id {
+                    // Original id was deleted, results can be anything, just make sure they don't
+                    // include the original id
+                    None => assert!(!found_ids.iter().any(|f_id| f_id.unwrap() == row_id)),
+                    // Original id remains or was remapped, make sure expected id in results
+                    Some(expected_id) => {
+                        assert!(found_ids.iter().any(|f_id| f_id.unwrap() == expected_id))
+                    }
+                };
+                // The invalid row id should never show up in results
+                assert!(!found_ids
+                    .iter()
+                    .any(|f_id| f_id.unwrap() == RowAddress::TOMBSTONE_ROW));
+            }
+        }
+    }
+
+    async fn generate_test_dataset(test_uri: &str) -> (Dataset, Arc<FixedSizeListArray>) {
         let vectors = generate_random_array(1000 * DIM);
         let metadata: HashMap<String, String> = vec![("test".to_string(), "ivf_pq".to_string())]
             .into_iter()
@@ -838,11 +1198,17 @@ mod tests {
         let array = Arc::new(FixedSizeListArray::try_new_from_values(vectors, DIM as i32).unwrap());
         let batch = RecordBatch::try_new(schema.clone(), vec![array.clone()]).unwrap();
 
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
+        let dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+        (dataset, array)
+    }
+
+    #[tokio::test]
+    async fn test_create_ivf_pq_with_centroids() {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
 
-        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
-        let mut dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+        let (mut dataset, vector_array) = generate_test_dataset(test_uri).await;
 
         let centroids = generate_random_array(2 * DIM);
         let ivf_centroids = FixedSizeListArray::try_new_from_values(centroids, DIM as i32).unwrap();
@@ -858,8 +1224,8 @@ mod tests {
             .await
             .unwrap();
 
-        let elem = array.value(10);
-        let query = elem.as_primitive::<Float32Type>();
+        let sample_query = vector_array.value(10);
+        let query = sample_query.as_primitive::<Float32Type>();
         let results = dataset
             .scan()
             .nearest("vector", query, 5)
@@ -872,5 +1238,162 @@ mod tests {
             .unwrap();
         assert_eq!(1, results.len());
         assert_eq!(5, results[0].num_rows());
+    }
+
+    fn partition_ids(mut ids: Vec<u64>, num_parts: u32) -> Vec<Vec<u64>> {
+        if num_parts > ids.len() as u32 {
+            panic!("Not enough ids to break into {num_parts} parts");
+        }
+        let mut rng = thread_rng();
+        ids.shuffle(&mut rng);
+
+        let values_per_part = ids.len() / num_parts as usize;
+        let parts_with_one_extra = ids.len() % num_parts as usize;
+
+        let mut parts = Vec::with_capacity(num_parts as usize);
+        let mut offset = 0;
+        for part_size in (0..num_parts).map(|part_idx| {
+            if part_idx < parts_with_one_extra as u32 {
+                values_per_part + 1
+            } else {
+                values_per_part
+            }
+        }) {
+            parts.push(Vec::from_iter(
+                ids[offset..(offset + part_size)].iter().copied(),
+            ));
+            offset += part_size;
+        }
+
+        parts
+    }
+
+    const BIG_OFFSET: u64 = 10000;
+
+    fn build_mapping(
+        row_ids_to_modify: &[u64],
+        row_ids_to_remove: &[u64],
+        max_id: u64,
+    ) -> HashMap<u64, Option<u64>> {
+        // Some big number we can add to row ids so they are remapped but don't intersect with anything
+        if max_id > BIG_OFFSET {
+            panic!("This logic will only work if the max row id is less than BIG_OFFSET");
+        }
+        row_ids_to_modify
+            .iter()
+            .copied()
+            .map(|val| (val, Some(val + BIG_OFFSET)))
+            .chain(row_ids_to_remove.iter().copied().map(|val| (val, None)))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn remap_ivf_pq_index() {
+        // Use small numbers to keep runtime down
+        const DIM: u32 = 8;
+        const CENTROIDS: u32 = 2;
+        const NUM_SUBVECTORS: u32 = 4;
+        const NUM_BITS: u32 = 8;
+        const INDEX_NAME: &str = "my_index";
+
+        // In this test we create a sample dataset with reliable data, train an IVF PQ index
+        // remap the rows, and then verify that we can still search the index and will get
+        // back the remapped row ids.
+
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let mut test_data = WellKnownIvfPqData::new(DIM, CENTROIDS);
+
+        let dataset = Arc::new(test_data.generate_dataset(test_uri).await.unwrap());
+        let ivf_params = IvfBuildParams::try_with_centroids(
+            CENTROIDS as usize,
+            test_data.get_centroids_as_list_arr(),
+        )
+        .unwrap();
+        let pq_params = PQBuildParams::new(NUM_SUBVECTORS as usize, NUM_BITS as usize);
+
+        let uuid = Uuid::new_v4();
+        let uuid_str = uuid.to_string();
+
+        build_ivf_pq_index(
+            &dataset,
+            WellKnownIvfPqData::COLUMN,
+            INDEX_NAME,
+            &uuid_str,
+            MetricType::L2,
+            &ivf_params,
+            &pq_params,
+        )
+        .await
+        .unwrap();
+
+        let index = open_index(dataset.clone(), WellKnownIvfPqData::COLUMN, &uuid_str)
+            .await
+            .unwrap();
+        let ivf_index = index.as_any().downcast_ref::<IVFIndex>().unwrap();
+
+        let prefilter = PreFilter::new(dataset.clone());
+
+        let is_not_remapped = Some;
+        let is_remapped = |row_id| Some(row_id + BIG_OFFSET);
+        let is_removed = |_| None;
+        let max_id = test_data.get_vectors().len() as u64 / test_data.dim as u64;
+        let row_ids = Vec::from_iter(0..max_id);
+
+        // Sanity check to make sure the index we built is behaving correctly.  Any
+        // input row, when used as a query, should be found in the results list with
+        // the same id
+        test_data
+            .check_index(ivf_index, &prefilter, &row_ids, is_not_remapped)
+            .await;
+
+        // When remapping we change the id of 1/3 of the rows, we remove another 1/3,
+        // and we keep 1/3 as they are
+        let partitioned_row_ids = partition_ids(row_ids, 3);
+        let row_ids_to_modify = &partitioned_row_ids[0];
+        let row_ids_to_remove = &partitioned_row_ids[1];
+        let row_ids_to_remain = &partitioned_row_ids[2];
+
+        let mapping = build_mapping(row_ids_to_modify, row_ids_to_remove, max_id);
+
+        let new_uuid = Uuid::new_v4();
+        let new_uuid_str = new_uuid.to_string();
+
+        remap_index_file(
+            &dataset,
+            &uuid_str,
+            &new_uuid_str,
+            dataset.version().version,
+            ivf_index,
+            &mapping,
+            INDEX_NAME.to_string(),
+            WellKnownIvfPqData::COLUMN.to_string(),
+            vec![],
+        )
+        .await
+        .unwrap();
+
+        let remapped = open_index(
+            dataset.clone(),
+            WellKnownIvfPqData::COLUMN,
+            &new_uuid.to_string(),
+        )
+        .await
+        .unwrap();
+        let ivf_remapped = remapped.as_any().downcast_ref::<IVFIndex>().unwrap();
+
+        // If the ids were remapped then make sure the new row id is in the results
+        test_data
+            .check_index(ivf_remapped, &prefilter, row_ids_to_modify, is_remapped)
+            .await;
+        // If the ids were removed then make sure the old row id isn't in the results
+        test_data
+            .check_index(ivf_remapped, &prefilter, row_ids_to_remove, is_removed)
+            .await;
+        // If the ids were not remapped then make sure they still return the old id
+        test_data
+            .check_index(ivf_remapped, &prefilter, row_ids_to_remain, is_not_remapped)
+            .await;
     }
 }

--- a/rust/lance/src/index/vector/opq.rs
+++ b/rust/lance/src/index/vector/opq.rs
@@ -326,6 +326,12 @@ impl VectorIndex for OPQIndex {
             message: "OPQ does not support load".to_string(),
         })
     }
+
+    fn check_can_remap(&self) -> Result<()> {
+        Err(Error::NotSupported {
+            source: "DiskANNIndex does not yet support remap".into(),
+        })
+    }
 }
 
 impl TryFrom<&OptimizedProductQuantizer> for Transform {

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -34,6 +34,7 @@
 //! alternative to [CommitHandler].
 
 use std::future;
+use std::ops::Range;
 use std::sync::Arc;
 use std::{fmt::Debug, sync::atomic::AtomicBool};
 
@@ -442,15 +443,24 @@ impl<T: CommitLock + Send + Sync> CommitHandler for Arc<T> {
     }
 }
 
+pub const NO_RESERVED_FRAGMENTS: Range<u64> = 0..0;
+
 #[derive(Debug, Clone)]
 pub struct CommitConfig {
     pub num_retries: u32,
+    // Fragment ids that have been previously reserved.  This is
+    // currently only used for rewrite operations but may be used
+    // for other operations in the future.
+    pub reserved_fragment_ids: Range<u64>,
     // TODO: add isolation_level
 }
 
 impl Default for CommitConfig {
     fn default() -> Self {
-        Self { num_retries: 5 }
+        Self {
+            num_retries: 5,
+            reserved_fragment_ids: NO_RESERVED_FRAGMENTS,
+        }
     }
 }
 
@@ -522,8 +532,13 @@ pub(crate) async fn commit_new_dataset(
 ) -> Result<Manifest> {
     let transaction_file = write_transaction_file(object_store, base_path, transaction).await?;
 
-    let (mut manifest, indices) =
-        transaction.build_manifest(None, vec![], &transaction_file, write_config)?;
+    let (mut manifest, indices) = transaction.build_manifest(
+        None,
+        vec![],
+        &transaction_file,
+        write_config,
+        NO_RESERVED_FRAGMENTS,
+    )?;
 
     write_manifest_file(
         object_store,
@@ -704,6 +719,7 @@ pub(crate) async fn commit_transaction(
                 dataset.load_indices().await?,
                 &transaction_file,
                 write_config,
+                commit_config.reserved_fragment_ids.clone(),
             )?,
         };
 

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -34,7 +34,6 @@
 //! alternative to [CommitHandler].
 
 use std::future;
-use std::ops::Range;
 use std::sync::Arc;
 use std::{fmt::Debug, sync::atomic::AtomicBool};
 
@@ -443,24 +442,15 @@ impl<T: CommitLock + Send + Sync> CommitHandler for Arc<T> {
     }
 }
 
-pub const NO_RESERVED_FRAGMENTS: Range<u64> = 0..0;
-
 #[derive(Debug, Clone)]
 pub struct CommitConfig {
     pub num_retries: u32,
-    // Fragment ids that have been previously reserved.  This is
-    // currently only used for rewrite operations but may be used
-    // for other operations in the future.
-    pub reserved_fragment_ids: Range<u64>,
     // TODO: add isolation_level
 }
 
 impl Default for CommitConfig {
     fn default() -> Self {
-        Self {
-            num_retries: 5,
-            reserved_fragment_ids: NO_RESERVED_FRAGMENTS,
-        }
+        Self { num_retries: 5 }
     }
 }
 
@@ -532,13 +522,8 @@ pub(crate) async fn commit_new_dataset(
 ) -> Result<Manifest> {
     let transaction_file = write_transaction_file(object_store, base_path, transaction).await?;
 
-    let (mut manifest, indices) = transaction.build_manifest(
-        None,
-        vec![],
-        &transaction_file,
-        write_config,
-        NO_RESERVED_FRAGMENTS,
-    )?;
+    let (mut manifest, indices) =
+        transaction.build_manifest(None, vec![], &transaction_file, write_config)?;
 
     write_manifest_file(
         object_store,
@@ -719,7 +704,6 @@ pub(crate) async fn commit_transaction(
                 dataset.load_indices().await?,
                 &transaction_file,
                 write_config,
-                commit_config.reserved_fragment_ids.clone(),
             )?,
         };
 


### PR DESCRIPTION
Currently, after compaction runs, any fragments that were covered by an index, and compacted, will no longer be covered by that index.

This PR fixes that.  During compaction we calculate the input and output row ids and then rewrite existing indices so that they cover the newly compacted fragments.

Closes #1378 