### PR TITLE
fix: add shutdown to async loader

### DIFF
--- a/python/python/lance/torch/async_dataset.py
+++ b/python/python/lance/torch/async_dataset.py
@@ -1,5 +1,6 @@
-from multiprocessing import Process, Queue
-from typing import Callable
+import contextlib
+from multiprocessing import Process, Queue, Value
+from typing import Callable, Iterable
 
 from torch.utils.data import IterableDataset
 
@@ -7,14 +8,23 @@ from torch.utils.data import IterableDataset
 def _worker_ep(
     dataset_creator: Callable[[], IterableDataset],
     queue: Queue,
+    shutdown: Value,
 ):
     dataset = dataset_creator()
-    while True:
+    while not shutdown.value:
         for item in dataset:
             queue.put(item)
         queue.put(None)
 
+    # put one last None so that the iterator knows to stop
+    queue.put(None)
 
+
+# This class is similar to torch.utils.data.Dataloader
+# except for a few things:
+# 1. We only use 1 worker
+# 2. The worker process is the same one after each complete iteration.
+#    This helps when dataset contains internal state like caching.
 class AsyncDataset(IterableDataset):
     def __init__(
         self,
@@ -26,16 +36,40 @@ class AsyncDataset(IterableDataset):
         self.queue = Queue(maxsize=queue_size)
         self.started = False
 
+        self.shutdown = Value("b", False)
+
     def _start(self):
         if self.started:
             return
         self.started = True
         self.worker = Process(
             target=_worker_ep,
-            args=(self.dataset_creator, self.queue),
-        ).start()
+            args=(self.dataset_creator, self.queue, self.shutdown),
+        )
+        self.worker.start()
 
     def __iter__(self):
         self._start()
         while (val := self.queue.get()) is not None:
             yield val
+
+    def close(self):
+        self.shutdown.value = True
+        for _ in self:
+            pass
+        self.queue.close()
+        self.worker.join()
+        self.worker.close()
+
+
+@contextlib.contextmanager
+def async_dataset(
+    dataset_creator: Callable[[], IterableDataset],
+    *,
+    queue_size: int = 4,
+) -> Iterable[AsyncDataset]:
+    try:
+        ds = AsyncDataset(dataset_creator, queue_size=queue_size)
+        yield ds
+    finally:
+        ds.close()


### PR DESCRIPTION
The loader didn't exit and was block script completion. This PR adds a context manager that ensures the async worker is closed.

Also added some comments about the difference