### PR TITLE
feat: poor man's SIMD lib

### DIFF
--- a/.github/workflows/duckdb.yml
+++ b/.github/workflows/duckdb.yml
@@ -34,7 +34,7 @@ jobs:
       #     path: integration/duckdb/build/lance.duckdb_extension
       #     retention-days: 1
   MacOS:
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 40
     defaults:
       run:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -27,14 +27,14 @@ jobs:
       with:
         python-minor-version: ${{ matrix.python-minor-version }}
         args: "--release --strip"
-        arm-build: ${{ matrix.platform == 'aarch64' }} 
+        arm-build: ${{ matrix.platform == 'aarch64' }}
     - uses: ./.github/workflows/upload_wheel
       with:
         token: ${{ secrets.PYPI_TOKEN }}
         repo: "pypi"
   mac:
     timeout-minutes: 60
-    runs-on: "macos-12"
+    runs-on: "macos-13"
     strategy:
       matrix:
         python-minor-version: ["8"]

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -132,7 +132,7 @@ jobs:
       run: sudo rm -rf target/wheels
   mac:
     timeout-minutes: 45
-    runs-on: "macos-12"
+    runs-on: macos-13
     defaults:
       run:
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-features --tests -- -D warnings
   mac-build:
-    runs-on: macos-12
+    runs-on: macos-13
     timeout-minutes: 45
     defaults:
       run:

--- a/.github/workflows/upload_wheel/action.yml
+++ b/.github/workflows/upload_wheel/action.yml
@@ -4,7 +4,7 @@ description: "Upload wheels to Pypi"
 inputs:
   os:
     required: true
-    description: "ubuntu-22.04 or macos-12"
+    description: "ubuntu-22.04 or macos-13"
   repo:
     required: false
     description: "pypi or testpypi"

--- a/rust/lance-linalg/benches/cosine.rs
+++ b/rust/lance-linalg/benches/cosine.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use arrow_array::Float32Array;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use lance_linalg::distance::cosine::cosine_distance_batch;
 #[cfg(target_os = "linux")]
@@ -31,7 +31,9 @@ fn bench_distance(c: &mut Criterion) {
 
     c.bench_function("Cosine(simd)", |b| {
         b.iter(|| {
-            cosine_distance_batch(key.values(), target.values(), DIMENSION);
+            black_box(
+                cosine_distance_batch(key.values(), target.values(), DIMENSION).collect::<Vec<_>>(),
+            );
         })
     });
 
@@ -41,7 +43,9 @@ fn bench_distance(c: &mut Criterion) {
 
     c.bench_function("Cosine(simd) second rng seed", |b| {
         b.iter(|| {
-            cosine_distance_batch(key.values(), target.values(), DIMENSION);
+            black_box(
+                cosine_distance_batch(key.values(), target.values(), DIMENSION).collect::<Vec<_>>(),
+            )
         })
     });
 }

--- a/rust/lance-linalg/benches/l2.rs
+++ b/rust/lance-linalg/benches/l2.rs
@@ -52,14 +52,14 @@ fn l2_simd_lib(x: &[f32], y: &[f32], dim: usize) -> Vec<f32> {
             let mut sum2 = f32x8::splat(0.0);
             for i in (0..x.len()).step_by(16) {
                 unsafe {
-                    let mut x1 = f32x8::load(x.as_ptr().add(i));
-                    let mut x2 = f32x8::load(y_row.as_ptr().add(i + 8));
-                    let y1 = f32x8::load(x.as_ptr().add(i));
+                    let x1 = f32x8::load(x.as_ptr().add(i));
+                    let x2 = f32x8::load(x.as_ptr().add(i + 8));
+                    let y1 = f32x8::load(y_row.as_ptr().add(i));
                     let y2 = f32x8::load(y_row.as_ptr().add(i + 8));
-                    x1 -= y1;
-                    x2 -= y2;
-                    sum1.multiply_add(x1, x1);
-                    sum2.multiply_add(x2, x2);
+                    let s = x1 - y1;
+                    let s2 = x2 - y2;
+                    sum1.multiply_add(s, s);
+                    sum2.multiply_add(s2, s2);
                 }
             }
             (sum1 + sum2).reduce_sum()
@@ -85,9 +85,7 @@ fn bench_distance(c: &mut Criterion) {
 
     c.bench_function("L2(simd)", |b| {
         b.iter(|| {
-            black_box(
-                l2_distance_batch(key.values(), target.values(), DIMENSION).count(),
-            );
+            black_box(l2_distance_batch(key.values(), target.values(), DIMENSION).count());
         })
     });
 

--- a/rust/lance-linalg/benches/l2.rs
+++ b/rust/lance-linalg/benches/l2.rs
@@ -85,7 +85,9 @@ fn bench_distance(c: &mut Criterion) {
 
     c.bench_function("L2(simd)", |b| {
         b.iter(|| {
-            l2_distance_batch(key.values(), target.values(), DIMENSION);
+            black_box(
+                l2_distance_batch(key.values(), target.values(), DIMENSION).collect::<Vec<_>>(),
+            );
         })
     });
 
@@ -129,7 +131,7 @@ fn bench_distance(c: &mut Criterion) {
 
     c.bench_function("L2(simd) second rng seed", |b| {
         b.iter(|| {
-            l2_distance_batch(key.values(), target.values(), DIMENSION);
+            black_box(l2_distance_batch(key.values(), target.values(), DIMENSION));
         })
     });
 

--- a/rust/lance-linalg/benches/l2.rs
+++ b/rust/lance-linalg/benches/l2.rs
@@ -28,7 +28,6 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
 
 use lance_linalg::distance::l2_distance_batch;
-use lance_linalg::simd::{f32::f32x8, SIMD};
 use lance_testing::datagen::generate_random_array_with_seed;
 
 #[inline]

--- a/rust/lance-linalg/benches/l2.rs
+++ b/rust/lance-linalg/benches/l2.rs
@@ -86,7 +86,7 @@ fn bench_distance(c: &mut Criterion) {
     c.bench_function("L2(simd)", |b| {
         b.iter(|| {
             black_box(
-                l2_distance_batch(key.values(), target.values(), DIMENSION).collect::<Vec<_>>(),
+                l2_distance_batch(key.values(), target.values(), DIMENSION).count(),
             );
         })
     });
@@ -131,7 +131,7 @@ fn bench_distance(c: &mut Criterion) {
 
     c.bench_function("L2(simd) second rng seed", |b| {
         b.iter(|| {
-            black_box(l2_distance_batch(key.values(), target.values(), DIMENSION));
+            black_box(l2_distance_batch(key.values(), target.values(), DIMENSION).count());
         })
     });
 

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -54,15 +54,6 @@ pub type ArrowBatchDistanceFunc = fn(&[f32], &FixedSizeListArray) -> Arc<Float32
 
 impl DistanceType {
     /// Compute the distance from one vector to a batch of vectors.
-    pub fn batch_func(&self) -> BatchDistanceFunc {
-        match self {
-            Self::L2 => l2_distance_batch,
-            Self::Cosine => cosine_distance_batch,
-            Self::Dot => dot_distance_batch,
-        }
-    }
-
-    /// Compute the distance from one vector to a batch of vectors.
     ///
     /// This propagates nulls to the output.
     pub fn arrow_batch_func(&self) -> ArrowBatchDistanceFunc {

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -75,13 +75,15 @@ impl Dot for [f64] {
 }
 
 /// Negative dot product, to present the relative order of dot distance.
-pub fn dot_distance_batch(from: &[f32], to: &[f32], dimension: usize) -> Arc<Float32Array> {
+pub fn dot_distance_batch<'a>(
+    from: &'a [f32],
+    to: &'a [f32],
+    dimension: usize,
+) -> Box<dyn Iterator<Item = f32> + 'a> {
     debug_assert_eq!(from.len(), dimension);
     debug_assert_eq!(to.len() % dimension, 0);
 
-    let dists = to.chunks_exact(dimension).map(|v| dot_distance(from, v));
-
-    Arc::new(Float32Array::new(dists.collect(), None))
+    Box::new(to.chunks_exact(dimension).map(|v| dot_distance(from, v)))
 }
 
 /// Compute negative dot product distance between a vector and a batch of vectors.

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -69,13 +69,12 @@ impl L2 for [f32] {
 
     #[inline]
     fn l2(&self, other: &[f32]) -> f32 {
-        let mut sum1 = f32x8::splat(0.0);
-        let mut sum2 = f32x8::splat(0.0);
-
         let len = self.len();
-        let remain = if len >= 16 {
-            let unrolling_len = len / 16 * 16;
-            for i in (0..unrolling_len).step_by(16) {
+        if len % 16 == 0 {  // Likely
+            let mut sum1 = f32x8::splat(0.0);
+            let mut sum2 = f32x8::splat(0.0);
+
+            for i in (0..len).step_by(16) {
                 unsafe {
                     let mut x1 = f32x8::load(self.as_ptr().add(i));
                     let mut x2 = f32x8::load(self.as_ptr().add(i + 8));
@@ -87,13 +86,11 @@ impl L2 for [f32] {
                     sum2.multiply_add(x2, x2);
                 }
             }
-            unrolling_len
-        } else {
-            0
-        };
-
-        if len - remain >= 8 {
-            for i in (remain..len).step_by(8) {
+            sum1 += sum2;
+            return sum1.reduce_sum();
+        } else if len % 8 == 0 {
+            let mut sum1 = f32x8::splat(0.0);
+            for i in (0..len).step_by(8) {
                 unsafe {
                     let mut x = f32x8::load(self.as_ptr().add(i));
                     let y = f32x8::load(other.as_ptr().add(i));
@@ -101,16 +98,11 @@ impl L2 for [f32] {
                     sum1.multiply_add(x, x);
                 }
             }
+            return sum1.reduce_sum();
         }
 
-        sum1 += sum2;
-        let mut l2_sum = sum1.reduce_sum();
-        let unaligned_remain = len / 8 * 8;
-        if unaligned_remain < self.len() {
-            l2_sum += l2_scalar(&self[unaligned_remain..], &other[unaligned_remain..]);
-        }
-
-        l2_sum
+        // Fallback to scalar
+        l2_scalar(self, other)
     }
 }
 
@@ -177,66 +169,6 @@ pub fn l2_distance_arrow_batch(from: &[f32], to: &FixedSizeListArray) -> Arc<Flo
     Arc::new(Float32Array::new(dists.collect(), to.nulls().cloned()))
 }
 
-#[cfg(target_arch = "x86_64")]
-mod x86_64 {
-    pub mod avx {
-        use super::super::l2_scalar;
-
-        #[inline]
-        pub fn l2_f32(from: &[f32], to: &[f32]) -> f32 {
-            unsafe {
-                use std::arch::x86_64::*;
-                debug_assert_eq!(from.len(), to.len());
-
-                // Get the potion of the vector that is aligned to 32 bytes.
-                let len = from.len() / 32 * 32;
-                let mut sums1 = _mm256_setzero_ps();
-                let mut sums2 = _mm256_setzero_ps();
-                let mut sums3 = _mm256_setzero_ps();
-                let mut sums4 = _mm256_setzero_ps();
-
-                // Manually unroll the loop by 4.
-                for i in (0..len).step_by(32) {
-                    let left = _mm256_loadu_ps(from.as_ptr().add(i));
-                    let l2 = _mm256_loadu_ps(from.as_ptr().add(i + 8));
-                    let l3 = _mm256_loadu_ps(from.as_ptr().add(i + 16));
-                    let l4 = _mm256_loadu_ps(from.as_ptr().add(i + 24));
-
-                    let right = _mm256_loadu_ps(to.as_ptr().add(i));
-                    let r2 = _mm256_loadu_ps(to.as_ptr().add(i + 8));
-                    let r3 = _mm256_loadu_ps(to.as_ptr().add(i + 16));
-                    let r4 = _mm256_loadu_ps(to.as_ptr().add(i + 24));
-                    let sub = _mm256_sub_ps(left, right);
-                    // sum = sub * sub + sum
-                    let s2 = _mm256_sub_ps(l2, r2);
-                    let s3 = _mm256_sub_ps(l3, r3);
-                    let s4 = _mm256_sub_ps(l4, r4);
-                    sums1 = _mm256_fmadd_ps(sub, sub, sums1);
-                    sums2 = _mm256_fmadd_ps(s2, s2, sums2);
-                    sums3 = _mm256_fmadd_ps(s3, s3, sums3);
-                    sums4 = _mm256_fmadd_ps(s4, s4, sums4);
-                }
-                sums1 = _mm256_add_ps(sums1, sums2);
-                sums3 = _mm256_add_ps(sums3, sums4);
-                sums1 = _mm256_add_ps(sums1, sums3);
-                // Shift and add vector, until only 1 value left.
-                // sums = [x0-x7], shift = [x4-x7]
-                let mut shift = _mm256_permute2f128_ps(sums1, sums1, 1);
-                // [x0+x4, x1+x5, ..]
-                sums1 = _mm256_add_ps(sums1, shift);
-                shift = _mm256_permute_ps(sums1, 14);
-                sums1 = _mm256_add_ps(sums1, shift);
-                sums1 = _mm256_hadd_ps(sums1, sums1);
-                let mut results: [f32; 8] = [0f32; 8];
-                _mm256_storeu_ps(results.as_mut_ptr(), sums1);
-
-                // Remaining
-                results[0] += l2_scalar(&from[len..], &to[len..]);
-                results[0]
-            }
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -73,17 +73,16 @@ fn l2_unrolling_f32(from: &[f32], to: &[f32]) -> f32 {
     for i in (0..dim).step_by(16) {
         unsafe {
             let mut x1 = f32x8::load_unaligned(from.as_ptr().add(i));
-            let mut x2 = f32x8::load_unaligned(from.as_ptr().add(i + 8));
+            let x2 = f32x8::load_unaligned(from.as_ptr().add(i + 8));
             let y1 = f32x8::load_unaligned(to.as_ptr().add(i));
-            let y2 = f32x8::load_unaligned(to.as_ptr().add(i + 8));
+            let mut y2 = f32x8::load_unaligned(to.as_ptr().add(i + 8));
             x1 -= y1;
-            x2 -= y2;
+            y2 -= x2;
             sum1.multiply_add(x1, x1);
-            sum2.multiply_add(x2, x2);
+            sum2.multiply_add(y2, y2);
         }
     }
-    sum1 += sum2;
-    sum1.reduce_sum()
+    (sum1 + sum2).reduce_sum()
 }
 
 impl L2 for [f32] {
@@ -155,7 +154,7 @@ pub fn l2_distance_batch<'a>(
 
     if dimension % 16 == 0 {
         // Likely
-        return Box::new(to.chunks_exact(dimension).map(|v| l2_unrolling_f32(from, v)));
+        return Box::new(to.chunks(dimension).map(|v| l2_unrolling_f32(from, v)));
     };
     Box::new(to.chunks_exact(dimension).map(|v| from.l2(v)))
 }

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -73,13 +73,13 @@ fn l2_unrolling_f32(from: &[f32], to: &[f32]) -> f32 {
     for i in (0..dim).step_by(16) {
         unsafe {
             let mut x1 = f32x8::load_unaligned(from.as_ptr().add(i));
-            let x2 = f32x8::load_unaligned(from.as_ptr().add(i + 8));
+            let mut x2 = f32x8::load_unaligned(from.as_ptr().add(i + 8));
             let y1 = f32x8::load_unaligned(to.as_ptr().add(i));
-            let mut y2 = f32x8::load_unaligned(to.as_ptr().add(i + 8));
+            let y2 = f32x8::load_unaligned(to.as_ptr().add(i + 8));
             x1 -= y1;
-            y2 -= x2;
+            x2 -= y2;
             sum1.multiply_add(x1, x1);
-            sum2.multiply_add(y2, y2);
+            sum2.multiply_add(x2, x2);
         }
     }
     (sum1 + sum2).reduce_sum()

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -72,8 +72,9 @@ impl L2 for [f32] {
         let mut sum1 = f32x8::splat(0.0);
         let mut sum2 = f32x8::splat(0.0);
 
-        let remain = if self.len() >= 16 {
-            let unrolling_len = self.len() / 16 * 16;
+        let len = self.len();
+        let remain = if len >= 16 {
+            let unrolling_len = len / 16 * 16;
             for i in (0..unrolling_len).step_by(16) {
                 unsafe {
                     let mut x1 = f32x8::load(self.as_ptr().add(i));
@@ -91,8 +92,8 @@ impl L2 for [f32] {
             0
         };
 
-        if remain < self.len() {
-            for i in (remain..self.len()).step_by(8) {
+        if len - remain >= 8 {
+            for i in (remain..len).step_by(8) {
                 unsafe {
                     let mut x = f32x8::load(self.as_ptr().add(i));
                     let y = f32x8::load(other.as_ptr().add(i));
@@ -104,7 +105,7 @@ impl L2 for [f32] {
 
         sum1 += sum2;
         let mut l2_sum = sum1.reduce_sum();
-        let unaligned_remain = self.len() / 8 * 8;
+        let unaligned_remain = len / 8 * 8;
         if unaligned_remain < self.len() {
             l2_sum += l2_scalar(&self[unaligned_remain..], &other[unaligned_remain..]);
         }

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -88,7 +88,7 @@ impl L2 for [f32] {
                 }
             }
             sum1 += sum2;
-            return sum1.reduce_sum();
+            sum1.reduce_sum()
         } else if len % 8 == 0 {
             let mut sum1 = f32x8::splat(0.0);
             for i in (0..len).step_by(8) {
@@ -99,7 +99,7 @@ impl L2 for [f32] {
                     sum1.multiply_add(x, x);
                 }
             }
-            return sum1.reduce_sum();
+            sum1.reduce_sum()
         } else {
             // Fallback to scalar
             l2_scalar(self, other)

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -76,10 +76,10 @@ impl L2 for [f32] {
 
             for i in (0..len).step_by(16) {
                 unsafe {
-                    let mut x1 = f32x8::load(self.as_ptr().add(i));
-                    let mut x2 = f32x8::load(self.as_ptr().add(i + 8));
-                    let y1 = f32x8::load(other.as_ptr().add(i));
-                    let y2 = f32x8::load(other.as_ptr().add(i + 8));
+                    let mut x1 = f32x8::load_unaligned(self.as_ptr().add(i));
+                    let mut x2 = f32x8::load_unaligned(self.as_ptr().add(i + 8));
+                    let y1 = f32x8::load_unaligned(other.as_ptr().add(i));
+                    let y2 = f32x8::load_unaligned(other.as_ptr().add(i + 8));
                     x1 -= y1;
                     x2 -= y2;
                     sum1.multiply_add(x1, x1);
@@ -92,17 +92,17 @@ impl L2 for [f32] {
             let mut sum1 = f32x8::splat(0.0);
             for i in (0..len).step_by(8) {
                 unsafe {
-                    let mut x = f32x8::load(self.as_ptr().add(i));
-                    let y = f32x8::load(other.as_ptr().add(i));
+                    let mut x = f32x8::load_unaligned(self.as_ptr().add(i));
+                    let y = f32x8::load_unaligned(other.as_ptr().add(i));
                     x -= y;
                     sum1.multiply_add(x, x);
                 }
             }
             return sum1.reduce_sum();
+        } else {
+            // Fallback to scalar
+            l2_scalar(self, other)
         }
-
-        // Fallback to scalar
-        l2_scalar(self, other)
     }
 }
 

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -64,27 +64,6 @@ impl L2 for [f16] {
     }
 }
 
-#[inline]
-fn l2_unrolling_f32(from: &[f32], to: &[f32]) -> f32 {
-    let dim = from.len();
-    let mut sum1 = f32x8::splat(0.0);
-    let mut sum2 = f32x8::splat(0.0);
-
-    for i in (0..dim).step_by(16) {
-        unsafe {
-            let mut x1 = f32x8::load_unaligned(from.as_ptr().add(i));
-            let mut x2 = f32x8::load_unaligned(from.as_ptr().add(i + 8));
-            let y1 = f32x8::load_unaligned(to.as_ptr().add(i));
-            let y2 = f32x8::load_unaligned(to.as_ptr().add(i + 8));
-            x1 -= y1;
-            x2 -= y2;
-            sum1.multiply_add(x1, x1);
-            sum2.multiply_add(x2, x2);
-        }
-    }
-    (sum1 + sum2).reduce_sum()
-}
-
 impl L2 for [f32] {
     type Output = f32;
 
@@ -93,7 +72,23 @@ impl L2 for [f32] {
         let len = self.len();
         if len % 16 == 0 {
             // Likely
-            l2_unrolling_f32(self, other)
+            let dim = self.len();
+            let mut sum1 = f32x8::splat(0.0);
+            let mut sum2 = f32x8::splat(0.0);
+
+            for i in (0..dim).step_by(16) {
+                unsafe {
+                    let mut x1 = f32x8::load_unaligned(self.as_ptr().add(i));
+                    let mut x2 = f32x8::load_unaligned(self.as_ptr().add(i + 8));
+                    let y1 = f32x8::load_unaligned(other.as_ptr().add(i));
+                    let y2 = f32x8::load_unaligned(other.as_ptr().add(i + 8));
+                    x1 -= y1;
+                    x2 -= y2;
+                    sum1.multiply_add(x1, x1);
+                    sum2.multiply_add(x2, x2);
+                }
+            }
+            (sum1 + sum2).reduce_sum()
         } else if len % 8 == 0 {
             let mut sum1 = f32x8::splat(0.0);
             for i in (0..len).step_by(8) {
@@ -152,10 +147,6 @@ pub fn l2_distance_batch<'a>(
     debug_assert_eq!(from.len(), dimension);
     debug_assert_eq!(to.len() % dimension, 0);
 
-    if dimension % 16 == 0 {
-        // Likely
-        return Box::new(to.chunks(dimension).map(|v| l2_unrolling_f32(from, v)));
-    };
     Box::new(to.chunks_exact(dimension).map(|v| from.l2(v)))
 }
 

--- a/rust/lance-linalg/src/lib.rs
+++ b/rust/lance-linalg/src/lib.rs
@@ -18,6 +18,7 @@ pub mod distance;
 pub mod kernels;
 pub mod kmeans;
 pub mod matrix;
+pub mod simd;
 
 pub use matrix::MatrixView;
 

--- a/rust/lance-linalg/src/simd.rs
+++ b/rust/lance-linalg/src/simd.rs
@@ -66,10 +66,6 @@ pub trait SIMD<T: Float>:
     /// c = a * b + c
     fn multiply_add(&mut self, a: Self, b: Self);
 
-    fn argmin(&self) -> u32;
-
-    fn argmax(&self) -> u32;
-
     /// Calculate the sum across this vector.
     fn reduce_sum(&self) -> T;
 }

--- a/rust/lance-linalg/src/simd.rs
+++ b/rust/lance-linalg/src/simd.rs
@@ -36,6 +36,13 @@ pub trait SIMD<T: Float>: std::fmt::Debug {
     /// Load unaligned data from memory.
     fn loadu(ptr: *const T) -> Self;
 
+    fn store(&self, ptr: *mut T);
+
+    /// fused multiply-add
+    ///
+    /// c = a * b + c
+    fn multiply_add(&mut self, a: Self, b: Self);
+
     fn argmin(&self) -> u32;
 
     fn argmax(&self) -> u32;

--- a/rust/lance-linalg/src/simd.rs
+++ b/rust/lance-linalg/src/simd.rs
@@ -38,6 +38,8 @@ pub trait SIMD<T: Float>: std::fmt::Debug {
 
     fn store(&self, ptr: *mut T);
 
+    fn store_unaligned(&self, ptr: *mut T);
+
     /// fused multiply-add
     ///
     /// c = a * b + c

--- a/rust/lance-linalg/src/simd.rs
+++ b/rust/lance-linalg/src/simd.rs
@@ -23,7 +23,7 @@
 //!
 //! The API are close to [std::simd] to make migration easier in the future.
 
-pub mod f32x8;
+pub mod f32;
 
 use num_traits::Float;
 

--- a/rust/lance-linalg/src/simd.rs
+++ b/rust/lance-linalg/src/simd.rs
@@ -38,15 +38,27 @@ pub trait SIMD<T: Float>:
     fn splat(val: T) -> Self;
 
     /// Load aligned data from aligned memory.
+    ///
+    /// # Safety
+    ///
+    /// It crashes if the ptr is not aligned.
     unsafe fn load(ptr: *const T) -> Self;
 
     /// Load unaligned data from memory.
+    ///
+    /// # Safety
     unsafe fn load_unaligned(ptr: *const T) -> Self;
 
     /// Store the values to aligned memory.
+    ///
+    /// # Safety
+    ///
+    /// It crashes if the ptr is not aligned
     unsafe fn store(&self, ptr: *mut T);
 
     /// Store the values to unaligned memory.
+    ///
+    /// # Safety
     unsafe fn store_unaligned(&self, ptr: *mut T);
 
     /// fused multiply-add

--- a/rust/lance-linalg/src/simd.rs
+++ b/rust/lance-linalg/src/simd.rs
@@ -34,7 +34,7 @@ pub trait SIMD<T: Float>: std::fmt::Debug {
     fn load(ptr: *const T) -> Self;
 
     /// Load unaligned data from memory.
-    fn loadu(ptr: *const T) -> Self;
+    fn load_unaligned(ptr: *const T) -> Self;
 
     fn store(&self, ptr: *mut T);
 

--- a/rust/lance-linalg/src/simd.rs
+++ b/rust/lance-linalg/src/simd.rs
@@ -1,0 +1,44 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Poor-man's SIMD
+//!
+//! The difference between this implementation and [std::simd] is that
+//! this implementation holds the SIMD register directly, thus it exposes more
+//! optimization opportunity to use wide range of instructions available.
+//!
+//! Also, it gives us more control, for example, it is likely that we will have
+//! f16/bf16 support before the standard library does.
+//!
+//! The API are close to [std::simd] to make migration easier in the future.
+
+pub mod f32x8;
+
+use num_traits::Float;
+
+pub trait SIMD<T: Float>: std::fmt::Debug {
+    fn splat(val: T) -> Self;
+
+    /// Load aligned data from memory.
+    fn load(ptr: *const T) -> Self;
+
+    /// Load unaligned data from memory.
+    fn loadu(ptr: *const T) -> Self;
+
+    fn argmin(&self) -> u32;
+
+    fn argmax(&self) -> u32;
+
+    fn reduce_sum(&self) -> T;
+}

--- a/rust/lance-linalg/src/simd.rs
+++ b/rust/lance-linalg/src/simd.rs
@@ -23,22 +23,31 @@
 //!
 //! The API are close to [std::simd] to make migration easier in the future.
 
+use std::ops::{Add, AddAssign, Mul, Sub, SubAssign};
+
 pub mod f32;
 
 use num_traits::Float;
 
-pub trait SIMD<T: Float>: std::fmt::Debug {
+/// Lance SIMD lib
+///
+pub trait SIMD<T: Float>:
+    std::fmt::Debug + AddAssign + Add + Mul + Sub + SubAssign + Copy + Clone + Sized
+{
+    /// Create a new instance with all lanes set to `val`.
     fn splat(val: T) -> Self;
 
-    /// Load aligned data from memory.
-    fn load(ptr: *const T) -> Self;
+    /// Load aligned data from aligned memory.
+    unsafe fn load(ptr: *const T) -> Self;
 
     /// Load unaligned data from memory.
-    fn load_unaligned(ptr: *const T) -> Self;
+    unsafe fn load_unaligned(ptr: *const T) -> Self;
 
-    fn store(&self, ptr: *mut T);
+    /// Store the values to aligned memory.
+    unsafe fn store(&self, ptr: *mut T);
 
-    fn store_unaligned(&self, ptr: *mut T);
+    /// Store the values to unaligned memory.
+    unsafe fn store_unaligned(&self, ptr: *mut T);
 
     /// fused multiply-add
     ///
@@ -49,5 +58,6 @@ pub trait SIMD<T: Float>: std::fmt::Debug {
 
     fn argmax(&self) -> u32;
 
+    /// Calculate the sum across this vector.
     fn reduce_sum(&self) -> T;
 }

--- a/rust/lance-linalg/src/simd/f32.rs
+++ b/rust/lance-linalg/src/simd/f32.rs
@@ -103,14 +103,6 @@ impl SIMD<f32> for f32x8 {
         }
     }
 
-    fn argmin(&self) -> u32 {
-        todo!()
-    }
-
-    fn argmax(&self) -> u32 {
-        todo!()
-    }
-
     fn multiply_add(&mut self, a: Self, b: Self) {
         #[cfg(target_arch = "x86_64")]
         unsafe {

--- a/rust/lance-linalg/src/simd/f32.rs
+++ b/rust/lance-linalg/src/simd/f32.rs
@@ -18,8 +18,8 @@ use std::fmt::Formatter;
 
 #[cfg(target_arch = "aarch64")]
 use std::arch::aarch64::{
-    float32x4x2_t, vaddq_f32, vaddvq_f32, vdupq_n_f32, vfmaq_f32, vld1q_f32_x2, vst1q_f32_x2,
-    vsubq_f32,
+    float32x4x2_t, vaddq_f32, vaddvq_f32, vdupq_n_f32, vfmaq_f32, vld1q_f32_x2, vmulq_f32,
+    vst1q_f32_x2, vsubq_f32,
 };
 #[cfg(target_arch = "x86_64")]
 use std::arch::x86_64::__mm256;
@@ -174,6 +174,21 @@ impl SubAssign for f32x8 {
         unsafe {
             self.0 .0 = vsubq_f32(self.0 .0, rhs.0 .0);
             self.0 .1 = vsubq_f32(self.0 .1, rhs.0 .1);
+        }
+    }
+}
+
+impl Mul for f32x8 {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self::Output {
+        #[cfg(target_arch = "aarch64")]
+        unsafe {
+            Self(float32x4x2_t(
+                vmulq_f32(self.0 .0, rhs.0 .0),
+                vmulq_f32(self.0 .1, rhs.0 .1),
+            ))
         }
     }
 }

--- a/rust/lance-linalg/src/simd/f32.rs
+++ b/rust/lance-linalg/src/simd/f32.rs
@@ -42,7 +42,9 @@ pub struct f32x8(float32x4x2_t);
 impl std::fmt::Debug for f32x8 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let mut arr = [0.0_f32; 8];
-        self.store_unaligned(arr.as_mut_ptr());
+        unsafe {
+            self.store_unaligned(arr.as_mut_ptr());
+        }
         write!(f, "f32x8({:?})", arr)
     }
 }
@@ -60,7 +62,7 @@ impl SIMD<f32> for f32x8 {
     }
 
     #[inline]
-    fn load(ptr: *const f32) -> Self {
+    unsafe fn load(ptr: *const f32) -> Self {
         #[cfg(target_arch = "x86_64")]
         unsafe {
             Self(_mm256_load_ps(ptr))
@@ -70,18 +72,16 @@ impl SIMD<f32> for f32x8 {
     }
 
     #[inline]
-    fn load_unaligned(ptr: *const f32) -> Self {
+    unsafe fn load_unaligned(ptr: *const f32) -> Self {
         #[cfg(target_arch = "x86_64")]
         unsafe {
             Self(_mm256_loadu_ps(ptr))
         }
         #[cfg(target_arch = "aarch64")]
-        unsafe {
-            Self(vld1q_f32_x2(ptr))
-        }
+        Self(vld1q_f32_x2(ptr))
     }
 
-    fn store(&self, ptr: *mut f32) {
+    unsafe fn store(&self, ptr: *mut f32) {
         #[cfg(target_arch = "x86_64")]
         unsafe {
             _mm256_store_ps(ptr, self.0);
@@ -92,7 +92,7 @@ impl SIMD<f32> for f32x8 {
         }
     }
 
-    fn store_unaligned(&self, ptr: *mut f32) {
+    unsafe fn store_unaligned(&self, ptr: *mut f32) {
         #[cfg(target_arch = "x86_64")]
         unsafe {
             _mm256_storeu_ps(ptr, self.0);

--- a/rust/lance-linalg/src/simd/f32.rs
+++ b/rust/lance-linalg/src/simd/f32.rs
@@ -68,7 +68,7 @@ impl SIMD<f32> for f32x8 {
             Self(_mm256_load_ps(ptr))
         }
         #[cfg(target_arch = "aarch64")]
-        Self::loadu(ptr)
+        Self::load_unaligned(ptr)
     }
 
     #[inline]

--- a/rust/lance-linalg/src/simd/f32.rs
+++ b/rust/lance-linalg/src/simd/f32.rs
@@ -236,8 +236,8 @@ mod tests {
         let a = (0..8).map(|f| f as f32).collect::<Vec<_>>();
         let b = (10..18).map(|f| f as f32).collect::<Vec<_>>();
 
-        let mut simd_a = f32x8::load_unaligned(a.as_ptr());
-        let simd_b = f32x8::load_unaligned(b.as_ptr());
+        let mut simd_a = unsafe { f32x8::load_unaligned(a.as_ptr()) };
+        let simd_b = unsafe { f32x8::load_unaligned(b.as_ptr()) };
         simd_a -= simd_b;
         assert_eq!(simd_a.reduce_sum(), -80.0);
 

--- a/rust/lance-linalg/src/simd/f32.rs
+++ b/rust/lance-linalg/src/simd/f32.rs
@@ -70,7 +70,7 @@ impl SIMD<f32> for f32x8 {
     }
 
     #[inline]
-    fn loadu(ptr: *const f32) -> Self {
+    fn load_unaligned(ptr: *const f32) -> Self {
         #[cfg(target_arch = "x86_64")]
         unsafe {
             Self(_mm256_loadu_ps(ptr))
@@ -244,8 +244,8 @@ mod tests {
         let a = (0..8).map(|f| f as f32).collect::<Vec<_>>();
         let b = (10..18).map(|f| f as f32).collect::<Vec<_>>();
 
-        let mut simd_a = f32x8::loadu(a.as_ptr());
-        let simd_b = f32x8::loadu(b.as_ptr());
+        let mut simd_a = f32x8::load_unaligned(a.as_ptr());
+        let simd_b = f32x8::load_unaligned(b.as_ptr());
         simd_a -= simd_b;
         assert_eq!(simd_a.reduce_sum(), -80.0);
 

--- a/rust/lance-linalg/src/simd/f32x8.rs
+++ b/rust/lance-linalg/src/simd/f32x8.rs
@@ -1,0 +1,166 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! `f32x8`, 8 of f32 values.s
+
+#[cfg(target_arch = "aarch64")]
+use std::arch::aarch64::{
+    float32x4x2_t, vaddq_f32, vaddvq_f32, vdupq_n_f32, vld1q_f32_x2, vsubq_f32,
+};
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::__mm256;
+use std::ops::{Add, AddAssign, Mul, Sub, SubAssign};
+
+use super::SIMD;
+
+/// 8 of 32-bit `f32` values. Use 256-bit SIMD if possible.
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::__mm256;
+/// 8 of 32-bit `f32` values. Use 256-bit SIMD if possible.
+#[allow(non_camel_case_types)]
+#[cfg(target_arch = "aarch64")]
+#[derive(Debug, Clone, Copy)]
+pub struct f32x8(float32x4x2_t);
+
+impl SIMD<f32> for f32x8 {
+    fn splat(val: f32) -> Self {
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            Self(__mm256::set1_ps(val))
+        }
+        #[cfg(target_arch = "aarch64")]
+        unsafe {
+            Self(float32x4x2_t(vdupq_n_f32(val), vdupq_n_f32(val)))
+        }
+    }
+
+    #[inline]
+    fn load(ptr: *const f32) -> Self {
+        Self::loadu(ptr)
+    }
+
+    #[inline]
+    fn loadu(ptr: *const f32) -> Self {
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            Self(__mm256_loadu_ps(ptr))
+        }
+        #[cfg(target_arch = "aarch64")]
+        unsafe {
+            Self(vld1q_f32_x2(ptr))
+        }
+    }
+
+    fn argmin(&self) -> u32 {
+        todo!()
+    }
+
+    fn argmax(&self) -> u32 {
+        todo!()
+    }
+
+    #[inline]
+    fn reduce_sum(&self) -> f32 {
+        #[cfg(target_arch = "aarch64")]
+        unsafe {
+            let sum = vaddq_f32(self.0 .0, self.0 .1);
+            vaddvq_f32(sum)
+        }
+    }
+}
+
+impl Add for f32x8 {
+    type Output = Self;
+
+    #[inline]
+    fn add(self, rhs: Self) -> Self::Output {
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            Self(__mm256_add_ps(self.0, rhs.0))
+        }
+        #[cfg(target_arch = "aarch64")]
+        unsafe {
+            Self(float32x4x2_t(
+                vaddq_f32(self.0 .0, rhs.0 .0),
+                vaddq_f32(self.0 .1, rhs.0 .1),
+            ))
+        }
+    }
+}
+
+impl AddAssign for f32x8 {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            Self(__mm256_add_ps(self.0, rhs.0))
+        }
+        #[cfg(target_arch = "aarch64")]
+        unsafe {
+            self.0 .0 = vaddq_f32(self.0 .0, rhs.0 .0);
+            self.0 .1 = vaddq_f32(self.0 .1, rhs.0 .1);
+        }
+    }
+}
+
+impl Sub for f32x8 {
+    type Output = Self;
+
+    #[inline]
+    fn sub(self, rhs: Self) -> Self::Output {
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            Self(__mm256_sub_ps(self.0, rhs.0))
+        }
+        #[cfg(target_arch = "aarch64")]
+        unsafe {
+            Self(float32x4x2_t(
+                vsubq_f32(self.0 .0, rhs.0 .0),
+                vsubq_f32(self.0 .1, rhs.0 .1),
+            ))
+        }
+    }
+}
+
+impl SubAssign for f32x8 {
+    #[inline]
+    fn sub_assign(&mut self, rhs: Self) {
+        #[cfg(target_arch = "x86_64")]
+        unsafe {
+            Self(__mm256_sub_ps(self.0, rhs.0))
+        }
+        #[cfg(target_arch = "aarch64")]
+        unsafe {
+            self.0 .0 = vsubq_f32(self.0 .0, rhs.0 .0);
+            self.0 .1 = vsubq_f32(self.0 .1, rhs.0 .1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_basic_ops() {
+        let a = (0..8).map(|f| f as f32).collect::<Vec<_>>();
+        let b = (10..18).map(|f| f as f32).collect::<Vec<_>>();
+
+        let mut simd_a = f32x8::load(a.as_ptr());
+        let simd_b = f32x8::load(b.as_ptr());
+        simd_a -= simd_b;
+        assert_eq!(simd_a.reduce_sum(), -80.0);
+    }
+}

--- a/rust/lance/src/index/vector/graph/persisted.rs
+++ b/rust/lance/src/index/vector/graph/persisted.rs
@@ -105,7 +105,7 @@ impl<V: Vertex + Debug> PersistedGraph<V> {
 
         let schema = file_reader.schema();
         let vertex_projection = schema.project(&[VERTEX_COL])?;
-        let vertex_size = if let Some(field) = vertex_projection.fields.get(0) {
+        let vertex_size = if let Some(field) = vertex_projection.fields.first() {
             match field.data_type() {
                 DataType::FixedSizeBinary(size) => size as usize,
                 _ => {

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -1070,15 +1070,10 @@ mod tests {
                     }
                     let distances = l2_distance_batch(
                         centroid,
-                        &centroids.values().slice(offset, length),
+                        &centroids.values()[offset..offset + length],
                         self.dim as usize,
                     );
-                    let min_distance = distances
-                        .values()
-                        .iter()
-                        .copied()
-                        .min_by(|a, b| a.total_cmp(b))
-                        .unwrap();
+                    let min_distance = distances.min_by(|a, b| a.total_cmp(b)).unwrap();
                     // In theory we could just replace this one vector but, out of laziness, we just retry all of them
                     if min_distance < distance_needed {
                         broken = true;

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -110,7 +110,7 @@ impl PQIndex {
                 subvec_centroids,
                 sub_vector_length,
             );
-            distance_table.extend(distances.values());
+            distance_table.extend(distances);
         }
 
         Ok(Arc::new(unsafe {


### PR DESCRIPTION
Make a SIMD lib for lance, to make writing SIMD easier and performant without needing `std::simd`. 

Only support `x86_64::avx2/fma` and onward, as well as `aarch64::neon` and onward. 