### PR TITLE
feat: expose latest version id api

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -590,6 +590,13 @@ class LanceDataset(pa.dataset.Dataset):
         """
         return self._ds.version()
 
+    @property
+    def latest_version(self) -> int:
+        """
+        Returns the lastest version of the dataset
+        """
+        return self._ds.latest_version()
+
     def restore(self):
         """
         Restore the currently checked out version as the latest version of the dataset.

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -151,6 +151,25 @@ def test_versions(tmp_path: Path):
     assert isinstance(v2["metadata"], dict)
 
 
+def test_version_id(tmp_path: Path):
+    table1 = pa.Table.from_pylist([{"a": 1, "b": 2}, {"a": 10, "b": 20}])
+    base_dir = tmp_path / "test"
+    original_ds = lance.write_dataset(table1, base_dir)
+
+    assert original_ds.version == 1
+    assert original_ds.latest_version == 1
+
+    table2 = pa.Table.from_pylist([{"s": "one"}, {"s": "two"}])
+    time.sleep(1)
+    updated_ds = lance.write_dataset(table2, base_dir, mode="overwrite")
+
+    assert original_ds.version == 1
+    assert original_ds.latest_version == 2
+
+    assert updated_ds.version == 2
+    assert updated_ds.latest_version == 2
+
+
 def test_asof_checkout(tmp_path: Path):
     table = pa.Table.from_pydict({"colA": [1, 2, 3], "colB": [4, 5, 6]})
     base_dir = tmp_path / "test"

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -497,6 +497,11 @@ impl Dataset {
         Ok(self.ds.version().version)
     }
 
+    fn latest_version(self_: PyRef<'_, Self>) -> PyResult<u64> {
+        RT.block_on(Some(self_.py()), self_.ds.latest_version_id())
+            .map_err(|err| PyIOError::new_err(err.to_string()))
+    }
+
     /// Restore the current version
     fn restore(&mut self) -> PyResult<()> {
         let mut new_self = self.ds.as_ref().clone();

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1163,6 +1163,16 @@ impl Dataset {
         Ok(versions)
     }
 
+    /// Get the latest version of the dataset
+    /// This is meant to be a fast path for checking if a dataset has changed. This is why
+    /// we don't return the full version struct.
+    pub async fn latest_version_id(&self) -> Result<u64> {
+        self.object_store
+            .commit_handler
+            .resolve_latest_version_id(&self.base, &self.object_store)
+            .await
+    }
+
     pub fn schema(&self) -> &Schema {
         &self.manifest.schema
     }


### PR DESCRIPTION
expose latest version id api.

This is useful for efficiently check if another writer has committed a new version.