### PR TITLE
feat: create an I/O scheduler that will eventually be used by the new file reader

### DIFF
--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -86,6 +86,10 @@ pub enum Error {
     InvalidTableLocation { message: String },
     /// Stream early stop
     Stop,
+    Wrapped {
+        error: BoxedError,
+        location: Location,
+    },
 }
 
 impl Error {

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -37,6 +37,7 @@ prost.workspace = true
 shellexpand.workspace = true
 snafu.workspace = true
 tokio.workspace = true
+tokio-stream = "0.1.14"
 tracing.workspace = true
 url.workspace = true
 

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -41,9 +41,15 @@ tracing.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+criterion.workspace = true
 parquet.workspace = true
+pprof.workspace = true
 rand.workspace = true
 tempfile.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true
+
+[[bench]]
+name = "scheduler"
+harness = false

--- a/rust/lance-io/benches/scheduler.rs
+++ b/rust/lance-io/benches/scheduler.rs
@@ -1,0 +1,238 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use lance_core::Result;
+use lance_io::{
+    object_store::ObjectStore,
+    scheduler::{BatchRequest, LoadedBatch, StoreScheduler},
+};
+use object_store::path::Path;
+use rand::{seq::SliceRandom, RngCore};
+use std::{fmt::Display, process::Command, sync::Arc};
+use tokio::{runtime::Runtime, sync::mpsc};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+#[cfg(target_os = "linux")]
+use pprof::criterion::{Output, PProfProfiler};
+
+#[derive(Clone, Copy, Debug)]
+struct FullReadParams {
+    io_parallelism: u32,
+    page_size: u64,
+}
+
+impl Display for FullReadParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "full_read,parallel={},read_size={}",
+            self.io_parallelism, self.page_size
+        )
+    }
+}
+
+async fn create_data(num_bytes: u64) -> (Arc<ObjectStore>, Path) {
+    let store_uri = std::env::var("STORE_URI").unwrap_or("/tmp/lance_bench".to_string());
+    println!(
+        "Reading from {}, use the environment variable STORE_URI to change this",
+        store_uri
+    );
+    let (obj_store, path) = ObjectStore::from_uri(&store_uri).await.unwrap();
+    let tmp_file = path.child("foo.file");
+
+    let mut some_data = vec![0; num_bytes as usize];
+    rand::thread_rng().fill_bytes(&mut some_data);
+    obj_store.put(&tmp_file, &some_data).await.unwrap();
+
+    (Arc::new(obj_store), tmp_file)
+}
+
+const DATA_SIZE: u64 = 128 * 1024 * 1024;
+
+async fn drain_task<F: std::future::Future<Output = Result<LoadedBatch<()>>>>(
+    mut rx: tokio::sync::mpsc::Receiver<F>,
+) -> u64 {
+    let mut bytes_received = 0;
+    while let Some(fut) = rx.recv().await {
+        let loaded = fut.await.unwrap();
+        bytes_received += loaded
+            .data_buffers
+            .iter()
+            .map(|bytes| bytes.len() as u64)
+            .sum::<u64>();
+    }
+    bytes_received
+}
+
+/// This benchmark creates a file with DATA_SIZE bytes and then reads from it sequentially
+/// with the given parallelism and read size
+fn bench_full_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("from_elem");
+
+    group.throughput(criterion::Throughput::Bytes(DATA_SIZE));
+
+    let runtime = Runtime::new().unwrap();
+    let (obj_store, tmp_file) = runtime.block_on(create_data(DATA_SIZE));
+
+    for io_parallelism in [1, 16, 32, 64] {
+        for page_size in [4096, 16 * 1024, 1024 * 1024] {
+            let params = FullReadParams {
+                io_parallelism,
+                page_size,
+            };
+            group.bench_with_input(BenchmarkId::from_parameter(params), &params, |b, params| {
+                b.iter(|| {
+                    let obj_store = obj_store.clone();
+                    if obj_store.is_local() {
+                        let path_str = format!("/{}", tmp_file);
+                        Command::new("dd")
+                            .arg(format!("of={}", path_str))
+                            .arg("oflag=nocache")
+                            .arg("conv=notrunc,fdatasync")
+                            .arg("count=0")
+                            .output()
+                            .unwrap();
+                    }
+                    runtime.block_on(async {
+                        let scheduler = StoreScheduler::new(obj_store, params.io_parallelism);
+                        let file_scheduler = scheduler.open_file(&tmp_file).await.unwrap();
+
+                        let (tx, rx) = mpsc::channel(1024);
+                        let drainer = tokio::spawn(drain_task(rx));
+                        let mut offset = 0;
+                        while offset < DATA_SIZE {
+                            #[allow(clippy::single_range_in_vec_init)]
+                            let req =
+                                BatchRequest::new_simple(vec![offset..(offset + params.page_size)]);
+                            let req = file_scheduler.submit_request(req);
+                            tx.send(req).await.unwrap();
+                            offset += params.page_size;
+                        }
+                        drop(tx);
+                        let bytes_received = drainer.await.unwrap();
+                        assert_eq!(bytes_received, DATA_SIZE);
+                    });
+                });
+            });
+        }
+    }
+}
+
+const INDICES_PER_ITER: usize = 1000;
+const INDICES_PER_BATCH: u32 = 10;
+
+#[derive(Clone, Debug)]
+struct RandomReadParams {
+    io_parallelism: u32,
+    item_size: u32,
+    indices: Arc<Vec<u32>>,
+}
+
+impl Display for RandomReadParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "random_read,parallel={},item_size={}",
+            self.io_parallelism, self.item_size
+        )
+    }
+}
+
+/// This benchmark creates a file with DATA_SIZE bytes which is then treated as
+/// a contiguous array of items with width `item_size`.  We read a random selection
+/// of INDICES_PER_ITER items from the array.  The selection is chosen randomly but
+/// sorted before reading (to mimic actual use and make coalescing easier)
+fn bench_random_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("from_elem");
+
+    group.throughput(criterion::Throughput::Elements(INDICES_PER_ITER as u64));
+
+    let runtime = Runtime::new().unwrap();
+    let (obj_store, tmp_file) = runtime.block_on(create_data(DATA_SIZE));
+
+    for io_parallelism in [1, 16, 32, 64] {
+        for item_size in [8, 1024, 4096] {
+            let num_indices = DATA_SIZE as u32 / item_size;
+            let mut rng = rand::thread_rng();
+            let mut indices = (0..num_indices).collect::<Vec<_>>();
+            let (shuffled, _) = indices.partial_shuffle(&mut rng, INDICES_PER_ITER);
+            let mut indices = shuffled.to_vec();
+            indices.sort_unstable();
+
+            let params = RandomReadParams {
+                io_parallelism,
+                item_size,
+                indices: Arc::new(indices),
+            };
+            group.bench_with_input(
+                BenchmarkId::from_parameter(&params),
+                &params,
+                |b, params| {
+                    b.iter(|| {
+                        let obj_store = obj_store.clone();
+                        if obj_store.is_local() {
+                            let path_str = format!("/{}", tmp_file);
+                            Command::new("dd")
+                                .arg(format!("of={}", path_str))
+                                .arg("oflag=nocache")
+                                .arg("conv=notrunc,fdatasync")
+                                .arg("count=0")
+                                .output()
+                                .unwrap();
+                        }
+                        runtime.block_on(async {
+                            let scheduler = StoreScheduler::new(obj_store, params.io_parallelism);
+                            let file_scheduler = scheduler.open_file(&tmp_file).await.unwrap();
+
+                            let (tx, rx) = mpsc::channel(1024);
+                            let drainer = tokio::spawn(drain_task(rx));
+                            let mut idx = 0;
+                            while idx < params.indices.len() {
+                                let iops = (idx..(idx + INDICES_PER_BATCH as usize))
+                                    .map(|idx| {
+                                        let start = idx as u64 * params.item_size as u64;
+                                        let end = start + params.item_size as u64;
+                                        start..end
+                                    })
+                                    .collect::<Vec<_>>();
+                                idx += INDICES_PER_BATCH as usize;
+                                let req = BatchRequest::new_simple(iops);
+                                let req = file_scheduler.submit_request(req);
+                                tx.send(req).await.unwrap();
+                            }
+                            drop(tx);
+                            let bytes_received = drainer.await.unwrap();
+                            assert_eq!(bytes_received, INDICES_PER_ITER as u64 * item_size as u64);
+                        });
+                    });
+                },
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+criterion_group!(
+    name=benches;
+    config = Criterion::default().significance_level(0.1).sample_size(10)
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets =bench_full_read, bench_random_read);
+
+#[cfg(not(target_os = "linux"))]
+criterion_group!(
+    name=benches;
+    config = Criterion::default().significance_level(0.1).sample_size(10);
+    targets = bench_full_read, bench_random_read);
+
+criterion_main!(benches);

--- a/rust/lance-io/src/lib.rs
+++ b/rust/lance-io/src/lib.rs
@@ -1,3 +1,16 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 
 use arrow_array::UInt32Array;
@@ -7,6 +20,7 @@ pub mod local;
 pub mod object_reader;
 pub mod object_store;
 pub mod object_writer;
+pub mod scheduler;
 pub mod stream;
 pub mod traits;
 pub mod utils;

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -14,112 +14,22 @@
 
 use bytes::Bytes;
 use futures::channel::oneshot;
-use futures::{FutureExt, Stream, StreamExt};
+use futures::{FutureExt, StreamExt};
 use object_store::path::Path;
 use snafu::{location, Location};
 use std::future::Future;
 use std::ops::Range;
 use std::sync::{Arc, Mutex};
-use std::task::Poll;
 use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use lance_core::{Error, Result};
 
 use crate::object_store::ObjectStore;
 use crate::traits::Reader;
 
-type FollowUpTask<C> = Box<dyn FnOnce(C, Vec<Bytes>) -> BatchRequest<C> + Send>;
-
-/// A collection of requested I/O operations with an optional follow-up task
-pub struct BatchRequest<C: Send> {
-    iops: Vec<Range<u64>>,
-    context: C,
-    follow_up: Option<FollowUpTask<C>>,
-}
-
-impl BatchRequest<()> {
-    /// Create a new simple request with no context or follow-up
-    ///
-    /// # Arguments
-    ///
-    /// * iops - the ranges to request.  There will be one `Bytes`
-    ///   instance in the response for each range (even if some
-    ///   ranges are coalesced).  For best performance these should
-    ///   be sorted so that the end of each range is less than or
-    ///   equal to the start of the next range
-    pub fn new_simple(iops: Vec<Range<u64>>) -> Self {
-        Self {
-            iops,
-            context: (),
-            follow_up: None,
-        }
-    }
-}
-
-impl<C: Send> BatchRequest<C> {
-    /// Create a new request with context
-    ///
-    /// The context will be delivered with the response.
-    ///
-    /// # Arguments
-    ///
-    /// * iops - the ranges to request.  See [`Self::new_simple`] for
-    ///   more details
-    /// * context - a context object.  This will be delivered with the
-    ///   response.
-    pub fn new_with_context(iops: Vec<Range<u64>>, context: C) -> Self {
-        Self {
-            iops,
-            context,
-            follow_up: None,
-        }
-    }
-
-    /// Create a new request with context and a follow-up
-    ///
-    /// The context will be delivered to the follow-up task and, eventually,
-    /// to the response.
-    ///
-    /// The follow-up task will be given the loaded data and then is expected
-    /// to generate an additional request.  For example, this is used when
-    /// doing an indirect load where the offsets or sizes of the desired data
-    /// are stored on disk.
-    ///
-    /// # Arguments
-    ///
-    /// * iops - the ranges to request.  See [`Self::new_simple`] for
-    ///   more details
-    /// * context - a context object.  This will be delivered with the
-    ///   response.
-    /// * follow_up - a follow up task that will generate the next chunk
-    ///   of I/O operations
-    pub fn new_with_follow_up<F: FnOnce(C, Vec<Bytes>) -> Self + Send + 'static>(
-        iops: Vec<Range<u64>>,
-        context: C,
-        follow_up: F,
-    ) -> Self {
-        Self {
-            iops,
-            context,
-            follow_up: Some(Box::new(follow_up)),
-        }
-    }
-}
-
-// A batch of data loaded in response to a BatchRequest
-pub struct LoadedBatch<C: Send> {
-    /// The loaded data, grouped into one or more data buffers
-    ///
-    /// Each requested Range will result in exactly one `Bytes` object in this
-    /// result.  This is true even if the ranges were coalesced into a single
-    /// read by the scheduler.
-    pub data_buffers: Vec<Bytes>,
-    /// The context object that was provided with the original request.
-    pub context: C,
-}
-
 // There is one instance of MutableBatch shared by all the I/O operations
-// that make up a single BatchRequest.  When all the I/O operations complete
+// that make up a single request.  When all the I/O operations complete
 // then the MutableBatch goes out of scope and the batch request is considered
 // complete
 struct MutableBatch<F: FnOnce(Result<Vec<Bytes>>) + Send> {
@@ -180,13 +90,13 @@ impl<F: FnOnce(Result<Vec<Bytes>>) + Send> DataSink for MutableBatch<F> {
     }
 }
 
-struct InnerIoTask {
+struct IoTask {
     reader: Arc<dyn Reader>,
     to_read: Range<u64>,
     when_done: Box<dyn FnOnce(Result<Bytes>) + Send>,
 }
 
-impl InnerIoTask {
+impl IoTask {
     async fn run(self) {
         let bytes = self
             .reader
@@ -196,46 +106,13 @@ impl InnerIoTask {
     }
 }
 
-// Combines two task receivers into a single stream of tasks
-//
-// If both receivers have data then items from the priority
-// queue will always be taken first.
-struct IoQueues {
-    regular_queue: mpsc::UnboundedReceiver<InnerIoTask>,
-    priority_queue: mpsc::UnboundedReceiver<InnerIoTask>,
-}
-
-impl Stream for IoQueues {
-    type Item = InnerIoTask;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        // If neither stream is ready then we will poll both of them
-        // and they will both register a waker with cx.  So we should get
-        // woken when either receiver receives an item
-        if let Poll::Ready(task) = self.priority_queue.poll_recv(cx) {
-            return Poll::Ready(task);
-        }
-        self.regular_queue.poll_recv(cx)
-    }
-}
-
 // Every time a scheduler starts up it launches a task to run the I/O loop.  This loop
 // repeats endlessly until the scheduler is destroyed.
-async fn run_io_loop(
-    tasks: mpsc::UnboundedReceiver<InnerIoTask>,
-    priority_tasks: mpsc::UnboundedReceiver<InnerIoTask>,
-    io_capacity: u32,
-) {
-    let io_queues = IoQueues {
-        priority_queue: priority_tasks,
-        regular_queue: tasks,
-    };
-    let task_stream = io_queues.map(|task| tokio::spawn(task.run()));
-    let mut task_stream = task_stream.buffer_unordered(io_capacity as usize);
-    while task_stream.next().await.is_some() {
+async fn run_io_loop(tasks: mpsc::UnboundedReceiver<IoTask>, io_capacity: u32) {
+    let io_stream = UnboundedReceiverStream::new(tasks);
+    let tokio_task_stream = io_stream.map(|task| tokio::spawn(task.run()));
+    let mut tokio_task_stream = tokio_task_stream.buffer_unordered(io_capacity as usize);
+    while tokio_task_stream.next().await.is_some() {
         // We don't actually do anything with the results here, they are sent
         // via the io tasks's when_done.  Instead we just keep chugging away
         // indefinitely until the tasks receiver returns none (scheduler has
@@ -249,8 +126,7 @@ async fn run_io_loop(
 /// TODO: This will also add coalescing
 pub struct StoreScheduler {
     object_store: Arc<ObjectStore>,
-    io_submitter: mpsc::UnboundedSender<InnerIoTask>,
-    priority_sender: Arc<mpsc::UnboundedSender<InnerIoTask>>,
+    io_submitter: mpsc::UnboundedSender<IoTask>,
 }
 
 impl StoreScheduler {
@@ -272,13 +148,11 @@ impl StoreScheduler {
         // from `when_done` futures to delivering data into a queue.  That queue should fill
         // up, causing the I/O loop to pause.
         let (reg_tx, reg_rx) = mpsc::unbounded_channel();
-        let (priority_tx, priority_rx) = mpsc::unbounded_channel();
         let scheduler = Self {
             object_store,
             io_submitter: reg_tx,
-            priority_sender: Arc::new(priority_tx),
         };
-        tokio::task::spawn(async move { run_io_loop(reg_rx, priority_rx, io_capacity).await });
+        tokio::task::spawn(async move { run_io_loop(reg_rx, io_capacity).await });
         scheduler
     }
 
@@ -291,47 +165,17 @@ impl StoreScheduler {
         })
     }
 
-    fn do_submit_request<C: Send + 'static>(
+    fn do_submit_request(
+        &self,
         reader: Arc<dyn Reader>,
-        request: BatchRequest<C>,
-        tx: oneshot::Sender<Result<LoadedBatch<C>>>,
-        priority_submitter: Arc<mpsc::UnboundedSender<InnerIoTask>>,
-        this_submitter: &mpsc::UnboundedSender<InnerIoTask>,
+        request: Vec<Range<u64>>,
+        tx: oneshot::Sender<Result<Vec<Bytes>>>,
     ) {
-        let num_iops = request.iops.len() as u32;
-
-        let context = request.context;
-        let follow_up = request.follow_up;
-        let reader_clone = reader.clone();
+        let num_iops = request.len() as u32;
 
         let when_all_io_done = move |bytes| {
-            match bytes {
-                Ok(bytes) => {
-                    if let Some(follow_up) = follow_up {
-                        // The current future is on the I/O critical path.  If the follow
-                        // up requires any significant CPU work then it will block
-                        // the I/O threads and so we run the follow-up in a new task
-                        tokio::task::spawn(async move {
-                            let next_req = (follow_up)(context, bytes);
-                            Self::do_submit_request(
-                                reader_clone,
-                                next_req,
-                                tx,
-                                priority_submitter.clone(),
-                                &priority_submitter,
-                            );
-                        });
-                    } else {
-                        let _ = tx.send(Ok(LoadedBatch {
-                            data_buffers: bytes,
-                            context,
-                        }));
-                    }
-                }
-                Err(err) => {
-                    let _ = tx.send(Err(err));
-                }
-            };
+            // We don't care if the receiver has given up
+            let _ = tx.send(bytes);
         };
 
         let dest = Arc::new(Mutex::new(Box::new(MutableBatch::new(
@@ -339,9 +183,9 @@ impl StoreScheduler {
             num_iops,
         ))));
 
-        for (task_idx, iop) in request.iops.into_iter().enumerate() {
+        for (task_idx, iop) in request.into_iter().enumerate() {
             let dest = dest.clone();
-            let task = InnerIoTask {
+            let task = IoTask {
                 reader: reader.clone(),
                 to_read: iop,
                 when_done: Box::new(move |bytes| {
@@ -349,26 +193,20 @@ impl StoreScheduler {
                     dest.deliver_data(bytes.map(|bytes| (task_idx, bytes)));
                 }),
             };
-            this_submitter
+            self.io_submitter
                 .send(task)
                 .expect("I/O scheduler thread panic'd");
         }
     }
 
-    fn submit_request<C: Send + 'static>(
+    fn submit_request(
         &self,
         reader: Arc<dyn Reader>,
-        request: BatchRequest<C>,
-    ) -> impl Future<Output = Result<LoadedBatch<C>>> + Send {
-        let (tx, rx) = oneshot::channel::<Result<LoadedBatch<C>>>();
+        request: Vec<Range<u64>>,
+    ) -> impl Future<Output = Result<Vec<Bytes>>> + Send {
+        let (tx, rx) = oneshot::channel::<Result<Vec<Bytes>>>();
 
-        Self::do_submit_request(
-            reader,
-            request,
-            tx,
-            self.priority_sender.clone(),
-            &self.io_submitter,
-        );
+        self.do_submit_request(reader, request, tx);
 
         // Right now, it isn't possible for I/O to be cancelled so a cancel error should
         // not occur
@@ -387,22 +225,18 @@ impl<'a> FileScheduler<'a> {
     ///
     /// The requests will be queued in a FIFO manner and, when all requests
     /// have been fulfilled, the returned future will be completed.
-    pub fn submit_request<C: Send + 'static>(
+    pub fn submit_request(
         &self,
-        request: BatchRequest<C>,
-    ) -> impl Future<Output = Result<LoadedBatch<C>>> + Send {
+        request: Vec<Range<u64>>,
+    ) -> impl Future<Output = Result<Vec<Bytes>>> + Send {
         self.root.submit_request(self.reader.clone(), request)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::VecDeque, mem::size_of};
+    use std::collections::VecDeque;
 
-    use arrow_array::UInt32Array;
-    use arrow_buffer::ScalarBuffer;
-    use byteorder::{LittleEndian, WriteBytesExt};
-    use bytes::BufMut;
     use object_store::path::Path;
     use rand::RngCore;
     use tempfile::tempdir;
@@ -436,7 +270,7 @@ mod tests {
             reqs.push_back(
                 #[allow(clippy::single_range_in_vec_init)]
                 file_scheduler
-                    .submit_request(BatchRequest::new_simple(vec![offset..offset + READ_SIZE]))
+                    .submit_request(vec![offset..offset + READ_SIZE])
                     .await
                     .unwrap(),
             );
@@ -447,123 +281,10 @@ mod tests {
         // Note: we should get parallel I/O even though we are consuming serially
         while offset < DATA_SIZE {
             let data = reqs.pop_front().unwrap();
-            let actual = &data.data_buffers[0];
+            let actual = &data[0];
             let expected = &some_data[offset as usize..(offset + READ_SIZE) as usize];
             assert_eq!(expected, actual);
             offset += READ_SIZE;
-        }
-    }
-
-    // This simulates the variable sized binary decoder
-    struct IndirectReadContext {
-        base_offset: u64,
-        offsets: Option<Vec<UInt32Array>>,
-    }
-
-    fn indirect_read_follow_up(
-        mut context: IndirectReadContext,
-        data: Vec<Bytes>,
-    ) -> BatchRequest<IndirectReadContext> {
-        let (iops, offsets): (Vec<_>, Vec<_>) = data
-            .into_iter()
-            .map(|bytes| {
-                let length = bytes.len() / size_of::<u32>();
-                debug_assert!(length > 1);
-                let offsets = ScalarBuffer::<u32>::new(bytes.into(), 0, length);
-                let start = context.base_offset + offsets[0] as u64;
-                let end = context.base_offset + offsets[length - 1] as u64;
-                let offsets = UInt32Array::new(offsets, None);
-                (start..end, offsets)
-            })
-            .unzip();
-        context.offsets = Some(offsets);
-        BatchRequest::new_with_context(iops, context)
-    }
-
-    #[tokio::test]
-    async fn test_full_indirect_read() {
-        let tmpdir = tempdir().unwrap();
-        let tmp_path = tmpdir.path().to_str().unwrap();
-        let tmp_path = Path::parse(tmp_path).unwrap();
-        let tmp_file = tmp_path.child("foo.file");
-
-        let obj_store = Arc::new(ObjectStore::local());
-
-        // We will pretend this is binary data and write 32Ki strings consisting
-        // of 32 characters each (1MiB of data + (256KiB + 8B) of offsets)
-        const STRING_WIDTH: u64 = 32;
-        const NUM_STRINGS: u64 = 32 * 1024;
-        const DATA_SIZE: u64 = STRING_WIDTH * NUM_STRINGS;
-        const OFFSET_SIZE: u64 = size_of::<u32>() as u64 * (NUM_STRINGS + 1);
-        let mut some_data = Vec::with_capacity((DATA_SIZE + OFFSET_SIZE) as usize);
-        // Initialize the offsets section with offsets
-        some_data.write_u32::<LittleEndian>(0).unwrap();
-        for idx in 0..NUM_STRINGS {
-            some_data
-                .write_u32::<LittleEndian>((idx as u32 + 1) * 32)
-                .unwrap();
-        }
-        // Initialize the data section with random data
-        some_data.put_bytes(0, DATA_SIZE as usize);
-        rand::thread_rng().fill_bytes(&mut some_data[OFFSET_SIZE as usize..]);
-        obj_store.put(&tmp_file, &some_data).await.unwrap();
-
-        let scheduler = StoreScheduler::new(obj_store, 16);
-
-        let file_scheduler = scheduler.open_file(&tmp_file).await.unwrap();
-
-        // Read it back in one big read
-        let indirect_context = IndirectReadContext {
-            base_offset: OFFSET_SIZE,
-            offsets: None,
-        };
-        #[allow(clippy::single_range_in_vec_init)]
-        let req = BatchRequest::new_with_follow_up(
-            vec![0..OFFSET_SIZE],
-            indirect_context,
-            indirect_read_follow_up,
-        );
-        let data = file_scheduler.submit_request(req).await.unwrap();
-
-        assert_eq!(data.data_buffers.len(), 1);
-        assert_eq!(data.data_buffers[0], some_data[OFFSET_SIZE as usize..]);
-
-        let offsets = data.context.offsets.unwrap().into_iter().next().unwrap();
-        assert!(offsets
-            .values()
-            .iter()
-            .enumerate()
-            .all(|(idx, len)| *len == (idx as u32 * STRING_WIDTH as u32)));
-
-        // // Read it back in batches
-        let mut reqs = VecDeque::new();
-        let mut offset = 0;
-        const BATCH_SIZE: u64 = 1024 * size_of::<u32>() as u64;
-        while offset < OFFSET_SIZE {
-            let indirect_context = IndirectReadContext {
-                base_offset: OFFSET_SIZE,
-                offsets: None,
-            };
-            #[allow(clippy::single_range_in_vec_init)]
-            let req = BatchRequest::new_with_follow_up(
-                vec![offset..offset + BATCH_SIZE + size_of::<u32>() as u64],
-                indirect_context,
-                indirect_read_follow_up,
-            );
-            reqs.push_back(file_scheduler.submit_request(req));
-            offset += BATCH_SIZE;
-        }
-
-        let mut data_offset = OFFSET_SIZE;
-        const DATA_BATCH_SIZE: u64 = 1024 * STRING_WIDTH;
-        // Note: we should get parallel I/O even though we are consuming serially
-        while data_offset < DATA_SIZE {
-            let data = reqs.pop_front().unwrap().await.unwrap();
-            let actual = &data.data_buffers[0];
-            let expected =
-                &some_data[data_offset as usize..(data_offset + DATA_BATCH_SIZE) as usize];
-            assert_eq!(expected, actual);
-            data_offset += DATA_BATCH_SIZE;
         }
     }
 }

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -1,0 +1,569 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::Bytes;
+use futures::channel::oneshot;
+use futures::{FutureExt, Stream, StreamExt};
+use object_store::path::Path;
+use snafu::{location, Location};
+use std::future::Future;
+use std::ops::Range;
+use std::sync::{Arc, Mutex};
+use std::task::Poll;
+use tokio::sync::mpsc;
+
+use lance_core::{Error, Result};
+
+use crate::object_store::ObjectStore;
+use crate::traits::Reader;
+
+type FollowUpTask<C> = Box<dyn FnOnce(C, Vec<Bytes>) -> BatchRequest<C> + Send>;
+
+/// A collection of requested I/O operations with an optional follow-up task
+pub struct BatchRequest<C: Send> {
+    iops: Vec<Range<u64>>,
+    context: C,
+    follow_up: Option<FollowUpTask<C>>,
+}
+
+impl BatchRequest<()> {
+    /// Create a new simple request with no context or follow-up
+    ///
+    /// # Arguments
+    ///
+    /// * iops - the ranges to request.  There will be one `Bytes`
+    ///   instance in the response for each range (even if some
+    ///   ranges are coalesced).  For best performance these should
+    ///   be sorted so that the end of each range is less than or
+    ///   equal to the start of the next range
+    pub fn new_simple(iops: Vec<Range<u64>>) -> Self {
+        Self {
+            iops,
+            context: (),
+            follow_up: None,
+        }
+    }
+}
+
+impl<C: Send> BatchRequest<C> {
+    /// Create a new request with context
+    ///
+    /// The context will be delivered with the response.
+    ///
+    /// # Arguments
+    ///
+    /// * iops - the ranges to request.  See [`Self::new_simple`] for
+    ///   more details
+    /// * context - a context object.  This will be delivered with the
+    ///   response.
+    pub fn new_with_context(iops: Vec<Range<u64>>, context: C) -> Self {
+        Self {
+            iops,
+            context,
+            follow_up: None,
+        }
+    }
+
+    /// Create a new request with context and a follow-up
+    ///
+    /// The context will be delivered to the follow-up task and, eventually,
+    /// to the response.
+    ///
+    /// The follow-up task will be given the loaded data and then is expected
+    /// to generate an additional request.  For example, this is used when
+    /// doing an indirect load where the offsets or sizes of the desired data
+    /// are stored on disk.
+    ///
+    /// # Arguments
+    ///
+    /// * iops - the ranges to request.  See [`Self::new_simple`] for
+    ///   more details
+    /// * context - a context object.  This will be delivered with the
+    ///   response.
+    /// * follow_up - a follow up task that will generate the next chunk
+    ///   of I/O operations
+    pub fn new_with_follow_up<F: FnOnce(C, Vec<Bytes>) -> Self + Send + 'static>(
+        iops: Vec<Range<u64>>,
+        context: C,
+        follow_up: F,
+    ) -> Self {
+        Self {
+            iops,
+            context,
+            follow_up: Some(Box::new(follow_up)),
+        }
+    }
+}
+
+// A batch of data loaded in response to a BatchRequest
+pub struct LoadedBatch<C: Send> {
+    /// The loaded data, grouped into one or more data buffers
+    ///
+    /// Each requested Range will result in exactly one `Bytes` object in this
+    /// result.  This is true even if the ranges were coalesced into a single
+    /// read by the scheduler.
+    pub data_buffers: Vec<Bytes>,
+    /// The context object that was provided with the original request.
+    pub context: C,
+}
+
+// There is one instance of MutableBatch shared by all the I/O operations
+// that make up a single BatchRequest.  When all the I/O operations complete
+// then the MutableBatch goes out of scope and the batch request is considered
+// complete
+struct MutableBatch<F: FnOnce(Result<Vec<Bytes>>) + Send> {
+    when_done: Option<F>,
+    data_buffers: Vec<Bytes>,
+    err: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+}
+
+impl<F: FnOnce(Result<Vec<Bytes>>) + Send> MutableBatch<F> {
+    fn new(when_done: F, num_data_buffers: u32) -> Self {
+        Self {
+            when_done: Some(when_done),
+            data_buffers: vec![Bytes::default(); num_data_buffers as usize],
+            err: None,
+        }
+    }
+}
+
+// Rather than keep track of when all the I/O requests are finished so that we
+// can deliver the batch of data we let Rust do that for us.  When all I/O's are
+// done then the MutableBatch will go out of scope and we know we have all the
+// data.
+impl<F: FnOnce(Result<Vec<Bytes>>) + Send> Drop for MutableBatch<F> {
+    fn drop(&mut self) {
+        // If we have an error, return that.  Otherwise return the data
+        let result = if self.err.is_some() {
+            Err(Error::Wrapped {
+                error: self.err.take().unwrap(),
+                location: location!(),
+            })
+        } else {
+            let mut data = Vec::new();
+            std::mem::swap(&mut data, &mut self.data_buffers);
+            Ok(data)
+        };
+        // We don't really care if no one is around to receive it, just let
+        // the result go out of scope and get cleaned up
+        (self.when_done.take().unwrap())(result);
+    }
+}
+
+trait DataSink: Send {
+    fn deliver_data(&mut self, data: Result<(usize, Bytes)>);
+}
+
+impl<F: FnOnce(Result<Vec<Bytes>>) + Send> DataSink for MutableBatch<F> {
+    // Called by worker tasks to add data to the MutableBatch
+    fn deliver_data(&mut self, data: Result<(usize, Bytes)>) {
+        match data {
+            Ok(data) => {
+                self.data_buffers[data.0] = data.1;
+            }
+            Err(err) => {
+                // This keeps the original error, if present
+                self.err.get_or_insert(Box::new(err));
+            }
+        }
+    }
+}
+
+struct InnerIoTask {
+    reader: Arc<dyn Reader>,
+    to_read: Range<u64>,
+    when_done: Box<dyn FnOnce(Result<Bytes>) + Send>,
+}
+
+impl InnerIoTask {
+    async fn run(self) {
+        let bytes = self
+            .reader
+            .get_range(self.to_read.start as usize..self.to_read.end as usize)
+            .await;
+        (self.when_done)(bytes);
+    }
+}
+
+// Combines two task receivers into a single stream of tasks
+//
+// If both receivers have data then items from the priority
+// queue will always be taken first.
+struct IoQueues {
+    regular_queue: mpsc::UnboundedReceiver<InnerIoTask>,
+    priority_queue: mpsc::UnboundedReceiver<InnerIoTask>,
+}
+
+impl Stream for IoQueues {
+    type Item = InnerIoTask;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        // If neither stream is ready then we will poll both of them
+        // and they will both register a waker with cx.  So we should get
+        // woken when either receiver receives an item
+        if let Poll::Ready(task) = self.priority_queue.poll_recv(cx) {
+            return Poll::Ready(task);
+        }
+        self.regular_queue.poll_recv(cx)
+    }
+}
+
+// Every time a scheduler starts up it launches a task to run the I/O loop.  This loop
+// repeats endlessly until the scheduler is destroyed.
+async fn run_io_loop(
+    tasks: mpsc::UnboundedReceiver<InnerIoTask>,
+    priority_tasks: mpsc::UnboundedReceiver<InnerIoTask>,
+    io_capacity: u32,
+) {
+    let io_queues = IoQueues {
+        priority_queue: priority_tasks,
+        regular_queue: tasks,
+    };
+    let task_stream = io_queues.map(|task| tokio::spawn(task.run()));
+    let mut task_stream = task_stream.buffer_unordered(io_capacity as usize);
+    while task_stream.next().await.is_some() {
+        // We don't actually do anything with the results here, they are sent
+        // via the io tasks's when_done.  Instead we just keep chugging away
+        // indefinitely until the tasks receiver returns none (scheduler has
+        // been shut down)
+    }
+}
+
+/// An I/O scheduler which wraps an ObjectStore and throttles the amount of\
+/// parallel I/O that can be run.
+///
+/// TODO: This will also add coalescing
+pub struct StoreScheduler {
+    object_store: Arc<ObjectStore>,
+    io_submitter: mpsc::UnboundedSender<InnerIoTask>,
+    priority_sender: Arc<mpsc::UnboundedSender<InnerIoTask>>,
+}
+
+impl StoreScheduler {
+    /// Create a new scheduler with the given I/O capacity
+    ///
+    /// # Arguments
+    ///
+    /// * object_store - the store to wrap
+    /// * io_capacity - the maximum number of parallel requests that will be allowed
+    pub fn new(object_store: Arc<ObjectStore>, io_capacity: u32) -> Self {
+        // TODO: we don't have any backpressure in place if the compute thread falls
+        // behind.  The scheduler thread will schedule ALL of the I/O and then the
+        // loaded data will eventually pile up.
+        //
+        // We could bound this channel but that wouldn't help.  If the decode thread
+        // was paused then the I/O loop would keep running and reading from this channel.
+        //
+        // Once the reader is finished we should revisit.  We will probably want to convert
+        // from `when_done` futures to delivering data into a queue.  That queue should fill
+        // up, causing the I/O loop to pause.
+        let (reg_tx, reg_rx) = mpsc::unbounded_channel();
+        let (priority_tx, priority_rx) = mpsc::unbounded_channel();
+        let scheduler = Self {
+            object_store,
+            io_submitter: reg_tx,
+            priority_sender: Arc::new(priority_tx),
+        };
+        tokio::task::spawn(async move { run_io_loop(reg_rx, priority_rx, io_capacity).await });
+        scheduler
+    }
+
+    /// Open a file for reading
+    pub async fn open_file(&self, path: &Path) -> Result<FileScheduler> {
+        let reader = self.object_store.open(path).await?;
+        Ok(FileScheduler {
+            reader: reader.into(),
+            root: self,
+        })
+    }
+
+    fn do_submit_request<C: Send + 'static>(
+        reader: Arc<dyn Reader>,
+        request: BatchRequest<C>,
+        tx: oneshot::Sender<Result<LoadedBatch<C>>>,
+        priority_submitter: Arc<mpsc::UnboundedSender<InnerIoTask>>,
+        this_submitter: &mpsc::UnboundedSender<InnerIoTask>,
+    ) {
+        let num_iops = request.iops.len() as u32;
+
+        let context = request.context;
+        let follow_up = request.follow_up;
+        let reader_clone = reader.clone();
+
+        let when_all_io_done = move |bytes| {
+            match bytes {
+                Ok(bytes) => {
+                    if let Some(follow_up) = follow_up {
+                        // The current future is on the I/O critical path.  If the follow
+                        // up requires any significant CPU work then it will block
+                        // the I/O threads and so we run the follow-up in a new task
+                        tokio::task::spawn(async move {
+                            let next_req = (follow_up)(context, bytes);
+                            Self::do_submit_request(
+                                reader_clone,
+                                next_req,
+                                tx,
+                                priority_submitter.clone(),
+                                &priority_submitter,
+                            );
+                        });
+                    } else {
+                        let _ = tx.send(Ok(LoadedBatch {
+                            data_buffers: bytes,
+                            context,
+                        }));
+                    }
+                }
+                Err(err) => {
+                    let _ = tx.send(Err(err));
+                }
+            };
+        };
+
+        let dest = Arc::new(Mutex::new(Box::new(MutableBatch::new(
+            when_all_io_done,
+            num_iops,
+        ))));
+
+        for (task_idx, iop) in request.iops.into_iter().enumerate() {
+            let dest = dest.clone();
+            let task = InnerIoTask {
+                reader: reader.clone(),
+                to_read: iop,
+                when_done: Box::new(move |bytes| {
+                    let mut dest = dest.lock().unwrap();
+                    dest.deliver_data(bytes.map(|bytes| (task_idx, bytes)));
+                }),
+            };
+            this_submitter
+                .send(task)
+                .expect("I/O scheduler thread panic'd");
+        }
+    }
+
+    fn submit_request<C: Send + 'static>(
+        &self,
+        reader: Arc<dyn Reader>,
+        request: BatchRequest<C>,
+    ) -> impl Future<Output = Result<LoadedBatch<C>>> + Send {
+        let (tx, rx) = oneshot::channel::<Result<LoadedBatch<C>>>();
+
+        Self::do_submit_request(
+            reader,
+            request,
+            tx,
+            self.priority_sender.clone(),
+            &self.io_submitter,
+        );
+
+        // Right now, it isn't possible for I/O to be cancelled so a cancel error should
+        // not occur
+        rx.map(|wrapped_err| wrapped_err.unwrap())
+    }
+}
+
+/// A throttled file reader
+pub struct FileScheduler<'a> {
+    reader: Arc<dyn Reader>,
+    root: &'a StoreScheduler,
+}
+
+impl<'a> FileScheduler<'a> {
+    /// Submit a batch of I/O requests to the reader
+    ///
+    /// The requests will be queued in a FIFO manner and, when all requests
+    /// have been fulfilled, the returned future will be completed.
+    pub fn submit_request<C: Send + 'static>(
+        &self,
+        request: BatchRequest<C>,
+    ) -> impl Future<Output = Result<LoadedBatch<C>>> + Send {
+        self.root.submit_request(self.reader.clone(), request)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::VecDeque, mem::size_of};
+
+    use arrow_array::UInt32Array;
+    use arrow_buffer::ScalarBuffer;
+    use byteorder::{LittleEndian, WriteBytesExt};
+    use bytes::BufMut;
+    use object_store::path::Path;
+    use rand::RngCore;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_full_seq_read() {
+        let tmpdir = tempdir().unwrap();
+        let tmp_path = tmpdir.path().to_str().unwrap();
+        let tmp_path = Path::parse(tmp_path).unwrap();
+        let tmp_file = tmp_path.child("foo.file");
+
+        let obj_store = Arc::new(ObjectStore::local());
+
+        // Write 1MiB of data
+        const DATA_SIZE: u64 = 1024 * 1024;
+        let mut some_data = vec![0; DATA_SIZE as usize];
+        rand::thread_rng().fill_bytes(&mut some_data);
+        obj_store.put(&tmp_file, &some_data).await.unwrap();
+
+        let scheduler = StoreScheduler::new(obj_store, 16);
+
+        let file_scheduler = scheduler.open_file(&tmp_file).await.unwrap();
+
+        // Read it back 4KiB at a time
+        const READ_SIZE: u64 = 4 * 1024;
+        let mut reqs = VecDeque::new();
+        let mut offset = 0;
+        while offset < DATA_SIZE {
+            reqs.push_back(
+                #[allow(clippy::single_range_in_vec_init)]
+                file_scheduler
+                    .submit_request(BatchRequest::new_simple(vec![offset..offset + READ_SIZE]))
+                    .await
+                    .unwrap(),
+            );
+            offset += READ_SIZE;
+        }
+
+        offset = 0;
+        // Note: we should get parallel I/O even though we are consuming serially
+        while offset < DATA_SIZE {
+            let data = reqs.pop_front().unwrap();
+            let actual = &data.data_buffers[0];
+            let expected = &some_data[offset as usize..(offset + READ_SIZE) as usize];
+            assert_eq!(expected, actual);
+            offset += READ_SIZE;
+        }
+    }
+
+    // This simulates the variable sized binary decoder
+    struct IndirectReadContext {
+        base_offset: u64,
+        offsets: Option<Vec<UInt32Array>>,
+    }
+
+    fn indirect_read_follow_up(
+        mut context: IndirectReadContext,
+        data: Vec<Bytes>,
+    ) -> BatchRequest<IndirectReadContext> {
+        let (iops, offsets): (Vec<_>, Vec<_>) = data
+            .into_iter()
+            .map(|bytes| {
+                let length = bytes.len() / size_of::<u32>();
+                debug_assert!(length > 1);
+                let offsets = ScalarBuffer::<u32>::new(bytes.into(), 0, length);
+                let start = context.base_offset + offsets[0] as u64;
+                let end = context.base_offset + offsets[length - 1] as u64;
+                let offsets = UInt32Array::new(offsets, None);
+                (start..end, offsets)
+            })
+            .unzip();
+        context.offsets = Some(offsets);
+        BatchRequest::new_with_context(iops, context)
+    }
+
+    #[tokio::test]
+    async fn test_full_indirect_read() {
+        let tmpdir = tempdir().unwrap();
+        let tmp_path = tmpdir.path().to_str().unwrap();
+        let tmp_path = Path::parse(tmp_path).unwrap();
+        let tmp_file = tmp_path.child("foo.file");
+
+        let obj_store = Arc::new(ObjectStore::local());
+
+        // We will pretend this is binary data and write 32Ki strings consisting
+        // of 32 characters each (1MiB of data + (256KiB + 8B) of offsets)
+        const STRING_WIDTH: u64 = 32;
+        const NUM_STRINGS: u64 = 32 * 1024;
+        const DATA_SIZE: u64 = STRING_WIDTH * NUM_STRINGS;
+        const OFFSET_SIZE: u64 = size_of::<u32>() as u64 * (NUM_STRINGS + 1);
+        let mut some_data = Vec::with_capacity((DATA_SIZE + OFFSET_SIZE) as usize);
+        // Initialize the offsets section with offsets
+        some_data.write_u32::<LittleEndian>(0).unwrap();
+        for idx in 0..NUM_STRINGS {
+            some_data
+                .write_u32::<LittleEndian>((idx as u32 + 1) * 32)
+                .unwrap();
+        }
+        // Initialize the data section with random data
+        some_data.put_bytes(0, DATA_SIZE as usize);
+        rand::thread_rng().fill_bytes(&mut some_data[OFFSET_SIZE as usize..]);
+        obj_store.put(&tmp_file, &some_data).await.unwrap();
+
+        let scheduler = StoreScheduler::new(obj_store, 16);
+
+        let file_scheduler = scheduler.open_file(&tmp_file).await.unwrap();
+
+        // Read it back in one big read
+        let indirect_context = IndirectReadContext {
+            base_offset: OFFSET_SIZE,
+            offsets: None,
+        };
+        #[allow(clippy::single_range_in_vec_init)]
+        let req = BatchRequest::new_with_follow_up(
+            vec![0..OFFSET_SIZE],
+            indirect_context,
+            indirect_read_follow_up,
+        );
+        let data = file_scheduler.submit_request(req).await.unwrap();
+
+        assert_eq!(data.data_buffers.len(), 1);
+        assert_eq!(data.data_buffers[0], some_data[OFFSET_SIZE as usize..]);
+
+        let offsets = data.context.offsets.unwrap().into_iter().next().unwrap();
+        assert!(offsets
+            .values()
+            .iter()
+            .enumerate()
+            .all(|(idx, len)| *len == (idx as u32 * STRING_WIDTH as u32)));
+
+        // // Read it back in batches
+        let mut reqs = VecDeque::new();
+        let mut offset = 0;
+        const BATCH_SIZE: u64 = 1024 * size_of::<u32>() as u64;
+        while offset < OFFSET_SIZE {
+            let indirect_context = IndirectReadContext {
+                base_offset: OFFSET_SIZE,
+                offsets: None,
+            };
+            #[allow(clippy::single_range_in_vec_init)]
+            let req = BatchRequest::new_with_follow_up(
+                vec![offset..offset + BATCH_SIZE + size_of::<u32>() as u64],
+                indirect_context,
+                indirect_read_follow_up,
+            );
+            reqs.push_back(file_scheduler.submit_request(req));
+            offset += BATCH_SIZE;
+        }
+
+        let mut data_offset = OFFSET_SIZE;
+        const DATA_BATCH_SIZE: u64 = 1024 * STRING_WIDTH;
+        // Note: we should get parallel I/O even though we are consuming serially
+        while data_offset < DATA_SIZE {
+            let data = reqs.pop_front().unwrap().await.unwrap();
+            let actual = &data.data_buffers[0];
+            let expected =
+                &some_data[data_offset as usize..(data_offset + DATA_BATCH_SIZE) as usize];
+            assert_eq!(expected, actual);
+            data_offset += DATA_BATCH_SIZE;
+        }
+    }
+}


### PR DESCRIPTION
I'm trying to commit the new file reader as a series of smaller PRs to help with the review.  This is an early PR that adds an I/O scheduler and some benchmarks.