### PR TITLE
fix: do not panic when performing a pushdown scan on a multi-data-file fragment

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -619,6 +619,25 @@ def test_merge_with_commit(tmp_path: Path):
     assert tbl == expected
 
 
+def test_merge_search(tmp_path: Path):
+    left_table = pa.Table.from_pydict({"id": [1, 2, 3], "left": ["a", "b", "c"]})
+    right_table = pa.Table.from_pydict({"id": [1, 2, 3], "right": ["A", "B", "C"]})
+
+    left_ds = lance.write_dataset(left_table, tmp_path / "left")
+    right_ds = lance.write_dataset(right_table, tmp_path / "right")
+    left_ds.merge(right_ds, "id")
+
+    full = left_ds.to_table()
+    partial = left_ds.to_table(columns=["left"])
+
+    assert full.column("left") == partial.column("left")
+
+    full = left_ds.to_table(filter="id < 3")
+    partial = left_ds.to_table(columns=["left"], filter="id < 3")
+
+    assert full.column("left") == partial.column("left")
+
+
 def test_data_files(tmp_path: Path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
     base_dir = tmp_path / "test"

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -625,22 +625,11 @@ def test_merge_search(tmp_path: Path):
 
     left_ds = lance.write_dataset(left_table, tmp_path / "left")
 
-    left_orig_data_files = os.listdir(tmp_path / "left" / "data")
-
     right_ds = lance.write_dataset(right_table, tmp_path / "right")
     left_ds.merge(right_ds, "id")
 
     full = left_ds.to_table()
     full_filtered = left_ds.to_table(filter="id < 3")
-
-    # This is bit of a white-box test so feel free to delete if it
-    # becomes irrelevant.  We want to make sure that the following
-    # operations don't even open the newly merged data file (since
-    # they shouldn't need to because they don't access those
-    # columns).  To do this we just delete those files.
-    for f in os.listdir(tmp_path / "left" / "data"):
-        if f not in left_orig_data_files:
-            os.remove(tmp_path / "left" / "data" / f)
 
     partial = left_ds.to_table(columns=["left"])
 


### PR DESCRIPTION
The normal scan algorithm is:

```
open fragment reader with projected schema
for batch in batches:
  scan batch
```

The pushdown algorithm is:

```
open fragment with full schema
for batch, simplified_projection in filter(batches):
  projected scan batch(simplified_projection)
```

This means that the data files that need to be read could change from batch to batch.  This was not previously being accounted for and now it is.

Closes #1871 