### PR TITLE
perf: more efficient treemap implementation for row ids

### DIFF
--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -21,9 +21,11 @@ use datafusion_common::ScalarValue;
 use datafusion_expr::{expr::InList, Between, BinaryExpr, Expr, Operator};
 
 use futures::join;
-use lance_core::{utils::mask::RowIdMask, Result};
+use lance_core::{
+    utils::mask::{RowIdMask, RowIdTreeMap},
+    Result,
+};
 use lance_datafusion::expr::safe_coerce_scalar;
-use roaring::RoaringTreemap;
 
 use super::{ScalarIndex, ScalarQuery};
 
@@ -244,7 +246,7 @@ impl ScalarIndexExpr {
             Self::Query(column, query) => {
                 let index = index_loader.load_index(column).await?;
                 let allow_list = index.search(query).await?;
-                let allow_list = RoaringTreemap::from_iter(allow_list.values().iter());
+                let allow_list = RowIdTreeMap::from_iter(allow_list.values().iter());
                 Ok(RowIdMask {
                     block_list: None,
                     allow_list: Some(allow_list),

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -28,10 +28,9 @@ use datafusion::physical_plan::{
 };
 use futures::stream::Stream;
 use futures::{FutureExt, StreamExt, TryStreamExt};
-use lance_core::utils::mask::RowIdMask;
+use lance_core::utils::mask::{RowIdMask, RowIdTreeMap};
 use lance_core::{ROW_ID, ROW_ID_FIELD};
 use lance_index::vector::{flat::flat_search, Query, DIST_COL};
-use roaring::RoaringTreemap;
 use snafu::{location, Location};
 use tokio::sync::mpsc::Receiver;
 use tokio::task::JoinHandle;
@@ -257,7 +256,7 @@ struct FilteredRowIdsToPrefilter(SendableRecordBatchStream);
 #[async_trait]
 impl FilterLoader for FilteredRowIdsToPrefilter {
     async fn load(mut self: Box<Self>) -> Result<RowIdMask> {
-        let mut allow_list = RoaringTreemap::new();
+        let mut allow_list = RowIdTreeMap::new();
         while let Some(batch) = self.0.next().await {
             let batch = batch?;
             let row_ids = batch.column_by_name(ROW_ID).expect(


### PR DESCRIPTION
Provides our own TreeMap implementation, which is optimized for the case where an entire fragment is added. When a full fragment is to be marked, we use `None` instead of a full `RoaringBitmap`.

Fixes #1633