### PR TITLE
feat: expose shuffler parameters for controlling memory usage

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -720,6 +720,16 @@ impl Dataset {
                     if let Some(f) = kwargs.get_item("precomputed_partitions_file")? {
                         ivf_params.precomputed_partitons_file = Some(f.to_string());
                     };
+
+                    if let Some(o) = kwargs.get_item("shuffle_partition_batches")? {
+                        ivf_params.shuffle_partition_batches =
+                            PyAny::downcast::<PyInt>(o)?.extract()?;
+                    };
+
+                    if let Some(o) = kwargs.get_item("shuffle_partition_concurrency")? {
+                        ivf_params.shuffle_partition_concurrency =
+                            PyAny::downcast::<PyInt>(o)?.extract()?;
+                    };
                 }
                 Box::new(VectorIndexParams::with_ivf_pq_params(
                     m_type, ivf_params, pq_params,

--- a/rust/lance-index/src/vector/ivf/builder.rs
+++ b/rust/lance-index/src/vector/ivf/builder.rs
@@ -37,6 +37,10 @@ pub struct IvfBuildParams {
     pub sample_rate: usize,
 
     pub precomputed_partitons_file: Option<String>,
+
+    pub shuffle_partition_batches: usize,
+
+    pub shuffle_partition_concurrency: usize,
 }
 
 impl Default for IvfBuildParams {
@@ -47,6 +51,8 @@ impl Default for IvfBuildParams {
             centroids: None,
             sample_rate: 256, // See faiss
             precomputed_partitons_file: None,
+            shuffle_partition_batches: 1024 * 10,
+            shuffle_partition_concurrency: 2,
         }
     }
 }

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -224,6 +224,8 @@ impl IVFIndex {
             ivf,
             self.ivf.num_partitions() as u32,
             pq_index.pq.num_sub_vectors(),
+            10000,
+            2,
         )
         .await?;
         let mut ivf_mut = Ivf::new(self.ivf.centroids.clone());
@@ -878,6 +880,8 @@ pub async fn build_ivf_pq_index(
         metric_type,
         stream,
         precomputed_partitions,
+        ivf_params.shuffle_partition_batches,
+        ivf_params.shuffle_partition_concurrency,
     )
     .await
 }
@@ -1015,6 +1019,8 @@ async fn write_index_file(
     metric_type: MetricType,
     stream: impl RecordBatchStream + Unpin + 'static,
     precomputed_partitons: Option<HashMap<u64, u32>>,
+    shuffle_partition_batches: usize,
+    shuffle_partition_concurrency: usize,
 ) -> Result<()> {
     let object_store = dataset.object_store();
     let path = dataset.indices_dir().child(uuid).child(INDEX_FILE_NAME);
@@ -1031,6 +1037,8 @@ async fn write_index_file(
         metric_type,
         0..num_partitions,
         precomputed_partitons,
+        shuffle_partition_batches,
+        shuffle_partition_concurrency,
     )
     .await?;
     info!("Built IVF partitions: {}s", start.elapsed().as_secs_f32());


### PR DESCRIPTION
Upstream fix for https://github.com/lancedb/lancedb/issues/767

TODO:
- [ ] tests? (honestly not sure what I can do about asserting the memory usage is less, spawn test in new process with cgroup limits?)
- [ ] pending test