### PR TITLE
fix: handle out-of-order columns

### DIFF
--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -259,8 +259,8 @@ impl FileReader {
     /// The row id column will have the name `_rowid` and will be of type `UInt64`.
     ///
     /// The row id is a 64-bit integer that is unique within the dataset. The
-    /// upper 32 bits are the fragment id, and the lower 32 bits are the row
-    /// number within the fragment.
+    /// most significant 32 bits are the fragment id, and the least significant
+    /// 32 bits are the row offset within the fragment.
     pub fn with_row_id(&mut self, v: bool) -> &mut Self {
         self.with_row_id = v;
         self

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -255,6 +255,12 @@ impl FileReader {
     }
 
     /// Instruct the FileReader to return meta row id column.
+    ///
+    /// The row id column will have the name `_rowid` and will be of type `UInt64`.
+    ///
+    /// The row id is a 64-bit integer that is unique within the dataset. The
+    /// upper 32 bits are the fragment id, and the lower 32 bits are the row
+    /// number within the fragment.
     pub fn with_row_id(&mut self, v: bool) -> &mut Self {
         self.with_row_id = v;
         self
@@ -270,7 +276,7 @@ impl FileReader {
         self
     }
 
-    /// Schema of the returning RecordBatch.
+    /// Requested projection of the data in this file, excluding the row id column.
     pub fn schema(&self) -> &Schema {
         &self.schema
     }


### PR DESCRIPTION
To support `ALTER COLUMN`, we need to start handling cases where the order of data files and order of columns aren't aligned. For example, if you have columns `a, b, c`, and then later replace column `b` in a new data file, you now have data files with `a, c` and `b`, respectively. But the schema is still `a, b, c`, so when you read from the data files, you can't just merge them (that would give `a, c, b`), you need to re-order them.