### PR TITLE
fix: crate publish

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 30
     defaults:
       run:
-        working-directory: ./rust
+        working-directory: .
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -29,4 +29,4 @@ jobs:
         with:
           registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           args: '--all-features'
-          path: ./rust
+          path: .

--- a/java/lance-jni/Cargo.toml
+++ b/java/lance-jni/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 description = "JNI bindings for Lance Columnar format"
 keywords.workspace = true
 categories.workspace = true
+publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 rust-version = "1.65"
 exclude = ["python/lance/conftest.py"]
+publish = false
 
 [lib]
 name = "lance"


### PR DESCRIPTION
https://github.com/lancedb/lance/pull/1928 moved the workspace `Cargo.toml` to the root directory