### PR TITLE
fix: spurious bug during compaction

### DIFF
--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -784,7 +784,10 @@ async fn rewrite_files(
     // information.
     let fragments = migrate_fragments(dataset.as_ref(), &task.fragments, recompute_stats).await?;
     let mut scanner = dataset.scan();
-    scanner.with_fragments(fragments.clone()).with_row_id();
+    scanner
+        .with_fragments(fragments.clone())
+        .scan_in_order(true)
+        .with_row_id();
 
     let data = SendableRecordBatchStream::from(scanner.try_into_stream().await?);
     let row_ids = Arc::new(RwLock::new(RoaringTreemap::new()));


### PR DESCRIPTION
During compaction we read in the row ids so we can use them for remapping.  We read the row ids into a tree map which is most efficient if we can read them in order and the current code is in fact assuming that the row ids arrive in order.  However, we weren't actually scanning in order and this could lead to failures during compaction.