### PR TITLE
feat: handroll ivf partition shuffle

### DIFF
--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -43,6 +43,7 @@ serde.workspace = true
 snafu.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies]
 approx.workspace = true

--- a/rust/lance-index/src/vector/ivf.rs
+++ b/rust/lance-index/src/vector/ivf.rs
@@ -39,6 +39,7 @@ use snafu::{location, Location};
 use tracing::{instrument, Instrument};
 
 mod builder;
+pub mod shuffler;
 
 use super::{PART_ID_COLUMN, PQ_CODE_COLUMN, RESIDUAL_COLUMN};
 use crate::vector::{

--- a/rust/lance-index/src/vector/ivf/shuffler.rs
+++ b/rust/lance-index/src/vector/ivf/shuffler.rs
@@ -1,0 +1,195 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Disk-based shuffle a stream of [RecordBatch] into each IVF partition.
+//!
+//! 1. write the entire stream to a file
+//! 2. count the number of rows in each partition
+//! 3. read the data back into memory and shuffle into grouped vectors
+//!
+//! Problems for the future:
+//! 1. while groupby column will stay the same, we may want to include extra data columns in the future
+//! 2. shuffling into memory is fast but we should add disk buffer to support bigger datasets
+
+use arrow_array::cast::AsArray;
+use arrow_array::{UInt32Array, UInt64Array, UInt8Array};
+use futures::{stream, StreamExt};
+use lance_core::datatypes::Schema;
+use lance_core::io::{FileReader, FileWriter, ReadBatchParams, RecordBatchStream};
+
+use crate::vector::{PART_ID_COLUMN, PQ_CODE_COLUMN};
+use lance_core::io::object_store::ObjectStore;
+use lance_core::{Error, Result, ROW_ID};
+use log::info;
+use object_store::path::Path;
+use snafu::{location, Location};
+use tempfile::TempDir;
+
+const UNSORTED_BUFFER: &str = "unsorted.lance";
+
+fn get_temp_dir() -> Result<Path> {
+    let dir = TempDir::new()?;
+    let tmp_dir_path = Path::from_filesystem_path(dir.path()).map_err(|e| Error::IO {
+        message: format!("failed to get buffer path in shuffler: {}", e),
+        location: location!(),
+    })?;
+    Ok(tmp_dir_path)
+}
+
+pub struct IvfShuffler {
+    num_partitions: u32,
+
+    pq_width: usize,
+
+    output_dir: Path,
+
+    schema: Schema,
+}
+
+impl IvfShuffler {
+    pub fn try_new(
+        num_partitions: u32,
+        pq_width: usize,
+        output_dir: Option<Path>,
+        schema: Schema,
+    ) -> Result<Self> {
+        let output_dir = match output_dir {
+            Some(output_dir) => output_dir,
+            None => get_temp_dir()?,
+        };
+
+        Ok(Self {
+            num_partitions,
+            pq_width,
+            output_dir,
+            schema,
+        })
+    }
+
+    pub async fn write_unsorted_stream(
+        &self,
+        data: impl RecordBatchStream + Unpin + 'static,
+    ) -> Result<()> {
+        let object_store = ObjectStore::local();
+        let path = self.output_dir.child(UNSORTED_BUFFER);
+        let writer = object_store.create(&path).await?;
+
+        let mut file_writer =
+            FileWriter::with_object_writer(writer, self.schema.clone(), &Default::default())?;
+
+        let mut data = Box::pin(data);
+
+        while let Some(batch) = data.next().await {
+            file_writer.write(&[batch?]).await?;
+        }
+
+        file_writer.finish().await?;
+
+        Ok(())
+    }
+
+    pub async fn count_partition_size(&self) -> Result<Vec<u64>> {
+        let object_store = ObjectStore::local();
+        let path = self.output_dir.child(UNSORTED_BUFFER);
+        let reader = FileReader::try_new(&object_store, &path).await?;
+
+        let mut partition_sizes = vec![0; self.num_partitions as usize];
+
+        let lance_schema = reader
+            .schema()
+            .project(&[PART_ID_COLUMN])
+            .expect("part id should exist");
+
+        let mut stream = stream::iter(0..reader.num_batches())
+            .map(|i| reader.read_batch(i as i32, ReadBatchParams::RangeFull, &lance_schema))
+            .buffered(64);
+
+        while let Some(batch) = stream.next().await {
+            let batch = batch?;
+            let part_ids: &UInt32Array = batch.column(0).as_primitive();
+            for part_id in part_ids.values() {
+                partition_sizes[*part_id as usize] += 1;
+            }
+        }
+
+        Ok(partition_sizes)
+    }
+
+    pub async fn shuffle_to_partitions(
+        &self,
+        partition_size: Vec<u64>,
+    ) -> Result<(Vec<Vec<u64>>, Vec<Vec<u8>>)> {
+        let mut row_id_buffers = partition_size
+            .iter()
+            .map(|s| Vec::with_capacity(*s as usize))
+            .collect::<Vec<_>>();
+        let mut pq_code_buffers = partition_size
+            .iter()
+            .map(|s| Vec::with_capacity((*s as usize) * self.pq_width))
+            .collect::<Vec<_>>();
+
+        let object_store = ObjectStore::local();
+        let path = self.output_dir.child(UNSORTED_BUFFER);
+        let reader = FileReader::try_new(&object_store, &path).await?;
+        let total_batch = reader.num_batches();
+
+        info!("Shuffling into memory");
+
+        let mut stream = stream::iter(0..reader.num_batches())
+            .map(|i| reader.read_batch(i as i32, ReadBatchParams::RangeFull, reader.schema()))
+            .buffered(16)
+            .enumerate();
+
+        while let Some((idx, batch)) = stream.next().await {
+            if idx % 100 == 0 {
+                info!("Shuffle Progress {}/{}", idx, total_batch);
+            }
+
+            let batch = batch?;
+
+            let row_ids: &UInt64Array = batch
+                .column_by_name(ROW_ID)
+                .expect("Row ID column not found")
+                .as_primitive();
+
+            let part_ids: &UInt32Array = batch
+                .column_by_name(PART_ID_COLUMN)
+                .expect("Partition ID column not found")
+                .as_primitive();
+
+            let pq_codes: &UInt8Array = batch
+                .column_by_name(PQ_CODE_COLUMN)
+                .expect("PQ Code column not found")
+                .as_fixed_size_list()
+                .values()
+                .as_primitive();
+
+            let num_sub_vectors = pq_codes.len() / row_ids.len();
+
+            row_ids
+                .values()
+                .iter()
+                .zip(part_ids.values().iter())
+                .enumerate()
+                .for_each(|(i, (row_id, part_id))| {
+                    row_id_buffers[*part_id as usize].push(*row_id);
+                    pq_code_buffers[*part_id as usize].extend(
+                        pq_codes.values()[i * num_sub_vectors..(i + 1) * num_sub_vectors].iter(),
+                    );
+                });
+        }
+
+        Ok((row_id_buffers, pq_code_buffers))
+    }
+}

--- a/rust/lance/src/index/vector/ivf/builder.rs
+++ b/rust/lance/src/index/vector/ivf/builder.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
 
+use arrow_array::{FixedSizeListArray, RecordBatch, UInt64Array, UInt8Array};
 use arrow_schema::{DataType, Field, Schema};
 use datafusion::error::DataFusionError;
 use datafusion::execution::context::SessionContext;
@@ -23,10 +24,15 @@ use datafusion::execution::memory_pool::{GreedyMemoryPool, MemoryPool, Unbounded
 use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use datafusion::logical_expr::col;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::scalar::ScalarValue;
+use futures::stream;
 use futures::{stream::repeat_with, StreamExt};
+use lance_arrow::FixedSizeListArrayExt;
+use lance_core::datatypes::Schema as LanceSchema;
 use lance_core::{io::Writer, ROW_ID, ROW_ID_FIELD};
 use lance_datafusion::dataframe::{BatchStreamGrouper, DataFrameExt};
 use lance_datafusion::exec::SessionContextExt;
+use lance_index::vector::ivf::shuffler::IvfShuffler;
 use lance_index::vector::pq::ProductQuantizer;
 use lance_index::vector::{PART_ID_COLUMN, PQ_CODE_COLUMN};
 use lance_linalg::distance::MetricType;
@@ -51,6 +57,7 @@ use crate::{io::RecordBatchStream, Error, Result};
 ///   a partition id. The stream is sorted by partition id.
 ///
 /// TODO: move this to `lance-index` crate.
+#[allow(dead_code)]
 pub async fn shuffle_dataset(
     data: impl RecordBatchStream + Unpin + 'static,
     column: &str,
@@ -126,6 +133,76 @@ pub async fn shuffle_dataset(
         .await?)
 }
 
+pub async fn shuffle_dataset_v2(
+    data: impl RecordBatchStream + Unpin + 'static,
+    column: &str,
+    ivf: Arc<dyn lance_index::vector::ivf::Ivf>,
+    num_partitions: u32,
+    num_sub_vectors: usize,
+) -> Result<(Vec<Vec<u64>>, Vec<Vec<u8>>)> {
+    let column: Arc<str> = column.into();
+    let stream = data
+        .zip(repeat_with(move || ivf.clone()))
+        .map(move |(b, ivf)| {
+            let col_ref = column.clone();
+
+            tokio::task::spawn(async move {
+                let batch = b?;
+                ivf.partition_transform(&batch, col_ref.as_ref()).await
+            })
+        })
+        .buffer_unordered(num_cpus::get())
+        .map(|res| match res {
+            Ok(Ok(batch)) => Ok(batch),
+            Ok(Err(err)) => Err(Error::IO {
+                message: err.to_string(),
+                location: location!(),
+            }),
+            Err(err) => Err(Error::IO {
+                message: err.to_string(),
+                location: location!(),
+            }),
+        })
+        .boxed();
+
+    // TODO: dynamically detect schema from the transforms.
+    let schema = Arc::new(Schema::new(vec![
+        ROW_ID_FIELD.clone(),
+        Field::new(PART_ID_COLUMN, DataType::UInt32, false),
+        Field::new(
+            PQ_CODE_COLUMN,
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::UInt8, true)),
+                num_sub_vectors as i32,
+            ),
+            false,
+        ),
+    ]));
+
+    let stream = lance_core::io::RecordBatchStreamAdapter::new(schema.clone(), stream);
+
+    let shuffler = IvfShuffler::try_new(
+        num_partitions,
+        num_sub_vectors,
+        None,
+        LanceSchema::try_from(schema.as_ref())?,
+    )?;
+
+    let start = std::time::Instant::now();
+    shuffler.write_unsorted_stream(stream).await?;
+    info!("wrote raw stream: {:?}", start.elapsed());
+
+    let start = std::time::Instant::now();
+    let partition_size = shuffler.count_partition_size().await?;
+    info!("counted partition sizes: {:?}", start.elapsed());
+
+    let start = std::time::Instant::now();
+    let partitions = shuffler.shuffle_to_partitions(partition_size).await?;
+    info!("shuffled: {:?}", start.elapsed());
+
+    Ok(partitions)
+}
+
 /// Build specific partitions of IVF index.
 ///
 ///
@@ -165,7 +242,47 @@ pub(super) async fn build_partitions(
         precomputed_partitons,
     )?;
 
-    let shuffled = shuffle_dataset(data, column, ivf_model, pq.num_sub_vectors()).await?;
+    let (row_id_buffers, pq_code_buffers) = shuffle_dataset_v2(
+        data,
+        column,
+        ivf_model,
+        ivf.num_partitions() as u32,
+        pq.num_sub_vectors(),
+    )
+    .await?;
+
+    let shuffled = stream::iter(
+        row_id_buffers
+            .into_iter()
+            .zip(pq_code_buffers.into_iter())
+            .enumerate(),
+    )
+    .map(|(idx, (row_ids, pq_codes))| {
+        let schema = Arc::new(Schema::new(vec![
+            ROW_ID_FIELD.clone(),
+            Field::new(
+                PQ_CODE_COLUMN,
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::UInt8, true)),
+                    pq.num_sub_vectors() as i32,
+                ),
+                false,
+            ),
+        ]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(UInt64Array::from_iter_values(row_ids.into_iter())),
+                Arc::new(FixedSizeListArray::try_new_from_values(
+                    UInt8Array::from_iter_values(pq_codes.into_iter()),
+                    pq.num_sub_vectors() as i32,
+                )?),
+            ],
+        )?;
+
+        Ok((vec![ScalarValue::UInt32(Some(idx as u32))], vec![batch]))
+    });
 
     write_index_partitions(writer, ivf, shuffled, None).await?;
 


### PR DESCRIPTION
New IVF partition shuffle logic.

this shuffle has three stages

1. dump transformed data to a lance file. Only PQ transform is support right now because I hardcoded the schema
2. group by partition id and count the size of each partition
3. allocate vectors exactly sized to the partition sizes and stream the data into these memory buffer

TODO:
- [ ] unit test