### PR TITLE
fix: repair the filter keyword in the torch dataset loader

### DIFF
--- a/python/python/lance/sampler.py
+++ b/python/python/lance/sampler.py
@@ -210,6 +210,7 @@ class Sampler(ABC):
         *args,
         batch_size: int = 128,
         columns: Optional[List[str]] = None,
+        filter: Optional[str] = None,
         batch_readahead: int = 16,
         with_row_id: bool = False,
         **kwargs,
@@ -231,6 +232,7 @@ class FragmentSampler(Sampler):
         *args,
         batch_size: int = 128,
         columns: Optional[List[str]] = None,
+        filter: Optional[str] = None,
         batch_readahead: int = 16,
         with_row_id: bool = False,
         **kwargs,
@@ -239,6 +241,7 @@ class FragmentSampler(Sampler):
             for batch in fragment.to_batches(
                 batch_size=batch_size,
                 columns=columns,
+                filter=filter,
                 with_row_id=with_row_id,
                 batch_readahead=batch_readahead,
             ):
@@ -346,6 +349,7 @@ class ShardedBatchSampler(Sampler):
         *args,
         batch_size: int = 128,
         columns: Optional[List[str]] = None,
+        filter: Optional[str] = None,
         batch_readahead: int = 16,
         with_row_id: Optional[bool] = None,
         **kwargs,
@@ -356,6 +360,9 @@ class ShardedBatchSampler(Sampler):
             warnings.warn(
                 "with_row_id is not supported for ShardedBatchSampler",
             )
+
+        if filter is not None:
+            raise ValueError("`filter` is not supported with ShardedBatchSampler")
 
         def _gen_ranges():
             for start in range(

--- a/python/python/lance/torch/data.py
+++ b/python/python/lance/torch/data.py
@@ -172,7 +172,9 @@ class LanceDataset(torch.utils.data.IterableDataset):
             The names of the column to read, by default None, which means reading all
             columns.
         filter : str, optional
-            If set, only rows that match the filter will be read.
+            If set, only rows that match the filter will be read.  Currently, this
+            can only be used when doing a full scan (`sampler` is None and
+            shard_granularity is None or "fragment" and `samples` is None)
         cache : str or bool, optional
             If set true, the dataset will be cached on disk from the first iteration.
             The following iterations will read from the cache.
@@ -219,7 +221,7 @@ class LanceDataset(torch.utils.data.IterableDataset):
                 if rank is not None or world_size is not None:
                     warnings.warn(
                         "rank and world_size are deprecated,"
-                        + " use SharedFragmentSampler instead.",
+                        + " use ShardedFragmentSampler instead.",
                     )
                     sampler = ShardedFragmentSampler(rank=rank, world_size=world_size)
                 else:
@@ -231,10 +233,10 @@ class LanceDataset(torch.utils.data.IterableDataset):
             else:
                 raise ValueError("Invalid shard_granularity: {}")
 
-        self.sampler: Sampler = sampler
+        if filter is not None and self.samples > 0 or self.samples is None:
+            raise ValueError("`filter` is not supported with `samples`")
 
-        if (samples is not None or sampler is not None) and filter is not None:
-            raise ValueError("Does not support sampling over filtered dataset")
+        self.sampler: Sampler = sampler
 
         self.cache = cache
         self.cached_ds: Optional[CachedDataset] = None
@@ -258,6 +260,7 @@ class LanceDataset(torch.utils.data.IterableDataset):
                 raw_stream = self.sampler(
                     self.dataset,
                     columns=self.columns,
+                    filter=self.filter,
                     batch_size=self.batch_size,
                     with_row_id=self.with_row_id,
                     batch_readahead=self.batch_readahead,


### PR DESCRIPTION
When support was added for sampling in #1900 it broke support for filtering on full scans (sampling and filtering is not yet supported).  This PR repairs support for filtering on full scans.

Closes #1932 