### PR TITLE
refactor: move commit_handler out of ObjectStore and into Dataset

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -36,6 +36,7 @@ use lance::index::{
     vector::{diskann::DiskANNParams, VectorIndexParams},
 };
 use lance_arrow::as_fixed_size_list_array;
+use lance_core::io::commit::CommitHandler;
 use lance_core::{datatypes::Schema, format::Fragment, io::object_store::ObjectStoreParams};
 use lance_index::{
     vector::{ivf::IvfBuildParams, pq::PQBuildParams},
@@ -165,18 +166,16 @@ impl Dataset {
         let mut params = ReadParams {
             index_cache_size: index_cache_size.unwrap_or(DEFAULT_INDEX_CACHE_SIZE),
             metadata_cache_size: metadata_cache_size.unwrap_or(DEFAULT_METADATA_CACHE_SIZE),
-            session: None,
             store_options: Some(ObjectStoreParams {
                 block_size,
                 ..Default::default()
             }),
+            ..Default::default()
         };
 
         if let Some(commit_handler) = commit_handler {
             let py_commit_lock = PyCommitLock::new(commit_handler);
-            let mut object_store_params = ObjectStoreParams::default();
-            object_store_params.set_commit_lock(Arc::new(py_commit_lock));
-            params.store_options = Some(object_store_params);
+            params.set_commit_lock(Arc::new(py_commit_lock));
         }
         let dataset = if let Some(ver) = version {
             RT.runtime
@@ -614,7 +613,7 @@ impl Dataset {
     /// Restore the current version
     fn restore(&mut self) -> PyResult<()> {
         let mut new_self = self.ds.as_ref().clone();
-        RT.block_on(None, new_self.restore(None))?
+        RT.block_on(None, new_self.restore())?
             .map_err(|err| PyIOError::new_err(err.to_string()))?;
         self.ds = Arc::new(new_self);
         Ok(())
@@ -857,18 +856,14 @@ impl Dataset {
         read_version: Option<u64>,
         commit_lock: Option<&PyAny>,
     ) -> PyResult<Self> {
-        let store_params = if let Some(commit_handler) = commit_lock {
-            let py_commit_lock = PyCommitLock::new(commit_handler.to_object(commit_handler.py()));
-            let mut object_store_params = ObjectStoreParams::default();
-            object_store_params.set_commit_lock(Arc::new(py_commit_lock));
-            Some(object_store_params)
-        } else {
-            None
-        };
+        let commit_handler = commit_lock.map(|commit_lock| {
+            Arc::new(PyCommitLock::new(commit_lock.to_object(commit_lock.py())))
+                as Arc<dyn CommitHandler>
+        });
         let ds = RT
             .block_on(
                 commit_lock.map(|cl| cl.py()),
-                LanceDataset::commit(dataset_uri, operation.0, read_version, store_params),
+                LanceDataset::commit(dataset_uri, operation.0, read_version, None, commit_handler),
             )?
             .map_err(|e| PyIOError::new_err(e.to_string()))?;
         Ok(Self {
@@ -919,14 +914,13 @@ fn parse_write_mode(mode: &str) -> PyResult<WriteMode> {
     }
 }
 
-pub fn get_object_store_params(options: &PyDict) -> Option<ObjectStoreParams> {
+pub fn get_commit_handler(options: &PyDict) -> Option<Arc<dyn CommitHandler>> {
     if options.is_none() {
         None
     } else if let Ok(Some(commit_handler)) = options.get_item("commit_handler") {
-        let py_commit_lock = PyCommitLock::new(commit_handler.to_object(options.py()));
-        let mut object_store_params = ObjectStoreParams::default();
-        object_store_params.set_commit_lock(Arc::new(py_commit_lock));
-        Some(object_store_params)
+        Some(Arc::new(PyCommitLock::new(
+            commit_handler.to_object(options.py()),
+        )))
     } else {
         None
     }
@@ -955,7 +949,7 @@ pub fn get_write_params(options: &PyDict) -> PyResult<Option<WriteParams>> {
             }
         }
 
-        p.store_params = get_object_store_params(options);
+        p.commit_handler = get_commit_handler(options);
 
         Some(p)
     };

--- a/rust/lance-core/src/io/commit.rs
+++ b/rust/lance-core/src/io/commit.rs
@@ -383,10 +383,7 @@ pub async fn commit_handler_from_url(
                 .await?,
             }))
         }
-        "gs" => Ok(Arc::new(RenameCommitHandler)),
-        "az" => Ok(Arc::new(RenameCommitHandler)),
-        "file" => Ok(Arc::new(RenameCommitHandler)),
-        "memory" => Ok(Arc::new(RenameCommitHandler)),
+        "gs" | "az" | "file" | "memory" => Ok(Arc::new(RenameCommitHandler)),
         unknown_scheme => Err(Error::IO {
             message: format!("Unsupported URI scheme: {}", unknown_scheme),
             location: location!(),

--- a/rust/lance-core/src/io/commit.rs
+++ b/rust/lance-core/src/io/commit.rs
@@ -36,22 +36,37 @@
 use std::fmt::Debug;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::time::{Duration, SystemTime};
 
+use aws_credential_types::provider::error::CredentialsError;
+use aws_credential_types::provider::ProvideCredentials;
 use futures::{
     future::{self, BoxFuture},
     stream::BoxStream,
     StreamExt, TryStreamExt,
 };
+use object_store::aws::AwsCredentialProvider;
 use object_store::{path::Path, Error as ObjectStoreError, ObjectStore};
 use snafu::{location, Location};
+use url::Url;
 
 #[cfg(feature = "dynamodb")]
 pub mod dynamodb;
 pub mod external_manifest;
 
+#[cfg(feature = "dynamodb")]
+use {
+    self::external_manifest::{ExternalManifestCommitHandler, ExternalManifestStore},
+    super::object_store::{build_aws_credential, StorageOptions},
+    object_store::aws::AmazonS3ConfigKey,
+    std::borrow::Cow,
+};
+
 use crate::format::{Index, Manifest};
 use crate::io::object_store::ObjectStoreExt;
 use crate::{Error, Result};
+
+use super::object_store::ObjectStoreParams;
 
 const LATEST_MANIFEST_NAME: &str = "_latest.manifest";
 const VERSIONS_DIR: &str = "_versions";
@@ -165,6 +180,9 @@ async fn write_latest_manifest(
     Ok(())
 }
 
+#[cfg(feature = "dynamodb")]
+const DDB_URL_QUERY_KEY: &str = "ddbTableName";
+
 /// Handle commits that prevent conflicting writes.
 ///
 /// Commit implementations ensure that if there are multiple concurrent writers
@@ -227,6 +245,153 @@ pub trait CommitHandler: Debug + Send + Sync {
         object_store: &dyn ObjectStore,
         manifest_writer: ManifestWriter,
     ) -> std::result::Result<(), CommitError>;
+}
+
+/// Adapt an object_store credentials into AWS SDK creds
+#[derive(Debug)]
+struct OSObjectStoreToAwsCredAdaptor(AwsCredentialProvider);
+
+impl ProvideCredentials for OSObjectStoreToAwsCredAdaptor {
+    fn provide_credentials<'a>(
+        &'a self,
+    ) -> aws_credential_types::provider::future::ProvideCredentials<'a>
+    where
+        Self: 'a,
+    {
+        aws_credential_types::provider::future::ProvideCredentials::new(async {
+            let creds = self
+                .0
+                .get_credential()
+                .await
+                .map_err(|e| CredentialsError::provider_error(Box::new(e)))?;
+            Ok(aws_credential_types::Credentials::new(
+                &creds.key_id,
+                &creds.secret_key,
+                creds.token.clone(),
+                Some(
+                    SystemTime::now()
+                        .checked_add(Duration::from_secs(
+                            60 * 10, //  10 min
+                        ))
+                        .expect("overflow"),
+                ),
+                "",
+            ))
+        })
+    }
+}
+
+#[cfg(feature = "dynamodb")]
+async fn build_dynamodb_external_store(
+    table_name: &str,
+    creds: AwsCredentialProvider,
+    region: &str,
+    app_name: &str,
+) -> Result<Arc<dyn ExternalManifestStore>> {
+    use std::env;
+
+    use super::commit::dynamodb::DynamoDBExternalManifestStore;
+    use aws_sdk_dynamodb::{config::Region, Client};
+
+    let dynamodb_config = aws_sdk_dynamodb::config::Builder::new()
+        .region(Some(Region::new(region.to_string())))
+        .credentials_provider(OSObjectStoreToAwsCredAdaptor(creds));
+    let dynamodb_config = match env::var("DYNAMODB_ENDPOINT") {
+        Ok(endpoint) => dynamodb_config.endpoint_url(endpoint),
+        _ => dynamodb_config,
+    };
+
+    let client = Client::from_conf(dynamodb_config.build());
+
+    DynamoDBExternalManifestStore::new_external_store(client.into(), table_name, app_name).await
+}
+
+pub async fn commit_handler_from_url(
+    url_or_path: &str,
+    // This looks unused if dynamodb feature disabled
+    #[allow(unused_variables)] options: &Option<ObjectStoreParams>,
+) -> Result<Arc<dyn CommitHandler>> {
+    let url = match Url::parse(url_or_path) {
+        Ok(url) if url.scheme().len() == 1 && cfg!(windows) => {
+            // On Windows, the drive is parsed as a scheme
+            return Ok(Arc::new(RenameCommitHandler));
+        }
+        Ok(url) => url,
+        Err(_) => {
+            return Ok(Arc::new(RenameCommitHandler));
+        }
+    };
+
+    match url.scheme() {
+        "s3" => Ok(Arc::new(UnsafeCommitHandler)),
+        #[cfg(not(feature = "dynamodb"))]
+        "s3+ddb" => Err(Error::InvalidInput {
+            source: "`s3+ddb://` scheme requires `dynamodb` feature to be enabled".into(),
+            location: location!(),
+        }),
+        #[cfg(feature = "dynamodb")]
+        "s3+ddb" => {
+            if url.query_pairs().count() != 1 {
+                return Err(Error::InvalidInput {
+                    source: "`s3+ddb://` scheme and expects exactly one query `ddbTableName`"
+                        .into(),
+                    location: location!(),
+                });
+            }
+            let table_name = match url.query_pairs().next() {
+                Some((Cow::Borrowed(key), Cow::Borrowed(table_name)))
+                    if key == DDB_URL_QUERY_KEY =>
+                {
+                    if table_name.is_empty() {
+                        return Err(Error::InvalidInput {
+                            source: "`s3+ddb://` scheme requires non empty dynamodb table name"
+                                .into(),
+                            location: location!(),
+                        });
+                    }
+                    table_name
+                }
+                _ => {
+                    return Err(Error::InvalidInput {
+                        source: "`s3+ddb://` scheme and expects exactly one query `ddbTableName`"
+                            .into(),
+                        location: location!(),
+                    });
+                }
+            };
+            let options = options.clone().unwrap_or_default();
+            let storage_options =
+                StorageOptions(options.storage_options.unwrap_or_default()).as_s3_options();
+            let region = storage_options
+                .get(&AmazonS3ConfigKey::Region)
+                .map(|s| s.to_string());
+
+            let (aws_creds, region) = build_aws_credential(
+                options.s3_credentials_refresh_offset,
+                options.aws_credentials.clone(),
+                region,
+            )
+            .await?;
+
+            Ok(Arc::new(ExternalManifestCommitHandler {
+                external_manifest_store: build_dynamodb_external_store(
+                    table_name,
+                    aws_creds.clone(),
+                    &region,
+                    "lancedb",
+                )
+                .await?,
+            }))
+        }
+        "gs" => Ok(Arc::new(RenameCommitHandler)),
+        "az" => Ok(Arc::new(RenameCommitHandler)),
+        "file" => Ok(Arc::new(RenameCommitHandler)),
+        "memory" => Ok(Arc::new(RenameCommitHandler)),
+        unknown_scheme => Err(Error::IO {
+            message: format!("Unsupported URI scheme: {}", unknown_scheme),
+            location: location!(),
+        }),
+    }
 }
 
 /// Errors that can occur when committing a manifest.

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -164,18 +164,14 @@ mod tests {
     use arrow_select::take::TakeOptions;
     use datafusion::physical_plan::SendableRecordBatchStream;
     use datafusion_common::ScalarValue;
-    use lance_core::io::object_store::ObjectStoreParams;
     use lance_datafusion::exec::reader_to_stream;
     use lance_datagen::{array, gen, BatchCount, RowCount};
     use tempfile::{tempdir, TempDir};
 
     fn test_store(tempdir: &TempDir) -> Arc<dyn IndexStore> {
         let test_path: &Path = tempdir.path();
-        let (object_store, test_path) = ObjectStore::from_path(
-            test_path.as_os_str().to_str().unwrap(),
-            &ObjectStoreParams::default(),
-        )
-        .unwrap();
+        let (object_store, test_path) =
+            ObjectStore::from_path(test_path.as_os_str().to_str().unwrap()).unwrap();
         Arc::new(LanceIndexStore::new(object_store, test_path.to_owned()))
     }
 

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -8,10 +8,7 @@ use async_trait::async_trait;
 use criterion::{criterion_group, criterion_main, Criterion};
 use datafusion::{physical_plan::SendableRecordBatchStream, scalar::ScalarValue};
 use futures::TryStreamExt;
-use lance::{
-    io::{object_store::ObjectStoreParams, ObjectStore},
-    Dataset,
-};
+use lance::{io::ObjectStore, Dataset};
 use lance_core::Result;
 use lance_datafusion::exec::reader_to_stream;
 use lance_datagen::{array, gen, BatchCount, RowCount};
@@ -55,11 +52,8 @@ impl BtreeTrainingSource for BenchmarkDataSource {
 impl BenchmarkFixture {
     fn test_store(tempdir: &TempDir) -> Arc<dyn IndexStore> {
         let test_path = tempdir.path();
-        let (object_store, test_path) = ObjectStore::from_path(
-            test_path.as_os_str().to_str().unwrap(),
-            &ObjectStoreParams::default(),
-        )
-        .unwrap();
+        let (object_store, test_path) =
+            ObjectStore::from_path(test_path.as_os_str().to_str().unwrap()).unwrap();
         Arc::new(LanceIndexStore::new(object_store, test_path))
     }
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -141,8 +141,17 @@ pub struct ReadParams {
 
     /// If present, dataset will use this to resolve the latest version
     ///
-    /// If not set, the default will be based on the object store.  Generally this will
-    /// be RenameCommitHandler unless the object store does not handle atomic renames (e.g. S3)
+    /// Lance needs to be able to make atomic updates to the manifest.  This involves
+    /// coordination between readers and writers and we can usually rely on the filesystem
+    /// to do this coordination for us.
+    ///
+    /// Some filesystems (e.g. S3) do not support atomic operations.  In this case, for
+    /// safety, we recommend an external commit mechnaism (such as dynamodb) and, on the
+    /// read path, we need to reach out to that external mechanism to figure out the latest
+    /// version of the dataset.
+    ///
+    /// If this is not set then a default behavior is chosen that is appropriate for the
+    /// filesystem.
     ///
     /// If a custom object store is provided (via store_params.object_store) then this
     /// must also be provided.

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -14,7 +14,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use lance_core::io::{
-    commit::CommitHandler,
+    commit::{commit_handler_from_url, CommitHandler},
     object_store::{ObjectStore, ObjectStoreParams},
 };
 use object_store::{aws::AwsCredentialProvider, DynObjectStore};
@@ -37,6 +37,7 @@ pub struct DatasetBuilder {
     /// cache is disabled.
     metadata_cache_size: usize,
     session: Option<Arc<Session>>,
+    commit_handler: Option<Arc<dyn CommitHandler>>,
     options: ObjectStoreParams,
     version: Option<u64>,
     table_uri: String,
@@ -49,6 +50,7 @@ impl DatasetBuilder {
             metadata_cache_size: DEFAULT_METADATA_CACHE_SIZE,
             table_uri: table_uri.as_ref().to_string(),
             options: ObjectStoreParams::default(),
+            commit_handler: None,
             session: None,
             version: None,
         }
@@ -86,7 +88,7 @@ impl DatasetBuilder {
     }
 
     pub fn with_commit_handler(mut self, commit_handler: Arc<dyn CommitHandler>) -> Self {
-        self.options.commit_handler = Some(commit_handler);
+        self.commit_handler = Some(commit_handler);
         self
     }
 
@@ -105,8 +107,14 @@ impl DatasetBuilder {
     }
 
     /// Directly set the object store to use.
-    pub fn with_object_store(mut self, object_store: Arc<DynObjectStore>, location: Url) -> Self {
+    pub fn with_object_store(
+        mut self,
+        object_store: Arc<DynObjectStore>,
+        location: Url,
+        commit_handler: Arc<dyn CommitHandler>,
+    ) -> Self {
         self.options.object_store = Some((object_store, location));
+        self.commit_handler = Some(commit_handler);
         self
     }
 
@@ -151,6 +159,10 @@ impl DatasetBuilder {
             self.session = Some(session);
         }
 
+        if let Some(commit_handler) = read_params.commit_handler {
+            self.commit_handler = Some(commit_handler);
+        }
+
         self
     }
 
@@ -165,19 +177,26 @@ impl DatasetBuilder {
     }
 
     /// Build a lance object store for the given config
-    pub async fn build_object_store(self) -> Result<ObjectStore> {
+    pub async fn build_object_store(self) -> Result<(ObjectStore, Arc<dyn CommitHandler>)> {
+        let commit_handler = match self.commit_handler {
+            Some(commit_handler) => Ok(commit_handler),
+            None => commit_handler_from_url(&self.table_uri, &Some(self.options.clone())).await,
+        }?;
+
         match &self.options.object_store {
-            Some(store) => Ok(ObjectStore::new(
-                store.0.clone(),
-                store.1.clone(),
-                self.options.block_size,
-                self.options.commit_handler,
-                self.options.object_store_wrapper,
+            Some(store) => Ok((
+                ObjectStore::new(
+                    store.0.clone(),
+                    store.1.clone(),
+                    self.options.block_size,
+                    self.options.object_store_wrapper,
+                ),
+                commit_handler,
             )),
             None => {
                 let (store, _path) =
                     ObjectStore::from_uri_and_params(&self.table_uri, &self.options).await?;
-                Ok(store)
+                Ok((store, commit_handler))
             }
         }
     }
@@ -194,17 +213,15 @@ impl DatasetBuilder {
 
         let version = self.version;
 
-        let object_store = self.build_object_store().await?;
+        let (object_store, commit_handler) = self.build_object_store().await?;
         let base_path = object_store.base_path();
         let manifest = match version {
             Some(version) => {
-                object_store
-                    .commit_handler
+                commit_handler
                     .resolve_version(base_path, version, &object_store.inner)
                     .await?
             }
-            None => object_store
-                .commit_handler
+            None => commit_handler
                 .resolve_latest_version(base_path, &object_store.inner)
                 .await
                 .map_err(|e| Error::DatasetNotFound {
@@ -219,6 +236,7 @@ impl DatasetBuilder {
             base_path.clone(),
             &manifest,
             session,
+            commit_handler,
         )
         .await
     }

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -130,7 +130,6 @@ impl<'a> CleanupTask<'a> {
     async fn process_manifests(&'a self) -> Result<CleanupInspection> {
         let inspection = Mutex::new(CleanupInspection::default());
         self.dataset
-            .object_store
             .commit_handler
             .list_manifests(&self.dataset.base, &self.dataset.object_store.inner)
             .await?

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1091,7 +1091,9 @@ mod tests {
             fragments,
         };
 
-        let new_dataset = Dataset::commit(test_uri, op, None, None).await.unwrap();
+        let new_dataset = Dataset::commit(test_uri, op, None, None, None)
+            .await
+            .unwrap();
 
         assert_eq!(new_dataset.count_rows().await.unwrap(), dataset_rows);
 
@@ -1179,7 +1181,9 @@ mod tests {
                 schema: full_schema.clone(),
             };
 
-            let dataset = Dataset::commit(test_uri, op, None, None).await.unwrap();
+            let dataset = Dataset::commit(test_uri, op, None, None, None)
+                .await
+                .unwrap();
 
             // We only kept the first fragment of 40 rows
             assert_eq!(

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -736,6 +736,7 @@ async fn reserve_fragment_ids(dataset: &Dataset, fragments: &mut Vec<Fragment>) 
     let manifest = commit_transaction(
         dataset,
         dataset.object_store(),
+        dataset.commit_handler.as_ref(),
         &transaction,
         &Default::default(),
         &Default::default(),
@@ -899,6 +900,7 @@ pub async fn commit_compaction(
     let manifest = commit_transaction(
         dataset,
         dataset.object_store(),
+        dataset.commit_handler.as_ref(),
         &transaction,
         &Default::default(),
         &Default::default(),

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -2758,7 +2758,7 @@ mod test {
             // APPEND -> DELETE
 
             dataset.checkout_version(append_version).await.unwrap();
-            dataset.restore(None).await.unwrap();
+            dataset.restore().await.unwrap();
 
             dataset.delete("not_indexed = 75").await.unwrap();
 
@@ -2767,7 +2767,7 @@ mod test {
             // DELETE
 
             let mut dataset = dataset.checkout_version(original_version).await.unwrap();
-            dataset.restore(None).await.unwrap();
+            dataset.restore().await.unwrap();
 
             dataset.delete("not_indexed = 75").await.unwrap();
 
@@ -2780,7 +2780,7 @@ mod test {
                 .unwrap();
             let compact_version = dataset.version().version;
             dataset.checkout_version(original_version).await.unwrap();
-            dataset.restore(None).await.unwrap();
+            dataset.restore().await.unwrap();
 
             Self {
                 _test_dir: test_dir,

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -54,7 +54,10 @@ use lance_core::{
         pb::{self, IndexMetadata},
         Fragment, Index, Manifest,
     },
-    io::{object_store::ObjectStore, reader::read_manifest, reader::read_manifest_indexes},
+    io::{
+        commit::CommitHandler, object_store::ObjectStore, reader::read_manifest,
+        reader::read_manifest_indexes,
+    },
     Error, Result,
 };
 use object_store::path::Path;
@@ -335,13 +338,13 @@ impl Transaction {
 
     pub(crate) async fn restore_old_manifest(
         object_store: &ObjectStore,
+        commit_handler: &dyn CommitHandler,
         base_path: &Path,
         version: u64,
         config: &ManifestWriteConfig,
         tx_path: &str,
     ) -> Result<(Manifest, Vec<Index>)> {
-        let path = object_store
-            .commit_handler
+        let path = commit_handler
             .resolve_version(base_path, version, &object_store.inner)
             .await?;
         let mut manifest = read_manifest(object_store, &path).await?;

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -26,6 +26,7 @@ use lance_core::{
     datatypes::Schema,
     format::Fragment,
     io::{
+        commit::CommitHandler,
         object_store::{ObjectStore, ObjectStoreParams},
         FileWriter,
     },
@@ -80,6 +81,15 @@ pub struct WriteParams {
     pub store_params: Option<ObjectStoreParams>,
 
     pub progress: Arc<dyn WriteFragmentProgress>,
+
+    /// If present, dataset will use this to update the latest version
+    ///
+    /// If not set, the default will be based on the object store.  Generally this will
+    /// be RenameCommitHandler unless the object store does not handle atomic renames (e.g. S3)
+    ///
+    /// If a custom object store is provided (via store_params.object_store) then this
+    /// must also be provided.
+    pub commit_handler: Option<Arc<dyn CommitHandler>>,
 }
 
 impl Default for WriteParams {
@@ -93,6 +103,7 @@ impl Default for WriteParams {
             mode: WriteMode::Create,
             store_params: None,
             progress: Arc::new(NoopFragmentWriteProgress::new()),
+            commit_handler: None,
         }
     }
 }

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -340,6 +340,7 @@ impl UpdateJob {
         let manifest = commit_transaction(
             self.dataset.as_ref(),
             self.dataset.object_store(),
+            self.dataset.commit_handler.as_ref(),
             &transaction,
             &Default::default(),
             &Default::default(),

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -241,6 +241,7 @@ impl DatasetIndexExt for Dataset {
         let new_manifest = commit_transaction(
             self,
             self.object_store(),
+            self.commit_handler.as_ref(),
             &transaction,
             &Default::default(),
             &Default::default(),
@@ -316,6 +317,7 @@ impl DatasetIndexExt for Dataset {
         let new_manifest = commit_transaction(
             self,
             self.object_store(),
+            self.commit_handler.as_ref(),
             &transaction,
             &Default::default(),
             &Default::default(),

--- a/rust/lance/src/io/commit/external_manifest.rs
+++ b/rust/lance/src/io/commit/external_manifest.rs
@@ -32,7 +32,6 @@ mod test {
     use crate::dataset::builder::DatasetBuilder;
     use crate::{
         dataset::{ReadParams, WriteMode, WriteParams},
-        io::object_store::ObjectStoreParams,
         Dataset,
     };
 
@@ -124,20 +123,14 @@ mod test {
 
     fn read_params(handler: Arc<dyn CommitHandler>) -> ReadParams {
         ReadParams {
-            store_options: Some(ObjectStoreParams {
-                commit_handler: Some(handler),
-                ..Default::default()
-            }),
+            commit_handler: Some(handler),
             ..Default::default()
         }
     }
 
     fn write_params(handler: Arc<dyn CommitHandler>) -> WriteParams {
         WriteParams {
-            store_params: Some(ObjectStoreParams {
-                commit_handler: Some(handler),
-                ..Default::default()
-            }),
+            commit_handler: Some(handler),
             ..Default::default()
         }
     }
@@ -169,10 +162,7 @@ mod test {
             ds_uri,
             Some(WriteParams {
                 mode: WriteMode::Append,
-                store_params: Some(ObjectStoreParams {
-                    commit_handler: Some(handler),
-                    ..Default::default()
-                }),
+                commit_handler: Some(handler),
                 ..Default::default()
             }),
         )


### PR DESCRIPTION
There are a number of (rust API only) breaking changes:

 * The `Dataset` methods `restore` and `append` no longer allow you to override the `ObjectStore` / `CommitHandler` of the existing dataset.  If you want to change these then reopen the dataset with a new `ObjectStore` / `CommitHandler`
 * `ObjectStoreParams` no longer has `commit_handler`.  It has moved to `ReadParams` and `WriteParams`
 * `DatasetBuilder::with_object_store` now requires the user to specify a `CommitHandler`
 * `ObjectStore` no longer has a `commit_handler` and the various construction methods no longer accept one