### PR TITLE
docs: fix typo

### DIFF
--- a/integration/duckdb_lance/duckdb-ext/README.md
+++ b/integration/duckdb_lance/duckdb-ext/README.md
@@ -3,4 +3,4 @@
 
 ## Credits
 
-This library was inspired by DuckDB Extension Framework](https://github.com/Mause/duckdb-extension-framework]
+This library was inspired by [DuckDB Extension Framework](https://github.com/Mause/duckdb-extension-framework).


### PR DESCRIPTION
Use correct Markdown syntax for a link.