### PR TITLE
fix: prevent OOM when IVF centroids are provided

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -982,6 +982,13 @@ class LanceDataset(pa.dataset.Dataset):
                 raise ValueError(
                     "num_partitions and num_sub_vectors are required for IVF_PQ"
                 )
+            if isinstance(num_partitions, float):
+                warnings.warn("num_partitions is float, converting to int")
+                num_partitions = int(num_partitions)
+            elif not isinstance(num_partitions, int):
+                raise TypeError(
+                    f"num_partitions must be int, got {type(num_partitions)}"
+                )
             kwargs["num_partitions"] = num_partitions
             kwargs["num_sub_vectors"] = num_sub_vectors
 

--- a/python/python/lance/torch/data.py
+++ b/python/python/lance/torch/data.py
@@ -36,7 +36,7 @@ __all__ = ["LanceDataset"]
 
 def _to_tensor(batch: pa.RecordBatch) -> Union[dict[str, torch.Tensor], torch.Tensor]:
     ret = {}
-    for col in batch.column_names:
+    for col in batch.schema.names:
         arr: pa.Array = batch[col]
         if pa.types.is_fixed_size_list(arr.type) and pa.types.is_floating(
             arr.type.value_type

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -154,6 +154,8 @@ def train_ivf_centroids_on_accelerator(
 
     from .torch.kmeans import KMeans
 
+    k = int(k)
+
     logging.info("Randomly select %s centroids from %s", k, dataset)
     samples = dataset.sample(k, [column], sorted=True).combine_chunks()
     fsl = samples.to_batches()[0][column]


### PR DESCRIPTION
These are a small collection of fixes I needed in order to run a benchmark for partitioning while using CUDA acceleration.

1. Regardless of whether IVF is going to be trained, we load in enough vectors to do the training. This causes OOM on large datasets, so I've changed this to skip loading those vectors if the IVF centroids have already been passed in. GPU training can handle larger than memory datasets thanks to it's data loader, so this makes large scale training with GPUs possible.
2. Added some cast to ints, as it's easy to accidentally get floats in some cases.
3. Handle older pyarrow versions in GPU training API