### PR TITLE
perf: minor change to cleanup allowing for size to be collected in parallel

### DIFF
--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -241,11 +241,14 @@ impl<'a> CleanupTask<'a> {
         let old_manifests = inspection.old_manifests.clone();
         let num_old_manifests = old_manifests.len();
 
+        // Ideally this collect shouldn't be needed here but it seems necessary
+        // to avoid https://github.com/rust-lang/rust/issues/102211
         let manifest_bytes_removed = stream::iter(&old_manifests)
-            .then(|path| async move { self.dataset.object_store.size(path).await })
-            // TODO: uncomment this after
-            // https://github.com/rust-lang/rust/issues/102211 is resolved
-            // .buffer_unordered(num_cpus::get())
+            .map(|path| self.dataset.object_store.size(path))
+            .collect::<Vec<_>>()
+            .await;
+        let manifest_bytes_removed = stream::iter(manifest_bytes_removed)
+            .buffer_unordered(num_cpus::get())
             .try_fold(0, |acc, size| async move { Ok(acc + (size as u64)) })
             .await;
 


### PR DESCRIPTION
While working on an unrelated task I figured out a way that we can sometimes workaround the bogus "higher ranked lifetime" error.