### PR TITLE
perf: small performance fixes for scan

### DIFF
--- a/rust/lance-core/src/encodings/plain.rs
+++ b/rust/lance-core/src/encodings/plain.rs
@@ -397,7 +397,7 @@ fn make_chunked_requests(
     // It might allow slightly larger sequential reads.
     for i in 0..indices.len() - 1 {
         // If contiguous, continue
-        if indices[i + 1] == indices[i] {
+        if indices[i + 1] == indices[i] + 1 {
             continue;
         }
         if indices[i + 1] as usize * byte_width > indices[start] as usize * byte_width + block_size


### PR DESCRIPTION
* Adds small optimization to pushdown scan where we eagerly skip pages that don't match
* Fixes contiguous check in `make_chunked_requests`, which fixes a bug that causes vector columns to be read in very small pieces.