### PR TITLE
chore: upgrade chrono and fix deprecation warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,10 @@ half = { "version" = "=2.3.1", default-features = false, features = [
 bytes = "1.4"
 byteorder = "1.5"
 clap = { version = "4", features = ["derive"] }
-chrono = "0.4.23"
+chrono = { version = "0.4.25", default-features = false, features = [
+    "std",
+    "now"
+] }
 criterion = { version = "0.5", features = ["async", "async_tokio"] }
 datafusion = { version = "35.0.0", default-features = false, features = [
     "regex_expressions",

--- a/rust/lance-core/src/utils/testing.rs
+++ b/rust/lance-core/src/utils/testing.rs
@@ -17,7 +17,7 @@
 use crate::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
-use chrono::Duration;
+use chrono::{Duration, TimeDelta};
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
@@ -252,6 +252,6 @@ impl<'a> MockClock<'a> {
 impl<'a> Drop for MockClock<'a> {
     fn drop(&mut self) {
         // Reset the clock to the epoch
-        mock_instant::MockClock::set_system_time(Duration::days(0).to_std().unwrap());
+        mock_instant::MockClock::set_system_time(TimeDelta::try_days(0).unwrap().to_std().unwrap());
     }
 }

--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -1054,7 +1054,7 @@ pub mod array {
     /// is a more common use pattern
     pub fn rand_date32() -> Box<dyn ArrayGenerator> {
         let now = chrono::Utc::now();
-        let one_year_ago = now - chrono::Duration::days(365);
+        let one_year_ago = now - chrono::TimeDelta::try_days(365).expect("TimeDelta try days");
         rand_date32_in_range(one_year_ago, now)
     }
 
@@ -1087,7 +1087,7 @@ pub mod array {
     /// is a more common use pattern
     pub fn rand_date64() -> Box<dyn ArrayGenerator> {
         let now = chrono::Utc::now();
-        let one_year_ago = now - chrono::Duration::days(365);
+        let one_year_ago = now - chrono::TimeDelta::try_days(365).expect("TimeDelta try_days");
         rand_date64_in_range(one_year_ago, now)
     }
 

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -143,7 +143,9 @@ impl Manifest {
         let nanos = self.timestamp_nanos % 1_000_000_000;
         let seconds = ((self.timestamp_nanos - nanos) / 1_000_000_000) as i64;
         Utc.from_utc_datetime(
-            &NaiveDateTime::from_timestamp_opt(seconds, nanos as u32).unwrap_or(NaiveDateTime::MIN),
+            &DateTime::from_timestamp(seconds, nanos as u32)
+                .unwrap_or_default()
+                .naive_utc(),
         )
     }
 

--- a/rust/lance/src/utils/temporal.rs
+++ b/rust/lance/src/utils/temporal.rs
@@ -19,7 +19,7 @@
 //! unit tests.  Anywhere in production code where we need to get the current time
 //! we should use the below methods and types instead of the builtin methods and types
 
-use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 #[cfg(test)]
 use mock_instant::{SystemTime as NativeSystemTime, UNIX_EPOCH};
 
@@ -34,8 +34,9 @@ pub fn utc_now() -> DateTime<Utc> {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system time before Unix epoch");
-    let naive =
-        NaiveDateTime::from_timestamp_opt(now.as_secs() as i64, now.subsec_nanos()).unwrap();
+    let naive = DateTime::from_timestamp(now.as_secs() as i64, now.subsec_nanos())
+        .expect("DateTime::from_timestamp")
+        .naive_utc();
     Utc.from_utc_datetime(&naive)
 }
 


### PR DESCRIPTION
Bump chrono to 0.4.25 and fix warnings.