### PR TITLE
feat: make tell synchronous and infallible

### DIFF
--- a/rust/lance-core/src/format/page_table.rs
+++ b/rust/lance-core/src/format/page_table.rs
@@ -99,7 +99,7 @@ impl PageTable {
             });
         }
 
-        let pos = writer.tell().await?;
+        let pos = writer.tell();
         let num_columns = self.pages.keys().max().unwrap() + 1 - field_id_offset;
         let num_batches = self
             .pages
@@ -149,7 +149,7 @@ mod tests {
 
     use super::*;
 
-    use crate::io::local::LocalObjectReader;
+    use crate::io::local::{LocalObjectReader, LocalObjectWriter};
     use tempfile;
 
     #[test]
@@ -183,9 +183,9 @@ mod tests {
         // here to represent the struct.
         let starting_field_id = 9;
 
-        let mut writer = tokio::fs::File::create(&path).await.unwrap();
+        let mut writer = LocalObjectWriter::open_local_path(&path).await.unwrap();
         let pos = page_table
-            .write(&mut writer, starting_field_id)
+            .write(writer.as_mut(), starting_field_id)
             .await
             .unwrap();
         writer.shutdown().await.unwrap();

--- a/rust/lance-core/src/io/object_writer.rs
+++ b/rust/lance-core/src/io/object_writer.rs
@@ -65,8 +65,8 @@ impl ObjectWriter {
 
 #[async_trait]
 impl Writer for ObjectWriter {
-    async fn tell(&mut self) -> Result<usize> {
-        Ok(self.cursor)
+    fn tell(&self) -> usize {
+        self.cursor
     }
 }
 
@@ -115,17 +115,17 @@ mod tests {
         let mut object_writer = ObjectWriter::new(&store, &Path::from("/foo"))
             .await
             .unwrap();
-        assert_eq!(object_writer.tell().await.unwrap(), 0);
+        assert_eq!(object_writer.tell(), 0);
 
         let buf = vec![0; 256];
         assert_eq!(object_writer.write(buf.as_slice()).await.unwrap(), 256);
-        assert_eq!(object_writer.tell().await.unwrap(), 256);
+        assert_eq!(object_writer.tell(), 256);
 
         assert_eq!(object_writer.write(buf.as_slice()).await.unwrap(), 256);
-        assert_eq!(object_writer.tell().await.unwrap(), 512);
+        assert_eq!(object_writer.tell(), 512);
 
         assert_eq!(object_writer.write(buf.as_slice()).await.unwrap(), 256);
-        assert_eq!(object_writer.tell().await.unwrap(), 256 * 3);
+        assert_eq!(object_writer.tell(), 256 * 3);
 
         object_writer.shutdown().await.unwrap();
     }
@@ -136,7 +136,7 @@ mod tests {
         let path = Path::from("/foo");
 
         let mut object_writer = ObjectWriter::new(&store, &path).await.unwrap();
-        assert_eq!(object_writer.tell().await.unwrap(), 0);
+        assert_eq!(object_writer.tell(), 0);
 
         let mut metadata = Metadata {
             manifest_position: Some(100),

--- a/rust/lance-core/src/io/traits.rs
+++ b/rust/lance-core/src/io/traits.rs
@@ -27,7 +27,7 @@ use crate::Result;
 #[async_trait]
 pub trait Writer: AsyncWrite + Unpin + Send {
     /// Tell the current offset.
-    async fn tell(&mut self) -> Result<usize>;
+    fn tell(&self) -> usize;
 }
 
 /// Lance Write Extension.
@@ -35,7 +35,7 @@ pub trait Writer: AsyncWrite + Unpin + Send {
 pub trait WriteExt: Writer {
     /// Write a protobuf message to the object, and returns the file position of the protobuf.
     async fn write_protobuf(&mut self, msg: &impl Message) -> Result<usize> {
-        let offset = self.tell().await?;
+        let offset = self.tell();
 
         let len = msg.encoded_len();
 

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -846,7 +846,7 @@ impl RemapPageTask {
             .as_any()
             .downcast_ref()
             .expect("Generic index writing not supported yet");
-        ivf.offsets.push(writer.tell().await?);
+        ivf.offsets.push(writer.tell());
         ivf.lengths
             .push(page.row_ids.as_ref().unwrap().len() as u32);
         PlainEncoder::write(writer, &[page.code.as_ref().unwrap().as_ref()]).await?;

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -64,7 +64,7 @@ pub(super) async fn write_index_partitions(
         }
 
         let total_records = row_id_array.iter().map(|a| a.len()).sum::<usize>();
-        ivf.add_partition(writer.tell().await?, total_records as u32);
+        ivf.add_partition(writer.tell(), total_records as u32);
         if total_records > 0 {
             let pq_refs = pq_array.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
             PlainEncoder::write(writer, &pq_refs).await?;

--- a/rust/lance/src/io/writer.rs
+++ b/rust/lance/src/io/writer.rs
@@ -358,7 +358,7 @@ impl FileWriter {
         page_table: &mut PageTable,
     ) -> Result<()> {
         let arrs_length: i32 = arrs.iter().map(|a| a.len() as i32).sum();
-        let page_info = PageInfo::new(object_writer.tell().await?, arrs_length as usize);
+        let page_info = PageInfo::new(object_writer.tell(), arrs_length as usize);
         page_table.set(field.id, batch_id, page_info);
         Ok(())
     }


### PR DESCRIPTION
`Writer::tell()` is a little awkward right now as it's async and fallible, even though there's not a good reason for either of those. If we keep track of the cursor in the writer, we can simplify the method.