### PR TITLE
feat: allow projection expression

### DIFF
--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -99,7 +99,7 @@ def test_indexed_vector_scan(indexed_dataset: lance.LanceDataset, data_table: pa
 
     def check_result(table: pa.Table):
         assert table.num_rows == 1
-        assert table.num_columns == 3
+        assert table.num_columns == 2
 
         actual_price = table["price"][0]
         assert actual_price == expected_price

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -78,9 +78,9 @@ def run(ds, q=None, assert_func=None):
             expected_columns.extend(ds.schema.names)
         else:
             expected_columns.extend(columns)
-        for c in ["vector", "_distance"]:
-            if c not in expected_columns:
-                expected_columns.append(c)
+        # TODO: _distance shouldn't be returned by default either
+        if "_distance" not in expected_columns:
+            expected_columns.append("_distance")
 
         for filter_ in filters:
             for rf in refine:
@@ -130,6 +130,8 @@ def test_ann_append(tmp_path):
     q = new_data["vector"][0].as_py()
 
     def func(rs: pa.Table):
+        if "vector" not in rs:
+            return
         assert rs["vector"][0].as_py() == q
 
     run(dataset, q=np.array(q), assert_func=func)

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -20,9 +21,11 @@ use arrow_array::{Array, Float32Array, Int64Array, RecordBatch};
 use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef, SortOptions};
 use arrow_select::concat::concat_batches;
 use async_recursion::async_recursion;
+use datafusion::common::DFSchema;
 use datafusion::logical_expr::{AggregateFunction, Expr};
 use datafusion::physical_expr::PhysicalSortExpr;
 use datafusion::physical_plan::expressions;
+use datafusion::physical_plan::projection::ProjectionExec as DFProjectionExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::{
     aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy},
@@ -35,10 +38,12 @@ use datafusion::physical_plan::{
     ExecutionPlan, SendableRecordBatchStream,
 };
 use datafusion::scalar::ScalarValue;
+use datafusion_physical_expr::expressions::Column;
+use datafusion_physical_expr::PhysicalExpr;
 use futures::stream::{Stream, StreamExt};
 use futures::TryStreamExt;
 use lance_arrow::floats::{coerce_float_vector, FloatType};
-use lance_core::ROW_ID_FIELD;
+use lance_core::{ROW_ID, ROW_ID_FIELD};
 use lance_datafusion::exec::execute_plan;
 use lance_datafusion::expr::parse_substrait;
 use lance_index::vector::{Query, DIST_COL};
@@ -129,7 +134,12 @@ impl ColumnOrdering {
 pub struct Scanner {
     dataset: Arc<Dataset>,
 
-    projections: Schema,
+    /// The physical schema (before dynamic projection) that must be loaded from the table
+    phyical_columns: Schema,
+
+    /// The expressions for all the columns to be in the output
+    /// Note: this doesn't include _distance, and _rowid
+    requested_output_expr: Option<Vec<(Expr, String)>>,
 
     /// If true then the filter will be applied before an index scan
     prefilter: bool,
@@ -178,6 +188,21 @@ pub struct Scanner {
     fragments: Option<Vec<Fragment>>,
 }
 
+/// lifted from datafusion
+/// If e is a direct column reference, returns the field level
+/// metadata for that field, if any. Otherwise returns None
+fn get_field_metadata(
+    e: &Arc<dyn PhysicalExpr>,
+    input_schema: &ArrowSchema,
+) -> Option<HashMap<String, String>> {
+    // Look up field by index in schema (not NAME as there can be more than one
+    // column with the same name)
+    e.as_any()
+        .downcast_ref::<Column>()
+        .map(|column| input_schema.field(column.index()).metadata())
+        .cloned()
+}
+
 impl Scanner {
     pub fn new(dataset: Arc<Dataset>) -> Self {
         let projection = dataset.schema().clone();
@@ -190,7 +215,8 @@ impl Scanner {
         let batch_size = std::cmp::max(dataset.object_store().block_size() / 4, DEFAULT_BATCH_SIZE);
         Self {
             dataset,
-            projections: projection,
+            phyical_columns: projection,
+            requested_output_expr: None,
             prefilter: false,
             filter: None,
             batch_size,
@@ -241,7 +267,49 @@ impl Scanner {
     ///
     /// Only select the specified columns. If not specified, all columns will be scanned.
     pub fn project<T: AsRef<str>>(&mut self, columns: &[T]) -> Result<&mut Self> {
-        self.projections = self.dataset.schema().project(columns)?;
+        self.project_with_transform(
+            &columns
+                .iter()
+                .map(|c| (c.as_ref(), format!("`{}`", c.as_ref())))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Projection with transform
+    ///
+    /// Only select the specified columns with the given transform.
+    pub fn project_with_transform(
+        &mut self,
+        columns: &[(impl AsRef<str>, impl AsRef<str>)],
+    ) -> Result<&mut Self> {
+        let planner = Planner::new(self.schema()?);
+        let mut output = HashMap::new();
+        let mut physical_cols_set = HashSet::new();
+        let mut physical_cols = vec![];
+        for (output_name, raw_expr) in columns {
+            if output.contains_key(output_name.as_ref()) {
+                return Err(Error::IO {
+                    message: format!("Duplicate column name: {}", output_name.as_ref()),
+                    location: location!(),
+                });
+            }
+            let expr = planner.parse_expr(raw_expr.as_ref())?;
+            for col in Planner::column_names_in_expr(&expr) {
+                if physical_cols_set.contains(&col) {
+                    continue;
+                }
+                physical_cols.push(col.clone());
+                physical_cols_set.insert(col);
+            }
+            output.insert(output_name.as_ref().to_string(), expr);
+        }
+        self.phyical_columns = self.dataset.schema().project(&physical_cols)?;
+
+        let mut output_cols = vec![];
+        for (name, _) in columns {
+            output_cols.push((output[name.as_ref()].clone(), name.as_ref().to_string()));
+        }
+        self.requested_output_expr = Some(output_cols);
         Ok(self)
     }
 
@@ -509,8 +577,8 @@ impl Scanner {
         Ok(schema)
     }
 
-    /// The output schema of the Scanner, in Lance Schema format.
-    pub(crate) fn output_schema(&self) -> Result<Arc<Schema>> {
+    /// The schema of the Scanner from lance physical takes
+    pub(crate) fn physical_schema(&self) -> Result<Arc<Schema>> {
         let mut extra_columns = vec![];
 
         if let Some(q) = self.nearest.as_ref() {
@@ -522,15 +590,107 @@ impl Scanner {
             extra_columns.push(vector_field);
             extra_columns.push(ArrowField::new(DIST_COL, DataType::Float32, true));
         };
+
         if self.with_row_id {
             extra_columns.push(ROW_ID_FIELD.clone());
         }
 
         let schema = if !extra_columns.is_empty() {
-            self.projections.merge(&ArrowSchema::new(extra_columns))?
+            self.phyical_columns
+                .merge(&ArrowSchema::new(extra_columns))?
         } else {
-            self.projections.clone()
+            self.phyical_columns.clone()
         };
+
+        // drop metadata
+        // NOTE: this is the current behavior as we don't return metadata in queries
+        // but do return metadata for regular scans
+        // We should make this behavior consistent -- probably by not returning metadata always
+        if self.nearest.is_some() {
+            Ok(Arc::new(Schema {
+                fields: schema.fields,
+                metadata: HashMap::new(),
+            }))
+        } else {
+            Ok(Arc::new(schema))
+        }
+    }
+
+    pub(crate) fn output_expr(&self) -> Result<Vec<(Arc<dyn PhysicalExpr>, String)>> {
+        let physical_schema = self.physical_schema()?;
+
+        // reset the id ordering becuase we will take the batch after projection
+        let physical_schema = ArrowSchema::new(
+            physical_schema
+                .fields
+                .iter()
+                .map(|f| ArrowField::new(f.name.clone(), f.data_type(), f.nullable))
+                .collect::<Vec<_>>(),
+        );
+        let df_schema = Arc::new(DFSchema::try_from(physical_schema.clone())?);
+
+        let project_star = self
+            .phyical_columns
+            .fields
+            .iter()
+            .map(|f| {
+                Ok((
+                    expressions::col(f.name.as_str(), &physical_schema)?.clone(),
+                    f.name.clone(),
+                ))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let output_expr = self.requested_output_expr.clone().map(|exprs| {
+            exprs
+                .iter()
+                .map(|(expr, name)| {
+                    Ok((
+                        datafusion::physical_expr::create_physical_expr(
+                            expr,
+                            &df_schema,
+                            &Default::default(),
+                        )?,
+                        name.clone(),
+                    ))
+                })
+                .collect::<Result<Vec<_>>>()
+        });
+
+        // Append the extra columns
+        let mut output_expr = output_expr.unwrap_or(Ok(project_star))?;
+
+        // distance goes before the row_id column
+        if self.nearest.is_some() {
+            let vector_expr = expressions::col(DIST_COL, &physical_schema)?;
+            output_expr.push((vector_expr, DIST_COL.to_string()));
+        }
+
+        if self.with_row_id {
+            let row_id_expr = expressions::col(ROW_ID, &physical_schema)?;
+            output_expr.push((row_id_expr, ROW_ID.to_string()));
+        }
+
+        Ok(output_expr)
+    }
+
+    /// The schema of the Scanner output
+    pub(crate) fn output_schema(&self) -> Result<Arc<Schema>> {
+        let arrow_schema = self.physical_schema()?.as_ref().into();
+        let output_expr = self.output_expr()?;
+
+        let mut fields = vec![];
+        for (expr, name) in output_expr {
+            let dtype = expr.data_type(&arrow_schema)?;
+            let nullable = expr.nullable(&arrow_schema)?;
+
+            let mut field = ArrowField::new(name, dtype, nullable);
+            field.set_metadata(get_field_metadata(&expr, &arrow_schema).unwrap_or_default());
+
+            fields.push(field);
+        }
+        let schema = (&ArrowSchema::new(fields)).try_into()?;
+
         Ok(Arc::new(schema))
     }
 
@@ -656,7 +816,7 @@ impl Scanner {
     /// 4. Limit / Offset
     /// 5. Take remaining columns / Projection
     pub async fn create_plan(&self) -> Result<Arc<dyn ExecutionPlan>> {
-        if self.projections.fields.is_empty() && !self.with_row_id {
+        if self.phyical_columns.fields.is_empty() && !self.with_row_id {
             return Err(Error::InvalidInput {
                 source:
                     "no columns were selected and with_row_id is false, there is nothing to scan"
@@ -668,10 +828,11 @@ impl Scanner {
         // TODO: Should we use them when postfiltering if there is no vector search?
         let use_scalar_index = self.prefilter || self.nearest.is_none();
 
+        let planner = Planner::new(Arc::new(self.dataset.schema().into()));
+
         // NOTE: we only support node that have one partition. So any nodes that
         // produce multiple need to be repartitioned to 1.
         let mut filter_plan = if let Some(filter) = self.filter.as_ref() {
-            let planner = Planner::new(Arc::new(self.dataset.schema().into()));
             let index_info = self.dataset.scalar_index_info().await?;
             let filter_plan =
                 planner.create_filter_plan(filter.clone(), &index_info, use_scalar_index)?;
@@ -719,7 +880,7 @@ impl Scanner {
         } else {
             match (&filter_plan.index_query, &mut filter_plan.refine_expr) {
                 (Some(index_query), None) => {
-                    self.scalar_indexed_scan(&self.projections, index_query)
+                    self.scalar_indexed_scan(&self.phyical_columns, index_query)
                         .await?
                 }
                 // TODO: support combined pushdown and scalar index scan
@@ -737,7 +898,7 @@ impl Scanner {
                 (None, _) => {
                     // The source is a full scan of the table
                     let with_row_id = filter_plan.has_refine() || self.with_row_id;
-                    self.scan(with_row_id, false, self.projections.clone().into())
+                    self.scan(with_row_id, false, self.phyical_columns.clone().into())
                 }
             }
         };
@@ -810,16 +971,21 @@ impl Scanner {
             plan = self.limit_node(plan);
         }
 
-        // Stage 5: take remaining columns / projection
-        let output_schema = self.output_schema()?;
-        let remaining_schema = output_schema.exclude(plan.schema().as_ref())?;
+        // Stage 5: take remaining columns required for projection
+        let physical_schema = self.physical_schema()?;
+        let remaining_schema = physical_schema.exclude(plan.schema().as_ref())?;
         if !remaining_schema.fields.is_empty() {
             plan = self.take(plan, &remaining_schema, self.batch_readahead)?;
         }
-        let output_arrow_schema = output_schema.as_ref().into();
+
+        // Stage 6: physical projection -- reorder physical columns needed before final projection
+        let output_arrow_schema = physical_schema.as_ref().into();
         if plan.schema().as_ref() != &output_arrow_schema {
-            plan = Arc::new(ProjectionExec::try_new(plan, output_schema)?);
+            plan = Arc::new(ProjectionExec::try_new(plan, physical_schema)?);
         }
+
+        // Stage 7: final projection
+        plan = Arc::new(DFProjectionExec::try_new(self.output_expr()?, plan)?);
 
         let optimizer = Planner::get_physical_optimizer();
         let options = Default::default();
@@ -1181,7 +1347,7 @@ impl Scanner {
         Ok(Arc::new(LancePushdownScanExec::try_new(
             self.dataset.clone(),
             fragments,
-            self.projections.clone().into(),
+            self.phyical_columns.clone().into(),
             predicate,
             config,
         )?))
@@ -1742,7 +1908,7 @@ mod test {
         let key: Float32Array = (32..64).map(|v| v as f32).collect();
         scan.filter("i > 100").unwrap();
         scan.prefilter(true);
-        scan.project(&["i"]).unwrap();
+        scan.project(&["i", "vec"]).unwrap();
         scan.nearest("vec", &key, 5).unwrap();
         scan.use_index(false);
 
@@ -1860,7 +2026,7 @@ mod test {
         let key: Float32Array = (32..64).map(|v| v as f32).collect();
         scan.nearest("vec", &key, 5).unwrap();
         scan.filter("i > 100").unwrap();
-        scan.project(&["i"]).unwrap();
+        scan.project(&["i", "vec"]).unwrap();
         scan.refine(5);
 
         let results = scan
@@ -2672,6 +2838,43 @@ mod test {
         );
     }
 
+    #[tokio::test]
+    async fn test_dynamic_projection() {
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+        let mut data_gen =
+            BatchGenerator::new().col(Box::new(IncrementingInt32::new().named("i".to_owned())));
+        Dataset::write(data_gen.batch(32), test_uri, None)
+            .await
+            .unwrap();
+
+        let dataset = Dataset::open(test_uri).await.unwrap();
+        assert_eq!(32, dataset.scan().count_rows().await.unwrap());
+
+        let mut scanner = dataset.scan();
+
+        let scan_res = scanner
+            .project_with_transform(&[("bool", "i > 15")])
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+
+        assert_eq!(1, scan_res.num_columns());
+
+        let bool_col = scan_res
+            .column_by_name("bool")
+            .expect("bool column should exist");
+        let bool_arr = bool_col.as_boolean();
+        for i in 0..32 {
+            if i > 15 {
+                assert!(bool_arr.value(i));
+            } else {
+                assert!(!bool_arr.value(i));
+            }
+        }
+    }
+
     struct ScalarIndexTestFixture {
         _test_dir: TempDir,
         dataset: Dataset,
@@ -2897,9 +3100,8 @@ mod test {
                 // 1 projected column
                 let mut expected_columns = 1;
                 if vector.is_some() {
-                    // vector column always included (TODO: should it be? #1565)
-                    // distance column included
-                    expected_columns += 2;
+                    // distance column if included always (TODO: it shouldn't)
+                    expected_columns += 1;
                 }
                 if params.with_row_id {
                     expected_columns += 1;
@@ -3467,6 +3669,26 @@ mod test {
       Projection: fields=[_rowid, s]
         FilterExec: i@1 > 10
           LanceScan: uri=..., projection=[s, i], row_id=true, ordered=false",
+        )
+        .await?;
+
+        // Scans with dynamic projection
+        // When an expression is specified in the projection, the plan should include a ProjectionExec
+        assert_plan_equals(
+            &dataset.dataset,
+            |scan| {
+                scan.project_with_transform(&[("matches", "regexp_match(s, \".*\")")])?
+                    .filter("i > 10")
+            },
+            "ProjectionExec: expr=[regexp_match(s@0, .*) as matches]
+  Projection: fields=[s]
+    RepartitionExec: partitioning=RoundRobinBatch(1), input_partitions=2
+      UnionExec
+        Take: columns=\"_rowid, s\"
+          MaterializeIndex: query=i > 10
+        Projection: fields=[_rowid, s]
+          FilterExec: i@1 > 10
+            LanceScan: uri=..., projection=[s, i], row_id=true, ordered=false",
         )
         .await?;
 

--- a/rust/lance/src/io/exec/optimizer.rs
+++ b/rust/lance/src/io/exec/optimizer.rs
@@ -21,8 +21,9 @@ use datafusion::{
     config::ConfigOptions,
     error::Result as DFResult,
     physical_optimizer::PhysicalOptimizerRule,
-    physical_plan::ExecutionPlan,
+    physical_plan::{projection::ProjectionExec as DFProjectionExec, ExecutionPlan},
 };
+use datafusion_physical_expr::expressions::Column;
 
 use super::TakeExec;
 
@@ -49,6 +50,57 @@ impl PhysicalOptimizerRule for CoalesceTake {
 
     fn name(&self) -> &str {
         "coalesce_take"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+/// Rule that eliminates [ProjectionExec] nodes that projects all columns
+/// from its input with no additional expressions.
+pub struct SimplifyProjection;
+
+impl PhysicalOptimizerRule for SimplifyProjection {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        plan.transform_down(&|plan| {
+            if let Some(proj) = plan.as_any().downcast_ref::<DFProjectionExec>() {
+                let children = &proj.children();
+                if children.len() != 1 {
+                    return Ok(Transformed::No(plan));
+                }
+
+                let input = &children[0];
+
+                // TODO: we could try to coalesce consecutive projections, something for later
+                // For now, we just keep things simple and only remove NoOp projections
+
+                // output has differnet schema, projection needed
+                if input.schema() != proj.schema() {
+                    return Ok(Transformed::No(plan));
+                }
+
+                if proj.expr().iter().enumerate().all(|(index, (expr, name))| {
+                    if let Some(expr) = expr.as_any().downcast_ref::<Column>() {
+                        // no renaming, no reordering
+                        expr.index() == index && expr.name() == name
+                    } else {
+                        false
+                    }
+                }) {
+                    return Ok(Transformed::Yes(input.clone()));
+                }
+            }
+            Ok(Transformed::No(plan))
+        })
+    }
+
+    fn name(&self) -> &str {
+        "simplify_projection"
     }
 
     fn schema_check(&self) -> bool {

--- a/rust/lance/src/io/exec/planner.rs
+++ b/rust/lance/src/io/exec/planner.rs
@@ -607,7 +607,10 @@ impl Planner {
     }
 
     pub fn get_physical_optimizer() -> PhysicalOptimizer {
-        PhysicalOptimizer::with_rules(vec![Arc::new(crate::io::exec::optimizer::CoalesceTake)])
+        PhysicalOptimizer::with_rules(vec![
+            Arc::new(crate::io::exec::optimizer::CoalesceTake),
+            Arc::new(crate::io::exec::optimizer::SimplifyProjection),
+        ])
     }
 }
 


### PR DESCRIPTION
BREAKING: vector queries no long return the vector column by default. i.e. unless the caller explicitly doesn't call `project` or `project(&["vec"])`, the vector column won't be returned

this PR implement `SELECT func(col) AS my_col` semantic to lance. Python changes will come in a later PR

this PR also partially addresses https://github.com/lancedb/lancedb/issues/953, where we no longer return the vector column by default