### PR TITLE
feat: better warnings when the PQ assignment over cosine distance is wrong

### DIFF
--- a/rust/lance-arrow/src/floats.rs
+++ b/rust/lance-arrow/src/floats.rs
@@ -14,6 +14,7 @@
 
 //! Floats Array
 
+use std::fmt::{Debug, Display};
 use std::iter::Sum;
 use std::{
     fmt::Formatter,
@@ -72,8 +73,12 @@ impl TryFrom<&DataType> for FloatType {
 
 /// Trait for float types used in Arrow Array.
 ///
-pub trait ArrowFloatType: std::fmt::Debug {
-    type Native: FromPrimitive + FloatToArrayType<ArrowType = Self> + AsPrimitive<f32>;
+pub trait ArrowFloatType: Debug {
+    type Native: FromPrimitive
+        + FloatToArrayType<ArrowType = Self>
+        + AsPrimitive<f32>
+        + Debug
+        + Display;
 
     const FLOAT_TYPE: FloatType;
 


### PR DESCRIPTION
If a vector or PQ sub-vector are all zeros, the cosine distance will be NaN. which results a failure when assigning PQ code.

Raise more meaningful error message