### PR TITLE
chore: fix cuda-based indexing with f16

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1065,12 +1065,13 @@ class LanceDataset(pa.dataset.Dataset):
                             f"Ivf centroids must be 2D array: (clusters, dim), "
                             f"got {ivf_centroids.shape}"
                         )
-                    if ivf_centroids.dtype != np.float32:
+                    if ivf_centroids.dtype not in [np.float16, np.float32, np.float64]:
                         raise TypeError(
-                            f"IVF centroids must be float32, got {ivf_centroids.dtype}"
+                            "IVF centroids must be floating number"
+                            + f"got {ivf_centroids.dtype}"
                         )
                     dim = ivf_centroids.shape[1]
-                    values = pa.array(ivf_centroids.reshape(-1), type=pa.float32())
+                    values = pa.array(ivf_centroids.reshape(-1))
                     ivf_centroids = pa.FixedSizeListArray.from_arrays(values, dim)
                 # Convert it to RecordBatch because Rust side only accepts RecordBatch.
                 ivf_centroids_batch = pa.RecordBatch.from_arrays(

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -183,7 +183,7 @@ def train_ivf_centroids_on_accelerator(
         )
         kmeans.fit(ds)
 
-    centroids = kmeans.centroids.cpu().float().numpy()
+    centroids = kmeans.centroids.cpu().numpy()
 
     with tempfile.NamedTemporaryFile(delete=False) as f:
         np.save(f, centroids)


### PR DESCRIPTION
Pytorch CUDA code pass the correct data type to rust , so rust can decide the data type correctly