### PR TITLE
fix: row_id range fix for index training on gpu

### DIFF
--- a/python/python/lance/sampler.py
+++ b/python/python/lance/sampler.py
@@ -69,15 +69,15 @@ def _efficient_sample(
     chunk_sample_size = n // max_takes
     for idx, i in enumerate(range(0, total_records, chunk_size)):
         # Add more randomness within each chunk.
-        offset = i + np.random.randint(0, chunk_size - chunk_sample_size)
+        offset = min(total_records - chunk_sample_size, i + np.random.randint(0, chunk_size - chunk_sample_size))
         buf.extend(
             dataset.take(
-                list(range(offset, offset + chunk_sample_size)),
+                list(range(max(i, offset), offset + chunk_sample_size)),
                 columns=columns,
             ).to_batches()
         )
         if idx % 50 == 0:
-            logging.info("Sampled at offset=%s, len=%s", offset, chunk_sample_size)
+            logging.info("Sampled at offset=%s, len=%s", max(i, offset), chunk_sample_size)
         if sum(len(b) for b in buf) >= batch_size:
             tbl = pa.Table.from_batches(buf)
             buf.clear()

--- a/python/python/lance/sampler.py
+++ b/python/python/lance/sampler.py
@@ -67,17 +67,34 @@ def _efficient_sample(
     assert total_records > n
     chunk_size = total_records // max_takes
     chunk_sample_size = n // max_takes
+
+    num_sampled = 0
+
     for idx, i in enumerate(range(0, total_records, chunk_size)):
-        # Add more randomness within each chunk.
-        offset = min(total_records - chunk_sample_size, i + np.random.randint(0, chunk_size - chunk_sample_size))
+        # If we have already sampled enough, break. This can happen if there
+        # is a remainder in the division.
+        if num_sampled >= n:
+            break
+        num_sampled += chunk_sample_size
+
+        # If we are at the last chunk, we may not have enough records to sample.
+        local_size = min(chunk_size, total_records - i)
+        local_sample_size = min(chunk_sample_size, local_size)
+
+        if local_sample_size < local_size:
+            # Add more randomness within each chunk, if there is room.
+            offset = i + np.random.randint(0, local_size - local_sample_size)
+        else:
+            offset = i
+
         buf.extend(
             dataset.take(
-                list(range(max(i, offset), offset + chunk_sample_size)),
+                list(range(offset, offset + local_sample_size)),
                 columns=columns,
             ).to_batches()
         )
         if idx % 50 == 0:
-            logging.info("Sampled at offset=%s, len=%s", max(i, offset), chunk_sample_size)
+            logging.info("Sampled at offset=%s, len=%s", offset, chunk_sample_size)
         if sum(len(b) for b in buf) >= batch_size:
             tbl = pa.Table.from_batches(buf)
             buf.clear()

--- a/python/python/tests/test_sampler.py
+++ b/python/python/tests/test_sampler.py
@@ -14,15 +14,19 @@
 
 from pathlib import Path
 
-import lance
 import numpy as np
 import pyarrow as pa
+import pytest
+
+import lance
 from lance.sampler import maybe_sample
 
 
-def test_sample_dataset(tmp_path: Path):
-    # 10240 of 32-d vectors.
-    data = np.random.random(10240 * 32).astype("f")
+# We use + 97 to test case where num_rows and chunk_size aren't exactly aligned.
+@pytest.mark.parametrize("nrows", [10, 10240, 10240 + 97, 10240 + 1024])
+def test_sample_dataset(tmp_path: Path, nrows: int):
+    # nrows of 32-d vectors.
+    data = np.random.random(nrows * 32).astype("f")
 
     fsl = pa.FixedSizeListArray.from_arrays(data, 32)
     tbl = pa.Table.from_arrays([fsl], ["vec"])
@@ -34,11 +38,11 @@ def test_sample_dataset(tmp_path: Path):
     assert len(simple_scan) == 1
     assert isinstance(simple_scan[0], pa.RecordBatch)
     assert simple_scan[0].schema == pa.schema([pa.field("vec", fsl.type)])
-    assert simple_scan[0].num_rows == 128
+    assert simple_scan[0].num_rows == min(nrows, 128)
 
     # Random path.
     large_scan = list(maybe_sample(ds, 128, ["vec"], max_takes=32))
     assert len(large_scan) == 1
     assert isinstance(large_scan[0], pa.RecordBatch)
     assert large_scan[0].schema == pa.schema([pa.field("vec", fsl.type)])
-    assert large_scan[0].num_rows == 128
+    assert large_scan[0].num_rows == min(nrows, 128)

--- a/python/python/tests/test_sampler.py
+++ b/python/python/tests/test_sampler.py
@@ -14,11 +14,10 @@
 
 from pathlib import Path
 
+import lance
 import numpy as np
 import pyarrow as pa
 import pytest
-
-import lance
 from lance.sampler import maybe_sample
 
 


### PR DESCRIPTION
The original sampling logic may create row_id range that is out of total_record length.
This diff makes sure the row_ids are within the range

Fixes #1662