### PR TITLE
test: fix flaky tests involving tokio::fs::File

### DIFF
--- a/rust/lance-core/src/encodings/binary.rs
+++ b/rust/lance-core/src/encodings/binary.rs
@@ -508,6 +508,7 @@ mod tests {
 
         let arrs = arr.iter().map(|a| a as &dyn Array).collect::<Vec<_>>();
         let pos = encoder.encode(arrs.as_slice()).await.unwrap();
+        writer.shutdown().await.unwrap();
         Ok(pos)
     }
 
@@ -746,7 +747,9 @@ mod tests {
             let mut encoder = BinaryEncoder::new(&mut object_writer);
 
             // let arrs = arr.iter().map(|a| a as &dyn Array).collect::<Vec<_>>();
-            encoder.encode(&[&data]).await.unwrap()
+            let pos = encoder.encode(&[&data]).await.unwrap();
+            object_writer.shutdown().await.unwrap();
+            pos
         };
 
         let reader = LocalObjectReader::open_local_path(&path, 1024).unwrap();

--- a/rust/lance-core/src/encodings/dictionary.rs
+++ b/rust/lance-core/src/encodings/dictionary.rs
@@ -217,6 +217,7 @@ mod tests {
     use crate::io::local::LocalObjectReader;
     use arrow_array::{Array, StringArray};
     use arrow_buffer::ArrowNativeType;
+    use tokio::io::AsyncWriteExt;
 
     async fn test_dict_decoder_for_type<T: ArrowDictionaryKeyType>() {
         let value_array: StringArray = vec![Some("a"), Some("b"), Some("c"), Some("d")]
@@ -248,6 +249,7 @@ mod tests {
             let mut object_writer = tokio::fs::File::create(&path).await.unwrap();
             let mut encoder = PlainEncoder::new(&mut object_writer, arr1.keys().data_type());
             pos = encoder.encode(arrs.as_slice()).await.unwrap();
+            object_writer.shutdown().await.unwrap();
         }
 
         let reader = LocalObjectReader::open_local_path(&path, 2048).unwrap();

--- a/rust/lance-core/src/encodings/plain.rs
+++ b/rust/lance-core/src/encodings/plain.rs
@@ -722,6 +722,7 @@ mod tests {
             let mut writer = tokio::fs::File::create(&path).await.unwrap();
             let mut encoder = PlainEncoder::new(&mut writer, array.data_type());
             assert_eq!(encoder.encode(&[&array]).await.unwrap(), 0);
+            writer.shutdown().await.unwrap();
         }
 
         let reader = LocalObjectReader::open_local_path(&path, 2048).unwrap();


### PR DESCRIPTION
When a tokio::fs::File is dropped it does not wait for any ongoing writes to finish (as this would be a synchronous blocking wait).  Instead, it is recommended that you call `shutdown` or `flush`.  This was causing some unit tests to fail intermittently because we were creating a `File`, writing to it, then immediately reading from it.  Sometimes these reads would fail because the data had not actually been written yet.