### PR TITLE
fix: aws creds resolution panic

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -162,7 +162,12 @@ impl CredentialProvider for AwsCredentialAdapter {
                 token: creds.session_token().map(|s| s.to_string()),
             }))
         } else {
-            let refreshed_creds = Arc::new(self.inner.provide_credentials().await.unwrap());
+            let refreshed_creds = Arc::new(self.inner.provide_credentials().await.map_err(|e| {
+                Error::Internal {
+                    message: format!("Failed to get AWS credentials: {}", e),
+                    location: Location::new(file!(), line!(), column!()),
+                }
+            })?);
 
             self.cache
                 .write()

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -165,7 +165,7 @@ impl CredentialProvider for AwsCredentialAdapter {
             let refreshed_creds = Arc::new(self.inner.provide_credentials().await.map_err(|e| {
                 Error::Internal {
                     message: format!("Failed to get AWS credentials: {}", e),
-                    location: snafu::location!(),
+                    location: location!(),
                 }
             })?);
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -162,12 +162,12 @@ impl CredentialProvider for AwsCredentialAdapter {
                 token: creds.session_token().map(|s| s.to_string()),
             }))
         } else {
-            let refreshed_creds = Arc::new(self.inner.provide_credentials().await.map_err(|e| {
-                Error::Internal {
+            let refreshed_creds = Arc::new(self.inner.provide_credentials().await.map_err(
+                |e| Error::Internal {
                     message: format!("Failed to get AWS credentials: {}", e),
                     location: location!(),
-                }
-            })?);
+                },
+            )?);
 
             self.cache
                 .write()

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -165,7 +165,7 @@ impl CredentialProvider for AwsCredentialAdapter {
             let refreshed_creds = Arc::new(self.inner.provide_credentials().await.map_err(|e| {
                 Error::Internal {
                     message: format!("Failed to get AWS credentials: {}", e),
-                    location: Location::new(file!(), line!(), column!()),
+                    location: snafu::location!(),
                 }
             })?);
 


### PR DESCRIPTION
Fixes issue where there will be a panic when trying to read s3 dataset if aws credentials cannoy be resolved