### PR TITLE
feat: add "merge insert" operation based on merge operation in other databases

### DIFF
--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -20,6 +20,7 @@ from .dataset import (
     LanceDataset,
     LanceOperation,
     LanceScanner,
+    MergeInsertBuilder,
     __version__,
     write_dataset,
 )
@@ -41,6 +42,7 @@ __all__ = [
     "LanceDataset",
     "LanceOperation",
     "LanceScanner",
+    "MergeInsertBuilder",
     "__version__",
     "write_dataset",
     "schema_to_json",

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -83,42 +83,10 @@ if TYPE_CHECKING:
     ]
 
 
-class MergeInsertBuilder(object):
-    def __init__(self, dataset: LanceDataset, on: Union[str, Iterable[str]]):
-        self.dataset = dataset
-        self.builder = _MergeInsertBuilder(dataset._ds, on)
-
-    def when_matched_update_all(self) -> MergeInsertBuilder:
-        self.builder.when_matched(True)
-        return self
-
-    def when_matched_do_nothing(self) -> MergeInsertBuilder:
-        self.builder.when_matched(False)
-        return self
-
-    def when_not_matched_insert_all(self) -> MergeInsertBuilder:
-        self.builder.when_not_matched(True)
-        return self
-
-    def when_not_matched_do_nothing(self) -> MergeInsertBuilder:
-        self.builder.when_not_matched(False)
-        return self
-
-    def when_not_matched_by_source_delete(self) -> MergeInsertBuilder:
-        self.builder.when_not_matched_by_source_delete()
-        return self
-
-    def when_not_matched_by_source_do_nothing(self) -> MergeInsertBuilder:
-        self.builder.when_not_matched_by_source_do_nothing()
-        return self
-
-    def when_not_matched_by_source_delete_if(self, expr: str) -> MergeInsertBuilder:
-        self.builder.when_not_matched_by_source_delete_if(expr, self.dataset._ds)
-        return self
-
+class MergeInsertBuilder(_MergeInsertBuilder):
     def execute(self, data_obj: ReaderLike, *, schema: Optional[pa.Schema] = None):
         reader = _coerce_reader(data_obj, schema)
-        self.builder.execute(reader, self.dataset._ds)
+        super(MergeInsertBuilder, self).execute(reader)
 
 
 class LanceDataset(pa.dataset.Dataset):
@@ -674,7 +642,7 @@ class LanceDataset(pa.dataset.Dataset):
         self,
         on: Union[str, Iterable[str]],
     ):
-        return MergeInsertBuilder(self, on)
+        return MergeInsertBuilder(self._ds, on)
 
     def update(
         self,

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -906,8 +906,8 @@ def test_merge_insert_incompatible_schema(tmp_path: Path):
         }
     )
 
-    with pytest.raises(OSError):
-        dataset.merge_insert("a").when_matched_update_all().execute(new_table)
+    # with pytest.raises(OSError):
+    dataset.merge_insert("a").when_matched_update_all().execute(new_table)
 
 
 def test_merge_insert_vector_column(tmp_path: Path):
@@ -942,7 +942,7 @@ def test_merge_insert_vector_column(tmp_path: Path):
         }
     )
 
-    assert dataset.to_table() == expected
+    assert dataset.to_table().sort_by("key") == expected
 
 
 def test_update_dataset(tmp_path: Path):

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -906,8 +906,8 @@ def test_merge_insert_incompatible_schema(tmp_path: Path):
         }
     )
 
-    # with pytest.raises(OSError):
-    dataset.merge_insert("a").when_matched_update_all().execute(new_table)
+    with pytest.raises(OSError):
+        dataset.merge_insert("a").when_matched_update_all().execute(new_table)
 
 
 def test_merge_insert_vector_column(tmp_path: Path):

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -807,46 +807,142 @@ def test_merge_insert(tmp_path: Path):
 
     is_new = pc.field("b") == 2
 
-    dataset.merge_insert("a").execute(new_table)
+    dataset.merge_insert("a").when_not_matched_insert_all().execute(new_table)
     table = dataset.to_table()
     assert table.num_rows == 1300
     assert table.filter(is_new).num_rows == 300
 
     dataset = lance.dataset(tmp_path / "dataset", version=version)
     dataset.restore()
-    dataset.merge_insert(
-        "a"
-    ).when_matched_update_all().when_not_matched_do_nothing().execute(new_table)
+    dataset.merge_insert("a").when_matched_update_all().execute(new_table)
     table = dataset.to_table()
     assert table.num_rows == 1000
     assert table.filter(is_new).num_rows == 700
 
     dataset = lance.dataset(tmp_path / "dataset", version=version)
     dataset.restore()
-    dataset.merge_insert("a").when_matched_update_all().execute(new_table)
+    dataset.merge_insert(
+        "a"
+    ).when_not_matched_insert_all().when_matched_update_all().execute(new_table)
     table = dataset.to_table()
     assert table.num_rows == 1300
     assert table.filter(is_new).num_rows == 1000
 
     dataset = lance.dataset(tmp_path / "dataset", version=version)
     dataset.restore()
-    dataset.merge_insert(
-        "a"
-    ).when_not_matched_by_source_delete().when_not_matched_do_nothing().execute(
-        new_table
-    )
+    dataset.merge_insert("a").when_not_matched_by_source_delete().execute(new_table)
     table = dataset.to_table()
     assert table.num_rows == 700
     assert table.filter(is_new).num_rows == 0
 
     dataset = lance.dataset(tmp_path / "dataset", version=version)
     dataset.restore()
-    dataset.merge_insert("a").when_not_matched_by_source_delete_if("a < 100").execute(
-        new_table
-    )
+    dataset.merge_insert("a").when_not_matched_by_source_delete(
+        "a < 100"
+    ).when_not_matched_insert_all().execute(new_table)
+
     table = dataset.to_table()
     assert table.num_rows == 1200
     assert table.filter(is_new).num_rows == 300
+
+    # If the user doesn't specify anything then the merge_insert is
+    # a no-op and the operation fails
+    dataset = lance.dataset(tmp_path / "dataset", version=version)
+    dataset.restore()
+    with pytest.raises(ValueError):
+        dataset.merge_insert("a").execute(new_table)
+
+
+def test_merge_insert_multiple_keys(tmp_path: Path):
+    nrows = 1000
+    # a - [0, 1, 2, ..., 999]
+    # b - [1, 1, 1, ..., 1]
+    # c - [0, 1, 0, ..., 1]
+    table = pa.Table.from_pydict(
+        {
+            "a": range(nrows),
+            "b": [1 for _ in range(nrows)],
+            "c": [i % 2 for i in range(nrows)],
+        }
+    )
+    dataset = lance.write_dataset(
+        table, tmp_path / "dataset", mode="create", max_rows_per_file=100
+    )
+
+    # a - [300, 301, 302, ..., 1299]
+    # b - [2, 2, 2, ..., 2]
+    # c - [0, 0, 0, ..., 0]
+    new_table = pa.Table.from_pydict(
+        {
+            "a": range(300, 300 + nrows),
+            "b": [2 for _ in range(nrows)],
+            "c": [0 for _ in range(nrows)],
+        }
+    )
+
+    is_new = pc.field("b") == 2
+
+    dataset.merge_insert(["a", "c"]).when_matched_update_all().execute(new_table)
+    table = dataset.to_table()
+    assert table.num_rows == 1000
+    assert table.filter(is_new).num_rows == 350
+
+
+def test_merge_insert_incompatible_schema(tmp_path: Path):
+    nrows = 1000
+    table = pa.Table.from_pydict(
+        {
+            "a": range(nrows),
+            "b": [1 for _ in range(nrows)],
+        }
+    )
+    dataset = lance.write_dataset(
+        table, tmp_path / "dataset", mode="create", max_rows_per_file=100
+    )
+
+    new_table = pa.Table.from_pydict(
+        {
+            "a": range(300, 300 + nrows),
+        }
+    )
+
+    with pytest.raises(OSError):
+        dataset.merge_insert("a").when_matched_update_all().execute(new_table)
+
+
+def test_merge_insert_vector_column(tmp_path: Path):
+    table = pa.Table.from_pydict(
+        {
+            "vec": pa.array([[1, 2, 3], [4, 5, 6]], pa.list_(pa.float32(), 3)),
+            "key": [1, 2],
+        }
+    )
+
+    new_table = pa.Table.from_pydict(
+        {
+            "vec": pa.array([[7, 8, 9], [10, 11, 12]], pa.list_(pa.float32(), 3)),
+            "key": [2, 3],
+        }
+    )
+
+    dataset = lance.write_dataset(
+        table, tmp_path / "dataset", mode="create", max_rows_per_file=100
+    )
+
+    dataset.merge_insert(
+        ["key"]
+    ).when_not_matched_insert_all().when_matched_update_all().execute(new_table)
+
+    expected = pa.Table.from_pydict(
+        {
+            "vec": pa.array(
+                [[1, 2, 3], [7, 8, 9], [10, 11, 12]], pa.list_(pa.float32(), 3)
+            ),
+            "key": [1, 2, 3],
+        }
+    )
+
+    assert dataset.to_table() == expected
 
 
 def test_update_dataset(tmp_path: Path):

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -136,7 +136,8 @@ def test_dataset_progress(tmp_path: Path):
 
     assert fragment == FragmentMetadata.from_json(json.dumps(metadata))
 
-    p = multiprocessing.Process(target=failing_write, args=(progress_uri, dataset_uri))
+    ctx = multiprocessing.get_context("spawn")
+    p = ctx.Process(target=failing_write, args=(progress_uri, dataset_uri))
     p.start()
     try:
         p.join()

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -131,10 +131,7 @@ impl MergeInsertBuilder {
             .when_matched(WhenMatched::DoNothing)
             .when_not_matched(WhenNotMatched::DoNothing);
 
-        Ok(Self {
-            builder: builder,
-            dataset,
-        })
+        Ok(Self { builder, dataset })
     }
 
     pub fn when_matched_update_all(mut slf: PyRefMut<Self>) -> PyResult<PyRefMut<Self>> {

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -48,7 +48,7 @@ use lance_linalg::distance::MetricType;
 use lance_table::format::Fragment;
 use lance_table::io::commit::CommitHandler;
 use object_store::path::Path;
-use pyo3::exceptions::PyStopIteration;
+use pyo3::exceptions::{PyStopIteration, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PySet, PyString};
 use pyo3::{
@@ -165,7 +165,7 @@ impl MergeInsertBuilder {
         let new_data: Box<dyn RecordBatchReader + Send> = if new_data.is_instance_of::<Scanner>() {
             let scanner: Scanner = new_data.extract()?;
             Box::new(
-                RT.block_on(Some(py), scanner.to_reader())?
+                RT.block_on(Some(py), async move { scanner.to_reader().await })?
                     .map_err(|err| PyValueError::new_err(err.to_string()))?,
             )
         } else {
@@ -178,7 +178,7 @@ impl MergeInsertBuilder {
             .map_err(|err| PyValueError::new_err(err.to_string()))?;
 
         let new_self = RT
-            .block_on(None, job.execute_reader(new_data))?
+            .block_on(Some(py), job.execute_reader(new_data))?
             .map_err(|err| PyIOError::new_err(err.to_string()))?;
 
         let dataset = self.dataset.as_ref(py);

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -112,7 +112,7 @@ impl MergeInsertBuilder {
             .map(|val| vec![val.to_string()])
             .or_else(|_| {
                 let iterator = on.iter().map_err(|_| {
-                    PyValueError::new_err(
+                    PyTypeError::new_err(
                         "The `on` argument to merge_insert must be a str or iterable of str",
                     )
                 })?;

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -165,7 +165,7 @@ impl MergeInsertBuilder {
         let new_data: Box<dyn RecordBatchReader + Send> = if new_data.is_instance_of::<Scanner>() {
             let scanner: Scanner = new_data.extract()?;
             Box::new(
-                RT.block_on(Some(py), async move { scanner.to_reader().await })?
+                RT.spawn(Some(py), async move { scanner.to_reader().await })?
                     .map_err(|err| PyValueError::new_err(err.to_string()))?,
             )
         } else {
@@ -178,7 +178,7 @@ impl MergeInsertBuilder {
             .map_err(|err| PyValueError::new_err(err.to_string()))?;
 
         let new_self = RT
-            .block_on(Some(py), job.execute_reader(new_data))?
+            .spawn(Some(py), job.execute_reader(new_data))?
             .map_err(|err| PyIOError::new_err(err.to_string()))?;
 
         let dataset = self.dataset.as_ref(py);

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -33,6 +33,7 @@ use dataset::cleanup::CleanupStats;
 use dataset::optimize::{
     PyCompaction, PyCompactionMetrics, PyCompactionPlan, PyCompactionTask, PyRewriteResult,
 };
+use dataset::MergeInsertBuilder;
 use env_logger::Env;
 use futures::StreamExt;
 use pyo3::exceptions::{PyIOError, PyValueError};
@@ -98,6 +99,7 @@ fn lance(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Operation>()?;
     m.add_class::<FileFragment>()?;
     m.add_class::<FragmentMetadata>()?;
+    m.add_class::<MergeInsertBuilder>()?;
     m.add_class::<DataFile>()?;
     m.add_class::<BFloat16>()?;
     m.add_class::<CleanupStats>()?;

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -37,8 +37,11 @@ use crate::{Error, Result};
 
 #[derive(Default)]
 pub struct SchemaCompareOptions {
+    /// Should the metadata be compared (default false)
     pub compare_metadata: bool,
+    /// Should the dictionaries be compared (default false)
     pub compare_dictionary: bool,
+    /// Should the field ids be compared (default false)
     pub compare_field_ids: bool,
 }
 /// Encoding enum.
@@ -219,19 +222,23 @@ impl Field {
         }
     }
 
-    pub fn compare_with_options(&self, other: &Self, options: &SchemaCompareOptions) -> bool {
-        self.name == other.name
-            && self.logical_type == other.logical_type
-            && self.nullable == other.nullable
-            && self.children.len() == other.children.len()
-            && self
-                .children
-                .iter()
-                .zip(&other.children)
-                .all(|(left, right)| left.compare_with_options(right, options))
-            && (!options.compare_field_ids || self.id == other.id)
-            && (!options.compare_dictionary || self.dictionary == other.dictionary)
-            && (!options.compare_metadata || self.metadata == other.metadata)
+    pub fn compare_with_options(&self, expected: &Self, options: &SchemaCompareOptions) -> bool {
+        if self.children.len() != expected.children.len() {
+            false
+        } else {
+            self.name == expected.name
+                && self.logical_type == expected.logical_type
+                && self.nullable == expected.nullable
+                && self.children.len() == expected.children.len()
+                && self
+                    .children
+                    .iter()
+                    .zip(&expected.children)
+                    .all(|(left, right)| left.compare_with_options(right, options))
+                && (!options.compare_field_ids || self.id == expected.id)
+                && (!options.compare_dictionary || self.dictionary == expected.dictionary)
+                && (!options.compare_metadata || self.metadata == expected.metadata)
+        }
     }
 
     pub fn extension_name(&self) -> Option<&str> {

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -409,6 +409,17 @@ impl Schema {
         self.fields.iter_mut().for_each(|f| f.reset_id());
     }
 
+    /// Create a new schema by adding fields to the end of this schema
+    pub fn extend(&mut self, fields: &[ArrowField]) -> Result<()> {
+        let fields = fields
+            .iter()
+            .map(Field::try_from)
+            .collect::<Result<Vec<_>>>()?;
+        self.fields.extend(fields);
+        self.set_field_id();
+        Ok(())
+    }
+
     /// Merge this schema from the other schema.
     ///
     /// After merging, the field IDs from `other` schema will be reassigned,

--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -34,8 +34,7 @@ pub enum Error {
     },
     #[snafu(display("Dataset already exists: {uri}, {location}"))]
     DatasetAlreadyExists { uri: String, location: Location },
-    // #[snafu(display("Append with different schema: original={original} new={new}"))]
-    #[snafu(display("Append with different schema:"))]
+    #[snafu(display("Append with different schema: {difference}"))]
     SchemaMismatch {
         difference: String,
         location: Location,

--- a/rust/lance-datafusion/src/lib.rs
+++ b/rust/lance-datafusion/src/lib.rs
@@ -2,3 +2,4 @@ pub mod chunker;
 pub mod dataframe;
 pub mod exec;
 pub mod expr;
+pub mod utils;

--- a/rust/lance-datafusion/src/utils.rs
+++ b/rust/lance-datafusion/src/utils.rs
@@ -1,0 +1,54 @@
+use arrow_array::RecordBatchReader;
+use datafusion::physical_plan::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream};
+use datafusion_common::DataFusionError;
+use futures::{stream, Stream, StreamExt, TryFutureExt, TryStreamExt};
+use lance_core::datatypes::Schema;
+use lance_core::{Error, Result};
+use tokio::task::spawn_blocking;
+
+fn background_iterator<I: Iterator + Send + 'static>(iter: I) -> impl Stream<Item = I::Item>
+where
+    I::Item: Send,
+{
+    stream::unfold(iter, |mut iter| {
+        spawn_blocking(|| iter.next().map(|val| (val, iter)))
+            .unwrap_or_else(|err| panic!("{}", err))
+    })
+    .fuse()
+}
+
+/// Convert reader to a stream and a schema.
+///
+/// Will peek the first batch to get the dictionaries for dictionary columns.
+///
+/// NOTE: this does not validate the schema. For example, for appends the schema
+/// should be checked to make sure it matches the existing dataset schema before
+/// writing.
+pub async fn reader_to_stream(
+    batches: Box<dyn RecordBatchReader + Send>,
+) -> Result<(SendableRecordBatchStream, Schema)> {
+    let arrow_schema = batches.schema();
+    let (peekable, schema) = spawn_blocking(move || {
+        let mut schema: Schema = Schema::try_from(batches.schema().as_ref())?;
+        let mut peekable = batches.peekable();
+        if let Some(batch) = peekable.peek() {
+            if let Ok(b) = batch {
+                schema.set_dictionary(b)?;
+            } else {
+                return Err(Error::from(batch.as_ref().unwrap_err()));
+            }
+        }
+        Ok((peekable, schema))
+    })
+    .await
+    .unwrap()?;
+    schema.validate()?;
+
+    let stream = RecordBatchStreamAdapter::new(
+        arrow_schema,
+        background_iterator(peekable).map_err(DataFusionError::from),
+    );
+    let stream = Box::pin(stream) as SendableRecordBatchStream;
+
+    Ok((stream, schema))
+}

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -10,7 +10,7 @@ use datafusion::{physical_plan::SendableRecordBatchStream, scalar::ScalarValue};
 use futures::TryStreamExt;
 use lance::{io::ObjectStore, Dataset};
 use lance_core::Result;
-use lance_datafusion::exec::reader_to_stream;
+use lance_datafusion::utils::reader_to_stream;
 use lance_datagen::{array, gen, BatchCount, RowCount};
 use lance_index::scalar::{
     btree::{train_btree_index, BTreeIndex, BtreeTrainingSource},
@@ -45,7 +45,7 @@ impl BtreeTrainingSource for BenchmarkDataSource {
         self: Box<Self>,
         _chunk_size: u32,
     ) -> Result<SendableRecordBatchStream> {
-        Ok(reader_to_stream(Box::new(Self::test_data()))?.0)
+        Ok(reader_to_stream(Box::new(Self::test_data())).await?.0)
     }
 }
 

--- a/rust/lance/src/datafusion.rs
+++ b/rust/lance/src/datafusion.rs
@@ -15,5 +15,6 @@
 //! Extends DataFusion
 //!
 
+pub(crate) mod dataframe;
 pub(crate) mod logical_expr;
 pub(crate) mod logical_plan;

--- a/rust/lance/src/datafusion/dataframe.rs
+++ b/rust/lance/src/datafusion/dataframe.rs
@@ -117,6 +117,9 @@ impl TableProvider for LanceTableProvider {
         scan.create_plan().await.map_err(DataFusionError::from)
     }
 
+    // Since we are using datafusion itself to apply the filters it should
+    // be safe to assume that we can exactly apply any of the given pushdown
+    // filters.
     fn supports_filters_pushdown(
         &self,
         filters: &[&Expr],

--- a/rust/lance/src/datafusion/dataframe.rs
+++ b/rust/lance/src/datafusion/dataframe.rs
@@ -1,0 +1,193 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    any::Any,
+    sync::{Arc, Mutex},
+};
+
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use async_trait::async_trait;
+use datafusion::{
+    dataframe::DataFrame,
+    datasource::{streaming::StreamingTable, TableProvider},
+    error::DataFusionError,
+    execution::{
+        context::{SessionContext, SessionState},
+        TaskContext,
+    },
+    logical_expr::{Expr, TableProviderFilterPushDown, TableType},
+    physical_plan::{streaming::PartitionStream, ExecutionPlan, SendableRecordBatchStream},
+};
+use lance_core::ROW_ID;
+
+use crate::Dataset;
+
+pub struct LanceTableProvider {
+    dataset: Arc<Dataset>,
+    full_schema: Arc<Schema>,
+    row_id_idx: Option<usize>,
+}
+
+impl LanceTableProvider {
+    fn new(dataset: Arc<Dataset>, with_row_id: bool) -> Self {
+        let full_schema = if with_row_id {
+            let mut full_schema = dataset.schema().clone();
+            full_schema
+                .extend(&[Field::new(ROW_ID, DataType::UInt64, false)])
+                .unwrap();
+            full_schema
+        } else {
+            dataset.schema().clone()
+        };
+        Self {
+            dataset,
+            full_schema: Arc::new(Schema::from(&full_schema)),
+            row_id_idx: if with_row_id {
+                Some(full_schema.fields.len() - 1)
+            } else {
+                None
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl TableProvider for LanceTableProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.full_schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    async fn scan(
+        &self,
+        _state: &SessionState,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        let mut scan = self.dataset.scan();
+        if let Some(projection) = projection {
+            let mut columns = Vec::with_capacity(projection.len());
+            for field_idx in projection {
+                if Some(*field_idx) == self.row_id_idx {
+                    scan.with_row_id();
+                } else {
+                    columns.push(self.full_schema.field(*field_idx).name());
+                }
+            }
+            if !columns.is_empty() {
+                scan.project(&columns)?;
+            }
+        }
+        let combined_filter = match filters.len() {
+            0 => None,
+            1 => Some(filters[0].clone()),
+            _ => {
+                let mut expr = filters[0].clone();
+                for filter in &filters[1..] {
+                    expr = Expr::and(expr, filter.clone());
+                }
+                Some(expr)
+            }
+        };
+        if let Some(combined_filter) = combined_filter {
+            scan.filter_expr(combined_filter);
+        }
+        scan.limit(limit.map(|l| l as i64), None)?;
+
+        scan.create_plan().await.map_err(DataFusionError::from)
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> datafusion::common::Result<Vec<TableProviderFilterPushDown>> {
+        Ok(filters
+            .iter()
+            .map(|_| TableProviderFilterPushDown::Exact)
+            .collect())
+    }
+}
+
+pub trait SessionContextExt {
+    /// Creates a DataFrame for reading a Lance dataset
+    fn read_lance(
+        &self,
+        dataset: Arc<Dataset>,
+        with_row_id: bool,
+    ) -> datafusion::common::Result<DataFrame>;
+    /// Creates a DataFrame for reading a stream of data
+    ///
+    /// This dataframe may only be queried once, future queries will fail
+    fn read_one_shot(
+        &self,
+        data: SendableRecordBatchStream,
+    ) -> datafusion::common::Result<DataFrame>;
+}
+
+struct OneShotPartitionStream {
+    data: Arc<Mutex<Option<SendableRecordBatchStream>>>,
+    schema: Arc<Schema>,
+}
+
+impl OneShotPartitionStream {
+    fn new(data: SendableRecordBatchStream) -> Self {
+        let schema = data.schema().clone();
+        Self {
+            data: Arc::new(Mutex::new(Some(data))),
+            schema,
+        }
+    }
+}
+
+impl PartitionStream for OneShotPartitionStream {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let mut stream = self.data.lock().unwrap();
+        stream
+            .take()
+            .expect("Attempt to consume a one shot dataframe multiple times")
+    }
+}
+
+impl SessionContextExt for SessionContext {
+    fn read_lance(
+        &self,
+        dataset: Arc<Dataset>,
+        with_row_id: bool,
+    ) -> datafusion::common::Result<DataFrame> {
+        self.read_table(Arc::new(LanceTableProvider::new(dataset, with_row_id)))
+    }
+
+    fn read_one_shot(
+        &self,
+        data: SendableRecordBatchStream,
+    ) -> datafusion::common::Result<DataFrame> {
+        let schema = data.schema().clone();
+        let part_stream = Arc::new(OneShotPartitionStream::new(data));
+        let provider = StreamingTable::try_new(schema, vec![part_stream])?;
+        self.read_table(Arc::new(provider))
+    }
+}

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -78,7 +78,9 @@ use crate::utils::temporal::{timestamp_to_nanos, utc_now, SystemTime};
 use crate::{Error, Result};
 use hash_joiner::HashJoiner;
 pub use lance_core::ROW_ID;
-
+pub use write::merge_insert::{
+    MergeInsertBuilder, MergeInsertJob, WhenMatched, WhenNotMatched, WhenNotMatchedBySource,
+};
 pub use write::update::{UpdateBuilder, UpdateJob};
 pub use write::{write_fragments, WriteMode, WriteParams};
 

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -28,6 +28,7 @@ use futures::{join, StreamExt, TryFutureExt, TryStreamExt};
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::{datatypes::Schema, Error, Result, ROW_ID};
 use lance_datafusion::chunker::chunk_stream;
+use lance_datafusion::utils::reader_to_stream;
 use lance_file::reader::FileReader;
 use lance_file::writer::FileWriter;
 use lance_io::object_store::ObjectStore;
@@ -41,7 +42,6 @@ use uuid::Uuid;
 use super::hash_joiner::HashJoiner;
 use super::scanner::Scanner;
 use super::updater::Updater;
-use super::write::reader_to_stream;
 use super::WriteParams;
 use crate::arrow::*;
 use crate::dataset::{Dataset, DATA_DIR};
@@ -78,7 +78,7 @@ impl FileFragment {
         let progress = params.progress.as_ref();
 
         let reader = Box::new(reader);
-        let (stream, schema) = reader_to_stream(reader)?;
+        let (stream, schema) = reader_to_stream(reader).await?;
 
         if schema.fields.is_empty() {
             return Err(Error::invalid_input(

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -18,12 +18,11 @@
 use std::sync::Arc;
 
 use arrow_array::RecordBatchReader;
-use datafusion::error::DataFusionError;
-use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::SendableRecordBatchStream;
-use futures::{StreamExt, TryStreamExt};
-use lance_core::{datatypes::Schema, Error, Result};
+use futures::StreamExt;
+use lance_core::{datatypes::Schema, Result};
 use lance_datafusion::chunker::chunk_stream;
+use lance_datafusion::utils::reader_to_stream;
 use lance_file::writer::FileWriter;
 use lance_io::object_store::{ObjectStore, ObjectStoreParams};
 use lance_table::format::Fragment;
@@ -105,37 +104,6 @@ impl Default for WriteParams {
     }
 }
 
-/// Convert reader to a stream and a schema.
-///
-/// Will peek the first batch to get the dictionaries for dictionary columns.
-///
-/// NOTE: this does not validate the schema. For example, for appends the schema
-/// should be checked to make sure it matches the existing dataset schema before
-/// writing.
-pub fn reader_to_stream(
-    batches: Box<dyn RecordBatchReader + Send>,
-) -> Result<(SendableRecordBatchStream, Schema)> {
-    let arrow_schema = batches.schema();
-    let mut schema: Schema = Schema::try_from(batches.schema().as_ref())?;
-    let mut peekable = batches.peekable();
-    if let Some(batch) = peekable.peek() {
-        if let Ok(b) = batch {
-            schema.set_dictionary(b)?;
-        } else {
-            return Err(Error::from(batch.as_ref().unwrap_err()));
-        }
-    }
-    schema.validate()?;
-
-    let stream = RecordBatchStreamAdapter::new(
-        arrow_schema,
-        futures::stream::iter(peekable).map_err(DataFusionError::from),
-    );
-    let stream = Box::pin(stream) as SendableRecordBatchStream;
-
-    Ok((stream, schema))
-}
-
 /// Writes the given data to the dataset and returns fragments.
 ///
 /// NOTE: the fragments have not yet been assigned an ID. That must be done
@@ -151,7 +119,7 @@ pub async fn write_fragments(
         &params.store_params.clone().unwrap_or_default(),
     )
     .await?;
-    let (stream, schema) = reader_to_stream(Box::new(data))?;
+    let (stream, schema) = reader_to_stream(Box::new(data)).await?;
     write_fragments_internal(Arc::new(object_store), &base, &schema, stream, params).await
 }
 
@@ -260,6 +228,8 @@ mod tests {
 
     use arrow_array::{Int32Array, RecordBatch};
     use arrow_schema::{DataType, Schema as ArrowSchema};
+    use datafusion::{error::DataFusionError, physical_plan::stream::RecordBatchStreamAdapter};
+    use futures::TryStreamExt;
 
     #[tokio::test]
     async fn test_chunking_large_batches() {

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -36,6 +36,7 @@ use uuid::Uuid;
 use super::progress::{NoopFragmentWriteProgress, WriteFragmentProgress};
 use super::DATA_DIR;
 
+pub mod merge_insert;
 pub mod update;
 
 /// The mode to write dataset.

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -1,0 +1,724 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The merge insert operation merges a batch of new data into an existing batch of old data.  This can be
+//! used to implement a bulk update-or-insert (upsert) or find-or-create operation.  It can also be used to
+//! replace a specified region of data with new data (e.g. replace the data for the month of January)
+//!
+//! The terminology for this operation can be slightly confusing.  We try and stick with the terminology from
+//! SQL.  The "target table" is the OLD data that already exists.  The "source table" is the NEW data which is
+//! being inserted into the dataset.
+//!
+//! In order for this operation to work we need to be able to match rows from the source table with rows in the
+//! target table.  For example, given a row we need to know if this is a brand new row or matches an existing row.
+//!
+//! This match condition is currently limited to an key-match.  This means we consider a row to be a match if the
+//! key columns are identical in both the source and the target.  This means that you will need some kind of
+//! meaningful key column to be able to perform a merge insert.
+
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
+
+use arrow_array::{cast::AsArray, types::UInt64Type, BooleanArray, RecordBatch, RecordBatchReader};
+use arrow_schema::{DataType, Schema};
+use datafusion::{
+    execution::context::{SessionConfig, SessionContext},
+    logical_expr::{Expr, JoinType},
+    physical_plan::{stream::RecordBatchStreamAdapter, PhysicalExpr, SendableRecordBatchStream},
+    scalar::ScalarValue,
+};
+
+use futures::{stream, Stream, StreamExt, TryStreamExt};
+use lance_core::{
+    error::{box_error, InvalidInputSnafu},
+    format::Fragment,
+    Error, Result,
+};
+use lance_datafusion::exec::reader_to_stream;
+use roaring::RoaringTreemap;
+use snafu::{location, Location, ResultExt};
+
+use crate::{
+    datafusion::dataframe::SessionContextExt,
+    dataset::transaction::{Operation, Transaction},
+    io::{commit::commit_transaction, exec::Planner},
+    Dataset,
+};
+
+use super::write_fragments_internal;
+
+/// Describes how rows should be handled when there is no matching row in the source table
+///
+/// These are old rows which do not match any new data
+#[derive(Debug, Clone)]
+pub enum WhenNotMatchedBySource {
+    /// Never delete rows from the target table
+    ///
+    /// This can be used for a find-or-create or an upsert operation
+    NeverDelete,
+    /// Delete all rows from target table that don't match a row in the source table
+    AlwaysDelete,
+    /// Delete rows from the target table if there is no match AND the expression evaluates to true
+    ///
+    /// This can be used to replace a region of data with new data
+    DeleteIf(Expr),
+}
+
+impl WhenNotMatchedBySource {
+    /// Create an instance of WhenNotMatchedBySource::DeleteIf from
+    /// an SQL filter string
+    ///
+    /// This will parse the filter string (using the schema of the provided
+    /// dataset) and simplify the resulting expression
+    pub fn delete_if(dataset: &Dataset, expr: &str) -> Result<Self> {
+        let planner = Planner::new(Arc::new(dataset.schema().into()));
+        let expr = planner
+            .parse_filter(expr)
+            .map_err(box_error)
+            .context(InvalidInputSnafu)?;
+        let expr = planner
+            .optimize_expr(expr)
+            .map_err(box_error)
+            .context(InvalidInputSnafu)?;
+        Ok(WhenNotMatchedBySource::DeleteIf(expr))
+    }
+}
+
+/// Describes how rows should be handled when there is a match between the target table and source table
+pub enum WhenMatched {
+    /// The row is deleted from the target table and a new row is inserted based on the source table
+    ///
+    /// This can be used to achieve upsert behavior
+    UpdateAll,
+    /// The row is kept unchanged
+    ///
+    /// This can be used to achieve find-or-create behavior
+    DoNothing,
+}
+
+/// Describes how rows should be handled when there is no matching row in the target table
+///
+/// These are new rows which do not match any old data
+pub enum WhenNotMatched {
+    /// The new row is inserted into the target table
+    ///
+    /// This is used in both find-or-create and upsert operations
+    InsertAll,
+    /// The new row is ignored
+    DoNothing,
+}
+
+#[derive(Debug, Clone)]
+struct MergeInsertParams {
+    // The column(s) to join on
+    on: Vec<String>,
+    // If true, then update all columns of the old data to the new data when there is a match
+    update_matched: bool,
+    // If true, then insert all columns of the new data when there is no match in the old data
+    insert_not_matched: bool,
+    // Controls whether data that is not matched by the source is deleted or not
+    delete_not_matched_by_source: WhenNotMatchedBySource,
+}
+
+/// A MergeInsertJob inserts new rows, deletes old rows, and updates existing rows all as
+/// part of a single transaction.
+pub struct MergeInsertJob {
+    // The column to merge the new data into
+    dataset: Arc<Dataset>,
+    // The parameters controlling how to merge the two streams
+    params: MergeInsertParams,
+}
+
+/// Build a merge insert operation.
+///
+/// This operation is similar to SQL's MERGE statement. It allows you to merge
+/// new data with existing data.
+///
+/// Use the [MergeInsertBuilder] to construct an merge insert job. For example:
+///
+/// ```ignore
+/// // find-or-create, insert new rows only
+/// let dataset = MergeInsertBuilder::new(dataset, vec!["my_key"])
+///     .build()?
+///     .execute(new_data)
+///     .await?;
+///
+/// // upsert, insert or update
+/// let dataset = MergeInsertBuilder::new(dataset, vec!["my_key"])
+///     .when_not_matched(WhenNotMatched::UpdateAll)
+///     .build()?
+///     .execute(new_data)
+///     .await?;
+///
+/// // replace data for month=january
+/// let dataset = MergeInsertBuilder::new(dataset, vec!["my_key"])
+///     .when_not_matched(WhenNotMatched::UpdateAll)
+///     .when_not_matched_by_source(
+///         WhenNotMatchedBySource::DeleteIf(month_eq_jan)
+///     )
+///     .build()?
+///     .execute(new_data)
+///     .await?;
+/// ```
+///
+#[derive(Debug, Clone)]
+pub struct MergeInsertBuilder {
+    dataset: Arc<Dataset>,
+    params: MergeInsertParams,
+}
+
+impl MergeInsertBuilder {
+    /// Creates a new builder
+    ///
+    /// By default this will build a job that has the same semantics as find-or-create
+    ///  - matching rows will be kept as-is
+    ///  - new rows in the new data will be inserted
+    ///  - rows in the old data that do not match will be left as-is
+    ///
+    /// Use the methods on this builder to customize that behavior
+    pub fn new(dataset: Arc<Dataset>, on: Vec<String>) -> Self {
+        Self {
+            dataset,
+            params: MergeInsertParams {
+                on,
+                update_matched: false,
+                insert_not_matched: true,
+                delete_not_matched_by_source: WhenNotMatchedBySource::NeverDelete,
+            },
+        }
+    }
+
+    /// Specify what should happen when a target row matches a row in the source
+    pub fn when_matched(mut self, behavior: WhenMatched) -> Self {
+        self.params.update_matched = match behavior {
+            WhenMatched::DoNothing => false,
+            WhenMatched::UpdateAll => true,
+        };
+        self
+    }
+
+    /// Specify what should happen when a source row has no match in the target
+    ///
+    /// These are typically "new rows"
+    pub fn when_not_matched(mut self, behavior: WhenNotMatched) -> Self {
+        self.params.insert_not_matched = match behavior {
+            WhenNotMatched::DoNothing => false,
+            WhenNotMatched::InsertAll => true,
+        };
+        self
+    }
+
+    /// Specify what should happen when a target row has no match in the source
+    ///
+    /// These are typically "old rows"
+    pub fn when_not_matched_by_source(mut self, behavior: WhenNotMatchedBySource) -> Self {
+        self.params.delete_not_matched_by_source = behavior;
+        self
+    }
+
+    /// Crate a merge insert job
+    pub fn build(&mut self) -> MergeInsertJob {
+        MergeInsertJob {
+            dataset: self.dataset.clone(),
+            params: self.params.clone(),
+        }
+    }
+}
+
+impl MergeInsertJob {
+    pub async fn execute_reader(
+        self,
+        source: Box<dyn RecordBatchReader + Send>,
+    ) -> Result<Arc<Dataset>> {
+        let (source, _) = reader_to_stream(source)?;
+        self.execute(source).await
+    }
+
+    /// Executes the merge insert job
+    ///
+    /// This will take in the source, merge it with the existing target data, and insert new
+    /// rows, update existing rows, and delete existing rows
+    pub async fn execute(self, source: SendableRecordBatchStream) -> Result<Arc<Dataset>> {
+        let session_config = SessionConfig::default().with_target_partitions(1);
+        let session_ctx = SessionContext::new_with_config(session_config);
+        let schema = source.schema();
+        let existing = session_ctx.read_lance(self.dataset.clone(), true)?;
+        let new_data = session_ctx.read_one_shot(source)?;
+        let merger = Merger::try_new(self.params, schema.clone())?;
+        let deleted_rows = merger.deleted_rows.clone();
+        let join_cols = merger
+            .params
+            .on
+            .iter()
+            .map(|c| c.as_str())
+            .collect::<Vec<_>>();
+        let joined = existing.join(new_data, JoinType::Full, &join_cols, &join_cols, None)?;
+        let joined = joined.execute_stream().await?;
+
+        let stream = joined
+            .and_then(move |batch| merger.clone().execute_batch(batch))
+            .try_flatten();
+
+        let stream = RecordBatchStreamAdapter::new(schema, stream);
+
+        let new_fragments = write_fragments_internal(
+            self.dataset.object_store.clone(),
+            &self.dataset.base,
+            self.dataset.schema(),
+            Box::pin(stream),
+            Default::default(),
+        )
+        .await?;
+
+        // Apply deletions
+        let removed_row_ids = Arc::into_inner(deleted_rows).unwrap().into_inner().unwrap();
+        let (old_fragments, removed_fragment_ids) =
+            Self::apply_deletions(&self.dataset, &removed_row_ids).await?;
+
+        // Commit updated and new fragments
+        Self::commit(
+            self.dataset,
+            removed_fragment_ids,
+            old_fragments,
+            new_fragments,
+        )
+        .await
+    }
+
+    // Delete a batch of rows by id, returns the fragments modified and the fragments removed
+    async fn apply_deletions(
+        dataset: &Dataset,
+        removed_row_ids: &RoaringTreemap,
+    ) -> Result<(Vec<Fragment>, Vec<u64>)> {
+        let bitmaps = Arc::new(removed_row_ids.bitmaps().collect::<BTreeMap<_, _>>());
+
+        enum FragmentChange {
+            Unchanged,
+            Modified(Fragment),
+            Removed(u64),
+        }
+
+        let mut updated_fragments = Vec::new();
+        let mut removed_fragments = Vec::new();
+
+        let mut stream = futures::stream::iter(dataset.get_fragments())
+            .map(move |fragment| {
+                let bitmaps_ref = bitmaps.clone();
+                async move {
+                    let fragment_id = fragment.id();
+                    if let Some(bitmap) = bitmaps_ref.get(&(fragment_id as u32)) {
+                        match fragment.extend_deletions(*bitmap).await {
+                            Ok(Some(new_fragment)) => {
+                                Ok(FragmentChange::Modified(new_fragment.metadata))
+                            }
+                            Ok(None) => Ok(FragmentChange::Removed(fragment_id as u64)),
+                            Err(e) => Err(e),
+                        }
+                    } else {
+                        Ok(FragmentChange::Unchanged)
+                    }
+                }
+            })
+            .buffer_unordered(num_cpus::get() * 4);
+
+        while let Some(res) = stream.next().await.transpose()? {
+            match res {
+                FragmentChange::Unchanged => {}
+                FragmentChange::Modified(fragment) => updated_fragments.push(fragment),
+                FragmentChange::Removed(fragment_id) => removed_fragments.push(fragment_id),
+            }
+        }
+
+        Ok((updated_fragments, removed_fragments))
+    }
+
+    // Commit the operation
+    async fn commit(
+        dataset: Arc<Dataset>,
+        removed_fragment_ids: Vec<u64>,
+        updated_fragments: Vec<Fragment>,
+        new_fragments: Vec<Fragment>,
+    ) -> Result<Arc<Dataset>> {
+        let operation = Operation::Update {
+            removed_fragment_ids,
+            updated_fragments,
+            new_fragments,
+        };
+        let transaction = Transaction::new(dataset.manifest.version, operation, None);
+
+        let manifest = commit_transaction(
+            dataset.as_ref(),
+            dataset.object_store(),
+            &transaction,
+            &Default::default(),
+            &Default::default(),
+        )
+        .await?;
+
+        let mut dataset = dataset.as_ref().clone();
+        dataset.manifest = Arc::new(manifest);
+
+        Ok(Arc::new(dataset))
+    }
+}
+
+// A sync-safe structure that is shared by all of the "process batch" tasks.
+//
+// Note: we are not currently using parallelism but this still needs to be sync because it is
+//       held across an await boundary (and we might user parallelism someday)
+#[derive(Debug, Clone)]
+struct Merger {
+    // As the merger runs it will update the list of deleted rows
+    deleted_rows: Arc<Mutex<RoaringTreemap>>,
+    // Physical delete expression, only set if params.delete_not_matched_by_source is DeleteIf
+    delete_expr: Option<Arc<dyn PhysicalExpr>>,
+    // The parameters controlling the merge
+    params: MergeInsertParams,
+}
+
+impl Merger {
+    // Creates a new merger with an empty set of deleted rows, compiles expressions, if present
+    fn try_new(params: MergeInsertParams, schema: Arc<Schema>) -> Result<Self> {
+        let delete_expr = if let WhenNotMatchedBySource::DeleteIf(expr) =
+            &params.delete_not_matched_by_source
+        {
+            let planner = Planner::new(schema.clone());
+            let physical_expr = planner.create_physical_expr(expr)?;
+            let data_type = physical_expr.data_type(&schema)?;
+            if data_type != DataType::Boolean {
+                return Err(Error::invalid_input(format!("Merge insert conditions must be expressions that return a boolean value, received expression ({}) which has data type {}", expr, data_type), location!()));
+            }
+            Some(physical_expr)
+        } else {
+            None
+        };
+        Ok(Self {
+            deleted_rows: Arc::new(Mutex::new(RoaringTreemap::new())),
+            delete_expr,
+            params,
+        })
+    }
+
+    // Retrieves a bitmap of rows where at least one of the columns in the range
+    // col_offset..coll_offset+num_cols is not null.
+    //
+    fn not_all_null(
+        batch: &RecordBatch,
+        col_offset: usize,
+        num_cols: usize,
+    ) -> Result<BooleanArray> {
+        // For our purposes we know there is always at least 1 on key
+        debug_assert_ne!(num_cols, 0);
+        let mut at_least_one_valid = arrow::compute::is_not_null(batch.column(col_offset))?;
+        for idx in col_offset + 1..col_offset + num_cols {
+            let is_valid = arrow::compute::is_not_null(batch.column(idx))?;
+            at_least_one_valid = arrow::compute::or(&at_least_one_valid, &is_valid)?;
+        }
+        Ok(at_least_one_valid)
+    }
+
+    // Since we are performing an
+    // outer join below we expect the results to look like:
+    //
+    // | LEFT KEYS | LEFT PAYLOAD | RIGHT KEYS | RIGHT PAYLOAD |
+    // | NULL      | NULL         | NOT NULL   | ************* | <- when not matched
+    // | ********* | ************ | ********** | ************* | <- when matched
+    // | ********* | ************ | NULL       | NULL          | <- when not matched by source
+    //
+    // To test which case we are in we check to see if all of LEFT KEYS or RIGHT KEYS are null
+    //
+    // This returns three selection bitmaps
+    //
+    //  - The first is true for rows that are in the left side only
+    //  - The second is true for rows in both the left and the right
+    //  - The third is true for rows in the right side only
+    fn extract_selections(
+        &self,
+        combined_batch: &RecordBatch,
+        right_offset: usize,
+        num_keys: usize,
+    ) -> Result<(BooleanArray, BooleanArray, BooleanArray)> {
+        let in_left = Self::not_all_null(&combined_batch, 0, num_keys)?;
+        let in_right = Self::not_all_null(&combined_batch, right_offset, num_keys)?;
+        let in_both = arrow::compute::and(&in_left, &in_right)?;
+        let left_only = arrow::compute::and(&in_left, &arrow::compute::not(&in_right)?)?;
+        let right_only = arrow::compute::and(&arrow::compute::not(&in_left)?, &in_right)?;
+        Ok((left_only, in_both, right_only))
+    }
+
+    // Given a batch of outer join data, split it into three different batches
+    //
+    // Process each sub-batch according to the merge insert params
+    //
+    // Returns 0, 1, or 2 batches
+    // Potentially updates (as a side-effect) the deleted rows vec
+    async fn execute_batch(
+        self,
+        batch: RecordBatch,
+    ) -> datafusion::common::Result<impl Stream<Item = datafusion::common::Result<RecordBatch>>>
+    {
+        let num_fields = batch.schema().fields.len();
+        // The schema of the combined batches will be:
+        // existing_data_keys, existing_data_non_keys, existing_data_row_id, new_data_keys, new_data_non_keys
+        // The keys and non_keys on both sides will be equal
+        debug_assert_eq!(num_fields % 2, 1);
+        let row_id_col = num_fields / 2;
+        let right_offset = row_id_col + 1;
+        let num_keys = self.params.on.len();
+
+        let right_cols = Vec::from_iter(right_offset..num_fields);
+
+        let mut batches = Vec::with_capacity(2);
+        let (left_only, in_both, right_only) =
+            self.extract_selections(&batch, right_offset, num_keys)?;
+
+        // There is no contention on this mutex.  We're only using it to bypass the rust
+        // borrow checker (the stream needs to be `sync` since it crosses an await point)
+        let mut deleted_row_ids = self.deleted_rows.lock().unwrap();
+
+        if self.params.insert_not_matched {
+            let not_matched = arrow::compute::filter_record_batch(&batch, &right_only)?;
+            let not_matched = not_matched.project(&right_cols)?;
+            batches.push(Ok(not_matched));
+        }
+        if self.params.update_matched {
+            let matched = arrow::compute::filter_record_batch(&batch, &in_both)?;
+            let row_ids = matched.column(row_id_col).as_primitive::<UInt64Type>();
+            deleted_row_ids.extend(row_ids.values());
+            let matched = matched.project(&right_cols)?;
+            batches.push(Ok(matched));
+        }
+        match self.params.delete_not_matched_by_source {
+            WhenNotMatchedBySource::AlwaysDelete => {
+                let unmatched = arrow::compute::filter(batch.column(row_id_col), &left_only)?;
+                let row_ids = unmatched.as_primitive::<UInt64Type>();
+                deleted_row_ids.extend(row_ids.values());
+            }
+            WhenNotMatchedBySource::DeleteIf(_) => {
+                let unmatched = arrow::compute::filter_record_batch(&batch, &left_only)?;
+                let to_delete = self.delete_expr.unwrap().evaluate(&unmatched)?;
+                match to_delete {
+                    datafusion::physical_plan::ColumnarValue::Array(mask) => {
+                        let row_ids = arrow::compute::filter(
+                            unmatched.column(row_id_col),
+                            mask.as_boolean(),
+                        )?;
+                        let row_ids = row_ids.as_primitive::<UInt64Type>();
+                        deleted_row_ids.extend(row_ids.values());
+                    }
+                    datafusion::physical_plan::ColumnarValue::Scalar(scalar) => {
+                        if let ScalarValue::Boolean(Some(true)) = scalar {
+                            let row_ids = unmatched.column(row_id_col).as_primitive::<UInt64Type>();
+                            deleted_row_ids.extend(row_ids.values());
+                        }
+                    }
+                }
+            }
+            WhenNotMatchedBySource::NeverDelete => {}
+        }
+        Ok(stream::iter(batches))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use arrow_array::{types::UInt32Type, RecordBatch, RecordBatchIterator, UInt32Array};
+    use arrow_schema::{DataType, Field, Schema};
+    use arrow_select::concat::concat_batches;
+    use datafusion::common::Column;
+    use lance_datafusion::exec::reader_to_stream;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    async fn check(
+        new_data: RecordBatch,
+        mut job: MergeInsertJob,
+        keys_from_left: &[u32],
+        keys_from_right: &[u32],
+    ) {
+        let mut dataset = (*job.dataset).clone();
+        dataset.restore(None).await.unwrap();
+        job.dataset = Arc::new(dataset);
+
+        let schema = new_data.schema();
+        let (new_stream, _) = reader_to_stream(Box::new(RecordBatchIterator::new(
+            [Ok(new_data)],
+            schema.clone(),
+        )))
+        .unwrap();
+
+        let merged_dataset = job.execute(new_stream).await.unwrap();
+
+        let batches = merged_dataset
+            .scan()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        let merged = concat_batches(&schema, &batches).unwrap();
+
+        let keyvals = merged
+            .column(0)
+            .as_primitive::<UInt32Type>()
+            .values()
+            .iter()
+            .zip(
+                merged
+                    .column(1)
+                    .as_primitive::<UInt32Type>()
+                    .values()
+                    .iter(),
+            );
+        let mut left_keys = keyvals
+            .clone()
+            .filter(|(_, &val)| val == 1)
+            .map(|(key, _)| key)
+            .copied()
+            .collect::<Vec<_>>();
+        let mut right_keys = keyvals
+            .clone()
+            .filter(|(_, &val)| val == 2)
+            .map(|(key, _)| key)
+            .copied()
+            .collect::<Vec<_>>();
+        left_keys.sort();
+        right_keys.sort();
+        assert_eq!(left_keys, keys_from_left);
+        assert_eq!(right_keys, keys_from_right);
+    }
+
+    #[tokio::test]
+    async fn test_basic_merge() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("key", DataType::UInt32, true),
+            Field::new("value", DataType::UInt32, true),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt32Array::from(vec![1, 2, 3, 4, 5, 6])),
+                Arc::new(UInt32Array::from(vec![1, 1, 1, 1, 1, 1])),
+            ],
+        )
+        .unwrap();
+
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let batches = RecordBatchIterator::new([Ok(batch)], schema.clone());
+        let ds = Arc::new(Dataset::write(batches, test_uri, None).await.unwrap());
+
+        let new_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt32Array::from(vec![4, 5, 6, 7, 8, 9])),
+                Arc::new(UInt32Array::from(vec![2, 2, 2, 2, 2, 2])),
+            ],
+        )
+        .unwrap();
+
+        let keys = vec!["key".to_string()];
+        // find-or-create, no delete
+        let job = MergeInsertBuilder::new(ds.clone(), keys.clone()).build();
+        check(new_batch.clone(), job, &[1, 2, 3, 4, 5, 6], &[7, 8, 9]).await;
+
+        // upsert, no delete
+        let job = MergeInsertBuilder::new(ds.clone(), keys.clone())
+            .when_matched(WhenMatched::UpdateAll)
+            .build();
+        check(new_batch.clone(), job, &[1, 2, 3], &[4, 5, 6, 7, 8, 9]).await;
+
+        // update only, no delete (not real case, just use update)
+        let job = MergeInsertBuilder::new(ds.clone(), keys.clone())
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .build();
+        check(new_batch.clone(), job, &[1, 2, 3], &[4, 5, 6]).await;
+
+        // No-op (not real case but techncially possible
+        let job = MergeInsertBuilder::new(ds.clone(), keys.clone())
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .build();
+        check(new_batch.clone(), job, &[1, 2, 3, 4, 5, 6], &[]).await;
+
+        // find-or-create, with delete all
+        let job = MergeInsertBuilder::new(ds.clone(), keys.clone())
+            .when_not_matched_by_source(WhenNotMatchedBySource::AlwaysDelete)
+            .build();
+        check(new_batch.clone(), job, &[4, 5, 6], &[7, 8, 9]).await;
+
+        // upsert, with delete all
+        let job = MergeInsertBuilder::new(ds.clone(), keys.clone())
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched_by_source(WhenNotMatchedBySource::AlwaysDelete)
+            .build();
+        check(new_batch.clone(), job, &[], &[4, 5, 6, 7, 8, 9]).await;
+
+        // update only, with delete all (unusual)
+        let job = MergeInsertBuilder::new(ds.clone(), keys.clone())
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .when_not_matched_by_source(WhenNotMatchedBySource::AlwaysDelete)
+            .build();
+        check(new_batch.clone(), job, &[], &[4, 5, 6]).await;
+
+        // just delete all (not real case, just use delete)
+        let job = MergeInsertBuilder::new(ds.clone(), keys.clone())
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .when_not_matched_by_source(WhenNotMatchedBySource::AlwaysDelete)
+            .build();
+        check(new_batch.clone(), job, &[4, 5, 6], &[]).await;
+
+        // For the "delete some" tests we use key > 1
+        let condition = Expr::gt(
+            Expr::Column(Column::new_unqualified("key")),
+            Expr::Literal(ScalarValue::UInt32(Some(1))),
+        );
+        // find-or-create, with delete some
+        let job = MergeInsertBuilder::new(ds.clone(), keys.clone())
+            .when_not_matched_by_source(WhenNotMatchedBySource::DeleteIf(condition.clone()))
+            .build();
+        check(new_batch.clone(), job, &[1, 4, 5, 6], &[7, 8, 9]).await;
+
+        // upsert, with delete some
+        let job = MergeInsertBuilder::new(ds.clone(), keys.clone())
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched_by_source(WhenNotMatchedBySource::DeleteIf(condition.clone()))
+            .build();
+        check(new_batch.clone(), job, &[1], &[4, 5, 6, 7, 8, 9]).await;
+
+        // update only, with delete some (unusual)
+        let job = MergeInsertBuilder::new(ds.clone(), keys.clone())
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .when_not_matched_by_source(WhenNotMatchedBySource::DeleteIf(condition.clone()))
+            .build();
+        check(new_batch.clone(), job, &[1], &[4, 5, 6]).await;
+
+        // just delete some (not real case, just use delete)
+        let job = MergeInsertBuilder::new(ds.clone(), keys.clone())
+            .when_not_matched(WhenNotMatched::DoNothing)
+            .when_not_matched_by_source(WhenNotMatchedBySource::DeleteIf(condition.clone()))
+            .build();
+        check(new_batch.clone(), job, &[1, 4, 5, 6], &[]).await;
+    }
+}

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -47,7 +47,7 @@ use lance_core::{
     error::{box_error, InvalidInputSnafu},
     Error, Result,
 };
-use lance_datafusion::exec::reader_to_stream;
+use lance_datafusion::utils::reader_to_stream;
 use lance_table::format::Fragment;
 use roaring::RoaringTreemap;
 use snafu::{location, Location, ResultExt};
@@ -262,7 +262,7 @@ impl MergeInsertJob {
         self,
         source: Box<dyn RecordBatchReader + Send>,
     ) -> Result<Arc<Dataset>> {
-        let (source, _) = reader_to_stream(source)?;
+        let (source, _) = reader_to_stream(source).await?;
         self.execute(source).await
     }
 
@@ -573,7 +573,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema};
     use arrow_select::concat::concat_batches;
     use datafusion::common::Column;
-    use lance_datafusion::exec::reader_to_stream;
+    use lance_datafusion::utils::reader_to_stream;
     use tempfile::tempdir;
 
     use super::*;
@@ -593,6 +593,7 @@ mod tests {
             [Ok(new_data)],
             schema.clone(),
         )))
+        .await
         .unwrap();
 
         let merged_dataset = job.execute(new_stream).await.unwrap();


### PR DESCRIPTION
The "merge insert" operation can insert new rows, delete old rows, and update old rows, all in a single transaction.  It is a generic operation that is used to provide upsert, find-or-create, and "replace range".

closes #1456 