### PR TITLE
fix: raise the manylinux version to 2_24 on aarch64 linux builds to avoid cross compilation issues

### DIFF
--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: "Build for arm64 instead of x86_64"
     # Note: this does *not* mean the host is arm64, since we might be cross-compiling.
     required: false
-    default: 'false'
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -42,13 +42,10 @@ runs:
         command: build
         working-directory: python
         target: aarch64-unknown-linux-gnu
-        manylinux: "2_17"
+        manylinux: "2_24"
         args: ${{ inputs.args }}
         before-script-linux: |
           set -e
-          # We can remove this once we upgrade to 2_28.
-          # https://github.com/briansmith/ring/issues/1728
-          export CFLAGS_aarch64_unknown_linux_gnu="-D__ARM_ARCH=8"
           apt install -y unzip
           if [ $(uname -m) = "x86_64" ]; then
             PROTOC_ARCH="x86_64"


### PR DESCRIPTION
The manylinux 2_17 image does not seem to be generating a working build of the `ring` library.  We had originally managed to get it to compile by setting `export CFLAGS_aarch64_unknown_linux_gnu="-D__ARM_ARCH=8"` however the library that was produced didn't work quite right and would generate "bad signature" when working with S3.  By bumping to manylinux 2_24 we are able to generate a successful build.  If someone needs 2_17 then they will need to dig into the `ring` library failure in more depth to figure out the exact cause of the issue.