### PR TITLE
chore: fix clippy lints on rust 1.75

### DIFF
--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -12,7 +12,7 @@ lto = "thin"
 [target.'cfg(all())']
 rustflags = [
     "-Wclippy::all",
-    # "-Wclippy::style",
+    "-Wclippy::style",
     "-Wclippy::fallible_impl_from",
     "-Wclippy::manual_let_else",
     "-Wclippy::redundant_pub_crate",

--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -415,7 +415,7 @@ impl RecordBatchExt for RecordBatch {
         }
         let left_struct_array: StructArray = self.clone().into();
         let right_struct_array: StructArray = other.clone().into();
-        self.try_new_from_struct_array(merge(&left_struct_array, &right_struct_array)?)
+        self.try_new_from_struct_array(merge(&left_struct_array, &right_struct_array))
     }
 
     fn drop_column(&self, name: &str) -> Result<Self> {
@@ -495,7 +495,7 @@ fn project(struct_array: &StructArray, fields: &Fields) -> Result<StructArray> {
 }
 
 /// Merge the fields and columns of two RecordBatch's recursively
-fn merge(left_struct_array: &StructArray, right_struct_array: &StructArray) -> Result<StructArray> {
+fn merge(left_struct_array: &StructArray, right_struct_array: &StructArray) -> StructArray {
     let mut fields: Vec<Field> = vec![];
     let mut columns: Vec<ArrayRef> = vec![];
     let right_fields = right_struct_array.fields();
@@ -520,7 +520,7 @@ fn merge(left_struct_array: &StructArray, right_struct_array: &StructArray) -> R
                     (DataType::Struct(_), DataType::Struct(_)) => {
                         let left_sub_array = left_column.as_struct();
                         let right_sub_array = right_column.as_struct();
-                        let merged_sub_array = merge(left_sub_array, right_sub_array)?;
+                        let merged_sub_array = merge(left_sub_array, right_sub_array);
                         fields.push(Field::new(
                             left_field.name(),
                             merged_sub_array.data_type().clone(),
@@ -565,7 +565,7 @@ fn merge(left_struct_array: &StructArray, right_struct_array: &StructArray) -> R
         .map(Arc::new)
         .zip(columns.iter().cloned())
         .collect::<Vec<_>>();
-    Ok(StructArray::from(zipped))
+    StructArray::from(zipped)
 }
 
 fn get_sub_array<'a>(array: &'a ArrayRef, components: &[&str]) -> Option<&'a ArrayRef> {

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Lance Developers.
+// Copyright 2024 Lance Developers.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -749,7 +749,7 @@ mod tests {
             let field = Field::try_from(&arrow_field).unwrap();
             assert_eq!(field.name, name);
             assert_eq!(field.data_type(), data_type);
-            assert_eq!(ArrowField::try_from(&field).unwrap(), arrow_field);
+            assert_eq!(ArrowField::from(&field), arrow_field);
         }
     }
 
@@ -801,7 +801,7 @@ mod tests {
         let field = Field::try_from(&arrow_field).unwrap();
         assert_eq!(field.name, "struct");
         assert_eq!(&field.data_type(), arrow_field.data_type());
-        assert_eq!(ArrowField::try_from(&field).unwrap(), arrow_field);
+        assert_eq!(ArrowField::from(&field), arrow_field);
     }
 
     #[test]

--- a/rust/lance-core/src/io/commit/external_manifest.rs
+++ b/rust/lance-core/src/io/commit/external_manifest.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Lance Developers.
+// Copyright 2024 Lance Developers.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rust/lance-datafusion/src/expr.rs
+++ b/rust/lance-datafusion/src/expr.rs
@@ -131,15 +131,9 @@ pub fn safe_coerce_scalar(value: &ScalarValue, ty: &DataType) -> Option<ScalarVa
             DataType::Int8 => {
                 val.and_then(|v| i8::try_from(v).map(|v| ScalarValue::Int8(Some(v))).ok())
             }
-            DataType::Int16 => {
-                val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
-            }
-            DataType::Int32 => {
-                val.and_then(|v| i32::try_from(v).map(|v| ScalarValue::Int32(Some(v))).ok())
-            }
-            DataType::Int64 => {
-                val.and_then(|v| i64::try_from(v).map(|v| ScalarValue::Int64(Some(v))).ok())
-            }
+            DataType::Int16 => val.map(|v| ScalarValue::Int16(Some(v.into()))),
+            DataType::Int32 => val.map(|v| ScalarValue::Int32(Some(v.into()))),
+            DataType::Int64 => val.map(|v| ScalarValue::Int64(Some(v.into()))),
             DataType::UInt8 => Some(value.clone()),
             DataType::UInt16 => val.map(|v| ScalarValue::UInt16(Some(u16::from(v)))),
             DataType::UInt32 => val.map(|v| ScalarValue::UInt32(Some(u32::from(v)))),

--- a/rust/lance-datafusion/src/expr.rs
+++ b/rust/lance-datafusion/src/expr.rs
@@ -149,12 +149,8 @@ pub fn safe_coerce_scalar(value: &ScalarValue, ty: &DataType) -> Option<ScalarVa
             DataType::Int16 => {
                 val.and_then(|v| i16::try_from(v).map(|v| ScalarValue::Int16(Some(v))).ok())
             }
-            DataType::Int32 => {
-                val.and_then(|v| i32::try_from(v).map(|v| ScalarValue::Int32(Some(v))).ok())
-            }
-            DataType::Int64 => {
-                val.and_then(|v| i64::try_from(v).map(|v| ScalarValue::Int64(Some(v))).ok())
-            }
+            DataType::Int32 => val.map(|v| ScalarValue::Int32(Some(v.into()))),
+            DataType::Int64 => val.map(|v| ScalarValue::Int64(Some(v.into()))),
             DataType::UInt8 => {
                 val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
             }
@@ -175,9 +171,7 @@ pub fn safe_coerce_scalar(value: &ScalarValue, ty: &DataType) -> Option<ScalarVa
             DataType::Int32 => {
                 val.and_then(|v| i32::try_from(v).map(|v| ScalarValue::Int32(Some(v))).ok())
             }
-            DataType::Int64 => {
-                val.and_then(|v| i64::try_from(v).map(|v| ScalarValue::Int64(Some(v))).ok())
-            }
+            DataType::Int64 => val.map(|v| ScalarValue::Int64(Some(v.into()))),
             DataType::UInt8 => {
                 val.and_then(|v| u8::try_from(v).map(|v| ScalarValue::UInt8(Some(v))).ok())
             }

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -508,10 +508,7 @@ impl Scanner {
                 message: format!("Column {} not found", q.column),
                 location: location!(),
             })?;
-            let vector_field = ArrowField::try_from(vector_field).map_err(|e| Error::IO {
-                message: format!("Failed to convert vector field: {}", e),
-                location: location!(),
-            })?;
+            let vector_field = ArrowField::from(vector_field);
             extra_columns.push(vector_field);
             extra_columns.push(ArrowField::new(DIST_COL, DataType::Float32, true));
         };

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -929,7 +929,7 @@ impl RemapPageTask {
     }
 }
 
-fn generate_remap_tasks(offsets: &Vec<usize>, lengths: &[u32]) -> Result<Vec<RemapPageTask>> {
+fn generate_remap_tasks(offsets: &[usize], lengths: &[u32]) -> Result<Vec<RemapPageTask>> {
     let mut tasks: Vec<RemapPageTask> = Vec::with_capacity(offsets.len() * 2 + 1);
 
     for (offset, length) in offsets.iter().zip(lengths.iter()) {

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -56,9 +56,9 @@ use crate::format::{DeletionFile, Fragment};
 use crate::index::DatasetIndexInternalExt;
 use crate::Dataset;
 
-#[cfg(all(target_feature = "dynamodb", tests))]
+#[cfg(all(target_feature = "dynamodb", test))]
 mod dynamodb;
-#[cfg(tests)]
+#[cfg(test)]
 mod external_manifest;
 pub use lance_core::io::commit::latest_manifest_path;
 

--- a/rust/lance/src/io/commit/external_manifest.rs
+++ b/rust/lance/src/io/commit/external_manifest.rs
@@ -292,8 +292,6 @@ mod test {
         // set the store back to dataset path with -{uuid} suffix
         let mut version_six = localfs
             .list(Some(&ds.base))
-            .await
-            .unwrap()
             .try_filter(|p| {
                 let p = p.clone();
                 async move { p.location.filename().unwrap().starts_with("6.manifest-") }

--- a/rust/lance/src/io/exec/projection.rs
+++ b/rust/lance/src/io/exec/projection.rs
@@ -46,7 +46,7 @@ impl ProjectionStream {
     fn new(input: SendableRecordBatchStream, projection: &Schema) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel(2);
 
-        let schema = Arc::new(ArrowSchema::try_from(projection).unwrap());
+        let schema = Arc::new(ArrowSchema::from(projection));
         let schema_clone = schema.clone();
         let bg_thread = tokio::spawn(async move {
             if let Err(e) = input
@@ -158,8 +158,7 @@ impl ExecutionPlan for ProjectionExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        let arrow_schema =
-            ArrowSchema::try_from(self.project.as_ref()).expect("convert to arrow schema");
+        let arrow_schema = ArrowSchema::from(self.project.as_ref());
         arrow_schema.into()
     }
 

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -246,7 +246,7 @@ impl ExecutionPlan for TakeExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        ArrowSchema::try_from(&self.output_schema).unwrap().into()
+        ArrowSchema::from(&self.output_schema).into()
     }
 
     fn output_partitioning(&self) -> datafusion::physical_plan::Partitioning {


### PR DESCRIPTION
Rust `1.75` clippy introduces a bunch of new warnings. This PR fixes them.