### PR TITLE
chore: use v0.2.44 cargo-workspace for bumping version

### DIFF
--- a/.github/workflows/bump-version/action.yml
+++ b/.github/workflows/bump-version/action.yml
@@ -23,5 +23,5 @@ runs:
     working-directory: rust
     shell: bash
     run: |
-      cargo install cargo-workspaces
+      cargo install cargo-workspaces --version 0.2.44
       cargo ws version --no-git-commit -y --exact --force 'lance*' ${{ inputs.part }}


### PR DESCRIPTION
the newest cargo-workspace can't be installed due to a compile error