### PR TITLE
chore: enable codecov

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,6 +94,7 @@ jobs:
         if: ${{ matrix.toolchain == 'stable' }}
         uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           codecov_yml_path: codecov.yml
           files: coverage.codecov
           flags: unittests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,7 @@ jobs:
           components: "rustfmt,clippy"
       - uses: Swatinem/rust-cache@v2
         with:
-          prefix-key: "buildjet-v0"
+          prefix-key: "buildjet-v1"
           workspaces: rust
           cache-provider: "buildjet"
       - name: Install dependencies
@@ -87,9 +87,6 @@ jobs:
         if: ${{ matrix.toolchain != 'stable' }}
         run: |
           cargo test
-      - name: Build benchmarks
-        if: ${{ matrix.toolchain == 'stable' }}
-        run: cargo build --benches
       - name: Upload coverage to Codecov
         if: ${{ matrix.toolchain == 'stable' }}
         uses: codecov/codecov-action@v4
@@ -117,7 +114,7 @@ jobs:
       - name: Run tests
         run: |
           cargo test --all-features -- --test-threads 1
-  clippy:
+  clippy_and_benchmark:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     steps:
@@ -131,6 +128,8 @@ jobs:
           sudo apt install -y protobuf-compiler libssl-dev
       - name: Run clippy
         run: cargo clippy --features cli,dynamodb,tensorflow,dynamodb_tests --tests --benches -- -D warnings
+      - name: Build benchmarks
+        run: cargo build --benches
   mac-build:
     runs-on: "macos-14"
     timeout-minutes: 45

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   linux-build:
-    runs-on: ubuntu-22.04
+    runs-on: buildjet-8vcpu-ubuntu-2204
     timeout-minutes: 45
     strategy:
       matrix:
@@ -41,9 +41,30 @@ jobs:
       CXX: g++-12
     steps:
       - uses: actions/checkout@v4
+      # pin the toolchain version to avoid surprises
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        if: ${{ matrix.toolchain == 'stable' }}
+        with:
+          toolchain: "1.76.0"
+          cache-workspaces: "src/rust"
+          # Disable full debug symbol generation to speed up CI build and keep memory down
+          # "1" means line tables only, which is useful for panic tracebacks.
+          rustflags: "-C debuginfo=1"
+          components: "rustfmt,clippy"
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        if: ${{ matrix.toolchain != 'stable' }}
+        with:
+          toolchain: "nightly"
+          cache-workspaces: "src/rust"
+          # Disable full debug symbol generation to speed up CI build and keep memory down
+          # "1" means line tables only, which is useful for panic tracebacks.
+          rustflags: "-C debuginfo=1"
+          components: "rustfmt,clippy"
       - uses: Swatinem/rust-cache@v2
         with:
+          prefix-key: "buildjet-v0"
           workspaces: rust
+          cache-provider: "buildjet"
       - name: Install dependencies
         run: |
           sudo apt update
@@ -52,18 +73,16 @@ jobs:
           rustup component add rustfmt
       - name: Run cargo fmt
         run: cargo fmt --check
-      # split everything us so we know what's slow.
-      - name: Build
-        run: |
-          cargo build --all-features --tests
       - name: Start DynamoDB local for tests
         if: ${{ matrix.toolchain == 'stable' }}
         run: |
           docker run -d -e AWS_ACCESS_KEY_ID=DUMMYKEY -e AWS_SECRET_ACCESS_KEY=DUMMYKEY -p 8000:8000 amazon/dynamodb-local
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run tests
         if: ${{ matrix.toolchain == 'stable' }}
         run: |
-          cargo test --features dynamodb,tensorflow,dynamodb_tests,cli
+          cargo llvm-cov --workspace --codecov --output-path coverage.codecov --features dynamodb,tensorflow,dynamodb_tests,cli
       - name: Run tests (nightly)
         if: ${{ matrix.toolchain != 'stable' }}
         run: |
@@ -71,6 +90,14 @@ jobs:
       - name: Build benchmarks
         if: ${{ matrix.toolchain == 'stable' }}
         run: cargo build --benches
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.toolchain == 'stable' }}
+        uses: codecov/codecov-action@v4
+        with:
+          codecov_yml_path: codecov.yml
+          files: coverage.codecov
+          flags: unittests
+          fail_ci_if_error: false
   linux-arm:
     runs-on: buildjet-4vcpu-ubuntu-2204-arm
     timeout-minutes: 30

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# make all status informational -- pass no matter what
+coverage:
+  status:
+    project:
+      default:
+        target: 50%
+        threshold: 10%
+        informational: true
+    patch:
+      default:
+        target: 50%
+        threshold: 10%
+        informational: true


### PR DESCRIPTION
enable codecov

also, because instrumentation build is slow at runtime:
* switch over to big buildjet runner
* pin rust version to `1.76` (1.70 is the default on buildjet)
* switch cache over to buildjet