### PR TITLE
fix: search stops early than expected

### DIFF
--- a/rust/lance-index/src/vector/graph.rs
+++ b/rust/lance-index/src/vector/graph.rs
@@ -186,7 +186,7 @@ pub(super) fn beam_search(
     while !candidates.is_empty() {
         let (dist, current) = candidates.pop_first().expect("candidates is empty");
         let furtherst = *results.last_key_value().expect("results set is empty").0;
-        if dist < furtherst {
+        if dist > furtherst {
             break;
         }
         let neighbors = graph.neighbors(current).ok_or_else(|| Error::Index {
@@ -199,15 +199,15 @@ pub(super) fn beam_search(
                 continue;
             }
             visited.insert(neighbor);
+            let furtherst = *results.last_key_value().expect("results set is empty").0;
             let dist = dist_calc.distance(&[neighbor])[0].into();
             if dist < furtherst || results.len() < k {
                 results.insert(dist, neighbor);
                 candidates.insert(dist, neighbor);
+                if results.len() > k {
+                    results.pop_last();
+                }
             }
-        }
-        // Maintain the size of the result set.
-        while results.len() > k {
-            results.pop_last();
         }
     }
     Ok(results)

--- a/rust/lance-index/src/vector/hnsw.rs
+++ b/rust/lance-index/src/vector/hnsw.rs
@@ -481,9 +481,9 @@ mod tests {
     #[test]
     fn test_search() {
         const DIM: usize = 32;
-        const TOTAL: usize = 1024;
-        const MAX_EDGES: usize = 32;
-        const K: usize = 10;
+        const TOTAL: usize = 10_000;
+        const MAX_EDGES: usize = 30;
+        const K: usize = 100;
 
         let data = generate_random_array(TOTAL * DIM);
         let mat = Arc::new(MatrixView::<Float32Type>::new(data.into(), DIM));
@@ -498,7 +498,7 @@ mod tests {
             .unwrap();
 
         let results: HashSet<u32> = hnsw
-            .search(q, 10, 150)
+            .search(q, K, 128)
             .unwrap()
             .iter()
             .map(|(i, _)| *i)
@@ -506,6 +506,6 @@ mod tests {
         let gt = ground_truth(&mat, q, K);
         let recall = results.intersection(&gt).count() as f32 / K as f32;
         // TODO: improve the recall.
-        assert!(recall >= 0.3, "Recall: {}", recall);
+        assert!(recall >= 0.9, "Recall: {}", recall);
     }
 }


### PR DESCRIPTION
- continue searching if candidate is closer than futherest result
- re-evaluate the furtherest result for each iteration
- remove furtherest result while adding new candidate

this fixes the very low recall problem, but it also brings the construction time to normal which may be much slower than former