### PR TITLE
chore: update arrow (to `48.0`) and datafusion (to `33.0`)

### DIFF
--- a/integration/duckdb_lance/Cargo.toml
+++ b/integration/duckdb_lance/Cargo.toml
@@ -8,8 +8,8 @@ lance = { path = "../../rust/lance" }
 duckdb-ext = { path = "./duckdb-ext" }
 lazy_static = "1.4.0"
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
-arrow-schema = "47.0.0"
-arrow-array = "47.0.0"
+arrow-schema = "48.0.0"
+arrow-array = "48.0.0"
 futures = "0.3"
 num-traits = "0.2"
 

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -11,10 +11,10 @@ name = "lance"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow = { version = "47.0.0", features = ["pyarrow"] }
-arrow-array = "47.0"
-arrow-data = "47.0"
-arrow-schema = "47.0"
+arrow = { version = "48.0.0", features = ["pyarrow"] }
+arrow-array = "48.0"
+arrow-data = "48.0"
+arrow-schema = "48.0"
 object_store = "0.7.1"
 async-trait = "0.1"
 chrono = "0.4.31"
@@ -30,7 +30,7 @@ lance-linalg = { path = "../rust/lance-linalg" }
 lazy_static = "1"
 log = "0.4"
 prost = "0.12"
-pyo3 = { version = "0.19", features = ["extension-module", "abi3-py38"] }
+pyo3 = { version = "0.20", features = ["extension-module", "abi3-py38"] }
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 uuid = "1.3.0"
 serde_json = "1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -47,17 +47,17 @@ lance-test-macros = { version = "=0.8.19", path = "./lance-test-macros" }
 lance-testing = { version = "=0.8.19", path = "./lance-testing" }
 approx = "0.5.1"
 # Note that this one does not include pyarrow
-arrow = { version = "47.0.0", optional = false }
-arrow-arith = "47.0"
-arrow-array = "47.0"
-arrow-buffer = "47.0"
-arrow-cast = "47.0"
-arrow-data = "47.0"
-arrow-ipc = { version = "47.0", features = ["zstd"] }
-arrow-ord = "47.0"
-arrow-row = "47.0"
-arrow-schema = "47.0"
-arrow-select = "47.0"
+arrow = { version = "48.0.0", optional = false }
+arrow-arith = "48.0"
+arrow-array = "48.0"
+arrow-buffer = "48.0"
+arrow-cast = "48.0"
+arrow-data = "48.0"
+arrow-ipc = { version = "48.0", features = ["zstd"] }
+arrow-ord = "48.0"
+arrow-row = "48.0"
+arrow-schema = "48.0"
+arrow-select = "48.0"
 async-recursion = "1.0"
 async-trait = "0.1"
 aws-config = "0.56"
@@ -71,13 +71,13 @@ bytes = "1.4"
 byteorder = "1.5"
 chrono = "0.4.23"
 criterion = { version = "0.5", features = ["async", "async_tokio"] }
-datafusion = { version = "32.0.0", default-features = false, features = [
+datafusion = { version = "33.0.0", default-features = false, features = [
     "regex_expressions",
 ] }
-datafusion-common = "32.0"
-datafusion-sql = "32.0"
-datafusion-expr = "32.0"
-datafusion-physical-expr = { version = "32.0.0", default-features = false }
+datafusion-common = "33.0"
+datafusion-sql = "33.0"
+datafusion-expr = "33.0"
+datafusion-physical-expr = { version = "33.0.0", default-features = false }
 either = "1.0"
 futures = "0.3"
 http = "0.2.9"
@@ -89,7 +89,7 @@ nohash-hasher = { version = "0.2.0" }
 num_cpus = "1.0"
 num-traits = "0.2"
 object_store = { version = "0.7.1", features = ["aws", "gcp", "azure"] }
-parquet = "47.0"
+parquet = "48.0"
 pin-project = "1.0"
 pprof = { version = "0.13", features = ["flamegraph", "criterion"] }
 prost = "0.12"

--- a/rust/lance-core/Cargo.toml
+++ b/rust/lance-core/Cargo.toml
@@ -55,7 +55,7 @@ url.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-arrow = "47.0"
+arrow = "48.0"
 rand.workspace = true
 tempfile.workspace = true
 lance-testing.workspace = true

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -175,8 +175,17 @@ impl ExecutionPlan for OneShotExec {
         }
     }
 
-    fn statistics(&self) -> datafusion_common::Statistics {
-        todo!()
+    fn statistics(&self) -> datafusion_common::Result<datafusion_common::Statistics> {
+        // Statistics are loaded irrespective of whether they are requested or
+        // not, so, we need to return an Ok response here.
+        //
+        // This is a bug in DF and should be fixed upstream.
+        //
+        // See: https://github.com/apache/arrow-datafusion/blob/93b21bdcd3d465ed78b610b54edf1418a47fc497/datafusion/physical-plan/src/display.rs#L263-L266
+
+        Ok(datafusion::physical_plan::Statistics::new_unknown(
+            self.schema().as_ref(),
+        ))
     }
 }
 

--- a/rust/lance-datafusion/src/expr.rs
+++ b/rust/lance-datafusion/src/expr.rs
@@ -14,266 +14,252 @@
 
 //! Utilities for working with datafusion expressions
 
+use arrow_array::ListArray;
 use arrow_schema::DataType;
-use datafusion_common::ScalarValue;
+use datafusion_common::{Result, ScalarValue};
 
 // This is slightly tedious but when we convert expressions from SQL strings to logical
 // datafusion expressions there is no type coercion that happens.  In other words "x = 7"
 // will always yield "x = 7_u64" regardless of the type of the column "x".  As a result, we
 // need to do that literal coercion ourselves.
-pub fn safe_coerce_scalar(value: &ScalarValue, ty: &DataType) -> Option<ScalarValue> {
-    match value {
-        ScalarValue::Int8(val) => match ty {
-            DataType::Int8 => Some(value.clone()),
-            DataType::Int16 => val.map(|v| ScalarValue::Int16(Some(i16::from(v)))),
-            DataType::Int32 => val.map(|v| ScalarValue::Int32(Some(i32::from(v)))),
-            DataType::Int64 => val.map(|v| ScalarValue::Int64(Some(i64::from(v)))),
-            DataType::UInt8 => {
-                val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
-            }
-            DataType::UInt16 => {
-                val.and_then(|v| u16::try_from(v).map(|v| ScalarValue::UInt16(Some(v))).ok())
-            }
-            DataType::UInt32 => {
-                val.and_then(|v| u32::try_from(v).map(|v| ScalarValue::UInt32(Some(v))).ok())
-            }
-            DataType::UInt64 => {
-                val.and_then(|v| u64::try_from(v).map(|v| ScalarValue::UInt64(Some(v))).ok())
-            }
-            DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(f32::from(v)))),
-            DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(f64::from(v)))),
-            _ => None,
-        },
-        ScalarValue::Int16(val) => match ty {
-            DataType::Int8 => {
-                val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
-            }
-            DataType::Int16 => Some(value.clone()),
-            DataType::Int32 => val.map(|v| ScalarValue::Int32(Some(i32::from(v)))),
-            DataType::Int64 => val.map(|v| ScalarValue::Int64(Some(i64::from(v)))),
-            DataType::UInt8 => {
-                val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
-            }
-            DataType::UInt16 => {
-                val.and_then(|v| u16::try_from(v).map(|v| ScalarValue::UInt16(Some(v))).ok())
-            }
-            DataType::UInt32 => {
-                val.and_then(|v| u32::try_from(v).map(|v| ScalarValue::UInt32(Some(v))).ok())
-            }
-            DataType::UInt64 => {
-                val.and_then(|v| u64::try_from(v).map(|v| ScalarValue::UInt64(Some(v))).ok())
-            }
-            DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(f32::from(v)))),
-            DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(f64::from(v)))),
-            _ => None,
-        },
-        ScalarValue::Int32(val) => match ty {
-            DataType::Int8 => {
-                val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
-            }
-            DataType::Int16 => {
-                val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
-            }
-            DataType::Int32 => Some(value.clone()),
-            DataType::Int64 => val.map(|v| ScalarValue::Int64(Some(i64::from(v)))),
-            DataType::UInt8 => {
-                val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
-            }
-            DataType::UInt16 => {
-                val.and_then(|v| u16::try_from(v).map(|v| ScalarValue::UInt16(Some(v))).ok())
-            }
-            DataType::UInt32 => {
-                val.and_then(|v| u32::try_from(v).map(|v| ScalarValue::UInt32(Some(v))).ok())
-            }
-            DataType::UInt64 => {
-                val.and_then(|v| u64::try_from(v).map(|v| ScalarValue::UInt64(Some(v))).ok())
-            }
-            // These conversions are inherently lossy as the full range of i32 cannot
-            // be represented in f32.  However, there is no f32::TryFrom(i32) and its not
-            // clear users would want that anyways
-            DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(v as f32))),
-            DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(v as f64))),
-            _ => None,
-        },
-        ScalarValue::Int64(val) => match ty {
-            DataType::Int8 => {
-                val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
-            }
-            DataType::Int16 => {
-                val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
-            }
-            DataType::Int32 => {
-                val.and_then(|v| i32::try_from(v).map(|v| ScalarValue::Int32(Some(v))).ok())
-            }
-            DataType::Int64 => Some(value.clone()),
-            DataType::UInt8 => {
-                val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
-            }
-            DataType::UInt16 => {
-                val.and_then(|v| u16::try_from(v).map(|v| ScalarValue::UInt16(Some(v))).ok())
-            }
-            DataType::UInt32 => {
-                val.and_then(|v| u32::try_from(v).map(|v| ScalarValue::UInt32(Some(v))).ok())
-            }
-            DataType::UInt64 => {
-                val.and_then(|v| u64::try_from(v).map(|v| ScalarValue::UInt64(Some(v))).ok())
-            }
-            // See above warning about lossy float conversion
-            DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(v as f32))),
-            DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(v as f64))),
-            _ => None,
-        },
-        ScalarValue::UInt8(val) => match ty {
-            DataType::Int8 => {
-                val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
-            }
-            DataType::Int16 => {
-                val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
-            }
-            DataType::Int32 => {
-                val.and_then(|v| i32::try_from(v).map(|v| ScalarValue::Int32(Some(v))).ok())
-            }
-            DataType::Int64 => {
-                val.and_then(|v| i64::try_from(v).map(|v| ScalarValue::Int64(Some(v))).ok())
-            }
-            DataType::UInt8 => Some(value.clone()),
-            DataType::UInt16 => val.map(|v| ScalarValue::UInt16(Some(u16::from(v)))),
-            DataType::UInt32 => val.map(|v| ScalarValue::UInt32(Some(u32::from(v)))),
-            DataType::UInt64 => val.map(|v| ScalarValue::UInt64(Some(u64::from(v)))),
-            DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(f32::from(v)))),
-            DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(f64::from(v)))),
-            _ => None,
-        },
-        ScalarValue::UInt16(val) => match ty {
-            DataType::Int8 => {
-                val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
-            }
-            DataType::Int16 => {
-                val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
-            }
-            DataType::Int32 => {
-                val.and_then(|v| i32::try_from(v).map(|v| ScalarValue::Int32(Some(v))).ok())
-            }
-            DataType::Int64 => {
-                val.and_then(|v| i64::try_from(v).map(|v| ScalarValue::Int64(Some(v))).ok())
-            }
-            DataType::UInt8 => {
-                val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
-            }
-            DataType::UInt16 => Some(value.clone()),
-            DataType::UInt32 => val.map(|v| ScalarValue::UInt32(Some(u32::from(v)))),
-            DataType::UInt64 => val.map(|v| ScalarValue::UInt64(Some(u64::from(v)))),
-            DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(f32::from(v)))),
-            DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(f64::from(v)))),
-            _ => None,
-        },
-        ScalarValue::UInt32(val) => match ty {
-            DataType::Int8 => {
-                val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
-            }
-            DataType::Int16 => {
-                val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
-            }
-            DataType::Int32 => {
-                val.and_then(|v| i32::try_from(v).map(|v| ScalarValue::Int32(Some(v))).ok())
-            }
-            DataType::Int64 => {
-                val.and_then(|v| i64::try_from(v).map(|v| ScalarValue::Int64(Some(v))).ok())
-            }
-            DataType::UInt8 => {
-                val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
-            }
-            DataType::UInt16 => {
-                val.and_then(|v| u16::try_from(v).map(|v| ScalarValue::UInt16(Some(v))).ok())
-            }
-            DataType::UInt32 => Some(value.clone()),
-            DataType::UInt64 => val.map(|v| ScalarValue::UInt64(Some(u64::from(v)))),
-            // See above warning about lossy float conversion
-            DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(v as f32))),
-            DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(v as f64))),
-            _ => None,
-        },
-        ScalarValue::UInt64(val) => match ty {
-            DataType::Int8 => {
-                val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
-            }
-            DataType::Int16 => {
-                val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
-            }
-            DataType::Int32 => {
-                val.and_then(|v| i32::try_from(v).map(|v| ScalarValue::Int32(Some(v))).ok())
-            }
-            DataType::Int64 => {
-                val.and_then(|v| i64::try_from(v).map(|v| ScalarValue::Int64(Some(v))).ok())
-            }
-            DataType::UInt8 => {
-                val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
-            }
-            DataType::UInt16 => {
-                val.and_then(|v| u16::try_from(v).map(|v| ScalarValue::UInt16(Some(v))).ok())
-            }
-            DataType::UInt32 => {
-                val.and_then(|v| u32::try_from(v).map(|v| ScalarValue::UInt32(Some(v))).ok())
-            }
-            DataType::UInt64 => Some(value.clone()),
-            // See above warning about lossy float conversion
-            DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(v as f32))),
-            DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(v as f64))),
-            _ => None,
-        },
-        ScalarValue::Float32(val) => match ty {
-            DataType::Float32 => Some(value.clone()),
-            DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(f64::from(v)))),
-            _ => None,
-        },
-        ScalarValue::Float64(val) => match ty {
-            DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(v as f32))),
-            DataType::Float64 => Some(value.clone()),
-            _ => None,
-        },
-        ScalarValue::Utf8(val) => match ty {
-            DataType::Utf8 => Some(value.clone()),
-            DataType::LargeUtf8 => Some(ScalarValue::LargeUtf8(val.clone())),
-            _ => None,
-        },
-        ScalarValue::Boolean(_) => match ty {
-            DataType::Boolean => Some(value.clone()),
-            _ => None,
-        },
-        ScalarValue::Null => Some(value.clone()),
-        ScalarValue::List(vals, _) => {
-            if let DataType::FixedSizeList(_, size) = ty {
-                if let Some(vals) = vals {
-                    if vals.len() as i32 != *size {
-                        return None;
+pub fn safe_coerce_scalar(value: &ScalarValue, ty: &DataType) -> Result<Option<ScalarValue>> {
+    let value =
+        match value {
+            ScalarValue::Int8(val) => {
+                match ty {
+                    DataType::Int8 => Some(value.clone()),
+                    DataType::Int16 => val.map(|v| ScalarValue::Int16(Some(i16::from(v)))),
+                    DataType::Int32 => val.map(|v| ScalarValue::Int32(Some(i32::from(v)))),
+                    DataType::Int64 => val.map(|v| ScalarValue::Int64(Some(i64::from(v)))),
+                    DataType::UInt8 => {
+                        val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
                     }
+                    DataType::UInt16 => val
+                        .and_then(|v| u16::try_from(v).map(|v| ScalarValue::UInt16(Some(v))).ok()),
+                    DataType::UInt32 => val
+                        .and_then(|v| u32::try_from(v).map(|v| ScalarValue::UInt32(Some(v))).ok()),
+                    DataType::UInt64 => val
+                        .and_then(|v| u64::try_from(v).map(|v| ScalarValue::UInt64(Some(v))).ok()),
+                    DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(f32::from(v)))),
+                    DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(f64::from(v)))),
+                    _ => None,
                 }
             }
-            let (new_values, field) = match ty {
-                DataType::List(field)
-                | DataType::LargeList(field)
-                | DataType::FixedSizeList(field, _) => {
-                    if let Some(vals) = vals {
-                        let values = vals
-                            .iter()
-                            .map(|val| safe_coerce_scalar(val, field.data_type()))
-                            .collect::<Option<Vec<_>>>();
-                        (values, field)
+            ScalarValue::Int16(val) => {
+                match ty {
+                    DataType::Int8 => {
+                        val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
+                    }
+                    DataType::Int16 => Some(value.clone()),
+                    DataType::Int32 => val.map(|v| ScalarValue::Int32(Some(i32::from(v)))),
+                    DataType::Int64 => val.map(|v| ScalarValue::Int64(Some(i64::from(v)))),
+                    DataType::UInt8 => {
+                        val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
+                    }
+                    DataType::UInt16 => val
+                        .and_then(|v| u16::try_from(v).map(|v| ScalarValue::UInt16(Some(v))).ok()),
+                    DataType::UInt32 => val
+                        .and_then(|v| u32::try_from(v).map(|v| ScalarValue::UInt32(Some(v))).ok()),
+                    DataType::UInt64 => val
+                        .and_then(|v| u64::try_from(v).map(|v| ScalarValue::UInt64(Some(v))).ok()),
+                    DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(f32::from(v)))),
+                    DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(f64::from(v)))),
+                    _ => None,
+                }
+            }
+            ScalarValue::Int32(val) => {
+                match ty {
+                    DataType::Int8 => {
+                        val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
+                    }
+                    DataType::Int16 => {
+                        val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
+                    }
+                    DataType::Int32 => Some(value.clone()),
+                    DataType::Int64 => val.map(|v| ScalarValue::Int64(Some(i64::from(v)))),
+                    DataType::UInt8 => {
+                        val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
+                    }
+                    DataType::UInt16 => val
+                        .and_then(|v| u16::try_from(v).map(|v| ScalarValue::UInt16(Some(v))).ok()),
+                    DataType::UInt32 => val
+                        .and_then(|v| u32::try_from(v).map(|v| ScalarValue::UInt32(Some(v))).ok()),
+                    DataType::UInt64 => val
+                        .and_then(|v| u64::try_from(v).map(|v| ScalarValue::UInt64(Some(v))).ok()),
+                    // These conversions are inherently lossy as the full range of i32 cannot
+                    // be represented in f32.  However, there is no f32::TryFrom(i32) and its not
+                    // clear users would want that anyways
+                    DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(v as f32))),
+                    DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(v as f64))),
+                    _ => None,
+                }
+            }
+            ScalarValue::Int64(val) => {
+                match ty {
+                    DataType::Int8 => {
+                        val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
+                    }
+                    DataType::Int16 => {
+                        val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
+                    }
+                    DataType::Int32 => {
+                        val.and_then(|v| i32::try_from(v).map(|v| ScalarValue::Int32(Some(v))).ok())
+                    }
+                    DataType::Int64 => Some(value.clone()),
+                    DataType::UInt8 => {
+                        val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
+                    }
+                    DataType::UInt16 => val
+                        .and_then(|v| u16::try_from(v).map(|v| ScalarValue::UInt16(Some(v))).ok()),
+                    DataType::UInt32 => val
+                        .and_then(|v| u32::try_from(v).map(|v| ScalarValue::UInt32(Some(v))).ok()),
+                    DataType::UInt64 => val
+                        .and_then(|v| u64::try_from(v).map(|v| ScalarValue::UInt64(Some(v))).ok()),
+                    // See above warning about lossy float conversion
+                    DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(v as f32))),
+                    DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(v as f64))),
+                    _ => None,
+                }
+            }
+            ScalarValue::UInt8(val) => match ty {
+                DataType::Int8 => {
+                    val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
+                }
+                DataType::Int16 => {
+                    val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
+                }
+                DataType::Int32 => {
+                    val.and_then(|v| i32::try_from(v).map(|v| ScalarValue::Int32(Some(v))).ok())
+                }
+                DataType::Int64 => {
+                    val.and_then(|v| i64::try_from(v).map(|v| ScalarValue::Int64(Some(v))).ok())
+                }
+                DataType::UInt8 => Some(value.clone()),
+                DataType::UInt16 => val.map(|v| ScalarValue::UInt16(Some(u16::from(v)))),
+                DataType::UInt32 => val.map(|v| ScalarValue::UInt32(Some(u32::from(v)))),
+                DataType::UInt64 => val.map(|v| ScalarValue::UInt64(Some(u64::from(v)))),
+                DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(f32::from(v)))),
+                DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(f64::from(v)))),
+                _ => None,
+            },
+            ScalarValue::UInt16(val) => match ty {
+                DataType::Int8 => {
+                    val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
+                }
+                DataType::Int16 => {
+                    val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
+                }
+                DataType::Int32 => {
+                    val.and_then(|v| i32::try_from(v).map(|v| ScalarValue::Int32(Some(v))).ok())
+                }
+                DataType::Int64 => {
+                    val.and_then(|v| i64::try_from(v).map(|v| ScalarValue::Int64(Some(v))).ok())
+                }
+                DataType::UInt8 => {
+                    val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
+                }
+                DataType::UInt16 => Some(value.clone()),
+                DataType::UInt32 => val.map(|v| ScalarValue::UInt32(Some(u32::from(v)))),
+                DataType::UInt64 => val.map(|v| ScalarValue::UInt64(Some(u64::from(v)))),
+                DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(f32::from(v)))),
+                DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(f64::from(v)))),
+                _ => None,
+            },
+            ScalarValue::UInt32(val) => match ty {
+                DataType::Int8 => {
+                    val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
+                }
+                DataType::Int16 => {
+                    val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
+                }
+                DataType::Int32 => {
+                    val.and_then(|v| i32::try_from(v).map(|v| ScalarValue::Int32(Some(v))).ok())
+                }
+                DataType::Int64 => {
+                    val.and_then(|v| i64::try_from(v).map(|v| ScalarValue::Int64(Some(v))).ok())
+                }
+                DataType::UInt8 => {
+                    val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
+                }
+                DataType::UInt16 => {
+                    val.and_then(|v| u16::try_from(v).map(|v| ScalarValue::UInt16(Some(v))).ok())
+                }
+                DataType::UInt32 => Some(value.clone()),
+                DataType::UInt64 => val.map(|v| ScalarValue::UInt64(Some(u64::from(v)))),
+                // See above warning about lossy float conversion
+                DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(v as f32))),
+                DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(v as f64))),
+                _ => None,
+            },
+            ScalarValue::UInt64(val) => {
+                match ty {
+                    DataType::Int8 => {
+                        val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
+                    }
+                    DataType::Int16 => {
+                        val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
+                    }
+                    DataType::Int32 => {
+                        val.and_then(|v| i32::try_from(v).map(|v| ScalarValue::Int32(Some(v))).ok())
+                    }
+                    DataType::Int64 => {
+                        val.and_then(|v| i64::try_from(v).map(|v| ScalarValue::Int64(Some(v))).ok())
+                    }
+                    DataType::UInt8 => {
+                        val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
+                    }
+                    DataType::UInt16 => val
+                        .and_then(|v| u16::try_from(v).map(|v| ScalarValue::UInt16(Some(v))).ok()),
+                    DataType::UInt32 => val
+                        .and_then(|v| u32::try_from(v).map(|v| ScalarValue::UInt32(Some(v))).ok()),
+                    DataType::UInt64 => Some(value.clone()),
+                    // See above warning about lossy float conversion
+                    DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(v as f32))),
+                    DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(v as f64))),
+                    _ => None,
+                }
+            }
+            ScalarValue::Float32(val) => match ty {
+                DataType::Float32 => Some(value.clone()),
+                DataType::Float64 => val.map(|v| ScalarValue::Float64(Some(f64::from(v)))),
+                _ => None,
+            },
+            ScalarValue::Float64(val) => match ty {
+                DataType::Float32 => val.map(|v| ScalarValue::Float32(Some(v as f32))),
+                DataType::Float64 => Some(value.clone()),
+                _ => None,
+            },
+            ScalarValue::Utf8(val) => match ty {
+                DataType::Utf8 => Some(value.clone()),
+                DataType::LargeUtf8 => Some(ScalarValue::LargeUtf8(val.clone())),
+                _ => None,
+            },
+            ScalarValue::Boolean(_) => match ty {
+                DataType::Boolean => Some(value.clone()),
+                _ => None,
+            },
+            ScalarValue::Null => Some(value.clone()),
+            ScalarValue::List(vals) => match ty {
+                DataType::List(_) => Some(ScalarValue::List(vals.clone())),
+                DataType::FixedSizeList(field, size) => {
+                    let inner = vals.as_any().downcast_ref::<ListArray>().unwrap();
+                    let vals = inner.values();
+                    if vals.len() == *size as usize {
+                        let mut values = Vec::new();
+                        for row in 0..vals.len() {
+                            let scalar = ScalarValue::try_from_array(vals.as_ref(), row)?;
+                            let scalar = safe_coerce_scalar(&scalar, field.data_type())?;
+                            values.push(scalar);
+                        }
+                        let values = values.into_iter().collect::<Option<Vec<_>>>();
+                        Some(ScalarValue::Fixedsizelist(values, field.clone(), *size))
                     } else {
-                        (None, field)
+                        None
                     }
-                }
-                _ => return None,
-            };
-
-            match ty {
-                DataType::List(_) => Some(ScalarValue::List(new_values, field.clone())),
-                DataType::FixedSizeList(_, size) => {
-                    Some(ScalarValue::Fixedsizelist(new_values, field.clone(), *size))
                 }
                 _ => None,
-            }
-        }
-        _ => None,
-    }
+            },
+            _ => None,
+        };
+    Ok(value)
 }

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -22,8 +22,8 @@ async-recursion.workspace = true
 async-trait.workspace = true
 datafusion.workspace = true
 datafusion-common.workspace = true
-datafusion-expr = "32.0.0"
-datafusion-physical-expr = { version = "32.0.0", default-features = false }
+datafusion-expr = "33.0.0"
+datafusion-physical-expr = { version = "33.0.0", default-features = false }
 futures.workspace = true
 half.workspace = true
 lance-arrow.workspace = true
@@ -53,7 +53,7 @@ lance-testing.workspace = true
 pprof.workspace = true
 tempfile.workspace = true
 sqlparser = "0.39.0"
-datafusion-sql = "32.0.0"
+datafusion-sql = "33.0.0"
 
 [build-dependencies]
 prost-build.workspace = true

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -301,15 +301,15 @@ impl Ord for OrderableScalarValue {
             (Fixedsizelist(_, _, _), _) => {
                 panic!("Attempt to compare Fixedsizelist with non-Fixedsizelist")
             }
-            (List(_, _), List(_, _)) => todo!(),
-            (List(v1, _), Null) => {
-                if v1.is_none() {
+            (List(_), List(_)) => todo!(),
+            (List(v1), Null) => {
+                if v1.is_empty() {
                     Ordering::Equal
                 } else {
                     Ordering::Greater
                 }
             }
-            (List(_, _), _) => {
+            (List(_), _) => {
                 panic!("Attempt to compare List with non-List")
             }
             (Date32(v1), Date32(v2)) => v1.cmp(v2),

--- a/rust/lance-index/src/scalar/flat.rs
+++ b/rust/lance-index/src/scalar/flat.rs
@@ -178,7 +178,7 @@ impl ScalarIndex for FlatIndex {
         // Since we have all the values in memory we can use basic arrow-rs compute
         // functions to satisfy scalar queries.
         let predicate = match query {
-            ScalarQuery::Equals(value) => arrow_ord::cmp::eq(self.values(), &value.to_scalar())?,
+            ScalarQuery::Equals(value) => arrow_ord::cmp::eq(self.values(), &value.to_scalar()?)?,
             ScalarQuery::IsNull() => arrow::compute::is_null(self.values())?,
             ScalarQuery::IsIn(values) => {
                 let choices = values
@@ -193,7 +193,7 @@ impl ScalarIndex for FlatIndex {
                 )?;
                 let result_col = in_list_expr.evaluate(&self.data)?;
                 result_col
-                    .into_array(self.data.num_rows())
+                    .into_array(self.data.num_rows())?
                     .as_any()
                     .downcast_ref::<BooleanArray>()
                     .expect("InList evaluation should return boolean array")
@@ -204,32 +204,32 @@ impl ScalarIndex for FlatIndex {
                     panic!("Scalar range query received with no upper or lower bound")
                 }
                 (Bound::Unbounded, Bound::Included(upper)) => {
-                    arrow_ord::cmp::lt_eq(self.values(), &upper.to_scalar())?
+                    arrow_ord::cmp::lt_eq(self.values(), &upper.to_scalar()?)?
                 }
                 (Bound::Unbounded, Bound::Excluded(upper)) => {
-                    arrow_ord::cmp::lt(self.values(), &upper.to_scalar())?
+                    arrow_ord::cmp::lt(self.values(), &upper.to_scalar()?)?
                 }
                 (Bound::Included(lower), Bound::Unbounded) => {
-                    arrow_ord::cmp::gt_eq(self.values(), &lower.to_scalar())?
+                    arrow_ord::cmp::gt_eq(self.values(), &lower.to_scalar()?)?
                 }
                 (Bound::Included(lower), Bound::Included(upper)) => arrow::compute::and(
-                    &arrow_ord::cmp::gt_eq(self.values(), &lower.to_scalar())?,
-                    &arrow_ord::cmp::lt_eq(self.values(), &upper.to_scalar())?,
+                    &arrow_ord::cmp::gt_eq(self.values(), &lower.to_scalar()?)?,
+                    &arrow_ord::cmp::lt_eq(self.values(), &upper.to_scalar()?)?,
                 )?,
                 (Bound::Included(lower), Bound::Excluded(upper)) => arrow::compute::and(
-                    &arrow_ord::cmp::gt_eq(self.values(), &lower.to_scalar())?,
-                    &arrow_ord::cmp::lt(self.values(), &upper.to_scalar())?,
+                    &arrow_ord::cmp::gt_eq(self.values(), &lower.to_scalar()?)?,
+                    &arrow_ord::cmp::lt(self.values(), &upper.to_scalar()?)?,
                 )?,
                 (Bound::Excluded(lower), Bound::Unbounded) => {
-                    arrow_ord::cmp::gt(self.values(), &lower.to_scalar())?
+                    arrow_ord::cmp::gt(self.values(), &lower.to_scalar()?)?
                 }
                 (Bound::Excluded(lower), Bound::Included(upper)) => arrow::compute::and(
-                    &arrow_ord::cmp::gt(self.values(), &lower.to_scalar())?,
-                    &arrow_ord::cmp::lt_eq(self.values(), &upper.to_scalar())?,
+                    &arrow_ord::cmp::gt(self.values(), &lower.to_scalar()?)?,
+                    &arrow_ord::cmp::lt_eq(self.values(), &upper.to_scalar()?)?,
                 )?,
                 (Bound::Excluded(lower), Bound::Excluded(upper)) => arrow::compute::and(
-                    &arrow_ord::cmp::gt(self.values(), &lower.to_scalar())?,
-                    &arrow_ord::cmp::lt(self.values(), &upper.to_scalar())?,
+                    &arrow_ord::cmp::gt(self.values(), &lower.to_scalar()?)?,
+                    &arrow_ord::cmp::lt(self.values(), &upper.to_scalar()?)?,
                 )?,
             },
         };

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -56,7 +56,7 @@ rand.workspace = true
 futures.workspace = true
 uuid.workspace = true
 shellexpand.workspace = true
-arrow = { version = "47.0.0", features = ["prettyprint"] }
+arrow = { version = "48.0.0", features = ["prettyprint"] }
 nohash-hasher.workspace = true
 num_cpus.workspace = true
 # TODO: use datafusion sub-modules to reduce build size?

--- a/rust/lance/src/datafusion/logical_expr.rs
+++ b/rust/lance/src/datafusion/logical_expr.rs
@@ -32,7 +32,7 @@ use snafu::{location, Location};
 fn resolve_value(expr: &Expr, data_type: &DataType) -> Result<Expr> {
     match expr {
         Expr::Literal(scalar_value) => {
-            Ok(Expr::Literal(safe_coerce_scalar(scalar_value, data_type).ok_or_else(|| Error::IO {
+            Ok(Expr::Literal(safe_coerce_scalar(scalar_value, data_type)?.ok_or_else(|| Error::IO {
                 message: format!("Received literal {expr} and could not convert to literal of type '{data_type:?}'"),
                 location: location!(),
             })?))

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -21,6 +21,7 @@ use arrow_array::cast::AsArray;
 use arrow_array::{RecordBatch, UInt64Array};
 use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
+use datafusion::common::stats::Precision;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning,
@@ -242,11 +243,11 @@ impl ExecutionPlan for KNNFlatExec {
         )))
     }
 
-    fn statistics(&self) -> Statistics {
-        Statistics {
-            num_rows: Some(self.query.k),
-            ..Default::default()
-        }
+    fn statistics(&self) -> DataFusionResult<Statistics> {
+        Ok(Statistics {
+            num_rows: Precision::Inexact(self.query.k),
+            ..Statistics::new_unknown(self.schema().as_ref())
+        })
     }
 }
 
@@ -519,11 +520,13 @@ impl ExecutionPlan for KNNIndexExec {
         )))
     }
 
-    fn statistics(&self) -> datafusion::physical_plan::Statistics {
-        Statistics {
-            num_rows: Some(self.query.k * self.query.refine_factor.unwrap_or(1) as usize),
-            ..Default::default()
-        }
+    fn statistics(&self) -> DataFusionResult<Statistics> {
+        Ok(Statistics {
+            num_rows: Precision::Inexact(
+                self.query.k * self.query.refine_factor.unwrap_or(1) as usize,
+            ),
+            ..Statistics::new_unknown(self.schema().as_ref())
+        })
     }
 }
 

--- a/rust/lance/src/io/exec/projection.rs
+++ b/rust/lance/src/io/exec/projection.rs
@@ -194,7 +194,7 @@ impl ExecutionPlan for ProjectionExec {
         Ok(Box::pin(ProjectionStream::new(input_stream, &self.project)))
     }
 
-    fn statistics(&self) -> datafusion::physical_plan::Statistics {
+    fn statistics(&self) -> datafusion::common::Result<datafusion::physical_plan::Statistics> {
         self.input.statistics()
     }
 }

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -161,8 +161,17 @@ impl ExecutionPlan for ScalarIndexExec {
         }))
     }
 
-    fn statistics(&self) -> datafusion::physical_plan::Statistics {
-        todo!()
+    fn statistics(&self) -> datafusion::error::Result<datafusion::physical_plan::Statistics> {
+        // Statistics are loaded irrespective of whether they are requested or
+        // not, so, we need to return an Ok response here.
+        //
+        // This is a bug in DF and should be fixed upstream.
+        //
+        // See: https://github.com/apache/arrow-datafusion/blob/93b21bdcd3d465ed78b610b54edf1418a47fc497/datafusion/physical-plan/src/display.rs#L263-L266
+
+        Ok(datafusion::physical_plan::Statistics::new_unknown(
+            self.schema().as_ref(),
+        ))
     }
 }
 
@@ -321,7 +330,16 @@ impl ExecutionPlan for MaterializeIndexExec {
         }))
     }
 
-    fn statistics(&self) -> datafusion::physical_plan::Statistics {
-        todo!()
+    fn statistics(&self) -> datafusion::error::Result<datafusion::physical_plan::Statistics> {
+        // Statistics are loaded irrespective of whether they are requested or
+        // not, so, we need to return an Ok response here.
+        //
+        // This is a bug in DF and should be fixed upstream.
+        //
+        // See: https://github.com/apache/arrow-datafusion/blob/93b21bdcd3d465ed78b610b54edf1418a47fc497/datafusion/physical-plan/src/display.rs#L263-L266
+
+        Ok(datafusion::physical_plan::Statistics::new_unknown(
+            self.schema().as_ref(),
+        ))
     }
 }

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -289,7 +289,7 @@ impl ExecutionPlan for TakeExec {
         )))
     }
 
-    fn statistics(&self) -> datafusion::physical_plan::Statistics {
+    fn statistics(&self) -> Result<datafusion::physical_plan::Statistics> {
         self.input.statistics()
     }
 }

--- a/rust/lance/src/io/exec/testing.rs
+++ b/rust/lance/src/io/exec/testing.rs
@@ -79,7 +79,16 @@ impl ExecutionPlan for TestingExec {
         todo!()
     }
 
-    fn statistics(&self) -> datafusion::physical_plan::Statistics {
-        todo!()
+    fn statistics(&self) -> datafusion::error::Result<datafusion::physical_plan::Statistics> {
+        // Statistics are loaded irrespective of whether they are requested or
+        // not, so, we need to return an Ok response here.
+        //
+        // This is a bug in DF and should be fixed upstream.
+        //
+        // See: https://github.com/apache/arrow-datafusion/blob/93b21bdcd3d465ed78b610b54edf1418a47fc497/datafusion/physical-plan/src/display.rs#L263-L266
+
+        Ok(datafusion::physical_plan::Statistics::new_unknown(
+            self.schema().as_ref(),
+        ))
     }
 }


### PR DESCRIPTION
### Known test failure:

Due to a change in DF where statistics are pulled even when not requested in `IndentVisitor`, the test `dataset::scanner::test::test_secondary_index_scans` fails since there's an error pulling statistics. The error corresponds to not being able to create a scalar from `FixedSizeList` (which should not be expected since a corresponding scalar exists).

**The error:**

```
This feature is not implemented: Can't create a scalar from data_type "FixedSizeList(Field { name: "item", data_type: Float32, nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {} }, 32)"
```

**Problematic DF Code:**

https://github.com/apache/arrow-datafusion/blob/93b21bdcd3d465ed78b610b54edf1418a47fc497/datafusion/physical-plan/src/display.rs#L263-L266

Fixes: #1694