### PR TITLE
ci: cancel in progress runs on new push

### DIFF
--- a/.github/workflows/duckdb.yml
+++ b/.github/workflows/duckdb.yml
@@ -8,6 +8,11 @@ on:
       - integration/duckdb_lance/*
       - .github/workflows/duckdb.yml
       - ./rust/*
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+  
 jobs:
   Linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/notebook.yml
+++ b/.github/workflows/notebook.yml
@@ -11,6 +11,10 @@ on:
       - protos/**
       - notebooks/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux:
     timeout-minutes: 30

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -3,6 +3,11 @@ name: PR Title Check
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   commitlint:
     permissions:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -14,6 +14,10 @@ on:
       - .github/workflows/build_mac_wheel/**
       - .github/workflows/run_tests/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # This env var is used by Swatinem/rust-cache@v2 for the cache
   # key, so we set it to make sure it is always consistent.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,10 @@ on:
       - protos/**
       - .github/workflows/rust.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # This env var is used by Swatinem/rust-cache@v2 for the cache
   # key, so we set it to make sure it is always consistent.


### PR DESCRIPTION
Adds concurrency config to cancel in progress actions when new commit pushed to PR or branch:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

When we have a PR open, and we notice some CI job has failed, it's common to immediately push a new commit with the fix before all the jobs have finished. This will start a new batch of jobs for the PR, but the old ones will continue to run in the background and will possibly also fail. This leads to confusing behaviour where we'll later receive emails about failed jobs on a PR from old commits.

<img width="2424" alt="Screenshot 2023-11-01 at 10 22 48 AM" src="https://github.com/lancedb/lance/assets/5846846/35d23f46-97d2-41e2-a0a1-11df62b4ed8a">
