### PR TITLE
feat: expose migration check

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1535,3 +1535,12 @@ def test_dynamic_projection(tmp_path: Path):
 
     expected = pa.Table.from_pylist([{"bool": False}, {"bool": True}])
     assert expected == table2
+
+
+def test_migrate_manifest(tmp_path: Path):
+    from lance.lance import manifest_needs_migration
+
+    table = pa.table({"x": [1, 2, 3]})
+    ds = lance.write_dataset(table, tmp_path)
+    # We shouldn't need a migration for a brand new dataset.
+    assert not manifest_needs_migration(ds)

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -258,7 +258,7 @@ impl Operation {
 pub struct Dataset {
     #[pyo3(get)]
     uri: String,
-    ds: Arc<LanceDataset>,
+    pub(crate) ds: Arc<LanceDataset>,
 }
 
 #[pymethods]


### PR DESCRIPTION
Exposes a utility function to check whether a Dataset's manifest needs a migration to be considered the latest version. Most users have no business calling this, so it's kept in the private module.