### PR TITLE
chore: dotprod should be on mac target, not haswell and better randomness for bf16

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -27,7 +27,7 @@ rustflags = [
 ]
 
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=haswell", "-C", "target-feature=+avx2,+fma,+f16c,+dotprod"]
+rustflags = ["-C", "target-cpu=haswell", "-C", "target-feature=+avx2,+fma,+f16c"]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "target-cpu=apple-m1", "-C", "target-feature=+neon,+fp16,+fhm"]
+rustflags = ["-C", "target-cpu=apple-m1", "-C", "target-feature=+neon,+fp16,+fhm,+dotprod"]

--- a/rust/lance-linalg/benches/dot.rs
+++ b/rust/lance-linalg/benches/dot.rs
@@ -97,12 +97,12 @@ fn bench_distance(c: &mut Criterion) {
     });
 
     let mut rng = rand::thread_rng();
-    let key = repeat_with(|| rng.gen::<f32>())
-        .map(bf16::from_f32)
+    let key = repeat_with(|| rng.gen::<u16>())
+        .map(bf16::from_bits)
         .take(DIMENSION)
         .collect::<Vec<_>>();
-    let target = repeat_with(|| rng.gen::<f32>())
-        .map(bf16::from_f32)
+    let target = repeat_with(|| rng.gen::<u16>())
+        .map(bf16::from_bits)
         .take(TOTAL * DIMENSION)
         .collect::<Vec<_>>();
     c.bench_function("Dot(bf16, auto-vectorization)", |b| {

--- a/rust/lance-linalg/benches/norm_l2.rs
+++ b/rust/lance-linalg/benches/norm_l2.rs
@@ -79,8 +79,8 @@ where
 
 fn bench_distance(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
-    let target = repeat_with(|| rng.gen::<f32>())
-        .map(bf16::from_f32)
+    let target = repeat_with(|| rng.gen::<u16>())
+        .map(bf16::from_bits)
         .take(TOTAL * DIMENSION)
         .collect::<Vec<_>>();
     c.bench_function("norm_l2(bf16, auto-vectorization)", |b| {


### PR DESCRIPTION
Generating bf16 from random f32's is biased.  Use random u16 as source instead.