### PR TITLE
feat: support `true` in deletion logic

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2885,8 +2885,7 @@ mod tests {
         let data = RecordBatch::try_new(schema.clone(), vec![vectors]);
         let reader = RecordBatchIterator::new(vec![data.unwrap()].into_iter().map(Ok), schema);
         let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
-        dataset.delete("vec IS NOT NULL").await.unwrap();
-        let dataset = Dataset::open(test_uri).await.unwrap();
+        dataset.delete("true").await.unwrap();
 
         let mut stream = dataset
             .scan()

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -504,10 +504,13 @@ impl FileFragment {
 
         // scan with predicate and row ids
         let mut scanner = self.scan();
-        scanner
-            .with_row_id()
-            .filter(predicate)?
-            .project::<&str>(&[])?;
+        scanner.with_row_id();
+
+        // if predicate is true, delete the whole fragment
+        // else, filter the predicate
+        if predicate != "true" {
+            scanner.filter(predicate)?.project::<&str>(&[])?;
+        }
 
         // As we get row ids, add them into our deletion vector
         scanner

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -504,13 +504,20 @@ impl FileFragment {
 
         // scan with predicate and row ids
         let mut scanner = self.scan();
-        scanner.with_row_id();
 
-        // if predicate is true, delete the whole fragment
-        // else, filter the predicate
-        if predicate != "true" {
-            scanner.filter(predicate)?.project::<&str>(&[])?;
+        // if predicate is `true`, delete the whole fragment
+        // else if predicate is `false`, filter the predicate
+        let predicate_lower = predicate.trim().to_lowercase();
+        if predicate_lower == "true" {
+            return Ok(None);
+        } else if predicate_lower == "false" {
+            return Ok(Some(self));
         }
+
+        scanner
+            .with_row_id()
+            .filter(predicate)?
+            .project::<&str>(&[])?;
 
         // As we get row ids, add them into our deletion vector
         scanner


### PR DESCRIPTION
Closes. #1074

This pull request extends the `delete` method to accept the parameter `delete('true')` 
to bypass the filter when `predicate == 'true'`.
