### PR TITLE
fix: pin away from pyarrow 15.0.1 as it is causing segmentation fault in tests

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylance"
-dependencies = ["pyarrow>=12", "numpy>=1.22"]
+dependencies = ["pyarrow>=12,<15.0.1", "numpy>=1.22"]
 description = "python wrapper for Lance columnar format"
 authors = [{ name = "Lance Devs", email = "dev@lancedb.com" }]
 license = { file = "LICENSE" }


### PR DESCRIPTION
I haven't yet figured out the cause but this test seems to trigger it reliably:

```
def test_tfrecord_parsing(tmp_path, sample_tf_example):
    serialized = sample_tf_example.SerializeToString()

    path = tmp_path / "test.tfrecord"
    with tf.io.TFRecordWriter(str(path)) as writer:
        writer.write(serialized)

    inferred_schema = infer_tfrecord_schema(str(path))

    assert inferred_schema == pa.schema({
        "1_int": pa.int64(),
        "2_int_list": pa.list_(pa.int64()),
        "3_float": pa.float32(),
        "4_float_list": pa.list_(pa.float32()),
        "5_bytes": pa.binary(),
        "6_bytes_list": pa.list_(pa.binary()),
        # tensors and strings assumed binary
        "7_string": pa.binary(),
        "8_tensor": pa.binary(),
        "9_tensor_bf16": pa.binary(),
    })
    # Segmentation fault during this call
    inferred_schema = infer_tfrecord_schema(
        str(path),
        tensor_features=["8_tensor", "9_tensor_bf16"],
        string_features=["7_string"],
    )
```