### PR TITLE
chore: unindexed fragment can handle mulitple deltas

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1924,10 +1924,6 @@ class LanceStats:
             The name of the index to get statistics for.
         """
         index_stats = json.loads(self._ds.index_statistics(index_name))
-        index_stats["num_indexed_rows"] = self._ds.count_indexed_rows(index_name)
-        index_stats["num_unindexed_rows"] = self._ds.count_unindexed_rows(index_name)
-        index_stats["index_cache_entry_count"] = self._ds.index_cache_entry_count()
-        index_stats["index_cache_hit_rate"] = self._ds.index_cache_hit_rate()
         return index_stats
 
 

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -394,7 +394,7 @@ def test_pre_populated_ivf_centroids(dataset, tmp_path: Path):
     assert actual_statistics["num_indexed_rows"] == 1000
     assert actual_statistics["num_unindexed_rows"] == 0
 
-    idx_stats = actual_statistics["deltas"][0]
+    idx_stats = actual_statistics["indices"][0]
     partitions = idx_stats.pop("partitions")
     idx_stats.pop("centroids")
     assert idx_stats == expected_statistics

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -399,8 +399,7 @@ def test_pre_populated_ivf_centroids(dataset, tmp_path: Path):
     idx_stats.pop("centroids")
     assert idx_stats == expected_statistics
     assert len(partitions) == 5
-    partition_keys = {"length"}
-    print(partitions)
+    partition_keys = {"size"}
     assert all([partition_keys == set(p.keys()) for p in partitions])
 
 
@@ -564,26 +563,12 @@ def test_index_cache_size(tmp_path):
         index_cache_size=10,
     )
 
-    assert (
-        indexed_dataset.stats.index_stats("vector_idx")["index_cache_entry_count"] == 2
-    )
     query_index(indexed_dataset, 1)
-    assert (
-        indexed_dataset.stats.index_stats("vector_idx")["index_cache_entry_count"] == 3
-    )
-    assert np.isclose(
-        indexed_dataset.stats.index_stats("vector_idx")["index_cache_hit_rate"], 18 / 25
-    )
+    assert np.isclose(indexed_dataset._ds.index_cache_hit_rate(), 0.25)
     query_index(indexed_dataset, 128)
-    assert (
-        indexed_dataset.stats.index_stats("vector_idx")["index_cache_entry_count"] == 11
-    )
-
     indexed_dataset = lance.LanceDataset(indexed_dataset.uri, index_cache_size=5)
     query_index(indexed_dataset, 128)
-    assert (
-        indexed_dataset.stats.index_stats("vector_idx")["index_cache_entry_count"] == 6
-    )
+    assert indexed_dataset._ds.index_cache_entry_count() == 6
 
 
 def test_f16_index(tmp_path: Path):

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -206,8 +206,7 @@ impl Dataset {
 
     /// Get index statistics
     fn index_statistics(&self, index_name: String) -> PyResult<String> {
-        let index_statistics = RT
-            .runtime
+        RT.runtime
             .block_on(self.ds.index_statistics(&index_name))
             .map_err(|err| match err {
                 lance::Error::IndexNotFound { .. } => {
@@ -217,9 +216,7 @@ impl Dataset {
                     "Failed to get index statistics for index {}: {}",
                     index_name, err
                 )),
-            })?;
-        serde_json::to_string(&index_statistics)
-            .map_err(|err| PyValueError::new_err(err.to_string()))
+            })
     }
 
     /// Load index metadata

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -211,7 +211,7 @@ impl Dataset {
             .block_on(self.ds.index_statistics(&index_name))
             .map_err(|err| match err {
                 lance::Error::IndexNotFound { .. } => {
-                    return PyKeyError::new_err(format!("Index \"{}\" not found", index_name))
+                    PyKeyError::new_err(format!("Index \"{}\" not found", index_name))
                 }
                 _ => PyIOError::new_err(format!(
                     "Failed to get index statistics for index {}: {}",

--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -78,6 +78,8 @@ pub enum Error {
     IO { message: String, location: Location },
     #[snafu(display("LanceError(Index): {message}, {location}"))]
     Index { message: String, location: Location },
+    #[snafu(display("Lance index not found: {identity}, {location}"))]
+    IndexNotFound { identity: String, location: Location },
     #[snafu(display("Cannot infer storage location from: {message}"))]
     InvalidTableLocation { message: String },
     /// Stream early stop

--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -79,7 +79,10 @@ pub enum Error {
     #[snafu(display("LanceError(Index): {message}, {location}"))]
     Index { message: String, location: Location },
     #[snafu(display("Lance index not found: {identity}, {location}"))]
-    IndexNotFound { identity: String, location: Location },
+    IndexNotFound {
+        identity: String,
+        location: Location,
+    },
     #[snafu(display("Cannot infer storage location from: {message}"))]
     InvalidTableLocation { message: String },
     /// Stream early stop

--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -44,8 +44,8 @@ pub trait Index: Send + Sync {
     /// Cast to [Index]
     fn as_index(self: Arc<Self>) -> Arc<dyn Index>;
 
-    /// Retrieve index statistics as a JSON string
-    fn statistics(&self) -> Result<String>;
+    /// Retrieve index statistics as a JSON Value
+    fn statistics(&self) -> Result<serde_json::Value>;
 
     /// Get the type of the index
     fn index_type(&self) -> IndexType;

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -794,7 +794,7 @@ impl Index for BTreeIndex {
         IndexType::Scalar
     }
 
-    fn statistics(&self) -> Result<String> {
+    fn statistics(&self) -> Result<serde_json::Value> {
         let min = self
             .page_lookup
             .tree
@@ -805,7 +805,7 @@ impl Index for BTreeIndex {
             .tree
             .last_key_value()
             .map(|(k, _)| k.clone());
-        serde_json::to_string(&BTreeStatistics {
+        serde_json::to_value(&BTreeStatistics {
             num_pages: self.page_lookup.tree.len() as u32,
             min,
             max,

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -68,7 +68,7 @@ pub trait DatasetIndexExt {
     /// Returns
     /// -------
     /// - `Ok(indices)`: if the index exists, returns the index.
-    /// - `Ok(empty)`: if the index does not exist.
+    /// - `Ok(vec![])`: if the index does not exist.
     /// - `Err(e)`: if there is an error loading indices.
     ///
     async fn load_indices_by_name(&self, name: &str) -> Result<Vec<Index>> {
@@ -88,5 +88,7 @@ pub trait DatasetIndexExt {
     async fn optimize_indices(&mut self) -> Result<()>;
 
     /// Find index with a given index_name and return its serialized statistics.
-    async fn index_statistics(&self, index_name: &str) -> Result<serde_json::Value>;
+    ///
+    /// If the index does not exist, return Error.
+    async fn index_statistics(&self, index_name: &str) -> Result<String>;
 }

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -89,14 +89,4 @@ pub trait DatasetIndexExt {
 
     /// Find index with a given index_name and return its serialized statistics.
     async fn index_statistics(&self, index_name: &str) -> Result<serde_json::Value>;
-
-    /// Count the rows that are not indexed by the given index.
-    ///
-    /// TODO: move to [DatasetInternalExt]
-    async fn count_unindexed_rows(&self, index_name: &str) -> Result<Option<usize>>;
-
-    /// Count the rows that are indexed by the given index.
-    ///
-    /// TODO: move to [DatasetInternalExt]
-    async fn count_indexed_rows(&self, index_name: &str) -> Result<Option<usize>>;
 }

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -64,10 +64,21 @@ pub trait DatasetIndexExt {
     }
 
     /// Loads a specific index with the given index name
-    async fn load_index_by_name(&self, name: &str) -> Result<Option<Index>> {
-        self.load_indices()
-            .await
-            .map(|indices| indices.iter().find(|idx| idx.name == name).cloned())
+    ///
+    /// Returns
+    /// -------
+    /// - `Ok(indices)`: if the index exists, returns the index.
+    /// - `Ok(empty)`: if the index does not exist.
+    /// - `Err(e)`: if there is an error loading indices.
+    ///
+    async fn load_indices_by_name(&self, name: &str) -> Result<Vec<Index>> {
+        self.load_indices().await.map(|indices| {
+            indices
+                .iter()
+                .filter(|idx| idx.name == name)
+                .cloned()
+                .collect()
+        })
     }
 
     /// Loads a specific index with the given index name.
@@ -77,7 +88,7 @@ pub trait DatasetIndexExt {
     async fn optimize_indices(&mut self) -> Result<()>;
 
     /// Find index with a given index_name and return its serialized statistics.
-    async fn index_statistics(&self, index_name: &str) -> Result<Option<String>>;
+    async fn index_statistics(&self, index_name: &str) -> Result<serde_json::Value>;
 
     /// Count the rows that are not indexed by the given index.
     ///

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2456,23 +2456,13 @@ mod tests {
         assert_eq!(fragment_bitmap.len(), 1);
         assert!(fragment_bitmap.contains(0));
 
-        let actual_statistics: serde_json::value::Value = serde_json::from_str(
-            &dataset
-                .index_statistics("embeddings_idx")
-                .await
-                .unwrap()
-                .unwrap(),
-        )
-        .unwrap();
+        let actual_statistics = dataset.index_statistics("embeddings_idx").await.unwrap();
         let actual_statistics = actual_statistics.as_object().unwrap();
         assert_eq!(actual_statistics["index_type"].as_str().unwrap(), "IVF");
         assert_eq!(actual_statistics["metric_type"].as_str().unwrap(), "l2");
         assert_eq!(actual_statistics["num_partitions"].as_i64().unwrap(), 10);
 
-        assert_eq!(
-            dataset.index_statistics("non-existent_idx").await.unwrap(),
-            None
-        );
+        assert!(dataset.index_statistics("non-existent_idx").await.is_err());
         assert_eq!(dataset.index_statistics("").await.unwrap(), None);
 
         // Overwrite should invalidate index

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Lance Developers.
+// Copyright 2024 Lance Developers.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2456,11 +2456,13 @@ mod tests {
         assert_eq!(fragment_bitmap.len(), 1);
         assert!(fragment_bitmap.contains(0));
 
-        let actual_statistics = dataset.index_statistics("embeddings_idx").await.unwrap();
+        let actual_statistics: serde_json::Value =
+            serde_json::from_str(&dataset.index_statistics("embeddings_idx").await.unwrap())
+                .unwrap();
         let actual_statistics = actual_statistics.as_object().unwrap();
         assert_eq!(actual_statistics["index_type"].as_str().unwrap(), "IVF");
 
-        let deltas = actual_statistics["deltas"].as_array().unwrap();
+        let deltas = actual_statistics["indices"].as_array().unwrap();
         assert_eq!(deltas.len(), 1);
         assert_eq!(deltas[0]["metric_type"].as_str().unwrap(), "l2");
         assert_eq!(deltas[0]["num_partitions"].as_i64().unwrap(), 10);

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -82,36 +82,3 @@ impl IndexRemapper for DatasetIndexRemapper {
         Ok(remapped)
     }
 }
-
-/// Returns the fragment ids that are not indexed by this index.
-pub(crate) async fn unindexed_fragments(index: &Index, dataset: &Dataset) -> Result<Vec<Fragment>> {
-    if index.dataset_version == dataset.version().version {
-        return Ok(vec![]);
-    }
-    if let Some(bitmap) = index.fragment_bitmap.as_ref() {
-        Ok(dataset
-            .fragments()
-            .iter()
-            .filter(|f| !bitmap.contains(f.id as u32))
-            .cloned()
-            .collect::<Vec<_>>())
-    } else {
-        let ds = dataset.checkout_version(index.dataset_version).await?;
-        let max_fragment_id_idx = ds.manifest.max_fragment_id().ok_or_else(|| Error::IO {
-            message: "No fragments in index version".to_string(),
-            location: location!(),
-        })?;
-        let max_fragment_id_ds = dataset
-            .manifest
-            .max_fragment_id()
-            .ok_or_else(|| Error::IO {
-                message: "No fragments in dataset version".to_string(),
-                location: location!(),
-            })?;
-        if max_fragment_id_idx < max_fragment_id_ds {
-            dataset.manifest.fragments_since(&ds.manifest)
-        } else {
-            Ok(vec![])
-        }
-    }
-}

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -16,13 +16,9 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use lance_core::{
-    format::{Fragment, Index},
-    Error, Result,
-};
+use lance_core::{format::Index, Result};
 use lance_index::DatasetIndexExt;
 use serde::{Deserialize, Serialize};
-use snafu::{location, Location};
 
 use crate::index::remap_index;
 use crate::Dataset;

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -48,7 +48,6 @@ use roaring::RoaringBitmap;
 use tracing::{info_span, instrument, Span};
 
 use super::Dataset;
-use crate::dataset::index::unindexed_fragments;
 use crate::datatypes::Schema;
 use crate::format::{Fragment, Index};
 use crate::index::DatasetIndexInternalExt;
@@ -917,7 +916,7 @@ impl Scanner {
         filter_plan: &FilterPlan,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // Check if we've created new versions since the index
-        let unindexed_fragments = unindexed_fragments(index, self.dataset.as_ref()).await?;
+        let unindexed_fragments = self.dataset.unindexed_fragments(&index.name).await?;
         if !unindexed_fragments.is_empty() {
             let mut columns = vec![q.column.clone()];
             let mut num_filter_columns = 0;

--- a/rust/lance/src/index/vector/diskann/search.rs
+++ b/rust/lance/src/index/vector/diskann/search.rs
@@ -221,7 +221,7 @@ impl Index for DiskANNIndex {
     }
 
     fn statistics(&self) -> Result<serde_json::Value> {
-        Ok(serde_json::to_value(&DiskANNIndexStatistics {
+        Ok(serde_json::to_value(DiskANNIndexStatistics {
             index_type: "DiskANNIndex".to_string(),
             length: self.graph.len(),
         })?)

--- a/rust/lance/src/index/vector/diskann/search.rs
+++ b/rust/lance/src/index/vector/diskann/search.rs
@@ -220,8 +220,8 @@ impl Index for DiskANNIndex {
         IndexType::Vector
     }
 
-    fn statistics(&self) -> Result<String> {
-        Ok(serde_json::to_string(&DiskANNIndexStatistics {
+    fn statistics(&self) -> Result<serde_json::Value> {
+        Ok(serde_json::to_value(&DiskANNIndexStatistics {
             index_type: "DiskANNIndex".to_string(),
             length: self.graph.len(),
         })?)

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -254,10 +254,7 @@ impl std::fmt::Debug for IVFIndex {
 
 #[derive(Serialize)]
 pub struct IvfIndexPartitionStatistics {
-    index: usize,
     length: u32,
-    offset: usize,
-    centroid: Vec<f32>,
 }
 
 #[derive(Serialize)]
@@ -294,12 +291,7 @@ impl Index for IVFIndex {
             .map(|(i, &len)| {
                 let centroid = self.ivf.centroids.value(i);
                 let centroid_arr: &Float32Array = as_primitive_array(centroid.as_ref());
-                IvfIndexPartitionStatistics {
-                    index: i,
-                    length: len,
-                    offset: self.ivf.offsets[i],
-                    centroid: centroid_arr.values().to_vec(),
-                }
+                IvfIndexPartitionStatistics { length: len }
             })
             .collect::<Vec<_>>();
 

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -254,7 +254,7 @@ impl std::fmt::Debug for IVFIndex {
 
 #[derive(Serialize)]
 pub struct IvfIndexPartitionStatistics {
-    length: u32,
+    size: u32,
 }
 
 #[derive(Serialize)]
@@ -327,7 +327,7 @@ impl Index for IVFIndex {
             .ivf
             .lengths
             .iter()
-            .map(|&len| IvfIndexPartitionStatistics { length: len })
+            .map(|&len| IvfIndexPartitionStatistics { size: len })
             .collect::<Vec<_>>();
 
         let centroid_vecs = centroids_to_vectors(&self.ivf.centroids)?;

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -288,15 +288,13 @@ fn centroids_to_vectors(centroids: &FixedSizeListArray) -> Result<Vec<Vec<f32>>>
                         .iter()
                         .map(|v| *v as f32)
                         .collect::<Vec<_>>()),
-                    _ => {
-                        return Err(Error::Index {
-                            message: format!(
-                                "IVF centroids must be FixedSizeList of floating number, got: {}",
-                                row.data_type()
-                            ),
-                            location: location!(),
-                        });
-                    }
+                    _ => Err(Error::Index {
+                        message: format!(
+                            "IVF centroids must be FixedSizeList of floating number, got: {}",
+                            row.data_type()
+                        ),
+                        location: location!(),
+                    }),
                 }
             } else {
                 Err(Error::Index {
@@ -332,7 +330,7 @@ impl Index for IVFIndex {
 
         let centroid_vecs = centroids_to_vectors(&self.ivf.centroids)?;
 
-        Ok(serde_json::to_value(&IvfIndexStatistics {
+        Ok(serde_json::to_value(IvfIndexStatistics {
             index_type: "IVF".to_string(),
             uuid: self.uuid.clone(),
             uri: to_local_path(self.reader.path()),

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -285,7 +285,7 @@ impl Index for IVFIndex {
         IndexType::Vector
     }
 
-    fn statistics(&self) -> Result<String> {
+    fn statistics(&self) -> Result<serde_json::Value> {
         let partitions_statistics = self
             .ivf
             .lengths
@@ -303,14 +303,13 @@ impl Index for IVFIndex {
             })
             .collect::<Vec<_>>();
 
-        Ok(serde_json::to_string(&IvfIndexStatistics {
+        Ok(serde_json::to_value(&IvfIndexStatistics {
             index_type: "IVF".to_string(),
             uuid: self.uuid.clone(),
             uri: to_local_path(self.reader.path()),
             metric_type: self.metric_type.to_string(),
             num_partitions: self.ivf.num_partitions(),
-            // TODO: Not ideal that we have to re-parse the JSON here
-            sub_index: serde_json::from_str(&self.sub_index.statistics()?)?,
+            sub_index: self.sub_index.statistics()?,
             partitions: partitions_statistics,
         })?)
     }

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -36,7 +36,7 @@ use lance_index::{
 };
 use lance_linalg::distance::MetricType;
 use roaring::RoaringBitmap;
-use serde::Serialize;
+use serde_json::json;
 use snafu::{location, Location};
 use tracing::instrument;
 
@@ -108,15 +108,6 @@ impl PQIndex {
     }
 }
 
-#[derive(Serialize)]
-pub struct PQIndexStatistics {
-    index_type: String,
-    nbits: u32,
-    num_sub_vectors: usize,
-    dimension: usize,
-    metric_type: String,
-}
-
 #[async_trait]
 impl Index for PQIndex {
     fn as_any(&self) -> &dyn Any {
@@ -131,14 +122,14 @@ impl Index for PQIndex {
         IndexType::Vector
     }
 
-    fn statistics(&self) -> Result<String> {
-        Ok(serde_json::to_string(&PQIndexStatistics {
-            index_type: "PQ".to_string(),
-            nbits: self.pq.num_bits(),
-            num_sub_vectors: self.pq.num_sub_vectors(),
-            dimension: self.pq.dimension(),
-            metric_type: self.metric_type.to_string(),
-        })?)
+    fn statistics(&self) -> Result<serde_json::Value> {
+        Ok(json!({
+            "index_type": "PQ",
+            "nbits": self.pq.num_bits(),
+            "num_sub_vectors": self.pq.num_sub_vectors(),
+            "dimension": self.pq.dimension(),
+            "metric_type": self.metric_type.to_string(),
+        }))
     }
 
     async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {


### PR DESCRIPTION
BREAKING CHANGE: 
* change the structure of `index_statistics` return to include a list of index deltas.
* Do not return the cache hit rate because it is a global counter, not per-index status.
* Support f16/f32/f64 as IVF centroids.
 