### PR TITLE
feat: make Dataset::nearest() accepts arbitrary query type

### DIFF
--- a/rust/lance-arrow/src/floats.rs
+++ b/rust/lance-arrow/src/floats.rs
@@ -55,7 +55,7 @@ impl std::fmt::Display for FloatType {
 /// Trait for float types used in Arrow Array.
 ///
 pub trait ArrowFloatType: std::fmt::Debug {
-    type Native: FromPrimitive + FloatToArrayType<ArrowType = Self>;
+    type Native: FromPrimitive + FloatToArrayType<ArrowType = Self> + AsPrimitive<f32>;
 
     const FLOAT_TYPE: FloatType;
 
@@ -69,7 +69,16 @@ pub trait ArrowFloatType: std::fmt::Debug {
 }
 
 pub trait FloatToArrayType:
-    Float + Bounded + Sum + AddAssign<Self> + AsPrimitive<f64> + DivAssign + Send + Sync + Copy
+    Float
+    + Bounded
+    + Sum
+    + AddAssign<Self>
+    + AsPrimitive<f64>
+    + AsPrimitive<f32>
+    + DivAssign
+    + Send
+    + Sync
+    + Copy
 {
     type ArrowType: ArrowFloatType<Native = Self>;
 }

--- a/rust/lance-index/src/vector.rs
+++ b/rust/lance-index/src/vector.rs
@@ -15,9 +15,7 @@
 //! Vector Index
 //!
 
-use std::sync::Arc;
-
-use arrow_array::Float32Array;
+use arrow_array::ArrayRef;
 use lance_linalg::distance::MetricType;
 
 pub mod flat;
@@ -43,7 +41,7 @@ pub struct Query {
     pub column: String,
 
     /// The vector to be searched.
-    pub key: Arc<Float32Array>,
+    pub key: ArrayRef,
 
     /// Top k results to return.
     pub k: usize,

--- a/rust/lance-index/src/vector/flat.rs
+++ b/rust/lance-index/src/vector/flat.rs
@@ -106,7 +106,7 @@ async fn flat_search_batch(
     let vectors = as_fixed_size_list_array(vectors.as_ref()).clone();
 
     tokio::task::spawn_blocking(move || {
-        let distances = mt.arrow_batch_func()(key.values(), &vectors) as ArrayRef;
+        let distances = mt.arrow_batch_func()(key.as_ref(), &vectors)? as ArrayRef;
 
         // We don't want any nulls in result, so limit to k or the number of valid values.
         let k = std::cmp::min(k, distances.len() - distances.null_count());

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -29,7 +29,6 @@ use lance_linalg::distance::{
 };
 use lance_linalg::kernels::{argmin, argmin_value_float};
 use lance_linalg::{distance::MetricType, MatrixView};
-use num_traits::{AsPrimitive, Float};
 use snafu::{location, Location};
 pub mod builder;
 pub mod transform;

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -18,8 +18,8 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use arrow_array::ArrayRef;
 use arrow_array::{cast::AsArray, types::Float32Type, Array, FixedSizeListArray, UInt8Array};
+use arrow_array::{ArrayRef, Float32Array};
 use async_trait::async_trait;
 use lance_arrow::floats::FloatArray;
 use lance_arrow::*;
@@ -27,9 +27,9 @@ use lance_core::{Error, Result};
 use lance_linalg::distance::{
     cosine_distance_batch, dot_distance_batch, l2_distance_batch, norm_l2, Cosine, Dot, L2,
 };
-use lance_linalg::kernels::{argmin, argmin_value};
+use lance_linalg::kernels::{argmin, argmin_value_float};
 use lance_linalg::{distance::MetricType, MatrixView};
-use num_traits::{AsPrimitive, Float, One};
+use num_traits::{AsPrimitive, Float};
 use snafu::{location, Location};
 pub mod builder;
 pub mod transform;
@@ -206,9 +206,9 @@ impl<T: ArrowFloatType + Cosine + Dot + L2> ProductQuantizerImpl<T> {
                                 dot_distance_batch(sub_vec, centroids, sub_vector_width)
                             }
                         };
-                        argmin_value(distances).unwrap().1.as_()
+                        argmin_value_float(distances).1
                     })
-                    .sum::<f64>()
+                    .sum::<f32>() as f64
             })
             .sum::<f64>();
         Ok(total_distortion / data.num_rows() as f64)
@@ -226,7 +226,7 @@ impl<T: ArrowFloatType + Cosine + Dot + L2> ProductQuantizerImpl<T> {
         // Build distance table for each sub-centroid to the query key.
         //
         // Distance table: `[T::Native: num_sub_vectors(row) * num_centroids(column)]`.
-        let mut distance_table: Vec<T::Native> = vec![];
+        let mut distance_table = vec![];
 
         let sub_vector_length = self.dimension / self.num_sub_vectors;
         key.as_slice()
@@ -238,18 +238,15 @@ impl<T: ArrowFloatType + Cosine + Dot + L2> ProductQuantizerImpl<T> {
                 distance_table.extend(distances);
             });
 
-        Ok(Arc::new(T::ArrayType::from(
-            code.values()
-                .chunks_exact(self.num_sub_vectors)
-                .map(|c| {
-                    c.iter()
-                        .enumerate()
-                        .map(|(sub_vec_idx, centroid)| {
-                            distance_table[sub_vec_idx * 256 + *centroid as usize]
-                        })
-                        .sum::<T::Native>()
-                })
-                .collect::<Vec<_>>(),
+        Ok(Arc::new(Float32Array::from_iter_values(
+            code.values().chunks_exact(self.num_sub_vectors).map(|c| {
+                c.iter()
+                    .enumerate()
+                    .map(|(sub_vec_idx, centroid)| {
+                        distance_table[sub_vec_idx * 256 + *centroid as usize]
+                    })
+                    .sum()
+            }),
         )))
     }
 
@@ -269,7 +266,7 @@ impl<T: ArrowFloatType + Cosine + Dot + L2> ProductQuantizerImpl<T> {
 
         // Distance table: `[f32: num_sub_vectors(row) * num_centroids(column)]`.
         let capacity = self.num_sub_vectors * num_centroids(self.num_bits);
-        let mut distance_table = Vec::<T::Native>::with_capacity(capacity);
+        let mut distance_table = Vec::with_capacity(capacity);
 
         let sub_vector_length = self.dimension / self.num_sub_vectors;
         key.as_slice()
@@ -282,18 +279,15 @@ impl<T: ArrowFloatType + Cosine + Dot + L2> ProductQuantizerImpl<T> {
             });
 
         // Compute distance from the pre-compute table.
-        Ok(Arc::new(T::ArrayType::from(
-            code.values()
-                .chunks_exact(self.num_sub_vectors)
-                .map(|c| {
-                    c.iter()
-                        .enumerate()
-                        .map(|(sub_vec_idx, centroid)| {
-                            distance_table[sub_vec_idx * 256 + *centroid as usize]
-                        })
-                        .sum::<T::Native>()
-                })
-                .collect(),
+        Ok(Arc::new(Float32Array::from_iter_values(
+            code.values().chunks_exact(self.num_sub_vectors).map(|c| {
+                c.iter()
+                    .enumerate()
+                    .map(|(sub_vec_idx, centroid)| {
+                        distance_table[sub_vec_idx * 256 + *centroid as usize]
+                    })
+                    .sum::<f32>()
+            }),
         )))
     }
 
@@ -317,8 +311,8 @@ impl<T: ArrowFloatType + Cosine + Dot + L2> ProductQuantizerImpl<T> {
         // xy table: `[f32: num_sub_vectors(row) * num_centroids(column)]`.
         // y_norm table: `[f32: num_sub_vectors(row) * num_centroids(column)]`.
         let num_centroids = num_centroids(self.num_bits);
-        let mut xy_table: Vec<T::Native> = Vec::with_capacity(self.num_sub_vectors * num_centroids);
-        let mut y2_table: Vec<T::Native> = Vec::with_capacity(self.num_sub_vectors * num_centroids);
+        let mut xy_table: Vec<f32> = Vec::with_capacity(self.num_sub_vectors * num_centroids);
+        let mut y2_table: Vec<f32> = Vec::with_capacity(self.num_sub_vectors * num_centroids);
 
         let x_norm = norm_l2(query.as_slice());
         let sub_vector_length = self.dimension / self.num_sub_vectors;
@@ -341,29 +335,26 @@ impl<T: ArrowFloatType + Cosine + Dot + L2> ProductQuantizerImpl<T> {
             });
 
         // Compute distance from the pre-compute table.
-        Ok(Arc::new(T::ArrayType::from(
-            code.values()
-                .chunks_exact(self.num_sub_vectors)
-                .map(|c| {
-                    let xy = c
-                        .iter()
-                        .enumerate()
-                        .map(|(sub_vec_idx, centroid)| {
-                            let idx = sub_vec_idx * num_centroids + *centroid as usize;
-                            xy_table[idx]
-                        })
-                        .sum::<T::Native>();
-                    let y2 = c
-                        .iter()
-                        .enumerate()
-                        .map(|(sub_vec_idx, centroid)| {
-                            let idx = sub_vec_idx * num_centroids + *centroid as usize;
-                            y2_table[idx]
-                        })
-                        .sum::<T::Native>();
-                    T::Native::one() - xy / (x_norm * y2.sqrt())
-                })
-                .collect::<Vec<_>>(),
+        Ok(Arc::new(Float32Array::from_iter_values(
+            code.values().chunks_exact(self.num_sub_vectors).map(|c| {
+                let xy = c
+                    .iter()
+                    .enumerate()
+                    .map(|(sub_vec_idx, centroid)| {
+                        let idx = sub_vec_idx * num_centroids + *centroid as usize;
+                        xy_table[idx]
+                    })
+                    .sum::<f32>();
+                let y2 = c
+                    .iter()
+                    .enumerate()
+                    .map(|(sub_vec_idx, centroid)| {
+                        let idx = sub_vec_idx * num_centroids + *centroid as usize;
+                        y2_table[idx]
+                    })
+                    .sum::<f32>();
+                1.0 - xy / (x_norm * y2.sqrt())
+            }),
         )))
     }
 }

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -21,7 +21,7 @@
 
 use std::sync::Arc;
 
-use arrow_array::{Array, ArrayRef, FixedSizeListArray, Float32Array};
+use arrow_array::{Array, FixedSizeListArray, Float32Array};
 use arrow_schema::ArrowError;
 
 pub mod cosine;

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -21,7 +21,7 @@
 
 use std::sync::Arc;
 
-use arrow_array::{FixedSizeListArray, Float32Array};
+use arrow_array::{Array, ArrayRef, FixedSizeListArray, Float32Array};
 use arrow_schema::ArrowError;
 
 pub mod cosine;
@@ -33,6 +33,8 @@ pub use cosine::*;
 pub use dot::*;
 pub use l2::*;
 pub use norm_l2::*;
+
+use crate::Result;
 
 /// Distance metrics type.
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -47,7 +49,7 @@ pub type MetricType = DistanceType;
 
 pub type DistanceFunc = fn(&[f32], &[f32]) -> f32;
 pub type BatchDistanceFunc = fn(&[f32], &[f32], usize) -> Arc<Float32Array>;
-pub type ArrowBatchDistanceFunc = fn(&[f32], &FixedSizeListArray) -> Arc<Float32Array>;
+pub type ArrowBatchDistanceFunc = fn(&dyn Array, &FixedSizeListArray) -> Result<Arc<Float32Array>>;
 
 impl DistanceType {
     /// Compute the distance from one vector to a batch of vectors.

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -304,16 +304,10 @@ pub fn cosine_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,
 ) -> Result<Arc<Float32Array>> {
-    match from.data_type() {
-        &DataType::Float16 => {
-            do_cosine_distance_arrow_batch::<Float16Type>(from.as_primitive(), to)
-        }
-        &DataType::Float32 => {
-            do_cosine_distance_arrow_batch::<Float32Type>(from.as_primitive(), to)
-        }
-        &DataType::Float64 => {
-            do_cosine_distance_arrow_batch::<Float64Type>(from.as_primitive(), to)
-        }
+    match *from.data_type() {
+        DataType::Float16 => do_cosine_distance_arrow_batch::<Float16Type>(from.as_primitive(), to),
+        DataType::Float32 => do_cosine_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),
+        DataType::Float64 => do_cosine_distance_arrow_batch::<Float64Type>(from.as_primitive(), to),
         _ => Err(Error::InvalidArgumentError(format!(
             "Unsupported data type {:?}",
             from.data_type()

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use arrow_array::{
     cast::AsArray,
     types::{Float16Type, Float32Type, Float64Type},
-    Array, ArrowNumericType, FixedSizeListArray, Float32Array,
+    Array, FixedSizeListArray, Float32Array,
 };
 use arrow_schema::DataType;
 use lance_arrow::bfloat16::BFloat16Type;

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -254,10 +254,10 @@ pub fn dot_distance_arrow_batch(
     let dimension = to.value_length() as usize;
     debug_assert_eq!(from.len(), dimension);
 
-    match from.data_type() {
-        &DataType::Float16 => do_dot_distance_arrow_batch::<Float16Type>(from.as_primitive(), to),
-        &DataType::Float32 => do_dot_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),
-        &DataType::Float64 => do_dot_distance_arrow_batch::<Float64Type>(from.as_primitive(), to),
+    match *from.data_type() {
+        DataType::Float16 => do_dot_distance_arrow_batch::<Float16Type>(from.as_primitive(), to),
+        DataType::Float32 => do_dot_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),
+        DataType::Float64 => do_dot_distance_arrow_batch::<Float64Type>(from.as_primitive(), to),
         _ => Err(Error::InvalidArgumentError(format!(
             "Unsupported data type: {:?}",
             from.data_type()

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -258,10 +258,10 @@ pub fn l2_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,
 ) -> Result<Arc<Float32Array>> {
-    match from.data_type() {
-        &DataType::Float16 => do_l2_distance_arrow_batch::<Float16Type>(from.as_primitive(), to),
-        &DataType::Float32 => do_l2_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),
-        &DataType::Float64 => do_l2_distance_arrow_batch::<Float64Type>(from.as_primitive(), to),
+    match *from.data_type() {
+        DataType::Float16 => do_l2_distance_arrow_batch::<Float16Type>(from.as_primitive(), to),
+        DataType::Float32 => do_l2_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),
+        DataType::Float64 => do_l2_distance_arrow_batch::<Float64Type>(from.as_primitive(), to),
         _ => Err(Error::ComputeError(format!(
             "Unsupported data type: {}",
             from.data_type()

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -24,14 +24,16 @@ use arrow_array::{
     types::{ArrowPrimitiveType, Float16Type, Float32Type, Float64Type},
     Array, ArrowNumericType, FixedSizeListArray, Float32Array,
 };
+use arrow_schema::DataType;
 use half::{bf16, f16};
-use lance_arrow::{bfloat16::BFloat16Type, ArrowFloatType, FloatToArrayType};
+use lance_arrow::{bfloat16::BFloat16Type, ArrowFloatType, FloatArray, FloatToArrayType};
 use num_traits::{AsPrimitive, Float};
 
 use crate::simd::{
     f32::{f32x16, f32x8},
     SIMD,
 };
+use crate::{Error, Result};
 
 /// Calculate the L2 distance between two vectors.
 ///
@@ -215,6 +217,31 @@ where
     Box::new(T::ArrowType::l2_batch(from, to, dimension))
 }
 
+fn do_l2_distance_arrow_batch<T: ArrowFloatType + L2>(
+    from: &T::ArrayType,
+    to: &FixedSizeListArray,
+) -> Result<Arc<Float32Array>> {
+    let dimension = to.value_length() as usize;
+    debug_assert_eq!(from.len(), dimension);
+
+    // TODO: if we detect there is a run of nulls, should we skip those?
+    let to_values =
+        to.values()
+            .as_any()
+            .downcast_ref::<T::ArrayType>()
+            .ok_or(Error::ComputeError(format!(
+                "Cannot downcast to the same type: {} != {}",
+                T::FLOAT_TYPE,
+                to.value_type()
+            )))?;
+    let dists = l2_distance_batch(from.as_slice(), to_values.as_slice(), dimension);
+
+    Ok(Arc::new(Float32Array::new(
+        dists.collect(),
+        to.nulls().cloned(),
+    )))
+}
+
 /// Compute L2 distance between a vector and a batch of vectors.
 ///
 /// Null buffer of `to` is propagated to the returned array.
@@ -227,22 +254,19 @@ where
 /// # Panics
 ///
 /// Panics if the length of `from` is not equal to the dimension (value length) of `to`.
-pub fn l2_distance_arrow_batch<T: ArrowNumericType>(
-    from: &[<T as ArrowPrimitiveType>::Native],
+pub fn l2_distance_arrow_batch(
+    from: &dyn Array,
     to: &FixedSizeListArray,
-) -> Arc<Float32Array>
-where
-    <T as ArrowPrimitiveType>::Native: FloatToArrayType,
-    <<T as ArrowPrimitiveType>::Native as FloatToArrayType>::ArrowType: L2,
-{
-    let dimension = to.value_length() as usize;
-    debug_assert_eq!(from.len(), dimension);
-
-    // TODO: if we detect there is a run of nulls, should we skip those?
-    let to_values = to.values().as_primitive::<T>().values();
-    let dists = l2_distance_batch(from, to_values, dimension);
-
-    Arc::new(Float32Array::new(dists.collect(), to.nulls().cloned()))
+) -> Result<Arc<Float32Array>> {
+    match from.data_type() {
+        &DataType::Float16 => do_l2_distance_arrow_batch::<Float16Type>(from.as_primitive(), to),
+        &DataType::Float32 => do_l2_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),
+        &DataType::Float64 => do_l2_distance_arrow_batch::<Float64Type>(from.as_primitive(), to),
+        _ => Err(Error::ComputeError(format!(
+            "Unsupported data type: {}",
+            from.data_type()
+        ))),
+    }
 }
 
 #[cfg(test)]

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -21,8 +21,8 @@ use std::sync::Arc;
 
 use arrow_array::{
     cast::AsArray,
-    types::{ArrowPrimitiveType, Float16Type, Float32Type, Float64Type},
-    Array, ArrowNumericType, FixedSizeListArray, Float32Array,
+    types::{Float16Type, Float32Type, Float64Type},
+    Array, FixedSizeListArray, Float32Array,
 };
 use arrow_schema::DataType;
 use half::{bf16, f16};

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -159,7 +159,7 @@ mod tests {
     use std::fmt::Debug;
 
     use approx::assert_relative_eq;
-    use num_traits::{FromPrimitive};
+    use num_traits::FromPrimitive;
 
     use super::*;
 

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -159,7 +159,7 @@ mod tests {
     use std::fmt::Debug;
 
     use approx::assert_relative_eq;
-    use num_traits::{AsPrimitive, FromPrimitive};
+    use num_traits::{FromPrimitive};
 
     use super::*;
 

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -173,7 +173,7 @@ mod tests {
 
         let result = data.as_slice().norm_l2();
         assert_relative_eq!(
-            result.as_(),
+            result as f64,
             (1..=37)
                 .map(|v| f64::from_i32(v * v).unwrap())
                 .sum::<f64>()
@@ -183,7 +183,7 @@ mod tests {
 
         let not_aligned = (&data[2..]).norm_l2();
         assert_relative_eq!(
-            not_aligned.as_(),
+            not_aligned as f64,
             (3..=37)
                 .map(|v| f64::from_i32(v * v).unwrap())
                 .sum::<f64>()

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -83,7 +83,7 @@ impl Normalize<f16> for &[f16] {
                     sums[i] += f32_vals[i].powi(2);
                 }
             }
-            f16::from_f32((sums.iter().copied().sum::<f32>() + sum).sqrt())
+            (sums.iter().copied().sum::<f32>() + sum).sqrt()
         }
     }
 }

--- a/rust/lance-linalg/src/simd/f16.c
+++ b/rust/lance-linalg/src/simd/f16.c
@@ -20,14 +20,14 @@
 #endif // __X86_64__
 
 /// Works on NEON + FP16 or AVX512FP16
-_Float16 norm_l2_f16(const _Float16 *data, uint32_t dimension) {
+float norm_l2_f16(const _Float16 *data, uint32_t dimension) {
   _Float16 sum = 0;
 
 #pragma clang loop unroll(enable) vectorize(enable) interleave(enable)
   for (uint32_t i = 0; i < dimension; i++) {
     sum += data[i] * data[i];
   }
-  return sum;
+  return (float) sum;
 }
 
 /// @brief Dot product of two f16 vectors.
@@ -35,17 +35,17 @@ _Float16 norm_l2_f16(const _Float16 *data, uint32_t dimension) {
 /// @param y A f16 vector
 /// @param dimension The dimension of the vectors
 /// @return The dot product of the two vectors.
-_Float16 dot_f16(const _Float16 *x, const _Float16 *y, uint32_t dimension) {
+float dot_f16(const _Float16 *x, const _Float16 *y, uint32_t dimension) {
   _Float16 sum = 0;
 
 #pragma clang loop unroll(enable) interleave(enable) vectorize(enable)
   for (uint32_t i = 0; i < dimension; i++) {
     sum += x[i] * y[i];
   }
-  return sum;
+  return (float) sum;
 }
 
-_Float16 l2_f16(const _Float16 *x, const _Float16 *y, uint32_t dimension) {
+float l2_f16(const _Float16 *x, const _Float16 *y, uint32_t dimension) {
   _Float16 sum = 0.0;
 
 #pragma clang loop unroll(enable) interleave(enable) vectorize_width(32)
@@ -53,5 +53,5 @@ _Float16 l2_f16(const _Float16 *x, const _Float16 *y, uint32_t dimension) {
     _Float16 s = x[i] - y[i];
     sum += s * s;
   }
-  return sum;
+  return (float) sum;
 }

--- a/rust/lance/src/index/vector/diskann/search.rs
+++ b/rust/lance/src/index/vector/diskann/search.rs
@@ -20,6 +20,7 @@ use std::{
 };
 
 use arrow_array::cast::AsArray;
+use arrow_array::types::Float32Type;
 use arrow_array::{ArrayRef, Float32Array, RecordBatch, UInt64Array};
 use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
@@ -231,7 +232,7 @@ impl VectorIndex for DiskANNIndex {
         let state = greedy_search(
             &self.graph,
             0,
-            query.key.as_primitive().values(),
+            query.key.as_primitive::<Float32Type>().values(),
             query.k,
             query.k * 2,
         )

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -156,10 +156,10 @@ impl IVFIndex {
         let part_index = self.load_partition(partition_id).await?;
 
         let partition_centroids = self.ivf.centroids.value(partition_id);
-        let residual_key = sub(query.key.as_ref(), &partition_centroids)?;
+        let residual_key = sub(&query.key, &partition_centroids)?;
         // Query in partition.
         let mut part_query = query.clone();
-        part_query.key = as_primitive_array(&residual_key).clone().into();
+        part_query.key = residual_key;
         let batch = part_index.search(&part_query, pre_filter).await?;
         Ok(batch)
     }

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -17,10 +17,9 @@
 use std::{any::Any, collections::HashMap, sync::Arc};
 
 use arrow_arith::numeric::sub;
-use arrow_array::types::{Float16Type, Float64Type};
 use arrow_array::{
     cast::{as_primitive_array, as_struct_array, AsArray},
-    types::Float32Type,
+    types::{Float16Type, Float32Type, Float64Type},
     Array, FixedSizeListArray, Float32Array, RecordBatch, StructArray, UInt32Array,
 };
 use arrow_ord::sort::sort_to_indices;
@@ -469,7 +468,7 @@ impl Ivf {
     /// Use the query vector to find `nprobes` closest partitions.
     fn find_partitions(
         &self,
-        query: &Float32Array,
+        query: &dyn Array,
         nprobes: usize,
         metric_type: MetricType,
     ) -> Result<UInt32Array> {

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -618,7 +618,7 @@ mod tests {
             stream,
             &Query {
                 column: "vector".to_string(),
-                key: Arc::new(as_primitive_array(&q).clone()),
+                key: q,
                 k: 10,
                 nprobes: 0,
                 refine_factor: None,


### PR DESCRIPTION
* Also makes all distant function returns `f32`, because it is the fastest type to do sorting later.