### PR TITLE
fix: various fixes to GPU kmeans

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylance"
-dependencies = ["pyarrow>=10", "numpy>=1.22"]
+dependencies = ["pyarrow>=12", "numpy>=1.22"]
 description = "python wrapper for Lance columnar format"
 authors = [
     { name = "Lance Devs", email = "dev@lancedb.com" },

--- a/python/python/lance/sampler.py
+++ b/python/python/lance/sampler.py
@@ -112,7 +112,7 @@ def maybe_sample(
     n: int,
     columns: Union[list[str], str],
     batch_size: int = 10240,
-    max_takes: int = 512,
+    max_takes: int = 1024,
 ) -> Generator[pa.RecordBatch, None, None]:
     """Sample n records from the dataset.
 

--- a/python/python/lance/torch/async_dataset.py
+++ b/python/python/lance/torch/async_dataset.py
@@ -69,7 +69,10 @@ class AsyncDataset(IterableDataset):
 
     def close(self):
         self.shutdown.value = True
-        for _ in self:
+        try:
+            for _ in self:
+                pass
+        except Exception:
             pass
         self.queue.close()
         self.worker.join()

--- a/python/python/lance/torch/data.py
+++ b/python/python/lance/torch/data.py
@@ -23,7 +23,6 @@ from typing import Iterable, Optional, Union
 
 import numpy as np
 import pyarrow as pa
-import semver
 import torch
 from torch.utils.data import Dataset, IterableDataset
 
@@ -31,8 +30,6 @@ from ..cache import CachedDataset
 from ..sampler import maybe_sample
 
 __all__ = ["LanceDataset"]
-
-_is_pa_12_or_later = semver.Version.parse(pa.__version__).major >= 12
 
 
 def _to_tensor(
@@ -47,7 +44,7 @@ def _to_tensor(
 
         if (
             pa.types.is_fixed_size_list(arr.type)
-            or (_is_pa_12_or_later and isinstance(arr.type, pa.FixedShapeTensorType))
+            or isinstance(arr.type, pa.FixedShapeTensorType)
         ) and pa.types.is_floating(arr.type.value_type):
             np_arrs = arr.to_numpy(zero_copy_only=False)
             np_tensor = np.stack(np_arrs)

--- a/python/python/lance/torch/kmeans.py
+++ b/python/python/lance/torch/kmeans.py
@@ -135,9 +135,6 @@ class KMeans:
             self._random_init(data)
             data = TensorDataset(data, batch_size=4096)
 
-        if self.metric == "cosine":
-            # Normalize the data
-            data = torch.nn.functional.normalize(data)
         assert self.centroids is not None
         self.centroids = self.centroids.to(self.device)
 

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -172,7 +172,7 @@ def train_ivf_centroids_on_accelerator(
         batch_size=20480,
         columns=[column],
         samples=sample_size,
-        cache=True,
+        cache=False,
     )
 
     with async_dataset(ds) as ds:


### PR DESCRIPTION
Better kmeans quality:
1. double the amount of takes allow during sampling
2. resample on every epoch

Dataset fix:
1. catch any error when draining the queue in async dataset
2. add logic to convert `FixedShapeTensorType` to tensor

Kmeans fix:
1. Remove normalize in `fit` method, where we might be calling `normalize` with a Dataset instance not a tensor. we already normalize in `_transform`