### PR TITLE
feat: allow prefiltering to be used with an index

### DIFF
--- a/python/python/benchmarks/test_search.py
+++ b/python/python/benchmarks/test_search.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import itertools
 import shutil
 from pathlib import Path
 from typing import NamedTuple, Union
@@ -172,10 +171,9 @@ def test_ivf_pq_index_search(test_dataset, benchmark):
 
 
 @pytest.mark.benchmark(group="query_ann")
-@pytest.mark.parametrize(
-    "selectivity, prefilter, use_index",
-    list(itertools.product((0.25, 0.75), (False, True), (False, True))),
-)
+@pytest.mark.parametrize("selectivity", (0.25, 0.75))
+@pytest.mark.parametrize("prefilter", (False, True))
+@pytest.mark.parametrize("use_index", (False, True))
 def test_filtered_search(test_dataset, benchmark, selectivity, prefilter, use_index):
     q = pc.random(N_DIMS).cast(pa.float32())
     threshold = int(round(selectivity * NUM_ROWS))

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -44,8 +44,7 @@ struct SchemaFieldIterPreOrder<'a> {
 impl<'a> SchemaFieldIterPreOrder<'a> {
     #[allow(dead_code)]
     fn new(schema: &'a Schema) -> Self {
-        let mut field_stack = Vec::new();
-        field_stack.reserve(schema.fields.len() * 2);
+        let mut field_stack = Vec::with_capacity(schema.fields.len() * 2);
         for field in schema.fields.iter().rev() {
             field_stack.push(field);
         }

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -746,7 +746,7 @@ impl Scanner {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let columns_in_filter = column_names_in_expr(prefilter.as_ref());
         let filter_schema = Arc::new(self.dataset.schema().project(&columns_in_filter)?);
-        let filter_input = self.scan(true, filter_schema);
+        let filter_input = self.scan(true, true, filter_schema);
         let filtered = Arc::new(FilterExec::try_new(prefilter, filter_input)?);
         Ok(Arc::new(KNNIndexExec::try_new(
             self.dataset.clone(),

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -855,9 +855,11 @@ mod test {
     use arrow::array::as_primitive_array;
     use arrow::compute::concat_batches;
     use arrow::datatypes::Int32Type;
+    use arrow_array::cast::AsArray;
+    use arrow_array::types::UInt64Type;
     use arrow_array::{
         ArrayRef, FixedSizeListArray, Int32Array, Int64Array, LargeStringArray,
-        RecordBatchIterator, StringArray, StructArray, UInt64Array,
+        RecordBatchIterator, StringArray, StructArray,
     };
     use arrow_ord::sort::sort_to_indices;
     use arrow_schema::DataType;

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -596,9 +596,6 @@ impl Scanner {
         };
         let knn_idx = indices.iter().find(|i| i.fields.contains(&column_id));
         if let Some(index) = knn_idx {
-            if prefilter.is_some() {
-                return Err(Error::NotSupported { source: "A prefilter cannot currently be used with a vector index.  Set use_index to false or remove the prefilter.".into() });
-            }
             // There is an index built for the column.
             // We will use the index.
             if let Some(rf) = q.refine_factor {
@@ -610,9 +607,14 @@ impl Scanner {
                 }
             }
 
-            let knn_node = self.ann(q, index)?; // _distance, _rowid
+            let ann_node = if let Some(prefilter) = prefilter {
+                self.prefilter_ann(q, index, prefilter)?
+            } else {
+                self.ann(q, index)?
+            }; // _distance, _rowid
+
             let with_vector = self.dataset.schema().project(&[&q.column])?;
-            let knn_node_with_vector = self.take(knn_node, &with_vector, self.batch_readahead)?;
+            let knn_node_with_vector = self.take(ann_node, &with_vector, self.batch_readahead)?;
             let mut knn_node = if q.refine_factor.is_some() {
                 self.flat_knn(knn_node_with_vector, q)?
             } else {
@@ -736,12 +738,31 @@ impl Scanner {
         Ok(Arc::new(KNNFlatExec::try_new(input, q.clone())?))
     }
 
+    fn prefilter_ann(
+        &self,
+        q: &Query,
+        index: &Index,
+        prefilter: Arc<dyn PhysicalExpr>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let columns_in_filter = column_names_in_expr(prefilter.as_ref());
+        let filter_schema = Arc::new(self.dataset.schema().project(&columns_in_filter)?);
+        let filter_input = self.scan(true, filter_schema);
+        let filtered = Arc::new(FilterExec::try_new(prefilter, filter_input)?);
+        Ok(Arc::new(KNNIndexExec::try_new(
+            self.dataset.clone(),
+            index.clone(),
+            q,
+            Some(filtered),
+        )?))
+    }
+
     /// Create an Execution plan to do indexed ANN search
     fn ann(&self, q: &Query, index: &Index) -> Result<Arc<dyn ExecutionPlan>> {
         Ok(Arc::new(KNNIndexExec::try_new(
             self.dataset.clone(),
             index.clone(),
             q,
+            None,
         )?))
     }
 
@@ -836,7 +857,7 @@ mod test {
     use arrow::datatypes::Int32Type;
     use arrow_array::{
         ArrayRef, FixedSizeListArray, Int32Array, Int64Array, LargeStringArray,
-        RecordBatchIterator, StringArray, StructArray,
+        RecordBatchIterator, StringArray, StructArray, UInt64Array,
     };
     use arrow_ord::sort::sort_to_indices;
     use arrow_schema::DataType;
@@ -1249,10 +1270,6 @@ mod test {
         scan.prefilter(true);
         scan.project(&["i"]).unwrap();
         scan.nearest("vec", &key, 5).unwrap();
-
-        // Prefilter with index not supported yet
-        assert!(scan.try_into_stream().await.is_err());
-
         scan.use_index(false);
 
         let results = scan
@@ -1764,6 +1781,80 @@ mod test {
         let knn = &take.children()[0];
         assert!(knn.as_any().is::<KNNIndexExec>());
         assert_eq!(knn.schema().field_names(), [DIST_COL, ROW_ID]);
+    }
+
+    #[tokio::test]
+    async fn test_ann_prefilter() {
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("filterable", DataType::Int32, true),
+            ArrowField::new("vector", fixed_size_list_type(2, DataType::Float32), true),
+        ]));
+
+        let vector_values = Float32Array::from_iter_values((0..600).map(|x| x as f32));
+
+        let batches = vec![RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..300)),
+                Arc::new(FixedSizeListArray::try_new_from_values(vector_values, 2).unwrap()),
+            ],
+        )
+        .unwrap()];
+
+        let write_params = WriteParams::default();
+        let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+        let mut dataset = Dataset::write(batches, test_uri, Some(write_params))
+            .await
+            .unwrap();
+
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                None,
+                &VectorIndexParams::ivf_pq(2, 8, 2, false, MetricType::L2, 2),
+                false,
+            )
+            .await
+            .unwrap();
+
+        let query_key = Arc::new(Float32Array::from_iter_values((0..2).map(|x| x as f32)));
+        let mut scan = dataset.scan();
+        scan.filter("filterable > 5").unwrap();
+        scan.nearest("vector", &query_key, 1).unwrap();
+        scan.with_row_id();
+
+        let batches = scan
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 0);
+
+        scan.prefilter(true);
+        let batches = scan
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1);
+
+        let first_match = batches[0]
+            .column_by_name(ROW_ID)
+            .unwrap()
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap()
+            .values()[0];
+
+        assert_eq!(6, first_match);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1846,13 +1846,7 @@ mod test {
             .unwrap();
         assert_eq!(batches.len(), 1);
 
-        let first_match = batches[0]
-            .column_by_name(ROW_ID)
-            .unwrap()
-            .as_any()
-            .downcast_ref::<UInt64Array>()
-            .unwrap()
-            .values()[0];
+        let first_match = batches[0][ROW_ID].as_primitive::<UInt64Type>().values()[0];
 
         assert_eq!(6, first_match);
     }

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -99,7 +99,7 @@ impl PreFilter {
             (Some(block_list), Some(allow_list)) => {
                 let block_list = block_list.get_ready();
                 let allow_list = allow_list.get_ready();
-                !block_list.contains(row_id) && allow_list.contains(row_id)
+                allow_list.contains(row_id) && !block_list.contains(row_id)
             }
             (Some(block_list), None) => {
                 let block_list = block_list.get_ready();

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -39,9 +39,14 @@ pub trait AllowListLoader: Send + 'static {
     async fn load(self: Box<Self>) -> Result<Arc<RoaringTreemap>>;
 }
 
-/// Filter out row ids that we know are not relevant to the query. This currently
-/// is just deleted rows.
+/// Filter out row ids that we know are not relevant to the query.
+///
+/// This could be both rows that are deleted (block_list) or a prefilter
+/// that should be applied to the search (allow_list)
 pub struct PreFilter {
+    // Expressing these as tasks allows us to start calculating the block list
+    // and allow list at the same time we start searching the query.  We will await
+    // these tasks only when we've done as much work as we can without them.
     block_list: Option<Arc<SharedPrerequisite<Arc<RoaringTreemap>>>>,
     allow_list: Option<Arc<SharedPrerequisite<Arc<RoaringTreemap>>>>,
 }

--- a/rust/lance/src/index/vector/diskann/search.rs
+++ b/rust/lance/src/index/vector/diskann/search.rs
@@ -222,12 +222,14 @@ impl VectorIndex for DiskANNIndex {
             Field::new(DIST_COL, DataType::Float32, true),
         ]));
 
+        pre_filter.wait_for_ready().await?;
+
         let mut candidates = Vec::with_capacity(query.k);
         for (distance, row) in state.candidates {
             if candidates.len() == query.k {
                 break;
             }
-            if pre_filter.check_one(row as u64).await? {
+            if pre_filter.check_one(row as u64) {
                 candidates.push((distance, row));
             }
         }

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -1417,7 +1417,7 @@ mod tests {
             fragment_bitmap: None,
         };
 
-        let prefilter = Arc::new(PreFilter::new(dataset.clone(), index_meta));
+        let prefilter = Arc::new(PreFilter::new(dataset.clone(), index_meta, None));
 
         let is_not_remapped = Some;
         let is_remapped = |row_id| Some(row_id + BIG_OFFSET);

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -36,7 +36,7 @@ use lance_linalg::{
     matrix::MatrixView,
 };
 use serde::Serialize;
-use tracing::instrument;
+use tracing::{instrument, Instrument};
 
 use super::VectorIndex;
 use crate::index::{prefilter::PreFilter, Index};
@@ -280,6 +280,7 @@ impl VectorIndex for PQIndex {
             ]));
             Ok(RecordBatch::try_new(schema, vec![distances, row_ids])?)
         })
+        .in_current_span()
         .await
     }
 

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -266,7 +266,7 @@ impl AllowListLoader for PreFilterBuilder {
                 .as_any()
                 .downcast_ref::<UInt64Array>()
                 .expect("row id column in input batch had incorrect type");
-            allow_list.extend(row_ids.values())
+            allow_list.extend(row_ids.iter().filter_map(|row_id| row_id))
         }
         Ok(Arc::new(allow_list))
     }

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -266,7 +266,7 @@ impl AllowListLoader for PreFilterBuilder {
                 .as_any()
                 .downcast_ref::<UInt64Array>()
                 .expect("row id column in input batch had incorrect type");
-            allow_list.extend(row_ids.iter().filter_map(|row_id| row_id))
+            allow_list.extend(row_ids.iter().flatten())
         }
         Ok(Arc::new(allow_list))
     }

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -17,17 +17,19 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use arrow_array::RecordBatch;
+use arrow_array::{RecordBatch, UInt64Array};
 use arrow_schema::{DataType, Field, Schema};
+use async_trait::async_trait;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
     RecordBatchStream as DFRecordBatchStream, SendableRecordBatchStream, Statistics,
 };
 use futures::stream::Stream;
-use futures::FutureExt;
-use lance_core::ROW_ID_FIELD;
+use futures::{FutureExt, StreamExt};
+use lance_core::{ROW_ID, ROW_ID_FIELD};
 use lance_index::vector::{flat::flat_search, Query, DIST_COL};
+use roaring::RoaringTreemap;
 use snafu::{location, Location};
 use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinHandle;
@@ -36,7 +38,7 @@ use tracing::{instrument, Instrument};
 use crate::dataset::scanner::DatasetRecordBatchStream;
 use crate::dataset::Dataset;
 use crate::format::Index;
-use crate::index::prefilter::PreFilter;
+use crate::index::prefilter::{AllowListLoader, PreFilter};
 use crate::index::vector::open_index;
 use crate::io::RecordBatchStream;
 use crate::{Error, Result};
@@ -247,6 +249,29 @@ impl ExecutionPlan for KNNFlatExec {
     }
 }
 
+// Utilities to convert an input (containing row ids) into an allow
+// list to be used for prefiltering
+pub struct PreFilterBuilder(SendableRecordBatchStream);
+
+#[async_trait]
+impl AllowListLoader for PreFilterBuilder {
+    async fn load(mut self: Box<Self>) -> Result<Arc<RoaringTreemap>> {
+        let mut allow_list = RoaringTreemap::new();
+        while let Some(batch) = self.0.next().await {
+            let batch = batch?;
+            let row_ids = batch.column_by_name(ROW_ID).expect(
+                "input batch missing row id column even though it is in the schema for the stream",
+            );
+            let row_ids = row_ids
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .expect("row id column in input batch had incorrect type");
+            allow_list.extend(row_ids.values())
+        }
+        Ok(Arc::new(allow_list))
+    }
+}
+
 /// KNN Node from reading a vector index.
 pub struct KNNIndexStream {
     rx: Receiver<datafusion::error::Result<RecordBatch>>,
@@ -258,21 +283,31 @@ impl KNNIndexStream {
         query: Query,
         dataset: Arc<Dataset>,
         index_meta: Index,
+        // An optional input containing a list of row ids to use as a prefilter
+        allow_list_input: Option<datafusion::physical_plan::SendableRecordBatchStream>,
     ) -> Result<RecordBatch> {
         let index =
             open_index(dataset.clone(), &query.column, &index_meta.uuid.to_string()).await?;
-        let pre_filter = Arc::new(PreFilter::new(dataset, index_meta));
+        let allow_list_loader = allow_list_input.map(|allow_list_input| {
+            Box::new(PreFilterBuilder(allow_list_input)) as Box<dyn AllowListLoader>
+        });
+        let pre_filter = Arc::new(PreFilter::new(dataset, index_meta, allow_list_loader));
         index.search(&query, pre_filter).await
     }
 
     #[instrument(level = "debug", skip_all, name = "KNNIndexStream::new")]
-    pub fn new(dataset: Arc<Dataset>, index: &Index, query: &Query) -> Self {
+    pub fn new(
+        dataset: Arc<Dataset>,
+        index: &Index,
+        query: &Query,
+        allow_list: Option<datafusion::physical_plan::SendableRecordBatchStream>,
+    ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel(2);
         let q = query.clone();
         let index = index.clone();
         let bg_thread = tokio::spawn(
             async move {
-                let result = match Self::knn_stream(q, dataset, index).await {
+                let result = match Self::knn_stream(q, dataset, index, allow_list).await {
                     Ok(b) => b,
                     Err(e) => {
                         tx.send(Err(datafusion::error::DataFusionError::Execution(format!(
@@ -344,6 +379,8 @@ impl Stream for KNNIndexStream {
 pub struct KNNIndexExec {
     /// Dataset to read from.
     dataset: Arc<Dataset>,
+    /// Optional input of valid row ids, used for prefiltering
+    allow_list: Option<Arc<dyn ExecutionPlan>>,
     /// The index metadata
     index: Index,
     /// The vector query to execute.
@@ -362,7 +399,12 @@ impl DisplayAs for KNNIndexExec {
 
 impl KNNIndexExec {
     /// Create a new [KNNIndexExec].
-    pub fn try_new(dataset: Arc<Dataset>, index: Index, query: &Query) -> Result<Self> {
+    pub fn try_new(
+        dataset: Arc<Dataset>,
+        index: Index,
+        query: &Query,
+        allow_list: Option<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Self> {
         let schema = dataset.schema();
         if schema.field(query.column.as_str()).is_none() {
             return Err(Error::IO {
@@ -378,6 +420,7 @@ impl KNNIndexExec {
             dataset,
             index,
             query: query.clone(),
+            allow_list,
         })
     }
 }
@@ -416,13 +459,20 @@ impl ExecutionPlan for KNNIndexExec {
 
     fn execute(
         &self,
-        _partition: usize,
-        _context: Arc<datafusion::execution::context::TaskContext>,
+        partition: usize,
+        context: Arc<datafusion::execution::context::TaskContext>,
     ) -> DataFusionResult<datafusion::physical_plan::SendableRecordBatchStream> {
+        let allow_list = self
+            .allow_list
+            .as_ref()
+            .map(|allow_list| allow_list.execute(partition, context))
+            .transpose()?;
+
         Ok(Box::pin(KNNIndexStream::new(
             self.dataset.clone(),
             &self.index,
             &self.query,
+            allow_list,
         )))
     }
 


### PR DESCRIPTION
Currently, prefiltering is restricted to searches that do not use an index.  This PR enables prefiltering to be used on an indexed column.  The approach is to first run a query to figure out the valid row ids and then pass this list of valid row ids to the index.