### PR TITLE
fix: spawn open_file tasks during scan to avoid potential deadlock

### DIFF
--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -165,7 +165,7 @@ impl LanceStream {
                 .map_ok(move |reader| scan_batches(reader, read_size))
                 // When we flatten the streams (one stream per fragment), we allow
                 // `fragment_readahead` stream to be read concurrently.
-                .try_flatten_unordered(None)
+                .try_flatten_unordered(fragment_readahead)
                 // We buffer up to `batch_readahead` batches across all streams.
                 .try_buffer_unordered(batch_readahead)
                 .stream_in_current_span()


### PR DESCRIPTION
The current scan implementation uses futures' `buffered` and `buffered_unordered` to drive parallelism.  Unfortunately, these methods can lead to deadlock.  A more detailed analysis of how this might happen is [here](https://blog.polybdenum.com/2022/07/24/fixing-the-next-thousand-deadlocks-why-buffered-streams-are-broken-and-how-to-make-them-safer.html).  The basic problem boils down to:

 * Create a big list/stream of futures, some of which depend on each other
 * Pass it into buffered
 * The buffered queue fills up with futures depending on futures that are not in the buffered queue
 * Deadlock because the futures that are not in the buffered queue are never polled

On the surface it *seems* like we are ok.  Our futures don't depend on each other, we don't have async locks in our code, any fragment can complete independently, any batch can complete independently, any column can complete independently.

However, my suspicion is that some kind of async lock (explicit or implicit) is being used in some underlying dependency (`reqwest`, `hyper`, and `rustls` could all be doing some kind of per-host / per-tcp connection pooling involving locks) and these libraries assume you are going to poll every future you create.  `open_file` seems to be the most 

At the moment the only thing I really know is that my test fails reliably without this change and it passes with this change.  I wouldn't say I understand everything.  For example, this fix makes sure the futures created by open_file and read_batch are spawned but it doesn't guarantee we spawn the per-column futures created within read_batch (but maybe it's enough that read_batch is spawned).

As a workaround for now we can spawn every future we create.  This will ensure the future does get polled.  However, I believe it also makes the `buffered` calls redundant and might be exceeding our readahead settings.

I think a better long-term fix would be an I/O scheduler, which I might try and tackle with my work on nullability.

Closes #1835 