### PR TITLE
perf: better parallelism in delete vector prefiltering

### DIFF
--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -48,6 +48,8 @@ pub enum Error {
     CommitConflict { version: u64, source: BoxedError },
     #[snafu(display("Encountered internal error. Please file a bug report at https://github.com/lancedb/lance/issues. {message}"))]
     Internal { message: String },
+    #[snafu(display("A prerequisite task failed: {message}"))]
+    PrerequisiteFailed { message: String },
     #[snafu(display("LanceError(Arrow): {message}"))]
     Arrow { message: String },
     #[snafu(display("LanceError(Schema): {message}, {location}"))]

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -78,6 +78,7 @@ tempfile = { workspace = true }
 tracing = { workspace = true }
 lazy_static = "1"
 base64 = "0.21.4"
+async_cell = "0.2.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accelerate-src = { version = "0.3.2", optional = true }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1199,6 +1199,15 @@ impl Dataset {
         read_manifest_indexes(&self.object_store, &manifest_file, &self.manifest).await
     }
 
+    /// Loads a specific index with the given id
+    pub async fn load_index(&self, uuid: &str) -> Option<Index> {
+        self.load_indices()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|idx| idx.uuid.to_string() == uuid)
+    }
+
     /// Find index with a given index_name and return its serialized statistics.
     pub async fn index_statistics(&self, index_name: &str) -> Result<Option<String>> {
         let index_uuid = self

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -722,7 +722,7 @@ impl Scanner {
     fn ann(&self, q: &Query, index: &Index) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(KNNIndexExec::try_new(
             self.dataset.clone(),
-            &index.uuid.to_string(),
+            index.clone(),
             q,
         )?))
     }

--- a/rust/lance/src/format/fragment.rs
+++ b/rust/lance/src/format/fragment.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::BTreeSet;
+use std::ops::Range;
 
 use serde::{Deserialize, Serialize};
 
@@ -229,6 +230,10 @@ impl RowAddress {
 
     pub fn first_row(fragment_id: u32) -> Self {
         Self::new_from_parts(fragment_id, 0)
+    }
+
+    pub fn fragment_range(fragment_id: u32) -> Range<u64> {
+        u64::from(Self::first_row(fragment_id))..u64::from(Self::first_row(fragment_id + 1))
     }
 
     pub fn fragment_id(&self) -> u32 {

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -17,15 +17,20 @@
 //! Based on the query, we might have information about which fragment ids and
 //! row ids can be excluded from the search.
 
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 
-use futures::stream::BoxStream;
+use futures::future;
+use futures::stream;
 use futures::{StreamExt, TryStreamExt};
+use roaring::{RoaringBitmap, RoaringTreemap};
+use tracing::instrument;
+use tracing::Instrument;
 
 use crate::error::Result;
-use crate::io::deletion::DeletionVector;
+use crate::format::Index;
+use crate::format::RowAddress;
+use crate::utils::future::SharedPrerequisite;
 use crate::Dataset;
 
 /// Filter out row ids that we know are not relevant to the query. This currently
@@ -34,10 +39,11 @@ pub struct PreFilter {
     dataset: Arc<Dataset>,
     has_deletion_vectors: bool,
     has_missing_fragments: bool,
+    block_list: Arc<SharedPrerequisite<Arc<RoaringTreemap>>>,
 }
 
 impl PreFilter {
-    pub fn new(dataset: Arc<Dataset>) -> Self {
+    pub fn new(dataset: Arc<Dataset>, index: Index) -> Self {
         let dataset_ref = dataset.as_ref();
         let mut has_fragment = Vec::new();
         let mut has_deletion_vectors = false;
@@ -54,10 +60,15 @@ impl PreFilter {
             has_deletion_vectors |= frag.deletion_file.is_some();
         }
         let has_missing_fragments = has_fragment.iter().any(|&x| !x);
+        let dataset_clone = dataset.clone();
+        let block_list = SharedPrerequisite::spawn(
+            Self::load_block_list(dataset_clone, index).in_current_span(),
+        );
         Self {
             dataset,
             has_deletion_vectors,
             has_missing_fragments,
+            block_list,
         }
     }
 
@@ -80,57 +91,70 @@ impl PreFilter {
         Ok(!deletion_vector.contains(local_row_id))
     }
 
+    #[instrument(level = "debug", skip_all)]
+    async fn load_block_list(dataset: Arc<Dataset>, index: Index) -> Result<Arc<RoaringTreemap>> {
+        let fragments = dataset.get_fragments();
+        let frag_id_deletion_vectors = stream::iter(fragments.iter())
+            .map(|frag| async move {
+                let id = frag.id() as u32;
+                let deletion_vector = frag.get_deletion_vector().await;
+                (id, deletion_vector)
+            })
+            .collect::<Vec<_>>()
+            .await;
+        let frag_id_deletion_vectors = stream::iter(frag_id_deletion_vectors)
+            .buffer_unordered(num_cpus::get())
+            .filter_map(|(id, maybe_deletion_vector)| {
+                let val = if let Ok(deletion_vector) = maybe_deletion_vector {
+                    deletion_vector.map(|deletion_vector| {
+                        Ok((id, RoaringBitmap::from(deletion_vector.as_ref())))
+                    })
+                } else {
+                    Some(Err(maybe_deletion_vector.unwrap_err()))
+                };
+                future::ready(val)
+            })
+            .try_collect::<Vec<_>>()
+            .await?;
+        let mut block_list = RoaringTreemap::from_bitmaps(frag_id_deletion_vectors);
+
+        let frag_ids_in_dataset: HashSet<u32> =
+            HashSet::from_iter(fragments.iter().map(|frag| frag.id() as u32));
+        if let Some(fragment_bitmap) = index.fragment_bitmap {
+            for frag_id in fragment_bitmap.into_iter() {
+                if !frag_ids_in_dataset.contains(&frag_id) {
+                    // Entire fragment has been deleted
+                    block_list.insert_range(RowAddress::fragment_range(frag_id));
+                }
+            }
+        }
+        Ok(Arc::new(block_list))
+    }
+
+    /// Waits for the prefilter to be fully loaded
+    ///
+    /// The prefilter loads in the background while the rest of the index
+    /// search is running.  When you are ready to use the prefilter you
+    /// must first call this method to ensure it is fully loaded.  This
+    /// allows `filter_row_ids` to be a synchronous method.
+    pub async fn wait_for_ready(&self) -> Result<()> {
+        self.block_list.wait_ready().await
+    }
+
     /// Check whether a slice of row ids should be included in a query.
     ///
     /// Returns a vector of indices into the input slice that should be included,
     /// also known as a selection vector.
-    pub async fn filter_row_ids(&self, row_ids: &[u64]) -> Result<Vec<u64>> {
-        let dataset = self.dataset.as_ref();
-        let mut relevant_fragments: HashMap<u32, _> = HashMap::new();
-        for row_id in row_ids {
-            let fragment_id = (row_id >> 32) as u32;
-            if let Entry::Vacant(entry) = relevant_fragments.entry(fragment_id) {
-                if let Some(fragment) = dataset.get_fragment(fragment_id as usize) {
-                    entry.insert(fragment);
-                }
-            }
-        }
-        let stream: BoxStream<_> = futures::stream::iter(relevant_fragments.drain())
-            .map(|(fragment_id, fragment)| async move {
-                let deletion_vector = match fragment.get_deletion_vector().await {
-                    Ok(Some(deletion_vector)) => deletion_vector,
-                    Ok(None) => return Ok((fragment_id, None)),
-                    Err(err) => return Err(err),
-                };
-                Ok((fragment_id, Some(deletion_vector)))
-            })
-            .buffer_unordered(num_cpus::get())
-            .boxed();
-        let deletion_vector_map: HashMap<u32, Option<Arc<DeletionVector>>> =
-            stream.try_collect::<HashMap<_, _>>().await?;
-
-        let selection_vector = row_ids
+    ///
+    /// This method must be called after `wait_for_ready`
+    #[instrument(level = "debug", skip_all)]
+    pub fn filter_row_ids(&self, row_ids: &[u64]) -> Vec<u64> {
+        let block_list = self.block_list.get_ready();
+        row_ids
             .iter()
             .enumerate()
-            .filter_map(|(i, row_id)| {
-                let fragment_id = (row_id >> 32) as u32;
-                let local_row_id = *row_id as u32;
-                match deletion_vector_map.get(&fragment_id) {
-                    Some(Some(deletion_vector)) => {
-                        if deletion_vector.contains(local_row_id) {
-                            None
-                        } else {
-                            Some(i as u64)
-                        }
-                    }
-                    // If the fragment has no deletion vector, then the row must be there.
-                    Some(None) => Some(i as u64),
-                    // If the fragment isn't found, then it must have been deleted.
-                    None => None,
-                }
-            })
-            .collect::<Vec<u64>>();
-
-        Ok(selection_vector)
+            .filter(|(_, row_id)| !block_list.contains(**row_id))
+            .map(|(idx, _)| idx as u64)
+            .collect::<Vec<_>>()
     }
 }

--- a/rust/lance/src/index/vector/diskann/search.rs
+++ b/rust/lance/src/index/vector/diskann/search.rs
@@ -224,7 +224,7 @@ impl Index for DiskANNIndex {
 #[async_trait]
 impl VectorIndex for DiskANNIndex {
     #[instrument(level = "debug", skip_all, name = "DiskANNIndex::search")]
-    async fn search(&self, query: &Query, pre_filter: &PreFilter) -> Result<RecordBatch> {
+    async fn search(&self, query: &Query, pre_filter: Arc<PreFilter>) -> Result<RecordBatch> {
         let state = greedy_search(&self.graph, 0, query.key.values(), query.k, query.k * 2).await?;
         let schema = Arc::new(Schema::new(vec![
             Field::new(ROW_ID, DataType::UInt64, false),

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -1404,7 +1404,7 @@ mod tests {
         let ivf_index = index.as_any().downcast_ref::<IVFIndex>().unwrap();
 
         let index_meta = crate::format::Index {
-            uuid: uuid.clone(),
+            uuid,
             dataset_version: 0,
             fields: Vec::new(),
             name: INDEX_NAME.to_string(),

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -122,6 +122,7 @@ impl IVFIndex {
     /// Parameters
     /// ----------
     ///  - partition_id: partition ID.
+    #[instrument(level = "debug", skip(self))]
     pub(crate) async fn load_partition(&self, partition_id: usize) -> Result<Arc<dyn VectorIndex>> {
         let cache_key = format!("{}-ivf-{}", self.uuid, partition_id);
         let part_index = if let Some(part_idx) = self.session.index_cache.get(&cache_key) {
@@ -144,7 +145,7 @@ impl IVFIndex {
         &self,
         partition_id: usize,
         query: &Query,
-        pre_filter: &PreFilter,
+        pre_filter: Arc<PreFilter>,
     ) -> Result<RecordBatch> {
         let part_index = self.load_partition(partition_id).await?;
 
@@ -274,17 +275,14 @@ impl Index for IVFIndex {
 #[async_trait]
 impl VectorIndex for IVFIndex {
     #[instrument(level = "debug", skip_all, name = "IVFIndex::search")]
-    async fn search(&self, query: &Query, pre_filter: &PreFilter) -> Result<RecordBatch> {
+    async fn search(&self, query: &Query, pre_filter: Arc<PreFilter>) -> Result<RecordBatch> {
         let partition_ids =
             self.ivf
                 .find_partitions(&query.key, query.nprobes, self.metric_type)?;
         assert!(partition_ids.len() <= query.nprobes);
         let part_ids = partition_ids.values().to_vec();
         let batches = stream::iter(part_ids)
-            .map(|part_id| async move {
-                self.search_in_partition(part_id as usize, query, pre_filter)
-                    .await
-            })
+            .map(|part_id| self.search_in_partition(part_id as usize, query, pre_filter.clone()))
             .buffer_unordered(num_cpus::get())
             .try_collect::<Vec<_>>()
             .await?;
@@ -1208,7 +1206,7 @@ mod tests {
         async fn check_index<F: Fn(u64) -> Option<u64>>(
             &mut self,
             index: &IVFIndex,
-            prefilter: &PreFilter,
+            prefilter: Arc<PreFilter>,
             ids_to_test: &Vec<u64>,
             row_id_map: F,
         ) {
@@ -1227,7 +1225,7 @@ mod tests {
                     metric_type: MetricType::L2,
                     use_index: true,
                 };
-                let search_result = index.search(&query, prefilter).await.unwrap();
+                let search_result = index.search(&query, prefilter.clone()).await.unwrap();
 
                 let found_ids = search_result.column(1);
                 let found_ids = found_ids.as_any().downcast_ref::<UInt64Array>().unwrap();
@@ -1405,7 +1403,15 @@ mod tests {
             .unwrap();
         let ivf_index = index.as_any().downcast_ref::<IVFIndex>().unwrap();
 
-        let prefilter = PreFilter::new(dataset.clone());
+        let index_meta = crate::format::Index {
+            uuid: uuid.clone(),
+            dataset_version: 0,
+            fields: Vec::new(),
+            name: INDEX_NAME.to_string(),
+            fragment_bitmap: None,
+        };
+
+        let prefilter = Arc::new(PreFilter::new(dataset.clone(), index_meta));
 
         let is_not_remapped = Some;
         let is_remapped = |row_id| Some(row_id + BIG_OFFSET);
@@ -1417,7 +1423,7 @@ mod tests {
         // input row, when used as a query, should be found in the results list with
         // the same id
         test_data
-            .check_index(ivf_index, &prefilter, &row_ids, is_not_remapped)
+            .check_index(ivf_index, prefilter.clone(), &row_ids, is_not_remapped)
             .await;
 
         // When remapping we change the id of 1/3 of the rows, we remove another 1/3,
@@ -1457,15 +1463,30 @@ mod tests {
 
         // If the ids were remapped then make sure the new row id is in the results
         test_data
-            .check_index(ivf_remapped, &prefilter, row_ids_to_modify, is_remapped)
+            .check_index(
+                ivf_remapped,
+                prefilter.clone(),
+                row_ids_to_modify,
+                is_remapped,
+            )
             .await;
         // If the ids were removed then make sure the old row id isn't in the results
         test_data
-            .check_index(ivf_remapped, &prefilter, row_ids_to_remove, is_removed)
+            .check_index(
+                ivf_remapped,
+                prefilter.clone(),
+                row_ids_to_remove,
+                is_removed,
+            )
             .await;
         // If the ids were not remapped then make sure they still return the old id
         test_data
-            .check_index(ivf_remapped, &prefilter, row_ids_to_remain, is_not_remapped)
+            .check_index(
+                ivf_remapped,
+                prefilter.clone(),
+                row_ids_to_remain,
+                is_not_remapped,
+            )
             .await;
     }
 }

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -184,28 +184,20 @@ impl PQIndex {
     }
 
     /// Filter the row id and PQ code arrays based on the pre-filter.
-    async fn filter_arrays(
-        &self,
+    fn filter_arrays(
         pre_filter: &PreFilter,
+        code: Arc<UInt8Array>,
+        row_ids: Arc<UInt64Array>,
+        num_sub_vectors: i32,
     ) -> Result<(Arc<UInt8Array>, Arc<UInt64Array>)> {
-        if self.code.is_none() || self.row_ids.is_none() {
-            return Err(Error::Index {
-                message: "PQIndex::filter_arrays: PQ is not initialized".to_string(),
-            });
-        }
-        let code = self.code.clone().unwrap();
-        let row_ids = self.row_ids.clone().unwrap();
-        let indices_to_keep = pre_filter.filter_row_ids(row_ids.values()).await?;
+        let indices_to_keep = pre_filter.filter_row_ids(row_ids.values());
         let indices_to_keep = UInt64Array::from(indices_to_keep);
 
         let row_ids = take(row_ids.as_ref(), &indices_to_keep, None)?;
         let row_ids = Arc::new(as_primitive_array(&row_ids).clone());
 
-        let code = FixedSizeListArray::try_new_from_values(
-            code.as_ref().clone(),
-            self.pq.num_sub_vectors as i32,
-        )
-        .unwrap();
+        let code = FixedSizeListArray::try_new_from_values(code.as_ref().clone(), num_sub_vectors)
+            .unwrap();
         let code = take(&code, &indices_to_keep, None)?;
         let code = as_fixed_size_list_array(&code).values().clone();
         let code = Arc::new(as_primitive_array(&code).clone());
@@ -244,25 +236,27 @@ impl VectorIndex for PQIndex {
     /// Search top-k nearest neighbors for `key` within one PQ partition.
     ///
     #[instrument(level = "debug", skip_all, name = "PQIndex::search")]
-    async fn search(&self, query: &Query, pre_filter: &PreFilter) -> Result<RecordBatch> {
+    async fn search(&self, query: &Query, pre_filter: Arc<PreFilter>) -> Result<RecordBatch> {
         if self.code.is_none() || self.row_ids.is_none() {
             return Err(Error::Index {
                 message: "PQIndex::search: PQ is not initialized".to_string(),
             });
         }
+        pre_filter.wait_for_ready().await?;
 
-        let (code, row_ids) = if pre_filter.is_empty() {
-            (
-                self.code.as_ref().unwrap().clone(),
-                self.row_ids.as_ref().unwrap().clone(),
-            )
-        } else {
-            self.filter_arrays(pre_filter).await?
-        };
+        let code = self.code.as_ref().unwrap().clone();
+        let row_ids = self.row_ids.as_ref().unwrap().clone();
 
         let this = self.clone();
         let query = query.clone();
+        let num_sub_vectors = self.pq.num_sub_vectors as i32;
         spawn_cpu(move || {
+            let (code, row_ids) = if pre_filter.is_empty() {
+                Ok((code, row_ids))
+            } else {
+                Self::filter_arrays(pre_filter.as_ref(), code, row_ids, num_sub_vectors)
+            }?;
+
             // Pre-compute distance table for each sub-vector.
             let distances = if this.metric_type == MetricType::L2 {
                 this.fast_l2_distances(&query.key, code.as_ref())?

--- a/rust/lance/src/index/vector/traits.rs
+++ b/rust/lance/src/index/vector/traits.rs
@@ -15,7 +15,7 @@
 //! Traits for vector index.
 //!
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use arrow_array::types::Float32Type;
 use arrow_array::RecordBatch;
@@ -52,7 +52,7 @@ pub(crate) trait VectorIndex: Send + Sync + std::fmt::Debug + Index {
     ///
     /// *WARNINGS*:
     ///  - Only supports `f32` now. Will add f64/f16 later.
-    async fn search(&self, query: &Query, pre_filter: &PreFilter) -> Result<RecordBatch>;
+    async fn search(&self, query: &Query, pre_filter: Arc<PreFilter>) -> Result<RecordBatch>;
 
     /// If the index is loadable by IVF, so it can be a sub-index that
     /// is loaded on demand by IVF.

--- a/rust/lance/src/io/deletion.rs
+++ b/rust/lance/src/io/deletion.rs
@@ -81,6 +81,16 @@ impl Default for DeletionVector {
     }
 }
 
+impl From<&DeletionVector> for RoaringBitmap {
+    fn from(value: &DeletionVector) -> Self {
+        match value {
+            DeletionVector::Bitmap(bitmap) => bitmap.clone(),
+            DeletionVector::Set(set) => Self::from_iter(set.iter()),
+            DeletionVector::NoDeletions => Self::new(),
+        }
+    }
+}
+
 impl PartialEq for DeletionVector {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {

--- a/rust/lance/src/utils.rs
+++ b/rust/lance/src/utils.rs
@@ -17,6 +17,7 @@
 
 //! Various utilities
 
+pub(crate) mod future;
 pub mod sql;
 pub mod temporal;
 #[cfg(test)]

--- a/rust/lance/src/utils/future.rs
+++ b/rust/lance/src/utils/future.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use async_cell::sync::AsyncCell;
+use futures::Future;
+
+/// An async background task whose output can be shared across threads (via cloning)
+///
+/// SharedPrerequisite is very similar to a shared future except:
+///  * It must be created by spawning a new task (runs in the background)
+///  * Shared future doesn't support Result.  This class handles errors by
+///      serializing them to string.
+///  * This class can optionally cache the output so that it can be accessed synchronously
+pub struct SharedPrerequisite<T: Clone>(Arc<AsyncCell<std::result::Result<T, String>>>);
+
+impl<T: Clone> SharedPrerequisite<T> {
+    /// Asynchronously get a cloned copy of the output
+    ///
+    /// If the child task failed then a PrerequisiteFailed error is raised.
+    #[allow(dead_code)]
+    pub async fn get_fut(&self) -> crate::Result<T> {
+        self.0
+            .get()
+            .await
+            .clone()
+            .map_err(|err| crate::Error::PrerequisiteFailed { message: err })
+    }
+
+    /// Synchronously get a cloned copy of the cached output
+    ///
+    /// Must be called after a call to `wait_ready`
+    pub fn get_ready(&self) -> T {
+        self.0
+            .try_get()
+            // There was no call to wait_ready and the value was accessed to early
+            .expect("SharedPrequisite cached value accessed without call to wait_ready")
+            // There was no call to wait_ready and the value was actually ready, but failed
+            .expect("SharedPrequisite cached value accessed without call to wait_ready")
+    }
+
+    /// Asynchronously wait for the output to be ready
+    ///
+    /// Must be called before `get_ready``
+    pub async fn wait_ready(&self) -> crate::Result<()> {
+        self.0
+            .get()
+            .await
+            .map(|_| ())
+            .map_err(|err| crate::Error::PrerequisiteFailed { message: err })
+    }
+
+    /// Launch a background task (using tokio::spawn) and get a shareable handle to the eventual result
+    pub fn spawn<F>(future: F) -> Arc<Self>
+    where
+        T: Clone + Send + 'static,
+        F: Future<Output = crate::Result<T>> + Send + 'static,
+    {
+        let cell = AsyncCell::<std::result::Result<T, String>>::shared();
+        let dst = cell.clone();
+        tokio::spawn(async move {
+            let res = future.await;
+            dst.set(res.map_err(|err| err.to_string()));
+        });
+        Arc::new(Self(cell))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::future;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_spawn_prereq() {
+        // On success
+        let fut = future::ready(crate::Result::Ok(7_u32));
+        let prereq = SharedPrerequisite::spawn(fut);
+
+        let mut tasks = Vec::with_capacity(10);
+        for _ in 0..10 {
+            let instance = prereq.clone();
+            tasks.push(tokio::spawn(async move {
+                instance.wait_ready().await.unwrap();
+                assert_eq!(instance.get_ready(), 7_u32);
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+
+        // On error
+        let fut = future::ready(crate::Result::Err(crate::Error::invalid_input("xyz")));
+        let prereq = SharedPrerequisite::<u32>::spawn(fut);
+
+        let mut tasks = Vec::with_capacity(10);
+        for _ in 0..10 {
+            let instance = prereq.clone();
+            tasks.push(tokio::spawn(async move {
+                let err = instance.wait_ready().await.unwrap_err();
+                assert!(err.to_string().contains("xyz"));
+                assert!(err.to_string().contains("task failed"));
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+    }
+}


### PR DESCRIPTION
The previous handling of delete files in an ANN search was sub optimal in a few ways that are fixed by this PR:

 * The synchronous portion of applying the prefilter was not run in parallel across the different PQ pages.  Now it is run in parallel as part of the spawn_cpu critical section.
 * The synchronous work of calculating the prefilter (converting from delete file to, previously, a hashmap) was repeated for each PQ page.  Now we run this once, in parallel with the IVF centroid calculation and any IVF/PQ page loading.
 * The prefilter was using a computationally heavy HashSet.  Now we use a roaring treemap.
