### PR TITLE
feat: create_index take torch.device object

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Optional, Union
 
 import numpy as np
 import pyarrow as pa

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -132,7 +132,7 @@ def train_ivf_centroids_on_accelerator(
     column: str,
     k: int,
     metric_type: str,
-    accelerator: Union[str, torch.Device],
+    accelerator: Union[str, "torch.Device"],
     *,
     sample_rate: int = 256,
 ) -> np.ndarray:

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -15,12 +15,15 @@
 
 import logging
 import re
-from typing import Optional, Union
+from typing import Optional, Union, TYPE_CHECKING
 
 import numpy as np
 import pyarrow as pa
 
 from . import LanceDataset
+
+if TYPE_CHECKING:
+    import torch
 
 
 def _normalize_vectors(vectors, ndim):
@@ -124,12 +127,12 @@ def vec_to_table(
 CUDA_REGEX = re.compile(r"^cuda(:\d+)?$")
 
 
-def train_ivf_centroids(
+def train_ivf_centroids_on_accelerator(
     dataset: LanceDataset,
     column: str,
     k: int,
     metric_type: str,
-    accelerator: str,
+    accelerator: Union[str, torch.Device],
     *,
     sample_rate: int = 256,
 ) -> np.ndarray:

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -15,7 +15,7 @@
 
 import logging
 import re
-from typing import Optional, Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 import pyarrow as pa

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -63,7 +63,11 @@ def pytest_collection_modifyitems(config, items):
         # torch.cuda.is_available will return True on some CI machines even though any
         # attempt to use CUDA will then fail.  torch.cuda.device_count seems to be more
         # reliable
-        if not torch.cuda.is_available or torch.cuda.device_count() <= 0:
+        if (
+            torch.backends.cuda.is_built()
+            and not torch.cuda.is_available
+            or torch.cuda.device_count() <= 0
+        ):
             disable_items_with_mark(
                 items, "cuda", "torch is installed but cuda is not available"
             )

--- a/python/python/tests/torch_tests/test_torch_kmeans.py
+++ b/python/python/tests/torch_tests/test_torch_kmeans.py
@@ -44,4 +44,6 @@ def test_torch_kmean_accept_torch_device(tmp_path: Path):
     tbl = pa.Table.from_arrays([arr], ["vector"])
     ds = lance.write(tbl, tmp_path)
     # Not raising exception if pass a `torch.device()` directly
-    train_ivf_centroids_on_accelerator(ds, "vector", "L2", accelerator=preferred_device())
+    train_ivf_centroids_on_accelerator(
+        ds, "vector", "L2", accelerator=preferred_device()
+    )

--- a/python/python/tests/torch_tests/test_torch_kmeans.py
+++ b/python/python/tests/torch_tests/test_torch_kmeans.py
@@ -21,7 +21,7 @@ import pytest
 
 torch = pytest.importorskip("pytorch")
 
-from lance.vector import train_ivf_centroids  # noqa: E402
+from lance.vector import train_ivf_centroids_on_accelerator  # noqa: E402
 
 
 def test_kmeans():
@@ -44,4 +44,4 @@ def test_torch_kmean_accept_torch_device(tmp_path: Path):
     tbl = pa.Table.from_arrays([arr], ["vector"])
     ds = lance.write(tbl, tmp_path)
     # Not raising exception if pass a `torch.device()` directly
-    train_ivf_centroids(ds, "vector", "L2", accelerator=preferred_device())
+    train_ivf_centroids_on_accelerator(ds, "vector", "L2", accelerator=preferred_device())


### PR DESCRIPTION
Allow `Dataset::create_index(..., accelerator=torch.device)` so that it can takes in `lance.torch.preferred_device()`