### PR TITLE
feat: make it possible to create and load scalar indices for a dataset

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -33,12 +33,13 @@ use lance::dataset::{
 };
 use lance::datatypes::Schema;
 use lance::format::Fragment;
+use lance::index::IndexType;
 use lance::index::{
     vector::{diskann::DiskANNParams, ivf::IvfBuildParams, VectorIndexParams},
     DatasetIndexExt,
 };
 use lance::io::object_store::ObjectStoreParams;
-use lance_index::{vector::pq::PQBuildParams, IndexType};
+use lance_index::vector::pq::PQBuildParams;
 use lance_linalg::distance::MetricType;
 use pyo3::exceptions::PyStopIteration;
 use pyo3::prelude::*;

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -33,13 +33,13 @@ use lance::dataset::{
 };
 use lance::datatypes::Schema;
 use lance::format::Fragment;
-use lance::index::IndexType;
 use lance::index::{
     vector::{diskann::DiskANNParams, ivf::IvfBuildParams, VectorIndexParams},
     DatasetIndexExt,
 };
 use lance::io::object_store::ObjectStoreParams;
 use lance_index::vector::pq::PQBuildParams;
+use lance_index::IndexType;
 use lance_linalg::distance::MetricType;
 use pyo3::exceptions::PyStopIteration;
 use pyo3::prelude::*;

--- a/rust/lance-core/src/format/index.rs
+++ b/rust/lance-core/src/format/index.rs
@@ -45,8 +45,6 @@ pub struct Index {
     pub fragment_bitmap: Option<RoaringBitmap>,
 }
 
-impl Index {}
-
 impl TryFrom<&pb::IndexMetadata> for Index {
     type Error = Error;
 

--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -21,6 +21,8 @@ use lance_core::Result;
 pub mod scalar;
 pub mod vector;
 
+pub const INDEX_FILE_NAME: &str = "index.idx";
+
 pub mod pb {
     #![allow(clippy::use_self)]
     include!(concat!(env!("OUT_DIR"), "/lance.index.pb.rs"));
@@ -34,4 +36,24 @@ pub trait Index: Send + Sync {
     fn as_index(self: Arc<Self>) -> Arc<dyn Index>;
     /// Retrieve index statistics as a JSON string
     fn statistics(&self) -> Result<String>;
+    /// Get the type of the index
+    fn index_type(&self) -> IndexType;
+}
+
+/// Index Type
+pub enum IndexType {
+    // Preserve 0-100 for simple indices.
+    Scalar = 0,
+    // 100+ and up for vector index.
+    /// Flat vector index.
+    Vector = 100,
+}
+
+impl std::fmt::Display for IndexType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Scalar => write!(f, "Scalar"),
+            Self::Vector => write!(f, "Vector"),
+        }
+    }
 }

--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -14,8 +14,7 @@
 
 //! Lance secondary index library
 
-use std::any::Any;
-use std::fmt;
+use std::{any::Any, sync::Arc};
 
 use lance_core::Result;
 
@@ -27,29 +26,12 @@ pub mod pb {
     include!(concat!(env!("OUT_DIR"), "/lance.index.pb.rs"));
 }
 
-/// Trait of a secondary index.
+/// Generic methods common across all types of secondary indices
 pub trait Index: Send + Sync {
     /// Cast to [Any].
     fn as_any(&self) -> &dyn Any;
-
-    // TODO: if we ever make this public, do so in such a way that `serde_json`
-    // isn't exposed at the interface. That way mismatched versions isn't an issue.
-    fn statistics(&self) -> Result<serde_json::Value>;
-}
-
-/// Index Type
-pub enum IndexType {
-    // Preserve 0-100 for simple indices.
-
-    // 100+ and up for vector index.
-    /// Flat vector index.
-    Vector = 100,
-}
-
-impl fmt::Display for IndexType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Vector => write!(f, "Vector"),
-        }
-    }
+    /// Cast to [Index]
+    fn as_index(self: Arc<Self>) -> Arc<dyn Index>;
+    /// Retrieve index statistics as a JSON string
+    fn statistics(&self) -> Result<String>;
 }

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -23,9 +23,11 @@ use datafusion_common::scalar::ScalarValue;
 
 use lance_core::Result;
 
+use crate::Index;
+
 pub mod btree;
 pub mod flat;
-pub mod lance;
+pub mod lance_format;
 
 /// Trait for storing an index (or parts of an index) into storage
 #[async_trait]
@@ -83,7 +85,7 @@ pub enum ScalarQuery {
 
 /// A trait for a scalar index, a structure that can determine row ids that satisfy scalar queries
 #[async_trait]
-pub trait ScalarIndex: Send + Sync + std::fmt::Debug {
+pub trait ScalarIndex: Send + Sync + std::fmt::Debug + Index {
     /// Search the scalar index
     ///
     /// Returns all row ids that satisfy the query, these row ids are not neccesarily ordered

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -13,22 +13,29 @@
 // limitations under the License.
 
 use std::{
+    any::Any,
     cmp::Ordering,
     collections::{BTreeMap, BinaryHeap},
-    fmt::Debug,
+    fmt::{Debug, Display},
     ops::Bound,
     sync::Arc,
 };
 
 use arrow_array::{Array, RecordBatch, UInt32Array, UInt64Array};
-use arrow_schema::{Field, Schema};
+use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
 use datafusion_common::ScalarValue;
 use datafusion_expr::Accumulator;
 use datafusion_physical_expr::expressions::{MaxAccumulator, MinAccumulator};
-use futures::{stream, FutureExt, Stream, StreamExt, TryStreamExt};
+use futures::{
+    stream::{self, BoxStream},
+    FutureExt, StreamExt, TryStreamExt,
+};
 use lance_core::{Error, Result};
+use serde::{Serialize, Serializer};
 use snafu::{location, Location};
+
+use crate::Index;
 
 use super::{
     flat::FlatIndexLoader, IndexReader, IndexStore, IndexWriter, ScalarIndex, ScalarQuery,
@@ -38,8 +45,14 @@ const BTREE_LOOKUP_NAME: &str = "page_lookup.lance";
 const BTREE_PAGES_NAME: &str = "page_data.lance";
 
 /// Wraps a ScalarValue and implements Ord (ScalarValue only implements PartialOrd)
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct OrderableScalarValue(ScalarValue);
+
+impl Display for OrderableScalarValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.0, f)
+    }
+}
 
 impl PartialEq for OrderableScalarValue {
     fn eq(&self, other: &Self) -> bool {
@@ -719,6 +732,55 @@ fn wrap_bound(bound: &Bound<ScalarValue>) -> Bound<OrderableScalarValue> {
     }
 }
 
+fn serialize_with_display<T: Display, S: Serializer>(
+    value: &Option<T>,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error> {
+    if let Some(value) = value {
+        serializer.collect_str(value)
+    } else {
+        serializer.collect_str("N/A")
+    }
+}
+
+#[derive(Serialize)]
+struct BTreeStatistics {
+    #[serde(serialize_with = "serialize_with_display")]
+    min: Option<OrderableScalarValue>,
+    #[serde(serialize_with = "serialize_with_display")]
+    max: Option<OrderableScalarValue>,
+    num_pages: u32,
+}
+
+impl Index for BTreeIndex {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+        self
+    }
+
+    fn statistics(&self) -> Result<String> {
+        let min = self
+            .page_lookup
+            .tree
+            .first_key_value()
+            .map(|(k, _)| k.clone());
+        let max = self
+            .page_lookup
+            .tree
+            .last_key_value()
+            .map(|(k, _)| k.clone());
+        serde_json::to_string(&BTreeStatistics {
+            num_pages: self.page_lookup.tree.len() as u32,
+            min,
+            max,
+        })
+        .map_err(|err| err.into())
+    }
+}
+
 #[async_trait]
 impl ScalarIndex for BTreeIndex {
     async fn search(&self, query: &ScalarQuery) -> Result<UInt64Array> {
@@ -861,13 +923,28 @@ fn btree_stats_as_batch(stats: Vec<EncodedBatch>) -> Result<RecordBatch> {
     Ok(RecordBatch::try_new(schema, columns)?)
 }
 
+#[async_trait]
+pub trait BtreeTrainingSource: Send + Sync {
+    /// Returns a stream of batches, ordered by the value column (in ascending order)
+    ///
+    /// Each batch should have chunk_size rows
+    ///
+    /// The schema for the batch is slightly flexible.
+    /// The first column may have any name or type, these are the values to index
+    /// The second column must be the row ids which must be UInt64Type
+    async fn scan_ordered_chunks(
+        self: Box<Self>,
+        chunk_size: u32,
+    ) -> Result<BoxStream<'static, Result<RecordBatch>>>;
+}
+
 /// Train a btree index from a stream of sorted page-size batches of values and row ids
 ///
 /// Note: This is likely to change.  It is unreasonable to expect the caller to do the sorting
 /// and re-chunking into page-size batches.  This is left for simplicity as this feature is still
 /// a work in progress
-pub async fn train_btree_index<S: Stream<Item = Result<RecordBatch>> + Unpin>(
-    mut batches: S,
+pub async fn train_btree_index(
+    data_source: Box<dyn BtreeTrainingSource + Send>,
     sub_index_trainer: &dyn SubIndexTrainer,
     index_store: &dyn IndexStore,
 ) -> Result<()> {
@@ -876,7 +953,10 @@ pub async fn train_btree_index<S: Stream<Item = Result<RecordBatch>> + Unpin>(
         .await?;
     let mut encoded_batches = Vec::new();
     let mut batch_idx = 0;
-    while let Some(batch) = batches.try_next().await? {
+    let mut batches_source = data_source.scan_ordered_chunks(4096).await?;
+    while let Some(batch) = batches_source.try_next().await? {
+        debug_assert_eq!(batch.num_columns(), 2);
+        debug_assert_eq!(*batch.column(1).data_type(), DataType::UInt64);
         encoded_batches.push(
             train_btree_page(batch, batch_idx, sub_index_trainer, sub_index_file.as_mut()).await?,
         );

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -35,7 +35,7 @@ use lance_core::{Error, Result};
 use serde::{Serialize, Serializer};
 use snafu::{location, Location};
 
-use crate::Index;
+use crate::{Index, IndexType};
 
 use super::{
     flat::FlatIndexLoader, IndexReader, IndexStore, IndexWriter, ScalarIndex, ScalarQuery,
@@ -759,6 +759,10 @@ impl Index for BTreeIndex {
 
     fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
         self
+    }
+
+    fn index_type(&self) -> IndexType {
+        IndexType::Scalar
     }
 
     fn statistics(&self) -> Result<String> {

--- a/rust/lance-index/src/scalar/flat.rs
+++ b/rust/lance-index/src/scalar/flat.rs
@@ -22,7 +22,7 @@ use datafusion_physical_expr::expressions::{in_list, lit, Column};
 use lance_core::Result;
 use serde::Serialize;
 
-use crate::Index;
+use crate::{Index, IndexType};
 
 use super::{
     btree::{SubIndexLoader, SubIndexTrainer},
@@ -116,6 +116,10 @@ impl Index for FlatIndex {
 
     fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
         self
+    }
+
+    fn index_type(&self) -> IndexType {
+        IndexType::Scalar
     }
 
     fn statistics(&self) -> Result<String> {

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -430,7 +430,7 @@ impl ProductQuantizerImpl {
         //
         // xy table: `[f32: num_sub_vectors(row) * num_centroids(column)]`.
         // y_norm table: `[f32: num_sub_vectors(row) * num_centroids(column)]`.
-        let num_centroids = ProductQuantizerImpl::num_centroids(self.num_bits);
+        let num_centroids = Self::num_centroids(self.num_bits);
         let mut xy_table: Vec<f32> = Vec::with_capacity(self.num_sub_vectors * num_centroids);
         let mut y2_table: Vec<f32> = Vec::with_capacity(self.num_sub_vectors * num_centroids);
 

--- a/rust/lance/benches/ivf_pq.rs
+++ b/rust/lance/benches/ivf_pq.rs
@@ -20,10 +20,11 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use lance::{
     arrow::*,
     dataset::{WriteMode, WriteParams},
-    index::{vector::VectorIndexParams, DatasetIndexExt, IndexType},
+    index::{vector::VectorIndexParams, DatasetIndexExt},
     Dataset,
 };
 
+use lance_index::IndexType;
 use lance_linalg::distance::MetricType;
 use lance_testing::datagen::generate_random_array;
 #[cfg(target_os = "linux")]

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -2,55 +2,76 @@ use std::sync::Arc;
 
 use arrow_array::{
     types::{UInt32Type, UInt64Type},
-    RecordBatchReader,
+    RecordBatch, RecordBatchReader,
 };
+use async_trait::async_trait;
 use criterion::{criterion_group, criterion_main, Criterion};
 use datafusion::scalar::ScalarValue;
-use futures::{stream, TryStreamExt};
+use futures::{
+    stream::{self, BoxStream},
+    StreamExt, TryStreamExt,
+};
 use lance::{
     io::{object_store::ObjectStoreParams, ObjectStore},
     Dataset,
 };
-use lance_core::Error;
+use lance_core::{Error, Result};
 use lance_datagen::{array, gen, BatchCount, RowCount};
 use lance_index::scalar::{
-    btree::{train_btree_index, BTreeIndex},
+    btree::{train_btree_index, BTreeIndex, BtreeTrainingSource},
     flat::FlatIndexTrainer,
-    lance::LanceIndexStore,
+    lance_format::LanceIndexStore,
     IndexStore, ScalarIndex, ScalarQuery,
 };
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
 use tempfile::TempDir;
 
-pub struct BenchmarkFixture {
+struct BenchmarkFixture {
     _datadir: TempDir,
     index_store: Arc<dyn IndexStore>,
     baseline_dataset: Arc<Dataset>,
 }
 
-impl BenchmarkFixture {
+struct BenchmarkDataSource {}
+
+impl BenchmarkDataSource {
     fn test_data() -> impl RecordBatchReader {
         gen()
             .col(Some("values".to_string()), array::step::<UInt32Type>())
             .col(Some("row_ids".to_string()), array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(1024), BatchCount::from(100 * 1024))
     }
+}
 
+#[async_trait]
+impl BtreeTrainingSource for BenchmarkDataSource {
+    async fn scan_ordered_chunks(
+        self: Box<Self>,
+        _chunk_size: u32,
+    ) -> Result<BoxStream<'static, Result<RecordBatch>>> {
+        Ok(
+            stream::iter(Self::test_data().map(|batch| batch.map_err(|err| Error::from(err))))
+                .boxed(),
+        )
+    }
+}
+
+impl BenchmarkFixture {
     fn test_store(tempdir: &TempDir) -> Arc<dyn IndexStore> {
         let test_path = tempdir.path();
-        let (object_store, _) = ObjectStore::from_path(
+        let (object_store, test_path) = ObjectStore::from_path(
             test_path.as_os_str().to_str().unwrap(),
             &ObjectStoreParams::default(),
         )
         .unwrap();
-        Arc::new(LanceIndexStore::new(object_store, test_path.to_owned()))
+        Arc::new(LanceIndexStore::new(object_store, test_path))
     }
 
     async fn write_baseline_data(tempdir: &TempDir) -> Arc<Dataset> {
         let test_path = tempdir.path().as_os_str().to_str().unwrap();
         Arc::new(
-            Dataset::write(Self::test_data(), test_path, None)
+            Dataset::write(BenchmarkDataSource::test_data(), test_path, None)
                 .await
                 .unwrap(),
         )
@@ -59,10 +80,13 @@ impl BenchmarkFixture {
     async fn train_scalar_index(index_store: &Arc<dyn IndexStore>) {
         let sub_index_trainer = FlatIndexTrainer::new(arrow_schema::DataType::UInt32);
 
-        let data = stream::iter(Self::test_data().map(|batch| batch.map_err(Error::from)));
-        train_btree_index(data, &sub_index_trainer, index_store.as_ref())
-            .await
-            .unwrap();
+        train_btree_index(
+            Box::new(BenchmarkDataSource {}),
+            &sub_index_trainer,
+            index_store.as_ref(),
+        )
+        .await
+        .unwrap();
     }
 
     async fn open() -> Self {

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -50,10 +50,7 @@ impl BtreeTrainingSource for BenchmarkDataSource {
         self: Box<Self>,
         _chunk_size: u32,
     ) -> Result<BoxStream<'static, Result<RecordBatch>>> {
-        Ok(
-            stream::iter(Self::test_data().map(|batch| batch.map_err(|err| Error::from(err))))
-                .boxed(),
-        )
+        Ok(stream::iter(Self::test_data().map(|batch| batch.map_err(Error::from))).boxed())
     }
 }
 

--- a/rust/lance/benches/vector_index.rs
+++ b/rust/lance/benches/vector_index.rs
@@ -23,6 +23,7 @@ use arrow_array::{
 use arrow_schema::{DataType, Field, FieldRef, Schema as ArrowSchema};
 use criterion::{criterion_group, criterion_main, Criterion};
 use futures::TryStreamExt;
+use lance_index::IndexType;
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
 use rand::{self, Rng};
@@ -31,7 +32,7 @@ use lance::dataset::{WriteMode, WriteParams};
 use lance::index::vector::ivf::IvfBuildParams;
 use lance::index::vector::pq::PQBuildParams;
 use lance::index::vector::VectorIndexParams;
-use lance::index::{DatasetIndexExt, IndexType};
+use lance::index::DatasetIndexExt;
 use lance::{arrow::as_fixed_size_list_array, dataset::Dataset};
 use lance_arrow::FixedSizeListArrayExt;
 use lance_linalg::distance::MetricType;

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -70,7 +70,7 @@ use crate::dataset::index::unindexed_fragments;
 use crate::datatypes::Schema;
 use crate::error::box_error;
 use crate::format::{Fragment, Index, Manifest};
-use crate::index::DatasetIndexExt;
+use crate::index::DatasetIndexInternalExt;
 use crate::io::commit::{commit_new_dataset, commit_transaction};
 use crate::session::Session;
 
@@ -1494,7 +1494,7 @@ mod tests {
     use crate::dataset::WriteMode::Overwrite;
     use crate::datatypes::Schema;
     use crate::index::scalar::ScalarIndexParams;
-    use crate::index::{vector::VectorIndexParams, DatasetIndexExt, IndexType};
+    use crate::index::{vector::VectorIndexParams, DatasetIndexExt};
     use crate::io::deletion::read_deletion_file;
 
     use arrow_array::{
@@ -1512,6 +1512,7 @@ mod tests {
     use lance_core::format::WriterVersion;
     use lance_datagen::{array, gen, BatchCount, RowCount};
     use lance_index::vector::DIST_COL;
+    use lance_index::IndexType;
     use lance_linalg::distance::MetricType;
     use lance_testing::datagen::generate_random_array;
     use tempfile::{tempdir, TempDir};

--- a/rust/lance/src/dataset/chunker.rs
+++ b/rust/lance/src/dataset/chunker.rs
@@ -21,8 +21,8 @@ use futures::{Stream, StreamExt};
 
 use crate::Result;
 
-/// Wraps a [`RecordBatchReader`] into an iterator of RecordBatch chunks of a given size.
-/// This slices but does not copy any buffers.
+/// Wraps a [`SendableRecordBatchStream`] into a stream of RecordBatch chunks of
+/// a given size.  This slices but does not copy any buffers.
 struct BatchReaderChunker {
     /// The inner stream
     inner: SendableRecordBatchStream,
@@ -108,7 +108,7 @@ impl BatchReaderChunker {
     }
 }
 
-pub(super) fn chunk_stream(
+pub fn chunk_stream(
     stream: SendableRecordBatchStream,
     chunk_size: usize,
 ) -> Pin<Box<dyn Stream<Item = Result<Vec<RecordBatch>>> + Send>> {

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -458,6 +458,7 @@ mod tests {
         utils::testing::{MockClock, ProxyObjectStore, ProxyObjectStorePolicy},
         Error, Result,
     };
+    use lance_index::IndexType;
     use lance_linalg::distance::MetricType;
     use lance_testing::datagen::{some_batch, BatchGenerator, IncrementingInt32};
     use snafu::{location, Location};
@@ -467,7 +468,7 @@ mod tests {
         dataset::{ReadParams, WriteMode, WriteParams},
         index::{
             vector::{StageParams, VectorIndexParams},
-            DatasetIndexExt, IndexType,
+            DatasetIndexExt,
         },
         io::{
             object_store::{ObjectStoreParams, WrappingObjectStore},

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1011,6 +1011,7 @@ mod test {
     use lance_core::ROW_ID;
     use lance_datagen::{array, gen, BatchCount, RowCount};
     use lance_index::vector::DIST_COL;
+    use lance_index::IndexType;
     use lance_testing::datagen::{BatchGenerator, IncrementingInt32};
     use tempfile::tempdir;
 
@@ -1018,10 +1019,7 @@ mod test {
     use crate::arrow::*;
     use crate::dataset::WriteMode;
     use crate::dataset::WriteParams;
-    use crate::index::{
-        DatasetIndexExt,
-        {vector::VectorIndexParams, IndexType},
-    };
+    use crate::index::{vector::VectorIndexParams, DatasetIndexExt};
 
     #[tokio::test]
     async fn test_batch_size() {

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -17,15 +17,21 @@
 
 use std::any::Any;
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use lance_core::io::{read_message, read_message_from_buf, read_metadata_offset, Reader};
+use lance_index::pb::index::Implementation;
+use lance_index::scalar::ScalarIndex;
+use lance_index::{pb, Index};
 use snafu::{location, Location};
 use uuid::Uuid;
 
 pub(crate) mod append;
 pub(crate) mod cache;
 pub(crate) mod prefilter;
+pub(crate) mod scalar;
 pub mod vector;
 
 use crate::dataset::transaction::{Operation, Transaction};
@@ -34,9 +40,29 @@ use crate::index::append::append_index;
 use crate::index::vector::remap_vector_index;
 use crate::io::commit::commit_transaction;
 use crate::{dataset::Dataset, Error, Result};
-pub use lance_index::{pb, Index, IndexType};
 
-use self::vector::{build_vector_index, VectorIndexParams};
+use self::scalar::build_scalar_index;
+use self::vector::{build_vector_index, VectorIndex, VectorIndexParams};
+
+const INDEX_FILE_NAME: &str = "index.idx";
+
+/// Index Type
+pub enum IndexType {
+    // Preserve 0-100 for simple indices.
+    Scalar = 0,
+    // 100+ and up for vector index.
+    /// Flat vector index.
+    Vector = 100,
+}
+
+impl fmt::Display for IndexType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Scalar => write!(f, "Scalar"),
+            Self::Vector => write!(f, "Vector"),
+        }
+    }
+}
 
 /// Builds index.
 #[async_trait]
@@ -119,6 +145,32 @@ pub trait DatasetIndexExt {
 
     /// Optimize indices.
     async fn optimize_indices(&mut self) -> Result<()>;
+
+    async fn open_generic_index(&self, column: &str, uuid: &str) -> Result<Arc<dyn Index>>;
+    async fn open_scalar_index(&self, column: &str, uuid: &str) -> Result<Arc<dyn ScalarIndex>>;
+    async fn open_vector_index(&self, column: &str, uuid: &str) -> Result<Arc<dyn VectorIndex>>;
+}
+
+async fn open_index_proto(dataset: &Dataset, reader: &dyn Reader) -> Result<pb::Index> {
+    let object_store = dataset.object_store();
+
+    let file_size = reader.size().await?;
+    let block_size = object_store.block_size();
+    let begin = if file_size < block_size {
+        0
+    } else {
+        file_size - block_size
+    };
+    let tail_bytes = reader.get_range(begin..file_size).await?;
+    let metadata_pos = read_metadata_offset(&tail_bytes)?;
+    let proto: pb::Index = if metadata_pos < file_size - tail_bytes.len() {
+        // We have not read the metadata bytes yet.
+        read_message(reader, metadata_pos).await?
+    } else {
+        let offset = tail_bytes.len() - (file_size - metadata_pos);
+        read_message_from_buf(&tail_bytes.slice(offset..))?
+    };
+    Ok(proto)
 }
 
 #[async_trait]
@@ -171,6 +223,9 @@ impl DatasetIndexExt for Dataset {
 
         let index_id = Uuid::new_v4();
         match index_type {
+            IndexType::Scalar => {
+                build_scalar_index(self, column, &index_id.to_string()).await?;
+            }
             IndexType::Vector => {
                 // Vector index params.
                 let vec_params = params
@@ -266,6 +321,74 @@ impl DatasetIndexExt for Dataset {
 
         self.manifest = Arc::new(new_manifest);
         Ok(())
+    }
+
+    async fn open_generic_index(&self, column: &str, uuid: &str) -> Result<Arc<dyn Index>> {
+        // Checking for cache existence is cheap so we just check both scalar and vector caches
+        if let Some(index) = self.session.index_cache.get_scalar(uuid) {
+            return Ok(index.as_index());
+        }
+        if let Some(index) = self.session.index_cache.get_vector(uuid) {
+            return Ok(index.as_index());
+        }
+
+        // Sometimes we want to open an index and we don't care if it is a scalar or vector index.
+        // For example, we might want to get statistics for an index, regardless of type.
+        //
+        // Currently, we solve this problem by checking for the existence of INDEX_FILE_NAME since
+        // only vector indices have this file.  In the future, once we support multiple kinds of
+        // scalar indices, we may start having this file with scalar indices too.  Once that happens
+        // we can just read this file and look at the `implementation` or `index_type` fields to
+        // determine what kind of index it is.
+        let index_dir = self.indices_dir().child(uuid);
+        let index_file = index_dir.child(INDEX_FILE_NAME);
+        if self.object_store.exists(&index_file).await? {
+            let index = self.open_vector_index(column, uuid).await?;
+            Ok(index.as_index())
+        } else {
+            let index = self.open_scalar_index(column, uuid).await?;
+            Ok(index.as_index())
+        }
+    }
+
+    async fn open_scalar_index(&self, _column: &str, uuid: &str) -> Result<Arc<dyn ScalarIndex>> {
+        if let Some(index) = self.session.index_cache.get_scalar(uuid) {
+            return Ok(index);
+        }
+
+        let index = crate::index::scalar::open_scalar_index(self, uuid).await?;
+        self.session.index_cache.insert_scalar(uuid, index.clone());
+        Ok(index)
+    }
+
+    async fn open_vector_index(&self, column: &str, uuid: &str) -> Result<Arc<dyn VectorIndex>> {
+        if let Some(index) = self.session.index_cache.get_vector(uuid) {
+            return Ok(index);
+        }
+
+        let index_dir = self.indices_dir().child(uuid);
+        let index_file = index_dir.child(INDEX_FILE_NAME);
+        let reader: Arc<dyn Reader> = self.object_store.open(&index_file).await?.into();
+
+        let proto = open_index_proto(self, reader.as_ref()).await?;
+        match &proto.implementation {
+            Some(Implementation::VectorIndex(vector_index)) => {
+                let dataset = Arc::new(self.clone());
+                crate::index::vector::open_vector_index(
+                    dataset,
+                    column,
+                    uuid,
+                    vector_index,
+                    index_dir,
+                    reader,
+                )
+                .await
+            }
+            None => Err(Error::Internal {
+                message: "Index proto was missing implementation field".into(),
+                location: location!(),
+            }),
+        }
     }
 }
 

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -21,7 +21,9 @@ use uuid::Uuid;
 
 use crate::dataset::index::unindexed_fragments;
 use crate::dataset::Dataset;
-use crate::index::vector::{ivf::IVFIndex, open_index};
+use crate::index::vector::ivf::IVFIndex;
+
+use super::DatasetIndexExt;
 
 /// Append new data to the index, without re-train.
 pub async fn append_index(
@@ -44,12 +46,9 @@ pub async fn append_index(
             location: location!(),
         })?;
 
-    let index = open_index(
-        dataset.clone(),
-        &column.name,
-        old_index.uuid.to_string().as_str(),
-    )
-    .await?;
+    let index = dataset
+        .open_vector_index(&column.name, old_index.uuid.to_string().as_str())
+        .await?;
 
     let Some(ivf_idx) = index.as_any().downcast_ref::<IVFIndex>() else {
         info!("Index type: {:?} does not support append", index);
@@ -181,7 +180,8 @@ mod tests {
         assert!(contained);
 
         // Check that the index has all 2000 rows.
-        let binding = open_index(Arc::new(dataset), "vector", index.uuid.to_string().as_str())
+        let binding = dataset
+            .open_vector_index("vector", index.uuid.to_string().as_str())
             .await
             .unwrap();
         let ivf_index = binding.as_any().downcast_ref::<IVFIndex>().unwrap();

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -23,7 +23,7 @@ use crate::dataset::index::unindexed_fragments;
 use crate::dataset::Dataset;
 use crate::index::vector::ivf::IVFIndex;
 
-use super::DatasetIndexExt;
+use super::DatasetIndexInternalExt;
 
 /// Append new data to the index, without re-train.
 pub async fn append_index(

--- a/rust/lance/src/index/cache.rs
+++ b/rust/lance/src/index/cache.rs
@@ -14,35 +14,46 @@
 
 use std::sync::Arc;
 
+use lance_index::scalar::ScalarIndex;
 use moka::sync::{Cache, ConcurrentCacheExt};
 
 use super::vector::VectorIndex;
 
 #[derive(Clone)]
 pub struct IndexCache {
-    cache: Arc<Cache<String, Arc<dyn VectorIndex>>>,
+    scalar_cache: Arc<Cache<String, Arc<dyn ScalarIndex>>>,
+    vector_cache: Arc<Cache<String, Arc<dyn VectorIndex>>>,
 }
 
 impl IndexCache {
     pub(crate) fn new(capacity: usize) -> Self {
         Self {
-            cache: Arc::new(Cache::new(capacity as u64)),
+            scalar_cache: Arc::new(Cache::new(capacity as u64)),
+            vector_cache: Arc::new(Cache::new(capacity as u64)),
         }
     }
 
     #[allow(dead_code)]
-    pub(crate) fn len(&self) -> usize {
-        self.cache.sync();
-        self.cache.entry_count() as usize
+    pub(crate) fn len_vector(&self) -> usize {
+        self.vector_cache.sync();
+        self.vector_cache.entry_count() as usize
     }
 
     /// Get an Index if present. Otherwise returns [None].
-    pub(crate) fn get(&self, key: &str) -> Option<Arc<dyn VectorIndex>> {
-        self.cache.get(key)
+    pub(crate) fn get_scalar(&self, key: &str) -> Option<Arc<dyn ScalarIndex>> {
+        self.scalar_cache.get(key)
+    }
+
+    pub(crate) fn get_vector(&self, key: &str) -> Option<Arc<dyn VectorIndex>> {
+        self.vector_cache.get(key)
     }
 
     /// Insert a new entry into the cache.
-    pub(crate) fn insert(&self, key: &str, index: Arc<dyn VectorIndex>) {
-        self.cache.insert(key.to_string(), index);
+    pub(crate) fn insert_scalar(&self, key: &str, index: Arc<dyn ScalarIndex>) {
+        self.scalar_cache.insert(key.to_string(), index);
+    }
+
+    pub(crate) fn insert_vector(&self, key: &str, index: Arc<dyn VectorIndex>) {
+        self.vector_cache.insert(key.to_string(), index);
     }
 }

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -1,0 +1,120 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Utilities for integrating scalar indices with datasets
+//!
+
+use std::{future, sync::Arc};
+
+use arrow::compute::kernels;
+use arrow_array::RecordBatch;
+use async_trait::async_trait;
+use futures::{stream::BoxStream, StreamExt, TryStreamExt};
+use lance_index::scalar::{
+    btree::{train_btree_index, BTreeIndex, BtreeTrainingSource},
+    flat::FlatIndexTrainer,
+    lance_format::LanceIndexStore,
+    ScalarIndex,
+};
+use snafu::{location, Location};
+use tracing::instrument;
+
+use lance_core::{Error, Result};
+
+use crate::{
+    dataset::{chunker, scanner::ColumnOrdering},
+    Dataset,
+};
+
+use super::IndexParams;
+
+#[derive(Default)]
+pub struct ScalarIndexParams {}
+
+impl IndexParams for ScalarIndexParams {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
+struct TrainingRequest {
+    dataset: Arc<Dataset>,
+    column: String,
+}
+
+#[async_trait]
+impl BtreeTrainingSource for TrainingRequest {
+    async fn scan_ordered_chunks(
+        self: Box<Self>,
+        chunk_size: u32,
+    ) -> Result<BoxStream<'static, Result<RecordBatch>>> {
+        let mut scan = self.dataset.scan();
+        let scan = scan
+            .with_row_id()
+            .order_by(Some(vec![ColumnOrdering::asc_nulls_first(
+                self.column.clone(),
+            )]))?
+            .project(&[&self.column])?;
+
+        let schema = scan.schema()?;
+        let ordered_batches = scan.try_into_stream().await?;
+        let chunked = chunker::chunk_stream(ordered_batches.into(), chunk_size as usize);
+        Ok(chunked
+            .and_then(move |batches| {
+                future::ready(
+                    // chunk_stream is zero-copy and so it gives us pieces of batches.  However, the btree
+                    // index needs 1 batch-per-page and so we concatenate here.
+                    kernels::concat::concat_batches(&schema, batches.iter()).map_err(|e| e.into()),
+                )
+            })
+            .boxed())
+    }
+}
+
+/// Build a Vector Index
+#[instrument(skip(dataset))]
+pub async fn build_scalar_index(dataset: &Dataset, column: &str, uuid: &str) -> Result<()> {
+    let training_request = Box::new(TrainingRequest {
+        dataset: Arc::new(dataset.clone()),
+        column: column.to_string(),
+    });
+    let field = dataset.schema().field(column).ok_or(Error::InvalidInput {
+        source: format!("No column with name {}", column).into(),
+        location: location!(),
+    })?;
+    // In theory it should be possible to create a scalar index (e.g. btree) on a nested field but
+    // performance would be poor and I'm not sure we want to allow that unless there is a need.
+    if field.data_type().is_nested() {
+        return Err(Error::InvalidInput {
+            source: "A scalar index can only be created on a non-nested field.".into(),
+            location: location!(),
+        });
+    }
+    let flat_index_trainer = FlatIndexTrainer::new(field.data_type());
+    let index_dir = dataset.indices_dir().child(uuid);
+    let index_store = LanceIndexStore::new((*dataset.object_store).clone(), index_dir);
+    train_btree_index(training_request, &flat_index_trainer, &index_store).await
+}
+
+pub async fn open_scalar_index(dataset: &Dataset, uuid: &str) -> Result<Arc<dyn ScalarIndex>> {
+    let index_dir = dataset.indices_dir().child(uuid);
+    let index_store = Arc::new(LanceIndexStore::new(
+        (*dataset.object_store).clone(),
+        index_dir,
+    ));
+    // Currently we assume all scalar indices are btree indices.  In the future, if this is not the
+    // case, we may need to store a metadata file in the index directory with scalar index metadata
+    let btree_index = BTreeIndex::load(index_store).await?;
+    Ok(btree_index as Arc<dyn ScalarIndex>)
+}

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -28,9 +28,10 @@ pub mod pq;
 mod traits;
 mod utils;
 
-use lance_core::io::{read_message, Reader};
+use lance_core::io::Reader;
 use lance_index::vector::pq::PQBuildParams;
 use lance_linalg::distance::*;
+use object_store::path::Path;
 use snafu::{location, Location};
 use tracing::instrument;
 use uuid::Uuid;
@@ -40,7 +41,7 @@ use self::{
     pq::PQIndex,
 };
 
-use super::{pb, IndexParams};
+use super::{pb, DatasetIndexExt, IndexParams};
 #[cfg(feature = "opq")]
 use crate::index::vector::opq::{OPQIndex, OptimizedProductQuantizer};
 use crate::{
@@ -52,12 +53,9 @@ use crate::{
             ivf::Ivf,
         },
     },
-    io::{read_message_from_buf, read_metadata_offset},
     Error, Result,
 };
 pub use traits::*;
-
-const INDEX_FILE_NAME: &str = "index.idx";
 
 /// Parameters of each index stage.
 #[derive(Debug, Clone)]
@@ -232,7 +230,9 @@ pub(crate) async fn remap_vector_index(
     old_metadata: &crate::format::Index,
     mapping: &HashMap<u64, Option<u64>>,
 ) -> Result<()> {
-    let old_index = open_index(dataset.clone(), column, &old_uuid.to_string()).await?;
+    let old_index = dataset
+        .open_vector_index(column, &old_uuid.to_string())
+        .await?;
     old_index.check_can_remap()?;
     let ivf_index: &IVFIndex =
         old_index
@@ -262,56 +262,15 @@ pub(crate) async fn remap_vector_index(
 }
 
 /// Open the Vector index on dataset, specified by the `uuid`.
-#[instrument(level = "debug", skip(dataset))]
-pub(crate) async fn open_index(
+#[instrument(level = "debug", skip(dataset, vec_idx, index_dir, reader))]
+pub(crate) async fn open_vector_index(
     dataset: Arc<Dataset>,
     column: &str,
     uuid: &str,
+    vec_idx: &lance_index::pb::VectorIndex,
+    index_dir: Path,
+    reader: Arc<dyn Reader>,
 ) -> Result<Arc<dyn VectorIndex>> {
-    if let Some(index) = dataset.session.index_cache.get(uuid) {
-        return Ok(index);
-    }
-
-    let index_dir = dataset.indices_dir().child(uuid);
-    let index_file = index_dir.child(INDEX_FILE_NAME);
-
-    let object_store = dataset.object_store();
-    let reader: Arc<dyn Reader> = object_store.open(&index_file).await?.into();
-
-    let file_size = reader.size().await?;
-    let block_size = object_store.block_size();
-    let begin = if file_size < block_size {
-        0
-    } else {
-        file_size - block_size
-    };
-    let tail_bytes = reader.get_range(begin..file_size).await?;
-    let metadata_pos = read_metadata_offset(&tail_bytes)?;
-    let proto: pb::Index = if metadata_pos < file_size - tail_bytes.len() {
-        // We have not read the metadata bytes yet.
-        read_message(reader.as_ref(), metadata_pos).await?
-    } else {
-        let offset = tail_bytes.len() - (file_size - metadata_pos);
-        read_message_from_buf(&tail_bytes.slice(offset..))?
-    };
-
-    if proto.columns.len() != 1 {
-        return Err(Error::Index {
-            message: "VectorIndex only supports 1 column".to_string(),
-            location: location!(),
-        });
-    }
-    assert_eq!(proto.index_type, pb::IndexType::Vector as i32);
-
-    let Some(idx_impl) = proto.implementation.as_ref() else {
-        return Err(Error::Index {
-            message: "Invalid protobuf for VectorIndex metadata".to_string(),
-            location: location!(),
-        });
-    };
-
-    let pb::index::Implementation::VectorIndex(vec_idx) = idx_impl;
-
     let metric_type = pb::VectorMetricType::try_from(vec_idx.metric_type)?.into();
 
     let mut last_stage: Option<Arc<dyn VectorIndex>> = None;
@@ -399,6 +358,6 @@ pub(crate) async fn open_index(
         });
     }
     let idx = last_stage.unwrap();
-    dataset.session.index_cache.insert(uuid, idx.clone());
+    dataset.session.index_cache.insert_vector(uuid, idx.clone());
     Ok(idx)
 }

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -41,7 +41,7 @@ use self::{
     pq::PQIndex,
 };
 
-use super::{pb, DatasetIndexExt, IndexParams};
+use super::{pb, DatasetIndexInternalExt, IndexParams};
 #[cfg(feature = "opq")]
 use crate::index::vector::opq::{OPQIndex, OptimizedProductQuantizer};
 use crate::{

--- a/rust/lance/src/index/vector/diskann/builder.rs
+++ b/rust/lance/src/index/vector/diskann/builder.rs
@@ -34,14 +34,14 @@ use rand::{distributions::Uniform, prelude::*, Rng, SeedableRng};
 use snafu::{location, Location};
 
 use crate::dataset::{Dataset, ROW_ID};
-use crate::index::pb;
 use crate::index::vector::diskann::row_vertex::RowVertexSerDe;
 use crate::index::vector::diskann::DiskANNParams;
 use crate::index::vector::graph::{
     builder::GraphBuilder, write_graph, VertexWithDistance, WriteGraphParams,
 };
 use crate::index::vector::graph::{Graph, Vertex};
-use crate::index::vector::{MetricType, INDEX_FILE_NAME};
+use crate::index::vector::MetricType;
+use crate::index::{pb, INDEX_FILE_NAME};
 use crate::{Error, Result};
 
 use super::row_vertex::RowVertex;

--- a/rust/lance/src/index/vector/diskann/search.rs
+++ b/rust/lance/src/index/vector/diskann/search.rs
@@ -23,7 +23,10 @@ use arrow_array::{ArrayRef, Float32Array, RecordBatch, UInt64Array};
 use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
 use lance_core::{io::Reader, Error, Result, ROW_ID_FIELD};
-use lance_index::vector::{Query, DIST_COL};
+use lance_index::{
+    vector::{Query, DIST_COL},
+    Index,
+};
 use object_store::path::Path;
 use ordered_float::OrderedFloat;
 use serde::Serialize;
@@ -40,7 +43,6 @@ use crate::{
     index::{
         prefilter::PreFilter,
         vector::graph::{GraphReadParams, PersistedGraph},
-        Index,
     },
 };
 
@@ -205,8 +207,12 @@ impl Index for DiskANNIndex {
         self
     }
 
-    fn statistics(&self) -> Result<serde_json::Value> {
-        Ok(serde_json::to_value(DiskANNIndexStatistics {
+    fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+        self
+    }
+
+    fn statistics(&self) -> Result<String> {
+        Ok(serde_json::to_string(&DiskANNIndexStatistics {
             index_type: "DiskANNIndex".to_string(),
             length: self.graph.len(),
         })?)

--- a/rust/lance/src/index/vector/diskann/search.rs
+++ b/rust/lance/src/index/vector/diskann/search.rs
@@ -25,7 +25,7 @@ use async_trait::async_trait;
 use lance_core::{io::Reader, Error, Result, ROW_ID_FIELD};
 use lance_index::{
     vector::{Query, DIST_COL},
-    Index,
+    Index, IndexType,
 };
 use object_store::path::Path;
 use ordered_float::OrderedFloat;
@@ -209,6 +209,10 @@ impl Index for DiskANNIndex {
 
     fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
         self
+    }
+
+    fn index_type(&self) -> IndexType {
+        IndexType::Vector
     }
 
     fn statistics(&self) -> Result<String> {

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -42,7 +42,7 @@ use lance_index::{
         pq::{PQBuildParams, ProductQuantizer, ProductQuantizerImpl},
         Query, DIST_COL, RESIDUAL_COLUMN,
     },
-    Index,
+    Index, IndexType,
 };
 use lance_linalg::matrix::MatrixView;
 use log::{debug, info, warn};
@@ -250,6 +250,10 @@ impl Index for IVFIndex {
 
     fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
         self
+    }
+
+    fn index_type(&self) -> IndexType {
+        IndexType::Vector
     }
 
     fn statistics(&self) -> Result<String> {
@@ -1019,7 +1023,7 @@ mod tests {
 
     use crate::{
         format::RowAddress,
-        index::{vector::VectorIndexParams, DatasetIndexExt, IndexType},
+        index::{vector::VectorIndexParams, DatasetIndexExt, DatasetIndexInternalExt, IndexType},
     };
 
     const DIM: usize = 32;

--- a/rust/lance/src/index/vector/opq.rs
+++ b/rust/lance/src/index/vector/opq.rs
@@ -288,8 +288,12 @@ impl Index for OPQIndex {
         self
     }
 
-    fn statistics(&self) -> Result<serde_json::Value> {
-        Ok(serde_json::to_value(OPQIndexStatistics {
+    fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+        self
+    }
+
+    fn statistics(&self) -> Result<String> {
+        Ok(serde_json::to_string(&OPQIndexStatistics {
             index_type: "OPQIndex".to_string(),
             dim: self
                 .opq
@@ -368,7 +372,7 @@ mod tests {
     use crate::dataset::{Dataset, ROW_ID};
     use crate::index::DatasetIndexExt;
     use crate::index::{
-        vector::{ivf::IVFIndex, open_index, opq::OPQIndex, VectorIndexParams},
+        vector::{ivf::IVFIndex, open_vector_index, opq::OPQIndex, VectorIndexParams},
         IndexType,
     };
 
@@ -424,7 +428,9 @@ mod tests {
         let uuid = index_file.file_name().to_str().unwrap().to_string();
 
         let dataset = Arc::new(dataset);
-        let index = open_index(dataset.clone(), "vector", &uuid).await.unwrap();
+        let index = open_vector_index(dataset.clone(), "vector", &uuid)
+            .await
+            .unwrap();
 
         if with_opq {
             let opq_idx = index.as_any().downcast_ref::<OPQIndex>().unwrap();

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -33,7 +33,7 @@ use lance_core::{
 pub use lance_index::vector::pq::{PQBuildParams, ProductQuantizerImpl};
 use lance_index::{
     vector::{pq::ProductQuantizer, Query, DIST_COL},
-    Index,
+    Index, IndexType,
 };
 use lance_linalg::{distance::MetricType, matrix::MatrixView};
 use serde::Serialize;
@@ -124,6 +124,10 @@ impl Index for PQIndex {
 
     fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
         self
+    }
+
+    fn index_type(&self) -> IndexType {
+        IndexType::Vector
     }
 
     fn statistics(&self) -> Result<String> {

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -31,14 +31,17 @@ use lance_core::{
     ROW_ID_FIELD,
 };
 pub use lance_index::vector::pq::{PQBuildParams, ProductQuantizerImpl};
-use lance_index::vector::{pq::ProductQuantizer, Query, DIST_COL};
+use lance_index::{
+    vector::{pq::ProductQuantizer, Query, DIST_COL},
+    Index,
+};
 use lance_linalg::{distance::MetricType, matrix::MatrixView};
 use serde::Serialize;
 use snafu::{location, Location};
 use tracing::{instrument, Instrument};
 
 use super::VectorIndex;
-use crate::index::{prefilter::PreFilter, Index};
+use crate::index::prefilter::PreFilter;
 use crate::{arrow::*, utils::tokio::spawn_cpu};
 use crate::{Error, Result};
 
@@ -119,8 +122,12 @@ impl Index for PQIndex {
         self
     }
 
-    fn statistics(&self) -> Result<serde_json::Value> {
-        Ok(serde_json::to_value(PQIndexStatistics {
+    fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+        self
+    }
+
+    fn statistics(&self) -> Result<String> {
+        Ok(serde_json::to_string(&PQIndexStatistics {
             index_type: "PQ".to_string(),
             nbits: self.pq.num_bits(),
             num_sub_vectors: self.pq.num_sub_vectors(),

--- a/rust/lance/src/index/vector/traits.rs
+++ b/rust/lance/src/index/vector/traits.rs
@@ -24,15 +24,15 @@ use lance_core::{
     io::{object_writer::ObjectWriter, Reader},
     Result,
 };
-use lance_index::vector::Query;
+use lance_index::{vector::Query, Index};
 use lance_linalg::MatrixView;
 
-use crate::index::{pb::Transform, prefilter::PreFilter, Index};
+use crate::index::{pb::Transform, prefilter::PreFilter};
 
 /// Vector Index for (Approximate) Nearest Neighbor (ANN) Search.
 #[async_trait]
 #[allow(clippy::redundant_pub_crate)]
-pub(crate) trait VectorIndex: Send + Sync + std::fmt::Debug + Index {
+pub trait VectorIndex: Send + Sync + std::fmt::Debug + Index {
     /// Search the vector for nearest neighbors.
     ///
     /// It returns a [RecordBatch] with Schema of:

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -415,13 +415,14 @@ mod tests {
         CommitError, CommitHandler, CommitLease, CommitLock, RenameCommitHandler,
         UnsafeCommitHandler,
     };
+    use lance_index::IndexType;
     use lance_linalg::distance::MetricType;
     use lance_testing::datagen::generate_random_array;
 
     use super::*;
 
     use crate::dataset::{transaction::Operation, WriteMode, WriteParams};
-    use crate::index::{vector::VectorIndexParams, DatasetIndexExt, IndexType};
+    use crate::index::{vector::VectorIndexParams, DatasetIndexExt};
     use crate::io::object_store::ObjectStoreParams;
     use crate::Dataset;
 

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -39,7 +39,7 @@ use crate::dataset::scanner::DatasetRecordBatchStream;
 use crate::dataset::Dataset;
 use crate::format::Index;
 use crate::index::prefilter::{AllowListLoader, PreFilter};
-use crate::index::vector::open_index;
+use crate::index::DatasetIndexExt;
 use crate::io::RecordBatchStream;
 use crate::{Error, Result};
 
@@ -286,8 +286,9 @@ impl KNNIndexStream {
         // An optional input containing a list of row ids to use as a prefilter
         allow_list_input: Option<datafusion::physical_plan::SendableRecordBatchStream>,
     ) -> Result<RecordBatch> {
-        let index =
-            open_index(dataset.clone(), &query.column, &index_meta.uuid.to_string()).await?;
+        let index = dataset
+            .open_vector_index(&query.column, &index_meta.uuid.to_string())
+            .await?;
         let allow_list_loader = allow_list_input.map(|allow_list_input| {
             Box::new(PreFilterBuilder(allow_list_input)) as Box<dyn AllowListLoader>
         });

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -39,7 +39,7 @@ use crate::dataset::scanner::DatasetRecordBatchStream;
 use crate::dataset::Dataset;
 use crate::format::Index;
 use crate::index::prefilter::{AllowListLoader, PreFilter};
-use crate::index::DatasetIndexExt;
+use crate::index::DatasetIndexInternalExt;
 use crate::io::RecordBatchStream;
 use crate::{Error, Result};
 

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -69,7 +69,7 @@ mod tests {
     #[test]
     fn test_disable_index_cache() {
         let no_cache = Session::new(0, 0);
-        assert!(no_cache.index_cache.get("abc").is_none());
+        assert!(no_cache.index_cache.get_vector("abc").is_none());
         let no_cache = Arc::new(no_cache);
 
         let pq = Arc::new(ProductQuantizerImpl::new(
@@ -80,10 +80,10 @@ mod tests {
             MetricType::L2,
         ));
         let idx = Arc::new(PQIndex::new(pq, MetricType::L2));
-        no_cache.index_cache.insert("abc", idx);
+        no_cache.index_cache.insert_vector("abc", idx);
 
-        assert!(no_cache.index_cache.get("abc").is_none());
-        assert_eq!(no_cache.index_cache.len(), 0);
+        assert!(no_cache.index_cache.get_vector("abc").is_none());
+        assert_eq!(no_cache.index_cache.len_vector(), 0);
     }
 
     #[test]
@@ -99,13 +99,13 @@ mod tests {
             MetricType::L2,
         ));
         let idx = Arc::new(PQIndex::new(pq, MetricType::L2));
-        session.index_cache.insert("abc", idx.clone());
+        session.index_cache.insert_vector("abc", idx.clone());
 
-        let found = session.index_cache.get("abc");
+        let found = session.index_cache.get_vector("abc");
         assert!(found.is_some());
         assert_eq!(format!("{:?}", found.unwrap()), format!("{:?}", idx));
-        assert!(session.index_cache.get("abc").is_some());
-        assert_eq!(session.index_cache.len(), 1);
+        assert!(session.index_cache.get_vector("abc").is_some());
+        assert_eq!(session.index_cache.len_vector(), 1);
 
         for iter_idx in 0..100 {
             let pq_other = Arc::new(ProductQuantizerImpl::new(
@@ -118,10 +118,10 @@ mod tests {
             let idx_other = Arc::new(PQIndex::new(pq_other, MetricType::L2));
             session
                 .index_cache
-                .insert(format!("{iter_idx}").as_str(), idx_other.clone());
+                .insert_vector(format!("{iter_idx}").as_str(), idx_other.clone());
         }
 
         // Capacity is 10 so there should be at most 10 items
-        assert_eq!(session.index_cache.len(), 10);
+        assert_eq!(session.index_cache.len_vector(), 10);
     }
 }


### PR DESCRIPTION
Three new methods are added to the dataset (via `DatasetIndexExt`):

 * `open_generic_index`
 * `open_scalar_index`
 * `open_vector_index`

Previously, there had only been `open_index` which was a free function (that took a `&Dataset`) and returned a `Arc<dyn VectorIndex>`.  That method still exists as an internal helper but users should now use `Dataset::open_vector_index` instead.

In addition, there is a new `IndexType` for `Scalar` and the `create_index` method will recognize this type.  Creating a scalar index currently does not require any parameters but it may in the future.

Opening a vector index today is rather involved.  First the proto metadata is loaded from disk.  This describes the detailed vector-specific parameters of the index (the index information in the manifest is very high-level and common across vector and scalar index types).  The scalar index does not need that today because we can assume all scalar indices are btree backed by flat.  As a result, we did not need to make any changes to any .proto files.  In the future, should we add new types of scalar indices and new parameters, we should be able to handle that similarly.  These could either be added to the existing `index.proto` or maintained in their own `scalar_index.proto` (or even stored in some other format entirely).

The generic `Index` trait has moved into `lance-index` and is required by both `ScalarIndex` and `VectorIndex`.  This trait has all of the "common" index operations.  Right now this is only a single method to fetch the statistics but in the future it will hopefully include things like remap and update/optimize.

The index statistics were previously returned as a `serde_json::Value`.  This is now returned as a simple `String`.