### PR TITLE
fix: assume default rust toolchain as stable

### DIFF
--- a/rust/lance-index/build.rs
+++ b/rust/lance-index/build.rs
@@ -22,7 +22,12 @@ fn main() -> Result<()> {
     prost_build.protoc_arg("--experimental_allow_proto3_optional");
     prost_build.compile_protos(&["./protos/index.proto"], &["./protos"])?;
 
-    let rust_toolchain = env::var("RUSTUP_TOOLCHAIN").unwrap();
+    let rust_toolchain = env::var("RUSTUP_TOOLCHAIN")
+        .or_else(|e| match e {
+            env::VarError::NotPresent => Ok("stable".into()),
+            e => Err(e),
+        })
+        .unwrap();
     if rust_toolchain.starts_with("nightly") {
         // enable the 'nightly' feature flag
         println!("cargo:rustc-cfg=feature=\"nightly\"");

--- a/rust/lance-linalg/build.rs
+++ b/rust/lance-linalg/build.rs
@@ -15,7 +15,12 @@
 use std::env;
 
 fn main() {
-    let rust_toolchain = env::var("RUSTUP_TOOLCHAIN").unwrap();
+    let rust_toolchain = env::var("RUSTUP_TOOLCHAIN")
+        .or_else(|e| match e {
+            env::VarError::NotPresent => Ok("stable".into()),
+            e => Err(e),
+        })
+        .unwrap();
     if rust_toolchain.starts_with("nightly") {
         // enable the 'nightly' feature flag
         println!("cargo:rustc-cfg=feature=\"nightly\"");


### PR DESCRIPTION
This PR removes the `rustup` dependency by assuming the default rustup toolchain version as `stable`.

It fixes a bug when it builds with standalone `cargo` (no rustup) given by package managers.