### PR TITLE
feat(python): add with_row_id to fragment scanner

### DIFF
--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -237,11 +237,16 @@ class LanceFragment(pa.dataset.Fragment):
         filter: Optional[Union[str, pa.compute.Expression]] = None,
         limit: int = 0,
         offset: Optional[int] = None,
+        with_row_id: bool = False,
     ) -> "LanceScanner":
         """See Dataset::scanner for details"""
         filter_str = str(filter) if filter is not None else None
         s = self._fragment.scanner(
-            columns=columns, filter=filter_str, limit=limit, offset=offset
+            columns=columns,
+            filter=filter_str,
+            limit=limit,
+            offset=offset,
+            with_row_id=with_row_id,
         )
         from .dataset import LanceScanner
 
@@ -256,9 +261,14 @@ class LanceFragment(pa.dataset.Fragment):
         filter: Optional[Union[str, pa.compute.Expression]] = None,
         limit: int = 0,
         offset: Optional[int] = None,
+        with_row_id: bool = False,
     ) -> Iterator[pa.RecordBatch]:
         return self.scanner(
-            columns=columns, filter=filter, limit=limit, offset=offset
+            columns=columns,
+            filter=filter,
+            limit=limit,
+            offset=offset,
+            with_row_id=with_row_id,
         ).to_batches()
 
     def to_table(
@@ -267,9 +277,14 @@ class LanceFragment(pa.dataset.Fragment):
         filter: Optional[Union[str, pa.compute.Expression]] = None,
         limit: int = 0,
         offset: Optional[int] = None,
+        with_row_id: bool = False,
     ) -> pa.Table:
         return self.scanner(
-            columns=columns, filter=filter, limit=limit, offset=offset
+            columns=columns,
+            filter=filter,
+            limit=limit,
+            offset=offset,
+            with_row_id=with_row_id,
         ).to_table()
 
     def add_columns(

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -197,7 +197,7 @@ impl FileFragment {
         scanner
             .limit(limit, offset)
             .map_err(|err| PyValueError::new_err(err.to_string()))?;
-        
+
         if with_row_id.unwrap_or(false) {
             scanner.with_row_id();
         }

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -180,6 +180,7 @@ impl FileFragment {
         filter: Option<String>,
         limit: Option<i64>,
         offset: Option<i64>,
+        with_row_id: Option<bool>,
     ) -> PyResult<Scanner> {
         let mut scanner = self_.fragment.scan();
         if let Some(cols) = columns {
@@ -196,6 +197,10 @@ impl FileFragment {
         scanner
             .limit(limit, offset)
             .map_err(|err| PyValueError::new_err(err.to_string()))?;
+        
+        if with_row_id.unwrap_or(false) {
+            scanner.with_row_id();
+        }
 
         let scn = Arc::new(scanner);
         Ok(Scanner::new(scn))


### PR DESCRIPTION
Add `with_row_id` parameter to `to_table`, `to_batches`, and `scanner` methods of LanceFragment (similar to LanceDataset). This just so the developer does not need to manually compute the row id.