### PR TITLE
fix: map the ErrorKind::NotFound to Error::NotFound

### DIFF
--- a/rust/lance-io/src/local.rs
+++ b/rust/lance-io/src/local.rs
@@ -47,7 +47,13 @@ pub fn to_local_path(path: &Path) -> String {
 /// Recursively remove a directory, specified by [`object_store::path::Path`].
 pub fn remove_dir_all(path: &Path) -> Result<()> {
     let local_path = to_local_path(path);
-    std::fs::remove_dir_all(local_path)?;
+    std::fs::remove_dir_all(local_path).map_err(|err| match err.kind() {
+        ErrorKind::NotFound => Error::NotFound {
+            uri: path.to_string(),
+            location: location!(),
+        },
+        _ => Error::from(err),
+    })?;
     Ok(())
 }
 


### PR DESCRIPTION
this makes it possible to recognize whether we are removing something not exists.
see https://github.com/lancedb/lancedb/issues/884