### PR TITLE
feat: support in-memory datasets

### DIFF
--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -89,7 +89,7 @@ def dataset(
         Approximately, ``n = Total Rows / number of IVF partitions``.
         ``pq = number of PQ sub-vectors``.
     """
-    ds = LanceDataset(
+    ds = LanceDataset.create(
         uri,
         version,
         block_size,
@@ -107,7 +107,7 @@ def dataset(
                 f"{ts_cutoff} is earlier than the first version of this dataset"
             )
         else:
-            return LanceDataset(
+            return LanceDataset.create(
                 uri,
                 ver_cutoff,
                 block_size,

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -702,6 +702,14 @@ class LanceDataset(pa.dataset.Dataset):
         Returns the lastest version of the dataset
         """
         return self._ds.latest_version()
+    
+    def checkout(self, version: int):
+        """
+        Checkout a specific version of the dataset.
+
+        This will NOT create a new commit. The dataset will become read-only.
+        """
+        self._ds.checkout(version)
 
     def restore(self):
         """

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1109,7 +1109,8 @@ class LanceDataset(pa.dataset.Dataset):
             The data to be written. Acceptable types are:
             - Pandas DataFrame, Pyarrow Table, Dataset, Scanner, or RecordBatchReader
         schema: Schema, optional
-            The schema of the incoming data. If not provided, the dataset schema will be used
+            The schema of the incoming data. If not provided,
+            the dataset schema will be used
         mode: str
             **overwrite** - create a new snapshot version
             **append** - create a new version that is the concat of the input the

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -702,7 +702,7 @@ class LanceDataset(pa.dataset.Dataset):
         Returns the lastest version of the dataset
         """
         return self._ds.latest_version()
-    
+
     def checkout(self, version: int):
         """
         Checkout a specific version of the dataset.

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -100,7 +100,7 @@ class LanceFragment(pa.dataset.Fragment):
     def __reduce__(self):
         from .dataset import LanceDataset
 
-        ds = LanceDataset(self._ds.uri, self._ds.version)
+        ds = LanceDataset.create(self._ds.uri, self._ds.version)
         return LanceFragment, (ds, self.fragment_id)
 
     @staticmethod

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -921,8 +921,10 @@ impl Dataset {
                 WriteMode::Overwrite => ds.overwrite(batches, params).await,
             },
             None => {
-                let mut params = WriteParams::default();
-                params.mode = WriteMode::Append;
+                let params = WriteParams {
+                    mode: WriteMode::Append,
+                    ..Default::default()
+                };
                 ds.append(batches, Some(params)).await
             }
         }

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -623,7 +623,8 @@ impl Dataset {
     }
 
     fn checkout(&mut self, version: u64) -> PyResult<()> {
-        let ds = RT.block_on(None, self.ds.checkout_version(version))?
+        let ds = RT
+            .block_on(None, self.ds.checkout_version(version))?
             .map_err(|err| PyIOError::new_err(err.to_string()))?;
         self.ds = Arc::new(ds);
         Ok(())

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -622,6 +622,13 @@ impl Dataset {
         Ok(())
     }
 
+    fn checkout(&mut self, version: u64) -> PyResult<()> {
+        let ds = RT.block_on(None, self.ds.checkout_version(version))?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?;
+        self.ds = Arc::new(ds);
+        Ok(())
+    }
+
     /// Cleanup old versions from the dataset
     fn cleanup_old_versions(
         &self,

--- a/rust/lance-core/src/io/object_store.rs
+++ b/rust/lance-core/src/io/object_store.rs
@@ -1233,6 +1233,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_inmemory_paths() {
+        let store = ObjectStore::memory();
+        let os_path = Path::from("test_file");
+        let mut writer = store.create(&os_path).await.unwrap();
+        writer.write_all(b"MEMORY").await.unwrap();
+        writer.shutdown().await.unwrap();
+
+        let reader = store.open(&os_path).await.unwrap();
+        let buf = reader.get_range(0..6).await.unwrap();
+        assert_eq!(buf.as_bytes(), b"MEMORY");
+    }
+
+    #[tokio::test]
     #[cfg(windows)]
     async fn test_windows_paths() {
         use std::path::Component;

--- a/rust/lance/benches/ivf_pq.rs
+++ b/rust/lance/benches/ivf_pq.rs
@@ -66,7 +66,7 @@ async fn create_dataset(path: &std::path::Path, dim: usize, mode: WriteMode) {
     };
 
     let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-    Dataset::write(reader, path.to_str().unwrap(), Some(write_params))
+    Dataset::write_to_uri(reader, path.to_str().unwrap(), Some(write_params))
         .await
         .unwrap();
 }

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -66,7 +66,7 @@ impl BenchmarkFixture {
     async fn write_baseline_data(tempdir: &TempDir) -> Arc<Dataset> {
         let test_path = tempdir.path().as_os_str().to_str().unwrap();
         Arc::new(
-            Dataset::write(BenchmarkDataSource::test_data(), test_path, None)
+            Dataset::write_to_uri(BenchmarkDataSource::test_data(), test_path, None)
                 .await
                 .unwrap(),
         )

--- a/rust/lance/benches/scan.rs
+++ b/rust/lance/benches/scan.rs
@@ -127,7 +127,7 @@ async fn create_file(path: &std::path::Path, mode: WriteMode) {
         ..Default::default()
     };
     let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-    Dataset::write(reader, test_uri, Some(write_params))
+    Dataset::write_to_uri(reader, test_uri, Some(write_params))
         .await
         .unwrap();
 }

--- a/rust/lance/benches/vector_index.rs
+++ b/rust/lance/benches/vector_index.rs
@@ -171,7 +171,7 @@ async fn create_file(path: &std::path::Path, mode: WriteMode) {
         ..Default::default()
     };
     let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-    let mut dataset = Dataset::write(reader, test_uri, Some(write_params))
+    let mut dataset = Dataset::write_to_uri(reader, test_uri, Some(write_params))
         .await
         .unwrap();
     let ivf_params = IvfBuildParams {

--- a/rust/lance/src/datafusion/logical_plan.rs
+++ b/rust/lance/src/datafusion/logical_plan.rs
@@ -141,7 +141,7 @@ mod tests {
         let batch_reader =
             RecordBatchIterator::new(batches.clone().into_iter().map(Ok), schema.clone());
 
-        Dataset::write(batch_reader, test_uri, Some(WriteParams::default()))
+        Dataset::write_to_uri(batch_reader, test_uri, Some(WriteParams::default()))
             .await
             .unwrap();
 
@@ -181,7 +181,7 @@ mod tests {
         let batch_reader =
             RecordBatchIterator::new(batches.clone().into_iter().map(Ok), schema.clone());
 
-        Dataset::write(batch_reader, test_uri, Some(WriteParams::default()))
+        Dataset::write_to_uri(batch_reader, test_uri, Some(WriteParams::default()))
             .await
             .unwrap();
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -550,9 +550,7 @@ impl Dataset {
         // parameter for API ergonomics.
         let batches = Box::new(batches);
         let params = params.unwrap_or_else(|| {
-            let mut inner = WriteParams::default();
-            inner.mode = WriteMode::Append;
-            inner
+            WriteParams { mode: WriteMode::Append, ..Default::default() }
         });
         self.write_impl(batches, params).await
     }
@@ -569,9 +567,7 @@ impl Dataset {
         // parameter for API ergonomics.
         let batches = Box::new(batches);
         let params = params.unwrap_or_else(|| {
-            let mut inner = WriteParams::default();
-            inner.mode = WriteMode::Overwrite;
-            inner
+            WriteParams { mode: WriteMode::Overwrite, ..Default::default() }
         });
         self.write_impl(batches, params).await
     }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -549,8 +549,9 @@ impl Dataset {
         // Box it so we don't monomorphize for every one. We take the generic
         // parameter for API ergonomics.
         let batches = Box::new(batches);
-        let params = params.unwrap_or_else(|| {
-            WriteParams { mode: WriteMode::Append, ..Default::default() }
+        let params = params.unwrap_or_else(|| WriteParams {
+            mode: WriteMode::Append,
+            ..Default::default()
         });
         self.write_impl(batches, params).await
     }
@@ -566,8 +567,9 @@ impl Dataset {
         // Box it so we don't monomorphize for every one. We take the generic
         // parameter for API ergonomics.
         let batches = Box::new(batches);
-        let params = params.unwrap_or_else(|| {
-            WriteParams { mode: WriteMode::Overwrite, ..Default::default() }
+        let params = params.unwrap_or_else(|| WriteParams {
+            mode: WriteMode::Overwrite,
+            ..Default::default()
         });
         self.write_impl(batches, params).await
     }

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -577,7 +577,7 @@ mod tests {
             data: impl RecordBatchReader + Send + 'static,
             mode: WriteMode,
         ) -> Result<()> {
-            Dataset::write(
+            Dataset::write_to_uri(
                 data,
                 &self.dataset_path,
                 Some(WriteParams {
@@ -1115,7 +1115,7 @@ mod tests {
 
         let schema = ArrowSchema::new(vec![Field::new("a", DataType::Int32, false)]);
         let reader = RecordBatchIterator::new(vec![], Arc::new(schema));
-        let dataset = Dataset::write(reader, test_uri, Default::default())
+        let dataset = Dataset::write_to_uri(reader, test_uri, Default::default())
             .await
             .unwrap();
         let store = dataset.object_store();

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -877,7 +877,7 @@ mod tests {
             ..Default::default()
         };
         let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        Dataset::write(batches, test_uri, Some(write_params))
+        Dataset::write_to_uri(batches, test_uri, Some(write_params))
             .await
             .unwrap();
 

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1116,7 +1116,7 @@ mod tests {
         let schema = Schema::new(vec![Field::new("a", DataType::Int64, false)]);
 
         let reader = RecordBatchIterator::new(vec![].into_iter().map(Ok), Arc::new(schema));
-        let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+        let mut dataset = Dataset::write_to_uri(reader, test_uri, None).await.unwrap();
 
         let plan = plan_compaction(&dataset, &CompactionOptions::default())
             .await
@@ -1144,7 +1144,7 @@ mod tests {
             max_rows_per_file: 10_000,
             ..Default::default()
         };
-        let dataset = Dataset::write(reader, test_uri, Some(write_params))
+        let dataset = Dataset::write_to_uri(reader, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -1162,7 +1162,7 @@ mod tests {
             mode: WriteMode::Overwrite,
             ..Default::default()
         };
-        let dataset = Dataset::write(reader, test_uri, Some(write_params))
+        let dataset = Dataset::write_to_uri(reader, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -1224,7 +1224,7 @@ mod tests {
             max_rows_per_file: 400,
             ..Default::default()
         };
-        Dataset::write(reader, test_uri, Some(write_params))
+        Dataset::write_to_uri(reader, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -1235,7 +1235,7 @@ mod tests {
             mode: WriteMode::Append,
             ..Default::default()
         };
-        let mut dataset = Dataset::write(reader, test_uri, Some(write_params))
+        let mut dataset = Dataset::write_to_uri(reader, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -1252,7 +1252,7 @@ mod tests {
             mode: WriteMode::Append,
             ..Default::default()
         };
-        let mut dataset = Dataset::write(reader, test_uri, Some(write_params))
+        let mut dataset = Dataset::write_to_uri(reader, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -1371,7 +1371,7 @@ mod tests {
             max_rows_per_group: 1_000,
             ..Default::default()
         };
-        let mut dataset = Dataset::write(reader, test_uri, Some(write_params))
+        let mut dataset = Dataset::write_to_uri(reader, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -1454,7 +1454,7 @@ mod tests {
             max_rows_per_file: 1000,
             ..Default::default()
         };
-        let mut dataset = Dataset::write(reader, test_uri, Some(write_params))
+        let mut dataset = Dataset::write_to_uri(reader, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -1505,7 +1505,7 @@ mod tests {
             max_rows_per_file: 1000,
             ..Default::default()
         };
-        let mut dataset = Dataset::write(reader, test_uri, Some(write_params))
+        let mut dataset = Dataset::write_to_uri(reader, test_uri, Some(write_params))
             .await
             .unwrap();
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1363,7 +1363,7 @@ mod test {
             ..Default::default()
         };
         let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        Dataset::write(batches, test_uri, Some(write_params))
+        Dataset::write_to_uri(batches, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -1403,7 +1403,9 @@ mod test {
         let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
-        Dataset::write(batches, test_uri, None).await.unwrap();
+        Dataset::write_to_uri(batches, test_uri, None)
+            .await
+            .unwrap();
 
         let dataset = Dataset::open(test_uri).await.unwrap();
         let mut scan = dataset.scan();
@@ -1490,7 +1492,9 @@ mod test {
         };
         let reader =
             RecordBatchIterator::new(expected_batches.clone().into_iter().map(Ok), schema.clone());
-        Dataset::write(reader, path, Some(params)).await.unwrap();
+        Dataset::write_to_uri(reader, path, Some(params))
+            .await
+            .unwrap();
         expected_batches
     }
 
@@ -1549,7 +1553,9 @@ mod test {
         };
         let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
 
-        let mut dataset = Dataset::write(reader, path, Some(params)).await.unwrap();
+        let mut dataset = Dataset::write_to_uri(reader, path, Some(params))
+            .await
+            .unwrap();
 
         if build_index {
             let params = VectorIndexParams::ivf_pq(2, 8, 2, false, MetricType::L2, 2);
@@ -1595,7 +1601,7 @@ mod test {
             schema.clone(),
         );
         Arc::new(
-            Dataset::write(
+            Dataset::write_to_uri(
                 new_data_reader,
                 test_uri,
                 Some(WriteParams {
@@ -2073,7 +2079,7 @@ mod test {
 
         let write_batch = |batch: RecordBatch| async {
             let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
-            Dataset::write(reader, test_uri, Some(params)).await
+            Dataset::write_to_uri(reader, test_uri, Some(params)).await
         };
 
         write_batch.clone()(batch1.clone()).await.unwrap();
@@ -2151,7 +2157,7 @@ mod test {
             .into_batch_rows(RowCount::from(5))
             .unwrap();
 
-        Dataset::write(
+        Dataset::write_to_uri(
             data.into_reader_rows(RowCount::from(5), BatchCount::from(1)),
             test_uri,
             None,
@@ -2232,7 +2238,7 @@ mod test {
             .into_batch_rows(RowCount::from(5))
             .unwrap();
 
-        Dataset::write(
+        Dataset::write_to_uri(
             data.into_reader_rows(RowCount::from(5), BatchCount::from(1)),
             test_uri,
             None,
@@ -2476,7 +2482,7 @@ mod test {
 
         let write_params = WriteParams::default();
         let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        let mut dataset = Dataset::write(batches, test_uri, Some(write_params))
+        let mut dataset = Dataset::write_to_uri(batches, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -2542,7 +2548,7 @@ mod test {
 
         let write_params = WriteParams::default();
         let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        Dataset::write(batches, test_uri, Some(write_params))
+        Dataset::write_to_uri(batches, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -2591,7 +2597,7 @@ mod test {
 
         let write_params = WriteParams::default();
         let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        Dataset::write(batches, test_uri, Some(write_params))
+        Dataset::write_to_uri(batches, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -2658,7 +2664,7 @@ mod test {
             max_rows_per_group: 10,
             ..Default::default()
         };
-        Dataset::write(batches, test_uri, Some(write_params))
+        Dataset::write_to_uri(batches, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -2745,7 +2751,7 @@ mod test {
             .unwrap()];
 
             let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-            let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+            let mut dataset = Dataset::write_to_uri(reader, test_uri, None).await.unwrap();
 
             assert_eq!(dataset.index_cache_entry_count(), 0);
             dataset
@@ -2829,7 +2835,7 @@ mod test {
             .unwrap()];
 
             let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-            let mut dataset = Dataset::write(
+            let mut dataset = Dataset::write_to_uri(
                 reader,
                 test_uri,
                 Some(WriteParams {
@@ -2887,7 +2893,7 @@ mod test {
         let mut data_gen = BatchGenerator::new().col(Box::new(
             IncrementingInt32::new().named("Filter_me".to_owned()),
         ));
-        Dataset::write(data_gen.batch(32), test_uri, None)
+        Dataset::write_to_uri(data_gen.batch(32), test_uri, None)
             .await
             .unwrap();
 
@@ -2956,7 +2962,7 @@ mod test {
                 .unwrap();
 
             // Write as two batches so we can later compact
-            let mut dataset = Dataset::write(
+            let mut dataset = Dataset::write_to_uri(
                 RecordBatchIterator::new(vec![Ok(data.clone())], data.schema().clone()),
                 test_uri,
                 Some(WriteParams {

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -395,7 +395,7 @@ mod tests {
         let test_uri = test_dir.path().to_str().unwrap();
 
         let batches = RecordBatchIterator::new([Ok(batch)], schema.clone());
-        let ds = Dataset::write(batches, test_uri, Some(write_params))
+        let ds = Dataset::write_to_uri(batches, test_uri, Some(write_params))
             .await
             .unwrap();
 

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -472,7 +472,7 @@ mod tests {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
         let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+        let mut dataset = Dataset::write_to_uri(reader, test_uri, None).await.unwrap();
 
         let params = VectorIndexParams::ivf_pq(2, 8, 2, false, MetricType::L2, 2);
         dataset

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -154,7 +154,9 @@ mod tests {
         let batch = RecordBatch::try_new(schema.clone(), vec![array.clone()]).unwrap();
 
         let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
-        let mut dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+        let mut dataset = Dataset::write_to_uri(batches, test_uri, None)
+            .await
+            .unwrap();
 
         let ivf_params = IvfBuildParams::new(IVF_PARTITIONS);
         let pq_params = PQBuildParams {

--- a/rust/lance/src/index/vector/diskann.rs
+++ b/rust/lance/src/index/vector/diskann.rs
@@ -148,7 +148,7 @@ mod tests {
         let test_uri = test_dir.path().to_str().unwrap();
 
         let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+        let mut dataset = Dataset::write_to_uri(reader, test_uri, None).await.unwrap();
 
         // Make sure valid arguments should create index successfully
         let params =

--- a/rust/lance/src/index/vector/diskann/builder.rs
+++ b/rust/lance/src/index/vector/diskann/builder.rs
@@ -424,7 +424,7 @@ mod tests {
             ..Default::default()
         };
         let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        Dataset::write(batches, uri, Some(write_params))
+        Dataset::write_to_uri(batches, uri, Some(write_params))
             .await
             .unwrap();
 

--- a/rust/lance/src/index/vector/graph/persisted.rs
+++ b/rust/lance/src/index/vector/graph/persisted.rs
@@ -426,7 +426,7 @@ mod tests {
             ..Default::default()
         };
         let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        let dataset = Dataset::write(batches, test_uri, Some(write_params))
+        let dataset = Dataset::write_to_uri(batches, test_uri, Some(write_params))
             .await
             .unwrap();
 

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -1292,7 +1292,7 @@ mod tests {
 
         async fn generate_dataset(&mut self, test_uri: &str) -> Result<Dataset> {
             let batches = self.generate_batches();
-            Dataset::write(batches, test_uri, None).await
+            Dataset::write_to_uri(batches, test_uri, None).await
         }
 
         async fn check_index<F: Fn(u64) -> Option<u64>>(
@@ -1361,7 +1361,9 @@ mod tests {
         let batch = RecordBatch::try_new(schema.clone(), vec![array.clone()]).unwrap();
 
         let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
-        let dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+        let dataset = Dataset::write_to_uri(batches, test_uri, None)
+            .await
+            .unwrap();
         (dataset, array)
     }
 
@@ -1691,7 +1693,9 @@ mod tests {
         let fsl = FixedSizeListArray::try_new_from_values(arr, DIM as i32).unwrap();
         let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(fsl)]).unwrap();
         let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
-        let mut dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+        let mut dataset = Dataset::write_to_uri(batches, test_uri, None)
+            .await
+            .unwrap();
 
         let params = VectorIndexParams::with_ivf_pq_params(
             MetricType::L2,

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -445,7 +445,7 @@ mod tests {
             }),
             ..Default::default()
         };
-        let dataset = Dataset::write(reader, "memory://test", Some(options))
+        let dataset = Dataset::write_to_uri(reader, "memory://test", Some(options))
             .await
             .unwrap();
 
@@ -619,7 +619,7 @@ mod tests {
             ];
 
         let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        let dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+        let dataset = Dataset::write_to_uri(reader, test_uri, None).await.unwrap();
         dataset.validate().await.unwrap();
 
         // From initial version, concurrently call create index 3 times,
@@ -685,7 +685,7 @@ mod tests {
                 false,
             )]));
 
-            let dataset = Dataset::write(
+            let dataset = Dataset::write_to_uri(
                 RecordBatchIterator::new(vec![].into_iter().map(Ok), schema.clone()),
                 test_uri,
                 None,
@@ -708,7 +708,7 @@ mod tests {
                     let uri = test_uri.to_string();
                     tokio::spawn(async move {
                         let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
-                        Dataset::write(
+                        Dataset::write_to_uri(
                             reader,
                             &uri,
                             Some(WriteParams {

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -597,7 +597,7 @@ mod tests {
         let q = as_fixed_size_list_array(&vector_arr).value(5);
 
         let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        Dataset::write(reader, test_uri, Some(write_params))
+        Dataset::write_to_uri(reader, test_uri, Some(write_params))
             .await
             .unwrap();
 

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -684,7 +684,9 @@ mod test {
         .unwrap()];
         let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
 
-        let dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+        let dataset = Dataset::write_to_uri(batches, test_uri, None)
+            .await
+            .unwrap();
 
         let fragments = dataset.fragments().clone();
         let projection = Arc::new(dataset.schema().clone());
@@ -749,7 +751,11 @@ mod test {
 
         let batches = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
 
-        let dataset = Arc::new(Dataset::write(batches, test_uri, None).await.unwrap());
+        let dataset = Arc::new(
+            Dataset::write_to_uri(batches, test_uri, None)
+                .await
+                .unwrap(),
+        );
 
         let fragments = dataset.fragments().clone();
         // [x.b, y.a]
@@ -834,7 +840,7 @@ mod test {
             ..Default::default()
         };
         let dataset = Arc::new(
-            Dataset::write(batches, test_uri, Some(write_params))
+            Dataset::write_to_uri(batches, test_uri, Some(write_params))
                 .await
                 .unwrap(),
         );
@@ -967,7 +973,7 @@ mod test {
             max_rows_per_group: 3,
             ..Default::default()
         };
-        let mut dataset = Dataset::write(reader, "memory://test", Some(params))
+        let mut dataset = Dataset::write_to_uri(reader, "memory://test", Some(params))
             .await
             .unwrap();
 
@@ -1172,7 +1178,7 @@ mod test {
                 max_rows_per_group: 3,
                 ..Default::default()
             };
-            Dataset::write(reader, uri, Some(write_params))
+            Dataset::write_to_uri(reader, uri, Some(write_params))
                 .await
                 .unwrap()
         }
@@ -1295,7 +1301,7 @@ mod test {
             max_rows_per_group: 10,
             ..Default::default()
         };
-        let mut dataset = Dataset::write(reader, test_uri, Some(write_params))
+        let mut dataset = Dataset::write_to_uri(reader, test_uri, Some(write_params))
             .await
             .unwrap();
 
@@ -1357,7 +1363,7 @@ mod test {
             max_rows_per_group: 4,
             ..Default::default()
         };
-        let mut dataset = Dataset::write(reader, test_uri, Some(write_params))
+        let mut dataset = Dataset::write_to_uri(reader, test_uri, Some(write_params))
             .await
             .unwrap();
 

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -336,7 +336,7 @@ mod tests {
         };
         let reader =
             RecordBatchIterator::new(expected_batches.clone().into_iter().map(Ok), schema.clone());
-        Dataset::write(reader, test_uri, Some(params))
+        Dataset::write_to_uri(reader, test_uri, Some(params))
             .await
             .unwrap();
 


### PR DESCRIPTION
To support in-memory LanceDB tables, we want to be able to keep a reference to the same object store across various dataset operations. This required the following changes:

1. Expose checkout method in the python lance dataset
2. Expose a write instance in the dataset for append/overwrite
3. Add overwrite to the rust dataset (like we have append)
4. Rename the existing `write_data` to `write_to_uri` to disambiguate from the `write_data` instance methods