### PR TITLE
ci: use M1 runner for now for release

### DIFF
--- a/.github/workflows/build_mac_wheel/action.yml
+++ b/.github/workflows/build_mac_wheel/action.yml
@@ -22,4 +22,4 @@ runs:
         command: build
         args: ${{ inputs.args }}
         working-directory: python
-
+        interpreter: 3.${{ inputs.python-minor-version }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         python-minor-version: ["8"]
         config:
-          - target: x86_64-apple-darwin,
+          - target: x86_64-apple-darwin
             runner: macos-13
           - target: aarch64-apple-darwin
             runner: macos-13-xlarge
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.${{ matrix.python-minor-version }}
+        python-version: 3.11
     - uses: ./.github/workflows/build_mac_wheel
       with:
         python-minor-version: ${{ matrix.python-minor-version }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -34,11 +34,15 @@ jobs:
         repo: "pypi"
   mac:
     timeout-minutes: 60
-    runs-on: "macos-13"
+    runs-on: ${{ matrix.config.runner }}
     strategy:
       matrix:
         python-minor-version: ["8"]
-        target: [x86_64-apple-darwin, aarch64-apple-darwin]
+        config:
+          - target: x86_64-apple-darwin,
+            runner: macos-13
+          - target: aarch64-apple-darwin
+            runner: macos-13-xlarge
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.15
     steps:
@@ -54,7 +58,7 @@ jobs:
     - uses: ./.github/workflows/build_mac_wheel
       with:
         python-minor-version: ${{ matrix.python-minor-version }}
-        args: "--release --strip --target ${{ matrix.target }}"
+        args: "--release --strip --target ${{ matrix.config.target }}"
     - uses: ./.github/workflows/upload_wheel
       with:
         python-minor-version: ${{ matrix.python-minor-version }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -168,7 +168,7 @@ jobs:
       matrix:
         python-minor-version: ["8"]
         config:
-          - target: x86_64-apple-darwin,
+          - target: x86_64-apple-darwin
             runner: macos-13
           - target: aarch64-apple-darwin
             runner: macos-13-xlarge
@@ -183,7 +183,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.${{ matrix.python-minor-version }}
+        python-version: 3.11
     - uses: ./.github/workflows/build_mac_wheel
       with:
         python-minor-version: ${{ matrix.python-minor-version }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -161,33 +161,6 @@ jobs:
     # Make sure wheels are not included in the Rust cache
     - name: Delete wheels
       run: rm -rf target/wheels
-  mac-validate-job:
-    timeout-minutes: 60
-    runs-on: ${{ matrix.config.runner }}
-    strategy:
-      matrix:
-        python-minor-version: ["8"]
-        config:
-          - target: x86_64-apple-darwin
-            runner: macos-13
-          - target: aarch64-apple-darwin
-            runner: macos-13-xlarge
-    env:
-      MACOSX_DEPLOYMENT_TARGET: 10.15
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: ${{ inputs.ref }}
-        fetch-depth: 0
-        lfs: true
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: 3.11
-    - uses: ./.github/workflows/build_mac_wheel
-      with:
-        python-minor-version: ${{ matrix.python-minor-version }}
-        args: "--release --strip --target ${{ matrix.config.target }}"
   windows:
     runs-on: windows-latest
     timeout-minutes: 90

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -161,6 +161,33 @@ jobs:
     # Make sure wheels are not included in the Rust cache
     - name: Delete wheels
       run: rm -rf target/wheels
+  mac-validate-job:
+    timeout-minutes: 60
+    runs-on: ${{ matrix.config.runner }}
+    strategy:
+      matrix:
+        python-minor-version: ["8"]
+        config:
+          - target: x86_64-apple-darwin,
+            runner: macos-13
+          - target: aarch64-apple-darwin
+            runner: macos-13-xlarge
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.15
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.ref }}
+        fetch-depth: 0
+        lfs: true
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.${{ matrix.python-minor-version }}
+    - uses: ./.github/workflows/build_mac_wheel
+      with:
+        python-minor-version: ${{ matrix.python-minor-version }}
+        args: "--release --strip --target ${{ matrix.config.target }}"
   windows:
     runs-on: windows-latest
     timeout-minutes: 90


### PR DESCRIPTION
Workaround until we find a proper fix for #1621.