### PR TITLE
ci: pin version of cargo publish action

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y protobuf-compiler libssl-dev
-      - uses: katyo/publish-crates@v2
+      - uses: albertlockett/publish-crates@v2.2
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           args: '--all-features'


### PR DESCRIPTION
Changes were introduced to the publish-crates action for how dev dependencies get resolved:
https://github.com/katyo/publish-crates/commit/2975306b7d9a99df113de64c106802fb5088be56#diff-20da981bb437131fc964cf3ac8dbda479f1ef5a050f6e750dd518f8a3c533663

This broke our build, as it made `lance-core` publish before it's dependency `lance-testing`.

Easiest solution is to pin the version of the action. Unfortunately, we can't pin to the upstream repo as not every commit has the `/dist` directory that gets created for releases (see [here](https://github.com/katyo/publish-crates/commit/c73a3c89510dd5d870696f1f084890d0b76224ab)), so I forked it.