### PR TITLE
feat: a tensor dataset that shared with the same behavior as Lance torch Dataset

### DIFF
--- a/python/python/lance/torch/data.py
+++ b/python/python/lance/torch/data.py
@@ -19,7 +19,7 @@
 from __future__ import annotations
 
 import math
-from typing import TYPE_CHECKING, Iterable, Optional, Union
+from typing import Iterable, Optional, Union
 
 import numpy as np
 import pyarrow as pa
@@ -28,9 +28,6 @@ from torch.utils.data import Dataset, IterableDataset
 
 from ..cache import CachedDataset
 from ..sampler import maybe_sample
-
-if TYPE_CHECKING:
-    from .. import LanceDataset as Dataset
 
 __all__ = ["LanceDataset"]
 
@@ -74,7 +71,11 @@ def _to_tensor(
 
 
 class TensorDataset(Dataset):
-    """A tensor dataset, returns in batch."""
+    """A PyTorch Dataset that wraps over a tensor, returns in batches.
+
+    Unlike `torch.utils.data.TensorDataset`, this has the same behavior as LanceDataset
+    that it yields tensor in batches.
+    """
 
     def __init__(
         self, data: Union[torch.Tensor, np.ndarray], batch_size: int, *args, **kwargs

--- a/python/python/lance/torch/data.py
+++ b/python/python/lance/torch/data.py
@@ -89,10 +89,12 @@ class TensorDataset(Dataset):
     def __repr__(self):
         return "LanceTensorDataset"
 
-    def __len__(self):
-        return math.ceil(self._data.shape[0])
+    def __len__(self) -> int:
+        return math.ceil(self._data.shape[0] / self._batch_size)
 
     def __getitem__(self, idx: int) -> torch.Tensor:
+        if idx >= len(self):
+            raise StopIteration
         start = idx * self._batch_size
         end = min((idx + 1) * self._batch_size, self._data.shape[0])
         return self._data[start:end, :]

--- a/python/python/lance/torch/data.py
+++ b/python/python/lance/torch/data.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Iterable, Optional, Union
 import numpy as np
 import pyarrow as pa
 import torch
-from torch.utils.data import IterableDataset, Dataset
+from torch.utils.data import Dataset, IterableDataset
 
 from ..cache import CachedDataset
 from ..sampler import maybe_sample

--- a/python/python/lance/torch/kmeans.py
+++ b/python/python/lance/torch/kmeans.py
@@ -23,6 +23,7 @@ from torch.utils.data import IterableDataset
 from tqdm import tqdm
 
 from . import preferred_device
+from .data import TensorDataset
 from .distance import cosine_distance, dot_distance, l2_distance
 
 __all__ = ["KMeans"]
@@ -132,6 +133,7 @@ class KMeans:
         start = time.time()
         if isinstance(data, (np.ndarray, torch.Tensor)):
             self._random_init(data)
+            data = TensorDataset(data, batch_size=4096)
 
         assert self.centroids is not None
         self.centroids = self.centroids.to(self.device)


### PR DESCRIPTION
Provide a TensorDataset that shared the same behavior with `lance.torch.data.LanceDataset`, which returns tensors in batches.

So GPU kmeans can run against to the in memory tensors as well.