### PR TITLE
feat: roundtrip bfloat16 vectors to Lance format

### DIFF
--- a/python/python/tests/test_tf.py
+++ b/python/python/tests/test_tf.py
@@ -438,8 +438,6 @@ def test_tfrecord_parsing(tmp_path, sample_tf_example):
 
 
 def test_tfrecord_roundtrip(tmp_path, sample_tf_example):
-    del sample_tf_example.features.feature["9_tensor_bf16"]
-
     serialized = sample_tf_example.SerializeToString()
 
     path = tmp_path / "test.tfrecord"

--- a/python/src/arrow.rs
+++ b/python/src/arrow.rs
@@ -20,6 +20,7 @@ use arrow_array::{RecordBatch, RecordBatchIterator, RecordBatchReader};
 use arrow_schema::{DataType, Field, Schema};
 use half::bf16;
 use lance::arrow::bfloat16::BFloat16Array;
+use lance_arrow::bfloat16::{ARROW_EXT_META_KEY, ARROW_EXT_NAME_KEY, BFLOAT16_EXT_NAME};
 use pyo3::{
     exceptions::PyValueError,
     ffi::Py_uintptr_t,
@@ -72,8 +73,8 @@ impl BFloat16 {
 }
 
 const EXPORT_METADATA: [(&str, &str); 2] = [
-    ("ARROW:extension:name", "lance.bfloat16"),
-    ("ARROW:extension:metadata", ""),
+    (ARROW_EXT_NAME_KEY, BFLOAT16_EXT_NAME),
+    (ARROW_EXT_META_KEY, ""),
 ];
 
 #[pyfunction]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -111,6 +111,7 @@ tokio = { version = "1.23", features = [
 tracing = "0.1"
 url = "2.3"
 uuid = { version = "1.2", features = ["v4", "serde"] }
+pretty_assertions = "1.4.0"
 
 [profile.bench]
 opt-level = 3

--- a/rust/lance-arrow/src/bfloat16.rs
+++ b/rust/lance-arrow/src/bfloat16.rs
@@ -23,10 +23,24 @@ use arrow_array::{
 };
 use arrow_buffer::MutableBuffer;
 use arrow_data::ArrayData;
-use arrow_schema::{ArrowError, DataType};
+use arrow_schema::{ArrowError, DataType, Field as ArrowField};
 use half::bf16;
 
 use crate::FloatArray;
+
+pub const ARROW_EXT_NAME_KEY: &str = "ARROW:extension:name";
+pub const ARROW_EXT_META_KEY: &str = "ARROW:extension:metadata";
+pub const BFLOAT16_EXT_NAME: &str = "lance.bfloat16";
+
+/// Check whether the given field is a bfloat16 field.
+pub fn is_bfloat16_field(field: &ArrowField) -> bool {
+    field.data_type() == &DataType::FixedSizeBinary(2)
+        && field
+            .metadata()
+            .get(ARROW_EXT_NAME_KEY)
+            .map(|name| name == BFLOAT16_EXT_NAME)
+            .unwrap_or_default()
+}
 
 #[derive(Debug)]
 pub struct BFloat16Type {}

--- a/rust/lance-arrow/src/bfloat16.rs
+++ b/rust/lance-arrow/src/bfloat16.rs
@@ -81,6 +81,10 @@ impl BFloat16Array {
         let binary_value = self.inner.value_unchecked(i);
         bf16::from_bits(u16::from_le_bytes([binary_value[0], binary_value[1]]))
     }
+
+    pub fn into_inner(self) -> FixedSizeBinaryArray {
+        self.inner
+    }
 }
 
 impl<'a> ArrayAccessor for &'a BFloat16Array {

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -136,11 +136,24 @@ impl TryFrom<&DataType> for LogicalType {
                 DataType::Struct(_) => "large_list.struct".to_string(),
                 _ => "large_list".to_string(),
             },
-            DataType::FixedSizeList(dt, len) => format!(
-                "fixed_size_list:{}:{}",
-                Self::try_from(dt.data_type())?.0,
-                *len
-            ),
+            DataType::FixedSizeList(field, len) => {
+                if field
+                    .metadata()
+                    .get("ARROW:extension:name")
+                    .map(|name| name == "lance.bfloat16")
+                    .unwrap_or_default()
+                {
+                    // Don't want to directly use `blfoat16`, in case a built-in type is added
+                    // that isn't identical to our extension type.
+                    format!("fixed_size_list:lance.bfloat16:{}", *len)
+                } else {
+                    format!(
+                        "fixed_size_list:{}:{}",
+                        Self::try_from(field.data_type())?.0,
+                        *len
+                    )
+                }
+            }
             DataType::FixedSizeBinary(len) => format!("fixed_size_binary:{}", *len),
             _ => {
                 return Err(Error::Schema {
@@ -195,20 +208,37 @@ impl TryFrom<&LogicalType> for DataType {
             match splits[0] {
                 "fixed_size_list" => {
                     if splits.len() != 3 {
-                        Err(Error::Schema {
+                        return Err(Error::Schema {
                             message: format!("Unsupported logical type: {}", lt),
                             location: location!(),
-                        })
-                    } else {
-                        let elem_type = (&LogicalType(splits[1].to_string())).try_into()?;
-                        let size: i32 = splits[2].parse::<i32>().map_err(|e: _| Error::Schema {
-                            message: e.to_string(),
-                            location: location!(),
-                        })?;
-                        Ok(FixedSizeList(
-                            Arc::new(ArrowField::new("item", elem_type, true)),
-                            size,
-                        ))
+                        });
+                    }
+
+                    let size: i32 = splits[2].parse::<i32>().map_err(|e: _| Error::Schema {
+                        message: e.to_string(),
+                        location: location!(),
+                    })?;
+
+                    match splits[1] {
+                        "lance.bfloat16" => {
+                            let field = ArrowField::new("item", Self::FixedSizeBinary(2), true)
+                                .with_metadata(
+                                    [
+                                        ("ARROW:extension:name".into(), "lance.bfloat16".into()),
+                                        ("ARROW:extension:metadata".into(), "".into()),
+                                    ]
+                                    .into(),
+                                );
+                            Ok(FixedSizeList(Arc::new(field), size))
+                        }
+                        data_type => {
+                            let elem_type = (&LogicalType(data_type.to_string())).try_into()?;
+
+                            Ok(FixedSizeList(
+                                Arc::new(ArrowField::new("item", elem_type, true)),
+                                size,
+                            ))
+                        }
                     }
                 }
                 "fixed_size_binary" => {

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -25,7 +25,7 @@ use arrow_array::{
 };
 use arrow_schema::{DataType, Field as ArrowField};
 use async_recursion::async_recursion;
-use lance_arrow::*;
+use lance_arrow::{bfloat16::ARROW_EXT_NAME_KEY, *};
 use snafu::{location, Location};
 
 use super::{Dictionary, LogicalType};
@@ -70,9 +70,7 @@ impl Field {
     }
 
     pub fn extension_name(&self) -> Option<&str> {
-        self.metadata
-            .get("ARROW:extension:name")
-            .map(String::as_str)
+        self.metadata.get(ARROW_EXT_NAME_KEY).map(String::as_str)
     }
 
     pub fn child(&self, name: &str) -> Option<&Self> {
@@ -623,10 +621,7 @@ impl From<&pb::Field> for Field {
             })
             .collect();
         if !field.extension_name.is_empty() {
-            lance_metadata.insert(
-                "ARROW:extension:name".to_string(),
-                field.extension_name.clone(),
-            );
+            lance_metadata.insert(ARROW_EXT_NAME_KEY.to_string(), field.extension_name.clone());
         }
         Self {
             name: field.name.clone(),

--- a/rust/lance-core/src/encodings/plain.rs
+++ b/rust/lance-core/src/encodings/plain.rs
@@ -312,9 +312,12 @@ impl<'a> PlainDecoder<'a> {
         let item_array = item_decoder
             .get(start * list_size as usize..end * list_size as usize)
             .await?;
-        Ok(Arc::new(FixedSizeListArray::try_new_from_values(
-            item_array, list_size,
-        )?) as ArrayRef)
+        Ok(Arc::new(FixedSizeListArray::new(
+            Arc::new(items.clone()),
+            list_size,
+            item_array,
+            None,
+        )) as ArrayRef)
     }
 
     async fn decode_fixed_size_binary(

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -102,6 +102,7 @@ prost-build.workspace = true
 
 [dev-dependencies]
 lance-test-macros = { workspace = true }
+pretty_assertions = { workspace = true }
 
 clap = { version = "4.1.1", features = ["derive"] }
 criterion = { workspace = true }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1603,7 +1603,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Fields as ArrowFields, Schema as ArrowSchema};
     use arrow_select::take::take;
     use futures::stream::TryStreamExt;
-    use lance_arrow::bfloat16;
+    use lance_arrow::bfloat16::{self, ARROW_EXT_META_KEY, ARROW_EXT_NAME_KEY, BFLOAT16_EXT_NAME};
     use lance_core::format::WriterVersion;
     use lance_datagen::{array, gen, BatchCount, RowCount};
     use lance_index::vector::DIST_COL;
@@ -3931,8 +3931,8 @@ mod tests {
         let inner_field = Arc::new(
             Field::new("item", DataType::FixedSizeBinary(2), true).with_metadata(
                 [
-                    ("ARROW:extension:name".into(), "lance.bfloat16".into()),
-                    ("ARROW:extension:metadata".into(), "".into()),
+                    (ARROW_EXT_NAME_KEY.into(), BFLOAT16_EXT_NAME.into()),
+                    (ARROW_EXT_META_KEY.into(), "".into()),
                 ]
                 .into(),
             ),

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1590,6 +1590,7 @@ mod tests {
     use crate::index::{vector::VectorIndexParams, DatasetIndexExt};
     use crate::io::deletion::read_deletion_file;
 
+    use arrow_array::FixedSizeListArray;
     use arrow_array::{
         builder::StringDictionaryBuilder,
         cast::{as_string_array, as_struct_array},
@@ -1602,12 +1603,14 @@ mod tests {
     use arrow_schema::{DataType, Field, Fields as ArrowFields, Schema as ArrowSchema};
     use arrow_select::take::take;
     use futures::stream::TryStreamExt;
+    use lance_arrow::bfloat16;
     use lance_core::format::WriterVersion;
     use lance_datagen::{array, gen, BatchCount, RowCount};
     use lance_index::vector::DIST_COL;
     use lance_index::IndexType;
     use lance_linalg::distance::MetricType;
     use lance_testing::datagen::generate_random_array;
+    use pretty_assertions::assert_eq;
     use tempfile::{tempdir, TempDir};
 
     // Used to validate that futures returned are Send.
@@ -3921,5 +3924,45 @@ mod tests {
 
         let row_count = batches.iter().map(|batch| batch.num_rows()).sum::<usize>();
         assert_eq!(row_count, 1900);
+    }
+
+    #[tokio::test]
+    async fn test_bfloat16_roundtrip() -> Result<()> {
+        let inner_field = Arc::new(
+            Field::new("item", DataType::FixedSizeBinary(2), true).with_metadata(
+                [
+                    ("ARROW:extension:name".into(), "lance.bfloat16".into()),
+                    ("ARROW:extension:metadata".into(), "".into()),
+                ]
+                .into(),
+            ),
+        );
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "fsl",
+            DataType::FixedSizeList(inner_field.clone(), 2),
+            false,
+        )]));
+
+        let values = bfloat16::BFloat16Array::from_iter_values(
+            (0..6).map(|i| i as f32).map(half::bf16::from_f32),
+        );
+        let vectors = FixedSizeListArray::new(inner_field, 2, Arc::new(values.into_inner()), None);
+
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(vectors)]).unwrap();
+
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch.clone())], schema.clone()),
+            test_uri,
+            None,
+        )
+        .await?;
+
+        let data = dataset.scan().try_into_batch().await?;
+        assert_eq!(batch, data);
+
+        Ok(())
     }
 }

--- a/rust/lance/src/utils/tfrecord.rs
+++ b/rust/lance/src/utils/tfrecord.rs
@@ -26,6 +26,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{StreamExt, TryStreamExt};
 use half::{bf16, f16};
+use lance_arrow::bfloat16::{ARROW_EXT_META_KEY, ARROW_EXT_NAME_KEY, BFLOAT16_EXT_NAME};
 use prost::Message;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -284,7 +285,7 @@ fn make_field(name: &str, feature_meta: &FeatureMeta) -> Result<ArrowField> {
 
             let inner_meta = match dtype {
                 TensorDataType::DtBfloat16 => Some(
-                    [("ARROW:extension:name", "lance.bfloat16")]
+                    [(ARROW_EXT_NAME_KEY, BFLOAT16_EXT_NAME)]
                         .into_iter()
                         .map(|(k, v)| (k.to_string(), v.to_string()))
                         .collect::<HashMap<String, String>>(),
@@ -309,11 +310,11 @@ fn make_field(name: &str, feature_meta: &FeatureMeta) -> Result<ArrowField> {
                 shape: shape.clone(),
             };
             metadata.insert(
-                "ARROW:extension:name".to_string(),
+                ARROW_EXT_NAME_KEY.to_string(),
                 "arrow.fixed_shape_tensor".to_string(),
             );
             metadata.insert(
-                "ARROW:extension:metadata".to_string(),
+                ARROW_EXT_META_KEY.to_string(),
                 serde_json::to_string(&tensor_metadata)?,
             );
             Some(metadata)
@@ -364,10 +365,10 @@ fn convert_column(records: &[Example], field: &ArrowField) -> Result<ArrayRef> {
             field.set_metadata(
                 [
                     (
-                        "ARROW:extension:name".to_string(),
-                        "lance.bfloat16".to_string(),
+                        ARROW_EXT_NAME_KEY.to_string(),
+                        BFLOAT16_EXT_NAME.to_string(),
                     ),
-                    ("ARROW:extension:metadata".to_string(), "".to_string()),
+                    (ARROW_EXT_META_KEY.to_string(), "".to_string()),
                 ]
                 .into_iter()
                 .collect(),


### PR DESCRIPTION
I've given up for now on supporting generic extension types in FSL (#1693), so for now we'll have a special case for bfloat16 where we have a specific string that refers to our extension type.

This will unblock further development on vector search with bfloat16, but there is also still substantial UX work before we want to advertise this to users.

Closes #1684.
