### PR TITLE
fix: fix bug in index remapping when plan contained multiple rewrite groups

### DIFF
--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -49,7 +49,10 @@ def test_dataset_optimize(tmp_path: Path):
 def create_table(min, max, nvec, ndim=8):
     mat = np.random.uniform(min, max, (nvec, ndim))
     tbl = vec_to_table(data=mat)
-    print(tbl)
+    # Add id column for filtering
+    tbl = pa.Table.from_pydict(
+        {"vector": tbl.column(0).chunk(0), "id": np.arange(0, nvec)}
+    )
     return tbl
 
 
@@ -121,6 +124,41 @@ def test_index_remapping(tmp_path: Path):
 
     # Now a combined scan is required
     check_index(has_knn_combined=True)
+
+
+def test_index_remapping_multiple_rewrite_tasks(tmp_path: Path):
+    base_dir = tmp_path / "dataset"
+    ds = lance.write_dataset(
+        create_table(min=0, max=1, nvec=300), base_dir, mode="overwrite"
+    )
+    ds = ds.create_index(
+        "vector",
+        index_type="IVF_PQ",
+        num_partitions=4,
+        num_sub_vectors=2,
+    )
+
+    assert ds.has_index
+
+    tbl = create_table(min=0, max=1, nvec=200)
+    ds = lance.write_dataset(tbl, base_dir, mode="append")
+
+    ds.delete("id % 4 == 0")
+    # We have a dataset with 2 small fragments.  Both fragments will
+    # be compacted with themselves since they have many deleted rows.
+    #
+    # However, they should not be compacted together because one of
+    # them is indexed and the other is not.
+    ds.optimize.compact_files()
+
+    fragments = list(ds.get_fragments())
+
+    assert len(fragments) == 2
+    index = ds.list_indices()[0]
+    frag_ids = index["fragment_ids"]
+
+    assert len(frag_ids) == 1
+    assert list(frag_ids)[0] == fragments[0].fragment_id
 
 
 def test_dataset_distributed_optimize(tmp_path: Path):


### PR DESCRIPTION
A bug would occur when some of the rewrite groups were covered by the index and other rewrite groups were not.