### PR TITLE
feat: safer API for physical_rows

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -897,6 +897,7 @@ class LanceDataset(pa.dataset.Dataset):
         operation: LanceOperation.BaseOperation,
         read_version: Optional[int] = None,
         commit_lock: Optional[CommitLock] = None,
+        manifest_write_config: Optional[Dict[str, Any]] = None,
     ) -> LanceDataset:
         """Create a new version of dataset
 
@@ -968,7 +969,7 @@ class LanceDataset(pa.dataset.Dataset):
                     f"commit_lock must be a function, got {type(commit_lock)}"
                 )
 
-        _Dataset.commit(base_uri, operation._to_inner(), read_version, commit_lock)
+        _Dataset.commit(base_uri, operation._to_inner(), read_version, commit_lock, manifest_write_config)
         return LanceDataset(base_uri)
 
     @property

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -897,7 +897,6 @@ class LanceDataset(pa.dataset.Dataset):
         operation: LanceOperation.BaseOperation,
         read_version: Optional[int] = None,
         commit_lock: Optional[CommitLock] = None,
-        manifest_write_config: Optional[Dict[str, Any]] = None,
     ) -> LanceDataset:
         """Create a new version of dataset
 
@@ -969,7 +968,7 @@ class LanceDataset(pa.dataset.Dataset):
                     f"commit_lock must be a function, got {type(commit_lock)}"
                 )
 
-        _Dataset.commit(base_uri, operation._to_inner(), read_version, commit_lock, manifest_write_config)
+        _Dataset.commit(base_uri, operation._to_inner(), read_version, commit_lock)
         return LanceDataset(base_uri)
 
     @property

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -347,7 +347,7 @@ class LanceFragment(pa.dataset.Fragment):
         >>> dataset = lance.write_dataset(tab, "dataset")
         >>> frag = dataset.get_fragment(0)
         >>> frag.delete("a > 1")
-        Fragment { id: 0, files: ..., deletion_file: Some(...), physical_rows: 3 }
+        Fragment { id: 0, files: ..., deletion_file: Some(...), physical_rows: Some(3) }
         >>> frag.delete("a > 0") is None
         True
 

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -184,5 +184,5 @@ def test_fragment_meta():
     assert repr(meta) == (
         'Fragment { id: 0, files: [DataFile { path: "0.lance", fields: [0] },'
         ' DataFile { path: "1.lance", fields: [1] }], deletion_file: None,'
-        " physical_rows: 100 }"
+        " physical_rows: Some(100) }"
     )

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -704,8 +704,9 @@ impl Dataset {
         self.ds.count_fragments()
     }
 
-    fn num_small_files(&self, max_rows_per_group: usize) -> usize {
-        self.ds.num_small_files(max_rows_per_group)
+    fn num_small_files(&self, max_rows_per_group: usize) -> PyResult<usize> {
+        RT.block_on(None, self.ds.num_small_files(max_rows_per_group))
+            .map_err(|err| PyIOError::new_err(err.to_string()))
     }
 
     fn get_fragments(self_: PyRef<'_, Self>) -> PyResult<Vec<FileFragment>> {

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -26,6 +26,7 @@ use chrono::Duration;
 use futures::StreamExt;
 use lance::arrow::as_fixed_size_list_array;
 use lance::dataset::progress::WriteFragmentProgress;
+use lance::dataset::ManifestWriteConfig;
 use lance::dataset::{
     fragment::FileFragment as LanceFileFragment, scanner::Scanner as LanceScanner,
     transaction::Operation as LanceOperation, Dataset as LanceDataset, ReadParams, Version,
@@ -515,8 +516,9 @@ impl Dataset {
         Ok(())
     }
 
-    fn count_deleted_rows(&self) -> usize {
-        self.ds.count_deleted_rows()
+    fn count_deleted_rows(&self) -> PyResult<usize> {
+        RT.block_on(None, self.ds.count_deleted_rows())?
+            .map_err(|err| PyIOError::new_err(err.to_string()))
     }
 
     fn versions(self_: PyRef<'_, Self>) -> PyResult<Vec<PyObject>> {
@@ -768,6 +770,7 @@ impl Dataset {
         operation: Operation,
         read_version: Option<u64>,
         commit_lock: Option<&PyAny>,
+        manifest_config: Option<&PyDict>,
     ) -> PyResult<Self> {
         let store_params = if let Some(commit_handler) = commit_lock {
             let py_commit_lock = PyCommitLock::new(commit_handler.to_object(commit_handler.py()));
@@ -777,10 +780,24 @@ impl Dataset {
         } else {
             None
         };
+
+        let mut write_config = ManifestWriteConfig::default();
+        if let Some(manifest_config) = manifest_config {
+            if let Some(recompute_stats) = manifest_config.get_item("recompute_stats") {
+                write_config.recompute_stats = recompute_stats.extract()?;
+            }
+        }
+
         let ds = RT
             .block_on(
                 commit_lock.map(|cl| cl.py()),
-                LanceDataset::commit(dataset_uri, operation.0, read_version, store_params),
+                LanceDataset::commit(
+                    dataset_uri,
+                    operation.0,
+                    read_version,
+                    store_params,
+                    &write_config,
+                ),
             )?
             .map_err(|e| PyIOError::new_err(e.to_string()))?;
         Ok(Self {

--- a/rust/lance-core/src/format/fragment.rs
+++ b/rust/lance-core/src/format/fragment.rs
@@ -369,7 +369,7 @@ mod tests {
                     {"path": "foobar.lance", "fields": [0]}],
                      "deletion_file": {"read_version": 123, "id": 456, "file_type": "array",
                                        "num_deleted_rows": 10},
-                "physical_rows": 0}),
+                "physical_rows": None::<usize>}),
         );
 
         let frag2 = Fragment::from_json(&json).unwrap();

--- a/rust/lance-core/src/format/fragment.rs
+++ b/rust/lance-core/src/format/fragment.rs
@@ -146,18 +146,9 @@ impl Fragment {
 
     pub fn num_rows(&self) -> Option<usize> {
         match (self.physical_rows, &self.deletion_file) {
-            // Unknown fragment length
-            (None, _) => None,
             // Known fragment length, no deletion file.
             (Some(len), None) => Some(len),
             // Known fragment length, but don't know deletion file size.
-            (
-                _,
-                Some(DeletionFile {
-                    num_deleted_rows: None,
-                    ..
-                }),
-            ) => None,
             (
                 Some(len),
                 Some(DeletionFile {
@@ -165,6 +156,7 @@ impl Fragment {
                     ..
                 }),
             ) => Some(len - num_deleted_rows),
+            _ => None,
         }
     }
 

--- a/rust/lance-core/src/io/deletion.rs
+++ b/rust/lance-core/src/io/deletion.rs
@@ -235,7 +235,7 @@ pub async fn write_deletion_file(
                 read_version,
                 id,
                 file_type: DeletionFileType::Array,
-                num_deleted_rows: set.len(),
+                num_deleted_rows: Some(set.len()),
             };
             let path = deletion_file_path(base, fragment_id, &deletion_file);
 
@@ -269,7 +269,7 @@ pub async fn write_deletion_file(
                 read_version,
                 id,
                 file_type: DeletionFileType::Bitmap,
-                num_deleted_rows: bitmap.len() as usize,
+                num_deleted_rows: Some(bitmap.len() as usize),
             };
             let path = deletion_file_path(base, fragment_id, &deletion_file);
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -647,7 +647,6 @@ impl Dataset {
         operation: Operation,
         read_version: Option<u64>,
         store_params: Option<ObjectStoreParams>,
-        manifest_config: &ManifestWriteConfig,
     ) -> Result<Self> {
         let read_version = read_version.map_or_else(
             || match operation {
@@ -705,12 +704,12 @@ impl Dataset {
                 dataset,
                 &object_store,
                 &transaction,
-                manifest_config,
+                &Default::default(),
                 &Default::default(),
             )
             .await?
         } else {
-            commit_new_dataset(&object_store, &base, &transaction, manifest_config).await?
+            commit_new_dataset(&object_store, &base, &transaction, &Default::default()).await?
         };
 
         Ok(Self {
@@ -1397,17 +1396,10 @@ impl Dataset {
     }
 }
 
-/// Configuration for writing a manifest file.
 #[derive(Debug)]
-pub struct ManifestWriteConfig {
-    /// If true, automatically set feature flags based on the schema. This defaults
-    /// to True.
-    pub auto_set_feature_flags: bool, // default true
-    pub timestamp: Option<SystemTime>, // default None
-    /// If true, will recompute statistics present in the manifest, such as
-    /// `physical_rows` in fragments or `num_deletions` in deletion files. Defaults
-    /// to false.
-    pub recompute_stats: bool, // default false
+pub(crate) struct ManifestWriteConfig {
+    auto_set_feature_flags: bool,  // default true
+    timestamp: Option<SystemTime>, // default None
 }
 
 impl Default for ManifestWriteConfig {
@@ -1415,7 +1407,6 @@ impl Default for ManifestWriteConfig {
         Self {
             auto_set_feature_flags: true,
             timestamp: None,
-            recompute_stats: false,
         }
     }
 }
@@ -1810,7 +1801,6 @@ mod tests {
             &ManifestWriteConfig {
                 auto_set_feature_flags: false,
                 timestamp: None,
-                recompute_stats: false,
             },
         )
         .await

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -958,9 +958,7 @@ mod tests {
             fragments,
         };
 
-        let new_dataset = Dataset::commit(test_uri, op, None, None, &Default::default())
-            .await
-            .unwrap();
+        let new_dataset = Dataset::commit(test_uri, op, None, None).await.unwrap();
 
         assert_eq!(new_dataset.count_rows().await.unwrap(), dataset_rows);
 
@@ -1048,9 +1046,7 @@ mod tests {
                 schema: full_schema.clone(),
             };
 
-            let dataset = Dataset::commit(test_uri, op, None, None, &Default::default())
-                .await
-                .unwrap();
+            let dataset = Dataset::commit(test_uri, op, None, None).await.unwrap();
 
             // We only kept the first fragment of 40 rows
             assert_eq!(

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -839,7 +839,7 @@ async fn rewrite_files(
     // It's possible the fragments are old and don't have physical rows or
     // num deletions recorded. If that's the case, we need to grab and set that
     // information.
-    let fragments = migrate_fragments(dataset.as_ref(), &task.fragments, false).await?;
+    let fragments = migrate_fragments(dataset.as_ref(), &task.fragments).await?;
     let mut scanner = dataset.scan();
     scanner.with_fragments(fragments.clone()).with_row_id();
 

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -771,7 +771,7 @@ fn transpose_row_ids(
             .map(|frag| {
                 frag.deletion_file
                     .as_ref()
-                    .map(|d| d.num_deleted_rows)
+                    .and_then(|d| d.num_deleted_rows)
                     .unwrap_or(0)
             })
             .sum::<usize>();
@@ -839,7 +839,7 @@ async fn rewrite_files(
     // It's possible the fragments are old and don't have physical rows or
     // num deletions recorded. If that's the case, we need to grab and set that
     // information.
-    let fragments = migrate_fragments(dataset.as_ref(), &task.fragments).await?;
+    let fragments = migrate_fragments(dataset.as_ref(), &task.fragments, false).await?;
     let mut scanner = dataset.scan();
     scanner.with_fragments(fragments.clone()).with_row_id();
 

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -193,7 +193,7 @@ pub async fn write_fragments_internal(
             let num_rows = writer.take().unwrap().finish().await?;
             debug_assert_eq!(num_rows, num_rows_in_current_file);
             params.progress.complete(fragments.last().unwrap()).await?;
-            fragments.last_mut().unwrap().physical_rows = num_rows;
+            fragments.last_mut().unwrap().physical_rows = Some(num_rows);
             num_rows_in_current_file = 0;
         }
     }
@@ -201,7 +201,7 @@ pub async fn write_fragments_internal(
     // Complete the final writer
     if let Some(mut writer) = writer.take() {
         let num_rows = writer.finish().await?;
-        fragments.last_mut().unwrap().physical_rows = num_rows;
+        fragments.last_mut().unwrap().physical_rows = Some(num_rows);
     }
 
     Ok(fragments)

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -154,20 +154,28 @@ pub(crate) async fn commit_new_dataset(
 ///
 /// Fields such as `physical_rows` and `num_deleted_rows` may not have been
 /// in older datasets. To bring these old manifests up-to-date, we add them here.
-async fn migrate_manifest(dataset: &Dataset, manifest: &mut Manifest) -> Result<()> {
-    if manifest.fragments.iter().all(|f| {
-        f.physical_rows.is_some()
-            && (f.deletion_file.is_none()
-                || f.deletion_file
+///
+/// To force recomputation of statistics (such as `physical_rows`), set `recompute_stats` to true.
+async fn migrate_manifest(
+    dataset: &Dataset,
+    manifest: &mut Manifest,
+    recompute_stats: bool,
+) -> Result<()> {
+    if !recompute_stats
+        && manifest.fragments.iter().all(|f| {
+            f.physical_rows.is_some()
+                && (f
+                    .deletion_file
                     .as_ref()
-                    .map(|d| d.num_deleted_rows)
-                    .unwrap_or_default()
-                    > 0)
-    }) {
+                    .map(|d| d.num_deleted_rows.is_some())
+                    .unwrap_or(true))
+        })
+    {
         return Ok(());
     }
 
-    manifest.fragments = Arc::new(migrate_fragments(dataset, dataset.fragments()).await?);
+    manifest.fragments =
+        Arc::new(migrate_fragments(dataset, dataset.fragments(), recompute_stats).await?);
 
     Ok(())
 }
@@ -178,28 +186,37 @@ async fn migrate_manifest(dataset: &Dataset, manifest: &mut Manifest) -> Result<
 pub(crate) async fn migrate_fragments(
     dataset: &Dataset,
     fragments: &[Fragment],
+    recompute_stats: bool,
 ) -> Result<Vec<Fragment>> {
     let dataset = Arc::new(dataset.clone());
     let new_fragments = futures::stream::iter(fragments)
         .map(|fragment| async {
-            let physical_rows = if let Some(physical_rows) = fragment.physical_rows {
+            let physical_rows = if recompute_stats {
+                None
+            } else {
+                fragment.physical_rows
+            };
+            let physical_rows = if let Some(physical_rows) = physical_rows {
                 Either::Right(futures::future::ready(Ok(physical_rows)))
             } else {
                 let file_fragment = FileFragment::new(dataset.clone(), fragment.clone());
                 Either::Left(async move { file_fragment.physical_rows().await })
             };
             let num_deleted_rows = match &fragment.deletion_file {
-                None => Either::Left(futures::future::ready(Ok(0))),
-                Some(deletion_file) if deletion_file.num_deleted_rows > 0 => {
-                    Either::Left(futures::future::ready(Ok(deletion_file.num_deleted_rows)))
+                None => Either::Left(futures::future::ready(Ok(None))),
+                Some(DeletionFile {
+                    num_deleted_rows: Some(deleted_rows),
+                    ..
+                }) if !recompute_stats => {
+                    Either::Left(futures::future::ready(Ok(Some(*deleted_rows))))
                 }
                 Some(_) => Either::Right(async {
                     let deletion_vector =
                         read_deletion_file(&dataset.base, fragment, dataset.object_store()).await?;
                     if let Some(deletion_vector) = deletion_vector {
-                        Ok(deletion_vector.len())
+                        Ok(Some(deletion_vector.len()))
                     } else {
-                        Ok(0)
+                        Ok(None)
                     }
                 }),
             };
@@ -327,7 +344,7 @@ pub(crate) async fn commit_transaction(
 
         manifest.version = target_version;
 
-        migrate_manifest(&dataset, &mut manifest).await?;
+        migrate_manifest(&dataset, &mut manifest, write_config.recompute_stats).await?;
 
         migrate_indices(&dataset, &mut indices).await?;
 


### PR DESCRIPTION
Issues like https://github.com/lancedb/lance/pull/1511 have shown the APIs where `0` is a sentinel value are dangerous and often mis-used. This PR changes `Fragment.physical_rows` and `DeletionFile.num_deleted_rows` to use `Option` instead, which forces the unknown case to be recognized and handled. This fixes some bugs in the handling of those.

There is another bug mentioned, but that is saved for another PR.