### PR TITLE
feat: add support for new and deleted data to scalar indices

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -823,14 +823,6 @@ class LanceDataset(pa.dataset.Dataset):
                 "category",
                 "BTREE",
             )
-
-        Experimental Status:
-
-        Scalar indices are experimental and only utilized if there is no new or deleted
-        data that has been uploaded since the index was created.  This limitation should
-        be addressed soon.  In the meantime, ``compact_files`` can be used to remove
-        deletion files and ``optimize_indices`` can be used to catch up the index with
-        new data.
         """
         if isinstance(column, str):
             column = [column]

--- a/python/python/tests/torch_tests/test_bench_utils.py
+++ b/python/python/tests/torch_tests/test_bench_utils.py
@@ -17,9 +17,11 @@ from pathlib import Path
 import lance
 import numpy as np
 import pyarrow as pa
-import torch
-from lance.torch.bench_utils import ground_truth, sort_tensors
-from lance.torch.distance import pairwise_l2
+import pytest
+
+torch = pytest.importorskip("torch")
+from lance.torch.bench_utils import ground_truth, sort_tensors  # noqa: E402
+from lance.torch.distance import pairwise_l2  # noqa: E402
 
 
 def test_sort_tensor():

--- a/python/python/tests/torch_tests/test_data.py
+++ b/python/python/tests/torch_tests/test_data.py
@@ -17,8 +17,10 @@ import shutil
 import lance
 import numpy as np
 import pyarrow as pa
-import torch
-from lance.torch.data import LanceDataset
+import pytest
+
+torch = pytest.importorskip("torch")
+from lance.torch.data import LanceDataset  # noqa: E402
 
 
 def test_iter_over_dataset(tmp_path):

--- a/rust/lance-core/src/utils/mask.rs
+++ b/rust/lance-core/src/utils/mask.rs
@@ -117,6 +117,9 @@ impl RowIdMask {
 
     /// Also block the given ids
     pub fn also_block(self, block_list: RowIdTreeMap) -> Self {
+        if block_list.is_empty() {
+            return self;
+        }
         if let Some(existing) = self.block_list {
             Self {
                 block_list: Some(existing | block_list),
@@ -290,6 +293,10 @@ impl RowIdTreeMap {
     /// Create an empty set
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
     }
 
     /// Add a bitmap for a single fragment

--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -256,6 +256,23 @@ impl ScalarIndexExpr {
             }
         }
     }
+
+    pub fn to_expr(&self) -> Expr {
+        match self {
+            Self::Not(inner) => Expr::Not(inner.to_expr().into()),
+            Self::And(lhs, rhs) => {
+                let lhs = lhs.to_expr();
+                let rhs = rhs.to_expr();
+                lhs.and(rhs)
+            }
+            Self::Or(lhs, rhs) => {
+                let lhs = lhs.to_expr();
+                let rhs = rhs.to_expr();
+                lhs.or(rhs)
+            }
+            Self::Query(column, query) => query.to_expr(column.clone()),
+        }
+    }
 }
 
 // Extract a column from the expression, if it is a column, or None

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -595,15 +595,6 @@ impl Scanner {
         }
     }
 
-    fn need_to_handle_delete_files(&self) -> bool {
-        let fragments = if let Some(fragments) = self.fragments.as_ref() {
-            fragments
-        } else {
-            self.dataset.fragments()
-        };
-        fragments.iter().any(|frag| frag.deletion_file.is_some())
-    }
-
     /// Create [`ExecutionPlan`] for Scan.
     ///
     /// An ExecutionPlan is a graph of operators that can be executed.
@@ -650,12 +641,9 @@ impl Scanner {
     /// 4. Limit / Offset
     /// 5. Take remaining columns / Projection
     async fn create_plan(&self) -> Result<Arc<dyn ExecutionPlan>> {
-        // TODO: Currently, if any of the fragments have a deletion file, we
-        // cannot use scalar indices.  This is fixable, but deferring for a
-        // future PR.
-        //
-        // Also, we do not use scalar indices if there is a post-filter.
-        let use_scalar_index = self.prefilter && !self.need_to_handle_delete_files();
+        // Scalar indices are only used when prefiltering
+        // TODO: Should we use them when postfiltering if there is no vector search?
+        let use_scalar_index = self.prefilter;
 
         // NOTE: we only support node that have one partition. So any nodes that
         // produce multiple need to be repartitioned to 1.
@@ -665,29 +653,22 @@ impl Scanner {
             let filter_plan =
                 planner.create_filter_plan(filter.clone(), &index_info, use_scalar_index)?;
 
-            // TODO: Remove this check once we handle indexed scans with new data
-            // This check is testing to see if we have an indexed query and new data
-            // and, if we do, falling back to a filter plan that does not use scalar indices
-            if let Some(index_query) = filter_plan.index_query.as_ref() {
-                let covered_frags = self.fragments_covered_by_index_query(index_query).await?;
+            // This tests if any of the fragments are missing the physical_rows property (old style)
+            // If they are then we cannot use scalar indices
+            if filter_plan.index_query.is_some() {
                 let fragments = if let Some(fragments) = self.fragments.as_ref() {
                     fragments
                 } else {
                     self.dataset.fragments()
                 };
-                let mut has_new_data = false;
                 let mut has_missing_row_count = false;
                 for frag in fragments {
-                    if !covered_frags.contains(frag.id as u32) {
-                        has_new_data = true;
-                        break;
-                    }
                     if frag.physical_rows.is_none() {
                         has_missing_row_count = true;
                         break;
                     }
                 }
-                if has_new_data || has_missing_row_count {
+                if has_missing_row_count {
                     // We need row counts to use scalar indices.  If we don't have them then
                     // fallback to a non-indexed filter
                     planner.create_filter_plan(filter.clone(), &index_info, false)?
@@ -1027,29 +1008,67 @@ impl Scanner {
             }
         }
 
-        if !missing_frags.is_empty() {
-            // TODO: If there is new data then we need this:
-            //
-            // MaterializeIndexExec(old_frags) -> Take -> Union
-            // Scan(new_frags) -> Filter -> Project    -|
-            //
-            // The project is to drop any columns we had to include
-            // in the full scan merely for the sake of fulfilling the
-            // filter (there may not be any and project can be skipped).
-            //
-            // This is TODO because we need to go from:
-            //   ScalarIndexExpr -> Expr -> PhysicalExpr
-            // which is doable but complex enough to defer to a future PR.
-            panic!("Indexed scans including new data not yet supported (and we should not be able to reach this point)");
-        }
-
         let plan = Arc::new(MaterializeIndexExec::new(
             self.dataset.clone(),
             index_expr.clone(),
             Arc::new(relevant_frags),
         ));
 
-        self.take(plan, projection, self.batch_readahead)
+        let taken = self.take(plan, projection, self.batch_readahead)?;
+
+        let new_data_path: Option<Arc<dyn ExecutionPlan>> = if !missing_frags.is_empty() {
+            // If there is new data then we need this:
+            //
+            // MaterializeIndexExec(old_frags) -> Take -> Union
+            // Scan(new_frags) -> Filter -> Project    -|
+            //
+            // The project is to drop any columns we had to include
+            // in the full scan merely for the sake of fulfilling the
+            // filter.
+            //
+            // If there were no extra columns then we still need the project
+            // because Materialize -> Take puts the row id at the left and
+            // Scan puts the row id at the right
+            let filter_expr = index_expr.to_expr();
+            let filter_cols = Planner::column_names_in_expr(&filter_expr);
+            let full_schema = self
+                .calc_new_fields(projection, &filter_cols)?
+                .map(|filter_only_schema| projection.merge(&filter_only_schema))
+                .transpose()?;
+            let schema = full_schema.as_ref().unwrap_or(projection);
+
+            let planner = Planner::new(Arc::new(schema.into()));
+            let optimized_filter = planner.optimize_expr(filter_expr)?;
+            let physical_refine_expr = planner.create_physical_expr(&optimized_filter)?;
+
+            let new_data_scan = self.scan_fragments(
+                true,
+                false,
+                Arc::new(schema.clone()),
+                missing_frags.into(),
+                false,
+            );
+            let filtered = Arc::new(FilterExec::try_new(physical_refine_expr, new_data_scan)?);
+            let projection = Schema::try_from(taken.schema().as_ref())?;
+            Some(Arc::new(ProjectionExec::try_new(
+                filtered,
+                projection.into(),
+            )?))
+        } else {
+            None
+        };
+
+        if let Some(new_data_path) = new_data_path {
+            let unioned = UnionExec::new(vec![taken, new_data_path]);
+            // Enforce only 1 partition.
+            let unioned = RepartitionExec::try_new(
+                Arc::new(unioned),
+                datafusion::physical_plan::Partitioning::RoundRobinBatch(1),
+            )?;
+            Ok(Arc::new(unioned))
+        } else {
+            Ok(taken)
+        }
     }
 
     /// Create an Execution plan with a scan node
@@ -3173,11 +3192,8 @@ mod test {
                     params,
                 )
                 .await;
-            // TODO: Remove below check once we support new data in scalar index scan
-            if !params.use_new_data && !params.use_deleted_data {
-                // Materialization is always required if there is a refine
-                assert!(query_plan.contains("MaterializeIndex"));
-            }
+            // Materialization is always required if there is a refine
+            assert!(query_plan.contains("MaterializeIndex"));
             // The result should not include the sample query
             self.assert_none(
                 &batch,
@@ -3206,15 +3222,13 @@ mod test {
             let (query_plan, batch) = self
                 .run_query("indexed != 50", Some(self.sample_query()), params)
                 .await;
-            // TODO: Remove below check once we support new data in scalar index scan
-            if !params.use_new_data && !params.use_deleted_data {
-                if params.use_index {
-                    // An ANN search whose prefilter is fully satisfied by the index should be
-                    // able to use a ScalarIndexQuery
-                    assert!(query_plan.contains("ScalarIndexQuery"));
-                } else {
-                    assert!(query_plan.contains("MaterializeIndex"));
-                }
+            if params.use_index {
+                // An ANN search whose prefilter is fully satisfied by the index should be
+                // able to use a ScalarIndexQuery
+                assert!(query_plan.contains("ScalarIndexQuery"));
+            } else {
+                // A KNN search requires materialization of the index
+                assert!(query_plan.contains("MaterializeIndex"));
             }
             // The result should not include the sample query
             self.assert_none(
@@ -3254,11 +3268,8 @@ mod test {
 
         async fn check_simple_indexed_only(&self, params: &ScalarTestParams) {
             let (query_plan, batch) = self.run_query("indexed != 50", None, params).await;
-            // TODO: Remove below check once we support new data in scalar index scan
-            if !params.use_new_data && !params.use_deleted_data {
-                // Materialization is always required for non-vector search
-                assert!(query_plan.contains("MaterializeIndex"));
-            }
+            // Materialization is always required for non-vector search
+            assert!(query_plan.contains("MaterializeIndex"));
             // The result should not include the targeted row
             self.assert_none(
                 &batch,
@@ -3294,11 +3305,8 @@ mod test {
                 None,
                 params
             ).await;
-            // TODO: Remove below check once we support new data in scalar index scan
-            if !params.use_new_data && !params.use_deleted_data {
-                // Materialization is always required for non-vector search
-                assert!(query_plan.contains("MaterializeIndex"));
-            }
+            // Materialization is always required for non-vector search
+            assert!(query_plan.contains("MaterializeIndex"));
             // The result should not include the targeted row
             self.assert_none(
                 &batch,

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -18,20 +18,24 @@
 //! row ids can be excluded from the search.
 
 use std::cell::OnceCell;
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 
 use async_trait::async_trait;
-use futures::future;
+use futures::future::BoxFuture;
 use futures::stream;
+use futures::FutureExt;
 use futures::StreamExt;
+use futures::TryStreamExt;
+use lance_core::format::Fragment;
 use lance_core::utils::mask::RowIdMask;
 use lance_core::utils::mask::RowIdTreeMap;
 use roaring::RoaringBitmap;
 use tracing::instrument;
 use tracing::Instrument;
 
+use crate::dataset::fragment::FileFragment;
 use crate::error::Result;
 use crate::format::Index;
 use crate::utils::future::SharedPrerequisite;
@@ -59,30 +63,16 @@ pub struct PreFilter {
 
 impl PreFilter {
     pub fn new(dataset: Arc<Dataset>, index: Index, filter: Option<Box<dyn FilterLoader>>) -> Self {
-        let dataset_ref = dataset.as_ref();
-        let mut has_fragment = Vec::new();
-        let mut has_deletion_vectors = false;
-        has_fragment.resize(
-            (dataset
-                .manifest
-                .max_fragment_id()
-                .map(|id| id + 1)
-                .unwrap_or(0)) as usize,
-            false,
-        );
-        for frag in dataset_ref.manifest.fragments.iter() {
-            has_fragment[frag.id as usize] = true;
-            has_deletion_vectors |= frag.deletion_file.is_some();
-        }
-        let has_missing_fragments = has_fragment.iter().any(|&x| !x);
-        let dataset_clone = dataset.clone();
-        let deleted_ids = if has_missing_fragments || has_deletion_vectors {
-            Some(SharedPrerequisite::spawn(
-                Self::load_deleted_ids(dataset_clone, index.fragment_bitmap).in_current_span(),
-            ))
-        } else {
-            None
-        };
+        let fragments = index.fragment_bitmap.unwrap_or_else(|| {
+            // If the index doesn't have a fragment bitmap then we don't know which fragments were covered
+            // by the index so we have to be very conservative and figure that any fragment that has ever
+            // been deleted might be part of the index
+            let mut bitmap = RoaringBitmap::new();
+            bitmap.insert_range(0..dataset.manifest.max_fragment_id);
+            bitmap
+        });
+        let deleted_ids = Self::create_deletion_mask(dataset.clone(), fragments)
+            .map(|deletion_mask_task| SharedPrerequisite::spawn(deletion_mask_task));
         let filtered_ids = filter
             .map(|filtered_ids| SharedPrerequisite::spawn(filtered_ids.load().in_current_span()));
         Self {
@@ -106,49 +96,79 @@ impl PreFilter {
     }
 
     #[instrument(level = "debug", skip_all)]
-    pub async fn load_deleted_ids(
+    async fn do_create_deletion_mask(
         dataset: Arc<Dataset>,
-        fragment_bitmap: Option<RoaringBitmap>,
+        missing_frags: Vec<u32>,
+        frags_with_deletion_files: Vec<u32>,
     ) -> Result<Arc<RowIdTreeMap>> {
         let fragments = dataset.get_fragments();
-        let frag_id_deletion_vectors = stream::iter(fragments.iter())
-            .map(|frag| async move {
-                let id = frag.id() as u32;
-                let deletion_vector = frag.get_deletion_vector().await;
-                (id, deletion_vector)
-            })
-            .collect::<Vec<_>>()
-            .await;
-        let mut frag_id_deletion_vectors = stream::iter(frag_id_deletion_vectors)
-            .buffer_unordered(num_cpus::get())
-            .filter_map(|(id, maybe_deletion_vector)| {
-                let val = if let Ok(deletion_vector) = maybe_deletion_vector {
-                    deletion_vector.map(|deletion_vector| {
-                        Ok((id, RoaringBitmap::from(deletion_vector.as_ref())))
-                    })
-                } else {
-                    Some(Err(maybe_deletion_vector.unwrap_err()))
-                };
-                future::ready(val)
-            });
+        let frag_map: Arc<HashMap<u32, &FileFragment>> = Arc::new(HashMap::from_iter(
+            fragments.iter().map(|frag| (frag.id() as u32, frag)),
+        ));
+        let frag_id_deletion_vectors = stream::iter(
+            frags_with_deletion_files
+                .iter()
+                .map(|frag_id| (frag_id, frag_map.clone())),
+        )
+        .map(|(frag_id, frag_map)| async move {
+            let frag = frag_map.get(&frag_id).unwrap();
+            frag.get_deletion_vector()
+                .await
+                .transpose()
+                .unwrap()
+                .map(|deletion_vector| (*frag_id, RoaringBitmap::from(deletion_vector.as_ref())))
+        })
+        .collect::<Vec<_>>()
+        .await;
+        let mut frag_id_deletion_vectors =
+            stream::iter(frag_id_deletion_vectors).buffer_unordered(num_cpus::get());
 
         let mut deleted_ids = RowIdTreeMap::new();
-        while let Some(res) = frag_id_deletion_vectors.next().await {
-            let (id, deletion_vector) = res?;
+        while let Some((id, deletion_vector)) = frag_id_deletion_vectors.try_next().await? {
             deleted_ids.insert_bitmap(id, deletion_vector);
         }
 
-        let frag_ids_in_dataset: HashSet<u32> =
-            HashSet::from_iter(fragments.iter().map(|frag| frag.id() as u32));
-        if let Some(fragment_bitmap) = fragment_bitmap {
-            for frag_id in fragment_bitmap.into_iter() {
-                if !frag_ids_in_dataset.contains(&frag_id) {
-                    // Entire fragment has been deleted
-                    deleted_ids.insert_fragment(frag_id);
-                }
-            }
+        for frag_id in missing_frags.into_iter() {
+            deleted_ids.insert_fragment(frag_id);
         }
         Ok(Arc::new(deleted_ids))
+    }
+
+    /// Creates a task to load deleted row ids in `fragments`
+    ///
+    /// If it can be synchronously determined that there are no missing row ids then
+    /// this function return None
+    pub fn create_deletion_mask(
+        dataset: Arc<Dataset>,
+        fragments: RoaringBitmap,
+    ) -> Option<BoxFuture<'static, Result<Arc<RowIdTreeMap>>>> {
+        let mut missing_frags = Vec::new();
+        let mut frags_with_deletion_files = Vec::new();
+        let frag_map: HashMap<u32, &Fragment> = HashMap::from_iter(
+            dataset
+                .manifest
+                .fragments
+                .iter()
+                .map(|frag| (frag.id as u32, frag)),
+        );
+        for frag_id in fragments.iter() {
+            let frag = frag_map.get(&frag_id);
+            if let Some(frag) = frag {
+                if frag.deletion_file.is_some() {
+                    frags_with_deletion_files.push(frag_id);
+                }
+            } else {
+                missing_frags.push(frag_id);
+            }
+        }
+        if missing_frags.is_empty() && frags_with_deletion_files.is_empty() {
+            None
+        } else {
+            Some(
+                Self::do_create_deletion_mask(dataset, missing_frags, frags_with_deletion_files)
+                    .boxed(),
+            )
+        }
     }
 
     /// Waits for the prefilter to be fully loaded

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -71,8 +71,8 @@ impl PreFilter {
             bitmap.insert_range(0..dataset.manifest.max_fragment_id);
             bitmap
         });
-        let deleted_ids = Self::create_deletion_mask(dataset.clone(), fragments)
-            .map(|deletion_mask_task| SharedPrerequisite::spawn(deletion_mask_task));
+        let deleted_ids =
+            Self::create_deletion_mask(dataset.clone(), fragments).map(SharedPrerequisite::spawn);
         let filtered_ids = filter
             .map(|filtered_ids| SharedPrerequisite::spawn(filtered_ids.load().in_current_span()));
         Self {
@@ -111,7 +111,7 @@ impl PreFilter {
                 .map(|frag_id| (frag_id, frag_map.clone())),
         )
         .map(|(frag_id, frag_map)| async move {
-            let frag = frag_map.get(&frag_id).unwrap();
+            let frag = frag_map.get(frag_id).unwrap();
             frag.get_deletion_vector()
                 .await
                 .transpose()

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -30,10 +30,14 @@ use lance_index::scalar::{
     ScalarIndex,
 };
 use pin_project::pin_project;
+use roaring::RoaringBitmap;
 use snafu::{location, Location};
 use tracing::instrument;
 
-use crate::{index::DatasetIndexInternalExt, Dataset};
+use crate::{
+    index::{prefilter::PreFilter, DatasetIndexInternalExt},
+    Dataset,
+};
 
 lazy_static::lazy_static! {
     pub static ref SCALAR_INDEX_SCHEMA: SchemaRef = Arc::new(Schema::new(vec![Field::new("result".to_string(), DataType::Binary, true)]));
@@ -251,7 +255,14 @@ impl MaterializeIndexExec {
         fragments: Arc<Vec<Fragment>>,
     ) -> Result<RecordBatch> {
         // TODO: multiple batches, stream without materializing all row ids in memory
-        let mask = expr.evaluate(dataset.as_ref()).await?;
+        let mask = expr.evaluate(dataset.as_ref());
+        let fragment_bitmap = RoaringBitmap::from_iter(fragments.iter().map(|frag| frag.id as u32));
+        // The user-requested `fragments` is guaranteed to be stricter than the index's fragment
+        // bitmap.  This node only runs on indexed fragments and any fragments that were deleted
+        // when the index was trained will still be deleted when the index is queried.
+        let prefilter = PreFilter::load_deleted_ids(dataset.clone(), Some(fragment_bitmap));
+        let (mut mask, prefilter) = futures::try_join!(mask, prefilter)?;
+        mask = mask.also_block((*prefilter).clone());
         let ids = match (mask.allow_list, mask.block_list) {
             (None, None) => FragIdIter::new(fragments).collect::<Vec<_>>(),
             (Some(allow_list), None) => FragIdIter::new(fragments)


### PR DESCRIPTION
When we are doing a `ScalarIndexQuery` we do not need to worry about new and deleted data because the ANN search already handles deletion and won't run on new data.

When we are doing an indexed scan then we do need to worry about this.

For new data we do:

```
# indexed fragments
MATERIALIZE_INDEX -> TAKE -> UNION
# new fragments
SCAN -> FILTER -> PROJECT -> UNION
```

To handle deleted data we load the deletion vectors as part of the materialize index node.