### PR TITLE
feat: improve error message when schema mismatch occurs

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -357,6 +357,18 @@ def test_to_batches(tmp_path: Path):
     assert sorted_batches == table
 
 
+def test_list_from_parquet(tmp_path: Path):
+    # This is a regression for GH-1482, the parquet reader creates
+    # list fields with the name 'element' instead of 'item'.  We should
+    # ignore that
+    tab = pa.Table.from_pydict(
+        {"x": pa.array([[1, 2], [3, 4]], pa.list_(pa.float32(), 2))}
+    )
+    pq.write_table(tab, tmp_path / "foo.parquet")
+    tab = pq.read_table(tmp_path / "foo.parquet")
+    lance.write_dataset(tab, tmp_path / "foo.lance")
+
+
 def test_pickle(tmp_path: Path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
     base_dir = tmp_path / "test"

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -27,6 +27,7 @@ mod schema;
 use crate::format::pb;
 use crate::{Error, Result};
 pub use field::Field;
+pub use field::SchemaCompareOptions;
 pub use schema::Schema;
 
 /// LogicalType is a string presentation of arrow type.

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -83,17 +83,27 @@ impl Field {
 
     fn explain_differences(
         &self,
-        expected: &Field,
+        expected: &Self,
         options: &SchemaCompareOptions,
         path: Option<&str>,
     ) -> Vec<String> {
         let mut differences = Vec::new();
         let self_name = path
-            .map(|path| path.to_owned() + "." + &self.name)
+            .map(|path| {
+                let mut self_name = path.to_owned();
+                self_name.push('.');
+                self_name.push_str(&self.name);
+                self_name
+            })
             .unwrap_or_else(|| self.name.clone());
         if self.name != expected.name {
             let expected_path = path
-                .map(|path| path.to_owned() + "." + &expected.name)
+                .map(|path| {
+                    let mut expected_path = path.to_owned();
+                    expected_path.push('.');
+                    expected_path.push_str(&expected.name);
+                    expected_path
+                })
                 .unwrap_or_else(|| expected.name.clone());
             differences.push(format!(
                 "expected name '{}' but name was '{}'",
@@ -191,7 +201,7 @@ impl Field {
 
     pub fn explain_difference(
         &self,
-        expected: &Field,
+        expected: &Self,
         options: &SchemaCompareOptions,
     ) -> Option<String> {
         let differences = self.explain_differences(expected, options, None);
@@ -202,7 +212,7 @@ impl Field {
         }
     }
 
-    pub fn compare_with_options(&self, other: &Field, options: &SchemaCompareOptions) -> bool {
+    pub fn compare_with_options(&self, other: &Self, options: &SchemaCompareOptions) -> bool {
         self.name == other.name
             && self.logical_type == other.logical_type
             && self.nullable == other.nullable

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -1113,7 +1113,7 @@ mod tests {
             compare_field_ids: true,
             ..Default::default()
         };
-        assert!(no_id.compare_with_options(&expected, &compare_ids));
+        assert!(!no_id.compare_with_options(&expected, &compare_ids));
     }
 
     #[test]

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -14,7 +14,12 @@
 
 //! Lance Schema Field
 
-use std::{cmp::max, collections::HashMap, fmt, sync::Arc};
+use std::{
+    cmp::max,
+    collections::{HashMap, HashSet},
+    fmt,
+    sync::Arc,
+};
 
 use arrow_array::{
     cast::AsArray,
@@ -35,6 +40,12 @@ use crate::{
     io::{read_binary_array, read_fixed_stride_array, Reader},
     Error, Result,
 };
+
+#[derive(Default)]
+pub struct SchemaCompareOptions {
+    pub compare_metadata: bool,
+    pub compare_dictionary: bool,
+}
 
 /// Lance Schema Field
 ///
@@ -67,6 +78,135 @@ impl Field {
             }
             lt => DataType::try_from(lt).unwrap(),
         }
+    }
+
+    fn explain_differences(
+        &self,
+        expected: &Field,
+        options: &SchemaCompareOptions,
+        path: Option<&str>,
+    ) -> Vec<String> {
+        let mut differences = Vec::new();
+        let self_name = path
+            .map(|path| path.to_owned() + "." + &self.name)
+            .unwrap_or_else(|| self.name.clone());
+        if self.name != expected.name {
+            let expected_path = path
+                .map(|path| path.to_owned() + "." + &expected.name)
+                .unwrap_or_else(|| expected.name.clone());
+            differences.push(format!(
+                "expected name '{}' but name was '{}'",
+                expected_path, self_name
+            ));
+        }
+        if self.logical_type != expected.logical_type {
+            differences.push(format!(
+                "`{}` should have type {} but type was {}",
+                self_name, expected.logical_type, self.logical_type
+            ));
+        }
+        if self.nullable != expected.nullable {
+            differences.push(format!(
+                "`{}` should have nullable={} but nullable={}",
+                self_name, expected.nullable, self.nullable
+            ))
+        }
+        if options.compare_dictionary && self.dictionary != expected.dictionary {
+            differences.push(format!(
+                "dictionary for `{}` did not match expected dictionary",
+                self_name
+            ));
+        }
+        if options.compare_metadata && self.metadata != expected.metadata {
+            differences.push(format!(
+                "metadata for `{}` did not match expected metadata",
+                self_name
+            ));
+        }
+        if self.children.len() != expected.children.len()
+            || !self
+                .children
+                .iter()
+                .zip(expected.children.iter())
+                .all(|(child, expected)| child.name == expected.name)
+        {
+            let self_children = self
+                .children
+                .iter()
+                .map(|child| child.name.clone())
+                .collect::<HashSet<_>>();
+            let expected_children = expected
+                .children
+                .iter()
+                .map(|child| child.name.clone())
+                .collect::<HashSet<_>>();
+            let missing = expected_children
+                .difference(&self_children)
+                .cloned()
+                .collect::<Vec<_>>();
+            let unexpected = self_children
+                .difference(&expected_children)
+                .cloned()
+                .collect::<Vec<_>>();
+            if missing.is_empty() && unexpected.is_empty() {
+                differences.push(format!(
+                    "`{}` field order mismatch, expected [{}] but was [{}]",
+                    self_name,
+                    expected
+                        .children
+                        .iter()
+                        .map(|child| child.name.clone())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    self.children
+                        .iter()
+                        .map(|child| child.name.clone())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ));
+            } else {
+                differences.push(format!(
+                    "`{}` had mismatched children, missing=[{}] unexpected=[{}]",
+                    self_name,
+                    missing.join(", "),
+                    unexpected.join(", ")
+                ));
+            }
+        } else {
+            differences.extend(self.children.iter().zip(expected.children.iter()).flat_map(
+                |(child, expected_child)| {
+                    child.explain_differences(expected_child, options, Some(&self_name))
+                },
+            ));
+        }
+        differences
+    }
+
+    pub fn explain_difference(
+        &self,
+        expected: &Field,
+        options: &SchemaCompareOptions,
+    ) -> Option<String> {
+        let differences = self.explain_differences(expected, options, None);
+        if differences.is_empty() {
+            None
+        } else {
+            Some(differences.join(", "))
+        }
+    }
+
+    pub fn compare_with_options(&self, other: &Field, options: &SchemaCompareOptions) -> bool {
+        self.name == other.name
+            && self.logical_type == other.logical_type
+            && self.nullable == other.nullable
+            && self.children.len() == other.children.len()
+            && self
+                .children
+                .iter()
+                .zip(&other.children)
+                .all(|(left, right)| left.compare_with_options(right, options))
+            && (!options.compare_dictionary || self.dictionary == other.dictionary)
+            && (!options.compare_metadata || self.metadata == other.metadata)
     }
 
     pub fn extension_name(&self) -> Option<&str> {
@@ -692,6 +832,7 @@ impl From<&Field> for Vec<pb::Field> {
 mod tests {
     use super::*;
 
+    use arrow_array::{DictionaryArray, StringArray, UInt32Array};
     use arrow_schema::{DataType, Fields, TimeUnit};
 
     #[test]
@@ -881,5 +1022,158 @@ mod tests {
         .try_into()
         .unwrap();
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_explain_difference() {
+        let expected: Field = ArrowField::new(
+            "a",
+            DataType::Struct(Fields::from(vec![
+                ArrowField::new("b", DataType::Int32, true),
+                ArrowField::new("c", DataType::Int32, true),
+            ])),
+            true,
+        )
+        .try_into()
+        .unwrap();
+
+        let opts = SchemaCompareOptions::default();
+        assert_eq!(expected.explain_difference(&expected, &opts), None);
+
+        let wrong_name: Field = ArrowField::new(
+            "b",
+            DataType::Struct(Fields::from(vec![
+                ArrowField::new("b", DataType::Int32, true),
+                ArrowField::new("c", DataType::Int32, true),
+            ])),
+            true,
+        )
+        .try_into()
+        .unwrap();
+
+        assert_eq!(
+            wrong_name.explain_difference(&expected, &opts),
+            Some("expected name 'a' but name was 'b'".to_string())
+        );
+
+        let wrong_child: Field = ArrowField::new(
+            "a",
+            DataType::Struct(Fields::from(vec![
+                ArrowField::new("b", DataType::Int32, false),
+                ArrowField::new("c", DataType::Int32, true),
+            ])),
+            true,
+        )
+        .try_into()
+        .unwrap();
+        assert_eq!(
+            wrong_child.explain_difference(&expected, &opts),
+            Some("`a.b` should have nullable=true but nullable=false".to_string())
+        );
+
+        let mismatched_children: Field = ArrowField::new(
+            "a",
+            DataType::Struct(Fields::from(vec![
+                ArrowField::new("d", DataType::Int32, false),
+                ArrowField::new("b", DataType::Int32, true),
+            ])),
+            true,
+        )
+        .try_into()
+        .unwrap();
+        assert_eq!(
+            mismatched_children.explain_difference(&expected, &opts),
+            Some("`a` had mismatched children, missing=[c] unexpected=[d]".to_string())
+        );
+
+        let reordered_children: Field = ArrowField::new(
+            "a",
+            DataType::Struct(Fields::from(vec![
+                ArrowField::new("c", DataType::Int32, false),
+                ArrowField::new("b", DataType::Int32, true),
+            ])),
+            true,
+        )
+        .try_into()
+        .unwrap();
+        assert_eq!(
+            reordered_children.explain_difference(&expected, &opts),
+            Some("`a` field order mismatch, expected [b, c] but was [c, b]".to_string())
+        );
+
+        let multiple_wrongs: Field = ArrowField::new(
+            "c",
+            DataType::Struct(Fields::from(vec![
+                ArrowField::new("b", DataType::Int32, true),
+                ArrowField::new("c", DataType::Float32, true),
+            ])),
+            true,
+        )
+        .try_into()
+        .unwrap();
+        assert_eq!(
+            multiple_wrongs.explain_difference(&expected, &opts),
+            Some(
+                "expected name 'a' but name was 'c', `c.c` should have type int32 but type was float"
+                    .to_string()
+            )
+        );
+
+        let mut expected: Field = ArrowField::new(
+            "a",
+            DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
+            true,
+        )
+        .try_into()
+        .unwrap();
+        let keys = UInt32Array::from_iter_values(vec![0, 1]);
+        let values: ArrayRef = Arc::new(StringArray::from_iter_values(&[
+            "a".to_string(),
+            "b".to_string(),
+        ]));
+        let dictionary: ArrayRef = Arc::new(DictionaryArray::new(keys, values));
+        expected.set_dictionary(&dictionary);
+
+        let no_dictionary: Field = ArrowField::new(
+            "a",
+            DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
+            true,
+        )
+        .try_into()
+        .unwrap();
+
+        // By default, do not compare dictionary
+        assert_eq!(no_dictionary.explain_difference(&expected, &opts), None);
+
+        let compare_dict = SchemaCompareOptions {
+            compare_dictionary: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            no_dictionary.explain_difference(&expected, &compare_dict),
+            Some("dictionary for `a` did not match expected dictionary".to_string())
+        );
+
+        let metadata = HashMap::<_, _>::from_iter(vec![("foo".to_string(), "bar".to_string())]);
+        let expected: Field = ArrowField::new("a", DataType::UInt32, true)
+            .with_metadata(metadata)
+            .try_into()
+            .unwrap();
+
+        let no_metadata: Field = ArrowField::new("a", DataType::UInt32, true)
+            .try_into()
+            .unwrap();
+
+        // By default, do not compare dictionary
+        assert_eq!(no_metadata.explain_difference(&expected, &opts), None);
+
+        let compare_metadata = SchemaCompareOptions {
+            compare_metadata: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            no_metadata.explain_difference(&expected, &compare_metadata),
+            Some("metadata for `a` did not match expected metadata".to_string())
+        );
     }
 }

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -1054,7 +1054,7 @@ mod tests {
         .try_into()
         .unwrap();
         let keys = UInt32Array::from_iter_values(vec![0, 1]);
-        let values: ArrayRef = Arc::new(StringArray::from_iter_values(&[
+        let values: ArrayRef = Arc::new(StringArray::from_iter_values([
             "a".to_string(),
             "b".to_string(),
         ]));
@@ -1070,16 +1070,13 @@ mod tests {
         .unwrap();
 
         // By default, do not compare dictionary
-        assert_eq!(no_dictionary.compare_with_options(&expected, &opts), true);
+        assert!(no_dictionary.compare_with_options(&expected, &opts));
 
         let compare_dict = SchemaCompareOptions {
             compare_dictionary: true,
             ..Default::default()
         };
-        assert_eq!(
-            no_dictionary.compare_with_options(&expected, &compare_dict),
-            false
-        );
+        assert!(!no_dictionary.compare_with_options(&expected, &compare_dict));
 
         let metadata = HashMap::<_, _>::from_iter(vec![("foo".to_string(), "bar".to_string())]);
         let expected: Field = ArrowField::new("a", DataType::UInt32, true)
@@ -1092,16 +1089,13 @@ mod tests {
             .unwrap();
 
         // By default, do not compare metadata
-        assert_eq!(no_metadata.compare_with_options(&expected, &opts), true);
+        assert!(no_metadata.compare_with_options(&expected, &opts));
 
         let compare_metadata = SchemaCompareOptions {
             compare_metadata: true,
             ..Default::default()
         };
-        assert_eq!(
-            no_metadata.compare_with_options(&expected, &compare_metadata),
-            false
-        );
+        assert!(!no_metadata.compare_with_options(&expected, &compare_metadata));
 
         let mut expected: Field = ArrowField::new("a", DataType::UInt32, true)
             .try_into()
@@ -1113,13 +1107,13 @@ mod tests {
             .try_into()
             .unwrap();
         // Do not compare ids by default
-        assert_eq!(no_id.compare_with_options(&expected, &opts), true);
+        assert!(no_id.compare_with_options(&expected, &opts));
 
         let compare_ids = SchemaCompareOptions {
             compare_field_ids: true,
             ..Default::default()
         };
-        assert_eq!(no_id.compare_with_options(&expected, &compare_ids), false);
+        assert!(no_id.compare_with_options(&expected, &compare_ids));
     }
 
     #[test]
@@ -1225,7 +1219,7 @@ mod tests {
         .try_into()
         .unwrap();
         let keys = UInt32Array::from_iter_values(vec![0, 1]);
-        let values: ArrayRef = Arc::new(StringArray::from_iter_values(&[
+        let values: ArrayRef = Arc::new(StringArray::from_iter_values([
             "a".to_string(),
             "b".to_string(),
         ]));

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -69,7 +69,7 @@ impl<'a> Iterator for SchemaFieldIterPreOrder<'a> {
 }
 
 impl Schema {
-    pub fn compare_with_options(&self, other: &Schema, options: &SchemaCompareOptions) -> bool {
+    pub fn compare_with_options(&self, other: &Self, options: &SchemaCompareOptions) -> bool {
         self.fields
             .iter()
             .zip(&other.fields)
@@ -79,7 +79,7 @@ impl Schema {
 
     pub fn explain_difference(
         &self,
-        expected: &Schema,
+        expected: &Self,
         options: &SchemaCompareOptions,
     ) -> Option<String> {
         if self.fields.len() != expected.fields.len()
@@ -148,11 +148,7 @@ impl Schema {
         }
     }
 
-    pub fn check_compatible(
-        &self,
-        expected: &Schema,
-        options: &SchemaCompareOptions,
-    ) -> Result<()> {
+    pub fn check_compatible(&self, expected: &Self, options: &SchemaCompareOptions) -> Result<()> {
         if !self.compare_with_options(expected, options) {
             let difference = self.explain_difference(expected, options);
             Err(Error::SchemaMismatch {

--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -36,7 +36,10 @@ pub enum Error {
     DatasetAlreadyExists { uri: String, location: Location },
     // #[snafu(display("Append with different schema: original={original} new={new}"))]
     #[snafu(display("Append with different schema:"))]
-    SchemaMismatch {},
+    SchemaMismatch {
+        difference: String,
+        location: Location,
+    },
     #[snafu(display("Dataset at path {path} was not found: {source}, {location}"))]
     DatasetNotFound {
         path: String,


### PR DESCRIPTION
In addition, this fixes #1482 since we compare lance schemas and not arrow schemas (and lance schemas do not have an inner "item"/"element" field.)