### PR TITLE
chore: update half to 2.3.1

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -56,7 +56,7 @@ arrow-schema = "47.0"
 arrow-select = "47.0"
 async-recursion = "1.0"
 async-trait = "0.1"
-half = { "version" = "=2.2.1", default-features = false, features = [
+half = { "version" = "=2.3.1", default-features = false, features = [
     "num-traits",
 ] }
 bytes = "1.4"


### PR DESCRIPTION
Updating `half` to `2.3.1`, which has been out for ~4 months.