### PR TITLE
feat: add support for scalar indices on temporal columns

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1177,9 +1177,16 @@ class LanceDataset(pa.dataset.Dataset):
             and not pa.types.is_floating(field.type)
             and not pa.types.is_boolean(field.type)
             and not pa.types.is_string(field.type)
+            and not pa.types.is_temporal(field.type)
         ):
             raise TypeError(
-                f"Scalar index column {column} must be int, float, bool, or str"
+                f"Scalar index column {column} must be int",
+                ", float, bool, str, or temporal",
+            )
+
+        if pa.types.is_duration(field.type):
+            raise TypeError(
+                f"Scalar index column {column} cannot currently be a duration"
             )
 
         index_type = index_type.upper()

--- a/rust/lance-datafusion/src/expr.rs
+++ b/rust/lance-datafusion/src/expr.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use arrow::compute::cast;
 use arrow_array::{cast::AsArray, ArrayRef};
-use arrow_schema::{DataType, Schema};
+use arrow_schema::{DataType, Schema, TimeUnit};
 use datafusion::{
     datasource::empty::EmptyTable, execution::context::SessionContext, logical_expr::Expr,
 };
@@ -36,6 +36,8 @@ use substrait::proto::{
     read_rel::{NamedTable, ReadType},
     rel, ExtendedExpression, Plan, PlanRel, ProjectRel, ReadRel, Rel, RelRoot,
 };
+
+const MS_PER_DAY: i64 = 86400000;
 
 // This is slightly tedious but when we convert expressions from SQL strings to logical
 // datafusion expressions there is no type coercion that happens.  In other words "x = 7"
@@ -265,6 +267,122 @@ pub fn safe_coerce_scalar(value: &ScalarValue, ty: &DataType) -> Option<ScalarVa
                 _ => None,
             }
         }
+        ScalarValue::TimestampSecond(seconds, _) => match ty {
+            DataType::Timestamp(TimeUnit::Second, _) => Some(value.clone()),
+            DataType::Timestamp(TimeUnit::Millisecond, tz) => seconds
+                .and_then(|v| v.checked_mul(1000))
+                .map(|val| ScalarValue::TimestampMillisecond(Some(val), tz.clone())),
+            DataType::Timestamp(TimeUnit::Microsecond, tz) => seconds
+                .and_then(|v| v.checked_mul(1000000))
+                .map(|val| ScalarValue::TimestampMicrosecond(Some(val), tz.clone())),
+            DataType::Timestamp(TimeUnit::Nanosecond, tz) => seconds
+                .and_then(|v| v.checked_mul(1000000000))
+                .map(|val| ScalarValue::TimestampNanosecond(Some(val), tz.clone())),
+            _ => None,
+        },
+        ScalarValue::TimestampMillisecond(millis, _) => match ty {
+            DataType::Timestamp(TimeUnit::Second, tz) => {
+                millis.map(|val| ScalarValue::TimestampSecond(Some(val / 1000), tz.clone()))
+            }
+            DataType::Timestamp(TimeUnit::Millisecond, _) => Some(value.clone()),
+            DataType::Timestamp(TimeUnit::Microsecond, tz) => millis
+                .and_then(|v| v.checked_mul(1000))
+                .map(|val| ScalarValue::TimestampMicrosecond(Some(val), tz.clone())),
+            DataType::Timestamp(TimeUnit::Nanosecond, tz) => millis
+                .and_then(|v| v.checked_mul(1000000))
+                .map(|val| ScalarValue::TimestampNanosecond(Some(val), tz.clone())),
+            _ => None,
+        },
+        ScalarValue::TimestampMicrosecond(micros, _) => match ty {
+            DataType::Timestamp(TimeUnit::Second, tz) => {
+                micros.map(|val| ScalarValue::TimestampSecond(Some(val / 1000000), tz.clone()))
+            }
+            DataType::Timestamp(TimeUnit::Millisecond, tz) => {
+                micros.map(|val| ScalarValue::TimestampMillisecond(Some(val / 1000), tz.clone()))
+            }
+            DataType::Timestamp(TimeUnit::Microsecond, _) => Some(value.clone()),
+            DataType::Timestamp(TimeUnit::Nanosecond, tz) => micros
+                .and_then(|v| v.checked_mul(1000))
+                .map(|val| ScalarValue::TimestampNanosecond(Some(val), tz.clone())),
+            _ => None,
+        },
+        ScalarValue::TimestampNanosecond(nanos, _) => {
+            match ty {
+                DataType::Timestamp(TimeUnit::Second, tz) => nanos
+                    .map(|val| ScalarValue::TimestampSecond(Some(val / 1000000000), tz.clone())),
+                DataType::Timestamp(TimeUnit::Millisecond, tz) => nanos
+                    .map(|val| ScalarValue::TimestampMillisecond(Some(val / 1000000), tz.clone())),
+                DataType::Timestamp(TimeUnit::Microsecond, tz) => {
+                    nanos.map(|val| ScalarValue::TimestampMicrosecond(Some(val / 1000), tz.clone()))
+                }
+                DataType::Timestamp(TimeUnit::Nanosecond, _) => Some(value.clone()),
+                _ => None,
+            }
+        }
+        ScalarValue::Date32(ticks) => match ty {
+            DataType::Date32 => Some(value.clone()),
+            DataType::Date64 => Some(ScalarValue::Date64(
+                ticks.map(|v| i64::from(v) * MS_PER_DAY),
+            )),
+            _ => None,
+        },
+        ScalarValue::Date64(ticks) => match ty {
+            DataType::Date32 => Some(ScalarValue::Date32(ticks.map(|v| (v / MS_PER_DAY) as i32))),
+            DataType::Date64 => Some(value.clone()),
+            _ => None,
+        },
+        ScalarValue::Time32Second(seconds) => {
+            match ty {
+                DataType::Time32(TimeUnit::Second) => Some(value.clone()),
+                DataType::Time32(TimeUnit::Millisecond) => {
+                    seconds.map(|val| ScalarValue::Time32Millisecond(Some(val * 1000)))
+                }
+                DataType::Time64(TimeUnit::Microsecond) => seconds
+                    .map(|val| ScalarValue::Time64Microsecond(Some(i64::from(val) * 1000000))),
+                DataType::Time64(TimeUnit::Nanosecond) => seconds
+                    .map(|val| ScalarValue::Time64Nanosecond(Some(i64::from(val) * 1000000000))),
+                _ => None,
+            }
+        }
+        ScalarValue::Time32Millisecond(millis) => match ty {
+            DataType::Time32(TimeUnit::Second) => {
+                millis.map(|val| ScalarValue::Time32Second(Some(val / 1000)))
+            }
+            DataType::Time32(TimeUnit::Millisecond) => Some(value.clone()),
+            DataType::Time64(TimeUnit::Microsecond) => {
+                millis.map(|val| ScalarValue::Time64Microsecond(Some(i64::from(val) * 1000)))
+            }
+            DataType::Time64(TimeUnit::Nanosecond) => {
+                millis.map(|val| ScalarValue::Time64Nanosecond(Some(i64::from(val) * 1000000)))
+            }
+            _ => None,
+        },
+        ScalarValue::Time64Microsecond(micros) => match ty {
+            DataType::Time32(TimeUnit::Second) => {
+                micros.map(|val| ScalarValue::Time32Second(Some((val / 1000000) as i32)))
+            }
+            DataType::Time32(TimeUnit::Millisecond) => {
+                micros.map(|val| ScalarValue::Time32Millisecond(Some((val / 1000) as i32)))
+            }
+            DataType::Time64(TimeUnit::Microsecond) => Some(value.clone()),
+            DataType::Time64(TimeUnit::Nanosecond) => {
+                micros.map(|val| ScalarValue::Time64Nanosecond(Some(val * 1000)))
+            }
+            _ => None,
+        },
+        ScalarValue::Time64Nanosecond(nanos) => match ty {
+            DataType::Time32(TimeUnit::Second) => {
+                nanos.map(|val| ScalarValue::Time32Second(Some((val / 1000000000) as i32)))
+            }
+            DataType::Time32(TimeUnit::Millisecond) => {
+                nanos.map(|val| ScalarValue::Time32Millisecond(Some((val / 1000000) as i32)))
+            }
+            DataType::Time64(TimeUnit::Microsecond) => {
+                nanos.map(|val| ScalarValue::Time64Microsecond(Some(val / 1000)))
+            }
+            DataType::Time64(TimeUnit::Nanosecond) => Some(value.clone()),
+            _ => None,
+        },
         ScalarValue::LargeList(values) => {
             let values = values.clone() as ArrayRef;
             let new_values = cast(&values, ty).ok()?;
@@ -423,7 +541,7 @@ pub async fn parse_substrait(expr: &[u8], input_schema: Arc<Schema>) -> Result<E
 mod tests {
     use super::*;
 
-    use arrow_schema::Field;
+    use arrow_schema::{Field, TimeUnit};
     use datafusion::logical_expr::{BinaryExpr, Operator};
     use datafusion_common::Column;
     use prost::Message;
@@ -432,6 +550,281 @@ mod tests {
         functions::functions_comparison::FunctionsComparisonExt,
         helpers::{literals::literal, schema::SchemaInfo},
     };
+
+    #[test]
+    fn test_temporal_coerce() {
+        // Conversion from timestamps in one resolution to timestamps in another resolution is allowed
+        // s->s
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampSecond(Some(5), None),
+                &DataType::Timestamp(TimeUnit::Second, None),
+            ),
+            Some(ScalarValue::TimestampSecond(Some(5), None))
+        );
+        // s->ms
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampSecond(Some(5), None),
+                &DataType::Timestamp(TimeUnit::Millisecond, None),
+            ),
+            Some(ScalarValue::TimestampMillisecond(Some(5000), None))
+        );
+        // s->us
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampSecond(Some(5), None),
+                &DataType::Timestamp(TimeUnit::Microsecond, None),
+            ),
+            Some(ScalarValue::TimestampMicrosecond(Some(5000000), None))
+        );
+        // s->ns
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampSecond(Some(5), None),
+                &DataType::Timestamp(TimeUnit::Nanosecond, None),
+            ),
+            Some(ScalarValue::TimestampNanosecond(Some(5000000000), None))
+        );
+        // ms->s
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampMillisecond(Some(5000), None),
+                &DataType::Timestamp(TimeUnit::Second, None),
+            ),
+            Some(ScalarValue::TimestampSecond(Some(5), None))
+        );
+        // ms->ms
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampMillisecond(Some(5000), None),
+                &DataType::Timestamp(TimeUnit::Millisecond, None),
+            ),
+            Some(ScalarValue::TimestampMillisecond(Some(5000), None))
+        );
+        // ms->us
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampMillisecond(Some(5000), None),
+                &DataType::Timestamp(TimeUnit::Microsecond, None),
+            ),
+            Some(ScalarValue::TimestampMicrosecond(Some(5000000), None))
+        );
+        // ms->ns
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampMillisecond(Some(5000), None),
+                &DataType::Timestamp(TimeUnit::Nanosecond, None),
+            ),
+            Some(ScalarValue::TimestampNanosecond(Some(5000000000), None))
+        );
+        // us->s
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampMicrosecond(Some(5000000), None),
+                &DataType::Timestamp(TimeUnit::Second, None),
+            ),
+            Some(ScalarValue::TimestampSecond(Some(5), None))
+        );
+        // us->ms
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampMicrosecond(Some(5000000), None),
+                &DataType::Timestamp(TimeUnit::Millisecond, None),
+            ),
+            Some(ScalarValue::TimestampMillisecond(Some(5000), None))
+        );
+        // us->us
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampMicrosecond(Some(5000000), None),
+                &DataType::Timestamp(TimeUnit::Microsecond, None),
+            ),
+            Some(ScalarValue::TimestampMicrosecond(Some(5000000), None))
+        );
+        // us->ns
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampMicrosecond(Some(5000000), None),
+                &DataType::Timestamp(TimeUnit::Nanosecond, None),
+            ),
+            Some(ScalarValue::TimestampNanosecond(Some(5000000000), None))
+        );
+        // ns->s
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampNanosecond(Some(5000000000), None),
+                &DataType::Timestamp(TimeUnit::Second, None),
+            ),
+            Some(ScalarValue::TimestampSecond(Some(5), None))
+        );
+        // ns->ms
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampNanosecond(Some(5000000000), None),
+                &DataType::Timestamp(TimeUnit::Millisecond, None),
+            ),
+            Some(ScalarValue::TimestampMillisecond(Some(5000), None))
+        );
+        // ns->us
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampNanosecond(Some(5000000000), None),
+                &DataType::Timestamp(TimeUnit::Microsecond, None),
+            ),
+            Some(ScalarValue::TimestampMicrosecond(Some(5000000), None))
+        );
+        // ns->ns
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampNanosecond(Some(5000000000), None),
+                &DataType::Timestamp(TimeUnit::Nanosecond, None),
+            ),
+            Some(ScalarValue::TimestampNanosecond(Some(5000000000), None))
+        );
+        // Precision loss on coercion is allowed (truncation)
+        // ns->s
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::TimestampNanosecond(Some(5987654321), None),
+                &DataType::Timestamp(TimeUnit::Second, None),
+            ),
+            Some(ScalarValue::TimestampSecond(Some(5), None))
+        );
+        // Conversions from date-32 to date-64 is allowed
+        assert_eq!(
+            safe_coerce_scalar(&ScalarValue::Date32(Some(5)), &DataType::Date32,),
+            Some(ScalarValue::Date32(Some(5)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(&ScalarValue::Date32(Some(5)), &DataType::Date64,),
+            Some(ScalarValue::Date64(Some(5 * MS_PER_DAY)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Date64(Some(5 * MS_PER_DAY)),
+                &DataType::Date32,
+            ),
+            Some(ScalarValue::Date32(Some(5)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(&ScalarValue::Date64(Some(5)), &DataType::Date64,),
+            Some(ScalarValue::Date64(Some(5)))
+        );
+        // Time-32 to time-64 (and within time-32 and time-64) is allowed
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time32Second(Some(5)),
+                &DataType::Time32(TimeUnit::Second),
+            ),
+            Some(ScalarValue::Time32Second(Some(5)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time32Second(Some(5)),
+                &DataType::Time32(TimeUnit::Millisecond),
+            ),
+            Some(ScalarValue::Time32Millisecond(Some(5000)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time32Second(Some(5)),
+                &DataType::Time64(TimeUnit::Microsecond),
+            ),
+            Some(ScalarValue::Time64Microsecond(Some(5000000)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time32Second(Some(5)),
+                &DataType::Time64(TimeUnit::Nanosecond),
+            ),
+            Some(ScalarValue::Time64Nanosecond(Some(5000000000)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time32Millisecond(Some(5000)),
+                &DataType::Time32(TimeUnit::Second),
+            ),
+            Some(ScalarValue::Time32Second(Some(5)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time32Millisecond(Some(5000)),
+                &DataType::Time32(TimeUnit::Millisecond),
+            ),
+            Some(ScalarValue::Time32Millisecond(Some(5000)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time32Millisecond(Some(5000)),
+                &DataType::Time64(TimeUnit::Microsecond),
+            ),
+            Some(ScalarValue::Time64Microsecond(Some(5000000)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time32Millisecond(Some(5000)),
+                &DataType::Time64(TimeUnit::Nanosecond),
+            ),
+            Some(ScalarValue::Time64Nanosecond(Some(5000000000)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time64Microsecond(Some(5000000)),
+                &DataType::Time32(TimeUnit::Second),
+            ),
+            Some(ScalarValue::Time32Second(Some(5)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time64Microsecond(Some(5000000)),
+                &DataType::Time32(TimeUnit::Millisecond),
+            ),
+            Some(ScalarValue::Time32Millisecond(Some(5000)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time64Microsecond(Some(5000000)),
+                &DataType::Time64(TimeUnit::Microsecond),
+            ),
+            Some(ScalarValue::Time64Microsecond(Some(5000000)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time64Microsecond(Some(5000000)),
+                &DataType::Time64(TimeUnit::Nanosecond),
+            ),
+            Some(ScalarValue::Time64Nanosecond(Some(5000000000)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time64Nanosecond(Some(5000000000)),
+                &DataType::Time32(TimeUnit::Second),
+            ),
+            Some(ScalarValue::Time32Second(Some(5)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time64Nanosecond(Some(5000000000)),
+                &DataType::Time32(TimeUnit::Millisecond),
+            ),
+            Some(ScalarValue::Time32Millisecond(Some(5000)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time64Nanosecond(Some(5000000000)),
+                &DataType::Time64(TimeUnit::Microsecond),
+            ),
+            Some(ScalarValue::Time64Microsecond(Some(5000000)))
+        );
+        assert_eq!(
+            safe_coerce_scalar(
+                &ScalarValue::Time64Nanosecond(Some(5000000000)),
+                &DataType::Time64(TimeUnit::Nanosecond),
+            ),
+            Some(ScalarValue::Time64Nanosecond(Some(5000000000)))
+        );
+    }
 
     #[tokio::test]
     async fn test_substrait_conversion() {

--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -1100,7 +1100,7 @@ pub mod array {
         let data_type = DataType::Time32(resolution.clone());
         let size = ByteCount::from(data_type.primitive_width().unwrap() as u64);
         let dist = Uniform::new(start, end);
-        let sample_fn = move |rng: &mut _| dist.sample(rng) as i32;
+        let sample_fn = move |rng: &mut _| dist.sample(rng);
 
         match resolution {
             TimeUnit::Second => Box::new(FnGen::<i32, Time32SecondArray, _>::new_known_size(
@@ -1128,7 +1128,7 @@ pub mod array {
         let data_type = DataType::Time64(resolution.clone());
         let size = ByteCount::from(data_type.primitive_width().unwrap() as u64);
         let dist = Uniform::new(start, end);
-        let sample_fn = move |rng: &mut _| dist.sample(rng) as i64;
+        let sample_fn = move |rng: &mut _| dist.sample(rng);
 
         match resolution {
             TimeUnit::Microsecond => {
@@ -1243,7 +1243,7 @@ pub mod array {
 
     pub fn rand_timestamp(data_type: &DataType) -> Box<dyn ArrayGenerator> {
         let now = chrono::Utc::now();
-        let one_year_ago = now - chrono::Duration::days(365);
+        let one_year_ago = now - chrono::Duration::try_days(365).unwrap();
         rand_timestamp_in_range(one_year_ago, now, data_type)
     }
 

--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -514,6 +514,39 @@ impl ArrayGenerator for RandomBinaryGenerator {
     }
 }
 
+// A function that converts an array from one type to another
+type WrapFn = Box<
+    dyn Fn(Arc<dyn arrow_array::Array>) -> Result<Arc<dyn arrow_array::Array>, ArrowError>
+        + Send
+        + Sync,
+>;
+
+struct WrappedGenerator {
+    generator: Box<dyn ArrayGenerator>,
+    data_type: DataType,
+    element_size_bytes: Option<ByteCount>,
+    wrap_fn: WrapFn,
+}
+
+impl ArrayGenerator for WrappedGenerator {
+    fn generate(
+        &mut self,
+        length: RowCount,
+        rng: &mut rand_xoshiro::Xoshiro256PlusPlus,
+    ) -> Result<Arc<dyn arrow_array::Array>, ArrowError> {
+        let array = self.generator.generate(length, rng)?;
+        (self.wrap_fn)(array)
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn element_size_bytes(&self) -> Option<ByteCount> {
+        self.element_size_bytes
+    }
+}
+
 pub struct CycleBinaryGenerator<T: ByteArrayType> {
     values: Vec<u8>,
     lengths: Vec<usize>,
@@ -878,11 +911,17 @@ impl BatchGeneratorBuilder {
 const MS_PER_DAY: i64 = 86400000;
 
 pub mod array {
+
     use arrow_array::types::{
         ArrowPrimitiveType, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
         UInt16Type, UInt32Type, UInt64Type, UInt8Type,
     };
-    use arrow_array::{ArrowNativeTypeOp, Date32Array, Date64Array, PrimitiveArray};
+    use arrow_array::{
+        ArrowNativeTypeOp, Date32Array, Date64Array, PrimitiveArray, Time32MillisecondArray,
+        Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
+        TimestampMicrosecondArray, TimestampNanosecondArray, TimestampSecondArray,
+    };
+    use arrow_schema::TimeUnit;
     use chrono::Utc;
     use rand::distributions::Uniform;
     use rand::prelude::Distribution;
@@ -1048,6 +1087,64 @@ pub mod array {
         cycle_vec(underlying, dimension)
     }
 
+    /// Create a generator of randomly sampled time32 values covering the entire
+    /// range of 1 day
+    pub fn rand_time32(resolution: &TimeUnit) -> Box<dyn ArrayGenerator> {
+        let start = 0;
+        let end = match resolution {
+            TimeUnit::Second => 86_400,
+            TimeUnit::Millisecond => 86_400_000,
+            _ => panic!(),
+        };
+
+        let data_type = DataType::Time32(resolution.clone());
+        let size = ByteCount::from(data_type.primitive_width().unwrap() as u64);
+        let dist = Uniform::new(start, end);
+        let sample_fn = move |rng: &mut _| dist.sample(rng) as i32;
+
+        match resolution {
+            TimeUnit::Second => Box::new(FnGen::<i32, Time32SecondArray, _>::new_known_size(
+                data_type, sample_fn, 1, size,
+            )),
+            TimeUnit::Millisecond => {
+                Box::new(FnGen::<i32, Time32MillisecondArray, _>::new_known_size(
+                    data_type, sample_fn, 1, size,
+                ))
+            }
+            _ => panic!(),
+        }
+    }
+
+    /// Create a generator of randomly sampled time64 values covering the entire
+    /// range of 1 day
+    pub fn rand_time64(resolution: &TimeUnit) -> Box<dyn ArrayGenerator> {
+        let start = 0_i64;
+        let end: i64 = match resolution {
+            TimeUnit::Microsecond => 86_400_000,
+            TimeUnit::Nanosecond => 86_400_000_000,
+            _ => panic!(),
+        };
+
+        let data_type = DataType::Time64(resolution.clone());
+        let size = ByteCount::from(data_type.primitive_width().unwrap() as u64);
+        let dist = Uniform::new(start, end);
+        let sample_fn = move |rng: &mut _| dist.sample(rng) as i64;
+
+        match resolution {
+            TimeUnit::Microsecond => {
+                Box::new(FnGen::<i64, Time64MicrosecondArray, _>::new_known_size(
+                    data_type, sample_fn, 1, size,
+                ))
+            }
+            TimeUnit::Nanosecond => {
+                Box::new(FnGen::<i64, Time64NanosecondArray, _>::new_known_size(
+                    data_type, sample_fn, 1, size,
+                ))
+            }
+            _ => panic!(),
+        }
+    }
+
     /// Create a generator of randomly sampled date32 values
     ///
     /// Instead of sampling the entire range, all values will be drawn from the last year as this
@@ -1089,6 +1186,75 @@ pub mod array {
         let now = chrono::Utc::now();
         let one_year_ago = now - chrono::TimeDelta::try_days(365).expect("TimeDelta try_days");
         rand_date64_in_range(one_year_ago, now)
+    }
+
+    /// Create a generator of randomly sampled timestamp values in the given range
+    ///
+    /// Currently just samples the entire range of u64 values and casts to timestamp
+    pub fn rand_timestamp_in_range(
+        start: chrono::DateTime<Utc>,
+        end: chrono::DateTime<Utc>,
+        data_type: &DataType,
+    ) -> Box<dyn ArrayGenerator> {
+        let end_ms = end.timestamp_millis();
+        let start_ms = start.timestamp_millis();
+        let (start_ticks, end_ticks) = match data_type {
+            DataType::Timestamp(TimeUnit::Nanosecond, _) => {
+                (start_ms * 1000 * 1000, end_ms * 1000 * 1000)
+            }
+            DataType::Timestamp(TimeUnit::Microsecond, _) => (start_ms * 1000, end_ms * 1000),
+            DataType::Timestamp(TimeUnit::Millisecond, _) => (start_ms, end_ms),
+            DataType::Timestamp(TimeUnit::Second, _) => (start.timestamp(), end.timestamp()),
+            _ => panic!(),
+        };
+        let dist = Uniform::new(start_ticks, end_ticks);
+
+        let data_type = data_type.clone();
+        let sample_fn = move |rng: &mut _| (dist.sample(rng));
+        let width = data_type
+            .primitive_width()
+            .map(|width| ByteCount::from(width as u64))
+            .unwrap();
+
+        match data_type {
+            DataType::Timestamp(TimeUnit::Nanosecond, _) => {
+                Box::new(FnGen::<i64, TimestampNanosecondArray, _>::new_known_size(
+                    data_type, sample_fn, 1, width,
+                ))
+            }
+            DataType::Timestamp(TimeUnit::Microsecond, _) => {
+                Box::new(FnGen::<i64, TimestampMicrosecondArray, _>::new_known_size(
+                    data_type, sample_fn, 1, width,
+                ))
+            }
+            DataType::Timestamp(TimeUnit::Millisecond, _) => {
+                Box::new(FnGen::<i64, TimestampMicrosecondArray, _>::new_known_size(
+                    data_type, sample_fn, 1, width,
+                ))
+            }
+            DataType::Timestamp(TimeUnit::Second, _) => {
+                Box::new(FnGen::<i64, TimestampSecondArray, _>::new_known_size(
+                    data_type, sample_fn, 1, width,
+                ))
+            }
+            _ => panic!(),
+        }
+    }
+
+    pub fn rand_timestamp(data_type: &DataType) -> Box<dyn ArrayGenerator> {
+        let now = chrono::Utc::now();
+        let one_year_ago = now - chrono::Duration::days(365);
+        rand_timestamp_in_range(one_year_ago, now, data_type)
+    }
+
+    pub fn rand_duration(data_type: &DataType) -> Box<dyn ArrayGenerator> {
+        let data_type_clone = data_type.clone();
+        Box::new(WrappedGenerator {
+            generator: rand::<Int64Type>(),
+            data_type: data_type.clone(),
+            element_size_bytes: Some(ByteCount(8)),
+            wrap_fn: Box::new(move |array| arrow_cast::cast(&array, &data_type_clone)),
+        })
     }
 
     /// Create a generator of randomly sampled date64 values
@@ -1159,7 +1325,11 @@ pub mod array {
             ),
             DataType::Date32 => rand_date32(),
             DataType::Date64 => rand_date64(),
-            _ => unimplemented!(),
+            DataType::Time32(resolution) => rand_time32(resolution),
+            DataType::Time64(resolution) => rand_time64(resolution),
+            DataType::Timestamp(_, _) => rand_timestamp(data_type),
+            DataType::Duration(_) => rand_duration(data_type),
+            _ => unimplemented!("random generation of {}", data_type),
         }
     }
 

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -167,7 +167,7 @@ mod tests {
         types::{Float32Type, Int32Type, UInt64Type},
         RecordBatchIterator, RecordBatchReader, UInt64Array,
     };
-    use arrow_schema::{DataType, Field};
+    use arrow_schema::{DataType, Field, TimeUnit};
     use arrow_select::take::TakeOptions;
     use datafusion::physical_plan::SendableRecordBatchStream;
     use datafusion_common::ScalarValue;
@@ -543,6 +543,14 @@ mod tests {
             DataType::Utf8,
             DataType::Float32,
             DataType::Date32,
+            DataType::Timestamp(TimeUnit::Nanosecond, None),
+            DataType::Date64,
+            DataType::Date32,
+            DataType::Time64(TimeUnit::Nanosecond),
+            DataType::Time32(TimeUnit::Second),
+            // Not supported today, error from datafusion:
+            // Min/max accumulator not implemented for Duration(Nanosecond)
+            // DataType::Duration(TimeUnit::Nanosecond),
         ] {
             let tempdir = tempdir().unwrap();
             let index_store = test_store(&tempdir);


### PR DESCRIPTION
This adds support for scalar indices to timestamp, date, and time columns.  Datafusion does not have a min/max accumulator for duration columns (I think there is some angst around how durations are ordered) and so we cannot support duration.  Time columns are supported but I can't find any way to create a time literal in Datafusion so those indices may be less useful at the moment.

Closes #1945