### PR TITLE
fix: fix query over f16 knn node and sift benchmark

### DIFF
--- a/benchmarks/sift/index.py
+++ b/benchmarks/sift/index.py
@@ -20,7 +20,6 @@ import time
 from subprocess import check_output
 
 import lance
-import numpy as np
 import pyarrow as pa
 
 

--- a/benchmarks/sift/index.py
+++ b/benchmarks/sift/index.py
@@ -80,6 +80,7 @@ def main():
         "arch": platform.machine(),
         "params": {
             "type": args.index_type,
+            "metric": args.metric,
         },
         "duration": end - start,
     }

--- a/benchmarks/sift/metrics.py
+++ b/benchmarks/sift/metrics.py
@@ -18,7 +18,6 @@ import argparse
 import time
 from typing import Optional
 
-import duckdb
 import lance
 import numpy as np
 import pandas as pd
@@ -26,8 +25,7 @@ from lance.torch.bench_utils import ground_truth as gt_func, recall
 
 
 def get_query_vectors(uri, nsamples=1000, normalize=False):
-    """
-    Get the query vectors as a 2d numpy array
+    """Get the query vectors as a 2d numpy array
 
     Parameters
     ----------
@@ -37,10 +35,9 @@ def get_query_vectors(uri, nsamples=1000, normalize=False):
         Number of samples to read from the dataset
     """
     tbl = lance.dataset(uri)
-    query_vectors = duckdb.query(
-        f"SELECT vector FROM tbl USING SAMPLE {nsamples}"
-    ).to_df()
-    query_vectors = np.array([np.array(x) for x in query_vectors.vector.values])
+    query_vectors = np.stack(
+        tbl.sample(nsamples, columns=["vector"])["vector"].to_numpy()
+    )
     if normalize:
         query_vectors = query_vectors / np.linalg.norm(query_vectors, axis=1)[:, None]
     return query_vectors.astype(np.float32)

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -177,8 +177,7 @@ impl KNNFlatExec {
                 location: location!(),
             })?;
         match field.data_type() {
-            DataType::FixedSizeList(list_field, _)
-                if matches!(list_field.data_type(), DataType::Float32) => {}
+            DataType::FixedSizeList(list_field, _) if list_field.data_type().is_floating() => {}
             _ => {
                 return Err(Error::IO {
                     message: format!(


### PR DESCRIPTION
Run end-to-end
```
./benchmark/sift/index.py f16.lance
./benchmark/sift/metrics.py f16.lance
```