### PR TITLE
test: make empty cluster message less noisy

### DIFF
--- a/python/python/tests/test_filter.py
+++ b/python/python/tests/test_filter.py
@@ -81,7 +81,6 @@ def test_simple_predicates(dataset):
 
 
 def test_sql_predicates(dataset):
-    print(dataset.to_table())
     # Predicate and expected number of rows
     predicates_nrows = [
         ("int >= 50", 50),

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -140,9 +140,8 @@ def test_dataset_progress(tmp_path: Path):
     p.start()
     try:
         p.join()
-    except Exception as e:
+    except Exception:
         # Allow a crash to happen
-        print(e)
         pass
 
     # In-progress file should be present

--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -92,7 +92,6 @@ def test_index_remapping(tmp_path: Path):
     # Compact the 2 fragments into 1.  Combined scan still not needed.
     dataset.optimize.compact_files()
     assert len(dataset.get_fragments()) == 1
-    print(dataset.get_fragments())
     check_index(has_knn_combined=False)
 
     # Add a new fragment and recalculate the index

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -112,11 +112,11 @@ def run(ds, q=None, assert_func=None):
 
 
 def test_flat(dataset):
-    print(run(dataset))
+    run(dataset)
 
 
 def test_ann(indexed_dataset):
-    print(run(indexed_dataset))
+    run(indexed_dataset)
 
 
 def test_ann_append(tmp_path):
@@ -132,7 +132,7 @@ def test_ann_append(tmp_path):
     def func(rs: pa.Table):
         assert rs["vector"][0].as_py() == q
 
-    print(run(dataset, q=np.array(q), assert_func=func))
+    run(dataset, q=np.array(q), assert_func=func)
 
 
 def test_index_with_nans(tmp_path):

--- a/python/python/tests/torch_tests/test_data.py
+++ b/python/python/tests/torch_tests/test_data.py
@@ -93,7 +93,6 @@ def test_sharded_torch_dataset(tmp_path):
     assert len(ds.get_fragments()) == 10
     for f in ds.get_fragments():
         assert f.count_rows() == 100
-        print(f.fragment_id)
 
     ds = LanceDataset(
         tmp_path, batch_size=10, columns=["ids"], rank=1, world_size=2, with_row_id=True

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -212,9 +212,12 @@ impl KMeanMembership {
                     *old += new;
                 }
             });
+
+        let mut empty_clusters = 0;
+
         cluster_cnts.iter().enumerate().for_each(|(i, &cnt)| {
             if cnt == 0 {
-                warn!("KMeans: cluster {} is empty", i);
+                empty_clusters += 1;
                 new_centroids[i * dimension..(i + 1) * dimension]
                     .iter_mut()
                     .for_each(|v| *v = T::Native::nan());
@@ -226,6 +229,14 @@ impl KMeanMembership {
                     .for_each(|v| *v /= T::Native::from_u64(cnt).unwrap());
             }
         });
+
+        if empty_clusters as f32 / self.k as f32 > 0.1 {
+            warn!(
+                "KMeans: more than 10% of clusters are empty: {} of {}.\nHelp: this could mean your dataset \
+                is too small to have a meaningful index (less than 5000 vectors) or has many duplicate vectors.",
+                empty_clusters, self.k
+            );
+        }
 
         split_clusters(&mut cluster_cnts, &mut new_centroids, dimension);
 


### PR DESCRIPTION
Also remove all the print statements in the Python unit tests.

This reduces the number of lines in `run_tests` output from 66,657 to just 959! ([before](https://github.com/lancedb/lance/actions/runs/7619172254/job/20751766152#step:6:66660), [after](https://github.com/lancedb/lance/actions/runs/7628532848/job/20779819788?pr=1859#step:6:962))