### PR TITLE
chore: bump half deps for HW acceleration in python

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1"
 chrono = "0.4.31"
 env_logger = "0.10"
 futures = "0.3"
-half = { version = "2.1", default-features = false, features = ["num-traits"] }
+half = { version = "2.3", default-features = false, features = ["num-traits", "std"] }
 lance = { path = "../rust/lance", features = ["tensorflow", "dynamodb"] }
 lance-arrow = { path = "../rust/lance-arrow" }
 lance-core = { path = "../rust/lance-core" }


### PR DESCRIPTION
[Half 2.3](https://github.com/starkat99/half-rs/releases/tag/v2.3.0) supports f16 HW acceleration. This is safe because our rust crate already uses 2.3.1