### PR TITLE
chore: expose externally computed shuffle buffer to python

### DIFF
--- a/python/python/lance/util.py
+++ b/python/python/lance/util.py
@@ -178,7 +178,7 @@ class KMeans:
         return self._kmeans.predict(arr)
 
 
-def sanity_check_vector_index(
+def validate_vector_index(
     dataset,
     column: str,
     refine_factor: int = 5,
@@ -187,6 +187,7 @@ def sanity_check_vector_index(
 ):
     """Run in-sample queries and make sure that the recall
     for k=1 is very high (should be near 100%)
+
     Parameters
     ----------
     dataset: LanceDataset

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -23,7 +23,7 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 import torch
-from lance.util import sanity_check_vector_index
+from lance.util import validate_vector_index
 from lance.vector import vec_to_table
 
 
@@ -146,7 +146,7 @@ def test_index_with_nans(tmp_path):
         num_sub_vectors=16,
         accelerator=torch.device("cpu"),
     )
-    sanity_check_vector_index(dataset, "vector")
+    validate_vector_index(dataset, "vector")
 
 
 def test_index_with_no_centroid_movement(tmp_path):
@@ -165,7 +165,7 @@ def test_index_with_no_centroid_movement(tmp_path):
         num_sub_vectors=4,
         accelerator=torch.device("cpu"),
     )
-    sanity_check_vector_index(dataset, "vector")
+    validate_vector_index(dataset, "vector")
 
 
 @pytest.mark.cuda
@@ -606,3 +606,23 @@ def test_vector_with_nans(tmp_path: Path):
     )
     assert len(tbl) == TOTAL - 1
     assert 1 not in tbl["_rowid"].to_numpy(), "Row with ID 1 is not in the index"
+
+
+def test_validate_vector_index(tmp_path: Path):
+    # make sure the sanity check is correctly catchting issues
+    ds = lance.write_dataset(create_table(), tmp_path)
+    validate_vector_index(ds, "vector", sample_size=100)
+
+    called = False
+
+    def direct_first_call_to_new_table(*args, **kwargs):
+        nonlocal called
+        if called:
+            return ds.to_table(*args, **kwargs)
+        called = True
+        return create_table()
+
+    # return a new random table so things fail
+    ds.sample = direct_first_call_to_new_table
+    with pytest.raises(ValueError, match="Vector index failed sanity check"):
+        validate_vector_index(ds, "vector", sample_size=100)

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -42,9 +42,10 @@ use lance_index::{
     DatasetIndexExt, IndexParams, IndexType,
 };
 use lance_linalg::distance::MetricType;
+use object_store::path::Path;
 use pyo3::exceptions::PyStopIteration;
 use pyo3::prelude::*;
-use pyo3::types::PySet;
+use pyo3::types::{PyList, PySet};
 use pyo3::{
     exceptions::{PyIOError, PyKeyError, PyValueError},
     pyclass,
@@ -719,15 +720,30 @@ impl Dataset {
                         ivf_params.precomputed_partitons_file = Some(f.to_string());
                     };
 
-                    if let Some(o) = kwargs.get_item("shuffle_partition_batches")? {
-                        ivf_params.shuffle_partition_batches =
-                            PyAny::downcast::<PyInt>(o)?.extract()?;
-                    };
-
-                    if let Some(o) = kwargs.get_item("shuffle_partition_concurrency")? {
-                        ivf_params.shuffle_partition_concurrency =
-                            PyAny::downcast::<PyInt>(o)?.extract()?;
-                    };
+                    match (
+                        kwargs.get_item("precomputed_shuffle_buffers")?,
+                        kwargs.get_item("precomputed_shuffle_buffers_path")?
+                    ) {
+                        (Some(l), Some(p)) => {
+                            let path = Path::parse(p.to_string()).map_err(|e| {
+                                PyValueError::new_err(format!(
+                                    "Failed to parse precomputed_shuffle_buffers_path: {}",
+                                    e
+                                ))
+                            })?;
+                            let list = PyAny::downcast::<PyList>(l)?
+                                .iter()
+                                .map(|f| f.to_string())
+                                .collect();
+                            ivf_params.precomputed_shuffle_buffers = Some((path, list));
+                        },
+                        (None, None) => {},
+                        _ => {
+                            return Err(PyValueError::new_err(
+                                "precomputed_shuffle_buffers and precomputed_shuffle_buffers_path must be specified together."
+                            ))
+                        }
+                    }
                 }
                 Box::new(VectorIndexParams::with_ivf_pq_params(
                     m_type, ivf_params, pq_params,

--- a/rust/lance-index/src/vector/ivf/builder.rs
+++ b/rust/lance-index/src/vector/ivf/builder.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use arrow_array::cast::AsArray;
 use arrow_array::{Array, FixedSizeListArray, UInt32Array, UInt64Array};
 use futures::TryStreamExt;
+use object_store::path::Path;
 use snafu::{location, Location};
 
 use lance_core::error::{Error, Result};
@@ -40,7 +41,16 @@ pub struct IvfBuildParams {
 
     pub sample_rate: usize,
 
+    /// Precomputed partitions file (row_id -> partition_id)
+    /// mutually exclusive with `precomputed_shuffle_buffers`
     pub precomputed_partitons_file: Option<String>,
+
+    /// Precomputed shuffle buffers (row_id -> partition_id, pq_code)
+    /// mutually exclusive with `precomputed_partitons_file`
+    /// requires `centroids` to be set
+    ///
+    /// The input is expected to be (/dir/to/buffers, [buffer1.lance, buffer2.lance, ...])
+    pub precomputed_shuffle_buffers: Option<(Path, Vec<String>)>,
 
     pub shuffle_partition_batches: usize,
 
@@ -55,6 +65,7 @@ impl Default for IvfBuildParams {
             centroids: None,
             sample_rate: 256, // See faiss
             precomputed_partitons_file: None,
+            precomputed_shuffle_buffers: None,
             shuffle_partition_batches: 1024 * 10,
             shuffle_partition_concurrency: 2,
         }

--- a/rust/lance/src/index/vector/ivf/builder.rs
+++ b/rust/lance/src/index/vector/ivf/builder.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
 
+use object_store::path::Path;
 use snafu::{location, Location};
 use tracing::instrument;
 
@@ -42,6 +43,7 @@ pub(super) async fn build_partitions(
     precomputed_partitons: Option<HashMap<u64, u32>>,
     shuffle_partition_batches: usize,
     shuffle_partition_concurrency: usize,
+    precomputed_shuffle_buffers: Option<(Path, Vec<String>)>,
 ) -> Result<()> {
     let schema = data.schema();
     if schema.column_with_name(column).is_none() {
@@ -75,6 +77,7 @@ pub(super) async fn build_partitions(
         pq.num_sub_vectors(),
         shuffle_partition_batches,
         shuffle_partition_concurrency,
+        precomputed_shuffle_buffers,
     )
     .await?;
 


### PR DESCRIPTION
expose the option to set pre computed shuffle buffers to python

also added a util for sanity checking an index with in-sample queries