### PR TITLE
chore: refactor distance table to separate function

### DIFF
--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -223,7 +223,7 @@ impl<T: ArrowFloatType + Cosine + Dot + L2> ProductQuantizerImpl<T> {
             ),
             location: Default::default(),
         })?;
-        Ok(build_distance_table_l2::<T>(
+        Ok(build_distance_table_l2(
             self.codebook.as_slice(),
             self.num_bits,
             self.num_sub_vectors,

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -1,0 +1,38 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use lance_arrow::ArrowFloatType;
+use lance_linalg::distance::{l2_distance_batch, L2};
+
+use super::utils::get_sub_vector_centroids;
+
+pub(super) fn build_distance_table_l2<T: ArrowFloatType + L2>(
+    codebook: &[T::Native],
+    num_bits: u32,
+    num_sub_vectors: usize,
+    query: &[T::Native],
+) -> Vec<f32> {
+    let dimension = codebook.len();
+
+    let sub_vector_length = query.len() / num_sub_vectors;
+    query
+        .chunks_exact(sub_vector_length)
+        .enumerate()
+        .flat_map(|(i, sub_vec)| {
+            let subvec_centroids =
+                get_sub_vector_centroids(codebook, dimension, num_bits, num_sub_vectors, i);
+            l2_distance_batch(sub_vec, subvec_centroids, sub_vector_length)
+        })
+        .collect()
+}

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -14,19 +14,22 @@
 
 use std::cmp::min;
 
-use lance_arrow::ArrowFloatType;
+use lance_arrow::FloatToArrayType;
 use lance_linalg::distance::{l2_distance_batch, L2};
 
 use super::{num_centroids, utils::get_sub_vector_centroids};
 
 /// Build a Distance Table from the query to each PQ centroid
 /// using L2 distance.
-pub(super) fn build_distance_table_l2<T: ArrowFloatType + L2>(
-    codebook: &[T::Native],
+pub(super) fn build_distance_table_l2<T: FloatToArrayType>(
+    codebook: &[T],
     num_bits: u32,
     num_sub_vectors: usize,
-    query: &[T::Native],
-) -> Vec<f32> {
+    query: &[T],
+) -> Vec<f32>
+where
+    T::ArrowType: L2,
+{
     let dimension = query.len();
 
     let sub_vector_length = dimension / num_sub_vectors;

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -12,20 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::min;
+
 use lance_arrow::ArrowFloatType;
 use lance_linalg::distance::{l2_distance_batch, L2};
 
-use super::utils::get_sub_vector_centroids;
+use super::{num_centroids, utils::get_sub_vector_centroids};
 
+/// Build a Distance Table from the query to each PQ centroid
+/// using L2 distance.
 pub(super) fn build_distance_table_l2<T: ArrowFloatType + L2>(
     codebook: &[T::Native],
     num_bits: u32,
     num_sub_vectors: usize,
     query: &[T::Native],
 ) -> Vec<f32> {
-    let dimension = codebook.len();
+    let dimension = query.len();
 
-    let sub_vector_length = query.len() / num_sub_vectors;
+    let sub_vector_length = dimension / num_sub_vectors;
     query
         .chunks_exact(sub_vector_length)
         .enumerate()
@@ -35,4 +39,87 @@ pub(super) fn build_distance_table_l2<T: ArrowFloatType + L2>(
             l2_distance_batch(sub_vec, subvec_centroids, sub_vector_length)
         })
         .collect()
+}
+
+/// Compute L2 distance from the query to all code.
+///
+/// Type parameters
+/// ---------------
+/// - C: the tile size of code-book to run at once.
+/// - V: the tile size of PQ code to run at once.
+///
+/// Parameters
+/// ----------
+/// - distance_table: the pre-computed L2 distance table.
+///   It is a flatten array of [num_sub_vectors, num_centroids] f32.
+/// - num_bits: the number of bits used for PQ.
+/// - num_sub_vectors: the number of sub-vectors.
+/// - code: the PQ code to be used to compute the distances.
+///
+/// Returns
+/// -------
+///  The squared L2 distance.
+///
+#[inline]
+pub(super) fn compute_l2_distance<const C: usize, const V: usize>(
+    distance_table: &[f32],
+    num_bits: u32,
+    num_sub_vectors: usize,
+    code: &[u8],
+) -> Vec<f32> {
+    let num_centroids = num_centroids(num_bits);
+
+    let iter = code.chunks_exact(num_sub_vectors * V);
+    let distances = iter.clone().flat_map(|c| {
+        let mut sums = [0.0_f32; V];
+        for i in (0..num_sub_vectors).step_by(C) {
+            for (vec_idx, sum) in sums.iter_mut().enumerate() {
+                let vec_start = vec_idx * num_sub_vectors;
+                #[cfg(all(feature = "nightly", target_feature = "avx512f"))]
+                {
+                    use std::arch::x86_64::*;
+                    if i + C <= self.num_sub_vectors {
+                        let mut offsets = [(i * num_centroids) as i32; C];
+                        for k in 0..C {
+                            offsets[k] += (k * num_centroids) as i32 + c[vec_start + k] as i32;
+                        }
+                        unsafe {
+                            let simd_offsets = _mm512_loadu_epi32(offsets.as_ptr());
+                            let v = _mm512_i32gather_ps(
+                                simd_offsets,
+                                distance_table.as_ptr() as *const u8,
+                                4,
+                            );
+                            *sum += _mm512_reduce_add_ps(v);
+                        }
+                    } else {
+                        let mut s = 0.0;
+                        for k in 0..self.num_sub_vectors - i {
+                            *sum +=
+                                distance_table[(i + k) * num_centroids + c[vec_start + k] as usize];
+                        }
+                    }
+                }
+                #[cfg(not(any(feature = "nightly", target_feature = "avx512f")))]
+                {
+                    let s = c[vec_start + i..]
+                        .iter()
+                        .take(min(C, num_sub_vectors - i))
+                        .enumerate()
+                        .map(|(k, c)| distance_table[(i + k) * num_centroids + *c as usize])
+                        .sum::<f32>();
+                    *sum += s;
+                }
+            }
+        }
+        sums.into_iter()
+    });
+    // Remainder
+    let remainder = iter.remainder().chunks(num_sub_vectors).map(|c| {
+        c.iter()
+            .enumerate()
+            .map(|(sub_vec_idx, code)| distance_table[sub_vec_idx * num_centroids + *code as usize])
+            .sum::<f32>()
+    });
+    distances.chain(remainder).collect()
 }

--- a/rust/lance-index/src/vector/pq/utils.rs
+++ b/rust/lance-index/src/vector/pq/utils.rs
@@ -14,7 +14,7 @@
 
 use std::sync::Arc;
 
-use lance_arrow::ArrowFloatType;
+use lance_arrow::{ArrowFloatType, FloatToArrayType};
 use lance_linalg::MatrixView;
 
 /// Divide a 2D vector in [`T::Array`] to `m` sub-vectors.
@@ -51,6 +51,26 @@ pub(super) fn divide_to_subvectors<T: ArrowFloatType>(
 // TODO: pub(crate)
 pub fn num_centroids(num_bits: impl Into<u32>) -> usize {
     2_usize.pow(num_bits.into())
+}
+
+pub(crate) fn get_sub_vector_centroids<T: FloatToArrayType>(
+    codebook: &[T],
+    dimension: usize,
+    num_bits: impl Into<u32>,
+    num_sub_vectors: usize,
+    sub_vector_idx: usize,
+) -> &[T] {
+    assert!(
+        sub_vector_idx < num_sub_vectors,
+        "sub_vector idx: {}, num_sub_vectors: {}",
+        sub_vector_idx,
+        num_sub_vectors
+    );
+
+    let num_centroids = num_centroids(num_bits);
+    let sub_vector_width = dimension / num_sub_vectors;
+    &codebook[sub_vector_idx * num_centroids * sub_vector_width
+        ..(sub_vector_idx + 1) * num_centroids * sub_vector_width]
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Extract `build distance table` and `use distance table to compute L2` into two separate functions for reusability. 