### PR TITLE
refactor: use function pointers instead of trait objects

### DIFF
--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -48,26 +48,25 @@ pub enum DistanceType {
 /// For backwards compatibility.
 pub type MetricType = DistanceType;
 
-pub type DistanceFunc = dyn Fn(&[f32], &[f32]) -> f32 + Send + Sync + 'static;
-pub type BatchDistanceFunc =
-    dyn Fn(&[f32], &[f32], usize) -> Arc<Float32Array> + Send + Sync + 'static;
+pub type DistanceFunc = fn(&[f32], &[f32]) -> f32;
+pub type BatchDistanceFunc = fn(&[f32], &[f32], usize) -> Arc<Float32Array>;
 
 impl DistanceType {
     /// Compute the distance from one vector to a batch of vectors.
-    pub fn batch_func(&self) -> Arc<BatchDistanceFunc> {
+    pub fn batch_func(&self) -> BatchDistanceFunc {
         match self {
-            Self::L2 => Arc::new(l2_distance_batch),
-            Self::Cosine => Arc::new(cosine_distance_batch),
-            Self::Dot => Arc::new(dot_distance_batch),
+            Self::L2 => l2_distance_batch,
+            Self::Cosine => cosine_distance_batch,
+            Self::Dot => dot_distance_batch,
         }
     }
 
     /// Returns the distance function between two vectors.
-    pub fn func(&self) -> Arc<DistanceFunc> {
+    pub fn func(&self) -> DistanceFunc {
         match self {
-            Self::L2 => Arc::new(l2_distance),
-            Self::Cosine => Arc::new(cosine_distance),
-            Self::Dot => Arc::new(dot_distance),
+            Self::L2 => l2_distance,
+            Self::Cosine => cosine_distance,
+            Self::Dot => dot_distance,
         }
     }
 }

--- a/rust/lance/src/index/vector/graph/builder.rs
+++ b/rust/lance/src/index/vector/graph/builder.rs
@@ -49,7 +49,7 @@ pub struct GraphBuilder<V: Vertex + Clone + Sync + Send> {
     metric_type: MetricType,
 
     /// Distance function.
-    distance_func: Arc<DistanceFunc>,
+    distance_func: DistanceFunc,
 }
 
 impl<V: Vertex + Clone + Sync + Send> GraphBuilder<V> {


### PR DESCRIPTION
Hopefully Rust is optimizing this already, but it's silly to wrap a function pointer in a trait object when we can just use the function pointer directly.