### PR TITLE
feat: add option to pass in precomputed row_id -> ivf partiton mapping and compute partiiton on GPU

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1028,9 +1028,17 @@ class LanceDataset(pa.dataset.Dataset):
                 # Use accelerator to train ivf centroids
                 from .vector import train_ivf_centroids_on_accelerator
 
-                ivf_centroids = train_ivf_centroids_on_accelerator(
-                    self, column[0], num_partitions, metric, accelerator
+                ivf_centroids, partitions_file = train_ivf_centroids_on_accelerator(
+                    self,
+                    column[0],
+                    num_partitions,
+                    metric,
+                    accelerator,
+                    assignment_loader_buffer_size=kwargs.get(
+                        "assignment_loader_buffer_size", 10
+                    ),
                 )
+                kwargs["precomputed_partitions_file"] = partitions_file
 
             if ivf_centroids is not None:
                 # User provided IVF centroids

--- a/python/python/lance/torch/data.py
+++ b/python/python/lance/torch/data.py
@@ -112,6 +112,7 @@ class LanceDataset(IterableDataset):
         filter: Optional[str] = None,
         samples: Optional[int] = 0,
         cache: Optional[Union[str, bool]] = None,
+        pin_memory: bool = False,
         with_row_id: bool = False,
         **kwargs,
     ):
@@ -122,6 +123,7 @@ class LanceDataset(IterableDataset):
         self.samples: Optional[int] = samples
         self.filter = filter
         self.with_row_id = with_row_id
+        self.pin_memory = pin_memory
 
         if samples is not None and filter is not None:
             raise ValueError("Does not support sampling over filtered dataset")

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -698,6 +698,10 @@ impl Dataset {
                         let centroids = as_fixed_size_list_array(batch.column(0));
                         ivf_params.centroids = Some(Arc::new(centroids.clone()))
                     };
+
+                    if let Some(f) = kwargs.get_item("precomputed_partitions_file") {
+                        ivf_params.precomputed_partitons_file = Some(f.to_string());
+                    };
                 }
                 Box::new(VectorIndexParams::with_ivf_pq_params(
                     m_type, ivf_params, pq_params,

--- a/rust/lance-index/benches/find_partitions.rs
+++ b/rust/lance-index/benches/find_partitions.rs
@@ -38,7 +38,7 @@ fn bench_partitions(c: &mut Criterion) {
         let matrix = MatrixView::<Float32Type>::new(centroids.clone(), DIMENSION);
 
         for k in &[1, 10, 50] {
-            let ivf = IvfImpl::new(matrix.clone(), MetricType::L2, vec![], None);
+            let ivf = IvfImpl::new(matrix.clone(), MetricType::L2, vec![], None, None);
 
             c.bench_function(format!("IVF{},k={},L2", num_centroids, k).as_str(), |b| {
                 b.iter(|| {
@@ -46,7 +46,7 @@ fn bench_partitions(c: &mut Criterion) {
                 })
             });
 
-            let ivf = IvfImpl::new(matrix.clone(), MetricType::Cosine, vec![], None);
+            let ivf = IvfImpl::new(matrix.clone(), MetricType::Cosine, vec![], None, None);
             c.bench_function(
                 format!("IVF{},k={},Cosine", num_centroids, k).as_str(),
                 |b| {

--- a/rust/lance-index/src/vector/ivf/builder.rs
+++ b/rust/lance-index/src/vector/ivf/builder.rs
@@ -35,6 +35,8 @@ pub struct IvfBuildParams {
     pub centroids: Option<Arc<FixedSizeListArray>>,
 
     pub sample_rate: usize,
+
+    pub precomputed_partitons_file: Option<String>,
 }
 
 impl Default for IvfBuildParams {
@@ -44,6 +46,7 @@ impl Default for IvfBuildParams {
             max_iters: 50,
             centroids: None,
             sample_rate: 256, // See faiss
+            precomputed_partitons_file: None,
         }
     }
 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -85,7 +85,7 @@ pub use write::{write_fragments, WriteMode, WriteParams};
 
 const INDICES_DIR: &str = "_indices";
 
-const DATA_DIR: &str = "data";
+pub const DATA_DIR: &str = "data";
 pub(crate) const DEFAULT_INDEX_CACHE_SIZE: usize = 256;
 pub(crate) const DEFAULT_METADATA_CACHE_SIZE: usize = 256;
 


### PR DESCRIPTION
This PR allows caller to pass in a precomputed `row_id -> ivf_partition` mapping. This is very helpful when the number of IVF is large and we want to rely on external mechanisms like GPU or distributed compute for computing these partitions.

Baseline:
```
[2023-12-04T18:03:19Z INFO  lance::index::vector::ivf::builder] IVF shuffler built
[2023-12-04T18:14:27Z INFO  lance::index::vector::ivf] Built IVF partitions: 722.0641s
```

This PR: (building partitons on GPU took 10 seconds)
```
[2023-12-04T17:36:55Z INFO  lance::index::vector::ivf] Loading precomputed partitions from file: 3ac9988f-74e6-4329-bedd-abf93a76c9e8.lance
[2023-12-04T17:36:55Z INFO  lance::index::vector::ivf] Loaded 10000000 rows of precomputed partitions
[2023-12-04T17:36:55Z INFO  lance::index::vector::ivf::builder] Building IVF shuffler
[2023-12-04T17:37:23Z INFO  lance::index::vector::ivf::builder] IVF shuffler built
[2023-12-04T17:47:04Z INFO  lance::index::vector::ivf] Built IVF partitions: 608.89886s
```