### PR TITLE
feat: allow externally generated shuffle buffer and multiple of them

### DIFF
--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -565,8 +565,7 @@ fn merge(left_struct_array: &StructArray, right_struct_array: &StructArray) -> R
         .map(Arc::new)
         .zip(columns.iter().cloned())
         .collect::<Vec<_>>();
-    StructArray::try_from(zipped)
-        .map_err(|e| ArrowError::ComputeError(format!("Failed to merge RecordBatch: {}", e)))
+    Ok(StructArray::from(zipped))
 }
 
 fn get_sub_array<'a>(array: &'a ArrayRef, components: &[&str]) -> Option<&'a ArrayRef> {

--- a/rust/lance-index/src/vector/ivf/shuffler.rs
+++ b/rust/lance-index/src/vector/ivf/shuffler.rs
@@ -52,6 +52,8 @@ fn get_temp_dir() -> Result<Path> {
 }
 
 pub struct IvfShuffler {
+    unsorted_buffers: Vec<String>,
+
     num_partitions: u32,
 
     pq_width: usize,
@@ -59,6 +61,16 @@ pub struct IvfShuffler {
     output_dir: Path,
 
     schema: Schema,
+}
+
+/// Represents a range of batches in a file that should be shuffled
+struct ShuffleInput {
+    // the idx of the file in IvfShuffler::unsorted_buffers
+    file_idx: usize,
+    // the start index of the batch in the file
+    start: usize,
+    // the end index of the batch in the file
+    end: usize,
 }
 
 impl IvfShuffler {
@@ -78,11 +90,21 @@ impl IvfShuffler {
             pq_width,
             output_dir,
             schema,
+            unsorted_buffers: vec![],
         })
     }
 
+    /// Set the unsorted buffers to be shuffled.
+    ///
+    /// # Safety
+    ///
+    /// user must ensure the buffers are valid.
+    pub unsafe fn set_unsorted_buffers(&mut self, unsorted_buffers: &[impl ToString]) {
+        self.unsorted_buffers = unsorted_buffers.iter().map(|x| x.to_string()).collect();
+    }
+
     pub async fn write_unsorted_stream(
-        &self,
+        &mut self,
         data: impl RecordBatchStream + Unpin + 'static,
     ) -> Result<()> {
         let object_store = ObjectStore::local();
@@ -100,37 +122,52 @@ impl IvfShuffler {
 
         file_writer.finish().await?;
 
+        unsafe {
+            self.set_unsorted_buffers(&[UNSORTED_BUFFER]);
+        }
+
         Ok(())
     }
 
-    async fn total_batches(&self) -> Result<usize> {
-        let object_store = ObjectStore::local();
-        let path = self.output_dir.child(UNSORTED_BUFFER);
-        let reader = FileReader::try_new(&object_store, &path).await?;
-        Ok(reader.num_batches())
+    async fn total_batches(&self) -> Result<Vec<usize>> {
+        let mut total_batches = vec![];
+        for buffer in &self.unsorted_buffers {
+            let object_store = ObjectStore::local();
+            let path = self.output_dir.child(buffer.as_str());
+            let reader = FileReader::try_new(&object_store, &path).await?;
+            total_batches.push(reader.num_batches());
+        }
+        Ok(total_batches)
     }
 
-    async fn count_partition_size(&self, start: usize, end: usize) -> Result<Vec<u64>> {
+    async fn count_partition_size(&self, inputs: &[ShuffleInput]) -> Result<Vec<u64>> {
         let object_store = ObjectStore::local();
-        let path = self.output_dir.child(UNSORTED_BUFFER);
-        let reader = FileReader::try_new(&object_store, &path).await?;
-
         let mut partition_sizes = vec![0; self.num_partitions as usize];
 
-        let lance_schema = reader
-            .schema()
-            .project(&[PART_ID_COLUMN])
-            .expect("part id should exist");
+        for &ShuffleInput {
+            file_idx,
+            start,
+            end,
+        } in inputs
+        {
+            let file_name = &self.unsorted_buffers[file_idx];
+            let path = self.output_dir.child(file_name.as_str());
+            let reader = FileReader::try_new(&object_store, &path).await?;
+            let lance_schema = reader
+                .schema()
+                .project(&[PART_ID_COLUMN])
+                .expect("part id should exist");
 
-        let mut stream = stream::iter(start..end)
-            .map(|i| reader.read_batch(i as i32, ReadBatchParams::RangeFull, &lance_schema))
-            .buffered(64);
+            let mut stream = stream::iter(start..end)
+                .map(|i| reader.read_batch(i as i32, .., &lance_schema))
+                .buffer_unordered(16);
 
-        while let Some(batch) = stream.next().await {
-            let batch = batch?;
-            let part_ids: &UInt32Array = batch.column(0).as_primitive();
-            for part_id in part_ids.values() {
-                partition_sizes[*part_id as usize] += 1;
+            while let Some(batch) = stream.next().await {
+                let batch = batch?;
+                let part_ids: &UInt32Array = batch.column(0).as_primitive();
+                part_ids.values().iter().for_each(|part_id| {
+                    partition_sizes[*part_id as usize] += 1;
+                });
             }
         }
 
@@ -139,9 +176,8 @@ impl IvfShuffler {
 
     async fn shuffle_to_partitions(
         &self,
+        inputs: &[ShuffleInput],
         partition_size: Vec<u64>,
-        start: usize,
-        end: usize,
     ) -> Result<(Vec<Vec<u64>>, Vec<Vec<u8>>)> {
         let mut row_id_buffers = partition_size
             .iter()
@@ -152,55 +188,63 @@ impl IvfShuffler {
             .map(|s| Vec::with_capacity((*s as usize) * self.pq_width))
             .collect::<Vec<_>>();
 
-        let object_store = ObjectStore::local();
-        let path = self.output_dir.child(UNSORTED_BUFFER);
-        let reader = FileReader::try_new(&object_store, &path).await?;
-        let total_batch = reader.num_batches();
-
         info!("Shuffling into memory");
 
-        let mut stream = stream::iter(start..end)
-            .map(|i| reader.read_batch(i as i32, ReadBatchParams::RangeFull, reader.schema()))
-            .buffered(16)
-            .enumerate();
+        for &ShuffleInput {
+            file_idx,
+            start,
+            end,
+        } in inputs
+        {
+            let object_store = ObjectStore::local();
+            let file_name = &self.unsorted_buffers[file_idx];
+            let path = self.output_dir.child(file_name.as_str());
+            let reader = FileReader::try_new(&object_store, &path).await?;
+            let total_batch = reader.num_batches();
 
-        while let Some((idx, batch)) = stream.next().await {
-            if idx % 100 == 0 {
-                info!("Shuffle Progress {}/{}", idx, total_batch);
+            let mut stream = stream::iter(start..end)
+                .map(|i| reader.read_batch(i as i32, ReadBatchParams::RangeFull, reader.schema()))
+                .buffered(16)
+                .enumerate();
+
+            while let Some((idx, batch)) = stream.next().await {
+                if idx % 100 == 0 {
+                    info!("Shuffle Progress {}/{}", idx, total_batch);
+                }
+
+                let batch = batch?;
+
+                let row_ids: &UInt64Array = batch
+                    .column_by_name(ROW_ID)
+                    .expect("Row ID column not found")
+                    .as_primitive();
+
+                let part_ids: &UInt32Array = batch
+                    .column_by_name(PART_ID_COLUMN)
+                    .expect("Partition ID column not found")
+                    .as_primitive();
+
+                let pq_codes: &UInt8Array = batch
+                    .column_by_name(PQ_CODE_COLUMN)
+                    .expect("PQ Code column not found")
+                    .as_fixed_size_list()
+                    .values()
+                    .as_primitive();
+
+                let num_sub_vectors = pq_codes.len() / row_ids.len();
+
+                row_ids
+                    .values()
+                    .iter()
+                    .zip(part_ids.values().iter())
+                    .enumerate()
+                    .for_each(|(i, (row_id, part_id))| {
+                        row_id_buffers[*part_id as usize].push(*row_id);
+                        pq_code_buffers[*part_id as usize].extend(
+                            &pq_codes.values()[i * num_sub_vectors..(i + 1) * num_sub_vectors],
+                        );
+                    });
             }
-
-            let batch = batch?;
-
-            let row_ids: &UInt64Array = batch
-                .column_by_name(ROW_ID)
-                .expect("Row ID column not found")
-                .as_primitive();
-
-            let part_ids: &UInt32Array = batch
-                .column_by_name(PART_ID_COLUMN)
-                .expect("Partition ID column not found")
-                .as_primitive();
-
-            let pq_codes: &UInt8Array = batch
-                .column_by_name(PQ_CODE_COLUMN)
-                .expect("PQ Code column not found")
-                .as_fixed_size_list()
-                .values()
-                .as_primitive();
-
-            let num_sub_vectors = pq_codes.len() / row_ids.len();
-
-            row_ids
-                .values()
-                .iter()
-                .zip(part_ids.values().iter())
-                .enumerate()
-                .for_each(|(i, (row_id, part_id))| {
-                    row_id_buffers[*part_id as usize].push(*row_id);
-                    pq_code_buffers[*part_id as usize].extend(
-                        pq_codes.values()[i * num_sub_vectors..(i + 1) * num_sub_vectors].iter(),
-                    );
-                });
         }
 
         Ok((row_id_buffers, pq_code_buffers))
@@ -211,18 +255,57 @@ impl IvfShuffler {
         batches_per_partition: usize,
         concurrent_jobs: usize,
     ) -> Result<Vec<String>> {
-        let total_batches = self.total_batches().await?;
+        let num_batches = self.total_batches().await?;
+        let total_batches = num_batches.iter().sum();
 
         stream::iter((0..total_batches).step_by(batches_per_partition))
-            .map(|i| async move {
+            .zip(stream::repeat(num_batches))
+            .map(|(i, num_batches)| async move {
+                // first, calculate which files and ranges needs to be processed
                 let start = i;
                 let end = std::cmp::min(i + batches_per_partition, total_batches);
+                let mut input = vec![];
 
-                let size_counts = self.count_partition_size(start, end).await?;
+                let mut cumulative_size = 0;
+                for (file_idx, partition_size) in num_batches.iter().enumerate() {
+                    let cur_start = cumulative_size;
+                    let cur_end = cumulative_size + partition_size;
 
+                    cumulative_size += partition_size;
+
+                    let should_include_file = start < cur_end && end > cur_start;
+
+                    if !should_include_file {
+                        continue;
+                    }
+
+                    // the currnet part doesn't overlap with the current batch
+                    if start >= cur_end {
+                        continue;
+                    }
+
+                    let local_start = if start < cur_start {
+                        0
+                    } else {
+                        start - cur_start
+                    };
+                    let local_end = std::cmp::min(end - cur_start, *partition_size);
+
+                    input.push(ShuffleInput {
+                        file_idx,
+                        start: local_start,
+                        end: local_end,
+                    });
+                }
+
+                // second, count the number of rows in each partition
+                let size_counts = self.count_partition_size(&input).await?;
+
+                // third, shuffle the data into each partition
                 let (row_id_buffers, pq_code_buffers) =
-                    self.shuffle_to_partitions(size_counts, start, end).await?;
+                    self.shuffle_to_partitions(&input, size_counts).await?;
 
+                // finally, write the shuffled data to disk
                 let object_store = ObjectStore::local();
                 let output_file = format!("sorted_{}.lance", i);
                 let path = self.output_dir.child(output_file.clone());
@@ -310,5 +393,200 @@ impl IvfShuffler {
         }
 
         Ok(streams)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use arrow_array::{
+        types::{UInt32Type, UInt64Type, UInt8Type},
+        Array,
+    };
+    use lance_core::io::RecordBatchStreamAdapter;
+
+    use super::*;
+
+    fn make_schema() -> Arc<ArrowSchema> {
+        Arc::new(ArrowSchema::new(vec![
+            ROW_ID_FIELD.clone(),
+            ArrowField::new(PART_ID_COLUMN, DataType::UInt32, false),
+            ArrowField::new(
+                PQ_CODE_COLUMN,
+                DataType::FixedSizeList(
+                    Arc::new(ArrowField::new("item", DataType::UInt8, true)),
+                    32,
+                ),
+                false,
+            ),
+        ]))
+    }
+
+    fn make_stream_and_shuffler() -> (impl RecordBatchStream, IvfShuffler) {
+        let schema = make_schema();
+
+        let schema2 = schema.clone();
+
+        let stream = stream::iter(0..100).map(move |idx| {
+            let row_ids = Arc::new(UInt64Array::from_iter(idx * 1024..(idx + 1) * 1024));
+
+            let part_id = Arc::new(UInt32Array::from_iter(
+                (idx * 1024..(idx + 1) * 1024).map(|_| idx as u32),
+            ));
+
+            let values = Arc::new(UInt8Array::from_iter((0..32 * 1024).map(|_| idx as u8)));
+            let pq_codes = Arc::new(
+                FixedSizeListArray::try_new_from_values(values as Arc<dyn Array>, 32).unwrap(),
+            );
+
+            Ok(RecordBatch::try_new(schema2.clone(), vec![row_ids, part_id, pq_codes]).unwrap())
+        });
+
+        let stream = RecordBatchStreamAdapter::new(schema.clone(), stream);
+
+        let shuffler =
+            IvfShuffler::try_new(100, 32, None, Schema::try_from(schema.as_ref()).unwrap())
+                .unwrap();
+
+        (stream, shuffler)
+    }
+
+    fn check_batch(batch: RecordBatch, idx: usize, num_rows: usize) {
+        let row_ids = batch
+            .column_by_name(ROW_ID)
+            .unwrap()
+            .as_primitive::<UInt64Type>();
+        let part_ids = batch
+            .column_by_name(PART_ID_COLUMN)
+            .unwrap()
+            .as_primitive::<UInt32Type>();
+        let pq_codes = batch
+            .column_by_name(PQ_CODE_COLUMN)
+            .unwrap()
+            .as_fixed_size_list()
+            .values()
+            .as_primitive::<UInt8Type>();
+
+        assert_eq!(row_ids.len(), num_rows);
+        assert_eq!(part_ids.len(), num_rows);
+        assert_eq!(pq_codes.len(), num_rows * 32);
+
+        for i in 0..num_rows {
+            assert_eq!(part_ids.value(i), idx as u32);
+        }
+
+        for v in pq_codes.values() {
+            assert_eq!(*v, idx as u8);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_shuffler_single_partition() {
+        let (stream, mut shuffler) = make_stream_and_shuffler();
+
+        shuffler.write_unsorted_stream(stream).await.unwrap();
+        let partition_files = shuffler.write_partitioned_shuffles(100, 1).await.unwrap();
+
+        assert_eq!(partition_files.len(), 1);
+
+        let mut result_stream = shuffler
+            .load_partitioned_shuffles(partition_files)
+            .await
+            .unwrap();
+
+        let mut num_batches = 0;
+        let mut stream = result_stream.pop().unwrap();
+
+        while let Some(item) = stream.next().await {
+            check_batch(item.unwrap(), num_batches, 1024);
+            num_batches += 1;
+        }
+
+        assert_eq!(num_batches, 100);
+    }
+
+    #[tokio::test]
+    async fn test_shuffler_multiple_partition() {
+        let (stream, mut shuffler) = make_stream_and_shuffler();
+
+        shuffler.write_unsorted_stream(stream).await.unwrap();
+        let partition_files = shuffler.write_partitioned_shuffles(1, 100).await.unwrap();
+
+        assert_eq!(partition_files.len(), 100);
+
+        let mut result_stream = shuffler
+            .load_partitioned_shuffles(partition_files)
+            .await
+            .unwrap();
+
+        let mut num_batches = 0;
+        result_stream.reverse();
+
+        while let Some(mut stream) = result_stream.pop() {
+            while let Some(item) = stream.next().await {
+                check_batch(item.unwrap(), num_batches, 1024);
+                num_batches += 1
+            }
+        }
+
+        assert_eq!(num_batches, 100);
+    }
+
+    #[tokio::test]
+    async fn test_shuffler_multi_buffer_single_partition() {
+        let (stream, mut shuffler) = make_stream_and_shuffler();
+        shuffler.write_unsorted_stream(stream).await.unwrap();
+
+        // set the same buffer twice we should get double the data
+        unsafe { shuffler.set_unsorted_buffers(&[UNSORTED_BUFFER, UNSORTED_BUFFER]) }
+
+        let partition_files = shuffler.write_partitioned_shuffles(200, 1).await.unwrap();
+
+        assert_eq!(partition_files.len(), 1);
+
+        let mut result_stream = shuffler
+            .load_partitioned_shuffles(partition_files)
+            .await
+            .unwrap();
+
+        let mut num_batches = 0;
+        result_stream.reverse();
+
+        while let Some(mut stream) = result_stream.pop() {
+            while let Some(item) = stream.next().await {
+                check_batch(item.unwrap(), num_batches, 2048);
+                num_batches += 1
+            }
+        }
+
+        assert_eq!(num_batches, 100);
+    }
+
+    #[tokio::test]
+    async fn test_shuffler_multi_buffer_multi_partition() {
+        let (stream, mut shuffler) = make_stream_and_shuffler();
+        shuffler.write_unsorted_stream(stream).await.unwrap();
+
+        // set the same buffer twice we should get double the data
+        unsafe { shuffler.set_unsorted_buffers(&[UNSORTED_BUFFER, UNSORTED_BUFFER]) }
+
+        let partition_files = shuffler.write_partitioned_shuffles(1, 32).await.unwrap();
+        assert_eq!(partition_files.len(), 200);
+
+        let mut result_stream = shuffler
+            .load_partitioned_shuffles(partition_files)
+            .await
+            .unwrap();
+
+        let mut num_batches = 0;
+        result_stream.reverse();
+
+        while let Some(mut stream) = result_stream.pop() {
+            while let Some(item) = stream.next().await {
+                check_batch(item.unwrap(), num_batches % 100, 1024);
+                num_batches += 1
+            }
+        }
+
+        assert_eq!(num_batches, 200);
     }
 }

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -71,7 +71,7 @@ use crate::{
         pb,
         prefilter::PreFilter,
         vector::{
-            ivf::{builder::shuffle_dataset_v2, io::write_index_partitions},
+            ivf::{builder::shuffle_dataset, io::write_index_partitions},
             Transformer,
         },
         INDEX_FILE_NAME,
@@ -218,7 +218,7 @@ impl IVFIndex {
             None,
         )?;
 
-        let shuffled = shuffle_dataset_v2(
+        let shuffled = shuffle_dataset(
             data,
             column,
             ivf,

--- a/rust/lance/src/index/vector/ivf/builder.rs
+++ b/rust/lance/src/index/vector/ivf/builder.rs
@@ -18,18 +18,10 @@ use std::sync::Arc;
 
 use arrow_array::RecordBatch;
 use arrow_schema::{DataType, Field, Schema};
-use datafusion::error::DataFusionError;
-use datafusion::execution::context::SessionContext;
-use datafusion::execution::memory_pool::{GreedyMemoryPool, MemoryPool, UnboundedMemoryPool};
-use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
-use datafusion::logical_expr::col;
-use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::Stream;
 use futures::{stream::repeat_with, StreamExt};
 use lance_core::datatypes::Schema as LanceSchema;
 use lance_core::{io::Writer, ROW_ID, ROW_ID_FIELD};
-use lance_datafusion::dataframe::{BatchStreamGrouper, DataFrameExt};
-use lance_datafusion::exec::SessionContextExt;
 use lance_index::vector::ivf::shuffler::IvfShuffler;
 use lance_index::vector::pq::ProductQuantizer;
 use lance_index::vector::{PART_ID_COLUMN, PQ_CODE_COLUMN};
@@ -41,97 +33,25 @@ use tracing::instrument;
 use crate::index::vector::ivf::{io::write_index_partitions, Ivf};
 use crate::{io::RecordBatchStream, Error, Result};
 
-/// Disk-based shuffle a stream of [RecordBatch] into each IVF partition.
+/// Disk-based shuffle for a stream of [RecordBatch] into each IVF partition.
 /// Sub-quantizer will be applied if provided.
 ///
 /// Parameters
 /// ----------
 ///   *data*: input data stream.
+///   *column*: column name of the vector column.
 ///   *ivf*: IVF model.
+///   *num_partitions*: number of IVF partitions.
+///   *num_sub_vectors*: number of PQ sub-vectors.
 ///
 /// Returns
 /// -------
-///   BatchStreamGrouper: a stream of `Vec<RecordBatch>` each associated with
-///   a partition id. The stream is sorted by partition id.
+///   Result<Vec<impl Stream<Item = Result<RecordBatch>>>>: a vector of streams
+///   of shuffled partitioned data. Each stream corresponds to a partition and
+///   is sorted within the stream. Consumer of these streams is expected to merge
+///   the streams into a single stream by k-list mergo algo.
 ///
-/// TODO: move this to `lance-index` crate.
-#[allow(dead_code)]
 pub async fn shuffle_dataset(
-    data: impl RecordBatchStream + Unpin + 'static,
-    column: &str,
-    ivf: Arc<dyn lance_index::vector::ivf::Ivf>,
-    // TODO: Once the transformer can generate schema automatically,
-    // we can remove `num_sub_vectors`.
-    num_sub_vectors: usize,
-) -> Result<BatchStreamGrouper> {
-    let column: Arc<str> = column.into();
-    let stream = data
-        .zip(repeat_with(move || ivf.clone()))
-        .map(move |(b, ivf)| {
-            let col_ref = column.clone();
-
-            tokio::task::spawn(async move {
-                let batch = b?;
-                ivf.partition_transform(&batch, col_ref.as_ref()).await
-            })
-        })
-        .buffer_unordered(num_cpus::get())
-        .map(|res| match res {
-            Ok(Ok(batch)) => Ok(batch),
-            Ok(Err(err)) => Err(DataFusionError::External(Box::new(err))),
-            Err(err) => Err(DataFusionError::Execution(err.to_string())),
-        })
-        .boxed();
-
-    // TODO: dynamically detect schema from the transforms.
-    let schema = Arc::new(Schema::new(vec![
-        ROW_ID_FIELD.clone(),
-        Field::new(PART_ID_COLUMN, DataType::UInt32, false),
-        Field::new(
-            PQ_CODE_COLUMN,
-            DataType::FixedSizeList(
-                Arc::new(Field::new("item", DataType::UInt8, true)),
-                num_sub_vectors as i32,
-            ),
-            false,
-        ),
-    ]));
-    let stream = Box::pin(RecordBatchStreamAdapter::new(schema, stream));
-
-    info!("Building IVF shuffler");
-
-    let memory_limit = if let Ok(memory_limit) = std::env::var("LANCE_MEMORY_LIMIT") {
-        match memory_limit.parse::<usize>() {
-            Ok(memory_limit) => Some(memory_limit),
-            Err(err) => {
-                log::error!(
-                    "Failed to parse LANCE_MEMORY_LIMIT: {}, using default of unbounded.",
-                    err
-                );
-                None
-            }
-        }
-    } else {
-        None
-    };
-
-    let memory_pool: Arc<dyn MemoryPool> = if let Some(memory_limit) = memory_limit {
-        Arc::new(GreedyMemoryPool::new(memory_limit))
-    } else {
-        Arc::new(UnboundedMemoryPool::default())
-    };
-    let runtime_config = RuntimeConfig::new().with_memory_pool(memory_pool);
-    let runtime_env = RuntimeEnv::new(runtime_config)?;
-    let context = SessionContext::new_with_config_rt(Default::default(), Arc::new(runtime_env));
-
-    Ok(context
-        .read_one_shot(stream)?
-        .sort(vec![col(PART_ID_COLUMN).sort(true, true)])?
-        .group_by_stream(&[PART_ID_COLUMN])
-        .await?)
-}
-
-pub async fn shuffle_dataset_v2(
     data: impl RecordBatchStream + Unpin + 'static,
     column: &str,
     ivf: Arc<dyn lance_index::vector::ivf::Ivf>,
@@ -179,7 +99,7 @@ pub async fn shuffle_dataset_v2(
 
     let stream = lance_core::io::RecordBatchStreamAdapter::new(schema.clone(), stream);
 
-    let shuffler = IvfShuffler::try_new(
+    let mut shuffler = IvfShuffler::try_new(
         num_partitions,
         num_sub_vectors,
         None,
@@ -240,7 +160,7 @@ pub(super) async fn build_partitions(
         precomputed_partitons,
     )?;
 
-    let stream = shuffle_dataset_v2(
+    let stream = shuffle_dataset(
         data,
         column,
         ivf_model,


### PR DESCRIPTION
This PR does a few things to the IVF shuffler

* add a `set_unsorted_buffers` method. This method allowes caller to set a list of buffers that is different from the `unsorted.lance` buffer used by default.
  * This is helpful for using externally calculated buffers (say buffers from multiple GPUs)
  * This also removed the limit of the number of rows that can be shuffled. Previously, we could only shuffle as many as 2^32-1 rows as we used a single shuffle buffer with a limit of 2^32 rows
* added logic to handle multiple shuffle buffers, by default we only use one buffer
* added a bunch of tests for the shuffler.

I will wire up python in the next PR to keep this smaller and more reviewable.