### PR TITLE
fix: use 1 for beam search candidate length for the levels above the assigned level

### DIFF
--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -160,13 +160,7 @@ impl HNSWBuilder {
         // ```
         for cur_level in self.levels.iter().rev().take(levels_to_search) {
             let candidates = beam_search(cur_level, &ep, vector, 1)?;
-            ep = if self.use_select_heuristic {
-                select_neighbors_heuristic(cur_level, query, &candidates, 1, self.extend_candidates)
-                    .map(|(_, id)| id)
-                    .collect()
-            } else {
-                select_neighbors(&candidates, 1).map(|(_, id)| id).collect()
-            };
+            ep = select_neighbors(&candidates, 1).map(|(_, id)| id).collect()
         }
 
         let m = self.len();

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -159,7 +159,7 @@ impl HNSWBuilder {
         //  }
         // ```
         for cur_level in self.levels.iter().rev().take(levels_to_search) {
-            let candidates = beam_search(cur_level, &ep, vector, self.ef_construction)?;
+            let candidates = beam_search(cur_level, &ep, vector, 1)?;
             ep = if self.use_select_heuristic {
                 select_neighbors_heuristic(cur_level, query, &candidates, 1, self.extend_candidates)
                     .map(|(_, id)| id)


### PR DESCRIPTION
To be consistent with the paper. 