### PR TITLE
perf: speed up materialization when there is no block list

### DIFF
--- a/python/python/benchmarks/test_search.py
+++ b/python/python/benchmarks/test_search.py
@@ -54,8 +54,18 @@ def create_base_dataset(data_dir: Path) -> lance.LanceDataset:
     if dataset:
         return dataset
 
-    table = create_table(NUM_ROWS, offset=0)
-    dataset = lance.write_dataset(table, tmp_path)
+    rows_remaining = NUM_ROWS
+    offset = 0
+    dataset = None
+    while rows_remaining > 0:
+        next_batch_length = min(rows_remaining, 1024 * 1024)
+        rows_remaining -= next_batch_length
+        table = create_table(next_batch_length, offset)
+        if offset == 0:
+            dataset = lance.write_dataset(table, tmp_path)
+        else:
+            dataset = lance.write_dataset(table, tmp_path, mode="append")
+        offset += next_batch_length
 
     dataset.create_index(
         column="vector",
@@ -65,6 +75,8 @@ def create_base_dataset(data_dir: Path) -> lance.LanceDataset:
         num_sub_vectors=16,
         num_bits=8,
     )
+
+    dataset.create_scalar_index("filterable", "BTREE")
 
     return dataset
 
@@ -208,14 +220,23 @@ def test_filtered_search(test_dataset, benchmark, selectivity, prefilter, use_in
         "filterable < 5000",
         "filterable > 5000",
     ),
+    ids=[
+        "none",
+        "equality",
+        "not_equality",
+        "in_list_one",
+        "not_in_list_one",
+        "not_equality_and_chain",
+        "in_list_three",
+        "less_than_selective",
+        "greater_than_not_selective",
+    ],
 )
-def test_scalar_index_prefilter(datasets: Datasets, benchmark, filter: str):
-    dataset = datasets.clean
-    dataset.create_scalar_index("filterable", "BTREE")
+def test_scalar_index_prefilter(test_dataset, benchmark, filter: str):
     q = pc.random(N_DIMS).cast(pa.float32())
     if filter is None:
         benchmark(
-            dataset.to_table,
+            test_dataset.to_table,
             nearest=dict(
                 column="vector",
                 q=q,
@@ -225,13 +246,54 @@ def test_scalar_index_prefilter(datasets: Datasets, benchmark, filter: str):
         )
     else:
         benchmark(
-            dataset.to_table,
+            test_dataset.to_table,
             nearest=dict(
                 column="vector",
                 q=q,
                 k=100,
                 nprobes=10,
             ),
+            prefilter=True,
+            filter=filter,
+        )
+
+
+@pytest.mark.benchmark(group="query_no_vec")
+@pytest.mark.parametrize(
+    "filter",
+    (
+        None,
+        "filterable = 0",
+        "filterable != 0",
+        "filterable IN (0)",
+        "filterable IN (0, 5000, 10000)",
+        "filterable NOT IN (0)",
+        "filterable != 0 AND filterable != 5000 AND filterable != 10000",
+        "filterable NOT IN (0, 5000, 10000)",
+        "filterable < 5000",
+        "filterable > 5000",
+    ),
+    ids=[
+        "none",
+        "equality",
+        "not_equality",
+        "in_list_one",
+        "in_list_three",
+        "not_in_list_one",
+        "not_equality_and_chain",
+        "not_in_list_three",
+        "less_than_selective",
+        "greater_than_not_selective",
+    ],
+)
+def test_scalar_index_search(test_dataset, benchmark, filter: str):
+    if filter is None:
+        benchmark(
+            test_dataset.to_table,
+        )
+    else:
+        benchmark(
+            test_dataset.to_table,
             prefilter=True,
             filter=filter,
         )

--- a/python/python/benchmarks/test_search.py
+++ b/python/python/benchmarks/test_search.py
@@ -227,7 +227,7 @@ def test_filtered_search(test_dataset, benchmark, selectivity, prefilter, use_in
         "in_list_one",
         "not_in_list_one",
         "not_equality_and_chain",
-        "in_list_three",
+        "not_in_list_three",
         "less_than_selective",
         "greater_than_not_selective",
     ],

--- a/rust/lance-core/src/utils/mask.rs
+++ b/rust/lance-core/src/utils/mask.rs
@@ -309,19 +309,16 @@ impl RowIdTreeMap {
             .values()
             .map(|row_id_selection| match row_id_selection {
                 RowIdSelection::Full => None,
-                RowIdSelection::Partial(indices) => Some(indices.len() as u64),
+                RowIdSelection::Partial(indices) => Some(indices.len()),
             })
-            .fold(Some(0_u64), |acc, next| match (acc, next) {
-                (Some(acc), Some(next)) => Some(acc + next),
-                _ => None,
-            })
+            .try_fold(0_u64, |acc, next| next.map(|next| next + acc))
     }
 
     /// An iterator of row ids
     ///
     /// If there are any "full fragment" items then this can't be calculated and None
     /// is returned
-    pub fn row_ids<'a>(&'a self) -> Option<impl Iterator<Item = RowAddress> + 'a> {
+    pub fn row_ids(&self) -> Option<impl Iterator<Item = RowAddress> + '_> {
         let inner_iters = self
             .inner
             .iter()

--- a/rust/lance-core/src/utils/mask.rs
+++ b/rust/lance-core/src/utils/mask.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::io::Write;
 use std::{collections::BTreeMap, io::Read};
 
@@ -357,6 +358,12 @@ impl RowIdTreeMap {
             Some(RowIdSelection::Full) => true,
             Some(RowIdSelection::Partial(fragment_set)) => fragment_set.contains(row_id),
         }
+    }
+
+    pub fn remove_fragments(&mut self, frag_ids: impl IntoIterator<Item = u32>) {
+        let frag_id_set = frag_ids.into_iter().collect::<HashSet<_>>();
+        self.inner
+            .retain(|frag_id, _| frag_id_set.contains(frag_id));
     }
 
     /// Compute the serialized size of the set.


### PR DESCRIPTION
Materialization converts a row id mask into a vector of row ids.  The old approach used a FragIdIter which was too slow.  In fact, we probably want to eventually get rid of FragIdIter entirely (see https://github.com/lancedb/lance/issues/1896).  In the meantime, when there is no block list, we can materialize by filtering the allow list with the fragment list instead.

This should greatly speed up indexed searches that don't have any vector search component.