### PR TITLE
feat: add a fast way to checkout a different version

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -690,6 +690,8 @@ class LanceDataset(pa.dataset.Dataset):
         """
         Load the given version of the dataset.
 
+        Unlike the :func:`dataset` constructor, this will re-use the
+        current cache.
         This is a no-op if the dataset is already at the given version.
         """
         ds = copy.copy(self)

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import random
@@ -681,9 +682,20 @@ class LanceDataset(pa.dataset.Dataset):
     @property
     def latest_version(self) -> int:
         """
-        Returns the lastest version of the dataset
+        Returns the latest version of the dataset.
         """
         return self._ds.latest_version()
+
+    def checkout_version(self, version) -> "LanceDataset":
+        """
+        Load the given version of the dataset.
+
+        This is a no-op if the dataset is already at the given version.
+        """
+        ds = copy.copy(self)
+        if version != ds.version:
+            ds._ds = self._ds.checkout_version(version)
+        return ds
 
     def restore(self):
         """

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -612,6 +612,16 @@ impl Dataset {
             .map_err(|err| PyIOError::new_err(err.to_string()))
     }
 
+    fn checkout_version(&self, version: u64) -> PyResult<Self> {
+        let ds = RT
+            .block_on(None, self.ds.checkout_version(version))?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?;
+        Ok(Self {
+            ds: Arc::new(ds),
+            uri: self.uri.clone(),
+        })
+    }
+
     /// Restore the current version
     fn restore(&mut self) -> PyResult<()> {
         let mut new_self = self.ds.as_ref().clone();


### PR DESCRIPTION
Currently, if you want to checkout a different version, you can't re-use the same session / cache. This means if you explicitly change version, you invalidate the cache, which isn't great.