### PR TITLE
feat: allow for more advanced storage options in objectstore

### DIFF
--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -75,6 +75,8 @@ pub enum Error {
     IO { message: String, location: Location },
     #[snafu(display("LanceError(Index): {message}, {location}"))]
     Index { message: String, location: Location },
+    #[snafu(display("Cannot infer storage location from: {message}"))]
+    InvalidTableLocation { message: String },
     /// Stream early stop
     Stop,
 }

--- a/rust/lance-core/src/io/object_store.rs
+++ b/rust/lance-core/src/io/object_store.rs
@@ -342,7 +342,7 @@ impl ObjectStore {
                 Self::from_path(uri, params)
             }
             Ok(url) => {
-                let store = Self::new_from_url(url.clone(), params).await?;
+                let store = Self::new_from_url(url.clone(), params.clone()).await?;
                 let path = Path::from(url.path());
                 Ok((store, path))
             }
@@ -427,14 +427,9 @@ impl ObjectStore {
         ))
     }
 
-    async fn new_from_url(url: Url, params: &ObjectStoreParams) -> Result<Self> {
+    async fn new_from_url(url: Url, params: ObjectStoreParams) -> Result<Self> {
         let mut storage_options = StorageOptions::default();
-        let mut options = ObjectStoreParams::default();
-        options.s3_credentials_refresh_offset = params.s3_credentials_refresh_offset;
-        options.aws_credentials = params.aws_credentials.clone();
-        options.commit_handler = params.commit_handler.clone();
-
-        configure_store(url.as_str(), &mut storage_options, options).await
+        configure_store(url.as_str(), &mut storage_options, params).await
     }
     /// Local object store.
     pub fn local() -> Self {

--- a/rust/lance-core/src/io/object_store.rs
+++ b/rust/lance-core/src/io/object_store.rs
@@ -16,7 +16,7 @@
 
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::path::Path as StdPath;
+use std::path::{Path as StdPath, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -27,16 +27,16 @@ use aws_credential_types::provider::error::CredentialsError;
 use aws_credential_types::provider::ProvideCredentials;
 use chrono::{DateTime, Utc};
 use futures::{future, stream::BoxStream, StreamExt, TryStreamExt};
-use http::header::{HeaderMap, CACHE_CONTROL};
-use object_store::aws::{AmazonS3ConfigKey, AwsCredential as ObjectStoreAwsCredential};
+use object_store::aws::{
+    AmazonS3ConfigKey, AwsCredential as ObjectStoreAwsCredential, AwsCredentialProvider,
+};
 use object_store::azure::AzureConfigKey;
 use object_store::gcp::GoogleConfigKey;
-use object_store::parse_url_opts;
 use object_store::{
-    aws::AmazonS3Builder, azure::MicrosoftAzureBuilder, gcp::GoogleCloudStorageBuilder,
-    local::LocalFileSystem, memory::InMemory, ClientOptions, CredentialProvider,
+    aws::AmazonS3Builder, local::LocalFileSystem, memory::InMemory, CredentialProvider,
     Error as ObjectStoreError, Result as ObjectStoreResult,
 };
+use object_store::{parse_url_opts, DynObjectStore};
 use object_store::{path::Path, ObjectMeta, ObjectStore as OSObjectStore};
 use shellexpand::tilde;
 use snafu::{location, Location};
@@ -140,9 +140,7 @@ impl AwsCredentialAdapter {
 
 /// Adapt an object_store credentials into AWS SDK creds
 #[derive(Debug)]
-struct OSObjectStoreToAwsCredAdaptor(
-    Arc<dyn CredentialProvider<Credential = ObjectStoreAwsCredential>>,
-);
+struct OSObjectStoreToAwsCredAdaptor(AwsCredentialProvider);
 
 impl ProvideCredentials for OSObjectStoreToAwsCredAdaptor {
     fn provide_credentials<'a>(
@@ -228,12 +226,9 @@ impl CredentialProvider for AwsCredentialAdapter {
 /// `credentials_refresh_offset` is the amount of time before expiry to refresh credentials.
 async fn build_aws_credential(
     credentials_refresh_offset: Duration,
-    credentials: Option<Arc<dyn CredentialProvider<Credential = ObjectStoreAwsCredential>>>,
+    credentials: Option<AwsCredentialProvider>,
     region: Option<String>,
-) -> Result<(
-    Arc<dyn CredentialProvider<Credential = ObjectStoreAwsCredential>>,
-    String,
-)> {
+) -> Result<(AwsCredentialProvider, String)> {
     use aws_config::meta::region::RegionProviderChain;
     const DEFAULT_REGION: &str = "us-west-2";
     let region_provider = RegionProviderChain::default_provider().or_else(DEFAULT_REGION);
@@ -263,26 +258,10 @@ async fn build_aws_credential(
     Ok((creds, region))
 }
 
-/// Build S3 ObjectStore using default credential chain.
-async fn build_s3_object_store(
-    uri: &str,
-    creds: Arc<dyn CredentialProvider<Credential = ObjectStoreAwsCredential>>,
-    region: &str,
-) -> Result<Arc<dyn OSObjectStore>> {
-    Ok(Arc::new(
-        AmazonS3Builder::from_env() // from_env to capture AWS_ENDPOINT env var
-            .with_url(uri)
-            .with_credentials(creds)
-            .with_region(region)
-            .with_allow_http(true)
-            .build()?,
-    ))
-}
-
 #[cfg(feature = "dynamodb")]
 async fn build_dynamodb_external_store(
     table_name: &str,
-    creds: Arc<dyn CredentialProvider<Credential = ObjectStoreAwsCredential>>,
+    creds: AwsCredentialProvider,
     region: &str,
     app_name: &str,
 ) -> Result<Arc<dyn ExternalManifestStore>> {
@@ -304,24 +283,6 @@ async fn build_dynamodb_external_store(
     DynamoDBExternalManifestStore::new_external_store(client.into(), table_name, app_name).await
 }
 
-async fn build_gcs_object_store(uri: &str) -> Result<Arc<dyn OSObjectStore>> {
-    // GCS enables cache for public buckets, we disable to improve consistency
-    let mut headers = HeaderMap::new();
-    headers.insert(CACHE_CONTROL, "no-cache".parse().unwrap());
-    Ok(Arc::new(
-        GoogleCloudStorageBuilder::from_env()
-            .with_url(uri)
-            .with_client_options(ClientOptions::new().with_default_headers(headers))
-            .build()?,
-    ))
-}
-
-async fn build_azure_object_store(uri: &str) -> Result<Arc<dyn OSObjectStore>> {
-    Ok(Arc::new(
-        MicrosoftAzureBuilder::from_env().with_url(uri).build()?,
-    ))
-}
-
 pub trait WrappingObjectStore: std::fmt::Debug + Send + Sync {
     fn wrap(&self, original: Arc<dyn OSObjectStore>) -> Arc<dyn OSObjectStore>;
 }
@@ -335,7 +296,7 @@ pub struct ObjectStoreParams {
     pub s3_credentials_refresh_offset: Duration,
 
     // Custom AWS Credentials
-    pub aws_credentials: Option<Arc<dyn CredentialProvider<Credential = ObjectStoreAwsCredential>>>,
+    pub aws_credentials: Option<AwsCredentialProvider>,
     pub aws_region: Option<String>,
 
     pub commit_handler: Option<Arc<dyn CommitHandler>>,
@@ -356,7 +317,7 @@ impl Default for ObjectStoreParams {
 
 impl ObjectStoreParams {
     pub fn with_aws_credentials(
-        credentials: Option<Arc<dyn CredentialProvider<Credential = ObjectStoreAwsCredential>>>,
+        credentials: Option<AwsCredentialProvider>,
         region: Option<String>,
     ) -> Self {
         Self {
@@ -480,146 +441,15 @@ impl ObjectStore {
         ))
     }
 
-    async fn new_from_url(mut url: Url, params: &ObjectStoreParams) -> Result<Self> {
-        // Block size: On local file systems, we use 4KB block size. On cloud
-        // object stores, we use 64KB block size. This is generally the largest
-        // block size where we don't see a latency penalty.
-        match url.scheme() {
-            "s3" | "s3+ddb" => {
-                if url.scheme() == "s3+ddb" && params.commit_handler.is_some() {
-                    return Err(Error::InvalidInput {
-                        source:
-                            "`s3+ddb://` scheme and custom commit handler are mutually exclusive"
-                                .into(),
-                        location: location!(),
-                    });
-                }
+    async fn new_from_url(url: Url, params: &ObjectStoreParams) -> Result<Self> {
+        let mut storage_options = StorageOptions::default();
+        let mut options = ObjectStoreOptions::new(url.to_string());
+        options.s3_credentials_refresh_offset = params.s3_credentials_refresh_offset;
+        options.aws_credentials = params.aws_credentials.clone();
+        options.commit_handler = params.commit_handler.clone();
 
-                let ddb_table_name = if url.scheme() == "s3" {
-                    None
-                } else {
-                    if url.query_pairs().count() != 1 {
-                        return Err(Error::InvalidInput {
-                            source:
-                                "`s3+ddb://` scheme and expects exactly one query `ddbTableName`"
-                                    .into(),
-                            location: location!(),
-                        });
-                    }
-                    match url.query_pairs().next() {
-                        Some((Cow::Borrowed(key), Cow::Borrowed(table_name)))
-                            if key == DDB_URL_QUERY_KEY =>
-                        {
-                            if table_name.is_empty() {
-                                return Err(Error::InvalidInput {
-                                    source:
-                                        "`s3+ddb://` scheme requires non empty dynamodb table name"
-                                            .into(),
-                                    location: location!(),
-                                });
-                            }
-                            Some(table_name)
-                        }
-                        _ => {
-                            return Err(Error::InvalidInput {
-                                source: "`s3+ddb://` scheme and expects exactly one query `ddbTableName`".into(),
-                                location: location!(),
-                            });
-                        }
-                    }
-                };
-
-                let (aws_creds, region) = build_aws_credential(
-                    params.s3_credentials_refresh_offset,
-                    params.aws_credentials.clone(),
-                    params.aws_region.clone(),
-                )
-                .await?;
-
-                let commit_handler = match ddb_table_name {
-                    #[cfg(feature = "dynamodb")]
-                    Some(table_name) => Arc::new(ExternalManifestCommitHandler {
-                        external_manifest_store: build_dynamodb_external_store(
-                            table_name,
-                            aws_creds.clone(),
-                            &region,
-                            "lancedb",
-                        )
-                        .await?,
-                    }),
-                    #[cfg(not(feature = "dynamodb"))]
-                    Some(_) => {
-                        return Err(Error::InvalidInput {
-                            source: "`s3+ddb://` scheme requires `dynamodb` feature to be enabled"
-                                .into(),
-                            location: location!(),
-                        });
-                    }
-                    None => params
-                        .commit_handler
-                        .clone()
-                        .unwrap_or_else(|| Arc::new(UnsafeCommitHandler)),
-                };
-
-                // before creating the OSObjectStore we need to rewrite the url to drop ddb related parts
-                url.set_scheme("s3").map_err(|()| Error::Internal {
-                    message: "could not set scheme".into(),
-                    location: location!(),
-                })?;
-                url.set_query(None);
-
-                Ok(Self {
-                    inner: build_s3_object_store(url.to_string().as_str(), aws_creds, &region)
-                        .await?
-                        .traced(),
-                    scheme: String::from(url.scheme()),
-                    base_path: Path::from(url.path()),
-                    block_size: 64 * 1024,
-                    commit_handler,
-                })
-            }
-            "gs" => Ok(Self {
-                inner: build_gcs_object_store(url.to_string().as_str())
-                    .await?
-                    .traced(),
-                scheme: String::from("gs"),
-                base_path: Path::from(url.path()),
-                block_size: 64 * 1024,
-                commit_handler: params
-                    .commit_handler
-                    .clone()
-                    .unwrap_or_else(|| Arc::new(RenameCommitHandler)),
-            }),
-            "az" => Ok(Self {
-                inner: build_azure_object_store(url.to_string().as_str())
-                    .await?
-                    .traced(),
-                scheme: String::from("az"),
-                base_path: Path::from(url.path()),
-                block_size: 64 * 1024,
-                commit_handler: params
-                    .commit_handler
-                    .clone()
-                    .unwrap_or_else(|| Arc::new(RenameCommitHandler)),
-            }),
-            "file" => Ok(Self::from_path(url.path(), params)?.0),
-            "memory" => Ok(Self {
-                inner: Arc::new(InMemory::new()).traced(),
-                scheme: String::from("memory"),
-                base_path: Path::from(url.path()),
-                block_size: 64 * 1024,
-                commit_handler: params
-                    .commit_handler
-                    .clone()
-                    .unwrap_or_else(|| Arc::new(RenameCommitHandler)),
-            }),
-            s => Err(Error::IO {
-                message: format!("Unsupported URI scheme: {}", s),
-                location: location!(),
-            }),
-        }
+        configure_store(url.as_str(), &mut storage_options, options).await
     }
-
     /// Local object store.
     pub fn local() -> Self {
         Self {
@@ -878,14 +708,6 @@ impl StorageOptions {
     }
 }
 
-pub(crate) fn str_is_truthy(val: &str) -> bool {
-    val.eq_ignore_ascii_case("1")
-        | val.eq_ignore_ascii_case("true")
-        | val.eq_ignore_ascii_case("on")
-        | val.eq_ignore_ascii_case("yes")
-        | val.eq_ignore_ascii_case("y")
-}
-
 impl From<HashMap<String, String>> for StorageOptions {
     fn from(value: HashMap<String, String>) -> Self {
         Self::new(value)
@@ -893,52 +715,145 @@ impl From<HashMap<String, String>> for StorageOptions {
 }
 
 async fn configure_store(
-    url: &Url,
-    options: &mut StorageOptions,
-    commit_handler: Option<Arc<dyn CommitHandler>>,
+    url: &str,
+    storage_options: &mut StorageOptions,
+    options: ObjectStoreOptions,
 ) -> Result<ObjectStore> {
+    let mut url = ensure_table_uri(url)?;
     // Block size: On local file systems, we use 4KB block size. On cloud
     // object stores, we use 64KB block size. This is generally the largest
     // block size where we don't see a latency penalty.
     match url.scheme() {
-        "s3" => {
-            options.with_env_s3();
+        "s3" | "s3+ddb" => {
+            storage_options.with_env_s3();
 
-            let (store, _) = parse_url_opts(url, options.as_azure_options())?;
-            let store = Arc::new(store);
+            if url.scheme() == "s3+ddb" && options.commit_handler.is_some() {
+                return Err(Error::InvalidInput {
+                    source: "`s3+ddb://` scheme and custom commit handler are mutually exclusive"
+                        .into(),
+                    location: location!(),
+                });
+            }
+
+            let ddb_table_name = if url.scheme() == "s3" {
+                None
+            } else {
+                if url.query_pairs().count() != 1 {
+                    return Err(Error::InvalidInput {
+                        source: "`s3+ddb://` scheme and expects exactly one query `ddbTableName`"
+                            .into(),
+                        location: location!(),
+                    });
+                }
+                match url.query_pairs().next() {
+                    Some((Cow::Borrowed(key), Cow::Borrowed(table_name)))
+                        if key == DDB_URL_QUERY_KEY =>
+                    {
+                        if table_name.is_empty() {
+                            return Err(Error::InvalidInput {
+                                source: "`s3+ddb://` scheme requires non empty dynamodb table name"
+                                    .into(),
+                                location: location!(),
+                            });
+                        }
+                        Some(table_name)
+                    }
+                    _ => {
+                        return Err(Error::InvalidInput {
+                            source:
+                                "`s3+ddb://` scheme and expects exactly one query `ddbTableName`"
+                                    .into(),
+                            location: location!(),
+                        });
+                    }
+                }
+            };
+            let storage_options = storage_options.as_s3_options();
+            let region = storage_options
+                .get(&AmazonS3ConfigKey::Region)
+                .map(|s| s.to_string());
+
+            let (aws_creds, region) = build_aws_credential(
+                options.s3_credentials_refresh_offset,
+                options.aws_credentials.clone(),
+                region,
+            )
+            .await?;
+
+            let commit_handler = match ddb_table_name {
+                #[cfg(feature = "dynamodb")]
+                Some(table_name) => Arc::new(ExternalManifestCommitHandler {
+                    external_manifest_store: build_dynamodb_external_store(
+                        table_name,
+                        aws_creds.clone(),
+                        &region,
+                        "lancedb",
+                    )
+                    .await?,
+                }),
+                #[cfg(not(feature = "dynamodb"))]
+                Some(_) => {
+                    return Err(Error::InvalidInput {
+                        source: "`s3+ddb://` scheme requires `dynamodb` feature to be enabled"
+                            .into(),
+                        location: location!(),
+                    });
+                }
+                None => options
+                    .commit_handler
+                    .clone()
+                    .unwrap_or_else(|| Arc::new(UnsafeCommitHandler)),
+            };
+
+            // before creating the OSObjectStore we need to rewrite the url to drop ddb related parts
+            url.set_scheme("s3").map_err(|()| Error::Internal {
+                message: "could not set scheme".into(),
+                location: location!(),
+            })?;
+
+            url.set_query(None);
+
+            // we can't use parse_url_opts here because we need to manually set the credentials provider
+            let mut builder = AmazonS3Builder::new();
+            for (key, value) in storage_options {
+                builder = builder.with_config(key, value);
+            }
+            builder = builder
+                .with_url(url.as_ref())
+                .with_credentials(aws_creds)
+                .with_region(region)
+                .with_allow_http(true);
+            let store = builder.build()?;
 
             Ok(ObjectStore {
-                inner: store,
+                inner: Arc::new(store),
                 scheme: String::from(url.scheme()),
                 base_path: Path::from(url.path()),
                 block_size: 64 * 1024,
-                commit_handler: commit_handler
-                    .clone()
-                    .unwrap_or_else(|| Arc::new(UnsafeCommitHandler)),
+                commit_handler,
             })
         }
-        "s3+ddb" => {
-            todo!()
-        }
-        "gs" => {
-            options.with_env_gcs();
 
-            let (store, _) = parse_url_opts(url, options.as_azure_options())?;
+        "gs" => {
+            storage_options.with_env_gcs();
+
+            let (store, _) = parse_url_opts(&url, storage_options.as_azure_options())?;
             let store = Arc::new(store);
             Ok(ObjectStore {
                 inner: store,
                 scheme: String::from("gs"),
                 base_path: Path::from(url.path()),
                 block_size: 64 * 1024,
-                commit_handler: commit_handler
+                commit_handler: options
+                    .commit_handler
                     .clone()
                     .unwrap_or_else(|| Arc::new(RenameCommitHandler)),
             })
         }
         "az" => {
-            options.with_env_azure();
+            storage_options.with_env_azure();
 
-            let (store, _) = parse_url_opts(url, options.as_azure_options())?;
+            let (store, _) = parse_url_opts(&url, storage_options.as_azure_options())?;
             let store = Arc::new(store);
 
             Ok(ObjectStore {
@@ -946,18 +861,20 @@ async fn configure_store(
                 scheme: String::from("az"),
                 base_path: Path::from(url.path()),
                 block_size: 64 * 1024,
-                commit_handler: commit_handler
+                commit_handler: options
+                    .commit_handler
                     .clone()
                     .unwrap_or_else(|| Arc::new(RenameCommitHandler)),
             })
         }
-        "file" => Ok(ObjectStore::new_from_path(url.path(), commit_handler)?.0),
+        "file" => Ok(ObjectStore::new_from_path(url.path(), options.commit_handler)?.0),
         "memory" => Ok(ObjectStore {
             inner: Arc::new(InMemory::new()).traced(),
             scheme: String::from("memory"),
             base_path: Path::from(url.path()),
             block_size: 64 * 1024,
-            commit_handler: commit_handler
+            commit_handler: options
+                .commit_handler
                 .clone()
                 .unwrap_or_else(|| Arc::new(RenameCommitHandler)),
         }),
@@ -969,12 +886,143 @@ async fn configure_store(
 }
 
 impl ObjectStore {
-    pub async fn try_new(
+    pub fn new(
+        store: Arc<DynObjectStore>,
         location: Url,
+        block_size: Option<usize>,
+        commit_handler: Option<Arc<dyn CommitHandler>>,
+    ) -> Self {
+        let scheme = location.scheme();
+        let block_size = block_size.unwrap_or_else(|| infer_block_size(scheme));
+        let commit_handler = commit_handler
+            .unwrap_or_else(|| Arc::new(RenameCommitHandler) as Arc<dyn CommitHandler>);
+        Self {
+            inner: store,
+            scheme: scheme.into(),
+            base_path: location.path().into(),
+            block_size,
+            commit_handler,
+        }
+    }
+    pub async fn try_new<T: AsRef<str>>(
+        location: T,
         options: impl Into<StorageOptions> + Clone,
     ) -> Result<Self> {
-        let mut options = options.into();
-        configure_store(&location, &mut options, None).await
+        let mut storage_options = options.into();
+        let options = ObjectStoreOptions::new(location.as_ref());
+        configure_store(location.as_ref(), &mut storage_options, options).await
+    }
+}
+
+fn infer_block_size(scheme: &str) -> usize {
+    // Block size: On local file systems, we use 4KB block size. On cloud
+    // object stores, we use 64KB block size. This is generally the largest
+    // block size where we don't see a latency penalty.
+    match scheme {
+        "file" => 4 * 1024,
+        _ => 64 * 1024,
+    }
+}
+
+fn str_is_truthy(val: &str) -> bool {
+    val.eq_ignore_ascii_case("1")
+        | val.eq_ignore_ascii_case("true")
+        | val.eq_ignore_ascii_case("on")
+        | val.eq_ignore_ascii_case("yes")
+        | val.eq_ignore_ascii_case("y")
+}
+
+/// Attempt to create a Url from given table location.
+///
+/// The location could be:
+///  * A valid URL, which will be parsed and returned
+///  * A path to a directory, which will be created and then converted to a URL.
+///
+/// If it is a local path, it will be created if it doesn't exist.
+///
+/// Extra slashes will be removed from the end path as well.
+///
+/// Will return an error if the location is not valid. For example,
+pub fn ensure_table_uri(table_uri: impl AsRef<str>) -> Result<Url> {
+    let table_uri = table_uri.as_ref();
+
+    enum UriType {
+        LocalPath(PathBuf),
+        Url(Url),
+    }
+    let uri_type: UriType = if let Ok(url) = Url::parse(table_uri) {
+        if url.scheme() == "file" {
+            UriType::LocalPath(url.to_file_path().map_err(|err| {
+                let msg = format!("Invalid table location: {}\nError: {:?}", table_uri, err);
+                Error::InvalidTableLocation { message: msg }
+            })?)
+        // NOTE this check is required to support absolute windows paths which may properly parse as url
+        } else if KNOWN_SCHEMES.contains(&url.scheme()) {
+            UriType::Url(url)
+        } else {
+            UriType::LocalPath(PathBuf::from(table_uri))
+        }
+    } else {
+        UriType::LocalPath(PathBuf::from(table_uri))
+    };
+
+    // If it is a local path, we need to create it if it does not exist.
+    let mut url = match uri_type {
+        UriType::LocalPath(path) => {
+            let path = std::fs::canonicalize(path).map_err(|err| Error::DatasetNotFound {
+                path: table_uri.to_string(),
+                source: Box::new(err),
+                location: location!(),
+            })?;
+            Url::from_directory_path(path).map_err(|_| {
+                let msg = format!(
+                    "Could not construct a URL from canonicalized path: {}.\n\
+                  Something must be very wrong with the table path.",
+                    table_uri
+                );
+                Error::InvalidTableLocation { message: msg }
+            })?
+        }
+        UriType::Url(url) => url,
+    };
+
+    let trimmed_path = url.path().trim_end_matches('/').to_owned();
+    url.set_path(&trimmed_path);
+    Ok(url)
+}
+
+lazy_static::lazy_static! {
+  static ref KNOWN_SCHEMES: Vec<&'static str> =
+      Vec::from([
+        "s3",
+        "s3+ddb",
+        "gs",
+        "az",
+        "file",
+        "memory"
+      ]);
+}
+
+#[derive(Debug)]
+pub struct ObjectStoreOptions {
+    pub block_size: Option<usize>,
+    pub table_uri: String,
+    pub object_store: Option<(Arc<DynObjectStore>, Url)>,
+    pub commit_handler: Option<Arc<dyn CommitHandler>>,
+    pub s3_credentials_refresh_offset: Duration,
+    pub aws_credentials: Option<AwsCredentialProvider>,
+}
+
+impl ObjectStoreOptions {
+    pub fn new<T: Into<String>>(table_uri: T) -> Self {
+        Self {
+            table_uri: table_uri.into(),
+            object_store: None,
+            commit_handler: None,
+            block_size: None,
+            s3_credentials_refresh_offset: Duration::from_secs(60),
+            aws_credentials: None,
+        }
     }
 }
 
@@ -1175,8 +1223,7 @@ mod tests {
         let mock_provider = Arc::new(MockAwsCredentialsProvider::default());
 
         let params = ObjectStoreParams {
-            aws_credentials: Some(mock_provider.clone()
-                as Arc<dyn CredentialProvider<Credential = ObjectStoreAwsCredential>>),
+            aws_credentials: Some(mock_provider.clone() as AwsCredentialProvider),
             ..ObjectStoreParams::default()
         };
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -231,7 +231,6 @@ impl Dataset {
     }
 
     /// Check out a version of the dataset with read params.
-    #[deprecated = "Use DatasetBuilder instead"]
     pub async fn checkout_with_params(
         uri: &str,
         version: u64,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -62,7 +62,6 @@ pub mod transaction;
 pub mod updater;
 mod write;
 
-use self::builder::DatasetBuilder;
 use self::cleanup::RemovalStats;
 use self::feature_flags::{apply_feature_flags, can_read_dataset, can_write_dataset};
 use self::fragment::FileFragment;

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -224,10 +224,8 @@ impl Dataset {
 
     /// Check out a version of the dataset.
     pub async fn checkout(uri: &str, version: u64) -> Result<Self> {
-        DatasetBuilder::from_uri(uri)
-            .with_version(version)
-            .load()
-            .await
+        let params = ReadParams::default();
+        Self::checkout_with_params(uri, version, &params).await
     }
 
     /// Check out a version of the dataset with read params.

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -1,0 +1,179 @@
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use lance_core::io::{
+    commit::CommitHandler,
+    object_store::{ObjectStore, ObjectStoreOptions},
+};
+use object_store::{aws::AwsCredentialProvider, DynObjectStore};
+use snafu::{location, Location};
+use url::Url;
+
+use super::{DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE};
+use crate::{
+    error::{Error, Result},
+    session::Session,
+    Dataset,
+};
+/// builder for loading a [`Dataset`].
+pub struct DatasetBuilder {
+    /// Cache size for index cache. If it is zero, index cache is disabled.
+    index_cache_size: usize,
+
+    /// Metadata cache size for the fragment metadata. If it is zero, metadata
+    /// cache is disabled.
+    metadata_cache_size: usize,
+
+    /// If present, dataset will use this shared [`Session`] instead creating a new one.
+    ///
+    /// This is useful for sharing the same session across multiple datasets.
+    session: Option<Arc<Session>>,
+    options: ObjectStoreOptions,
+    storage_options: Option<HashMap<String, String>>,
+    version: Option<u64>,
+}
+
+impl DatasetBuilder {
+    pub fn from_uri<T: AsRef<str>>(table_uri: T) -> Self {
+        let opts = ObjectStoreOptions::new(table_uri.as_ref());
+        Self {
+            index_cache_size: DEFAULT_INDEX_CACHE_SIZE,
+            metadata_cache_size: DEFAULT_METADATA_CACHE_SIZE,
+            session: None,
+            options: opts,
+            storage_options: None,
+            version: None,
+        }
+    }
+}
+
+// Much of this builder is directly inspired from the to delta-rs table builder implementation
+// https://github.com/delta-io/delta-rs/main/crates/deltalake-core/src/table/builder.rs
+
+impl DatasetBuilder {
+    /// Set the cache size for indices. Set to zero, to disable the cache.
+    pub fn with_index_cache_size(mut self, cache_size: usize) -> Self {
+        self.index_cache_size = cache_size;
+        self
+    }
+
+    /// Set the cache size for the file metadata. Set to zero to disable this cache.
+    pub fn with_metadata_cache_size(mut self, cache_size: usize) -> Self {
+        self.metadata_cache_size = cache_size;
+        self
+    }
+
+    /// Set a shared session for the datasets.
+    pub fn with_session(mut self, session: Arc<Session>) -> Self {
+        self.session = Some(session);
+        self
+    }
+
+    /// The block size passed to the underlying Object Store reader.
+    ///
+    /// This is used to control the minimal request size.
+    pub fn with_block_size(mut self, block_size: usize) -> Self {
+        self.options.block_size = Some(block_size);
+        self
+    }
+
+    /// Sets `version` to the builder
+    pub fn with_version(mut self, version: u64) -> Self {
+        self.version = Some(version);
+        self
+    }
+
+    pub fn with_commit_handler(mut self, commit_handler: Arc<dyn CommitHandler>) -> Self {
+        self.options.commit_handler = Some(commit_handler);
+        self
+    }
+
+    /// Sets the s3 credentials refresh.
+    /// This only applies to s3 storage.
+    pub fn with_s3_credentials_refresh_offset(mut self, offset: Duration) -> Self {
+        self.options.s3_credentials_refresh_offset = offset;
+        self
+    }
+
+    /// Sets the aws credentials provider.
+    /// This only applies to aws object store.
+    pub fn with_aws_credentials_provider(mut self, credentials: AwsCredentialProvider) -> Self {
+        self.options.aws_credentials = Some(credentials);
+        self
+    }
+
+    /// Directly set the object store to use.
+    pub fn with_object_store(mut self, object_store: Arc<DynObjectStore>, location: Url) -> Self {
+        self.options.object_store = Some((object_store, location));
+        self
+    }
+
+    /// Set options used to initialize storage backend
+    ///
+    /// Options may be passed in the HashMap or set as environment variables. See documentation of
+    /// underlying object store implementation for details.
+    ///
+    /// - [Azure options](https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html#variants)
+    /// - [S3 options](https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html#variants)
+    /// - [Google options](https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html#variants)
+    pub fn with_storage_options(mut self, storage_options: HashMap<String, String>) -> Self {
+        self.storage_options = Some(storage_options);
+        self
+    }
+
+    /// Build a lance object store for the given config
+    pub async fn build_object_store(self) -> Result<ObjectStore> {
+        match &self.options.object_store {
+            Some(store) => Ok(ObjectStore::new(
+                store.0.clone(),
+                store.1.clone(),
+                self.options.block_size,
+                self.options.commit_handler,
+            )),
+            None => {
+                ObjectStore::try_new(
+                    self.options.table_uri,
+                    self.storage_options.unwrap_or_default(),
+                )
+                .await
+            }
+        }
+    }
+
+    pub async fn load(self) -> Result<Dataset> {
+        let session = self.session.clone().unwrap_or_else(|| {
+            Arc::new(Session::new(
+                self.index_cache_size,
+                self.metadata_cache_size,
+            ))
+        });
+        let version = self.version;
+
+        let object_store = self.build_object_store().await?;
+        let base_path = object_store.base_path();
+        let manifest = match version {
+            Some(version) => {
+                object_store
+                    .commit_handler
+                    .resolve_version(base_path, version, &object_store.inner)
+                    .await?
+            }
+            None => object_store
+                .commit_handler
+                .resolve_latest_version(base_path, &object_store.inner)
+                .await
+                .map_err(|e| Error::DatasetNotFound {
+                    path: base_path.to_string(),
+                    source: Box::new(e),
+                    location: location!(),
+                })?,
+        };
+
+        Dataset::checkout_manifest(
+            Arc::new(object_store.clone()),
+            base_path.clone(),
+            &manifest,
+            session,
+        )
+        .await
+    }
+}

--- a/rust/lance/src/lib.rs
+++ b/rust/lance/src/lib.rs
@@ -78,9 +78,7 @@
 //! # })
 //!
 //! ```
-
-use std::collections::HashMap;
-
+//!
 use dataset::builder::DatasetBuilder;
 pub use lance_core::{datatypes, encodings, error, format};
 pub use lance_core::{Error, Result};
@@ -97,17 +95,8 @@ pub use dataset::Dataset;
 
 /// Creates and loads a [`Dataset`] from the given path.
 /// Infers the storage backend to use from the scheme in the given table path.
+///
+/// For more advanced configurations use [`DatasetBuilder`].
 pub async fn open_dataset<T: AsRef<str>>(table_uri: T) -> Result<Dataset> {
     DatasetBuilder::from_uri(table_uri.as_ref()).load().await
-}
-
-/// Same as `open_dataset`, but also accepts storage options to aid in building the underlying object store
-pub async fn open_dataset_with_storage_options(
-    table_uri: impl AsRef<str>,
-    storage_options: HashMap<String, String>,
-) -> Result<Dataset> {
-    DatasetBuilder::from_uri(table_uri)
-        .with_storage_options(storage_options)
-        .load()
-        .await
 }

--- a/rust/lance/src/lib.rs
+++ b/rust/lance/src/lib.rs
@@ -79,6 +79,9 @@
 //!
 //! ```
 
+use std::collections::HashMap;
+
+use dataset::builder::DatasetBuilder;
 pub use lance_core::{datatypes, encodings, error, format};
 pub use lance_core::{Error, Result};
 
@@ -91,3 +94,20 @@ pub mod session;
 pub mod utils;
 
 pub use dataset::Dataset;
+
+/// Creates and loads a [`Dataset`] from the given path.
+/// Infers the storage backend to use from the scheme in the given table path.
+pub async fn open_dataset<T: AsRef<str>>(table_uri: T) -> Result<Dataset> {
+    DatasetBuilder::from_uri(table_uri.as_ref()).load().await
+}
+
+/// Same as `open_dataset`, but also accepts storage options to aid in building the underlying object store
+pub async fn open_dataset_with_storage_options(
+    table_uri: impl AsRef<str>,
+    storage_options: HashMap<String, String>,
+) -> Result<Dataset> {
+    DatasetBuilder::from_uri(table_uri)
+        .with_storage_options(storage_options)
+        .load()
+        .await
+}


### PR DESCRIPTION
closes https://github.com/lancedb/lance/issues/1542

This takes a few components, and a lot of inspiration from the delta-rs implementation. The idea being it'll make it easier for others to adopt if it's familiar to other data formats (_with delta being the closest in nature to lance_).


Overall, I think these changes make it not only much more ergonomic, but also much easier to fine tune the lower level object store settings. 


### Some top level functions exposed that mirror delta-rs. 
```rust
let path = "gs://my-bucket/my_table.lance";
// using the default storage options
let dataset = lance::open_dataset(path).await.unwrap();

// using custom storage options
let mut options: HashMap<String, String> = HashMap::new();
options.insert(
    "service_account_path".into(),
    "~/.service_acct_key.json".into(),
);
let dataset = lance::open_dataset_with_storage_options(path, options.clone())
    .await
    .unwrap();
```

### Additionally a `DatasetBuilder` for even more control. 

```rust
    // using the dataset builder
    use lance::{dataset::builder::DatasetBuilder, Dataset};

    let dataset: Dataset = DatasetBuilder::from_uri(path)
        .with_block_size(1024 * 4)
        .with_index_cache_size(0)
        .with_storage_options(options)
        .load()
        .await
        .unwrap();
```

### Original functionality is still retained.

```rust
let dataset = Dataset::open(path).await.unwrap();
```

A lot of the original functionality _could_ be deprecated and removed as there is some duplication now. But I didn't want to break anything within the bindings libraries, or otherwise introduce a breaking change. 

Still todo:

- [x] combine `ObjectStoreParams` with my new `ObjectStoreOptions` 


---
## Suggested Follow ups
now that we have a simpler builder pattern for initializing the `Dataset` and `ObjectStore`, we could deprecate & remove many of the now redundant factory methods

for example, `Dataset` has 4 different factory methods that can now be initialized via the builder instead

- `Dataset::open`
- `Dataset::open_with_params`
- `Dataset::checkout`
- `Dataset::checkout_with_params`

Similarly, `ObjectStore` has many factory methods as well that can be replaced by using the builder. 

- `ObjectStore::from_uri`
- `ObjectStore::from_uri_and_params`
- `ObjectStore::from_path`
- `ObjectStore::new_from_path`
- `ObjectStore::new_from_url`
