### PR TITLE
feat: add sorting to the scanner

### DIFF
--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -242,7 +242,7 @@ impl ArrayGeneratorExt for Box<dyn ArrayGenerator> {
     fn with_validity(self, validity: &[bool]) -> Box<dyn ArrayGenerator> {
         Box::new(CycleNullGenerator {
             generator: self,
-            validity: validity.iter().copied().collect(),
+            validity: validity.to_vec(),
             idx: 0,
         })
     }

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -18,6 +18,7 @@ no-default-features = true
 [dependencies]
 lance-arrow = { workspace = true }
 lance-core = { workspace = true }
+lance-datagen = { workspace = true }
 lance-linalg = { workspace = true }
 lance-index = { workspace = true }
 arrow-arith = { workspace = true }

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -651,7 +651,7 @@ impl Scanner {
                 plan = self.take(plan, &remaining_schema, self.batch_readahead)?;
             }
             let col_exprs = ordering
-                .into_iter()
+                .iter()
                 .map(|col| {
                     Ok(PhysicalSortExpr {
                         expr: expressions::col(&col.column_name, plan.schema().as_ref())?,

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -414,6 +414,10 @@ impl Scanner {
     /// the first batch can be returned.
     pub fn order_by(&mut self, ordering: Option<Vec<ColumnOrdering>>) -> Result<&mut Self> {
         if let Some(ordering) = &ordering {
+            if ordering.is_empty() {
+                self.ordering = None;
+                return Ok(self);
+            }
             // Verify early that the fields exist
             for column in ordering {
                 self.dataset
@@ -1795,6 +1799,18 @@ mod test {
             .unwrap();
 
         assert_eq!(batches_by_str[0], sorted_by_str);
+
+        // Ensure an empty sort vec does not break anything (sorting is disabled)
+        dataset
+            .scan()
+            .order_by(Some(vec![]))
+            .unwrap()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
     }
 
     #[tokio::test]


### PR DESCRIPTION
This uses datafusion to sort the scanner results.  It will be needed for training scalar indices.  In addition, this PR adds some new capabilities to the array generators that I was using for testing the sort method.