### PR TITLE
chore: add shortcuts for creating arrow types

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
+    "arrow-shortcuts",
+    "arrow-shortcuts-macros",
     "lance-arrow",
     "lance-core",
     "lance-datagen",
@@ -58,6 +60,8 @@ arrow-ord = "47.0"
 arrow-row = "47.0"
 arrow-schema = "47.0"
 arrow-select = "47.0"
+arrow-shortcuts = { version = "47.0", path = "./arrow-shortcuts" }
+arrow-shortcuts-macros = { version = "47.0", path = "./arrow-shortcuts-macros" }
 async-recursion = "1.0"
 async-trait = "0.1"
 aws-config = "0.56"

--- a/rust/arrow-shortcuts-macros/Cargo.toml
+++ b/rust/arrow-shortcuts-macros/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "arrow-shortcuts-macros"
+version = "47.0.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+description = "Shortcut macros for working with Arrow (don't use directly)"
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+proc-macro2 = "1.0.67"
+quote = "1.0.33"
+syn = { version = "2.0.37", features = ["full"] }
+
+[lib]
+proc-macro = true

--- a/rust/arrow-shortcuts-macros/src/lib.rs
+++ b/rust/arrow-shortcuts-macros/src/lib.rs
@@ -1,0 +1,598 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    token::{As, Bracket, Comma, Paren},
+    ExprLit,
+};
+
+// Convert a type "path" (e.g. u32 or my_crate::foo::my_udt) to an arrow type
+// using ArrowTypeInfer
+fn path_to_arrow_type(type_path: &syn::TypePath) -> proc_macro2::TokenStream {
+    quote! { <#type_path as ::arrow_shortcuts::util::ArrowTypeInfer>::arrow_type() }
+}
+
+// Convert an array type (e.g. [u32; 32]) to an arrow type
+fn type_array_to_arrow_type(
+    type_array: &syn::TypeArray,
+    nullable: bool,
+) -> proc_macro2::TokenStream {
+    let inner_type = rust_type_to_arrow_type(type_array.elem.as_ref(), nullable);
+    let len = &type_array.len;
+    quote! {
+      ::arrow_shortcuts::arrow_schema::DataType::FixedSizeList(
+        ::std::sync::Arc::new(::arrow_shortcuts::arrow_schema::Field::new(
+            "item",
+            #inner_type,
+            #nullable,
+        )),
+        #len,
+      )
+    }
+}
+
+// Convert a slice type (e.g. &[u32]) to an arrow type
+fn type_slice_to_arrow_type(
+    type_slice: &syn::TypeSlice,
+    nullable: bool,
+) -> proc_macro2::TokenStream {
+    let inner_type = rust_type_to_arrow_type(type_slice.elem.as_ref(), nullable);
+    quote! {
+        ::arrow_shortcuts::arrow_schema::DataType::List(
+            ::std::sync::Arc::new(::arrow_shortcuts::arrow_schema::Field::new(
+                "item",
+                #inner_type,
+                #nullable
+            ))
+        )
+    }
+}
+
+// Convert a reference type (e.g. &u32) to an arrow type.  We just treat it the same as the non-reference type
+// This is mainly here for things like &str
+fn type_ref_to_arrow_type(type_ref: &syn::TypeReference) -> proc_macro2::TokenStream {
+    quote! { <#type_ref as ::arrow_shortcuts::util::ArrowTypeInfer>::arrow_type() }
+}
+
+// Parse the special "never" type (!) to the null arrow type
+fn never_to_arrow_type() -> proc_macro2::TokenStream {
+    quote! { ::arrow_shortcuts::arrow_schema::DataType::Null }
+}
+
+// Convert a rust type to an arrow type
+fn rust_type_to_arrow_type(type_: &syn::Type, nullable: bool) -> proc_macro2::TokenStream {
+    match type_ {
+        syn::Type::Array(type_array) => type_array_to_arrow_type(type_array, nullable),
+        syn::Type::BareFn(..) => panic!("The arr_type! macro is not compatible with functions"),
+        syn::Type::Never(..) => never_to_arrow_type(),
+        syn::Type::Paren(paren_type) => rust_type_to_arrow_type(paren_type.elem.as_ref(), false),
+        syn::Type::Path(type_path) => path_to_arrow_type(type_path),
+        syn::Type::Reference(type_ref) => type_ref_to_arrow_type(type_ref),
+        syn::Type::Slice(type_slice) => type_slice_to_arrow_type(type_slice, nullable),
+        syn::Type::Tuple(..) => panic!("union support not available in arr_type! macro"),
+        _ => panic!("input cannot be converted to an arrow type"),
+    }
+}
+
+// Convert rust code to an arrow field
+//
+// Example Input:
+//  my_field: f32
+//
+// Example Output:
+//  Field::new("my_field", DataType::Float32, true)
+fn rust_field_to_arrow_field(field: &Field, nullable: bool) -> proc_macro2::TokenStream {
+    let name = field.name.to_string();
+    let type_ = rust_to_arrow_type(&field.ty, nullable);
+    quote! {::std::sync::Arc::new(
+        ::arrow_shortcuts::arrow_schema::Field::new(#name, #type_, #nullable),
+    )}
+}
+
+// Convert a rust struct (which, itself, is special syntax) to an arrow struct type
+fn rust_struct_to_arrow_type(struct_: &NestedType, nullable: bool) -> proc_macro2::TokenStream {
+    let parsed_fields = struct_
+        .fields
+        .iter()
+        .map(|field| rust_field_to_arrow_field(field, nullable))
+        .collect::<Vec<_>>();
+    quote! {
+        ::arrow_shortcuts::arrow_schema::DataType::Struct(
+            [#(#parsed_fields),*]
+            .into(),
+        )
+    }
+}
+
+// Convert rust code to an arrow type
+//
+// Example input:
+//  u32
+//
+// Equivalent output:
+//  DataType::UInt32
+//
+// Actual output:
+//  <u32 as ArrowTypeInfer>::arrow_type()
+fn rust_to_arrow_type(type_: &ArrowTypeParam, nullable: bool) -> proc_macro2::TokenStream {
+    match type_ {
+        ArrowTypeParam::SimpleType(type_) => rust_type_to_arrow_type(type_, nullable),
+        ArrowTypeParam::StructType(struct_) => rust_struct_to_arrow_type(struct_, nullable),
+    }
+}
+
+// Convert rust code to an arrow schema
+//
+// Example input:
+//  {
+//     vector: [f32; 128],
+//     metadata: {
+//       caption: &str,
+//       user_score: f64
+//     }
+//  }
+//
+// Example output:
+//
+// Schema::new([field_one, field_two])
+fn rust_to_arrow_schema(schema: &NestedType) -> proc_macro2::TokenStream {
+    let parsed_fields = schema
+        .fields
+        .iter()
+        .map(|field| rust_field_to_arrow_field(field, true))
+        .collect::<Vec<_>>();
+    quote! {
+        ::arrow_shortcuts::arrow_schema::Schema::new([#(#parsed_fields),*])
+    }
+}
+
+// Convert a rust literal to an optional array item that can be fed to an arrow array constructor
+//
+// Example Input (not null):
+//  7
+// Example Output:
+//  Some(7)
+//
+// Example Input (null):
+//  ()
+// Example Output (null):
+//  None
+fn rust_to_array_item(values: &ArrayElement) -> proc_macro2::TokenStream {
+    match values {
+        ArrayElement::Lit(lit) => {
+            let val = &lit.lit;
+            quote! { Some(#val) }
+        }
+        // TODO
+        // ArrayElement::Array(array) => todo!(),
+        ArrayElement::Null(_) => quote! { None },
+    }
+}
+
+// Convert a rust type literal to an Arrow array type
+//
+// Example Input:
+//  u32
+//
+// Equivalent Output:
+//  UInt32Array
+//
+// Actual Output:
+//  <u32 as ArrowTypeInfer>::ArrayType
+fn path_to_array_type(type_path: &syn::TypePath) -> proc_macro2::TokenStream {
+    quote! { <#type_path as ::arrow_shortcuts::util::ArrowTypeInfer>::ArrayType }
+}
+
+// Same as path_to_array_type but for ref types (e.g. &u32)
+fn ref_to_array_type(type_ref: &syn::TypeReference) -> proc_macro2::TokenStream {
+    quote! { <#type_ref as ::arrow_shortcuts::util::ArrowTypeInfer>::ArrayType }
+}
+
+enum TypeKind {
+    Null,
+    Scalar,
+    // TODO
+    // Array,
+}
+
+// Convert a rust type to an Arrow array type
+fn type_to_array_type(type_: &syn::Type) -> (proc_macro2::TokenStream, TypeKind) {
+    match type_ {
+        syn::Type::Path(type_path) => (path_to_array_type(type_path), TypeKind::Scalar),
+        syn::Type::Reference(type_ref) => (ref_to_array_type(type_ref), TypeKind::Scalar),
+        syn::Type::Never(_) => (
+            quote! { ::arrow_shortcuts::arrow_array::NullArray },
+            TypeKind::Null,
+        ),
+        // TODO: syn::Type::Array & syn::Type::Slice should convert to FixedArray / Array TypeKind
+        _ => panic!("input cannot be converted to an array type"),
+    }
+}
+
+// Convert rust code to an arrow array
+//
+// Example Input:
+//  [0, 3, ()] as u32
+//
+// Equivalent Output:
+//  UInt32Array::from(vec![Some(0), Some(3), None])
+//
+// Actual Output:
+//  <u32 as ArrowTypeInfer>::ArrayType::from(vec![Some(0), Some(3), None])
+fn rust_to_array(array: &TypedArrowArray) -> (proc_macro2::TokenStream, u32) {
+    let (array_type, type_kind) = type_to_array_type(&array.ty);
+    // TODO: Add a case for array types (e.g. arr_array!([[1, 2], [3, 4]] as [u32; 2]))
+    let values = array
+        .array
+        .elems
+        .iter()
+        .map(rust_to_array_item)
+        .collect::<Vec<_>>();
+    let num_values = values.len();
+    let tokens = if matches!(type_kind, TypeKind::Null) {
+        quote! { <#array_type>::new(#num_values) }
+    } else {
+        quote! {
+            <#array_type>::from(vec![#(#values),*])
+        }
+    };
+    (tokens, num_values as u32)
+}
+
+// Wraps an array in an Arc
+fn wrap_array(arr: proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    quote! {
+        ::std::sync::Arc::new(#arr) as ::std::sync::Arc<dyn ::arrow_shortcuts::arrow_array::Array>
+    }
+}
+
+// Convert rust code to an arrow record batch
+//
+// Example Input:
+//  {
+//    "x": [1, 2, ()] as u32,
+//    "y": [0, (), 3] as f32,
+//  }
+//
+// Example Output:
+//   RecordBatch::try_new(schema, vec![x_array, y_array]).unwrap()
+//
+// Safety:
+//   RecordBatch::try_new will fail if:
+//     * there are no columns (this will fail to compile)
+//     * the schema has a different length than the arrays
+//         (this is not possible since both are generated from the same ground truth)
+//     * the arrays have differing lengths (this will fail to compile)
+//
+//   All cases are accounted for and so it is safe to unwrap
+fn rust_to_arrow_batch(batch: &ArrowBatch) -> syn::Result<proc_macro2::TokenStream> {
+    let fields = batch
+        .fields
+        .iter()
+        .map(|field| {
+            let name = &field.name;
+            let ty = &field.array.ty;
+            quote! {#name: #ty}
+        })
+        .collect::<Vec<_>>();
+    let schema = quote! {
+        ::arrow_shortcuts_macros::arr_schema!({
+            #(#fields),*
+        })
+    };
+    let schema = quote! { ::std::sync::Arc::new(#schema) };
+    let arrs_and_lens = batch.fields.iter().map(|field| rust_to_array(&field.array));
+    let lens = arrs_and_lens
+        .clone()
+        .map(|(_, len)| len)
+        .collect::<Vec<_>>();
+    if lens.is_empty() {
+        return Err(syn::Error::new(
+            batch.brace_token.span.open(),
+            "the arr_batch macro requires at least one array",
+        ));
+    }
+    let first_len = lens[0];
+    if let Some(mismatched_len) = lens[1..].iter().find(|&l| *l != first_len) {
+        return Err(syn::Error::new(
+            batch.brace_token.span.open(),
+            format!("all arrays must have equal length.  First array has length {}, a subsequent array has length {}", first_len, mismatched_len)
+        ));
+    }
+    let arrs = arrs_and_lens.map(|(arr, _)| wrap_array(arr));
+    let arrs = quote! {vec![#(#arrs),*]};
+    Ok(quote! {
+        ::arrow_shortcuts::arrow_array::RecordBatch::try_new(#schema, #arrs).unwrap()
+    })
+}
+
+// New rust syntax for a field (identifier: type)
+//
+// Examples:
+//  foo: u32
+//  blah: my_crate::MyUdf
+struct Field {
+    name: syn::Ident,
+    _colon_token: syn::Token![:],
+    ty: ArrowTypeParam,
+}
+
+impl Parse for Field {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            name: input.parse()?,
+            _colon_token: input.parse()?,
+            ty: input.parse()?,
+        })
+    }
+}
+
+// New rust syntax for a nested type ({field, field, field})
+//
+// Examples:
+//  {x: u32, y: f32, udf: my_crate::MyUdf}
+//  {score: f32, points: {x: f32, y: f32}}
+//  {vector: [f32; 768], label: &str}
+struct NestedType {
+    _brace_token: syn::token::Brace,
+    fields: syn::punctuated::Punctuated<Field, syn::Token![,]>,
+}
+
+impl Parse for NestedType {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        Ok(Self {
+            _brace_token: syn::braced!(content in input),
+            fields: content.parse_terminated(Field::parse, syn::Token![,])?,
+        })
+    }
+}
+
+// A field's type, can either be a simple type or a nested type
+enum ArrowTypeParam {
+    SimpleType(syn::Type),
+    StructType(NestedType),
+}
+
+impl syn::parse::Parse for ArrowTypeParam {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(syn::token::Brace) {
+            input.parse().map(ArrowTypeParam::StructType)
+        } else {
+            input.parse().map(ArrowTypeParam::SimpleType)
+        }
+    }
+}
+
+fn arrow_type2(input: proc_macro2::TokenStream) -> syn::Result<proc_macro2::TokenStream> {
+    let type_: ArrowTypeParam = syn::parse2(input)?;
+    Ok(rust_to_arrow_type(&type_, true))
+}
+
+/// A macro to create arrow types from rust types
+///
+/// This macro takes in a rust type and desugars it into an equivalent Arrow DataType.  This
+/// macro works by relying on the ArrowTypeInfer trait.  To use this macro with your own user
+/// defined types you should implement the ArrowTypeInfer trait.
+///
+/// # Examples
+/// ```ignore
+/// // Basic type
+/// assert_eq!(arr_type!(u32), DataType::UInt32);
+/// // Fixed size list
+/// assert_eq!(
+/// arr_type!([i32; 5]),
+///   DataType::FixedSizeList(Arc::new(Field::new("item", arr_type!(i32), true)), 5)
+/// );
+/// // Variable size list
+/// assert_eq!(
+/// arr_type!([i32]),
+///   DataType::List(Arc::new(Field::new("item", arr_type!(i32), true)))
+/// );
+/// // Nested (struct) types
+/// assert_eq!(
+///   arr_type!({
+///     foo: i32,
+///     bar: f32,
+///   }),
+///   DataType::Struct([arr_field!(foo: i32), arr_field!(bar: f32),].into())
+/// );
+/// ```
+#[proc_macro]
+pub fn arr_type(input: TokenStream) -> TokenStream {
+    let input = proc_macro2::TokenStream::from(input);
+    arrow_type2(input).unwrap().into()
+}
+
+fn arrow_field2(input: proc_macro2::TokenStream) -> syn::Result<proc_macro2::TokenStream> {
+    let field: Field = syn::parse2(input)?;
+    Ok(rust_field_to_arrow_field(&field, true))
+}
+
+/// A macro to create arrow types from a field-like rust syntax
+///
+/// # Examples
+/// ```ignore
+/// assert_eq!(arr_field!(score: f32), Field::new("score", DataType::Float32, true))
+/// ```
+#[proc_macro]
+pub fn arr_field(input: TokenStream) -> TokenStream {
+    let input = proc_macro2::TokenStream::from(input);
+    arrow_field2(input).unwrap().into()
+}
+
+fn arrow_schema2(input: proc_macro2::TokenStream) -> syn::Result<proc_macro2::TokenStream> {
+    let struct_type: NestedType = syn::parse2(input)?;
+    Ok(rust_to_arrow_schema(&struct_type))
+}
+
+/// A macro to create arrow schemas from a dictionary-like rust syntax
+///
+/// # Examples
+/// ```ignore
+/// let schema = arr_schema!({
+///   vector: [f32; 128],
+///   metadata: {
+///     caption: &str,
+///     user_score: f64
+///  }
+/// });
+/// ```
+#[proc_macro]
+pub fn arr_schema(input: TokenStream) -> TokenStream {
+    let input = proc_macro2::TokenStream::from(input);
+    arrow_schema2(input).unwrap().into()
+}
+
+// This is just () which we interpret as null in arr_array construction
+struct NullLit {
+    pub _paren: Paren,
+}
+
+impl Parse for NullLit {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let _content;
+        Ok(Self {
+            _paren: syn::parenthesized!(_content in input),
+        })
+    }
+}
+
+// Syntax for an element of an array.  Either a literal or ()
+enum ArrayElement {
+    Null(NullLit),
+    Lit(ExprLit),
+    // TODO: support arrays of arrays
+    // Array(ArrowArray),
+}
+
+impl Parse for ArrayElement {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        if lookahead.peek(syn::token::Paren) {
+            input.parse().map(ArrayElement::Null)
+        } else if lookahead.peek(syn::token::Bracket) {
+            todo!()
+            // input.parse().map(ArrayElement::Array)
+        } else {
+            input.parse().map(ArrayElement::Lit)
+        }
+    }
+}
+
+// Syntax for an array ([value, value, value])
+struct ArrowArray {
+    pub _bracket: Bracket,
+    pub elems: Punctuated<ArrayElement, Comma>,
+}
+
+// Syntax for an array with a type ([value, value, value] as type)
+//
+// Examples:
+//  [0, (), 5] as u32
+//  [(), ()] as f64
+//  [(), ()] as !
+struct TypedArrowArray {
+    pub array: ArrowArray,
+    pub _as: As,
+    pub ty: syn::Type,
+}
+
+impl Parse for ArrowArray {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        Ok(Self {
+            _bracket: syn::bracketed!(content in input),
+            elems: content.parse_terminated(ArrayElement::parse, syn::Token![,])?,
+        })
+    }
+}
+
+impl Parse for TypedArrowArray {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            array: input.parse::<ArrowArray>()?,
+            _as: input.parse::<As>()?,
+            ty: input.parse::<syn::Type>()?,
+        })
+    }
+}
+
+fn arrow_array2(input: proc_macro2::TokenStream) -> syn::Result<proc_macro2::TokenStream> {
+    let arrow_array: TypedArrowArray = syn::parse2(input)?;
+    Ok(rust_to_array(&arrow_array).0)
+}
+
+/// A macro to create arrow arrays from an array-like rust syntax
+///
+/// # Examples
+/// ```ignore
+/// assert_eq!(
+///     arr_array!([1, (), 5] as u8),
+///     UInt8Array::from(vec![Some(1), None, Some(5)])
+/// );
+/// assert_eq!(arr_array!([(), ()] as !), NullArray::new(2),)
+/// ```
+#[proc_macro]
+pub fn arr_array(input: TokenStream) -> TokenStream {
+    let input = proc_macro2::TokenStream::from(input);
+    arrow_array2(input).unwrap().into()
+}
+
+// Syntax for a column in a record batch (name: [value, value] as type)
+struct BatchField {
+    name: syn::Ident,
+    _colon_token: syn::Token![:],
+    array: TypedArrowArray,
+}
+
+impl Parse for BatchField {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            name: input.parse()?,
+            _colon_token: input.parse()?,
+            array: input.parse()?,
+        })
+    }
+}
+
+// Syntax for a record batch ({batch_field, batch_field, batch_field})
+struct ArrowBatch {
+    brace_token: syn::token::Brace,
+    fields: syn::punctuated::Punctuated<BatchField, syn::Token![,]>,
+}
+
+impl Parse for ArrowBatch {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let content;
+        Ok(Self {
+            brace_token: syn::braced!(content in input),
+            fields: content.parse_terminated(BatchField::parse, syn::Token![,])?,
+        })
+    }
+}
+
+fn arrow_batch2(input: proc_macro2::TokenStream) -> syn::Result<proc_macro2::TokenStream> {
+    let arrow_batch: ArrowBatch = syn::parse2(input)?;
+    rust_to_arrow_batch(&arrow_batch)
+}
+
+/// A macro to create arrow arrays from an array-like rust syntax
+///
+/// # Examples
+/// ```ignore
+/// let batch = arr_batch!({
+///   x: [1, 2, ()] as u8,
+///   y: [4, (), 5] as u16,
+///   strings: [(), "x", "y"] as &str,
+///   // Not yet supported
+///   // vecs: [[1, 2, 3], [4, (), 6], ()] as [u16; 3],
+/// });
+/// ```
+#[proc_macro]
+pub fn arr_batch(input: TokenStream) -> TokenStream {
+    let input = proc_macro2::TokenStream::from(input);
+    arrow_batch2(input).unwrap().into()
+}

--- a/rust/arrow-shortcuts/Cargo.toml
+++ b/rust/arrow-shortcuts/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "arrow-shortcuts"
+version = "47.0.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+readme.workspace = true
+description = "Shortcuts for working with Arrow"
+keywords.workspace = true
+categories.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+arrow-array.workspace = true
+arrow-schema.workspace = true
+arrow-shortcuts-macros.workspace = true

--- a/rust/arrow-shortcuts/src/lib.rs
+++ b/rust/arrow-shortcuts/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod util;
+
+pub use arrow_array;
+pub use arrow_schema;
+pub use arrow_shortcuts_macros as macros;

--- a/rust/arrow-shortcuts/src/util.rs
+++ b/rust/arrow-shortcuts/src/util.rs
@@ -1,0 +1,115 @@
+use crate::arrow_array::{
+    BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
+    StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+};
+use crate::arrow_schema::DataType;
+
+pub trait ArrowTypeInfer {
+    type ArrayType;
+
+    fn arrow_type() -> DataType;
+}
+
+impl ArrowTypeInfer for bool {
+    type ArrayType = BooleanArray;
+
+    fn arrow_type() -> DataType {
+        DataType::Boolean
+    }
+}
+
+impl ArrowTypeInfer for i8 {
+    type ArrayType = Int8Array;
+
+    fn arrow_type() -> DataType {
+        DataType::Int8
+    }
+}
+
+impl ArrowTypeInfer for i16 {
+    type ArrayType = Int16Array;
+
+    fn arrow_type() -> DataType {
+        DataType::Int16
+    }
+}
+
+impl ArrowTypeInfer for i32 {
+    type ArrayType = Int32Array;
+
+    fn arrow_type() -> DataType {
+        DataType::Int32
+    }
+}
+
+impl ArrowTypeInfer for i64 {
+    type ArrayType = Int64Array;
+
+    fn arrow_type() -> DataType {
+        DataType::Int64
+    }
+}
+
+impl ArrowTypeInfer for u8 {
+    type ArrayType = UInt8Array;
+
+    fn arrow_type() -> DataType {
+        DataType::UInt8
+    }
+}
+
+impl ArrowTypeInfer for u16 {
+    type ArrayType = UInt16Array;
+
+    fn arrow_type() -> DataType {
+        DataType::UInt16
+    }
+}
+
+impl ArrowTypeInfer for u32 {
+    type ArrayType = UInt32Array;
+
+    fn arrow_type() -> DataType {
+        DataType::UInt32
+    }
+}
+
+impl ArrowTypeInfer for u64 {
+    type ArrayType = UInt64Array;
+
+    fn arrow_type() -> DataType {
+        DataType::UInt64
+    }
+}
+
+impl ArrowTypeInfer for f32 {
+    type ArrayType = Float32Array;
+
+    fn arrow_type() -> DataType {
+        DataType::Float32
+    }
+}
+
+impl ArrowTypeInfer for f64 {
+    type ArrayType = Float64Array;
+
+    fn arrow_type() -> DataType {
+        DataType::Float64
+    }
+}
+
+impl ArrowTypeInfer for &str {
+    type ArrayType = StringArray;
+
+    fn arrow_type() -> DataType {
+        DataType::Utf8
+    }
+}
+
+impl ArrowTypeInfer for String {
+    type ArrayType = StringArray;
+
+    fn arrow_type() -> DataType {
+        DataType::Utf8
+    }
+}

--- a/rust/arrow-shortcuts/tests/test_arrays.rs
+++ b/rust/arrow-shortcuts/tests/test_arrays.rs
@@ -1,0 +1,69 @@
+use arrow_array::{
+    BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
+    NullArray, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+};
+use arrow_shortcuts::macros::arr_array;
+
+#[test]
+pub fn test_arrays() {
+    // ----- Basic primitives
+    assert_eq!(
+        arr_array!([1, (), 5] as u8),
+        UInt8Array::from(vec![Some(1), None, Some(5)])
+    );
+    assert_eq!(
+        arr_array!([1, (), 5] as u16),
+        UInt16Array::from(vec![Some(1), None, Some(5)])
+    );
+    assert_eq!(
+        arr_array!([1, (), 5] as u32),
+        UInt32Array::from(vec![Some(1), None, Some(5)])
+    );
+    assert_eq!(
+        arr_array!([1, (), 5] as u64),
+        UInt64Array::from(vec![Some(1), None, Some(5)])
+    );
+    assert_eq!(
+        arr_array!([1, (), 5] as i8),
+        Int8Array::from(vec![Some(1), None, Some(5)])
+    );
+    assert_eq!(
+        arr_array!([1, (), 5] as i16),
+        Int16Array::from(vec![Some(1), None, Some(5)])
+    );
+    assert_eq!(
+        arr_array!([1, (), 5] as i32),
+        Int32Array::from(vec![Some(1), None, Some(5)])
+    );
+    assert_eq!(
+        arr_array!([1, (), 5] as i64),
+        Int64Array::from(vec![Some(1), None, Some(5)])
+    );
+    assert_eq!(
+        arr_array!([1.0, (), 5.0] as f32),
+        Float32Array::from(vec![Some(1.0), None, Some(5.0)])
+    );
+    assert_eq!(
+        arr_array!([1.0, (), 5.0] as f64),
+        Float64Array::from(vec![Some(1.0), None, Some(5.0)])
+    );
+    assert_eq!(
+        arr_array!([false, false, true] as bool),
+        BooleanArray::from(vec![Some(false), Some(false), Some(true)])
+    );
+    assert_eq!(
+        arr_array!(["x", "y", "z"] as &str),
+        StringArray::from(vec![Some("x"), Some("y"), Some("z")])
+    );
+    // All null
+    assert_eq!(
+        arr_array!([(), (), ()] as f64),
+        Float64Array::from(vec![None, None, None])
+    );
+    // Null typed array
+    assert_eq!(arr_array!([(), ()] as !), NullArray::new(2),)
+
+    // TODO
+    // nested arrays
+    // list arrays
+}

--- a/rust/arrow-shortcuts/tests/test_batch.rs
+++ b/rust/arrow-shortcuts/tests/test_batch.rs
@@ -1,0 +1,32 @@
+use std::sync::Arc;
+
+use arrow_schema::DataType;
+use arrow_shortcuts::arrow_array::{RecordBatch, StringArray, UInt16Array, UInt8Array};
+use arrow_shortcuts::arrow_schema::{Field, Schema};
+use arrow_shortcuts::macros::arr_batch;
+
+#[test]
+pub fn test_arrays() {
+    let batch = arr_batch!({
+        x: [1, 2, ()] as u8,
+        y: [4, (), 5] as u16,
+        strings: [(), "x", "y"] as &str,
+        // Not yet supported
+        // vecs: [[1, 2, 3], [4, (), 6], ()] as &[u16],
+    });
+    let expected_schema = Schema::new(vec![
+        Field::new("x", DataType::UInt8, true),
+        Field::new("y", DataType::UInt16, true),
+        Field::new("strings", DataType::Utf8, true),
+    ]);
+    let expected_batch = RecordBatch::try_new(
+        Arc::new(expected_schema),
+        vec![
+            Arc::new(UInt8Array::from_iter(&[Some(1), Some(2), None])),
+            Arc::new(UInt16Array::from_iter(&[Some(4), None, Some(5)])),
+            Arc::new(StringArray::from_iter(&[None, Some("x"), Some("y")])),
+        ],
+    )
+    .unwrap();
+    assert_eq!(batch, expected_batch);
+}

--- a/rust/arrow-shortcuts/tests/test_types.rs
+++ b/rust/arrow-shortcuts/tests/test_types.rs
@@ -1,0 +1,147 @@
+use std::sync::Arc;
+
+use arrow_array::FixedSizeBinaryArray;
+use arrow_schema::Schema;
+use arrow_shortcuts::macros::{arr_field, arr_schema, arr_type};
+use arrow_shortcuts::{
+    arrow_schema::{DataType, Field},
+    util::ArrowTypeInfer,
+};
+
+#[test]
+pub fn test_types() {
+    // ----- Basic primitives
+    assert_eq!(arr_type!(!), DataType::Null);
+    assert_eq!(arr_type!(bool), DataType::Boolean);
+    assert_eq!(arr_type!(i8), DataType::Int8);
+    assert_eq!(arr_type!(i16), DataType::Int16);
+    assert_eq!(arr_type!(i32), DataType::Int32);
+    assert_eq!(arr_type!(i64), DataType::Int64);
+    assert_eq!(arr_type!(u8), DataType::UInt8);
+    assert_eq!(arr_type!(u16), DataType::UInt16);
+    assert_eq!(arr_type!(u32), DataType::UInt32);
+    assert_eq!(arr_type!(u64), DataType::UInt64);
+    assert_eq!(arr_type!(f32), DataType::Float32);
+    assert_eq!(arr_type!(f64), DataType::Float64);
+    assert_eq!(arr_type!(&str), DataType::Utf8);
+    assert_eq!(arr_type!(String), DataType::Utf8);
+
+    // ----- Fixed size lists
+    assert_eq!(
+        arr_type!([i32; 5]),
+        DataType::FixedSizeList(Arc::new(Field::new("item", arr_type!(i32), true)), 5)
+    );
+    // Can surround any type with parens to make implicit fields non-nullable
+    assert_eq!(
+        arr_type!(([i32; 5])),
+        DataType::FixedSizeList(Arc::new(Field::new("item", arr_type!(i32), false)), 5)
+    );
+    const DIM: i32 = 128;
+    // Make sure we can use a non-literal for fixed-size-list size
+    assert_eq!(
+        arr_type!([i32; DIM]),
+        DataType::FixedSizeList(Arc::new(Field::new("item", arr_type!(i32), true)), DIM)
+    );
+    // Nested list
+    assert_eq!(
+        arr_type!([[i32; 2]; 4]),
+        DataType::FixedSizeList(Arc::new(Field::new("item", arr_type!([i32; 2]), true)), 4)
+    );
+
+    // ----- Variable size lists
+
+    assert_eq!(
+        arr_type!([i32]),
+        DataType::List(Arc::new(Field::new("item", arr_type!(i32), true)))
+    );
+    assert_eq!(
+        arr_type!([[i32; 4]]),
+        DataType::List(Arc::new(Field::new("item", arr_type!([i32; 4]), true)))
+    );
+
+    // ----- Structs
+
+    assert_eq!(
+        arr_type!({
+            foo: i32,
+            bar: f32,
+        }),
+        DataType::Struct([arr_field!(foo: i32), arr_field!(bar: f32),].into())
+    );
+    // Nested is ok
+    assert_eq!(
+        arr_type!({
+            score: f32,
+            location: {
+                x: f32,
+                y: f64
+            }
+        }),
+        DataType::Struct(
+            [
+                arr_field!(score: f32),
+                Arc::new(Field::new(
+                    "location",
+                    DataType::Struct([arr_field!(x: f32), arr_field!(y: f64)].into()),
+                    true
+                ))
+            ]
+            .into()
+        )
+    );
+
+    // ----- Fields
+
+    assert_eq!(
+        arr_field!(x: i32),
+        Arc::new(Field::new("x", arr_type!(i32), true))
+    );
+
+    // ----- Schemas
+
+    assert_eq!(
+        arr_schema!({
+            x: i32,
+            y: f32
+        }),
+        Schema::new([arr_field!(x: i32), arr_field!(y: f32),])
+    );
+
+    // Even nested schemas
+    assert_eq!(
+        arr_schema!({
+            vector: [f32; 128],
+            metadata: {
+                caption: &str,
+                user_score: f64
+            }
+        }),
+        Schema::new([
+            arr_field!(vector: [f32; 128]),
+            arr_field!(metadata: {
+                caption: &str,
+                user_score: f64
+            })
+        ])
+    );
+
+    // ----- Limitations
+
+    // Can't do lists of nested types
+    // arr_type!([{x: i32}]); - ERR
+}
+
+struct Uuid;
+
+impl ArrowTypeInfer for Uuid {
+    type ArrayType = FixedSizeBinaryArray;
+
+    fn arrow_type() -> DataType {
+        DataType::FixedSizeBinary(16)
+    }
+}
+
+#[test]
+pub fn custom_types() {
+    assert_eq!(arr_type!(Uuid), DataType::FixedSizeBinary(16));
+}

--- a/rust/lance-core/Cargo.toml
+++ b/rust/lance-core/Cargo.toml
@@ -20,6 +20,7 @@ arrow-data.workspace = true
 arrow-ipc.workspace = true
 arrow-schema.workspace = true
 arrow-select.workspace = true
+arrow-shortcuts.workspace = true
 async-recursion.workspace = true
 async-trait.workspace = true
 lance-arrow.workspace = true

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -464,6 +464,7 @@ mod tests {
     use arrow_schema::{
         DataType, Field as ArrowField, Fields as ArrowFields, Schema as ArrowSchema,
     };
+    use arrow_shortcuts::macros::arr_schema;
 
     #[test]
     fn test_schema_projection() {
@@ -529,15 +530,11 @@ mod tests {
         assert_eq!(ArrowSchema::from(&projected), expected_arrow_schema);
 
         let projected = schema.project_by_ids(&[2]);
-        let expected_arrow_schema = ArrowSchema::new(vec![ArrowField::new(
-            "b",
-            DataType::Struct(ArrowFields::from(vec![ArrowField::new(
-                "f1",
-                DataType::Utf8,
-                true,
-            )])),
-            true,
-        )]);
+        let expected_arrow_schema = arr_schema!({
+            b: {
+                f1: &str
+            }
+        });
         assert_eq!(ArrowSchema::from(&projected), expected_arrow_schema);
     }
 

--- a/rust/lance-core/src/io/writer/statistics.rs
+++ b/rust/lance-core/src/io/writer/statistics.rs
@@ -903,6 +903,7 @@ mod tests {
         UInt32Array, UInt64Array, UInt8Array,
     };
     use arrow_select::interleave::interleave;
+    use arrow_shortcuts::macros::arr_schema;
     use num_traits::One;
     use proptest::{prop_assert, prop_assert_eq, strategy::Strategy, test_runner::TestCaseError};
 
@@ -1619,10 +1620,7 @@ mod tests {
         use crate::datatypes::Schema;
 
         // Check the output schema is correct
-        let arrow_schema = ArrowSchema::new(vec![
-            ArrowField::new("a", DataType::Int32, true),
-            ArrowField::new("b", DataType::Utf8, true),
-        ]);
+        let arrow_schema = arr_schema!({a: i32, b: &str});
         let schema = Schema::try_from(&arrow_schema).unwrap();
         let mut collector = StatisticsCollector::new(&schema.fields);
 


### PR DESCRIPTION
I've been mildly annoyed at times with the readability of creating arrow schemas / batches (mostly in unit tests).  For fun, I played around a little with macros to see if I could improve the experience and this is what I came up with.  This can replace code that looks like this:

```
let schema = Schema::new(vec![
    Field::new("x", DataType::UInt8, true),
    Field::new("y", DataType::UInt16, true),
    Field::new("strings", DataType::Utf8, true),
]);
let batch = RecordBatch::try_new(
    Arc::new(schema),
    vec![
        Arc::new(UInt8Array::from_iter(&[Some(1), Some(2), None])),
        Arc::new(UInt16Array::from_iter(&[Some(4), None, Some(5)])),
        Arc::new(StringArray::from_iter(&[None, Some("x"), Some("y")])),
    ],
)
.unwrap();
```

with code that looks like this:

```
let batch = arr_batch!({
    x: [1, 2, ()] as u8,
    y: [4, (), 5] as u16,
    strings: [(), "x", "y"] as &str,
});
```

There are five macros, `arr_type, arr_field, arr_schema, arr_array, arr_batch`.  For more examples of each of these take a look at the unit tests in the `arrow_shortcuts` crate.

This isn't yet complete.  There are a few MVP features I think would be needed (and will be needed if we want to replace existing code):

 * Better support for declaring types as nullable
 * Ability to specify large string / large binary
 * Ability for `arr_array` to create arrays of arrays (e.g. `arr_array!([[1, 2], [3, ()]] as [u32; 2])`

Drafting this at the moment to see if there is any interest before I put more work into finishing it off.