### PR TITLE
fix: nightly compile error

### DIFF
--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -81,7 +81,7 @@ pub(super) fn compute_l2_distance<const C: usize, const V: usize>(
                 #[cfg(all(feature = "nightly", target_feature = "avx512f"))]
                 {
                     use std::arch::x86_64::*;
-                    if i + C <= self.num_sub_vectors {
+                    if i + C <= num_sub_vectors {
                         let mut offsets = [(i * num_centroids) as i32; C];
                         for k in 0..C {
                             offsets[k] += (k * num_centroids) as i32 + c[vec_start + k] as i32;
@@ -97,7 +97,7 @@ pub(super) fn compute_l2_distance<const C: usize, const V: usize>(
                         }
                     } else {
                         let mut s = 0.0;
-                        for k in 0..self.num_sub_vectors - i {
+                        for k in 0..num_sub_vectors - i {
                             *sum +=
                                 distance_table[(i + k) * num_centroids + c[vec_start + k] as usize];
                         }


### PR DESCRIPTION
```
$ RUSTFLAGS="-C target-cpu=cascadelake -C target-feature=+avx2,+avx512f,+avx512vl" cargo +nightly build
   Compiling prost v0.12.3
warning: unstable feature specified for `-Ctarget-feature`: `avx512f`
  |
  = note: this feature is not stably supported; its behavior can change in the future

warning: unstable feature specified for `-Ctarget-feature`: `avx512vl`
  |
  = note: this feature is not stably supported; its behavior can change in the future

warning: `lance-arrow` (lib) generated 2 warnings
warning: `lance-linalg` (build script) generated 2 warnings (2 duplicates)
   Compiling lance-linalg v0.9.18 (/home/albertlockett/sophon/src/lance/rust/lance-linalg)
warning: `lance-datagen` (lib) generated 2 warnings (2 duplicates)
   Compiling lance-testing v0.9.18
   Compiling prost-types v0.12.3
   Compiling lance-core v0.9.18 (/home/albertlockett/sophon/src/lance/rust/lance-core)
   Compiling prost-build v0.12.3
   Compiling substrait v0.22.1
   Compiling lance-file v0.9.18 (/home/albertlockett/sophon/src/lance/rust/lance-file)
   Compiling lance-table v0.9.18 (/home/albertlockett/sophon/src/lance/rust/lance-table)
   Compiling lance-index v0.9.18 (/home/albertlockett/sophon/src/lance/rust/lance-index)
   Compiling lance-io v0.9.18 (/home/albertlockett/sophon/src/lance/rust/lance-io)
warning: `lance-index` (build script) generated 2 warnings (2 duplicates)
warning: `lance-table` (build script) generated 2 warnings (2 duplicates)
warning: `lance-core` (lib) generated 2 warnings (2 duplicates)
warning: `lance-file` (build script) generated 2 warnings (2 duplicates)
warning: `lance-linalg` (lib) generated 2 warnings (2 duplicates)
warning: `lance-io` (lib) generated 2 warnings (2 duplicates)
warning: `lance-file` (lib) generated 2 warnings (2 duplicates)
   Compiling datafusion-substrait v35.0.0
   Compiling lance-datafusion v0.9.18 (/home/albertlockett/sophon/src/lance/rust/lance-datafusion)
warning: `lance-table` (lib) generated 2 warnings (2 duplicates)
error[E0424]: expected value, found module `self`
  --> /home/albertlockett/sophon/src/lance/rust/lance-index/src/vector/pq/distance.rs:84:33
   |
67 | pub(super) fn compute_l2_distance<const C: usize, const V: usize>(
   |               ------------------- this function can't have a `self` parameter
...
84 |                     if i + C <= self.num_sub_vectors {
   |                                 ^^^^ `self` value is a keyword only available in methods with a `self` parameter

error[E0424]: expected value, found module `self`
   --> /home/albertlockett/sophon/src/lance/rust/lance-index/src/vector/pq/distance.rs:100:37
    |
67  | pub(super) fn compute_l2_distance<const C: usize, const V: usize>(
    |               ------------------- this function can't have a `self` parameter
...
100 |                         for k in 0..self.num_sub_vectors - i {
    |                                     ^^^^ `self` value is a keyword only available in methods with a `self` parameter
    |
help: you might have meant to write `.` instead of `..`
    |
100 -                         for k in 0..self.num_sub_vectors - i {
100 +                         for k in 0.self.num_sub_vectors - i {
    |

warning: `lance-datafusion` (lib) generated 2 warnings (2 duplicates)
warning: unused import: `std::cmp::min`
  --> /home/albertlockett/sophon/src/lance/rust/lance-index/src/vector/pq/distance.rs:15:5
   |
15 | use std::cmp::min;
   |     ^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

For more information about this error, try `rustc --explain E0424`.
warning: `lance-index` (lib) generated 1 warning
error: could not compile `lance-index` (lib) due to 2 previous errors; 1 warning emitted
```