### PR TITLE
chore: minor changes to tracing instrumentation

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -172,12 +172,14 @@ impl Dataset {
     /// Open an existing dataset.
     ///
     /// See also [DatasetBuilder].
+    #[instrument]
     pub async fn open(uri: &str) -> Result<Self> {
         DatasetBuilder::from_uri(uri).load().await
     }
 
     /// Open a dataset with read params.
     #[deprecated(since = "0.8.17", note = "Please use `DatasetBuilder` instead.")]
+    #[instrument(skip(params))]
     pub async fn open_with_params(uri: &str, params: &ReadParams) -> Result<Self> {
         let (mut object_store, base_path) = match params.store_options.as_ref() {
             Some(store_options) => ObjectStore::from_uri_and_params(uri, store_options).await?,
@@ -839,6 +841,7 @@ impl Dataset {
         Ok(counts.iter().sum())
     }
 
+    #[instrument(skip_all, fields(num_rows=row_indices.len()))]
     pub async fn take(&self, row_indices: &[u64], projection: &Schema) -> Result<RecordBatch> {
         if row_indices.is_empty() {
             let schema = Arc::new(projection.into());

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -154,7 +154,7 @@ pub async fn write_fragments(
 /// This is a private variant that takes a `SendableRecordBatchStream` instead
 /// of a reader. We don't expose the stream at our interface because it is a
 /// DataFusion type.
-#[instrument(skip_all)]
+#[instrument(level = "debug", skip_all)]
 pub async fn write_fragments_internal(
     object_store: Arc<ObjectStore>,
     base_dir: &Path,

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -69,7 +69,7 @@ impl BtreeTrainingSource for TrainingRequest {
 }
 
 /// Build a Vector Index
-#[instrument(skip(dataset))]
+#[instrument(level = "debug", skip(dataset))]
 pub async fn build_scalar_index(dataset: &Dataset, column: &str, uuid: &str) -> Result<()> {
     let training_request = Box::new(TrainingRequest {
         dataset: Arc::new(dataset.clone()),

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -160,7 +160,7 @@ fn is_diskann(stages: &[StageParams]) -> bool {
 }
 
 /// Build a Vector Index
-#[instrument(skip(dataset))]
+#[instrument(level = "debug", skip(dataset))]
 pub(crate) async fn build_vector_index(
     dataset: &Dataset,
     column: &str,
@@ -222,7 +222,7 @@ pub(crate) async fn build_vector_index(
     Ok(())
 }
 
-#[instrument(skip_all, fields(old_uuid = old_uuid.to_string(), new_uuid = new_uuid.to_string(), num_rows = mapping.len()))]
+#[instrument(level = "debug", skip_all, fields(old_uuid = old_uuid.to_string(), new_uuid = new_uuid.to_string(), num_rows = mapping.len()))]
 pub(crate) async fn remap_vector_index(
     dataset: Arc<Dataset>,
     column: &str,

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -39,7 +39,7 @@ use nohash_hasher::IntMap;
 use roaring::RoaringBitmap;
 use serde::Serialize;
 use snafu::{location, Location};
-use tracing::{instrument, Instrument};
+use tracing::instrument;
 
 use super::VectorIndex;
 use crate::index::prefilter::PreFilter;

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -204,7 +204,6 @@ impl VectorIndex for PQIndex {
             ]));
             Ok(RecordBatch::try_new(schema, vec![distances, row_ids])?)
         })
-        .in_current_span()
         .await
     }
 


### PR DESCRIPTION
These are pretty minor fixes but I am trying to make sure that all the spans we have are debug level except for those at the dataset/scanner layer (which are info).  Then, I am trying to make sure that all of our debug scans always roll up to one of the info spans.  This generates better traces as there are fewer (and more meaningful) root spans.