### PR TITLE
fix: remove lru_cache from instance method and add lint to catch future issues

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -64,7 +64,7 @@ torch = [
 ]
 
 [tool.ruff]
-select = ["F", "E", "W", "I", "G", "TCH", "PERF", "CPY001"]
+select = ["F", "E", "W", "I", "G", "TCH", "PERF", "CPY001", "B019"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -23,7 +23,6 @@ import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from functools import lru_cache
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -114,9 +113,10 @@ class LanceDataset(pa.dataset.Dataset):
         """
         return self._uri
 
-    @lru_cache(maxsize=None)
     def list_indices(self) -> List[Dict[str, Any]]:
-        return self._ds.load_indices()
+        if getattr(self, "_list_indices_res", None) is None:
+            self._list_indices_res = self._ds.load_indices()
+        return self._list_indices_res
 
     def index_statistics(self, index_name: str) -> Dict[str, Any]:
         warnings.warn(


### PR DESCRIPTION
`@lru_cache` on an instance method causes the cache to ref the instance, which causes a reference loop that can't be GC'd.

We could make a `weakref_self_lru_cache` for this purpose, but a `getattr` guard is simple enough 