### PR TITLE
refactor: split any reference to fragment or manifest out of the file reader

### DIFF
--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -22,9 +22,10 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
-import torch
-from lance.util import validate_vector_index
-from lance.vector import vec_to_table
+
+torch = pytest.importorskip("torch")
+from lance.util import validate_vector_index  # noqa: E402
+from lance.vector import vec_to_table  # noqa: E402
 
 
 def create_table(nvec=1000, ndim=128, nans=0):

--- a/rust/lance-core/src/cache.rs
+++ b/rust/lance-core/src/cache.rs
@@ -17,8 +17,11 @@
 use std::any::{Any, TypeId};
 use std::sync::Arc;
 
+use futures::Future;
 use moka::sync::Cache;
 use object_store::path::Path;
+
+use crate::Result;
 
 pub const DEFAULT_INDEX_CACHE_SIZE: usize = 128;
 pub const DEFAULT_METADATA_CACHE_SIZE: usize = 128;
@@ -48,5 +51,28 @@ impl FileMetadataCache {
 
     pub fn insert<T: Send + Sync + 'static>(&self, path: Path, metadata: Arc<T>) {
         self.cache.insert((path, TypeId::of::<T>()), metadata);
+    }
+
+    /// Get an item
+    ///
+    /// If it exists in the cache return that
+    ///
+    /// If it doesn't then run `loader` to load the item, insert into cache, and return
+    pub async fn get_or_insert<T: Send + Sync + 'static, F, Fut>(
+        &self,
+        path: &Path,
+        loader: F,
+    ) -> Result<Arc<T>>
+    where
+        F: Fn(&Path) -> Fut,
+        Fut: Future<Output = Result<T>>,
+    {
+        if let Some(metadata) = self.get::<T>(path) {
+            return Ok(metadata);
+        }
+
+        let metadata = Arc::new(loader(path).await?);
+        self.insert(path.to_owned(), metadata.clone());
+        Ok(metadata)
     }
 }

--- a/rust/lance-core/src/format.rs
+++ b/rust/lance-core/src/format.rs
@@ -25,7 +25,7 @@ mod page_table;
 
 pub use fragment::*;
 pub use index::Index;
-pub use manifest::{Manifest, WriterVersion};
+pub use manifest::{Manifest, SelfDescribingFileReader, WriterVersion};
 pub use metadata::{Metadata, StatisticsMetadata};
 pub use page_table::{PageInfo, PageTable};
 

--- a/rust/lance-core/src/io/reader.rs
+++ b/rust/lance-core/src/io/reader.rs
@@ -15,7 +15,6 @@
 //! Lance Data File Reader
 
 // Standard
-use std::borrow::Cow;
 use std::ops::{Range, RangeTo};
 use std::sync::Arc;
 
@@ -30,10 +29,8 @@ use arrow_array::{
 use arrow_array::{make_array, BooleanArray};
 use arrow_buffer::{ArrowNativeType, NullBuffer};
 use arrow_schema::{DataType, FieldRef, Schema as ArrowSchema};
-use arrow_select::{
-    concat::{concat, concat_batches},
-    filter::filter_record_batch,
-};
+use arrow_select::concat::{concat, concat_batches};
+use arrow_select::filter::filter_record_batch;
 use async_recursion::async_recursion;
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::{Bytes, BytesMut};
@@ -45,19 +42,21 @@ use prost::Message;
 use snafu::{location, Location};
 use tracing::instrument;
 
-use super::deletion::{deletion_file_path, read_deletion_file, DeletionVector};
 use crate::io::utils::{read_metadata_offset, read_struct_from_buf};
+use crate::ROW_ID;
 use crate::{
     cache::FileMetadataCache,
     datatypes::{Field, Schema},
     encodings::{dictionary::DictionaryDecoder, AsyncIndex},
-    format::{pb, Fragment, Index, Manifest, Metadata, PageInfo, PageTable, MAGIC},
+    format::{pb, Index, Manifest, Metadata, PageInfo, PageTable, MAGIC},
     io::{
         object_store::ObjectStore, read_fixed_stride_array, read_message, read_struct,
         ReadBatchParams, Reader, RecordBatchStream, RecordBatchStreamAdapter,
     },
-    Error, Result, ROW_ID, ROW_ID_FIELD,
+    Error, Result, ROW_ID_FIELD,
 };
+
+use super::deletion::DeletionVector;
 
 /// Read Manifest on URI.
 ///
@@ -161,7 +160,7 @@ pub struct FileReader {
     object_reader: Arc<dyn Reader>,
     metadata: Arc<Metadata>,
     page_table: Arc<PageTable>,
-    projection: Option<Schema>,
+    schema: Schema,
 
     /// The id of the fragment which this file belong to.
     /// For simple file access, this can just be zero.
@@ -175,9 +174,6 @@ pub struct FileReader {
     /// marked as null. This is used as a performance optimization to
     /// avoid copying data.
     make_deletions_null: bool,
-
-    // deletion vector indicating which rows are deleting in the fragment
-    deletion_vector: Option<Arc<DeletionVector>>,
 
     /// Page table for statistics
     stats_page_table: Arc<Option<PageTable>>,
@@ -207,118 +203,73 @@ impl FileReader {
     ///
     /// The session passed in is used to cache metadata about the file. If no session
     /// is passed in, there will be no caching.
-    #[instrument(level = "debug", skip(object_store, manifest, session))]
-    pub async fn try_new_with_fragment(
+    #[instrument(level = "debug", skip(object_store, schema, session))]
+    pub async fn try_new_with_fragment_id(
         object_store: &ObjectStore,
         path: &Path,
-        fragment_id: u64,
-        manifest: Option<&Manifest>,
+        schema: Schema,
+        fragment_id: u32,
+        field_id_offset: u32,
         session: Option<&FileMetadataCache>,
     ) -> Result<Self> {
         let object_reader = object_store.open(path).await?;
-        let is_dataset = manifest.is_some();
 
         let metadata = Self::read_metadata(object_reader.as_ref(), session).await?;
 
-        // m is either
-        // a ref if passed in as Some(&manifest), or
-        // a value we read in the else block
-        // since we don't want to clone the manifest and force everything into a value
-        // we need this m variable here so the else block has a place to store the read
-        // manifest value. If we declare this var in the else block, it won't live long
-        // enough and the returned ref will be invalid.
-        let mut m: Manifest;
-        let manifest = if let Some(m) = manifest {
-            m
-        } else {
-            m = read_struct(object_reader.as_ref(), metadata.manifest_position.unwrap()).await?;
-            m.schema.load_dictionary(object_reader.as_ref()).await?;
-            &m
-        };
+        Self::try_new_from_reader(
+            path,
+            object_reader,
+            metadata,
+            schema,
+            fragment_id,
+            field_id_offset,
+            session,
+        )
+        .await
+    }
 
-        // read the fragment metadata so we can handle deletion
-        let fragment = if is_dataset {
-            let fragment = manifest
-                .fragments
-                .iter()
-                .find(|frag| frag.id == fragment_id)
-                .map(|f| f.to_owned())
-                .ok_or(Error::IO {
-                    message: format!("Fragment {} not found in manifest", fragment_id),
-                    location: location!(),
-                })?;
-            Some(fragment)
-        } else {
-            None
-        };
-
+    pub async fn try_new_from_reader(
+        path: &Path,
+        object_reader: Box<dyn Reader>,
+        metadata: Arc<Metadata>,
+        schema: Schema,
+        fragment_id: u32,
+        field_id_offset: u32,
+        session: Option<&FileMetadataCache>,
+    ) -> Result<Self> {
         let page_table = async {
+            let num_fields = schema.max_field_id().unwrap_or_default() + 1 - field_id_offset as i32;
             Self::load_from_cache(session, path, |_| async {
-                // TODO: we should have a more efficient way to look up the fields
-                // present in a data file. We might want to include this info in the
-                // data file's metadata.
-                let field_ids = if let Some(fragment) = fragment.as_ref() {
-                    Cow::Borrowed(
-                        &fragment
-                            .files
-                            .iter()
-                            .find(|f| path.to_string().ends_with(&f.path))
-                            .ok_or_else(|| Error::Internal {
-                                message: format!(
-                                    "File {} not found in fragment {:?}",
-                                    path, fragment
-                                ),
-                                location: location!(),
-                            })?
-                            .fields,
-                    )
-                } else {
-                    let max_id = manifest.schema.max_field_id().unwrap() as i32 + 1;
-                    Cow::Owned((0..max_id).collect::<Vec<i32>>())
-                };
-
                 PageTable::load(
                     object_reader.as_ref(),
                     metadata.page_table_position,
-                    field_ids.len() as i32,
+                    num_fields,
                     metadata.num_batches() as i32,
-                    field_ids[0],
+                    field_id_offset as i32,
                 )
                 .await
             })
             .await
         };
 
-        let projection = manifest.schema.clone();
-
-        let deletion_vector = async {
-            if let Some(fragment) = &fragment {
-                Self::load_deletion_vector(object_store, fragment, session).await
-            } else {
-                Ok(None)
-            }
-        };
-
         let stats_page_table = Self::read_stats_page_table(object_reader.as_ref(), session);
 
-        // Can concurrently load page tables and deletion vectors
-        let (page_table, deletion_vector, stats_page_table) =
-            futures::try_join!(page_table, deletion_vector, stats_page_table)?;
+        // Can concurrently load page tables
+        let (page_table, stats_page_table) = futures::try_join!(page_table, stats_page_table)?;
 
         Ok(Self {
             object_reader: object_reader.into(),
             metadata,
-            projection: Some(projection),
+            schema,
             page_table,
-            fragment_id,
+            fragment_id: fragment_id as u64,
             with_row_id: false,
             make_deletions_null: false,
-            deletion_vector,
             stats_page_table,
         })
     }
 
-    async fn read_metadata(
+    pub async fn read_metadata(
         object_reader: &dyn Reader,
         cache: Option<&FileMetadataCache>,
     ) -> Result<Arc<Metadata>> {
@@ -384,48 +335,16 @@ impl FileReader {
         Fut: Future<Output = Result<T>>,
     {
         if let Some(cache) = cache {
-            if let Some(metadata) = cache.get::<T>(path) {
-                return Ok(metadata);
-            }
-        }
-
-        let metadata = Arc::new(loader(path).await?);
-        if let Some(cache) = cache {
-            cache.insert(path.to_owned(), metadata.clone());
-        }
-        Ok(metadata)
-    }
-
-    async fn load_deletion_vector(
-        object_store: &ObjectStore,
-        fragment: &Fragment,
-        cache: Option<&FileMetadataCache>,
-    ) -> Result<Option<Arc<DeletionVector>>> {
-        if let Some(deletion_file) = &fragment.deletion_file {
-            let path = deletion_file_path(object_store.base_path(), fragment.id, deletion_file);
-
-            let deletion_vector = Self::load_from_cache(cache, &path, |_| async {
-                read_deletion_file(object_store.base_path(), fragment, object_store)
-                    .await?
-                    .ok_or(Error::IO {
-                        message: format!(
-                            "Deletion file {:?} not found in fragment {}",
-                            deletion_file, fragment.id
-                        ),
-                        location: location!(),
-                    })
-            })
-            .await?;
-            Ok(Some(deletion_vector))
+            cache.get_or_insert(path, loader).await
         } else {
-            Ok(None)
+            Ok(Arc::new(loader(path).await?))
         }
     }
 
     /// Open one Lance data file for read.
     // TODO: make this crate(pub) once the migration to lance-core is done.
-    pub async fn try_new(object_store: &ObjectStore, path: &Path) -> Result<Self> {
-        Self::try_new_with_fragment(object_store, path, 0, None, None).await
+    pub async fn try_new(object_store: &ObjectStore, path: &Path, schema: Schema) -> Result<Self> {
+        Self::try_new_with_fragment_id(object_store, path, schema, 0, 0, None).await
     }
 
     /// Instruct the FileReader to return meta row id column.
@@ -446,7 +365,7 @@ impl FileReader {
 
     /// Schema of the returning RecordBatch.
     pub fn schema(&self) -> &Schema {
-        self.projection.as_ref().unwrap()
+        &self.schema
     }
 
     pub fn num_batches(&self) -> usize {
@@ -476,6 +395,7 @@ impl FileReader {
         batch_id: i32,
         params: impl Into<ReadBatchParams>,
         projection: &Schema,
+        deletion_vector: Option<&DeletionVector>,
     ) -> Result<RecordBatch> {
         read_batch(
             self,
@@ -483,7 +403,7 @@ impl FileReader {
             projection,
             batch_id,
             self.with_row_id,
-            self.deletion_vector.clone(),
+            deletion_vector,
         )
         .await
     }
@@ -497,16 +417,17 @@ impl FileReader {
         &self,
         range: Range<usize>,
         projection: &Schema,
+        deletion_vector: Option<&DeletionVector>,
     ) -> Result<RecordBatch> {
         let range_in_batches = self.metadata.range_to_batches(range)?;
-        let batches =
-            stream::iter(range_in_batches)
-                .map(|(batch_id, range)| async move {
-                    self.read_batch(batch_id, range, projection).await
-                })
-                .buffered(num_cpus::get())
-                .try_collect::<Vec<_>>()
-                .await?;
+        let batches = stream::iter(range_in_batches)
+            .map(|(batch_id, range)| async move {
+                self.read_batch(batch_id, range, projection, deletion_vector)
+                    .await
+            })
+            .buffered(num_cpus::get())
+            .try_collect::<Vec<_>>()
+            .await?;
         if batches.len() == 1 {
             return Ok(batches[0].clone());
         }
@@ -518,12 +439,22 @@ impl FileReader {
     ///
     /// The indices must be sorted.
     #[instrument(level = "debug", skip_all)]
-    pub async fn take(&self, indices: &[u32], projection: &Schema) -> Result<RecordBatch> {
+    pub async fn take(
+        &self,
+        indices: &[u32],
+        projection: &Schema,
+        deletion_vector: Option<&DeletionVector>,
+    ) -> Result<RecordBatch> {
         let indices_in_batches = self.metadata.group_indices_to_batches(indices);
         let batches = stream::iter(indices_in_batches)
             .map(|batch| async move {
-                self.read_batch(batch.batch_id, batch.offsets.as_slice(), projection)
-                    .await
+                self.read_batch(
+                    batch.batch_id,
+                    batch.offsets.as_slice(),
+                    projection,
+                    deletion_vector,
+                )
+                .await
             })
             .buffered(num_cpus::get() * 4)
             .try_collect::<Vec<_>>()
@@ -615,9 +546,9 @@ pub fn batches_stream(
         .zip(stream::repeat_with(move || {
             (this.clone(), projection.clone())
         }))
-        .map(|(batch_id, (reader, projection))| async move {
+        .map(move |(batch_id, (reader, projection))| async move {
             reader
-                .read_batch(batch_id, ReadBatchParams::RangeFull, &projection)
+                .read_batch(batch_id, ReadBatchParams::RangeFull, &projection, None)
                 .await
         })
         .buffered(2)
@@ -635,7 +566,7 @@ async fn read_batch(
     schema: &Schema,
     batch_id: i32,
     with_row_id: bool,
-    deletion_vector: Option<Arc<DeletionVector>>,
+    deletion_vector: Option<&DeletionVector>,
 ) -> Result<RecordBatch> {
     let batch = if !schema.fields.is_empty() {
         // We box this because otherwise we get a higher-order lifetime error.
@@ -1088,10 +1019,12 @@ mod tests {
     use super::*;
 
     use crate::format::Fragment;
+    use crate::format::SelfDescribingFileReader;
     use crate::io::deletion::write_deletion_file;
     use crate::io::deletion::DeletionVector;
     use crate::io::object_store::ObjectStore;
     use crate::io::{write_manifest, WriteExt};
+    use crate::ROW_ID;
     use arrow_array::Int32Array;
     use arrow_array::{
         builder::{Int32Builder, LargeListBuilder, ListBuilder, StringBuilder},
@@ -1119,9 +1052,10 @@ mod tests {
         let path = Path::from("/foo");
 
         // Write 10 batches.
-        let mut file_writer = FileWriter::try_new(&store, &path, schema, &Default::default())
-            .await
-            .unwrap();
+        let mut file_writer =
+            FileWriter::try_new(&store, &path, schema.clone(), &Default::default())
+                .await
+                .unwrap();
         for batch_id in 0..10 {
             let value_range = batch_id * 10..batch_id * 10 + 10;
             let columns: Vec<ArrayRef> = vec![
@@ -1137,14 +1071,18 @@ mod tests {
         }
         file_writer.finish().await.unwrap();
 
-        let fragment = 123;
-        let mut reader = FileReader::try_new_with_fragment(&store, &path, fragment, None, None)
-            .await
-            .unwrap();
+        let fragment = 123_u64;
+        let mut reader =
+            FileReader::try_new_with_fragment_id(&store, &path, schema, fragment as u32, 0, None)
+                .await
+                .unwrap();
         reader.with_row_id(true);
 
         for b in 0..10 {
-            let batch = reader.read_batch(b, .., reader.schema()).await.unwrap();
+            let batch = reader
+                .read_batch(b, .., reader.schema(), None)
+                .await
+                .unwrap();
             let row_ids_col = &batch[ROW_ID];
             // Do the same computation as `compute_row_id`.
             let start_pos = (fragment << 32) + 10 * b as u64;
@@ -1204,9 +1142,11 @@ mod tests {
         }
         file_writer.finish().await.unwrap();
 
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
         let batch = reader
-            .take(&[1, 15, 20, 25, 30, 48, 90], reader.schema())
+            .take(&[1, 15, 20, 25, 30, 48, 90], reader.schema(), None)
             .await
             .unwrap();
         let dict_keys = UInt8Array::from_iter_values([1, 1, 6, 4, 2, 6, 6]);
@@ -1267,16 +1207,17 @@ mod tests {
         frag_struct.deletion_file = deletion_file;
         frag_struct.add_file("foo", &schema);
 
-        let manifest = Manifest::new(schema, Arc::new(vec![frag_struct]));
-
         let mut reader =
-            FileReader::try_new_with_fragment(&store, &path, fragment, Some(&manifest), None)
+            FileReader::try_new_with_fragment_id(&store, &path, schema, fragment as u32, 0, None)
                 .await
                 .unwrap();
         reader.with_row_id(true);
 
         for b in 0..10 {
-            let batch = reader.read_batch(b, .., reader.schema()).await.unwrap();
+            let batch = reader
+                .read_batch(b, .., reader.schema(), Some(&dv))
+                .await
+                .unwrap();
             let row_ids_col = &batch[ROW_ID];
             // Do the same computation as `compute_row_id`.
             let start_pos = (fragment << 32) + 10 * b as u64;
@@ -1326,16 +1267,17 @@ mod tests {
         frag_struct.deletion_file = deletion_file;
         frag_struct.add_file("foo", &schema);
 
-        let manifest = Manifest::new(schema, Arc::new(vec![frag_struct]));
-
         let mut reader =
-            FileReader::try_new_with_fragment(&store, &path, fragment, Some(&manifest), None)
+            FileReader::try_new_with_fragment_id(&store, &path, schema, fragment as u32, 0, None)
                 .await
                 .unwrap();
         reader.with_row_id(false);
 
         for b in 0..10 {
-            let batch = reader.read_batch(b, .., reader.schema()).await.unwrap();
+            let batch = reader
+                .read_batch(b, .., reader.schema(), None)
+                .await
+                .unwrap();
             // if we didn't request rowid we should not get it back
             assert!(!batch
                 .schema()
@@ -1375,8 +1317,13 @@ mod tests {
         file_writer.write(&[batch.clone()]).await.unwrap();
         file_writer.finish().await.unwrap();
 
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
-        let actual_batch = reader.read_batch(0, .., reader.schema()).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
+        let actual_batch = reader
+            .read_batch(0, .., reader.schema(), None)
+            .await
+            .unwrap();
 
         if field_nullable {
             assert_eq!(
@@ -1421,8 +1368,13 @@ mod tests {
         file_writer.write(&batches).await.unwrap();
         file_writer.finish().await.unwrap();
 
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
-        let actual_batch = reader.read_batch(0, .., reader.schema()).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
+        let actual_batch = reader
+            .read_batch(0, .., reader.schema(), None)
+            .await
+            .unwrap();
         let expected = concat_batches(&arrow_schema, batches_ref).unwrap();
         assert_eq!(expected, actual_batch);
     }
@@ -1463,9 +1415,14 @@ mod tests {
             Arc::new(expected_struct_array) as ArrayRef,
         )]));
 
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
         let params = ReadBatchParams::Range(1..2);
-        let slice_of_batch = reader.read_batch(0, params, reader.schema()).await.unwrap();
+        let slice_of_batch = reader
+            .read_batch(0, params, reader.schema(), None)
+            .await
+            .unwrap();
         assert_eq!(expected_batch, slice_of_batch);
     }
 
@@ -1565,7 +1522,9 @@ mod tests {
         file_writer.finish().await.unwrap();
 
         // read the file back
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
 
         async fn read_array_w_params(
             reader: &FileReader,
@@ -1676,8 +1635,10 @@ mod tests {
         file_writer.finish().await.unwrap();
 
         // read the file back
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
-        let actual = reader.take(&[1, 3, 5, 9], &schema).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
+        let actual = reader.take(&[1, 3, 5, 9], &schema, None).await.unwrap();
 
         let value_builder = Int32Builder::new();
         let mut list_builder = ListBuilder::new(value_builder);
@@ -1749,8 +1710,13 @@ mod tests {
         let file_size_bytes = store.size(&path).await.unwrap();
         assert!(file_size_bytes < 1_000);
 
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
-        let actual_batch = reader.read_batch(0, .., reader.schema()).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
+        let actual_batch = reader
+            .read_batch(0, .., reader.schema(), None)
+            .await
+            .unwrap();
         assert_eq!(batch, actual_batch);
     }
 
@@ -1771,8 +1737,13 @@ mod tests {
         file_writer.write(&[batch]).await.unwrap();
         file_writer.finish().await.unwrap();
 
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
-        let actual_batch = reader.read_range(7..25, reader.schema()).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
+        let actual_batch = reader
+            .read_range(7..25, reader.schema(), None)
+            .await
+            .unwrap();
 
         assert_eq!(
             actual_batch.column_by_name("i").unwrap().as_ref(),
@@ -1843,7 +1814,9 @@ mod tests {
         }
         writer.finish().await.unwrap();
 
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
         let stream = batches_stream(reader, schema, |id| id % 2 == 0);
         let batches = stream.try_collect::<Vec<_>>().await.unwrap();
 
@@ -1885,8 +1858,13 @@ mod tests {
         file_writer.write(&[batch]).await.unwrap();
         file_writer.finish().await.unwrap();
 
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
-        let actual = reader.take(&[2, 4, 5, 8, 4555], &schema).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
+        let actual = reader
+            .take(&[2, 4, 5, 8, 4555], &schema, None)
+            .await
+            .unwrap();
 
         assert_eq!(
             actual.column_by_name("b").unwrap().as_ref(),

--- a/rust/lance-core/src/io/reader.rs
+++ b/rust/lance-core/src/io/reader.rs
@@ -583,11 +583,8 @@ async fn read_batch(
         None
     };
 
-    let should_fetch_row_id = with_row_id
-        || !matches!(
-            deletion_vector.as_deref(),
-            None | Some(DeletionVector::NoDeletions)
-        );
+    let should_fetch_row_id =
+        with_row_id || !matches!(deletion_vector, None | Some(DeletionVector::NoDeletions));
 
     let num_rows = if let Some(batch) = &batch {
         batch.num_rows()

--- a/rust/lance-core/src/io/writer.rs
+++ b/rust/lance-core/src/io/writer.rs
@@ -623,7 +623,10 @@ mod tests {
     use arrow_select::concat::concat_batches;
     use object_store::path::Path;
 
-    use crate::io::{object_store::ObjectStore, FileReader};
+    use crate::{
+        format::SelfDescribingFileReader,
+        io::{object_store::ObjectStore, FileReader},
+    };
 
     #[tokio::test]
     async fn test_write_file() {
@@ -800,8 +803,13 @@ mod tests {
         file_writer.write(&[batch.clone()]).await.unwrap();
         file_writer.finish().await.unwrap();
 
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
-        let actual = reader.read_batch(0, .., reader.schema()).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
+        let actual = reader
+            .read_batch(0, .., reader.schema(), None)
+            .await
+            .unwrap();
         assert_eq!(actual, batch);
     }
 
@@ -829,8 +837,13 @@ mod tests {
         file_writer.write(&[batch.clone()]).await.unwrap();
         file_writer.finish().await.unwrap();
 
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
-        let actual = reader.read_batch(0, .., reader.schema()).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
+        let actual = reader
+            .read_batch(0, .., reader.schema(), None)
+            .await
+            .unwrap();
         assert_eq!(actual, batch);
     }
 
@@ -866,8 +879,13 @@ mod tests {
         file_writer.write(&[batch.clone()]).await.unwrap();
         file_writer.finish().await.unwrap();
 
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
-        let actual = reader.read_batch(0, .., reader.schema()).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
+        let actual = reader
+            .read_batch(0, .., reader.schema(), None)
+            .await
+            .unwrap();
         assert_eq!(actual, batch);
     }
 
@@ -959,7 +977,9 @@ mod tests {
 
         file_writer.finish().await.unwrap();
 
-        let reader = FileReader::try_new(&store, &path).await.unwrap();
+        let reader = FileReader::try_new_self_described(&store, &path, None)
+            .await
+            .unwrap();
 
         let read_stats = reader.read_page_stats(&[0, 1, 5, 6]).await.unwrap();
         assert!(read_stats.is_some());
@@ -1063,12 +1083,14 @@ mod tests {
     }
 
     async fn read_file_as_one_batch(object_store: &ObjectStore, path: &Path) -> RecordBatch {
-        let reader = FileReader::try_new(object_store, path).await.unwrap();
+        let reader = FileReader::try_new_self_described(object_store, path, None)
+            .await
+            .unwrap();
         let mut batches = vec![];
         for i in 0..reader.num_batches() {
             batches.push(
                 reader
-                    .read_batch(i as i32, .., reader.schema())
+                    .read_batch(i as i32, .., reader.schema(), None)
                     .await
                     .unwrap(),
             );

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -171,7 +171,7 @@ impl FileFragment {
     }
 
     fn get_field_id_offset(data_file: &DataFile) -> u32 {
-        data_file.fields.iter().nth(0).copied().unwrap_or(0) as u32
+        data_file.fields.get(0).copied().unwrap_or(0) as u32
     }
 
     async fn open_readers(&self, projection: &Schema) -> Result<Vec<(FileReader, Schema)>> {

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -25,7 +25,7 @@ use datafusion::scalar::ScalarValue;
 use futures::future::try_join_all;
 use futures::stream::BoxStream;
 use futures::{join, StreamExt, TryFutureExt, TryStreamExt};
-use lance_core::format::DeletionFile;
+use lance_core::format::{DataFile, DeletionFile};
 use lance_core::{
     datatypes::Schema,
     io::{
@@ -36,7 +36,6 @@ use lance_core::{
     Error, Result, ROW_ID,
 };
 use lance_datafusion::chunker::chunk_stream;
-use object_store::path::Path;
 use snafu::{location, Location};
 use uuid::Uuid;
 
@@ -150,26 +149,12 @@ impl FileFragment {
     /// Parameters
     /// - projection: The projection schema.
     pub async fn open(&self, projection: &Schema) -> Result<FragmentReader> {
-        let full_schema = self.dataset.schema();
-
-        let mut opened_files = vec![];
-        for data_file in self.metadata.files.iter() {
-            let data_file_schema = data_file.schema(full_schema);
-            let schema_per_file = data_file_schema.intersection(projection)?;
-            if !schema_per_file.fields.is_empty() {
-                let path = self.dataset.data_dir().child(data_file.path.as_str());
-                let reader = FileReader::try_new_with_fragment(
-                    &self.dataset.object_store,
-                    &path,
-                    self.id() as u64,
-                    Some(self.dataset.manifest.as_ref()),
-                    Some(&self.dataset.session.file_metadata_cache),
-                )
-                .await?;
-                let initialized_schema = reader.schema().project_by_schema(&schema_per_file)?;
-                opened_files.push((reader, initialized_schema));
-            }
-        }
+        let open_files = self.open_readers(projection);
+        let deletion_vec_load =
+            self.load_deletion_vector(&self.dataset.object_store, &self.metadata);
+        let (opened_files, deletion_vec) = join!(open_files, deletion_vec_load);
+        let opened_files = opened_files?;
+        let deletion_vec = deletion_vec?;
 
         if opened_files.is_empty() {
             return Err(Error::IO {
@@ -182,7 +167,37 @@ impl FileFragment {
             });
         }
 
-        FragmentReader::try_new(self.id(), opened_files)
+        FragmentReader::try_new(self.id(), deletion_vec, opened_files)
+    }
+
+    fn get_field_id_offset(data_file: &DataFile) -> u32 {
+        data_file.fields.iter().nth(0).copied().unwrap_or(0) as u32
+    }
+
+    async fn open_readers(&self, projection: &Schema) -> Result<Vec<(FileReader, Schema)>> {
+        let full_schema = self.dataset.schema();
+
+        let mut opened_files = vec![];
+        for data_file in self.metadata.files.iter() {
+            let data_file_schema = data_file.schema(full_schema);
+            let schema_per_file = data_file_schema.intersection(projection)?;
+            if !schema_per_file.fields.is_empty() {
+                let path = self.dataset.data_dir().child(data_file.path.as_str());
+                let field_id_offset = Self::get_field_id_offset(data_file);
+                let reader = FileReader::try_new_with_fragment_id(
+                    &self.dataset.object_store,
+                    &path,
+                    self.schema().clone(),
+                    self.id() as u32,
+                    field_id_offset,
+                    Some(&self.dataset.session.file_metadata_cache),
+                )
+                .await?;
+                let initialized_schema = reader.schema().project_by_schema(&schema_per_file)?;
+                opened_files.push((reader, initialized_schema));
+            }
+        }
+        Ok(opened_files)
     }
 
     /// Count the rows in this fragment.
@@ -216,6 +231,36 @@ impl FileFragment {
         }
     }
 
+    async fn load_deletion_vector(
+        &self,
+        object_store: &ObjectStore,
+        fragment: &Fragment,
+    ) -> Result<Option<Arc<DeletionVector>>> {
+        if let Some(deletion_file) = &fragment.deletion_file {
+            let path = deletion_file_path(object_store.base_path(), fragment.id, deletion_file);
+
+            let deletion_vector = self
+                .dataset
+                .session
+                .file_metadata_cache
+                .get_or_insert(&path, |_| async {
+                    read_deletion_file(object_store.base_path(), fragment, object_store)
+                        .await?
+                        .ok_or(Error::IO {
+                            message: format!(
+                                "Deletion file {:?} not found in fragment {}",
+                                deletion_file, fragment.id
+                            ),
+                            location: location!(),
+                        })
+                })
+                .await?;
+            Ok(Some(deletion_vector))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Get the number of physical rows in the fragment. This includes deleted rows.
     ///
     /// If there are no deleted rows, this is equal to the number of rows in the
@@ -238,15 +283,14 @@ impl FileFragment {
         }
 
         // Just open any file. All of them should have same size.
-        let path = self
-            .dataset
-            .data_dir()
-            .child(self.metadata.files[0].path.as_str());
-        let reader = FileReader::try_new_with_fragment(
+        let some_file = &self.metadata.files[0];
+        let path = self.dataset.data_dir().child(some_file.path.as_str());
+        let reader = FileReader::try_new_with_fragment_id(
             &self.dataset.object_store,
             &path,
-            self.id() as u64,
-            None,
+            self.schema().clone(),
+            self.id() as u32,
+            Self::get_field_id_offset(some_file),
             Some(&self.dataset.session.file_metadata_cache),
         )
         .await?;
@@ -262,22 +306,27 @@ impl FileFragment {
     /// * `Fragment.physical_rows` matches length of file
     /// * `DeletionFile.num_deleted_rows` matches length of deletion vector
     pub async fn validate(&self) -> Result<()> {
-        let data_file_paths: Vec<Path> = self
+        let get_lengths = self
             .metadata
             .files
             .iter()
-            .map(|data_file| self.dataset.data_dir().child(data_file.path.as_str()))
-            .collect::<Vec<_>>();
-        let get_lengths = data_file_paths.iter().map(|path| {
-            let reader = FileReader::try_new_with_fragment(
-                &self.dataset.object_store,
-                path,
-                self.id() as u64,
-                Some(self.dataset.manifest.as_ref()),
-                Some(&self.dataset.session.file_metadata_cache),
-            );
-            reader.map_ok(|r| r.len())
-        });
+            .map(|data_file| {
+                let path = self.dataset.data_dir().child(data_file.path.as_str());
+                let field_id_offset = Self::get_field_id_offset(data_file);
+                (path, field_id_offset)
+            })
+            .map(|(path, field_id_offset)| async move {
+                let reader = FileReader::try_new_with_fragment_id(
+                    &self.dataset.object_store,
+                    &path,
+                    self.schema().clone(),
+                    self.id() as u32,
+                    field_id_offset,
+                    Some(&self.dataset.session.file_metadata_cache),
+                )
+                .await?;
+                Result::Ok(reader.len())
+            });
         let get_lengths = try_join_all(get_lengths);
 
         let deletion_vector = read_deletion_file(
@@ -290,8 +339,9 @@ impl FileFragment {
 
         let get_lengths = get_lengths?;
         let expected_length = get_lengths.first().unwrap_or(&0);
-        for (length, path) in get_lengths.iter().zip(data_file_paths.into_iter()) {
+        for (length, data_file) in get_lengths.iter().zip(self.metadata.files.iter()) {
             if length != expected_length {
+                let path = self.dataset.data_dir().child(data_file.path.as_str());
                 return Err(Error::corrupt_file(
                     path,
                     format!(
@@ -670,6 +720,9 @@ pub struct FragmentReader {
     /// Readers and schema of each opened data file.
     readers: Vec<(FileReader, Schema)>,
 
+    /// The deleted row IDs
+    deletion_vec: Option<Arc<DeletionVector>>,
+
     /// ID of the fragment
     fragment_id: usize,
 }
@@ -696,7 +749,11 @@ fn merge_batches(batches: &[RecordBatch]) -> Result<RecordBatch> {
 }
 
 impl FragmentReader {
-    fn try_new(fragment_id: usize, readers: Vec<(FileReader, Schema)>) -> Result<Self> {
+    fn try_new(
+        fragment_id: usize,
+        deletion_vec: Option<Arc<DeletionVector>>,
+        readers: Vec<(FileReader, Schema)>,
+    ) -> Result<Self> {
         if readers.is_empty() {
             return Err(Error::IO {
                 message: "Cannot create FragmentReader with zero readers".to_string(),
@@ -715,6 +772,7 @@ impl FragmentReader {
         }
         Ok(Self {
             readers,
+            deletion_vec,
             fragment_id,
         })
     }
@@ -778,7 +836,12 @@ impl FragmentReader {
         let mut batches = vec![];
         for (reader, schema) in self.readers.iter() {
             let batch = reader
-                .read_batch(batch_id as i32, params.clone(), schema)
+                .read_batch(
+                    batch_id as i32,
+                    params.clone(),
+                    schema,
+                    self.deletion_vec.as_ref().map(|dv| dv.as_ref()),
+                )
                 .await?;
             batches.push(batch);
         }
@@ -801,7 +864,12 @@ impl FragmentReader {
 
             async move {
                 reader
-                    .read_batch(batch_id as i32, params, &projection?)
+                    .read_batch(
+                        batch_id as i32,
+                        params,
+                        &projection?,
+                        self.deletion_vec.as_ref().map(|dv| dv.as_ref()),
+                    )
                     .await
             }
         });
@@ -816,7 +884,13 @@ impl FragmentReader {
         // We need to fix
         let mut batches = vec![];
         for (reader, schema) in self.readers.iter() {
-            let batch = reader.read_range(range.start..range.end, schema).await?;
+            let batch = reader
+                .read_range(
+                    range.start..range.end,
+                    schema,
+                    self.deletion_vec.as_ref().map(|dv| dv.as_ref()),
+                )
+                .await?;
             batches.push(batch);
         }
 
@@ -827,7 +901,13 @@ impl FragmentReader {
     pub async fn take(&self, indices: &[u32]) -> Result<RecordBatch> {
         // Boxed to avoid lifetime issue.
         let stream: BoxStream<_> = futures::stream::iter(&self.readers)
-            .map(|(reader, schema)| reader.take(indices, schema))
+            .map(|(reader, schema)| {
+                reader.take(
+                    indices,
+                    schema,
+                    self.deletion_vec.as_ref().map(|dv| dv.as_ref()),
+                )
+            })
             .buffered(num_cpus::get())
             .boxed();
         let batches: Vec<RecordBatch> = stream.try_collect::<Vec<_>>().await?;
@@ -1317,13 +1397,14 @@ mod tests {
         .unwrap();
 
         let (object_store, base_path) = ObjectStore::from_uri(test_uri).await.unwrap();
-        let file_reader = FileReader::try_new_with_fragment(
+        let file_reader = FileReader::try_new_with_fragment_id(
             &object_store,
             &base_path
                 .child("data")
                 .child(fragment.files[0].path.as_str()),
+            schema.as_ref().try_into().unwrap(),
             10,
-            None,
+            0,
             None,
         )
         .await

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -171,7 +171,7 @@ impl FileFragment {
     }
 
     fn get_field_id_offset(data_file: &DataFile) -> u32 {
-        data_file.fields.get(0).copied().unwrap_or(0) as u32
+        data_file.fields.first().copied().unwrap_or(0) as u32
     }
 
     async fn open_readers(&self, projection: &Schema) -> Result<Vec<(FileReader, Schema)>> {

--- a/rust/lance/src/index/vector/graph/persisted.rs
+++ b/rust/lance/src/index/vector/graph/persisted.rs
@@ -23,6 +23,7 @@ use arrow_array::{
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
 use async_trait::async_trait;
 use lance_arrow::{as_fixed_size_binary_array, as_fixed_size_list_array};
+use lance_core::format::SelfDescribingFileReader;
 use lance_core::{
     datatypes::Schema,
     io::{object_store::ObjectStore, FileReader, FileWriter},
@@ -102,7 +103,12 @@ impl<V: Vertex + Debug> PersistedGraph<V> {
         serde: Arc<dyn VertexSerDe<V> + Send + Sync>,
     ) -> Result<Self> {
         let object_store = dataset.object_store();
-        let file_reader = FileReader::try_new(object_store, path).await?;
+        let file_reader = FileReader::try_new_self_described(
+            object_store,
+            path,
+            Some(&dataset.session.file_metadata_cache),
+        )
+        .await?;
 
         let schema = file_reader.schema();
         let vertex_projection = schema.project(&[VERTEX_COL])?;
@@ -163,7 +169,11 @@ impl<V: Vertex + Debug> PersistedGraph<V> {
         let end = (id + 1) as usize;
         let batch = self
             .reader
-            .read_range(id as usize..(id + 1) as usize, &self.vertex_projection)
+            .read_range(
+                id as usize..(id + 1) as usize,
+                &self.vertex_projection,
+                None,
+            )
             .await?;
         assert_eq!(batch.num_rows(), end - id as usize);
 
@@ -204,7 +214,11 @@ impl<V: Vertex + Debug> PersistedGraph<V> {
         }
         let batch = self
             .reader
-            .read_range(id as usize..(id + 1) as usize, &self.neighbors_projection)
+            .read_range(
+                id as usize..(id + 1) as usize,
+                &self.neighbors_projection,
+                None,
+            )
             .await?;
         {
             let mut cache = self.neighbors_cache.lock().unwrap();
@@ -247,7 +261,7 @@ impl<V: Vertex + Send + Sync + Debug> Graph for PersistedGraph<V> {
         }
         let batch = self
             .reader
-            .read_range(id..(id + 1), &self.neighbors_projection)
+            .read_range(id..(id + 1), &self.neighbors_projection, None)
             .await?;
         {
             let mut cache = self.neighbors_cache.lock().unwrap();


### PR DESCRIPTION
I'm working on splitting the file format and the table format into their own crates.  One point of difficulty was that the file reader referred to the fragment / manifest for loading deletion vectors and other information.  This PR brings all of that up into the fragment level.

The deletions are still passed to the file reader as a deletion vector, so this PR doesn't change where the work happens.  However the argument is now provided at read time instead of at open time.

There are no API changes and should be no changes to the format or how things are interpreted.  This is purely a refactor.