### PR TITLE
ci: cross compile arm wheels

### DIFF
--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -11,6 +11,7 @@ inputs:
     default: ""
   arm-build:
     description: "Build for arm64 instead of x86_64"
+    # Note: this does *not* mean the host is arm64, since we might be cross-compiling.
     required: false
     default: 'false'
 runs:
@@ -31,9 +32,9 @@ runs:
         args: ${{ inputs.args }}
         before-script-linux: |
           yum install -y openssl-devel \
-            && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip > /tmp/protoc.zip \
+            && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-$(uname -m).zip > /tmp/protoc.zip \
             && unzip /tmp/protoc.zip -d /usr/local \
-            && rm -rf /tmp/*
+            && rm /tmp/protoc.zip
     - name: Build Arm Manylinux Wheel
       if: ${{ inputs.arm-build == 'true' }}
       uses: PyO3/maturin-action@v1
@@ -44,7 +45,13 @@ runs:
         manylinux: "2_17"
         args: ${{ inputs.args }}
         before-script-linux: |
-          apt install -y unzip \
-            && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-aarch_64.zip > /tmp/protoc.zip \
+          set -e
+          apt install -y unzip
+          if [ $(uname -m) = "x86_64" ]; then
+            PROTOC_ARCH="x86_64"
+          else
+            PROTOC_ARCH="aarch_64"
+          fi
+          curl -L https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-$PROTOC_ARCH.zip > /tmp/protoc.zip \
             && unzip /tmp/protoc.zip -d /usr/local \
-            && rm -rf /tmp/*
+            && rm /tmp/protoc.zip

--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -20,23 +20,31 @@ runs:
       shell: bash
       run: |
         echo "ARM BUILD: ${{ inputs.arm-build }}"
-    - name: Build manylinux image
+    - name: Build x86_64 Manylinux wheel
       if: ${{ inputs.arm-build == 'false' }}
-      shell: bash
-      working-directory: python
-      run: |
-        docker build -t pylance_manylinux -f tools/Dockerfile.manylinux2014  tools/
-    - name: Build manylinux image (arm)
-      if: ${{ inputs.arm-build == 'true' }}
-      shell: bash
-      working-directory: python
-      run: |
-        docker build -t pylance_manylinux -f tools/Dockerfile.manylinux2014_aarch64 tools/
-    - name: Build wheel
       uses: PyO3/maturin-action@v1
       with:
         command: build
-        args: ${{ inputs.args }}
         working-directory: python
-        container: pylance_manylinux
-        docker-options: "-e SOME_FLAG_TO_INVALIDATE_CACHE=1"
+        target: x86_64-unknown-linux-gnu
+        manylinux: "2_17"
+        args: ${{ inputs.args }}
+        before-script-linux: |
+          yum install -y openssl-devel \
+            && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip > /tmp/protoc.zip \
+            && unzip /tmp/protoc.zip -d /usr/local \
+            && rm -rf /tmp/*
+    - name: Build Arm Manylinux Wheel
+      if: ${{ inputs.arm-build == 'true' }}
+      uses: PyO3/maturin-action@v1
+      with:
+        command: build
+        working-directory: python
+        target: aarch64-unknown-linux-gnu
+        manylinux: "2_17"
+        args: ${{ inputs.args }}
+        before-script-linux: |
+          apt install -y unzip \
+            && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-aarch_64.zip > /tmp/protoc.zip \
+            && unzip /tmp/protoc.zip -d /usr/local \
+            && rm -rf /tmp/*

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: ./.github/workflows/build_linux_wheel
       with:
         python-minor-version: ${{ matrix.python-minor-version }}
-        args: "--release"
+        args: "--release --strip"
         arm-build: ${{ matrix.platform == 'aarch64' }} 
     - uses: ./.github/workflows/upload_wheel
       with:
@@ -79,7 +79,7 @@ jobs:
       - uses: ./.github/workflows/build_windows_wheel
         with:
           python-minor-version: ${{ matrix.python-minor-version }}
-          args: "--release"
+          args: "--release --strip"
           vcpkg_token: ${{ secrets.VCPKG_GITHUB_PACKAGES }}
       - uses: ./.github/workflows/upload_wheel
         with:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       matrix:
         python-minor-version: [ "8" ]
-        arm:
-          - "false"
-          - "true"
+        platform:
+          - x86_64
+          - aarch64
     runs-on: "ubuntu-22.04"
     steps:
     - uses: actions/checkout@v3
@@ -27,7 +27,7 @@ jobs:
       with:
         python-minor-version: ${{ matrix.python-minor-version }}
         args: "--release"
-        arm-build: ${{ matrix.arm }}
+        arm-build: ${{ matrix.platform == 'aarch64' }} 
     - uses: ./.github/workflows/upload_wheel
       with:
         python-minor-version: ${{ matrix.python-minor-version }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -30,7 +30,6 @@ jobs:
         arm-build: ${{ matrix.platform == 'aarch64' }} 
     - uses: ./.github/workflows/upload_wheel
       with:
-        python-minor-version: ${{ matrix.python-minor-version }}
         token: ${{ secrets.PYPI_TOKEN }}
         repo: "pypi"
   mac:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,6 +10,9 @@ jobs:
     strategy:
       matrix:
         python-minor-version: [ "8" ]
+        arm:
+          - "false"
+          - "true"
     runs-on: "ubuntu-22.04"
     steps:
     - uses: actions/checkout@v3
@@ -24,36 +27,7 @@ jobs:
       with:
         python-minor-version: ${{ matrix.python-minor-version }}
         args: "--release"
-    - uses: ./.github/workflows/upload_wheel
-      with:
-        python-minor-version: ${{ matrix.python-minor-version }}
-        token: ${{ secrets.PYPI_TOKEN }}
-        repo: "pypi"
-  linux-arm:
-    timeout-minutes: 60
-    strategy:
-      matrix:
-        python-minor-version: [ "8" ]
-    runs-on: buildjet-4vcpu-ubuntu-2204-arm
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        lfs: true
-    - name: Set up Python
-      run: |
-        sudo apt update
-        sudo apt install wget software-properties-common
-        sudo add-apt-repository ppa:deadsnakes/ppa
-        sudo apt install python3.${{ matrix.python-minor-version }}
-        sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.${{ matrix.python-minor-version }} 1
-        sudo apt install python3-pip
-        sudo apt install python3.${{ matrix.python-minor-version }}-distutils
-    - uses: ./.github/workflows/build_linux_wheel
-      with:
-        python-minor-version: ${{ matrix.python-minor-version }}
-        args: "--release"
-        arm-build: "true"
+        arm-build: ${{ matrix.arm }}
     - uses: ./.github/workflows/upload_wheel
       with:
         python-minor-version: ${{ matrix.python-minor-version }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -131,34 +131,6 @@ jobs:
     # Make sure wheels are not included in the Rust cache
     - name: Delete wheels
       run: sudo rm -rf target/wheels
-  # TODO: delete this before merge
-  linux-release-test:
-    timeout-minutes: 60
-    strategy:
-      matrix:
-        python-minor-version: [ "8" ]
-        platform:
-          - x86_64
-          - aarch64
-    runs-on: "ubuntu-22.04"
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        lfs: true
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.${{ matrix.python-minor-version }}
-    - uses: ./.github/workflows/build_linux_wheel
-      with:
-        python-minor-version: ${{ matrix.python-minor-version }}
-        args: "--release --strip"
-        arm-build: ${{ matrix.platform == 'aarch64' }} 
-    - name: Upload test wheel
-      uses: actions/upload-artifact@v3
-      with:
-        path: python/target/wheels/pylance-*.whl
   mac:
     timeout-minutes: 45
     runs-on: "macos-12"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -131,33 +131,6 @@ jobs:
     # Make sure wheels are not included in the Rust cache
     - name: Delete wheels
       run: sudo rm -rf target/wheels
-  linux-release-test:
-    timeout-minutes: 60
-    strategy:
-      matrix:
-        python-minor-version: [ "8" ]
-        arm:
-          - "false"
-          - "true"
-    runs-on: "ubuntu-22.04"
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        lfs: true
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.${{ matrix.python-minor-version }}
-    - uses: ./.github/workflows/build_linux_wheel
-      with:
-        python-minor-version: ${{ matrix.python-minor-version }}
-        args: "--release"
-        arm-build: ${{ matrix.arm }}
-    - uses: ./.github/workflows/upload_wheel
-      with:
-        repo: "pypi"
-
   mac:
     timeout-minutes: 45
     runs-on: "macos-12"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -153,7 +153,7 @@ jobs:
     - uses: ./.github/workflows/build_linux_wheel
       with:
         python-minor-version: ${{ matrix.python-minor-version }}
-        args: "--release"
+        args: "--release --strip"
         arm-build: ${{ matrix.platform == 'aarch64' }} 
     - name: Upload test wheel
       uses: actions/upload-artifact@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -131,6 +131,34 @@ jobs:
     # Make sure wheels are not included in the Rust cache
     - name: Delete wheels
       run: sudo rm -rf target/wheels
+  # TODO: delete this before merge
+  linux-release-test:
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        python-minor-version: [ "8" ]
+        platform:
+          - x86_64
+          - aarch64
+    runs-on: "ubuntu-22.04"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        lfs: true
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.${{ matrix.python-minor-version }}
+    - uses: ./.github/workflows/build_linux_wheel
+      with:
+        python-minor-version: ${{ matrix.python-minor-version }}
+        args: "--release"
+        arm-build: ${{ matrix.platform == 'aarch64' }} 
+    - uses: ./.github/workflows/upload_wheel
+      with:
+        token: ${{ secrets.PYPI_TOKEN }}
+        repo: "testpypi"
   mac:
     timeout-minutes: 45
     runs-on: "macos-12"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -131,6 +131,33 @@ jobs:
     # Make sure wheels are not included in the Rust cache
     - name: Delete wheels
       run: sudo rm -rf target/wheels
+  linux-release-test:
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        python-minor-version: [ "8" ]
+        arm:
+          - "false"
+          - "true"
+    runs-on: "ubuntu-22.04"
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        lfs: true
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.${{ matrix.python-minor-version }}
+    - uses: ./.github/workflows/build_linux_wheel
+      with:
+        python-minor-version: ${{ matrix.python-minor-version }}
+        args: "--release"
+        arm-build: ${{ matrix.arm }}
+    - uses: ./.github/workflows/upload_wheel
+      with:
+        repo: "pypi"
+
   mac:
     timeout-minutes: 45
     runs-on: "macos-12"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -155,10 +155,10 @@ jobs:
         python-minor-version: ${{ matrix.python-minor-version }}
         args: "--release"
         arm-build: ${{ matrix.platform == 'aarch64' }} 
-    - uses: ./.github/workflows/upload_wheel
+    - name: Upload test wheel
+      uses: actions/upload-artifact@v3
       with:
-        token: ${{ secrets.PYPI_TOKEN }}
-        repo: "testpypi"
+        path: python/target/wheels/pylance-*.whl
   mac:
     timeout-minutes: 45
     runs-on: "macos-12"

--- a/python/DEVELOPMENT.md
+++ b/python/DEVELOPMENT.md
@@ -223,3 +223,52 @@ sophisticated enough to represent asynchronous parallel work.
 
 As a result, a single instrumented async method may appear as many different
 spans in the UI.
+
+
+## Building wheels locally
+
+### Linux
+
+On Mac or Linux, you can build manylinux wheels locally for Linux. The easiest
+way to do this is to use `zig` with `maturin build`. Before you do this, you'll
+need to make you (1) [install zig](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager)
+and (2) install the toolchains:
+
+```shell
+rustup target add x86_64-unknown-linux-gnu
+rustup target add aarch64-unknown-linux-gnu
+```
+
+For x86 Linux:
+
+```shell
+maturin build --release --zig \
+    --target x86_64-unknown-linux-gnu \
+    --compatibility manylinux2014 \
+    --out wheels
+```
+
+For ARM / aarch64 Linux:
+
+```shell
+maturin build --release --zig \
+    --target aarch_64-unknown-linux-gnu \
+    --compatibility manylinux2014 \
+    --out wheels
+```
+
+### MacOS
+
+On a Mac, you can build wheels locally for MacOS:
+
+```shell
+maturin build --release \
+    --target aarch64-apple-darwin \
+    --out wheels
+```
+
+```shell
+maturin build --release \
+    --target x86_64-apple-darwin \
+    --out wheels
+```

--- a/python/tools/Dockerfile.manylinux2014
+++ b/python/tools/Dockerfile.manylinux2014
@@ -1,8 +1,0 @@
-FROM quay.io/pypa/manylinux2014_x86_64
-
-ENV LD_LIBRARY_PATH=/usr/local/lib
-
-RUN yum install -y openssl-devel \
-  && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip > /tmp/protoc.zip \
-  && unzip /tmp/protoc.zip -d /usr/local \
-  && rm -rf /tmp/*

--- a/python/tools/Dockerfile.manylinux2014_aarch64
+++ b/python/tools/Dockerfile.manylinux2014_aarch64
@@ -1,8 +1,0 @@
-FROM quay.io/pypa/manylinux2014_aarch64
-
-ENV LD_LIBRARY_PATH=/usr/local/lib
-
-RUN yum install -y openssl-devel \
-  && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-aarch_64.zip > /tmp/protoc.zip \
-  && unzip /tmp/protoc.zip -d /usr/local \
-  && rm -rf /tmp/*


### PR DESCRIPTION
The maturin action wheels support both x86 and Arm hosts to build for *either* target. This makes it a lot easier than our custom builds, which require the host to be the same as the target.

This removes our custom docker files and instead uses the ones provided by maturin.

closes #1286, #1392

