### PR TITLE
fix: only read the data file's fields from the page table and not the whole dataset's fields

### DIFF
--- a/python/python/tests/test_schema_evolution.py
+++ b/python/python/tests/test_schema_evolution.py
@@ -133,6 +133,14 @@ def test_add_columns_exprs(tmp_path):
     assert dataset.to_table() == pa.table({"a": range(100), "b": range(1, 101)})
 
 
+def test_add_many_columns(tmp_path: Path):
+    table = pa.table([pa.array([1, 2, 3])], names=["0"])
+    dataset = lance.write_dataset(table, tmp_path)
+    dataset.add_columns(dict([(str(i), "0") for i in range(1, 1000)]))
+    dataset = lance.dataset(tmp_path)
+    assert dataset.to_table().num_rows == 3
+
+
 def test_query_after_merge(tmp_path):
     # https://github.com/lancedb/lance/issues/1905
     tab = pa.table({

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -439,6 +439,7 @@ impl SelfDescribingFileReader for FileReader {
         let mut manifest: Manifest = read_struct(object_reader.as_ref(), manifest_position).await?;
         populate_schema_dictionary(&mut manifest.schema, object_reader.as_ref()).await?;
         let schema = manifest.schema;
+        let num_fields = schema.max_field_id().unwrap_or_default() + 1;
         Self::try_new_from_reader(
             path,
             object_reader.into(),
@@ -446,6 +447,7 @@ impl SelfDescribingFileReader for FileReader {
             schema,
             0,
             0,
+            num_fields as u32,
             cache,
         )
         .await

--- a/rust/lance/src/index/vector/hnsw.rs
+++ b/rust/lance/src/index/vector/hnsw.rs
@@ -74,6 +74,7 @@ impl HNSWIndex {
             schema,
             0,
             0,
+            2,
             None,
         )
         .await?;
@@ -192,6 +193,7 @@ impl VectorIndex for HNSWIndex {
             schema,
             0,
             0,
+            2,
             None,
         )
         .await?;
@@ -224,6 +226,7 @@ impl VectorIndex for HNSWIndex {
             schema,
             0,
             0,
+            2,
             None,
         )
         .await?;


### PR DESCRIPTION
During the refactor to split things into lance-file and lance-table I introduced a bug.  There were a number of code paths for opening a file reader and I consolidated them into one.  However, when we were reading one data file from several data files, we ended up trying to load too many fields from the page table (more fields than exist in the page table).

Most of the time, this was ok.  The read would read past the end of the page table and grab part of the schema (effectively garbage data).  We never actually accessed this data and so we would get away with it.  However, if the fragment schema was considerably larger than the data file schema, then the read would go past the end of the file and cause an error.