### PR TITLE
chore: update cc dependency to 1.0.83

### DIFF
--- a/rust/lance-linalg/Cargo.toml
+++ b/rust/lance-linalg/Cargo.toml
@@ -30,7 +30,7 @@ criterion = { workspace = true }
 lance-testing = { path = "../lance-testing" }
 
 [build-dependencies]
-cc = "1"
+cc = "1.0.83"
 
 [features]
 avx512fp16 = []
@@ -65,4 +65,3 @@ harness = false
 [[bench]]
 name = "compute_partition"
 harness = false
-


### PR DESCRIPTION
Our build script is using the `std` function which was added in [`1.0.83`](https://github.com/rust-lang/cc-rs/releases/tag/1.0.83)