### PR TITLE
fix: prevent stats meta from breaking old readers

### DIFF
--- a/protos/format.proto
+++ b/protos/format.proto
@@ -233,6 +233,10 @@ message DeletionFile {
 
 // Metadata of one Lance file.
 message Metadata {
+  // 4 was used for StatisticsMetadata in the past, but has been moved to prevent
+  // a bug in older readers.
+  reserved 4;
+
   // Position of the manifest in the file. If it is zero, the manifest is stored
   // externally.
   uint64 manifest_position = 1;
@@ -288,7 +292,7 @@ message Metadata {
 	  uint64 page_table_position = 3;
   }
 
-  StatisticsMetadata statistics = 4;
+  StatisticsMetadata statistics = 5;
 } // Metadata
 
 // Supported encodings.


### PR DESCRIPTION
Older readers have a bug where they will read past the end of the file when reading the statistics metadata. Those older readers were before statistics were even used, so we don't care about them working. This commit moves the proto field so that only newer readers will pick it up.

Closes #1697