### PR TITLE
chore(java): provide conversion utilities between jni objects and rust objects

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -15,8 +15,8 @@
 use arrow::array::RecordBatchReader;
 
 use lance::dataset::{Dataset, WriteParams};
-use lance::Result;
 
+use crate::Result;
 use crate::RT;
 
 pub struct BlockingDataset {
@@ -39,7 +39,7 @@ impl BlockingDataset {
     }
 
     pub fn count_rows(&self) -> Result<usize> {
-        RT.block_on(self.inner.count_rows())
+        Ok(RT.block_on(self.inner.count_rows())?)
     }
 
     pub fn close(&self) {}

--- a/java/lance-jni/src/error.rs
+++ b/java/lance-jni/src/error.rs
@@ -1,0 +1,104 @@
+// Copyright 2024 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::str::Utf8Error;
+
+use jni::errors::Error as JniError;
+use snafu::{Location, Snafu};
+
+/// Java Exception types
+pub enum JavaException {
+    IllegalArgumentException,
+    IOException,
+    RuntimeException,
+}
+
+impl JavaException {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::IllegalArgumentException => "java/lang/IllegalArgumentException",
+            Self::IOException => "java/io/IOException",
+            Self::RuntimeException => "java/lang/RuntimeException",
+        }
+    }
+}
+
+#[derive(Debug, Snafu)]
+#[snafu(visibility(pub))]
+pub enum Error {
+    #[snafu(display("JNI error: {}", message))]
+    Jni { message: String },
+    #[snafu(display("Invalid argument: {}", message))]
+    InvalidArgument { message: String },
+    #[snafu(display("IO error: {}, location: {}", message, location))]
+    IO { message: String, location: Location },
+    #[snafu(display("Arrow error: {}", message))]
+    Arrow { message: String, location: Location },
+    #[snafu(display("Index error: {}, location", message))]
+    Index { message: String, location: Location },
+    #[snafu(display("Unknown error"))]
+    Other { message: String },
+}
+
+impl Error {
+    /// Throw as Java Exception
+    pub fn throw(&self, env: &mut jni::JNIEnv) {
+        match self {
+            Self::InvalidArgument { .. } => {
+                self.throw_as(env, JavaException::IllegalArgumentException)
+            }
+            Self::IO { .. } | Self::Index { .. } => self.throw_as(env, JavaException::IOException),
+            Self::Arrow { .. } | Self::Other { .. } | Self::Jni { .. } => {
+                self.throw_as(env, JavaException::RuntimeException)
+            }
+        }
+    }
+
+    /// Throw as an concrete Java Exception
+    pub fn throw_as(&self, env: &mut jni::JNIEnv, exception: JavaException) {
+        env.throw_new(exception.as_str(), self.to_string())
+            .expect("Error when throwing Java exception");
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl From<JniError> for Error {
+    fn from(source: JniError) -> Self {
+        Self::Jni {
+            message: source.to_string(),
+        }
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(source: Utf8Error) -> Self {
+        Self::InvalidArgument {
+            message: source.to_string(),
+        }
+    }
+}
+
+impl From<lance::Error> for Error {
+    fn from(source: lance::Error) -> Self {
+        match source {
+            lance::Error::IO { message, location } => Self::IO { message, location },
+            lance::Error::Arrow { message, location } => Self::Arrow { message, location },
+            lance::Error::Index { message, location } => Self::Index { message, location },
+            _ => Self::Other {
+                message: source.to_string(),
+            },
+        }
+    }
+}

--- a/java/lance-jni/src/jni_helpers.rs
+++ b/java/lance-jni/src/jni_helpers.rs
@@ -13,15 +13,9 @@
 // limitations under the License.
 
 use jni::objects::{JMap, JObject, JString, JValue};
-use jni::strings::JavaStr;
 use jni::JNIEnv;
 
-use crate::{Error, Result};
-
-pub fn throw_java_exception(env: &mut JNIEnv, err_msg: &str) {
-    env.throw_new("java/lang/RuntimeException", err_msg)
-        .expect("Error throwing exception");
-}
+use crate::Result;
 
 pub trait FromJObject<T> {
     fn extract(&self) -> Result<T>;
@@ -52,11 +46,11 @@ impl FromJObject<f64> for JObject<'_> {
 }
 
 pub trait FromJString {
-    fn extract(&self, env: &JNIEnv) -> Result<String>;
+    fn extract(&self, env: &mut JNIEnv) -> Result<String>;
 }
 
 impl FromJString for JString<'_> {
-    fn extract(&self, env: &JNIEnv) -> Result<String> {
+    fn extract(&self, env: &mut JNIEnv) -> Result<String> {
         Ok(env.get_string(self)?.into())
     }
 }

--- a/java/lance-jni/src/jni_helpers.rs
+++ b/java/lance-jni/src/jni_helpers.rs
@@ -51,6 +51,16 @@ impl FromJObject<f64> for JObject<'_> {
     }
 }
 
+pub trait FromJString {
+    fn extract(&self, env: &JNIEnv) -> Result<String>;
+}
+
+impl FromJString for JString<'_> {
+    fn extract(&self, env: &JNIEnv) -> Result<String> {
+        Ok(env.get_string(self)?.into())
+    }
+}
+
 pub trait JMapExt {
     fn get_string(&self, env: &mut JNIEnv, key: &str) -> Result<Option<String>>;
 
@@ -64,7 +74,7 @@ impl JMapExt for JMap<'_, '_, '_> {
         let key_obj: JObject = env.new_string(key)?.into();
         if let Some(value) = self.get(env, &key_obj)? {
             let value_str: JString = value.into();
-            Ok(Some(env.get_string(&value_str)?.into()))
+            Ok(Some(value_str.extract(env)?))
         } else {
             Ok(None)
         }

--- a/java/lance-jni/src/lib.rs
+++ b/java/lance-jni/src/lib.rs
@@ -35,7 +35,7 @@ mod blocking_dataset;
 pub mod error;
 mod jni_helpers;
 
-use self::jni_helpers::{FromJObject, JMapExt};
+use self::jni_helpers::{FromJObject, FromJString, JMapExt};
 use crate::blocking_dataset::BlockingDataset;
 pub use error::{Error, Result};
 
@@ -54,7 +54,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_writeWithFfiStream<'local>
     path: JString,
     params: JObject,
 ) -> JObject<'local> {
-    let path_str: String = ok_or_throw!(&env, env.get_string(&path).into());
+    let path_str: String = ok_or_throw!(&env, path.extract(&env));
 
     let write_params = ok_or_throw!(&env, extract_write_params(&mut env, &params));
 
@@ -129,9 +129,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_open<'local>(
     _obj: JObject,
     path: JString,
 ) -> JObject<'local> {
-    let Ok(path_str) = jni_helpers::extract_path_str(&mut env, &path) else {
-        return JObject::null();
-    };
+    let path_str: String = ok_or_throw!(&env, path.extract(&env));
 
     match BlockingDataset::open(&path_str) {
         Ok(dataset) => attach_native_dataset(&mut env, dataset),

--- a/java/lance-jni/src/traits.rs
+++ b/java/lance-jni/src/traits.rs
@@ -67,6 +67,22 @@ pub trait JMapExt {
     fn get_i64(&self, env: &mut JNIEnv, key: &str) -> Result<Option<i64>>;
 }
 
+fn get_map_value<T>(env: &mut JNIEnv, map: &JMap, key: &str) -> Result<Option<T>>
+where
+    for<'a> JObject<'a>: FromJObject<T>,
+{
+    let key_obj: JObject = env.new_string(key)?.into();
+    if let Some(value) = map.get(env, &key_obj)? {
+        if value.is_null() {
+            Ok(None)
+        } else {
+            Ok(Some(value.extract()?))
+        }
+    } else {
+        Ok(None)
+    }
+}
+
 impl JMapExt for JMap<'_, '_, '_> {
     fn get_string(&self, env: &mut JNIEnv, key: &str) -> Result<Option<String>> {
         let key_obj: JObject = env.new_string(key)?.into();
@@ -79,20 +95,10 @@ impl JMapExt for JMap<'_, '_, '_> {
     }
 
     fn get_i32(&self, env: &mut JNIEnv, key: &str) -> Result<Option<i32>> {
-        let key_obj: JObject = env.new_string(key)?.into();
-        if let Some(value) = self.get(env, &key_obj)? {
-            Ok(Some(value.extract()?))
-        } else {
-            Ok(None)
-        }
+        get_map_value(env, self, key)
     }
 
     fn get_i64(&self, env: &mut JNIEnv, key: &str) -> Result<Option<i64>> {
-        let key_obj: JObject = env.new_string(key)?.into();
-        if let Some(value) = self.get(env, &key_obj)? {
-            Ok(Some(value.extract()?))
-        } else {
-            Ok(None)
-        }
+        get_map_value(env, self, key)
     }
 }

--- a/java/lance-jni/src/traits.rs
+++ b/java/lance-jni/src/traits.rs
@@ -21,6 +21,10 @@ pub trait FromJObject<T> {
     fn extract(&self) -> Result<T>;
 }
 
+pub trait IntoJava {
+    fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> JObject<'a>;
+}
+
 impl FromJObject<i32> for JObject<'_> {
     fn extract(&self) -> Result<i32> {
         Ok(JValue::from(self).i()?)

--- a/java/lance-jni/src/traits.rs
+++ b/java/lance-jni/src/traits.rs
@@ -21,6 +21,7 @@ pub trait FromJObject<T> {
     fn extract(&self) -> Result<T>;
 }
 
+/// Convert a Rust type into a Java Object.
 pub trait IntoJava {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> JObject<'a>;
 }
@@ -65,6 +66,10 @@ pub trait JMapExt {
     fn get_i32(&self, env: &mut JNIEnv, key: &str) -> Result<Option<i32>>;
 
     fn get_i64(&self, env: &mut JNIEnv, key: &str) -> Result<Option<i64>>;
+
+    fn get_f32(&self, env: &mut JNIEnv, key: &str) -> Result<Option<f32>>;
+
+    fn get_f64(&self, env: &mut JNIEnv, key: &str) -> Result<Option<f64>>;
 }
 
 fn get_map_value<T>(env: &mut JNIEnv, map: &JMap, key: &str) -> Result<Option<T>>
@@ -99,6 +104,14 @@ impl JMapExt for JMap<'_, '_, '_> {
     }
 
     fn get_i64(&self, env: &mut JNIEnv, key: &str) -> Result<Option<i64>> {
+        get_map_value(env, self, key)
+    }
+
+    fn get_f32(&self, env: &mut JNIEnv, key: &str) -> Result<Option<f32>> {
+        get_map_value(env, self, key)
+    }
+
+    fn get_f64(&self, env: &mut JNIEnv, key: &str) -> Result<Option<f64>> {
         get_map_value(env, self, key)
     }
 }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -55,9 +55,9 @@ impl TryFrom<&str> for WriteMode {
 
     fn try_from(value: &str) -> Result<Self> {
         match value.to_lowercase().as_str() {
-            "create" => Ok(WriteMode::Create),
-            "append" => Ok(WriteMode::Append),
-            "overwrite" => Ok(WriteMode::Overwrite),
+            "create" => Ok(Self::Create),
+            "append" => Ok(Self::Append),
+            "overwrite" => Ok(Self::Overwrite),
             _ => Err(Error::IO {
                 message: format!("Invalid write mode: {}", value),
                 location: location!(),

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use arrow_array::RecordBatchReader;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::StreamExt;
-use lance_core::{datatypes::Schema, Result};
+use lance_core::{datatypes::Schema, Error, Result};
 use lance_datafusion::chunker::chunk_stream;
 use lance_datafusion::utils::reader_to_stream;
 use lance_file::writer::FileWriter;
@@ -29,6 +29,7 @@ use lance_table::format::Fragment;
 use lance_table::io::commit::CommitHandler;
 use lance_table::io::manifest::ManifestDescribing;
 use object_store::path::Path;
+use snafu::{location, Location};
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -47,6 +48,22 @@ pub enum WriteMode {
     Append,
     /// Overwrite a dataset as a new version, or create new dataset if not exist.
     Overwrite,
+}
+
+impl TryFrom<&str> for WriteMode {
+    type Error = Error;
+
+    fn try_from(value: &str) -> Result<Self> {
+        match value.to_lowercase().as_str() {
+            "create" => Ok(WriteMode::Create),
+            "append" => Ok(WriteMode::Append),
+            "overwrite" => Ok(WriteMode::Overwrite),
+            _ => Err(Error::IO {
+                message: format!("Invalid write mode: {}", value),
+                location: location!(),
+            }),
+        }
+    }
 }
 
 /// Dataset Write Parameters


### PR DESCRIPTION
Add conversions between Errors, Java/Rust objects.
Modeled after `pyo3`