### PR TITLE
chore: do not run test on intel mac anymore, and reduce python target

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -75,7 +75,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        python-minor-version: [ "8", "9", "10", "11" ]
+        python-minor-version: [ "8", "11" ]
     runs-on: "ubuntu-22.04"
     defaults:
       run:
@@ -138,7 +138,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        mac-runner: [ "macos-13", "macos-13-xlarge" ]
+        mac-runner: [ "macos-13-xlarge" ]
     runs-on: "${{ matrix.mac-runner }}"
     defaults:
       run:
@@ -152,7 +152,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: python

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,7 +99,7 @@ jobs:
   mac-build:
     strategy:
       matrix:
-        mac-runner: [ "macos-13", "macos-13-xlarge" ]
+        mac-runner: [ "macos-13-xlarge" ]
     runs-on: "${{ matrix.mac-runner }}"
     timeout-minutes: 45
     defaults:


### PR DESCRIPTION
* Closes #1725 
* Still do release on Intel Mac for the time being.