### PR TITLE
refactor!: index stats to handle error and bunch of bugs

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -31,17 +31,15 @@ use lance::dataset::{
     scanner::Scanner as LanceScanner, transaction::Operation as LanceOperation,
     Dataset as LanceDataset, ReadParams, Version, WriteMode, WriteParams,
 };
-use lance::index::IndexParams;
 use lance::index::{
     scalar::ScalarIndexParams,
     vector::{diskann::DiskANNParams, VectorIndexParams},
-    DatasetIndexExt,
 };
 use lance_arrow::as_fixed_size_list_array;
 use lance_core::{datatypes::Schema, format::Fragment, io::object_store::ObjectStoreParams};
 use lance_index::{
     vector::{ivf::IvfBuildParams, pq::PQBuildParams},
-    IndexType,
+    DatasetIndexExt, IndexParams, IndexType,
 };
 use lance_linalg::distance::MetricType;
 use pyo3::exceptions::PyStopIteration;
@@ -808,7 +806,9 @@ impl Dataset {
     }
 
     fn count_unindexed_rows(&self, index_name: String) -> PyResult<Option<usize>> {
-        let idx = RT.block_on(None, self.ds.load_index_by_name(index_name.as_str()))?;
+        let idx = RT
+            .block_on(None, self.ds.load_index_by_name(index_name.as_str()))?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?;
         if let Some(index) = idx {
             RT.block_on(
                 None,
@@ -825,7 +825,9 @@ impl Dataset {
     }
 
     fn count_indexed_rows(&self, index_name: String) -> PyResult<Option<usize>> {
-        let idx = RT.block_on(None, self.ds.load_index_by_name(index_name.as_str()))?;
+        let idx = RT
+            .block_on(None, self.ds.load_index_by_name(index_name.as_str()))?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?;
         if let Some(index) = idx {
             RT.block_on(
                 None,

--- a/rust/lance-core/src/format/index.rs
+++ b/rust/lance-core/src/format/index.rs
@@ -1,19 +1,16 @@
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
+// Copyright 2024 Lance Developers.
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Metadata for index
 

--- a/rust/lance-core/src/lib.rs
+++ b/rust/lance-core/src/lib.rs
@@ -34,3 +34,8 @@ lazy_static::lazy_static! {
 }
 
 pub(crate) const DELETION_DIRS: &str = "_deletions";
+
+/// Trait for a Lance Dataset 
+pub trait Dataset {
+
+}

--- a/rust/lance-core/src/lib.rs
+++ b/rust/lance-core/src/lib.rs
@@ -35,7 +35,5 @@ lazy_static::lazy_static! {
 
 pub(crate) const DELETION_DIRS: &str = "_deletions";
 
-/// Trait for a Lance Dataset 
-pub trait Dataset {
-
-}
+/// Trait for a Lance Dataset
+pub trait Dataset {}

--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Lance Developers.
+// Copyright 2024 Lance Developers.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 use std::{any::Any, sync::Arc};
 
 use async_trait::async_trait;
-use lance_core::Result;
+use lance_core::{format::Index as IndexMetadata, Result};
 use roaring::RoaringBitmap;
 
 pub mod scalar;
@@ -66,4 +66,66 @@ impl std::fmt::Display for IndexType {
             Self::Vector => write!(f, "Vector"),
         }
     }
+}
+
+pub trait IndexParams: Send + Sync {
+    fn as_any(&self) -> &dyn Any;
+}
+
+/// Extends Lance Dataset with secondary index.
+///
+#[async_trait]
+pub trait DatasetIndexExt {
+    /// Create indices on columns.
+    ///
+    /// Upon finish, a new dataset version is generated.
+    ///
+    /// Parameters:
+    ///
+    ///  - `columns`: the columns to build the indices on.
+    ///  - `index_type`: specify [`IndexType`].
+    ///  - `name`: optional index name. Must be unique in the dataset.
+    ///            if not provided, it will auto-generate one.
+    ///  - `params`: index parameters.
+    ///  - `replace`: replace the existing index if it exists.
+    async fn create_index(
+        &mut self,
+        columns: &[&str],
+        index_type: IndexType,
+        name: Option<String>,
+        params: &dyn IndexParams,
+        replace: bool,
+    ) -> Result<()>;
+
+    /// Read all indices of this Dataset version.
+    async fn load_indices(&self) -> Result<Vec<IndexMetadata>>;
+
+    /// Loads all the indies of a given UUID.
+    ///
+    /// Note that it is possible to have multiple indices with the same UUID,
+    /// as they are the deltas of the same index.
+    async fn load_index(&self, uuid: &str) -> Result<Vec<IndexMetadata>> {
+        self.load_indices().await.map(|indices| {
+            indices
+                .into_iter()
+                .filter(|idx| idx.uuid.to_string() == uuid)
+                .collect()
+        })
+    }
+
+    /// Loads a specific index with the given index name
+    async fn load_index_by_name(&self, name: &str) -> Result<Option<IndexMetadata>> {
+        self.load_indices()
+            .await
+            .map(|indices| indices.into_iter().find(|idx| idx.name == name))
+    }
+
+    /// Loads a specific index with the given index name.
+    async fn load_scalar_index_for_column(&self, col: &str) -> Result<Option<IndexMetadata>>;
+
+    /// Optimize indices.
+    async fn optimize_indices(&mut self) -> Result<()>;
+
+    /// Find index with a given index_name and return its serialized statistics.
+    async fn index_statistics(&self, index_name: &str) -> Result<Option<String>>;
 }

--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -35,16 +35,21 @@ pub mod pb {
 }
 
 /// Generic methods common across all types of secondary indices
+///
 #[async_trait]
 pub trait Index: Send + Sync {
     /// Cast to [Any].
     fn as_any(&self) -> &dyn Any;
+
     /// Cast to [Index]
     fn as_index(self: Arc<Self>) -> Arc<dyn Index>;
+
     /// Retrieve index statistics as a JSON string
     fn statistics(&self) -> Result<String>;
+
     /// Get the type of the index
     fn index_type(&self) -> IndexType;
+
     /// Read through the index and determine which fragment ids are covered by the index
     ///
     /// This is a kind of slow operation.  It's better to use the fragment_bitmap.  This

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -1,0 +1,74 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use async_trait::async_trait;
+
+use lance_core::{format::Index, Result};
+
+use crate::{IndexParams, IndexType};
+
+// Extends Lance Dataset with secondary index.
+///
+#[async_trait]
+pub trait DatasetIndexExt {
+    /// Create indices on columns.
+    ///
+    /// Upon finish, a new dataset version is generated.
+    ///
+    /// Parameters:
+    ///
+    ///  - `columns`: the columns to build the indices on.
+    ///  - `index_type`: specify [`IndexType`].
+    ///  - `name`: optional index name. Must be unique in the dataset.
+    ///            if not provided, it will auto-generate one.
+    ///  - `params`: index parameters.
+    ///  - `replace`: replace the existing index if it exists.
+    async fn create_index(
+        &mut self,
+        columns: &[&str],
+        index_type: IndexType,
+        name: Option<String>,
+        params: &dyn IndexParams,
+        replace: bool,
+    ) -> Result<()>;
+
+    /// Read all indices of this Dataset version.
+    async fn load_indices(&self) -> Result<Vec<Index>>;
+
+    /// Loads all the indies of a given UUID.
+    ///
+    /// Note that it is possible to have multiple indices with the same UUID,
+    /// as they are the deltas of the same index.
+    async fn load_index(&self, uuid: &str) -> Result<Option<Index>> {
+        self.load_indices()
+            .await
+            .map(|indices| indices.into_iter().find(|idx| idx.uuid.to_string() == uuid))
+    }
+
+    /// Loads a specific index with the given index name
+    async fn load_index_by_name(&self, name: &str) -> Result<Option<Index>> {
+        self.load_indices()
+            .await
+            .map(|indices| indices.into_iter().find(|idx| idx.name == name))
+    }
+
+    /// Loads a specific index with the given index name.
+    async fn load_scalar_index_for_column(&self, col: &str) -> Result<Option<Index>>;
+
+    /// Optimize indices.
+    async fn optimize_indices(&mut self) -> Result<()>;
+
+    /// Find index with a given index_name and return its serialized statistics.
+    async fn index_statistics(&self, index_name: &str) -> Result<Option<String>>;
+}

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -71,4 +71,14 @@ pub trait DatasetIndexExt {
 
     /// Find index with a given index_name and return its serialized statistics.
     async fn index_statistics(&self, index_name: &str) -> Result<Option<String>>;
+
+    /// Count the rows that are not indexed by the given index.
+    ///
+    /// TODO: move to [DatasetInternalExt]
+    async fn count_unindexed_rows(&self, index_name: &str) -> Result<Option<usize>>;
+
+    /// Count the rows that are indexed by the given index.
+    ///
+    /// TODO: move to [DatasetInternalExt]
+    async fn count_indexed_rows(&self, index_name: &str) -> Result<Option<usize>>;
 }

--- a/rust/lance/benches/ivf_pq.rs
+++ b/rust/lance/benches/ivf_pq.rs
@@ -17,14 +17,14 @@ use std::sync::Arc;
 use arrow_array::{FixedSizeListArray, RecordBatch, RecordBatchIterator};
 use arrow_schema::{DataType, Field, FieldRef, Schema};
 use criterion::{criterion_group, criterion_main, Criterion};
+
 use lance::{
     arrow::*,
     dataset::{WriteMode, WriteParams},
-    index::{vector::VectorIndexParams, DatasetIndexExt},
+    index::vector::VectorIndexParams,
     Dataset,
 };
-
-use lance_index::IndexType;
+use lance_index::{DatasetIndexExt, IndexType};
 use lance_linalg::distance::MetricType;
 use lance_testing::datagen::generate_random_array;
 #[cfg(target_os = "linux")]

--- a/rust/lance/benches/vector_index.rs
+++ b/rust/lance/benches/vector_index.rs
@@ -20,18 +20,17 @@ use arrow_array::{
 use arrow_schema::{DataType, Field, FieldRef, Schema as ArrowSchema};
 use criterion::{criterion_group, criterion_main, Criterion};
 use futures::TryStreamExt;
-use lance::dataset::builder::DatasetBuilder;
-use lance_index::IndexType;
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
 use rand::{self, Rng};
 
-use lance::dataset::{WriteMode, WriteParams};
+use lance::dataset::{builder::DatasetBuilder, Dataset, WriteMode, WriteParams};
 use lance::index::vector::VectorIndexParams;
-use lance::index::DatasetIndexExt;
-use lance::{arrow::as_fixed_size_list_array, dataset::Dataset};
-use lance_arrow::FixedSizeListArrayExt;
-use lance_index::vector::{ivf::IvfBuildParams, pq::PQBuildParams};
+use lance_arrow::{as_fixed_size_list_array, FixedSizeListArrayExt};
+use lance_index::{
+    vector::{ivf::IvfBuildParams, pq::PQBuildParams},
+    DatasetIndexExt, IndexType,
+};
 use lance_linalg::distance::MetricType;
 
 fn bench_ivf_pq_index(c: &mut Criterion) {

--- a/rust/lance/src/bin/lq.rs
+++ b/rust/lance/src/bin/lq.rs
@@ -20,8 +20,9 @@ use futures::TryStreamExt;
 use snafu::{location, Location};
 
 use lance::dataset::Dataset;
-use lance::index::{vector::VectorIndexParams, DatasetIndexExt};
+use lance::index::vector::VectorIndexParams;
 use lance::{Error, Result};
+use lance_index::DatasetIndexExt;
 use lance_linalg::distance::MetricType;
 
 #[derive(Parser)]

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -35,7 +35,7 @@ use lance_core::io::{
     commit::CommitError,
     object_store::{ObjectStore, ObjectStoreParams},
     read_metadata_offset, read_struct,
-    reader::{read_manifest, read_manifest_indexes},
+    reader::read_manifest,
     write_manifest, ObjectWriter, WriteExt,
 };
 use log::warn;
@@ -69,11 +69,9 @@ use self::fragment::FileFragment;
 use self::scanner::{DatasetRecordBatchStream, Scanner};
 use self::transaction::{Operation, Transaction};
 use self::write::{reader_to_stream, write_fragments_internal};
-use crate::dataset::index::unindexed_fragments;
 use crate::datatypes::Schema;
 use crate::error::box_error;
 use crate::format::{Fragment, Index, Manifest};
-use crate::index::DatasetIndexInternalExt;
 use crate::io::commit::{commit_new_dataset, commit_transaction};
 use crate::session::Session;
 
@@ -1261,7 +1259,7 @@ impl Dataset {
         &self.object_store
     }
 
-    async fn manifest_file(&self, version: u64) -> Result<Path> {
+    pub(crate) async fn manifest_file(&self, version: u64) -> Result<Path> {
         self.object_store
             .commit_handler
             .resolve_version(&self.base, version, &self.object_store.inner)
@@ -1354,94 +1352,6 @@ impl Dataset {
 
     pub(crate) fn fragments(&self) -> &Arc<Vec<Fragment>> {
         &self.manifest.fragments
-    }
-
-    /// Read all indices of this Dataset version.
-    pub async fn load_indices(&self) -> Result<Vec<Index>> {
-        let manifest_file = self.manifest_file(self.version().version).await?;
-        read_manifest_indexes(&self.object_store, &manifest_file, &self.manifest).await
-    }
-
-    /// Loads a specific index with the given id
-    pub async fn load_index(&self, uuid: &str) -> Option<Index> {
-        self.load_indices()
-            .await
-            .unwrap()
-            .into_iter()
-            .find(|idx| idx.uuid.to_string() == uuid)
-    }
-
-    pub async fn load_index_by_name(&self, name: &str) -> Option<Index> {
-        self.load_indices()
-            .await
-            .unwrap()
-            .into_iter()
-            .find(|idx| idx.name == name)
-    }
-
-    pub(crate) async fn load_scalar_index_for_column(&self, col: &str) -> Result<Option<Index>> {
-        Ok(self
-            .load_indices()
-            .await?
-            .into_iter()
-            .filter(|idx| idx.fields.len() == 1)
-            .find(|idx| {
-                let field = self.schema().field_by_id(idx.fields[0]);
-                if let Some(field) = field {
-                    field.name == col
-                } else {
-                    false
-                }
-            }))
-    }
-
-    /// Find index with a given index_name and return its serialized statistics.
-    pub async fn index_statistics(&self, index_name: &str) -> Result<Option<String>> {
-        let index_uuid = self
-            .load_index_by_name(index_name)
-            .await
-            .map(|idx| idx.uuid.to_string());
-
-        if let Some(index_uuid) = index_uuid {
-            let index_statistics = self
-                .open_generic_index("vector", &index_uuid)
-                .await?
-                .statistics()
-                .unwrap();
-            Ok(Some(index_statistics))
-        } else {
-            Ok(None)
-        }
-    }
-
-    pub async fn count_unindexed_rows(&self, index_uuid: &str) -> Result<Option<usize>> {
-        let index = self.load_index(index_uuid).await;
-
-        if let Some(index) = index {
-            let unindexed_frags = unindexed_fragments(&index, self).await?;
-            let unindexed_rows = unindexed_frags
-                .iter()
-                .map(Fragment::num_rows)
-                // sum the number of rows in each fragment if no fragment returned None from row_count
-                .try_fold(0, |a, b| b.map(|b| a + b).ok_or(()));
-
-            Ok(unindexed_rows.ok())
-        } else {
-            Ok(None)
-        }
-    }
-
-    pub async fn count_indexed_rows(&self, index_uuid: &str) -> Result<Option<usize>> {
-        let count_rows = self.count_rows();
-        let count_unindexed_rows = self.count_unindexed_rows(index_uuid);
-
-        let (count_rows, count_unindexed_rows) =
-            futures::try_join!(count_rows, count_unindexed_rows)?;
-
-        match count_unindexed_rows {
-            Some(count_unindexed_rows) => Ok(Some(count_rows - count_unindexed_rows)),
-            None => Ok(None),
-        }
     }
 
     /// Gets the number of files that are so small they don't even have a full

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -461,7 +461,7 @@ mod tests {
         utils::testing::{MockClock, ProxyObjectStore, ProxyObjectStorePolicy},
         Error, Result,
     };
-    use lance_index::IndexType;
+    use lance_index::{DatasetIndexExt, IndexType};
     use lance_linalg::distance::MetricType;
     use lance_testing::datagen::{some_batch, BatchGenerator, IncrementingInt32};
     use snafu::{location, Location};
@@ -469,10 +469,7 @@ mod tests {
 
     use crate::{
         dataset::{builder::DatasetBuilder, ReadParams, WriteMode, WriteParams},
-        index::{
-            vector::{StageParams, VectorIndexParams},
-            DatasetIndexExt,
-        },
+        index::vector::{StageParams, VectorIndexParams},
         io::{
             object_store::{ObjectStoreParams, WrappingObjectStore},
             ObjectStore,

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -23,7 +23,7 @@ use lance_core::{
 use serde::{Deserialize, Serialize};
 use snafu::{location, Location};
 
-use crate::index::remap_index;
+use crate::index::{remap_index, DatasetIndexExt};
 use crate::Dataset;
 
 use super::optimize::{IndexRemapper, IndexRemapperOptions, RemappedIndex};

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -20,10 +20,11 @@ use lance_core::{
     format::{Fragment, Index},
     Error, Result,
 };
+use lance_index::DatasetIndexExt;
 use serde::{Deserialize, Serialize};
 use snafu::{location, Location};
 
-use crate::index::{remap_index, DatasetIndexExt};
+use crate::index::remap_index;
 use crate::Dataset;
 
 use super::optimize::{IndexRemapper, IndexRemapperOptions, RemappedIndex};

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -106,7 +106,7 @@ use uuid::Uuid;
 use crate::format::RowAddress;
 use crate::io::commit::{commit_transaction, migrate_fragments};
 use crate::Result;
-use crate::{format::Fragment, Dataset};
+use crate::{format::Fragment, index::DatasetIndexExt, Dataset};
 
 use super::fragment::FileFragment;
 use super::index::DatasetIndexRemapperOptions;

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -99,6 +99,7 @@ use std::sync::{Arc, RwLock};
 use async_trait::async_trait;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{StreamExt, TryStreamExt};
+use lance_index::DatasetIndexExt;
 use roaring::{RoaringBitmap, RoaringTreemap};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -106,7 +107,7 @@ use uuid::Uuid;
 use crate::format::RowAddress;
 use crate::io::commit::{commit_transaction, migrate_fragments};
 use crate::Result;
-use crate::{format::Fragment, index::DatasetIndexExt, Dataset};
+use crate::{format::Fragment, Dataset};
 
 use super::fragment::FileFragment;
 use super::index::DatasetIndexRemapperOptions;

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -40,8 +40,8 @@ use futures::TryStreamExt;
 use lance_arrow::floats::{coerce_float_vector, FloatType};
 use lance_core::ROW_ID_FIELD;
 use lance_datafusion::exec::execute_plan;
-use lance_index::scalar::expression::ScalarIndexExpr;
 use lance_index::vector::{Query, DIST_COL};
+use lance_index::{scalar::expression::ScalarIndexExpr, DatasetIndexExt};
 use lance_linalg::distance::MetricType;
 use log::debug;
 use roaring::RoaringBitmap;
@@ -51,7 +51,7 @@ use super::Dataset;
 use crate::dataset::index::unindexed_fragments;
 use crate::datatypes::Schema;
 use crate::format::{Fragment, Index};
-use crate::index::{DatasetIndexExt, DatasetIndexInternalExt};
+use crate::index::DatasetIndexInternalExt;
 use crate::io::exec::{FilterPlan, MaterializeIndexExec, PreFilterSource, ScalarIndexExec};
 use crate::io::{
     exec::{

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -51,7 +51,7 @@ use super::Dataset;
 use crate::dataset::index::unindexed_fragments;
 use crate::datatypes::Schema;
 use crate::format::{Fragment, Index};
-use crate::index::DatasetIndexInternalExt;
+use crate::index::{DatasetIndexExt, DatasetIndexInternalExt};
 use crate::io::exec::{FilterPlan, MaterializeIndexExec, PreFilterSource, ScalarIndexExec};
 use crate::io::{
     exec::{

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1338,8 +1338,7 @@ mod test {
     use futures::TryStreamExt;
     use lance_core::ROW_ID;
     use lance_datagen::{array, gen, BatchCount, Dimension, RowCount};
-    use lance_index::vector::DIST_COL;
-    use lance_index::IndexType;
+    use lance_index::{vector::DIST_COL, DatasetIndexExt, IndexType};
     use lance_testing::datagen::{BatchGenerator, IncrementingInt32};
     use tempfile::{tempdir, TempDir};
 
@@ -1349,7 +1348,7 @@ mod test {
     use crate::dataset::WriteMode;
     use crate::dataset::WriteParams;
     use crate::index::scalar::ScalarIndexParams;
-    use crate::index::{vector::VectorIndexParams, DatasetIndexExt};
+    use crate::index::vector::VectorIndexParams;
 
     #[tokio::test]
     async fn test_batch_size() {

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -545,4 +545,89 @@ mod tests {
             .await
             .is_err());
     }
+
+    #[tokio::test]
+    async fn test_count_index_rows() {
+        let test_dir = tempdir().unwrap();
+        let dimensions = 16;
+        let column_name = "vec";
+        let field = Field::new(
+            column_name,
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                dimensions,
+            ),
+            false,
+        );
+        let schema = Arc::new(Schema::new(vec![field]));
+
+        let float_arr = generate_random_array(512 * dimensions as usize);
+
+        let vectors =
+            arrow_array::FixedSizeListArray::try_new_from_values(float_arr, dimensions).unwrap();
+
+        let record_batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(vectors)]).unwrap();
+
+        let reader =
+            RecordBatchIterator::new(vec![record_batch].into_iter().map(Ok), schema.clone());
+
+        let test_uri = test_dir.path().to_str().unwrap();
+        let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+        dataset.validate().await.unwrap();
+
+        // Make sure it returns None if there's no index with the passed identifier
+        assert_eq!(dataset.count_unindexed_rows("bad_id").await.unwrap(), None);
+        assert_eq!(dataset.count_indexed_rows("bad_id").await.unwrap(), None);
+
+        // Create an index
+        let params = VectorIndexParams::ivf_pq(10, 8, 2, false, MetricType::L2, 10);
+        dataset
+            .create_index(
+                &[column_name],
+                IndexType::Vector,
+                Some("vec_idx".into()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let index = dataset
+            .load_index_by_name("vec_idx")
+            .await
+            .unwrap()
+            .unwrap();
+        let index_uuid = &index.uuid.to_string();
+
+        // Make sure there are no unindexed rows
+        assert_eq!(
+            dataset.count_unindexed_rows(index_uuid).await.unwrap(),
+            Some(0)
+        );
+        assert_eq!(
+            dataset.count_indexed_rows(index_uuid).await.unwrap(),
+            Some(512)
+        );
+
+        // Now we'll append some rows which shouldn't be indexed and see the
+        // count change
+        let float_arr = generate_random_array(512 * dimensions as usize);
+        let vectors =
+            arrow_array::FixedSizeListArray::try_new_from_values(float_arr, dimensions).unwrap();
+
+        let record_batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(vectors)]).unwrap();
+
+        let reader = RecordBatchIterator::new(vec![record_batch].into_iter().map(Ok), schema);
+        dataset.append(reader, None).await.unwrap();
+
+        // Make sure the new rows are not indexed
+        assert_eq!(
+            dataset.count_unindexed_rows(index_uuid).await.unwrap(),
+            Some(512)
+        );
+        assert_eq!(
+            dataset.count_indexed_rows(index_uuid).await.unwrap(),
+            Some(512)
+        );
+    }
 }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -336,8 +336,7 @@ impl DatasetIndexExt for Dataset {
             let index_statistics = self
                 .open_generic_index("vector", &index_uuid)
                 .await?
-                .statistics()
-                .unwrap();
+                .statistics()?;
             Ok(Some(index_statistics))
         } else {
             Ok(None)

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -44,6 +44,7 @@ use lance_core::{
     io::commit::{CommitConfig, CommitError},
     Error, Result,
 };
+use lance_index::DatasetIndexExt;
 use object_store::path::Path;
 use prost::Message;
 
@@ -53,7 +54,7 @@ use crate::dataset::fragment::FileFragment;
 use crate::dataset::transaction::{Operation, Transaction};
 use crate::dataset::{write_manifest_file, ManifestWriteConfig};
 use crate::format::{DeletionFile, Fragment};
-use crate::index::{DatasetIndexExt, DatasetIndexInternalExt};
+use crate::index::DatasetIndexInternalExt;
 use crate::Dataset;
 
 #[cfg(all(target_feature = "dynamodb", test))]

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -53,7 +53,7 @@ use crate::dataset::fragment::FileFragment;
 use crate::dataset::transaction::{Operation, Transaction};
 use crate::dataset::{write_manifest_file, ManifestWriteConfig};
 use crate::format::{DeletionFile, Fragment};
-use crate::index::DatasetIndexInternalExt;
+use crate::index::{DatasetIndexExt, DatasetIndexInternalExt};
 use crate::Dataset;
 
 #[cfg(all(target_feature = "dynamodb", test))]

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -414,14 +414,14 @@ mod tests {
         CommitError, CommitHandler, CommitLease, CommitLock, RenameCommitHandler,
         UnsafeCommitHandler,
     };
-    use lance_index::IndexType;
+    use lance_index::{DatasetIndexExt, IndexType};
     use lance_linalg::distance::MetricType;
     use lance_testing::datagen::generate_random_array;
 
     use super::*;
 
     use crate::dataset::{transaction::Operation, WriteMode, WriteParams};
-    use crate::index::{vector::VectorIndexParams, DatasetIndexExt};
+    use crate::index::vector::VectorIndexParams;
     use crate::io::object_store::ObjectStoreParams;
     use crate::Dataset;
 

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -35,7 +35,7 @@ use snafu::{location, Location};
 use tracing::instrument;
 
 use crate::{
-    index::{prefilter::PreFilter, DatasetIndexInternalExt},
+    index::{prefilter::PreFilter, DatasetIndexExt, DatasetIndexInternalExt},
     Dataset,
 };
 

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -25,9 +25,12 @@ use lance_core::{
     format::{Fragment, RowAddress},
     Error, Result, ROW_ID_FIELD,
 };
-use lance_index::scalar::{
-    expression::{ScalarIndexExpr, ScalarIndexLoader},
-    ScalarIndex,
+use lance_index::{
+    scalar::{
+        expression::{ScalarIndexExpr, ScalarIndexLoader},
+        ScalarIndex,
+    },
+    DatasetIndexExt,
 };
 use pin_project::pin_project;
 use roaring::RoaringBitmap;
@@ -35,7 +38,7 @@ use snafu::{location, Location};
 use tracing::instrument;
 
 use crate::{
-    index::{prefilter::PreFilter, DatasetIndexExt, DatasetIndexInternalExt},
+    index::{prefilter::PreFilter, DatasetIndexInternalExt},
     Dataset,
 };
 


### PR DESCRIPTION
BREAKING CHANGE: removed single-purpose stats API from public API and refactored `DatasetIndexExt` to `lance-index`.

Also, fixed a few places that `unwrap()` results.