### PR TITLE
fix: stronger numeric guarantees for distance kernels

### DIFF
--- a/rust/lance-linalg/Cargo.toml
+++ b/rust/lance-linalg/Cargo.toml
@@ -30,6 +30,7 @@ approx = { workspace = true }
 arrow-arith = { workspace = true }
 criterion = { workspace = true }
 lance-testing = { path = "../lance-testing" }
+proptest.workspace = true
 
 [build-dependencies]
 cc = "1.0.83"

--- a/rust/lance-linalg/benches/norm_l2.rs
+++ b/rust/lance-linalg/benches/norm_l2.rs
@@ -33,6 +33,7 @@ use pprof::criterion::{Output, PProfProfiler};
 const DIMENSION: usize = 1024;
 const TOTAL: usize = 1024 * 1024; // 1M vectors
 
+#[allow(clippy::type_complexity)]
 fn run_bench<T: ArrowFloatType>(
     c: &mut Criterion,
     target: &[T::Native],

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -288,7 +288,6 @@ mod tests {
     use crate::test_utils::{
         arbitrary_bf16, arbitrary_f16, arbitrary_f32, arbitrary_f64, arbitrary_vector_pair,
     };
-    use approx::assert_relative_eq;
     use num_traits::{Float, FromPrimitive};
     use proptest::prelude::*;
 

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -43,13 +43,14 @@ use crate::Result;
 // Please make sure run `cargo bench --bench dot` with and without AVX-512 before any change.
 // Tested `target-features`: avx512f,avx512vl,f16c
 #[inline]
-fn dot_scalar<T, Output: Real + Sum + AddAssign + 'static, const LANES: usize>(
+fn dot_scalar<
+    T: AsPrimitive<Output>,
+    Output: Real + Sum + AddAssign + 'static,
+    const LANES: usize,
+>(
     from: &[T],
     to: &[T],
-) -> Output
-where
-    T: AsPrimitive<Output>,
-{
+) -> Output {
     let x_chunks = to.chunks_exact(LANES);
     let y_chunks = from.chunks_exact(LANES);
     let sum = if x_chunks.remainder().is_empty() {

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -290,6 +290,7 @@ mod tests {
     };
     use approx::assert_relative_eq;
     use num_traits::{Float, FromPrimitive};
+    use proptest::prelude::*;
 
     #[test]
     fn test_dot() {
@@ -336,7 +337,7 @@ mod tests {
         (2.0 * T::epsilon().as_() * dot) as f32
     }
 
-    fn do_dot_test<T: FloatToArrayType>(x: &[T], y: &[T])
+    fn do_dot_test<T: FloatToArrayType>(x: &[T], y: &[T]) -> std::result::Result<(), TestCaseError>
     where
         T::ArrowType: Dot,
     {
@@ -348,28 +349,29 @@ mod tests {
 
         let max_error = max_error::<T>(&f64_x, &f64_y);
 
-        assert_relative_eq!(expected, result, epsilon = max_error);
+        prop_assert!(approx::relative_eq!(expected, result, epsilon = max_error));
+        Ok(())
     }
 
     proptest::proptest! {
         #[test]
         fn test_dot_f16((x, y) in arbitrary_vector_pair(arbitrary_f16, 4..4048)) {
-            do_dot_test(&x, &y);
+            do_dot_test(&x, &y)?;
         }
 
         #[test]
         fn test_dot_bf16((x, y) in arbitrary_vector_pair(arbitrary_bf16, 4..4048)){
-            do_dot_test(&x, &y);
+            do_dot_test(&x, &y)?;
         }
 
         #[test]
         fn test_dot_f32((x, y) in arbitrary_vector_pair(arbitrary_f32, 4..4048)){
-            do_dot_test(&x, &y);
+            do_dot_test(&x, &y)?;
         }
 
         #[test]
         fn test_dot_f64((x, y) in arbitrary_vector_pair(arbitrary_f64, 4..4048)){
-            do_dot_test(&x, &y);
+            do_dot_test(&x, &y)?;
         }
     }
 }

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -38,9 +38,11 @@ use crate::simd::{
 };
 use crate::{Error, Result};
 
+use super::Normalize;
+
 /// Calculate the L2 distance between two vectors.
 ///
-pub trait L2: ArrowFloatType {
+pub trait L2: ArrowFloatType + Normalize {
     /// Calculate the L2 distance between two vectors.
     fn l2(x: &[Self::Native], y: &[Self::Native]) -> f32;
 

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -67,13 +67,14 @@ where
 ///
 /// This is pub for test/benchmark only. use [l2] instead.
 #[inline]
-pub fn l2_scalar<T, Output: Float + Sum + AddAssign + 'static, const LANES: usize>(
+pub fn l2_scalar<
+    T: AsPrimitive<Output>,
+    Output: Float + Sum + AddAssign + 'static,
+    const LANES: usize,
+>(
     from: &[T],
     to: &[T],
-) -> Output
-where
-    T: AsPrimitive<Output>,
-{
+) -> Output {
     let x_chunks = from.chunks_exact(LANES);
     let y_chunks = to.chunks_exact(LANES);
 
@@ -411,9 +412,9 @@ mod tests {
         let y_f64 = y.iter().map(|v| v.to_f64().unwrap()).collect::<Vec<f64>>();
 
         let result = l2(x, y);
-        let reference = l2_distance_reference(&x_f64, &y_f64);
+        let reference = l2_distance_reference(&x_f64, &y_f64) as f32;
 
-        assert_relative_eq!(result as f64, reference, max_relative = 1e-6);
+        assert_relative_eq!(result, reference, max_relative = 1e-6);
     }
 
     // Test L2 distance over different types.

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -166,7 +166,7 @@ mod tests {
         data.iter().map(|v| (*v * *v)).sum::<f64>().sqrt() as f32
     }
 
-    fn do_norm_l2_test<T: FloatToArrayType>(data: &[T])
+    fn do_norm_l2_test<T: FloatToArrayType>(data: &[T]) -> std::result::Result<(), TestCaseError>
     where
         T::ArrowType: Normalize,
     {
@@ -178,28 +178,29 @@ mod tests {
         let result = norm_l2(data);
         let reference = norm_l2_reference(&f64_data);
 
-        assert_relative_eq!(result, reference, max_relative = 1e-6);
+        prop_assert!(approx::relative_eq!(result, reference, max_relative = 1e-6));
+        Ok(())
     }
 
     proptest::proptest! {
         #[test]
         fn test_l2_norm_f16(data in prop::collection::vec(arbitrary_f16(), 4..4048)) {
-            do_norm_l2_test(&data);
+            do_norm_l2_test(&data)?;
         }
 
         #[test]
         fn test_l2_norm_bf16(data in prop::collection::vec(arbitrary_bf16(), 4..4048)){
-            do_norm_l2_test(&data);
+            do_norm_l2_test(&data)?;
         }
 
         #[test]
         fn test_l2_norm_f32(data in prop::collection::vec(arbitrary_f32(), 4..4048)){
-            do_norm_l2_test(&data);
+            do_norm_l2_test(&data)?;
         }
 
         #[test]
         fn test_l2_norm_f64(data in prop::collection::vec(arbitrary_f64(), 4..4048)){
-            do_norm_l2_test(&data);
+            do_norm_l2_test(&data)?;
         }
     }
 }

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -116,12 +116,13 @@ impl Normalize for Float64Type {
 
 /// NOTE: this is only pub for benchmarking purposes
 #[inline]
-pub fn norm_l2_impl<T, Output: Float + Sum + 'static + AddAssign, const LANES: usize>(
-    vector: &[T],
-) -> Output
-where
+pub fn norm_l2_impl<
     T: AsPrimitive<Output>,
-{
+    Output: Float + Sum + 'static + AddAssign,
+    const LANES: usize,
+>(
+    vector: &[T],
+) -> Output {
     let chunks = vector.chunks_exact(LANES);
     let sum = if chunks.remainder().is_empty() {
         Output::zero()

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -158,7 +158,6 @@ where
 mod tests {
     use super::*;
     use crate::test_utils::{arbitrary_bf16, arbitrary_f16, arbitrary_f32, arbitrary_f64};
-    use approx::assert_relative_eq;
     use proptest::prelude::*;
 
     /// Reference implementation of L2 norm.

--- a/rust/lance-linalg/src/lib.rs
+++ b/rust/lance-linalg/src/lib.rs
@@ -22,6 +22,9 @@ pub mod kmeans;
 pub mod matrix;
 pub mod simd;
 
+#[cfg(test)]
+pub(crate) mod test_utils;
+
 pub use matrix::MatrixView;
 
 use arrow_schema::ArrowError;

--- a/rust/lance-linalg/src/simd/f16.c
+++ b/rust/lance-linalg/src/simd/f16.c
@@ -64,7 +64,7 @@ float FUNC(l2_f16)(const FP16 *x, const FP16 *y, uint32_t dimension) {
 
 #pragma clang loop unroll(enable) interleave(enable) vectorize(enable)
   for (uint32_t i = 0; i < dimension; i++) {
-    float s = x[i] - y[i];
+    float s = (float) x[i] - (float) y[i];
     sum += s * s;
   }
   return sum;

--- a/rust/lance-linalg/src/test_utils.rs
+++ b/rust/lance-linalg/src/test_utils.rs
@@ -1,0 +1,83 @@
+use half::{bf16, f16};
+use proptest::prelude::*;
+
+/// Arbitrary finite f16 value.
+pub fn arbitrary_f16() -> impl Strategy<Value = f16> {
+    any::<u16>().prop_map(|bits| {
+        // Convert arbitrary u16 to f16
+        let val = f16::from_bits(bits);
+        // Convert Inf -> Max, -Inf -> Min, NaN -> 0
+        if val.is_infinite() && val.is_sign_positive() {
+            f16::MAX
+        } else if val.is_infinite() && val.is_sign_negative() {
+            f16::MIN
+        } else if val.is_nan() {
+            f16::from_f32(0.0)
+        } else {
+            val
+        }
+    })
+}
+
+pub fn arbitrary_bf16() -> impl Strategy<Value = bf16> {
+    any::<u16>()
+        .prop_map(|bits| {
+            // Convert arbitrary u16 to bf16
+            let val = bf16::from_bits(bits);
+            // Convert Inf -> Max, -Inf -> Min, NaN -> 0
+            if val.is_infinite() && val.is_sign_positive() {
+                bf16::MAX
+            } else if val.is_infinite() && val.is_sign_negative() {
+                bf16::MIN
+            } else if val.is_nan() {
+                bf16::from_f32(0.0)
+            } else {
+                val
+            }
+        })
+        .prop_map(|val: bf16| {
+            let scaling = bf16::from_f32(1e12 / f32::MAX);
+            val * scaling
+        })
+}
+
+/// Arbitrary finite f32 value, in the range of +-1e12.
+///
+/// We limit the range to avoid overflow. The f32 Max is around 3.4e38, so this
+/// gives enough room for multiplying and adding without overflow.
+pub fn arbitrary_f32() -> impl Strategy<Value = f32> {
+    use proptest::num::f32::*;
+    let scaling = 1e12 / f32::MAX;
+    (NORMAL | SUBNORMAL | POSITIVE | NEGATIVE).prop_map(move |val: f32| val * scaling)
+}
+
+/// Arbitrary finite f64 value, in the range of +-1e12.
+///
+/// We limit the range to avoid overflow. Right now, it's mainly limited to
+/// keep L2 norm finite. If we changed L2 Norm to be able to return a f64, we
+/// can broaden these test values.
+pub fn arbitrary_f64() -> impl Strategy<Value = f64> {
+    use proptest::num::f64::*;
+    let scaling = 1e12 / f64::MAX;
+    (NORMAL | SUBNORMAL | POSITIVE | NEGATIVE).prop_map(move |val: f64| val * scaling)
+}
+
+/// Arbitrary finite f16 vector.
+// pub fn artibrary_vector<T>(values: impl Strategy<Value = T>, dim_range: std::ops::Range<usize>) -> impl Strategy<Value = Vec<T>> {
+//     prop::collection::vec(values, dim_range)
+// }
+
+/// Two arbitrary vectors with matching dimensions
+pub fn arbitrary_vector_pair<T: std::fmt::Debug, S>(
+    values: impl Fn() -> S + 'static,
+    dim_range: std::ops::Range<usize>,
+) -> impl Strategy<Value = (Vec<T>, Vec<T>)>
+where
+    S: Strategy<Value = T>,
+{
+    dim_range.prop_flat_map(move |dim| {
+        let x = prop::collection::vec(values(), dim);
+        let y = prop::collection::vec(values(), dim);
+        (x, y)
+    })
+}

--- a/rust/lance-linalg/src/test_utils.rs
+++ b/rust/lance-linalg/src/test_utils.rs
@@ -62,11 +62,6 @@ pub fn arbitrary_f64() -> impl Strategy<Value = f64> {
     (NORMAL | SUBNORMAL | POSITIVE | NEGATIVE).prop_map(move |val: f64| val * scaling)
 }
 
-/// Arbitrary finite f16 vector.
-// pub fn artibrary_vector<T>(values: impl Strategy<Value = T>, dim_range: std::ops::Range<usize>) -> impl Strategy<Value = Vec<T>> {
-//     prop::collection::vec(values, dim_range)
-// }
-
 /// Two arbitrary vectors with matching dimensions
 pub fn arbitrary_vector_pair<T: std::fmt::Debug, S>(
     values: impl Fn() -> S + 'static,


### PR DESCRIPTION
This adds tests to each of the distance kernels making sure they produce accurate output over a wide range of inputs.