### PR TITLE
chore: fix compile error caused by new datafusion version

### DIFF
--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -422,9 +422,14 @@ impl MergeInsertJob {
             Arc::new(ProjectionExec::try_new(target, Arc::new(projected_schema))?);
 
         // 6 - Finally, join the input (source table) with the taken data (target table)
-        let source_key = Column::new_with_schema(&index_column, shared_input.schema().as_ref())?;
-        let target_key =
-            Column::new_with_schema(&index_column, target_projected.schema().as_ref())?;
+        let source_key = Arc::new(Column::new_with_schema(
+            &index_column,
+            shared_input.schema().as_ref(),
+        )?);
+        let target_key = Arc::new(Column::new_with_schema(
+            &index_column,
+            target_projected.schema().as_ref(),
+        )?);
         let joined = Arc::new(
             HashJoinExec::try_new(
                 target_projected,

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -229,7 +229,8 @@ mod tests {
             SortMergeJoinExec::try_new(
                 shared.clone(),
                 shared,
-                vec![(Column::new("x", 0), Column::new("x", 0))],
+                vec![(Arc::new(Column::new("x", 0)), Arc::new(Column::new("x", 0)))],
+                None,
                 JoinType::Inner,
                 vec![SortOptions::default()],
                 true,


### PR DESCRIPTION
the signature of some methods from datafusion have changed, fix them