### PR TITLE
ci: fix docs deployment

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - docs/**
+      - .github/workflows/docs-check.yml
 
 env:
   # Disable full debug symbol generation to speed up CI build and keep memory down

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           cache: 'pip'
           cache-dependency-path: "docs/requirements.txt"
       - name: Install dependencies

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.11"
           cache: 'pip'
           cache-dependency-path: "docs/requirements.txt"
       - name: Install dependencies


### PR DESCRIPTION
In #1908, we upgraded all CI to Python 3.12, but noted that tensorflow doesn't support that Pyhton version. Unfortunately, this made our docs deployment failed, since we require tensorflow for those:

https://github.com/lancedb/lance/actions/runs/7791323487/job/21247154480

This brings down the required Python version for now.