### PR TITLE
chore: make lance-linalg benchmark ready to test bf16 data

### DIFF
--- a/rust/lance-arrow/src/bfloat16.rs
+++ b/rust/lance-arrow/src/bfloat16.rs
@@ -15,6 +15,7 @@
 //! bfloat16 support for Apache Arrow.
 
 use std::fmt::Formatter;
+use std::slice;
 
 use arrow_array::{
     builder::BooleanBufferBuilder, iterator::ArrayIter, Array, ArrayAccessor, ArrayRef,
@@ -275,8 +276,13 @@ mod from_arrow {
 impl FloatArray<BFloat16Type> for BFloat16Array {
     type FloatType = BFloat16Type;
 
-    fn as_slice(&self) -> &[<BFloat16Type as ArrowFloatType>::Native] {
-        unsafe { std::mem::transmute(self.inner.value_data()) }
+    fn as_slice(&self) -> &[bf16] {
+        unsafe {
+            slice::from_raw_parts(
+                self.inner.value_data().as_ptr() as *const bf16,
+                self.inner.value_data().len() / 2,
+            )
+        }
     }
 }
 

--- a/rust/lance-arrow/src/bfloat16.rs
+++ b/rust/lance-arrow/src/bfloat16.rs
@@ -26,7 +26,7 @@ use arrow_data::ArrayData;
 use arrow_schema::{ArrowError, DataType};
 use half::bf16;
 
-use crate::{ArrowFloatType, FloatArray};
+use crate::FloatArray;
 
 #[derive(Debug)]
 pub struct BFloat16Type {}

--- a/rust/lance-index/benches/find_partitions.rs
+++ b/rust/lance-index/benches/find_partitions.rs
@@ -28,7 +28,7 @@ fn bench_partitions(c: &mut Criterion) {
     const DIMENSION: usize = 1536;
     const SEED: [u8; 32] = [42; 32];
 
-    let query: Float32Array = generate_random_array_with_seed(DIMENSION, SEED);
+    let query: Float32Array = generate_random_array_with_seed::<Float32Type>(DIMENSION, SEED);
 
     for num_centroids in &[10240, 65536] {
         let centroids = Arc::new(generate_random_array_with_seed::<Float32Type>(

--- a/rust/lance-linalg/benches/argmin.rs
+++ b/rust/lance-linalg/benches/argmin.rs
@@ -14,10 +14,12 @@
 
 use std::{sync::Arc, time::Duration};
 
+use arrow_array::types::Float32Type;
 use arrow_array::{Float32Array, UInt32Array};
 use criterion::{criterion_group, criterion_main, Criterion};
 use lance_linalg::kernels::argmin_opt;
 use lance_testing::datagen::generate_random_array_with_seed;
+use num_traits::Float;
 
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
@@ -45,7 +47,7 @@ fn bench_argmin(c: &mut Criterion) {
     const TOTAL: usize = 1024;
     const SEED: [u8; 32] = [42; 32];
 
-    let target = generate_random_array_with_seed(TOTAL * DIMENSION, SEED);
+    let target = generate_random_array_with_seed::<Float32Type>(TOTAL * DIMENSION, SEED);
 
     c.bench_function("argmin(arrow)", |b| {
         b.iter(|| {

--- a/rust/lance-linalg/benches/argmin.rs
+++ b/rust/lance-linalg/benches/argmin.rs
@@ -19,7 +19,6 @@ use arrow_array::{Float32Array, UInt32Array};
 use criterion::{criterion_group, criterion_main, Criterion};
 use lance_linalg::kernels::argmin_opt;
 use lance_testing::datagen::generate_random_array_with_seed;
-use num_traits::Float;
 
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};

--- a/rust/lance-linalg/benches/cosine.rs
+++ b/rust/lance-linalg/benches/cosine.rs
@@ -17,10 +17,10 @@ use arrow_array::{
     Float32Array,
 };
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use lance_arrow::{ArrowFloatType, FloatArray};
+use lance_arrow::{bfloat16::BFloat16Type, ArrowFloatType, FloatArray};
+use lance_linalg::distance::cosine::{cosine_distance_batch, Cosine};
 use num_traits::Float;
 
-use lance_linalg::distance::cosine::{cosine_distance_batch, Cosine};
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
 
@@ -75,14 +75,13 @@ fn run_bench<T: ArrowFloatType + Cosine>(c: &mut Criterion) {
 }
 
 fn bench_distance(c: &mut Criterion) {
-    // run_bench::<BFloat16Type>(c);
+    run_bench::<BFloat16Type>(c);
     run_bench::<Float16Type>(c);
     run_bench::<Float32Type>(c);
     run_bench::<Float64Type>(c);
 
     let key: Float32Array = generate_random_array_with_seed::<Float32Type>(8, [0; 32]);
-    let target: Float32Array =
-        generate_random_array_with_seed::<Float32Type>(1024 * 1024 * 8, [42; 32]);
+    let target = generate_random_array_with_seed::<Float32Type>(1024 * 1024 * 8, [42; 32]);
 
     c.bench_function("Cosine(simd,f32x8) rng seed", |b| {
         b.iter(|| {

--- a/rust/lance-linalg/benches/cosine.rs
+++ b/rust/lance-linalg/benches/cosine.rs
@@ -12,45 +12,78 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use arrow_array::Float32Array;
+use arrow_array::{
+    types::{Float16Type, Float32Type, Float64Type},
+    Float32Array,
+};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use lance_arrow::bfloat16::BFloat16Type;
+use lance_arrow::{ArrowFloatType, FloatArray};
+use num_traits::Float;
 
-use lance_linalg::distance::cosine::cosine_distance_batch;
+use lance_linalg::distance::cosine::{cosine_distance_batch, Cosine};
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
 
 use lance_testing::datagen::generate_random_array_with_seed;
 
-fn bench_distance(c: &mut Criterion) {
+fn cosine_scalar<T: Float>(x: &[T], y: &[T], dim: usize) -> Vec<T> {
+    y.chunks_exact(dim)
+        .map(|vec| {
+            let mut dot = T::zero();
+            let mut x_norm = T::zero();
+            let mut y_norm = T::zero();
+
+            for (&xi, &yi) in x.iter().zip(vec.iter()) {
+                dot = dot + xi * yi;
+                x_norm = x_norm + xi * xi;
+                y_norm = y_norm + yi * yi;
+            }
+            dot / (x_norm * y_norm).sqrt()
+        })
+        .collect()
+}
+
+fn run_bench<T: ArrowFloatType + Cosine>(c: &mut Criterion) {
     const DIMENSION: usize = 1024;
     const TOTAL: usize = 1024 * 1024; // 1M vectors
 
-    let key: Float32Array = generate_random_array_with_seed(DIMENSION, [0; 32]);
-    // 1M of 1024 D vectors. 4GB in memory.
-    let target: Float32Array = generate_random_array_with_seed(TOTAL * DIMENSION, [42; 32]);
+    let type_name = std::any::type_name::<T::Native>();
+    let key = generate_random_array_with_seed::<T>(DIMENSION, [0; 32]);
+    let target = generate_random_array_with_seed::<T>(TOTAL * DIMENSION, [42; 32]);
 
-    c.bench_function("Cosine(simd)", |b| {
+    c.bench_function(format!("Cosine({}, scalar)", type_name).as_str(), |b| {
         b.iter(|| {
-            black_box(
-                cosine_distance_batch(key.values(), target.values(), DIMENSION).collect::<Vec<_>>(),
-            );
+            black_box(cosine_scalar(key.as_slice(), target.as_slice(), DIMENSION));
         })
     });
 
-    let key: Float32Array = generate_random_array_with_seed(DIMENSION, [5; 32]);
-    // 1M of 1024 D vectors. 4GB in memory.
-    let target: Float32Array = generate_random_array_with_seed(TOTAL * DIMENSION, [7; 32]);
+    c.bench_function(
+        format!("Cosine({}, auto-vectorized)", type_name).as_str(),
+        |b| {
+            b.iter(|| {
+                black_box(
+                    cosine_distance_batch::<T::Native>(
+                        key.as_slice(),
+                        target.as_slice(),
+                        DIMENSION,
+                    )
+                    .collect::<Vec<_>>(),
+                );
+            })
+        },
+    );
+}
 
-    c.bench_function("Cosine(simd) second rng seed", |b| {
-        b.iter(|| {
-            black_box(
-                cosine_distance_batch(key.values(), target.values(), DIMENSION).collect::<Vec<_>>(),
-            )
-        })
-    });
+fn bench_distance(c: &mut Criterion) {
+    // run_bench::<BFloat16Type>(c);
+    run_bench::<Float16Type>(c);
+    run_bench::<Float32Type>(c);
+    run_bench::<Float64Type>(c);
 
-    let key: Float32Array = generate_random_array_with_seed(8, [0; 32]);
-    let target: Float32Array = generate_random_array_with_seed(TOTAL * 8, [42; 32]);
+    let key: Float32Array = generate_random_array_with_seed::<Float32Type>(8, [0; 32]);
+    let target: Float32Array =
+        generate_random_array_with_seed::<Float32Type>(1024 * 1024 * 8, [42; 32]);
 
     c.bench_function("Cosine(simd,f32x8) rng seed", |b| {
         b.iter(|| {

--- a/rust/lance-linalg/benches/cosine.rs
+++ b/rust/lance-linalg/benches/cosine.rs
@@ -17,7 +17,6 @@ use arrow_array::{
     Float32Array,
 };
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use lance_arrow::bfloat16::BFloat16Type;
 use lance_arrow::{ArrowFloatType, FloatArray};
 use num_traits::Float;
 

--- a/rust/lance-linalg/benches/l2.rs
+++ b/rust/lance-linalg/benches/l2.rs
@@ -12,64 +12,55 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use arrow_arith::{aggregate::sum, arity::binary};
 use arrow_array::{
     types::{Float16Type, Float32Type, Float64Type},
-    ArrowNumericType, Float32Array, NativeAdapter, PrimitiveArray,
+    Float32Array,
 };
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use num_traits::{AsPrimitive, Float, FromPrimitive};
+
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
 
-use lance_arrow::FloatToArrayType;
-use lance_linalg::distance::{l2::l2, l2_distance_batch, L2};
+use lance_arrow::{ArrowFloatType, FloatArray};
+use lance_linalg::distance::{
+    l2::{l2, l2_scalar},
+    l2_distance_batch, L2,
+};
 use lance_testing::datagen::generate_random_array_with_seed;
 
 const TOTAL: usize = 1024 * 1024; // 1M vectors
 
-#[inline]
-fn l2_arrow_arity<T: ArrowNumericType>(x: &PrimitiveArray<T>, y: &PrimitiveArray<T>) -> f32
-where
-    T::Native: Float + AsPrimitive<f32>,
-{
-    let m: PrimitiveArray<T> = binary(x, y, |a, b| (a - b).powi(2)).unwrap();
-    sum(&m).unwrap().as_()
-}
-
-fn run_bench<T: ArrowNumericType>(c: &mut Criterion)
-where
-    T::Native: FromPrimitive + FloatToArrayType,
-    NativeAdapter<T>: From<T::Native>,
-    <T::Native as FloatToArrayType>::ArrowType: L2,
-{
+fn run_bench<T: ArrowFloatType + L2>(c: &mut Criterion) {
     const DIMENSION: usize = 1024;
     const TOTAL: usize = 1024 * 1024; // 1M vectors
 
-    let key: PrimitiveArray<T> = generate_random_array_with_seed(DIMENSION, [0; 32]);
+    let key = generate_random_array_with_seed::<T>(DIMENSION, [0; 32]);
     // 1M of 1024 D vectors
-    let target: PrimitiveArray<T> = generate_random_array_with_seed(TOTAL * DIMENSION, [42; 32]);
+    let target = generate_random_array_with_seed::<T>(TOTAL * DIMENSION, [42; 32]);
 
     let type_name = std::any::type_name::<T::Native>();
 
-    c.bench_function(format!("L2({type_name}, arrow_artiy)").as_str(), |b| {
+    c.bench_function(format!("L2({type_name}, scalar)").as_str(), |b| {
         b.iter(|| unsafe {
-            Float32Array::from_trusted_len_iter((0..target.len() / DIMENSION).map(|idx| {
-                let arr = target.slice(idx * DIMENSION, DIMENSION);
-                Some(l2_arrow_arity(&key, &arr))
-            }));
+            Float32Array::from_trusted_len_iter(
+                target
+                    .as_slice()
+                    .chunks(DIMENSION)
+                    .map(|arr| Some(l2_scalar::<T::Native, 32>(key.as_slice(), arr))),
+            );
         });
     });
 
     c.bench_function(
         format!("L2({type_name}, auto-vectorization)").as_str(),
         |b| {
-            let x = &key.values()[..];
             b.iter(|| unsafe {
-                Float32Array::from_trusted_len_iter((0..target.len() / 1024).map(|idx| {
-                    let y = target.values()[idx * DIMENSION..(idx + 1) * DIMENSION].as_ref();
-                    Some(black_box(l2(x, y)))
-                }));
+                Float32Array::from_trusted_len_iter(
+                    target
+                        .as_slice()
+                        .chunks(DIMENSION)
+                        .map(|y| Some(black_box(l2(key.as_slice(), y)))),
+                );
             });
         },
     );
@@ -78,24 +69,24 @@ where
 fn bench_distance(c: &mut Criterion) {
     const DIMENSION: usize = 1024;
 
+    run_bench::<Float16Type>(c);
     run_bench::<Float32Type>(c);
-
-    let key: Float32Array = generate_random_array_with_seed(DIMENSION, [0; 32]);
-    let target: Float32Array = generate_random_array_with_seed(TOTAL * DIMENSION, [42; 32]);
+    let key: Float32Array = generate_random_array_with_seed::<Float32Type>(DIMENSION, [0; 32]);
+    let target: Float32Array =
+        generate_random_array_with_seed::<Float32Type>(TOTAL * DIMENSION, [42; 32]);
     c.bench_function("L2(f32, simd)", |b| {
         b.iter(|| {
             black_box(l2_distance_batch(key.values(), target.values(), DIMENSION).count());
         })
     });
 
-    run_bench::<Float16Type>(c);
     run_bench::<Float64Type>(c);
 }
 
 fn bench_small_distance(c: &mut Criterion) {
-    let key: Float32Array = generate_random_array_with_seed(8, [5; 32]);
+    let key = generate_random_array_with_seed::<Float32Type>(8, [5; 32]);
     // 1M of 1024 D vectors. 4GB in memory.
-    let target: Float32Array = generate_random_array_with_seed(TOTAL * 8, [7; 32]);
+    let target = generate_random_array_with_seed::<Float32Type>(TOTAL * 8, [7; 32]);
     c.bench_function("L2(simd,f32x8)", |b| {
         b.iter(|| {
             black_box(l2_distance_batch(key.values(), target.values(), 8).count());

--- a/rust/lance-linalg/benches/norm_l2.rs
+++ b/rust/lance-linalg/benches/norm_l2.rs
@@ -48,7 +48,7 @@ where
     for<'a> &'a [T::Native]: Normalize<T::Native>,
 {
     // 1M of 1024 D vectors
-    let target: PrimitiveArray<T> = generate_random_array_with_seed(TOTAL * DIMENSION, [42; 32]);
+    let target = generate_random_array_with_seed::<T>(TOTAL * DIMENSION, [42; 32]);
 
     let type_name = std::any::type_name::<T::Native>();
 

--- a/rust/lance-linalg/benches/norm_l2.rs
+++ b/rust/lance-linalg/benches/norm_l2.rs
@@ -14,50 +14,42 @@
 
 use std::iter::repeat_with;
 
-use arrow_arith::{aggregate::sum, numeric::mul};
-use arrow_array::types::{Float16Type, Float64Type};
 use arrow_array::{
-    cast::AsArray, types::Float32Type, ArrowNumericType, Float32Array, NativeAdapter,
-    PrimitiveArray,
+    types::{Float16Type, Float32Type, Float64Type},
+    Float32Array,
 };
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use half::bf16;
-use num_traits::FromPrimitive;
+use num_traits::Float;
 use rand::Rng;
+
+use lance_arrow::{ArrowFloatType, FloatArray};
+use lance_linalg::distance::norm_l2;
+use lance_linalg::distance::norm_l2::Normalize;
+use lance_testing::datagen::generate_random_array_with_seed;
 
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
 
-use lance_arrow::FloatToArrayType;
-use lance_linalg::distance::norm_l2::Normalize;
-use lance_testing::datagen::generate_random_array_with_seed;
-
-#[inline]
-fn norm_l2_arrow<T: ArrowNumericType>(x: &PrimitiveArray<T>) -> T::Native {
-    let m = mul(&x, &x).unwrap();
-    sum(m.as_primitive::<T>()).unwrap()
-}
-
 const DIMENSION: usize = 1024;
 const TOTAL: usize = 1024 * 1024; // 1M vectors
 
-fn run_bench<T: ArrowNumericType>(c: &mut Criterion)
+fn run_bench<T: ArrowFloatType>(c: &mut Criterion)
 where
-    T::Native: FromPrimitive + FloatToArrayType,
-    NativeAdapter<T>: From<T::Native>,
-    for<'a> &'a [T::Native]: Normalize<T::Native>,
+    T::Native: Float,
 {
     // 1M of 1024 D vectors
     let target = generate_random_array_with_seed::<T>(TOTAL * DIMENSION, [42; 32]);
 
     let type_name = std::any::type_name::<T::Native>();
 
-    c.bench_function(format!("NormL2({type_name}, arrow)").as_str(), |b| {
-        b.iter(|| unsafe {
-            PrimitiveArray::<T>::from_trusted_len_iter((0..target.len() / DIMENSION).map(|idx| {
-                let arr = target.slice(idx * DIMENSION, DIMENSION);
-                Some(norm_l2_arrow(&arr))
-            }))
+    c.bench_function(format!("NormL2({type_name}, scalar)").as_str(), |b| {
+        b.iter(|| {
+            target
+                .as_slice()
+                .chunks(DIMENSION)
+                .map(|arr| arr.iter().map(|&x| x * x).sum::<T::Native>().sqrt())
+                .collect::<Vec<_>>()
         });
     });
 
@@ -67,9 +59,9 @@ where
             b.iter(|| {
                 black_box(
                     target
-                        .values()
+                        .as_slice()
                         .chunks_exact(DIMENSION)
-                        .map(|arr| arr.norm_l2())
+                        .map(norm_l2)
                         .collect::<Vec<_>>(),
                 );
             });
@@ -98,7 +90,8 @@ fn bench_distance(c: &mut Criterion) {
     run_bench::<Float32Type>(c);
 
     // 1M of 1024 D vectors. 4GB in memory.
-    let target: Float32Array = generate_random_array_with_seed(TOTAL * DIMENSION, [42; 32]);
+    let target: Float32Array =
+        generate_random_array_with_seed::<Float32Type>(TOTAL * DIMENSION, [42; 32]);
     c.bench_function("norm_l2(f32, SIMD)", |b| {
         b.iter(|| {
             black_box(

--- a/rust/lance-linalg/src/simd/f16.c
+++ b/rust/lance-linalg/src/simd/f16.c
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <math.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #ifdef __X86_64__
 #include <immintrin.h>
-#endif // __X86_64__
+#endif  // __X86_64__
 
 /// Works on NEON + FP16 or AVX512FP16
 float norm_l2_f16(const _Float16 *data, uint32_t dimension) {
@@ -27,7 +28,7 @@ float norm_l2_f16(const _Float16 *data, uint32_t dimension) {
   for (uint32_t i = 0; i < dimension; i++) {
     sum += data[i] * data[i];
   }
-  return (float) sum;
+  return (float)sum;
 }
 
 /// @brief Dot product of two f16 vectors.
@@ -42,7 +43,7 @@ float dot_f16(const _Float16 *x, const _Float16 *y, uint32_t dimension) {
   for (uint32_t i = 0; i < dimension; i++) {
     sum += x[i] * y[i];
   }
-  return (float) sum;
+  return (float)sum;
 }
 
 float l2_f16(const _Float16 *x, const _Float16 *y, uint32_t dimension) {
@@ -53,5 +54,26 @@ float l2_f16(const _Float16 *x, const _Float16 *y, uint32_t dimension) {
     _Float16 s = x[i] - y[i];
     sum += s * s;
   }
-  return (float) sum;
+  return (float)sum;
+}
+
+/// @brief Cosine similarity between two f16 vectors.
+/// @param x A f16 vector
+/// @param y A f16 vector
+/// @param dimension The dimension of the vectors
+/// @return The cosine similarity between the two vectors.
+float cosine_f16(const _Float16 *x, const _Float16 *y, uint32_t dimension) {
+  float xy = 0.0;
+  float x2 = 0.0;
+  float y2 = 0.0;
+
+#pragma clang loop unroll(enable) interleave(enable) vectorize_width(32)
+  for (uint32_t i = 0; i < dimension; i++) {
+    _Float16 xi = x[i];
+    _Float16 yi = y[i];
+    xy += xi * yi;
+    x2 += xi * xi;
+    y2 += yi * yi;
+  }
+  return xy / sqrt(x2) / sqrt(y2);
 }

--- a/rust/lance-linalg/src/simd/f16.c
+++ b/rust/lance-linalg/src/simd/f16.c
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <math.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #ifdef __X86_64__
 #include <immintrin.h>
-#endif  // __X86_64__
+#endif // __X86_64__
 
 /// Works on NEON + FP16 or AVX512FP16
 float norm_l2_f16(const _Float16 *data, uint32_t dimension) {
@@ -28,7 +27,7 @@ float norm_l2_f16(const _Float16 *data, uint32_t dimension) {
   for (uint32_t i = 0; i < dimension; i++) {
     sum += data[i] * data[i];
   }
-  return (float)sum;
+  return (float) sum;
 }
 
 /// @brief Dot product of two f16 vectors.
@@ -43,7 +42,7 @@ float dot_f16(const _Float16 *x, const _Float16 *y, uint32_t dimension) {
   for (uint32_t i = 0; i < dimension; i++) {
     sum += x[i] * y[i];
   }
-  return (float)sum;
+  return (float) sum;
 }
 
 float l2_f16(const _Float16 *x, const _Float16 *y, uint32_t dimension) {
@@ -54,26 +53,5 @@ float l2_f16(const _Float16 *x, const _Float16 *y, uint32_t dimension) {
     _Float16 s = x[i] - y[i];
     sum += s * s;
   }
-  return (float)sum;
-}
-
-/// @brief Cosine similarity between two f16 vectors.
-/// @param x A f16 vector
-/// @param y A f16 vector
-/// @param dimension The dimension of the vectors
-/// @return The cosine similarity between the two vectors.
-float cosine_f16(const _Float16 *x, const _Float16 *y, uint32_t dimension) {
-  float xy = 0.0;
-  float x2 = 0.0;
-  float y2 = 0.0;
-
-#pragma clang loop unroll(enable) interleave(enable) vectorize_width(32)
-  for (uint32_t i = 0; i < dimension; i++) {
-    _Float16 xi = x[i];
-    _Float16 yi = y[i];
-    xy += xi * yi;
-    x2 += xi * xi;
-    y2 += yi * yi;
-  }
-  return xy / sqrt(x2) / sqrt(y2);
+  return (float) sum;
 }

--- a/rust/lance-testing/src/datagen.rs
+++ b/rust/lance-testing/src/datagen.rs
@@ -18,12 +18,9 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::{iter::repeat_with, ops::Range};
 
-use arrow_array::{
-    ArrowNumericType, Float32Array, Int32Array, NativeAdapter, PrimitiveArray, RecordBatch,
-    RecordBatchIterator, RecordBatchReader,
-};
+use arrow_array::{Float32Array, Int32Array, RecordBatch, RecordBatchIterator, RecordBatchReader};
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
-use lance_arrow::{fixed_size_list_type, FixedSizeListArrayExt};
+use lance_arrow::{fixed_size_list_type, ArrowFloatType, FixedSizeListArrayExt};
 use num_traits::{real::Real, FromPrimitive};
 use rand::{
     distributions::Uniform, prelude::Distribution, rngs::StdRng, seq::SliceRandom, Rng, SeedableRng,
@@ -199,17 +196,17 @@ pub fn some_batch() -> impl RecordBatchReader {
 }
 
 /// Create a random float32 array.
-pub fn generate_random_array_with_seed<T: ArrowNumericType>(
-    n: usize,
-    seed: [u8; 32],
-) -> PrimitiveArray<T>
+pub fn generate_random_array_with_seed<T: ArrowFloatType>(n: usize, seed: [u8; 32]) -> T::ArrayType
 where
     T::Native: Real + FromPrimitive,
-    NativeAdapter<T>: From<T::Native>,
 {
     let mut rng = StdRng::from_seed(seed);
 
-    PrimitiveArray::<T>::from_iter(repeat_with(|| T::Native::from_f32(rng.gen::<f32>())).take(n))
+    T::ArrayType::from(
+        repeat_with(|| T::Native::from_f32(rng.gen::<f32>()).unwrap())
+            .take(n)
+            .collect::<Vec<_>>(),
+    )
 }
 
 /// Create a random float32 array where each element is uniformly


### PR DESCRIPTION
* Allow `generate_random_data` to create random array for bf16, f16, f32, f64
* Fix `BFloat16Array.as_slice()`
* Change cosine benchmark to support multiple data types