### PR TITLE
fix: fix an issue where the GPU index trainer was taking too much data into memory

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import os
+import random
 import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -376,6 +377,32 @@ class LanceDataset(pa.dataset.Dataset):
             prefilter=prefilter,
             with_row_id=with_row_id,
         ).to_batches()
+
+    def sample(
+        self,
+        num_rows: int,
+        columns: Optional[List[str]] = None,
+        **kwargs,
+    ) -> pa.Table:
+        """Select a random sample of data
+
+        Parameters
+        ----------
+        num_rows: int
+            number of rows to retrieve
+        columns: list of strings, optional
+            list of column names to be fetched.  All columns are fetched
+            if not specified.
+        **kwargs : dict, optional
+            see scanner() method for full parameter description.
+
+        Returns
+        -------
+        table : Table
+        """
+        total_num_rows = self.count_rows()
+        indices = random.sample(range(total_num_rows), num_rows)
+        return self.take(indices, columns, **kwargs)
 
     def take(
         self,

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -143,10 +143,10 @@ def train_ivf_centroids(
     total_size = dataset.count_rows()
     sample_size = min(k * sample_rate, total_size)
 
-    if total_size < k * sample_size:
+    if total_size < sample_size:
         samples = dataset.to_table(columns=[column])[column].combine_chunks()
     else:
-        samples = dataset.sample(k * sample_rate)[column]
+        samples = dataset.sample(sample_size, columns=[column])[column].combine_chunks()
 
     if CUDA_REGEX.match(accelerator) or accelerator == "mps":
         logging.info(f"Training IVF partitions using GPU({accelerator})")

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -141,9 +141,9 @@ def train_ivf_centroids(
         )
 
     total_size = dataset.count_rows()
-    sample_size = min(k * sample_rate, total_size)
+    sample_size = k * sample_rate
 
-    if total_size < sample_size:
+    if total_size <= sample_size:
         samples = dataset.to_table(columns=[column])[column].combine_chunks()
     else:
         samples = dataset.sample(sample_size, columns=[column])[column].combine_chunks()

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -207,6 +207,26 @@ def test_asof_checkout(tmp_path: Path):
     assert len(ds.to_table()) == 9
 
 
+def test_sample(tmp_path: Path):
+    table1 = pa.Table.from_pydict({"x": [0, 10, 20, 30, 40, 50], "y": range(6)})
+    base_dir = tmp_path / "test"
+    lance.write_dataset(table1, base_dir)
+
+    dataset = lance.dataset(base_dir)
+    sampled = dataset.sample(3)
+
+    assert sampled.num_rows == 3
+    assert sampled.num_columns == 2
+
+    sampled = dataset.sample(4, columns=["x"])
+
+    assert sampled.num_rows == 4
+    assert sampled.num_columns == 1
+
+    for row in sampled.column(0).chunk(0):
+        assert row.as_py() % 10 == 0
+
+
 def test_take(tmp_path: Path):
     table1 = pa.Table.from_pylist([{"a": 1, "b": 2}, {"a": 10, "b": 20}])
     base_dir = tmp_path / "test"


### PR DESCRIPTION
the old computation calculated `k * sample_rate` as `sample_size` and then took the whole dataset unless there were `k * sample_size` rows which is `k * k * sample_rate`.  I've reworded the logic to hopefully be a bit clearer.

Once this was fixed the next issue was that the `dataset.sample` method doesn't actually exist and so I added it.