### PR TITLE
fix: force fragments to be stored in the manifest in id-order

### DIFF
--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -197,10 +197,11 @@ def test_index_remapping_multiple_rewrite_tasks(tmp_path: Path):
     assert len(fragments) == 2
 
     index = ds.list_indices()[0]
-    frag_ids = index["fragment_ids"]
+    index_frag_ids = list(index["fragment_ids"])
+    frag_ids = [frag.fragment_id for frag in fragments]
 
-    assert len(frag_ids) == 1
-    assert list(frag_ids)[0] == fragments[0].fragment_id
+    assert len(index_frag_ids) == 1
+    assert index_frag_ids[0] in frag_ids
 
 
 def test_dataset_distributed_optimize(tmp_path: Path):

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1363,12 +1363,7 @@ mod tests {
             .iter()
             .map(|f| f.id())
             .collect::<Vec<_>>();
-        // Fragment ids are assigned on task completion, but that isn't deterministic.
-        // But we can say the old fragment id=3 should be in the middle, and all
-        // the other ids should be greater than 6.
-        assert_eq!(fragment_ids[2], 3);
-        assert!(fragment_ids.iter().all(|id| *id > 6 || *id == 3));
-        dataset.validate().await.unwrap();
+        assert_eq!(fragment_ids, vec![3, 7, 8, 9, 10]);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -499,8 +499,15 @@ pub async fn plan_compaction(
     dataset: &Dataset,
     options: &CompactionOptions,
 ) -> Result<CompactionPlan> {
-    // We assume here that get_fragments is returning the fragments in a
-    // meaningful order that we want to preserve.
+    // get_fragments should be returning fragments in sorted order (by id)
+    // and fragment ids should be unique
+    debug_assert!(
+        dataset
+            .get_fragments()
+            .windows(2)
+            .all(|w| w[0].id() < w[1].id()),
+        "fragments in manifest are not sorted"
+    );
     let mut fragment_metrics = futures::stream::iter(dataset.get_fragments())
         .map(|fragment| async move {
             match collect_metrics(&fragment).await {

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -506,6 +506,9 @@ impl Transaction {
             }
         };
 
+        // If a fragment was reserved then it may not belong at the end of the fragments list.
+        final_fragments.sort_by_key(|frag| frag.id);
+
         let mut manifest = if let Some(current_manifest) = current_manifest {
             Manifest::new_from_previous(current_manifest, schema, Arc::new(final_fragments))
         } else {


### PR DESCRIPTION
Closes #1926 