### PR TITLE
ci: remove stdsimd reference

### DIFF
--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -67,3 +67,7 @@ harness = false
 [[bench]]
 name = "pq_dist_table"
 harness = false
+
+[features]
+default = []
+stdsimd = []

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -67,7 +67,3 @@ harness = false
 [[bench]]
 name = "pq_dist_table"
 harness = false
-
-[features]
-default = []
-stdsimd = []

--- a/rust/lance-index/build.rs
+++ b/rust/lance-index/build.rs
@@ -1,7 +1,5 @@
 use std::io::Result;
 
-use rustc_version::{version_meta, Channel};
-
 fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=protos");
 

--- a/rust/lance-index/build.rs
+++ b/rust/lance-index/build.rs
@@ -3,10 +3,6 @@ use std::io::Result;
 use rustc_version::{version_meta, Channel};
 
 fn main() -> Result<()> {
-    if version_meta().unwrap().channel == Channel::Nightly {
-        println!("cargo:rustc-cfg=nightly");
-    }
-
     println!("cargo:rerun-if-changed=protos");
 
     let mut prost_build = prost_build::Config::new();

--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -14,8 +14,6 @@
 
 //! Lance secondary index library
 
-#![cfg_attr(all(nightly, feature = "stdsimd"), feature(stdsimd))]
-
 use std::{any::Any, sync::Arc};
 
 use async_trait::async_trait;

--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -14,7 +14,7 @@
 
 //! Lance secondary index library
 
-#![cfg_attr(nightly, feature(stdsimd))]
+#![cfg_attr(all(nightly, feature = "stdsimd"), feature(stdsimd))]
 
 use std::{any::Any, sync::Arc};
 


### PR DESCRIPTION
Our build was broken because the `stdsimd` feature went away:

https://docs.rs/crate/lance/0.9.14/builds/1117911

But it doesn't seem like we actually use any SIMD in the index crate anyways, so I'm just removing that line. (It seems all the SIMD was moved to the `linalg` crate.