### PR TITLE
fix: compile error when older versions of tokio were used

### DIFF
--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -193,9 +193,9 @@ impl StoreScheduler {
                     dest.deliver_data(bytes.map(|bytes| (task_idx, bytes)));
                 }),
             };
-            self.io_submitter
-                .send(task)
-                .expect("I/O scheduler thread panic'd");
+            if self.io_submitter.send(task).is_err() {
+                panic!("unable to submit I/O because the I/O thread has panic'd");
+            }
         }
     }
 


### PR DESCRIPTION
In some versions of tokio `SendError<T>` only implements `Debug` if `T` is `Debug` (and we can't easily do that here because `T` contains `Reader` which is not `Debug`).  So, instead, we just panic directly.  The `SendError` wouldn't contain any additional useful information anyways.