### PR TITLE
perf: improve f16 performance for norm L2 on aarch64

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -30,4 +30,4 @@ rustflags = [
 rustflags = ["-C", "target-cpu=haswell", "-C", "target-feature=+avx2,+fma,+f16c"]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "target-cpu=apple-m1", "-C", "target-feature=+neon,+fp16"]
+rustflags = ["-C", "target-cpu=apple-m1", "-C", "target-feature=+neon,+fp16,+fhm"]

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,5 +1,5 @@
 [profile.release]
-lto = "thin"
+lto = "fat"
 codegen-units = 1
 
 [profile.release-with-debug]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -63,7 +63,7 @@ aws-config = "0.56"
 aws-credential-types = "0.56"
 aws-sdk-dynamodb = "0.34"
 half = { "version" = "=2.3.1", default-features = false, features = [
-    "num-traits",
+    "num-traits", "std",
 ] }
 bytes = "1.4"
 byteorder = "1.5"

--- a/rust/lance-linalg/benches/norm_l2.rs
+++ b/rust/lance-linalg/benches/norm_l2.rs
@@ -25,7 +25,7 @@ use num_traits::FromPrimitive;
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
 
-use lance_linalg::distance::norm_l2::{norm_l2, Normalize};
+use lance_linalg::distance::norm_l2::Normalize;
 use lance_testing::datagen::generate_random_array_with_seed;
 
 #[inline]
@@ -65,7 +65,7 @@ where
                     target
                         .values()
                         .chunks_exact(DIMENSION)
-                        .map(|arr| norm_l2(arr))
+                        .map(|arr| arr.norm_l2())
                         .collect::<Vec<_>>(),
                 );
             });
@@ -81,9 +81,13 @@ fn bench_distance(c: &mut Criterion) {
     let target: Float32Array = generate_random_array_with_seed(TOTAL * DIMENSION, [42; 32]);
     c.bench_function("norm_l2(f32, SIMD)", |b| {
         b.iter(|| {
-            target.values().chunks_exact(DIMENSION).for_each(|arr| {
-                let _ = arr.norm_l2();
-            })
+            black_box(
+                target
+                    .values()
+                    .chunks_exact(DIMENSION)
+                    .map(|arr| arr.norm_l2())
+                    .collect::<Vec<_>>(),
+            )
         });
     });
 

--- a/rust/lance-linalg/benches/norm_l2.rs
+++ b/rust/lance-linalg/benches/norm_l2.rs
@@ -13,8 +13,14 @@
 // limitations under the License.
 
 use arrow_arith::{aggregate::sum, numeric::mul};
-use arrow_array::{cast::AsArray, types::Float32Type, Float32Array};
-use criterion::{criterion_group, criterion_main, Criterion};
+use arrow_array::types::{Float16Type, Float64Type};
+use arrow_array::{
+    cast::AsArray, types::Float32Type, ArrowNumericType, Float32Array, NativeAdapter,
+    PrimitiveArray,
+};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use lance_arrow::FloatToArrayType;
+use num_traits::FromPrimitive;
 
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
@@ -23,44 +29,65 @@ use lance_linalg::distance::norm_l2::{norm_l2, Normalize};
 use lance_testing::datagen::generate_random_array_with_seed;
 
 #[inline]
-fn norm_l2_arrow(x: &Float32Array) -> f32 {
+fn norm_l2_arrow<T: ArrowNumericType>(x: &PrimitiveArray<T>) -> T::Native {
     let m = mul(&x, &x).unwrap();
-    sum(m.as_primitive::<Float32Type>()).unwrap()
+    sum(m.as_primitive::<T>()).unwrap()
 }
 
-fn bench_distance(c: &mut Criterion) {
-    const DIMENSION: usize = 1024;
-    const TOTAL: usize = 1024 * 1024; // 1M vectors
+const DIMENSION: usize = 1024;
+const TOTAL: usize = 1024 * 1024; // 1M vectors
 
-    // 1M of 1024 D vectors. 4GB in memory.
-    let target = generate_random_array_with_seed(TOTAL * DIMENSION, [42; 32]);
+fn run_bench<T: ArrowNumericType>(c: &mut Criterion)
+where
+    T::Native: FromPrimitive + FloatToArrayType,
+    NativeAdapter<T>: From<T::Native>,
+    for<'a> &'a [T::Native]: Normalize<T::Native>,
+{
+    // 1M of 1024 D vectors
+    let target: PrimitiveArray<T> = generate_random_array_with_seed(TOTAL * DIMENSION, [42; 32]);
 
-    c.bench_function("norm_l2(arrow)", |b| {
+    let type_name = std::any::type_name::<T::Native>();
+
+    c.bench_function(format!("NormL2({type_name}, arrow)").as_str(), |b| {
         b.iter(|| unsafe {
-            Float32Array::from_trusted_len_iter((0..target.len() / DIMENSION).map(|idx| {
+            PrimitiveArray::<T>::from_trusted_len_iter((0..target.len() / DIMENSION).map(|idx| {
                 let arr = target.slice(idx * DIMENSION, DIMENSION);
                 Some(norm_l2_arrow(&arr))
             }))
         });
     });
 
-    c.bench_function("norm_l2(auto-vectorization)", |b| {
-        b.iter(|| unsafe {
-            Float32Array::from_trusted_len_iter((0..target.len() / DIMENSION).map(|idx| {
-                let arr = target.slice(idx * DIMENSION, DIMENSION);
-                Some(norm_l2(arr.values()))
-            }))
+    c.bench_function(
+        format!("NormL2({type_name}, auto-vectorization)").as_str(),
+        |b| {
+            b.iter(|| {
+                black_box(
+                    target
+                        .values()
+                        .chunks_exact(DIMENSION)
+                        .map(|arr| norm_l2(arr))
+                        .collect::<Vec<_>>(),
+                );
+            });
+        },
+    );
+}
+
+fn bench_distance(c: &mut Criterion) {
+    run_bench::<Float16Type>(c);
+    run_bench::<Float32Type>(c);
+
+    // 1M of 1024 D vectors. 4GB in memory.
+    let target: Float32Array = generate_random_array_with_seed(TOTAL * DIMENSION, [42; 32]);
+    c.bench_function("norm_l2(f32, SIMD)", |b| {
+        b.iter(|| {
+            target.values().chunks_exact(DIMENSION).for_each(|arr| {
+                let _ = arr.norm_l2();
+            })
         });
     });
 
-    c.bench_function("norm_l2(SIMD)", |b| {
-        b.iter(|| unsafe {
-            Float32Array::from_trusted_len_iter((0..target.len() / DIMENSION).map(|idx| {
-                let arr = &target.values()[idx * DIMENSION..(idx + 1) * DIMENSION];
-                Some(arr.norm_l2())
-            }))
-        });
-    });
+    run_bench::<Float64Type>(c);
 }
 
 #[cfg(target_os = "linux")]

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -40,6 +40,7 @@ impl Normalize<f16> for &[f16] {
             // No explict f16c CVT instructions available in [std::arch::aarch64].
             // So, we convert to f32 manually and then back to f16.
             // This is about 40% faster than the scalar implementation on a M2 Macbook Pro.
+            // Sadly, more than half the time is do element-wise load and cvt f16 -> f32.
             //
             // Please run `cargo bench --bench norm_l2" on Apple Silicon when
             // change the following code.

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -40,17 +40,18 @@ impl Normalize<f16> for &[f16] {
             // No explict f16c CVT instructions available in [std::arch::aarch64].
             // So, we convert to f32 manually and then back to f16.
             // This is about 40% faster than the scalar implementation on a M2 Macbook Pro.
-            // Sadly, more than half the time is do element-wise load and cvt f16 -> f32.
+            // Sadly, more than half the time is doing element-wise load and cvt f16 -> f32.
             //
             // Please run `cargo bench --bench norm_l2" on Apple Silicon when
             // change the following code.
             const LANES: usize = 4;
             let chunks = self.chunks_exact(LANES);
-            let sum = if chunks.remainder().is_empty() {
-                0.0
-            } else {
-                chunks.remainder().iter().map(|v| v.to_f32().powi(2)).sum()
-            };
+            let sum = chunks
+                .remainder()
+                .iter()
+                .map(|v| v.to_f32().powi(2))
+                .sum::<f32>();
+
             let mut sums: [f32; LANES] = [0_f32; LANES];
             for chk in chunks {
                 // Convert to f32

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -89,7 +89,7 @@ impl Normalize<f64> for &[f64] {
 /// The parameters must be cache line aligned. For example, from
 /// Arrow Arrays, i.e., Float32Array
 #[inline]
-pub fn norm_l2<T: Real + Sum>(vector: &[T]) -> T {
+pub fn norm_l2<T: Float + Sum>(vector: &[T]) -> T {
     const LANES: usize = 16;
     let chunks = vector.chunks_exact(LANES);
     let sum = if chunks.remainder().is_empty() {

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -43,7 +43,7 @@ impl Normalize<f16> for &[f16] {
             //
             // Please run `cargo bench --bench norm_l2" on Apple Silicon when
             // change the following code.
-            const LANES: usize = 8;
+            const LANES: usize = 4;
             let chunks = self.chunks_exact(LANES);
             let sum = if chunks.remainder().is_empty() {
                 0.0

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -72,14 +72,6 @@ impl Normalize<f16> for &[f16] {
     }
 }
 
-pub fn norm_l2_f16(x: &[f16]) -> f16 {
-    x.norm_l2()
-}
-
-pub fn norm_l2_f32(x: &[f32]) -> f32 {
-    norm_l2(&x)
-}
-
 impl Normalize<bf16> for &[bf16] {
     type Output = bf16;
 


### PR DESCRIPTION
Explicilty convert to f32 on Mac M1/M2, achieve about 40% speed up without explicit SIMD, due to the lacking of `f16p` instructions in `std::arch::aarch64`.