### PR TITLE
fix: update merge_insert code to use latest df version

### DIFF
--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -429,7 +429,7 @@ impl MergeInsertJob {
             HashJoinExec::try_new(
                 target_projected,
                 shared_input,
-                vec![(target_key, source_key)],
+                vec![(Arc::new(target_key), Arc::new(source_key))],
                 None,
                 &JoinType::Full,
                 PartitionMode::CollectLeft,
@@ -477,6 +477,7 @@ impl MergeInsertJob {
             WhenNotMatchedBySource::Keep
         );
         if can_use_scalar_index {
+            dbg!("Using scalar index for merge insert");
             if let Some(index) = self.join_key_as_scalar_index().await? {
                 self.create_indexed_scan_joined_stream(source, index).await
             } else {
@@ -484,6 +485,7 @@ impl MergeInsertJob {
                 self.create_full_table_joined_stream(source).await
             }
         } else {
+            dbg!("Falling back to slow merge insert");
             info!("The merge insert operation is configured to delete rows from the target table, this requires a potentially costly full table scan");
             self.create_full_table_joined_stream(source).await
         }

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -477,7 +477,6 @@ impl MergeInsertJob {
             WhenNotMatchedBySource::Keep
         );
         if can_use_scalar_index {
-            dbg!("Using scalar index for merge insert");
             if let Some(index) = self.join_key_as_scalar_index().await? {
                 self.create_indexed_scan_joined_stream(source, index).await
             } else {
@@ -485,7 +484,6 @@ impl MergeInsertJob {
                 self.create_full_table_joined_stream(source).await
             }
         } else {
-            dbg!("Falling back to slow merge insert");
             info!("The merge insert operation is configured to delete rows from the target table, this requires a potentially costly full table scan");
             self.create_full_table_joined_stream(source).await
         }

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -229,7 +229,8 @@ mod tests {
             SortMergeJoinExec::try_new(
                 shared.clone(),
                 shared,
-                vec![(Column::new("x", 0), Column::new("x", 0))],
+                vec![(Arc::new(Column::new("x", 0)), Arc::new(Column::new("x", 0)))],
+                None,
                 JoinType::Inner,
                 vec![SortOptions::default()],
                 true,


### PR DESCRIPTION
https://github.com/lancedb/lance/commit/73b4b30233bbad573be8013bddf2955f4d11bf2a broke the build because it was written against an older DF version and we had updated between the last time CI ran on the PR and the actual merge.

This updates the merge insert code to use the newer DF APIs.