### PR TITLE
fix: google objectstore uses proper gs configuration

### DIFF
--- a/rust/lance-core/src/io/object_store.rs
+++ b/rust/lance-core/src/io/object_store.rs
@@ -821,8 +821,7 @@ async fn configure_store(
 
         "gs" => {
             storage_options.with_env_gcs();
-
-            let (store, _) = parse_url_opts(&url, storage_options.as_azure_options())?;
+            let (store, _) = parse_url_opts(&url, storage_options.as_gcs_options())?;
             let store = Arc::new(store);
             Ok(ObjectStore {
                 inner: store,


### PR DESCRIPTION
gs was converting to azure options instead of gcs options. 