### PR TITLE
feat: allow casting in `alter_columns()`

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -611,7 +611,14 @@ class LanceDataset(pa.dataset.Dataset):
         raise NotImplementedError("Versioning not yet supported in Rust")
 
     def alter_columns(self, *alterations: Iterable[Dict[str, Any]]):
-        """Alter column names and nullability.
+        """Alter column name, data type, and nullability.
+
+        Columns that are renamed can keep any indices that are on them. However, if
+        the column is cast to a different type, its indices will be dropped.
+
+        Column types can be upcasted (such as int32 to int64) or downcasted
+        (such as int64 to int32). However, downcasting will fail if there are
+        any values that cannot be represented in the new type.
 
         Parameters
         ----------
@@ -631,9 +638,6 @@ class LanceDataset(pa.dataset.Dataset):
             - "data_type": pyarrow.DataType, optional
                 The new data type to cast the column to. If not specified, the column
                 data type is not changed.
-
-        Columns that are renamed can keep any indices that are on them. However, if
-        the column is casted to a different type, it's indices will be dropped.
 
         Examples
         --------

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -628,6 +628,12 @@ class LanceDataset(pa.dataset.Dataset):
                 nullability is not changed. Only non-nullable columns can be changed
                 to nullable. Currently, you cannot change a nullable column to
                 non-nullable.
+            - "data_type": pyarrow.DataType, optional
+                The new data type to cast the column to. If not specified, the column
+                data type is not changed.
+
+        Columns that are renamed can keep any indices that are on them. However, if
+        the column is casted to a different type, it's indices will be dropped.
 
         Examples
         --------
@@ -644,6 +650,10 @@ class LanceDataset(pa.dataset.Dataset):
         0  1  a
         1  2  b
         2  3  c
+        >>> dataset.alter_columns({"path": "x", "data_type": pa.int32()})
+        >>> dataset.schema
+        x: int32
+        b: string
         """
         self._ds.alter_columns(list(alterations))
 

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -618,7 +618,11 @@ class LanceDataset(pa.dataset.Dataset):
 
         Column types can be upcasted (such as int32 to int64) or downcasted
         (such as int64 to int32). However, downcasting will fail if there are
-        any values that cannot be represented in the new type.
+        any values that cannot be represented in the new type. In general,
+        columns can be casted to same general type: integers to integers,
+        floats to floats, and strings to strings. However, strings, binary, and
+        list columns can be casted between their size variants. For example,
+        string to large string, binary to large binary, and list to large list.
 
         Parameters
         ----------

--- a/python/python/tests/test_schema_evolution.py
+++ b/python/python/tests/test_schema_evolution.py
@@ -184,10 +184,11 @@ def test_alter_columns(tmp_path: Path):
 
     dataset.alter_columns(
         {"path": "x", "data_type": pa.int32()},
+        {"path": "y", "data_type": pa.large_string()},
     )
     expected_schema = pa.schema([
         pa.field("x", pa.int32()),
-        pa.field("y", pa.string(), nullable=False),
+        pa.field("y", pa.large_string(), nullable=False),
     ])
     assert dataset.schema == expected_schema
 
@@ -198,6 +199,9 @@ def test_alter_columns(tmp_path: Path):
     assert dataset.to_table() == expected_tab
     with pytest.raises(Exception, match="Can't cast value 1024 to type Int8"):
         dataset.alter_columns({"path": "x", "data_type": pa.int8()})
+
+    with pytest.raises(Exception, match='Cannot cast column "x" from Int32 to Utf8'):
+        dataset.alter_columns({"path": "x", "data_type": pa.string()})
 
     with pytest.raises(Exception, match='Column "q" does not exist'):
         dataset.alter_columns({"path": "q", "name": "z"})

--- a/python/python/tests/test_schema_evolution.py
+++ b/python/python/tests/test_schema_evolution.py
@@ -181,3 +181,18 @@ def test_alter_columns(tmp_path: Path):
         schema=expected_schema,
     )
     assert dataset.to_table() == expected_tab
+
+    dataset.alter_columns(
+        {"path": "x", "data_type": pa.int32()},
+    )
+    expected_schema = pa.schema([
+        pa.field("x", pa.int32()),
+        pa.field("y", pa.string(), nullable=False),
+    ])
+    assert dataset.schema == expected_schema
+
+    expected_tab = pa.table(
+        {"x": pa.array([1, 2, 3], type=pa.int32()), "y": pa.array(["a", "b", "c"])},
+        schema=expected_schema,
+    )
+    assert dataset.to_table() == expected_tab

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -647,6 +647,23 @@ impl Dataset {
                     .get_item("data_type")?
                     .map(|n| n.extract())
                     .transpose()?;
+
+                for key in obj.keys().iter().map(|k| k.extract::<String>()) {
+                    let k = key?;
+                    if k != "path" && k != "name" && k != "nullable" && k != "data_type" {
+                        return Err(PyValueError::new_err(format!(
+                            "Unknown key: {}. Valid keys are name, nullable, and data_type.",
+                            k
+                        )));
+                    }
+                }
+
+                if name.is_none() && nullable.is_none() && data_type.is_none() {
+                    return Err(PyValueError::new_err(
+                        "At least one of name, nullable, or data_type must be specified",
+                    ));
+                }
+
                 let mut alteration = ColumnAlteration::new(path);
                 if let Some(name) = name {
                     alteration = alteration.rename(name);

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -643,12 +643,19 @@ impl Dataset {
                     obj.get_item("name")?.map(|n| n.extract()).transpose()?;
                 let nullable: Option<bool> =
                     obj.get_item("nullable")?.map(|n| n.extract()).transpose()?;
+                let data_type: Option<PyArrowType<DataType>> = obj
+                    .get_item("data_type")?
+                    .map(|n| n.extract())
+                    .transpose()?;
                 let mut alteration = ColumnAlteration::new(path);
                 if let Some(name) = name {
                     alteration = alteration.rename(name);
                 }
                 if let Some(nullable) = nullable {
                     alteration = alteration.set_nullable(nullable);
+                }
+                if let Some(data_type) = data_type {
+                    alteration = alteration.cast_to(data_type.0);
                 }
                 Ok(alteration)
             })

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -221,7 +221,7 @@ impl FileFragment {
     fn updater(&self, columns: Option<Vec<String>>) -> PyResult<Updater> {
         let cols = columns.as_deref();
         let inner = RT
-            .block_on(None, async { self.fragment.updater(cols).await })?
+            .block_on(None, async { self.fragment.updater(cols, None).await })?
             .map_err(|err| PyIOError::new_err(err.to_string()))?;
         Ok(Updater::new(inner))
     }

--- a/rust/lance-arrow/Cargo.toml
+++ b/rust/lance-arrow/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 arrow-array = { workspace = true }
 arrow-buffer = { workspace = true }
 arrow-data = { workspace = true }
+arrow-cast ={ workspace = true }
 arrow-schema = { workspace = true }
 arrow-select = { workspace = true }
 half = { workspace = true }

--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -33,6 +33,7 @@ pub use schema::*;
 pub mod bfloat16;
 pub mod floats;
 pub use floats::*;
+pub mod cast;
 
 type Result<T> = std::result::Result<T, ArrowError>;
 

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -273,7 +273,7 @@ impl Schema {
         let filtered_fields = self
             .fields
             .iter()
-            .filter_map(|f| f.project_by_filter(&|f| column_ids.contains(&f.id)))
+            .filter_map(|f| f.project_by_ids(column_ids))
             .collect();
         Self {
             fields: filtered_fields,
@@ -605,7 +605,7 @@ mod tests {
             ArrowField::new("c", DataType::Float64, false),
         ]);
         let schema = Schema::try_from(&arrow_schema).unwrap();
-        let projected = schema.project_by_ids(&[1, 2, 4, 5]);
+        let projected = schema.project_by_ids(&[2, 4, 5]);
 
         let expected_arrow_schema = ArrowSchema::new(vec![
             ArrowField::new(
@@ -628,6 +628,18 @@ mod tests {
                 DataType::Utf8,
                 true,
             )])),
+            true,
+        )]);
+        assert_eq!(ArrowSchema::from(&projected), expected_arrow_schema);
+
+        let projected = schema.project_by_ids(&[1]);
+        let expected_arrow_schema = ArrowSchema::new(vec![ArrowField::new(
+            "b",
+            DataType::Struct(ArrowFields::from(vec![
+                ArrowField::new("f1", DataType::Utf8, true),
+                ArrowField::new("f2", DataType::Boolean, false),
+                ArrowField::new("f3", DataType::Float32, false),
+            ])),
             true,
         )]);
         assert_eq!(ArrowSchema::from(&projected), expected_arrow_schema);

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -489,6 +489,10 @@ impl Transaction {
             }
             Operation::Merge { ref fragments, .. } => {
                 final_fragments.extend(fragments.clone());
+
+                // Some fields that have indices may have been removed, so we should
+                // remove those indices as well.
+                Self::retain_relevant_indices(&mut final_indices, &schema)
             }
             Operation::Project { .. } => {
                 final_fragments.extend(maybe_existing_fragments?.clone());


### PR DESCRIPTION
This allows casting a column in place. For example, a user could change a `fixed_size_list<f32, _>` column to a `fixed_size_list<f16, _>`. In a future PR, we will make sure the indices can be preserved as part of the transaction.