### PR TITLE
feat: allow opening FragmentReader with just row id

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1100,7 +1100,7 @@ impl Dataset {
                 )
             })?;
 
-            let reader = fragment.open(projection.as_ref()).await?;
+            let reader = fragment.open(projection.as_ref(), false).await?;
             reader.read_range(range).await
         } else if row_id_meta.sorted {
             // Don't need to re-arrange data, just concatenate
@@ -1803,7 +1803,7 @@ mod tests {
         assert_eq!(dataset.count_fragments(), 10);
         for fragment in &fragments {
             assert_eq!(fragment.count_rows().await.unwrap(), 100);
-            let reader = fragment.open(dataset.schema()).await.unwrap();
+            let reader = fragment.open(dataset.schema(), false).await.unwrap();
             assert_eq!(reader.num_batches(), 10);
             for i in 0..reader.num_batches() {
                 assert_eq!(reader.num_rows_in_batch(i), 10);

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -143,7 +143,11 @@ impl FileFragment {
         self.metadata.id as usize
     }
 
-    /// Open all the data files as part of the projection schema.
+    /// Open a FileFragment with a given default projection.
+    ///
+    /// All read operations (other than `read_projected`) will use the supplied
+    /// default projection. For `read_projected`, the projection must be a subset
+    /// of the default projection.
     ///
     /// Parameters
     /// - `projection`: The projection schema.

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -265,7 +265,7 @@ impl FragmentScanner {
 
         // We will call the reader with projections. In order for this to work
         // we must ensure that we open the fragment with the maximal schema.
-        let mut reader = fragment.open(dataset.schema()).await?;
+        let mut reader = fragment.open(dataset.schema(), false).await?;
         if config.make_deletions_null {
             reader.with_make_deletions_null();
         }

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -44,10 +44,8 @@ async fn open_file(
     with_row_id: bool,
     with_make_deletions_null: bool,
 ) -> Result<FragmentReader> {
-    let mut reader = file_fragment.open(projection.as_ref()).await?;
-    if with_row_id {
-        reader.with_row_id();
-    };
+    let mut reader = file_fragment.open(projection.as_ref(), with_row_id).await?;
+
     if with_make_deletions_null {
         reader.with_make_deletions_null();
     };


### PR DESCRIPTION
This will be useful for cases where users want to add columns to a dataset that aren't based on existing columns. We still need to scan the row ids so we can match the batching structure in the new data files we write.