### PR TITLE
feat: add alter columns for names and nullability

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -610,6 +610,43 @@ class LanceDataset(pa.dataset.Dataset):
         """
         raise NotImplementedError("Versioning not yet supported in Rust")
 
+    def alter_columns(self, *alterations: Iterable[Dict[str, Any]]):
+        """Alter column names and nullability.
+
+        Parameters
+        ----------
+        alterations : Iterable[Dict[str, Any]]
+            A sequence of dictionaries, each with the following keys:
+            - "path": str
+                The column path to alter. For a top-level column, this is the name.
+                For a nested column, this is the dot-separated path, e.g. "a.b.c".
+            - "name": str, optional
+                The new name of the column. If not specified, the column name is
+                not changed.
+            - "nullable": bool, optional
+                Whether the column should be nullable. If not specified, the column
+                nullability is not changed. Only non-nullable columns can be changed
+                to nullable. Currently, you cannot change a nullable column to
+                non-nullable.
+
+        Examples
+        --------
+        >>> import lance
+        >>> import pyarrow as pa
+        >>> schema = pa.schema([pa.field('a', pa.int64()),
+        ...                     pa.field('b', pa.string(), nullable=False)])
+        >>> table = pa.table({"a": [1, 2, 3], "b": ["a", "b", "c"]})
+        >>> dataset = lance.write_dataset(table, "example")
+        >>> dataset.alter_columns({"path": "a", "name": "x"},
+        ...                       {"path": "b", "nullable": True})
+        >>> dataset.to_table().to_pandas()
+           x  b
+        0  1  a
+        1  2  b
+        2  3  c
+        """
+        self._ds.alter_columns(list(alterations))
+
     def merge(
         self,
         data_obj: ReaderLike,

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -634,7 +634,7 @@ impl Dataset {
         let alterations = alterations
             .iter()
             .map(|obj| {
-                let obj = PyAny::downcast::<PyDict>(obj)?;
+                let obj = obj.downcast::<PyDict>()?;
                 let path: String = obj
                     .get_item("path")?
                     .ok_or_else(|| PyValueError::new_err("path is required"))?

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -25,6 +25,7 @@ use chrono::Duration;
 
 use futures::{StreamExt, TryFutureExt};
 use lance::dataset::builder::DatasetBuilder;
+use lance::dataset::ColumnAlteration;
 use lance::dataset::{
     fragment::FileFragment as LanceFileFragment, progress::WriteFragmentProgress,
     scanner::Scanner as LanceScanner, transaction::Operation as LanceOperation,
@@ -627,6 +628,40 @@ impl Dataset {
         let stream = self.ds.take_scan(slice_stream, projection, batch_readahead);
 
         Ok(PyArrowType(Box::new(LanceReader::from_stream(stream))))
+    }
+
+    fn alter_columns(&mut self, alterations: &PyList) -> PyResult<()> {
+        let alterations = alterations
+            .iter()
+            .map(|obj| {
+                let obj = PyAny::downcast::<PyDict>(obj)?;
+                let path: String = obj
+                    .get_item("path")?
+                    .ok_or_else(|| PyValueError::new_err("path is required"))?
+                    .extract()?;
+                let name: Option<String> =
+                    obj.get_item("name")?.map(|n| n.extract()).transpose()?;
+                let nullable: Option<bool> =
+                    obj.get_item("nullable")?.map(|n| n.extract()).transpose()?;
+                let mut alteration = ColumnAlteration::new(path);
+                if let Some(name) = name {
+                    alteration = alteration.rename(name);
+                }
+                if let Some(nullable) = nullable {
+                    alteration = alteration.set_nullable(nullable);
+                }
+                Ok(alteration)
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+
+        let mut new_self = self.ds.as_ref().clone();
+        new_self = RT
+            .spawn(None, async move {
+                new_self.alter_columns(&alterations).await.map(|_| new_self)
+            })?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?;
+        self.ds = Arc::new(new_self);
+        Ok(())
     }
 
     fn merge(

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1693,8 +1693,7 @@ impl Dataset {
 
     /// Modify columns in the dataset, changing their name, type, or nullability.
     ///
-    /// If a column has an index, it's index will be preserved or transformed to
-    /// the new type as part of the operation.
+    /// If a column has an index, it's index will be preserved.
     pub async fn alter_columns(&mut self, alterations: &[ColumnAlteration]) -> Result<()> {
         // Validate we aren't making nullable columns non-nullable and that all
         // the referenced columns actually exist.

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1730,6 +1730,8 @@ impl Dataset {
             }
         }
 
+        new_schema.validate()?;
+
         // If we aren't casting a column, we don't need to touch the fragments.
         let transaction = Transaction::new(
             self.manifest.version,
@@ -4367,6 +4369,13 @@ mod tests {
             metadata.clone(),
         );
         assert_eq!(&ArrowSchema::from(dataset.schema()), &expected_schema);
+
+        // Rename to duplicate name fails
+        let err = dataset
+            .alter_columns(&[ColumnAlteration::new("b".into()).rename("x".into())])
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("Duplicate field name \"x\""));
 
         // Rename a nested column.
         dataset

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -4305,6 +4305,8 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
     async fn test_rename_columns() -> Result<()> {
         let metadata: HashMap<String, String> = [("k1".into(), "v1".into())].into();
 


### PR DESCRIPTION
Initial pass on `alter_columns()` API. This allows renaming columns and making them nullable. A future PR will allow casting the type of column.