### PR TITLE
chore: expose avx512fp16 feature via main lance crate

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -42,6 +42,7 @@ tracing = "0.1.37"
 
 [features]
 datagen = ["lance-datagen"]
+avx512fp16 = ["lance/avx512fp16"]
 
 [build-dependencies]
 prost-build = "0.11"

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -116,6 +116,7 @@ env_logger = "0.10.0"
 tracing-chrome = "0.7.1"
 
 [features]
+avx512fp16 = ["lance-linalg/avx512fp16"]
 cli = ["clap"]
 # opq = ["cblas", "lapack", "openblas-src", "accelerate-src"]
 tensorflow = ["tfrecord"]


### PR DESCRIPTION
`lance-linalg` has a feature flag `avx512fp16`, once enabled, it compiles the `f16.c` for auto-vectorized routines for `f16` on CPUs with `avx512fp16` instruction set.

This PR propagate the optional feature flag (avx512fp16) to the lance crate, so that we can build `avx512fp16` from the main crate as well.

Did not use `RUSTCFLAGS="-C target-feature=+avx512fp16" because rustc (`1.74` at the time of wriitng), does not pass this feature to `build.rs` .