### PR TITLE
chore: accumulate indexed and unindexed fragments per column

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -805,7 +805,7 @@ impl Dataset {
         }
     }
 
-    fn count_unindexed_rows(&self, index_name: String) -> PyResult<Option<usize>> {
+    fn count_unindexed_rows(&self, index_name: String) -> PyResult<usize> {
         let idx = RT.block_on(None, self.ds.load_index_by_name(index_name.as_str()))?;
         if let Some(index) = idx {
             RT.block_on(
@@ -822,7 +822,7 @@ impl Dataset {
         }
     }
 
-    fn count_indexed_rows(&self, index_name: String) -> PyResult<Option<usize>> {
+    fn count_indexed_rows(&self, index_name: String) -> PyResult<usize> {
         let idx = RT.block_on(None, self.ds.load_index_by_name(index_name.as_str()))?;
         if let Some(index) = idx {
             RT.block_on(

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -24,18 +24,16 @@ use async_trait::async_trait;
 use chrono::Duration;
 
 use futures::StreamExt;
-use lance::dataset::builder::DatasetBuilder;
-use lance::dataset::UpdateBuilder;
 use lance::dataset::{
-    fragment::FileFragment as LanceFileFragment, progress::WriteFragmentProgress,
-    scanner::Scanner as LanceScanner, transaction::Operation as LanceOperation,
-    Dataset as LanceDataset, ReadParams, Version, WriteMode, WriteParams,
+    builder::DatasetBuilder, fragment::FileFragment as LanceFileFragment,
+    progress::WriteFragmentProgress, scanner::Scanner as LanceScanner,
+    transaction::Operation as LanceOperation, Dataset as LanceDataset, ReadParams, UpdateBuilder,
+    Version, WriteMode, WriteParams,
 };
-use lance::index::IndexParams;
 use lance::index::{
     scalar::ScalarIndexParams,
     vector::{diskann::DiskANNParams, VectorIndexParams},
-    DatasetIndexExt,
+    DatasetIndexExt, DatasetIndexInternalExt, IndexParams,
 };
 use lance_arrow::as_fixed_size_list_array;
 use lance_core::{datatypes::Schema, format::Fragment, io::object_store::ObjectStoreParams};

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -69,7 +69,6 @@ use self::fragment::FileFragment;
 use self::scanner::{DatasetRecordBatchStream, Scanner};
 use self::transaction::{Operation, Transaction};
 use self::write::{reader_to_stream, write_fragments_internal};
-use crate::dataset::index::unindexed_fragments;
 use crate::datatypes::Schema;
 use crate::error::box_error;
 use crate::format::{Fragment, Index, Manifest};
@@ -1411,36 +1410,6 @@ impl Dataset {
             Ok(Some(index_statistics))
         } else {
             Ok(None)
-        }
-    }
-
-    pub async fn count_unindexed_rows(&self, index_uuid: &str) -> Result<Option<usize>> {
-        let index = self.load_index(index_uuid).await;
-
-        if let Some(index) = index {
-            let unindexed_frags = unindexed_fragments(&index, self).await?;
-            let unindexed_rows = unindexed_frags
-                .iter()
-                .map(Fragment::num_rows)
-                // sum the number of rows in each fragment if no fragment returned None from row_count
-                .try_fold(0, |a, b| b.map(|b| a + b).ok_or(()));
-
-            Ok(unindexed_rows.ok())
-        } else {
-            Ok(None)
-        }
-    }
-
-    pub async fn count_indexed_rows(&self, index_uuid: &str) -> Result<Option<usize>> {
-        let count_rows = self.count_rows();
-        let count_unindexed_rows = self.count_unindexed_rows(index_uuid);
-
-        let (count_rows, count_unindexed_rows) =
-            futures::try_join!(count_rows, count_unindexed_rows)?;
-
-        match count_unindexed_rows {
-            Some(count_unindexed_rows) => Ok(Some(count_rows - count_unindexed_rows)),
-            None => Ok(None),
         }
     }
 
@@ -3428,87 +3397,6 @@ mod tests {
                 &Field::new(DIST_COL, DataType::Float32, true)
             );
         }
-    }
-
-    #[tokio::test]
-    async fn test_count_index_rows() {
-        let test_dir = tempdir().unwrap();
-        let dimensions = 16;
-        let column_name = "vec";
-        let field = Field::new(
-            column_name,
-            DataType::FixedSizeList(
-                Arc::new(Field::new("item", DataType::Float32, true)),
-                dimensions,
-            ),
-            false,
-        );
-        let schema = Arc::new(ArrowSchema::new(vec![field]));
-
-        let float_arr = generate_random_array(512 * dimensions as usize);
-
-        let vectors =
-            arrow_array::FixedSizeListArray::try_new_from_values(float_arr, dimensions).unwrap();
-
-        let record_batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(vectors)]).unwrap();
-
-        let reader =
-            RecordBatchIterator::new(vec![record_batch].into_iter().map(Ok), schema.clone());
-
-        let test_uri = test_dir.path().to_str().unwrap();
-        let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
-        dataset.validate().await.unwrap();
-
-        // Make sure it returns None if there's no index with the passed identifier
-        assert_eq!(dataset.count_unindexed_rows("bad_id").await.unwrap(), None);
-        assert_eq!(dataset.count_indexed_rows("bad_id").await.unwrap(), None);
-
-        // Create an index
-        let params = VectorIndexParams::ivf_pq(10, 8, 2, false, MetricType::L2, 10);
-        dataset
-            .create_index(
-                &[column_name],
-                IndexType::Vector,
-                Some("vec_idx".into()),
-                &params,
-                true,
-            )
-            .await
-            .unwrap();
-
-        let index = dataset.load_index_by_name("vec_idx").await.unwrap();
-        let index_uuid = &index.uuid.to_string();
-
-        // Make sure there are no unindexed rows
-        assert_eq!(
-            dataset.count_unindexed_rows(index_uuid).await.unwrap(),
-            Some(0)
-        );
-        assert_eq!(
-            dataset.count_indexed_rows(index_uuid).await.unwrap(),
-            Some(512)
-        );
-
-        // Now we'll append some rows which shouldn't be indexed and see the
-        // count change
-        let float_arr = generate_random_array(512 * dimensions as usize);
-        let vectors =
-            arrow_array::FixedSizeListArray::try_new_from_values(float_arr, dimensions).unwrap();
-
-        let record_batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(vectors)]).unwrap();
-
-        let reader = RecordBatchIterator::new(vec![record_batch].into_iter().map(Ok), schema);
-        dataset.append(reader, None).await.unwrap();
-
-        // Make sure the new rows are not indexed
-        assert_eq!(
-            dataset.count_unindexed_rows(index_uuid).await.unwrap(),
-            Some(512)
-        );
-        assert_eq!(
-            dataset.count_indexed_rows(index_uuid).await.unwrap(),
-            Some(512)
-        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -293,6 +293,7 @@ impl DatasetIndexExt for Dataset {
             if idx.dataset_version == self.manifest.version {
                 continue;
             }
+
             let Some((new_id, new_frag_ids)) = append_index(dataset.clone(), idx).await? else {
                 continue;
             };

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -352,6 +352,13 @@ pub trait DatasetIndexInternalExt {
     /// Parameters
     /// ----------
     /// - *column*: the name of the column.
+    ///
+    /// Returns
+    /// -------
+    /// (fragment_bitmap, unindexed_fragments)
+    ///
+    /// fragment_bitmap: a bitmap of all the fragments that are indexed on the column.
+    /// unindexed_fragments: a vector of fragments that are not indexed on the column.
     async fn unindexed_fragments(&self, column: &str) -> Result<(RoaringBitmap, Vec<&Fragment>)>;
 
     /// Count the number of rows that are not indexed on the column.

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -442,7 +442,10 @@ impl DatasetIndexInternalExt for Dataset {
         })
     }
 
-    async fn unindexed_fragments(&self, column: &str) -> Result<(RoaringBitmap, Vec<&Fragment>)> {
+    async fn unindexed_fragments<'a>(
+        &'a self,
+        column: &str,
+    ) -> Result<(RoaringBitmap, Vec<&'a Fragment>)> {
         let field_id = self.schema().field_id(column)?;
         let indices = self.load_indices().await?;
 
@@ -468,7 +471,12 @@ impl DatasetIndexInternalExt for Dataset {
             }
         }
 
-        todo!()
+        let unindexed = self
+            .fragments()
+            .iter()
+            .filter(|f| !bitmap.contains(f.id as u32))
+            .collect::<Vec<_>>();
+        Ok((bitmap, unindexed))
     }
 }
 

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -185,7 +185,6 @@ mod tests {
 
         dataset.optimize_indices().await.unwrap();
         let index = &dataset.load_indices().await.unwrap()[0];
-        let dataset = Dataset::open(test_uri).await.unwrap();
         let (_, unindexed) = dataset.unindexed_fragments("vector").await.unwrap();
         assert!(
             unindexed.is_empty(),


### PR DESCRIPTION
To support delta index, we allow one column to have multiple indices, so we need to change the way to compute unindexed fragments.