### PR TITLE
fix: small bug in _updated_centroids() in kmeans.py, wrong initialization of zero_counts

### DIFF
--- a/python/python/lance/torch/kmeans.py
+++ b/python/python/lance/torch/kmeans.py
@@ -174,7 +174,7 @@ class KMeans:
         self, centroids: torch.Tensor, counts: torch.Tensor
     ) -> torch.Tensor:
         centroids = centroids / counts[:, None]
-        zero_counts = centroids == 0
+        zero_counts = counts == 0
         for idx in zero_counts.nonzero(as_tuple=False):
             # split the largest cluster and remove empty cluster
             max_idx = torch.argmax(counts).item()


### PR DESCRIPTION
Spotted a one-line bug in _updated_centroids()