### PR TITLE
docs: schema evolution

### DIFF
--- a/docs/read_and_write.rst
+++ b/docs/read_and_write.rst
@@ -41,48 +41,6 @@ also supports writing a dataset in iterator of :py:class:`pyarrow.RecordBatch` e
 :py:meth:`lance.write_dataset` supports writing :py:class:`pyarrow.Table`, :py:class:`pandas.DataFrame`,
 :py:class:`pyarrow.Dataset`, and ``Iterator[pyarrow.RecordBatch]``. Check its doc for more details.
 
-Adding new columns
-~~~~~~~~~~~~~~~~~~
-
-New columns can be merged into an existing dataset in using :py:meth:`lance.Dataset.merge`.
-This allows filling in additional columns without having to rewrite the whole dataset.
-
-To use the ``merge`` method, provide a new table that includes the columns you
-want to add, and a column name to use for joining the new data to the existing
-dataset.
-
-For example, imagine we have a dataset of embeddings and ids:
-
-.. testcode::
-
-    import lance
-    import pyarrow as pa
-    import numpy as np
-    table = pa.table({
-       "id": pa.array([1, 2, 3]),
-       "embedding": pa.array([np.array([1, 2, 3]), np.array([4, 5, 6]),
-                              np.array([7, 8, 9])])
-    })
-    dataset = lance.write_dataset(table, "embeddings")
-
-Now if we want to add a column of labels we have generated, we can do so by merging a new table:
-
-.. testcode::
-
-    new_data = pa.table({
-       "id": pa.array([1, 2, 3]),
-       "label": pa.array(["horse", "rabbit", "cat"])
-    })
-    dataset.merge(new_data, "id")
-    dataset.to_table().to_pandas()
-
-.. testoutput::
-
-       id  embedding   label
-    0   1  [1, 2, 3]   horse
-    1   2  [4, 5, 6]  rabbit
-    2   3  [7, 8, 9]     cat
-
 Deleting rows
 ~~~~~~~~~~~~~
 
@@ -258,6 +216,226 @@ example:
          .when_not_matched_by_source_delete("age >= 40") \
          .execute()
 
+
+Evolving the schema
+-------------------
+
+Lance supports schema evolution: adding, removing, and altering columns in a
+dataset. Most of these operations can be performed *without* rewriting the
+data files in the dataset, making them very efficient operations.
+
+In general, schema changes will conflict with most other concurrent write 
+operations. For example, if you change the schema of the dataset while someone
+else is appending data to it, either your schema change or the append will fail,
+depending on the order of the operations. Thus, it's recommended to perform
+schema changes when no other writes are happening.
+
+Renaming columns
+~~~~~~~~~~~~~~~~
+
+Columns can be renamed using the :py:meth:`lance.LanceDataset.alter_columns`
+method.
+
+.. testcode::
+
+    import lance
+    import pyarrow as pa
+    table = pa.table({"id": pa.array([1, 2, 3])})
+    dataset = lance.write_dataset(table, "ids")
+    dataset.alter_columns({"path": "id", "name": "new_id"})
+    dataset.to_table().to_pandas()
+
+.. testoutput::
+
+       new_id
+    0       1
+    1       2
+    2       3
+
+This works for nested columns as well. To address a nested column, use a dot
+(``.``) to separate the levels of nesting. For example:
+
+.. testcode::
+
+    data = [
+      {"meta": {"id": 1, "name": "Alice"}},
+      {"meta": {"id": 2, "name": "Bob"}},
+    ]
+    dataset = lance.write_dataset(data, "nested_rename")
+    dataset.alter_columns({"path": "meta.id", "name": "new_id"})
+
+.. testoutput::
+
+        meta
+      0  {"new_id": 1, "name": "Alice"}
+      1  {"new_id": 2, "name": "Bob"}
+
+
+Casting column data types
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to changing column names, you can also change the data type of a
+column using the :py:meth:`lance.LanceDataset.alter_columns` method. This
+requires rewriting that column to new data files, but does not require rewriting
+the any other columns.
+
+.. note::
+
+  If the column has an index, the index will be dropped if the column type is
+  changed.
+
+This method can be used to change the vector type of a column. For example, we
+can change a float32 embedding column into a float16 column to save disk space:
+
+.. testcode::
+
+    import lance
+    import pyarrow as pa
+    import numpy as np
+    table = pa.table({
+       "id": pa.array([1, 2, 3]),
+       "embedding": pa.FixedShapeTensorArray.from_numpy_ndarray(
+           np.random.rand(3, 128).astype("float32"))
+    })
+    dataset = lance.write_dataset(table, "embeddings")
+    dataset.alter_columns({"path": "embedding",
+                           "type": pa.list_(pa.float16(), 128)})
+    dataset.schema()
+
+.. testoutput::
+
+    id: int64
+    embedding: fixed_size_list<item: float16, 128>
+
+
+Adding new columns
+~~~~~~~~~~~~~~~~~~~
+
+New columns can be added and populated within a single operation using the
+:py:meth:`lance.LanceDataset.add_columns` method. There are two ways to specify
+how to populate the new columns: first, by providing a SQL expression for each
+new column, or second, by providing a function to generate the new column data.
+
+SQL expressions can either be independent expressions or reference existing
+columns. SQL literal values can be used to set a single value for all 
+existing rows.
+
+.. testcode::
+
+    import lance
+    import pyarrow as pa
+    table = pa.table({"name": pa.array(["Alice", "Bob", "Carla"])})
+    dataset = lance.write_dataset(table, "names")
+    dataset.add_columns({
+        "hash": "sha256(name)",
+        "status": "'active'",
+    })
+    dataset.to_table().to_pandas()
+  
+.. testoutput::
+
+        name         hash...   status
+    0  Alice  3bc51062973c...  active
+    1    Bob  cd9fb1e148cc...  active
+    2  Carla  ad8d83ffd82b...  active
+
+You can also provide a Python function to generate the new column data. This can
+be used, for example, to compute a new embedding column. This function should
+take a PyArrow RecordBatch and return either a PyArrow RecordBatch or a Pandas
+DataFrame. The function will be called once for each batch in the dataset.
+
+If the function is expensive to compute and can fail, it is recommended to set
+a checkpoint file in the UDF. This checkpoint file saves the state of the UDF
+after each invocation, so that if the UDF fails, it can be restarted from the
+last checkpoint. Note that this file can get quite large, since it needs to store
+unsaved results for up to an entire data file.
+
+.. code-block::
+
+    import lance
+    import pyarrow as pa
+    import numpy as np
+
+    table = pa.table({"id": pa.array([1, 2, 3])})
+    dataset = lance.write_dataset(table, "ids")
+
+    @lance.batch_udf(checkpoint_file="embedding_checkpoint.sqlite")
+    def add_random_vector(batch):
+        embeddings = np.random.rand(batch.num_rows, 128).astype("float32")
+        return pd.DataFrame({"embedding": embeddings})
+    dataset.add_columns(add_random_vector)
+
+
+Adding new columns using merge
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you have pre-computed one or more new columns, you can add them to an existing
+dataset using the :py:meth:`lance.LanceDataset.merge` method. This allows filling in
+additional columns without having to rewrite the whole dataset.
+
+
+To use the ``merge`` method, provide a new table that includes the columns you
+want to add, and a column name to use for joining the new data to the existing
+dataset.
+
+For example, imagine we have a dataset of embeddings and ids:
+
+.. testcode::
+
+    import lance
+    import pyarrow as pa
+    import numpy as np
+    table = pa.table({
+       "id": pa.array([1, 2, 3]),
+       "embedding": pa.array([np.array([1, 2, 3]), np.array([4, 5, 6]),
+                              np.array([7, 8, 9])])
+    })
+    dataset = lance.write_dataset(table, "embeddings")
+
+Now if we want to add a column of labels we have generated, we can do so by merging a new table:
+
+.. testcode::
+
+    new_data = pa.table({
+       "id": pa.array([1, 2, 3]),
+       "label": pa.array(["horse", "rabbit", "cat"])
+    })
+    dataset.merge(new_data, "id")
+    dataset.to_table().to_pandas()
+
+.. testoutput::
+
+       id  embedding   label
+    0   1  [1, 2, 3]   horse
+    1   2  [4, 5, 6]  rabbit
+    2   3  [7, 8, 9]     cat
+
+
+Dropping columns
+~~~~~~~~~~~~~~~~
+
+Finally, you can drop columns from a dataset using the :py:meth:`lance.LanceDataset.drop_columns`.
+This is a metadata-only operation and does not delete the data on disk. This makes
+it very quick.
+
+.. testcode::
+
+    import lance
+    import pyarrow as pa
+    table = pa.table({"id": pa.array([1, 2, 3]),
+                      "name": pa.array(["Alice", "Bob", "Carla"])})
+    dataset = lance.write_dataset(table, "names")
+    dataset.drop_columns(["name"])
+    dataset.schema()
+  
+.. testoutput::
+
+    id: int64
+
+To actually remove the data from disk, the files must be rewritten to remove the
+columns and then the old files must be deleted. This can be done using 
+:py:meth:`lance.dataset.DatasetOptimizer.compact_files()` followed by
+:py:meth:`lance.LanceDataset.cleanup_old_versions()`.
 
 
 Reading Lance Dataset

--- a/docs/read_and_write.rst
+++ b/docs/read_and_write.rst
@@ -277,7 +277,7 @@ Casting column data types
 In addition to changing column names, you can also change the data type of a
 column using the :py:meth:`lance.LanceDataset.alter_columns` method. This
 requires rewriting that column to new data files, but does not require rewriting
-the any other columns.
+the other columns.
 
 .. note::
 
@@ -285,7 +285,8 @@ the any other columns.
   changed.
 
 This method can be used to change the vector type of a column. For example, we
-can change a float32 embedding column into a float16 column to save disk space:
+can change a float32 embedding column into a float16 column to save disk space
+at the cost of lower precision:
 
 .. testcode::
 
@@ -374,7 +375,7 @@ dataset using the :py:meth:`lance.LanceDataset.merge` method. This allows fillin
 additional columns without having to rewrite the whole dataset.
 
 
-To use the ``merge`` method, provide a new table that includes the columns you
+To use the ``merge`` method, provide a new dataset that includes the columns you
 want to add, and a column name to use for joining the new data to the existing
 dataset.
 
@@ -414,8 +415,8 @@ Now if we want to add a column of labels we have generated, we can do so by merg
 Dropping columns
 ~~~~~~~~~~~~~~~~
 
-Finally, you can drop columns from a dataset using the :py:meth:`lance.LanceDataset.drop_columns`.
-This is a metadata-only operation and does not delete the data on disk. This makes
+Finally, you can drop columns from a dataset using the :py:meth:`lance.LanceDataset.drop_columns`
+method. This is a metadata-only operation and does not delete the data on disk. This makes
 it very quick.
 
 .. testcode::

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -716,10 +716,14 @@ class LanceDataset(pa.dataset.Dataset):
         list columns can be casted between their size variants. For example,
         string to large string, binary to large binary, and list to large list.
 
+        Columns that are renamed can keep any indices that are on them. However, if
+        the column is casted to a different type, it's indices will be dropped.
+
         Parameters
         ----------
         alterations : Iterable[Dict[str, Any]]
             A sequence of dictionaries, each with the following keys:
+
             - "path": str
                 The column path to alter. For a top-level column, this is the name.
                 For a nested column, this is the dot-separated path, e.g. "a.b.c".
@@ -903,16 +907,16 @@ class LanceDataset(pa.dataset.Dataset):
     def drop_columns(self, columns: List[str]):
         """Drop one or more columns from the dataset
 
+        This is a metadata-only operation and does not remove the data from the
+        underlying storage. In order to remove the data, you must subsequently
+        call ``compact_files`` to rewrite the data without the removed columns and
+        then call ``cleanup_old_versions`` to remove the old files.
+
         Parameters
         ----------
         columns : list of str
             The names of the columns to drop. These can be nested column references
             (e.g. "a.b.c") or top-level column names (e.g. "a").
-
-        This is a metadata-only operation and does not remove the data from the
-        underlying storage. In order to remove the data, you must subsequently
-        call ``compact_files`` to rewrite the data without the removed columns and
-        then call ``cleanup_old_versions`` to remove the old files.
 
         Examples
         --------

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1301,7 +1301,8 @@ impl Dataset {
         let joiner = Arc::new(HashJoiner::try_new(stream, right_on).await?);
         // Final schema is union of current schema, plus the RHS schema without
         // the right_on key.
-        let new_schema: Schema = self.schema().merge(joiner.out_schema().as_ref())?;
+        let mut new_schema: Schema = self.schema().merge(joiner.out_schema().as_ref())?;
+        new_schema.set_field_id(Some(self.manifest.max_field_id()));
 
         // Write new data file to each fragment. Parallelism is done over columns,
         // so no parallelism done at this level.

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -912,118 +912,6 @@ impl Dataset {
         })
     }
 
-    /// Merge this dataset with another arrow Table / Dataset, and returns a new version of dataset.
-    ///
-    /// Parameters:
-    ///
-    /// - `stream`: the stream of [`RecordBatch`] to merge.
-    /// - `left_on`: the column name to join on the left side (self).
-    /// - `right_on`: the column name to join on the right side (stream).
-    ///
-    /// Returns: a new version of dataset.
-    ///
-    /// It performs a left-join on the two datasets.
-    async fn merge_impl(
-        &mut self,
-        stream: Box<dyn RecordBatchReader + Send>,
-        left_on: &str,
-        right_on: &str,
-    ) -> Result<()> {
-        // Sanity check.
-        if self.schema().field(left_on).is_none() {
-            return Err(Error::invalid_input(
-                format!("Column {} does not exist in the left side dataset", left_on),
-                location!(),
-            ));
-        };
-        let right_schema = stream.schema();
-        if right_schema.field_with_name(right_on).is_err() {
-            return Err(Error::invalid_input(
-                format!(
-                    "Column {} does not exist in the right side dataset",
-                    right_on
-                ),
-                location!(),
-            ));
-        };
-        for field in right_schema.fields() {
-            if field.name() == right_on {
-                // right_on is allowed to exist in the dataset, since it may be
-                // the same as left_on.
-                continue;
-            }
-            if self.schema().field(field.name()).is_some() {
-                return Err(Error::invalid_input(
-                    format!(
-                        "Column {} exists in both sides of the dataset",
-                        field.name()
-                    ),
-                    location!(),
-                ));
-            }
-        }
-
-        // Hash join
-        let joiner = Arc::new(HashJoiner::try_new(stream, right_on).await?);
-        // Final schema is union of current schema, plus the RHS schema without
-        // the right_on key.
-        let mut new_schema: Schema = self.schema().merge(joiner.out_schema().as_ref())?;
-        new_schema.set_field_id(Some(self.manifest.max_field_id()));
-
-        // Write new data file to each fragment. Parallelism is done over columns,
-        // so no parallelism done at this level.
-        let updated_fragments: Vec<Fragment> = stream::iter(self.get_fragments())
-            .then(|f| {
-                let joiner = joiner.clone();
-                async move { f.merge(left_on, &joiner).await.map(|f| f.metadata) }
-            })
-            .try_collect::<Vec<_>>()
-            .await?;
-
-        let transaction = Transaction::new(
-            self.manifest.version,
-            Operation::Merge {
-                fragments: updated_fragments,
-                schema: new_schema,
-            },
-            None,
-        );
-
-        let manifest = commit_transaction(
-            self,
-            &self.object_store,
-            self.commit_handler.as_ref(),
-            &transaction,
-            &Default::default(),
-            &Default::default(),
-        )
-        .await?;
-
-        self.manifest = Arc::new(manifest);
-
-        Ok(())
-    }
-
-    pub async fn merge(
-        &mut self,
-        stream: impl RecordBatchReader + Send + 'static,
-        left_on: &str,
-        right_on: &str,
-    ) -> Result<()> {
-        let stream = Box::new(stream);
-        self.merge_impl(stream, left_on, right_on).await
-    }
-
-    /// Drop columns from the dataset and return updated dataset. Note that this
-    /// is a zero-copy operation and column is not physically removed from the
-    /// dataset.
-    /// Parameters:
-    /// - `columns`: the list of column names to drop.
-    #[deprecated(since = "0.9.12", note = "Please use `drop_columns` instead.")]
-    pub async fn drop(&mut self, columns: &[&str]) -> Result<()> {
-        self.drop_columns(columns).await
-    }
-
     /// Create a Scanner to scan the dataset.
     pub fn scan(&self) -> Scanner {
         Scanner::new(Arc::new(self.clone()))
@@ -1312,6 +1200,21 @@ impl Dataset {
 }
 
 /// # Schema Evolution
+///
+/// Lance datasets supports evolving the schema. Several operations are
+/// supported that mirror common SQL operations:
+///
+/// - [Self::add_columns()]: Add new columns to the dataset, similar to `ALTER TABLE ADD COLUMN`.
+/// - [Self::drop_columns()]: Drop columns from the dataset, similar to `ALTER TABLE DROP COLUMN`.
+/// - [Self::alter_columns()]: Modify columns in the dataset, changing their name, type, or nullability.
+///                    Similar to `ALTER TABLE ALTER COLUMN`.
+///
+/// In addition, one operation is unique to Lance: [`merge`](Self::merge). This
+/// operation allows inserting precomputed data into the dataset.
+///
+/// Because these operations change the schema of the dataset, they will conflict
+/// with most other concurrent operations. Therefore, they should be performed
+/// when no other write operations are being run.
 impl Dataset {
     /// Append new columns to the dataset.
     pub async fn add_columns(
@@ -1324,7 +1227,12 @@ impl Dataset {
 
     /// Modify columns in the dataset, changing their name, type, or nullability.
     ///
-    /// If a column has an index, it's index will be preserved.
+    /// If only changing the name or nullability of a column, this is a zero-copy
+    /// operation and any indices will be preserved. If changing the type of a
+    /// column, the data for that column will be rewritten and any indices will
+    /// be dropped. The old column data will not be immediately deleted. To remove
+    /// it, call [optimize::compact_files()] and then
+    /// [cleanup::cleanup_old_versions()] on the dataset.
     pub async fn alter_columns(&mut self, alterations: &[ColumnAlteration]) -> Result<()> {
         schema_evolution::alter_columns(self, alterations).await
     }
@@ -1333,10 +1241,121 @@ impl Dataset {
     ///
     /// This is a metadata-only operation and does not remove the data from the
     /// underlying storage. In order to remove the data, you must subsequently
-    /// call `compact_files` to rewrite the data without the removed columns and
-    /// then call `cleanup_old_versions` to remove the old files.
+    /// call [optimize::compact_files()] to rewrite the data without the removed columns and
+    /// then call [cleanup::cleanup_old_versions()] to remove the old files.
     pub async fn drop_columns(&mut self, columns: &[&str]) -> Result<()> {
         schema_evolution::drop_columns(self, columns).await
+    }
+
+    /// Drop columns from the dataset and return updated dataset. Note that this
+    /// is a zero-copy operation and column is not physically removed from the
+    /// dataset.
+    /// Parameters:
+    /// - `columns`: the list of column names to drop.
+    #[deprecated(since = "0.9.12", note = "Please use `drop_columns` instead.")]
+    pub async fn drop(&mut self, columns: &[&str]) -> Result<()> {
+        self.drop_columns(columns).await
+    }
+
+    async fn merge_impl(
+        &mut self,
+        stream: Box<dyn RecordBatchReader + Send>,
+        left_on: &str,
+        right_on: &str,
+    ) -> Result<()> {
+        // Sanity check.
+        if self.schema().field(left_on).is_none() {
+            return Err(Error::invalid_input(
+                format!("Column {} does not exist in the left side dataset", left_on),
+                location!(),
+            ));
+        };
+        let right_schema = stream.schema();
+        if right_schema.field_with_name(right_on).is_err() {
+            return Err(Error::invalid_input(
+                format!(
+                    "Column {} does not exist in the right side dataset",
+                    right_on
+                ),
+                location!(),
+            ));
+        };
+        for field in right_schema.fields() {
+            if field.name() == right_on {
+                // right_on is allowed to exist in the dataset, since it may be
+                // the same as left_on.
+                continue;
+            }
+            if self.schema().field(field.name()).is_some() {
+                return Err(Error::invalid_input(
+                    format!(
+                        "Column {} exists in both sides of the dataset",
+                        field.name()
+                    ),
+                    location!(),
+                ));
+            }
+        }
+
+        // Hash join
+        let joiner = Arc::new(HashJoiner::try_new(stream, right_on).await?);
+        // Final schema is union of current schema, plus the RHS schema without
+        // the right_on key.
+        let new_schema: Schema = self.schema().merge(joiner.out_schema().as_ref())?;
+
+        // Write new data file to each fragment. Parallelism is done over columns,
+        // so no parallelism done at this level.
+        let updated_fragments: Vec<Fragment> = stream::iter(self.get_fragments())
+            .then(|f| {
+                let joiner = joiner.clone();
+                async move { f.merge(left_on, &joiner).await.map(|f| f.metadata) }
+            })
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let transaction = Transaction::new(
+            self.manifest.version,
+            Operation::Merge {
+                fragments: updated_fragments,
+                schema: new_schema,
+            },
+            None,
+        );
+
+        let manifest = commit_transaction(
+            self,
+            &self.object_store,
+            self.commit_handler.as_ref(),
+            &transaction,
+            &Default::default(),
+            &Default::default(),
+        )
+        .await?;
+
+        self.manifest = Arc::new(manifest);
+
+        Ok(())
+    }
+
+    /// Merge this dataset with another arrow Table / Dataset, and returns a new version of dataset.
+    ///
+    /// Parameters:
+    ///
+    /// - `stream`: the stream of [`RecordBatch`] to merge.
+    /// - `left_on`: the column name to join on the left side (self).
+    /// - `right_on`: the column name to join on the right side (stream).
+    ///
+    /// Returns: a new version of dataset.
+    ///
+    /// It performs a left-join on the two datasets.
+    pub async fn merge(
+        &mut self,
+        stream: impl RecordBatchReader + Send + 'static,
+        left_on: &str,
+        right_on: &str,
+    ) -> Result<()> {
+        let stream = Box::new(stream);
+        self.merge_impl(stream, left_on, right_on).await
     }
 }
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1201,7 +1201,7 @@ impl Dataset {
 
 /// # Schema Evolution
 ///
-/// Lance datasets supports evolving the schema. Several operations are
+/// Lance datasets support evolving the schema. Several operations are
 /// supported that mirror common SQL operations:
 ///
 /// - [Self::add_columns()]: Add new columns to the dataset, similar to `ALTER TABLE ADD COLUMN`.


### PR DESCRIPTION
* Adds a documentation section for schema evolution methods, describing each.
* Consolidates methods for schema evolution in Rust, so they have their own header.