### PR TITLE
ci: bump GHA to macos-14 to use free m1 GHA

### DIFF
--- a/.github/workflows/duckdb.yml
+++ b/.github/workflows/duckdb.yml
@@ -12,7 +12,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   Linux:
     runs-on: ubuntu-22.04
@@ -39,7 +39,7 @@ jobs:
       #     path: integration/duckdb/build/lance.duckdb_extension
       #     retention-days: 1
   MacOS:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 40
     defaults:
       run:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -42,7 +42,7 @@ jobs:
           - target: x86_64-apple-darwin
             runner: macos-13
           - target: aarch64-apple-darwin
-            runner: macos-13-xlarge
+            runner: macos-14
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.15
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -136,10 +136,7 @@ jobs:
       run: sudo rm -rf target/wheels
   mac:
     timeout-minutes: 45
-    strategy:
-      matrix:
-        mac-runner: [ "macos-13-xlarge" ]
-    runs-on: "${{ matrix.mac-runner }}"
+    runs-on: "macos-14"
     defaults:
       run:
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -97,10 +97,7 @@ jobs:
       - name: Run clippy
         run: cargo clippy --features cli,dynamodb,tensorflow,dynamodb_tests --tests --benches -- -D warnings
   mac-build:
-    strategy:
-      matrix:
-        mac-runner: [ "macos-13-xlarge" ]
-    runs-on: "${{ matrix.mac-runner }}"
+    runs-on: "macos-14"
     timeout-minutes: 45
     defaults:
       run:


### PR DESCRIPTION
GHA announcement: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/ 