### PR TITLE
fix: latent bug in index append

### DIFF
--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -85,7 +85,7 @@ pub async fn merge_indices<'a>(
         frag_bitmap.extend(idx.fragment_bitmap.as_ref().unwrap().iter());
     });
     unindexed.iter().for_each(|frag| {
-        frag_bitmap.push(frag.id as u32);
+        frag_bitmap.insert(frag.id as u32);
     });
 
     let (new_uuid, indices_merged) = match indices[0].index_type() {


### PR DESCRIPTION
this is a latent bug that only happens when there is concurrent:
* compact WITH index remap, and
* index append
because compact can reserve fragment ids and a smaller fragment id can now show up in a later commit.

By calling `push`, the new fragment with smaller id is never added to the bitmap