### PR TITLE
fix: when we optimize indices we are incorrectly updating the list of indexed fragments

### DIFF
--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -206,6 +206,7 @@ impl From<serde_json::Error> for Error {
     }
 }
 
+#[track_caller]
 fn arrow_io_error_from_msg(message: String) -> ArrowError {
     ArrowError::IoError(
         message.clone(),

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -21,6 +21,7 @@ use lance_core::{
     Error, Result,
 };
 use nohash_hasher::IntMap;
+use roaring::RoaringBitmap;
 use serde::{Deserialize, Serialize};
 use snafu::{location, Location};
 
@@ -80,6 +81,17 @@ impl IndexRemapper for DatasetIndexRemapper {
             }
         }
         Ok(remapped)
+    }
+}
+
+pub async fn indexed_fragment_ids(index: &Index, dataset: &Dataset) -> Result<RoaringBitmap> {
+    if let Some(bitmap) = &index.fragment_bitmap {
+        Ok(bitmap.clone())
+    } else {
+        let ds = dataset.checkout_version(index.dataset_version).await?;
+        Ok(RoaringBitmap::from_iter(
+            ds.fragments().iter().map(|frag| frag.id as u32),
+        ))
     }
 }
 

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -288,7 +288,7 @@ impl DatasetIndexExt for Dataset {
             if idx.dataset_version == self.manifest.version {
                 continue;
             }
-            let Some(new_id) = append_index(dataset.clone(), idx).await? else {
+            let Some((new_id, new_frag_ids)) = append_index(dataset.clone(), idx).await? else {
                 continue;
             };
 
@@ -297,7 +297,7 @@ impl DatasetIndexExt for Dataset {
                 name: idx.name.clone(),
                 fields: idx.fields.clone(),
                 dataset_version: self.manifest.version,
-                fragment_bitmap: Some(self.get_fragments().iter().map(|f| f.id() as u32).collect()),
+                fragment_bitmap: Some(new_frag_ids),
             };
             removed_indices.push(idx.clone());
             new_indices.push(new_idx);

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -105,7 +105,7 @@ impl Stream for KNNFlatStream {
                 Poll::Ready(Ok(())) => true,
                 Poll::Ready(Err(join_error)) => {
                     return Poll::Ready(Some(Err(DataFusionError::Execution(format!(
-                        "ExecNode(Projection): thread panicked: {}",
+                        "ExecNode(KNNFlatStream): thread panicked: {}",
                         join_error
                     )))));
                 }
@@ -381,7 +381,7 @@ impl Stream for KNNIndexStream {
                 Poll::Ready(Ok(())) => true,
                 Poll::Ready(Err(join_error)) => {
                     return Poll::Ready(Some(Err(DataFusionError::Execution(format!(
-                        "ExecNode(Projection): thread panicked: {}",
+                        "ExecNode(KNNIndexStream): thread panicked: {}",
                         join_error
                     )))));
                 }

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -145,7 +145,7 @@ impl Stream for Take {
                 Poll::Ready(Ok(())) => true,
                 Poll::Ready(Err(join_error)) => {
                     return Poll::Ready(Some(Err(DataFusionError::Execution(format!(
-                        "ExecNode(Projection): thread panicked: {}",
+                        "ExecNode(Take): thread panicked: {}",
                         join_error
                     )))));
                 }


### PR DESCRIPTION
The current approach updates the indexed fragments to match the current dataset version.  This is incorrect because updating indices does not (necessarily) remove deleted fragments from the index data.  Instead we should only be adding new fragment ids to the index's fragment id list.