### PR TITLE
feat: migrate IVF_PQ indices when vector column is casted

### DIFF
--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -94,6 +94,8 @@ message Transaction {
     UUID old_id = 1;
     // the id of the new index
     UUID new_id = 2;
+    // The new field ids it is based on. May be empty if unchanged.
+    repeated int32 new_field_ids = 3;
   }
 
   // An operation that rewrites but does not change the data in the table. These

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -87,6 +87,15 @@ message Transaction {
     repeated IndexMetadata removed_indices = 2;
   }
 
+  // During a rewrite an index may be rewritten.  We only serialize the UUID
+  // since a rewrite should not change the other index parameters.
+  message RewrittenIndex {
+    // The id of the index that will be replaced
+    UUID old_id = 1;
+    // the id of the new index
+    UUID new_id = 2;
+  }
+
   // An operation that rewrites but does not change the data in the table. These
   // kinds of operations just rearrange data.
   message Rewrite {
@@ -102,15 +111,6 @@ message Transaction {
     //
     // These fragments IDs are not yet assigned.
     repeated DataFragment new_fragments = 2;
-
-    // During a rewrite an index may be rewritten.  We only serialize the UUID
-    // since a rewrite should not change the other index parameters.
-    message RewrittenIndex {
-      // The id of the index that will be replaced
-      UUID old_id = 1;
-      // the id of the new index
-      UUID new_id = 2;
-    }
 
     // A group of rewrite files that are all part of the same rewrite.
     message RewriteGroup {
@@ -139,6 +139,8 @@ message Transaction {
     repeated DataFragment fragments = 1;
     // The new schema
     repeated lance.file.Field schema = 2;
+    // Migrated index ids
+    repeated RewrittenIndex rewritten_indices = 4;
     // Schema metadata.
     map<string, bytes> schema_metadata = 3;
   }

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -241,7 +241,11 @@ impl Operation {
     fn merge(fragments: Vec<FragmentMetadata>, schema: PyArrowType<ArrowSchema>) -> PyResult<Self> {
         let schema = convert_schema(&schema.0)?;
         let fragments = into_fragments(fragments);
-        let op = LanceOperation::Merge { fragments, schema };
+        let op = LanceOperation::Merge {
+            fragments,
+            schema,
+            rewritten_indices: vec![],
+        };
         Ok(Self(op))
     }
 

--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -52,6 +52,9 @@ pub trait Index: Send + Sync {
     /// Cast to [Any].
     fn as_any(&self) -> &dyn Any;
 
+    /// Cast to mut [Any]
+    fn as_mut_any(&mut self) -> &mut dyn Any;
+
     /// Cast to [Index]
     fn as_index(self: Arc<Self>) -> Arc<dyn Index>;
 

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -784,6 +784,10 @@ impl Index for BTreeIndex {
         self
     }
 
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
+    }
+
     fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
         self
     }

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -35,9 +35,7 @@ use datafusion_physical_expr::{
     PhysicalSortExpr,
 };
 use futures::{
-    future::BoxFuture,
-    stream::{self},
-    FutureExt, Stream, StreamExt, TryFutureExt, TryStreamExt,
+    future::BoxFuture, stream, FutureExt, Stream, StreamExt, TryFutureExt, TryStreamExt,
 };
 use lance_core::{Error, Result};
 use lance_datafusion::{

--- a/rust/lance-index/src/scalar/flat.rs
+++ b/rust/lance-index/src/scalar/flat.rs
@@ -139,6 +139,10 @@ impl Index for FlatIndex {
         self
     }
 
+    fn as_mut_any(&mut self) -> &mut dyn Any {
+        self
+    }
+
     fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
         self
     }

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -67,6 +67,8 @@ pub trait ProductQuantizer: Send + Sync + std::fmt::Debug {
 
     fn dimension(&self) -> usize;
 
+    fn metric_type(&self) -> MetricType;
+
     // TODO: move to pub(crate) once the refactor of lance::index to lance-index is done.
     fn codebook_as_fsl(&self) -> FixedSizeListArray;
 
@@ -434,6 +436,10 @@ impl<T: ArrowFloatType + Dot + L2 + 'static> ProductQuantizer for ProductQuantiz
 
     fn dimension(&self) -> usize {
         self.dimension
+    }
+
+    fn metric_type(&self) -> MetricType {
+        self.metric_type
     }
 
     fn codebook_as_fsl(&self) -> FixedSizeListArray {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1874,11 +1874,12 @@ impl Dataset {
                     .filter(|index| index.fields.len() == 1 && index.fields[0] == from_field.id)
                     .collect::<Vec<_>>();
                 for index in affected_indices {
-                    let res = cast_index(&self, &index.uuid, from_field, to_field).await;
+                    let res = cast_index(self, &index.uuid, from_field, to_field).await;
                     match res {
                         Ok(new_id) => rewritten_indices.push(RewrittenIndex {
-                            old_id: index.uuid.clone(),
+                            old_id: index.uuid,
                             new_id,
+                            new_field_ids: vec![to_field.id],
                         }),
                         // If it's not yet supported, we just skip it.
                         Err(Error::NotSupported { .. }) => continue,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -4771,6 +4771,7 @@ mod tests {
             .scan()
             .nearest("vec", &vec![0.0f32; 128].into(), 10)
             .unwrap()
+            .nprobs(10)
             .try_into_batch()
             .await
             .unwrap();

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -4767,6 +4767,15 @@ mod tests {
         let actual_data = dataset.scan().try_into_batch().await?;
         assert_eq!(actual_data, expected_data);
 
+        let query_data = dataset
+            .scan()
+            .nearest("vec", &vec![0.0f32; 128].into(), 10)
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(query_data.num_rows(), 10);
+
         Ok(())
     }
 }

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1559,6 +1559,7 @@ mod tests {
             Operation::Merge {
                 schema,
                 fragments: vec![frag],
+                rewritten_indices: vec![],
             },
             Some(dataset.manifest.version),
             None,

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -893,6 +893,7 @@ pub async fn commit_compaction(
         .map(|rewritten| RewrittenIndex {
             old_id: rewritten.original,
             new_id: rewritten.new,
+            new_field_ids: vec![],
         })
         .collect();
 

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -165,7 +165,7 @@ pub(crate) async fn cast_index(
             })
         }
         IndexType::Vector => {
-            cast_vector_index(dataset, generic, &new_id, from_field, to_field).await?;
+            cast_vector_index(dataset, index_id, &new_id, matched, from_field, to_field).await?;
         }
     }
 

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -301,6 +301,10 @@ pub(crate) async fn cast_vector_index(
     from_field: &Field,
     to_field: &Field,
 ) -> Result<()> {
+    // let old_index = dataset
+    //     .open_vector_index(column, &old_uuid.to_string())
+    //     .await?;
+    // old_index.cast(to_field.data_type())?;
     todo!()
 }
 

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -27,11 +27,12 @@ mod utils;
 #[cfg(test)]
 mod fixture_test;
 
+use lance_core::datatypes::Field;
 use lance_file::reader::FileReader;
 use lance_index::vector::hnsw::HNSW;
 use lance_index::vector::ivf::storage::IvfData;
 use lance_index::vector::{hnsw::builder::HnswBuildParams, ivf::IvfBuildParams, pq::PQBuildParams};
-use lance_index::{INDEX_AUXILIARY_FILE_NAME, INDEX_METADATA_SCHEMA_KEY};
+use lance_index::{Index, INDEX_AUXILIARY_FILE_NAME, INDEX_METADATA_SCHEMA_KEY};
 use lance_io::traits::Reader;
 use lance_linalg::distance::*;
 use lance_table::format::Index as IndexMetadata;
@@ -290,6 +291,17 @@ pub(crate) async fn remap_vector_index(
     )
     .await?;
     Ok(())
+}
+
+#[instrument(level = "debug", skip_all, fields(new_uuid = new_uuid.to_string(), dataset_uri = dataset.base.to_string(), column = from_field.name))]
+pub(crate) async fn cast_vector_index(
+    dataset: &Dataset,
+    index: Arc<dyn Index>,
+    new_uuid: &Uuid,
+    from_field: &Field,
+    to_field: &Field,
+) -> Result<()> {
+    todo!()
 }
 
 /// Open the Vector index on dataset, specified by the `uuid`.

--- a/rust/lance/src/index/vector/fixture_test.rs
+++ b/rust/lance/src/index/vector/fixture_test.rs
@@ -62,6 +62,10 @@ mod test {
             self
         }
 
+        fn as_mut_any(&mut self) -> &mut dyn Any {
+            self
+        }
+
         /// Cast to [Index]
         fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
             self
@@ -116,6 +120,10 @@ mod test {
 
         fn remap(&mut self, _mapping: &HashMap<u64, Option<u64>>) -> Result<()> {
             Ok(())
+        }
+
+        fn cast(&mut self, _to: &Field) -> Result<()> {
+            todo!()
         }
 
         /// The metric type of this vector index.

--- a/rust/lance/src/index/vector/hnsw.rs
+++ b/rust/lance/src/index/vector/hnsw.rs
@@ -21,7 +21,7 @@ use std::{
 
 use arrow_array::{cast::AsArray, types::Float32Type, Float32Array, RecordBatch, UInt64Array};
 
-use arrow_schema::DataType;
+use arrow_schema::{DataType, Field as ArrowField};
 use async_trait::async_trait;
 use lance_arrow::*;
 use lance_core::{datatypes::Schema, Error, Result, ROW_ID};
@@ -103,6 +103,10 @@ impl HNSWIndex {
 impl Index for HNSWIndex {
     /// Cast to [Any].
     fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_mut_any(&mut self) -> &mut dyn Any {
         self
     }
 
@@ -251,6 +255,13 @@ impl VectorIndex for HNSWIndex {
     fn remap(&mut self, _mapping: &HashMap<u64, Option<u64>>) -> Result<()> {
         Err(Error::Index {
             message: "Remapping HNSW in this way not supported".to_string(),
+            location: location!(),
+        })
+    }
+
+    fn cast(&mut self, _to: &ArrowField) -> Result<()> {
+        Err(Error::Index {
+            message: "Casting HNSW not supported".to_string(),
             location: location!(),
         })
     }

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -1037,14 +1037,17 @@ pub(crate) async fn mutate_index_file(
 
     mutate_ivf(&mut new_index)?;
 
-    let pq_sub_index = index
+    let mut pq_sub_index = index
         .sub_index
         .as_any()
         .downcast_ref::<PQIndex>()
         .ok_or_else(|| Error::NotSupported {
             source: "Remapping a non-pq sub-index".into(),
             location: location!(),
-        })?;
+        })?
+        .clone();
+
+    mutate_pq(&mut pq_sub_index)?;
 
     let metadata = IvfPQIndexMetadata {
         name,

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -252,6 +252,10 @@ impl VectorIndex for PQIndex {
     }
 
     fn remap(&mut self, mapping: &HashMap<u64, Option<u64>>) -> Result<()> {
+        if self.code.is_none() {
+            // If there are no codes, then we can skip this.
+            return Ok(());
+        }
         let code = self
             .code
             .as_ref()
@@ -289,21 +293,21 @@ impl VectorIndex for PQIndex {
                 self.pq.num_bits(),
                 self.pq.dimension(),
                 Arc::new(codebook.as_primitive().clone()),
-                self.metric_type,
+                self.pq.metric_type(),
             )),
             DataType::Float32 => Arc::new(ProductQuantizerImpl::<Float32Type>::new(
                 self.pq.num_sub_vectors(),
                 self.pq.num_bits(),
                 self.pq.dimension(),
                 Arc::new(codebook.as_primitive().clone()),
-                self.metric_type,
+                self.pq.metric_type(),
             )),
             DataType::Float64 => Arc::new(ProductQuantizerImpl::<Float64Type>::new(
                 self.pq.num_sub_vectors(),
                 self.pq.num_bits(),
                 self.pq.dimension(),
                 Arc::new(codebook.as_primitive().clone()),
-                self.metric_type,
+                self.pq.metric_type(),
             )),
             _ => {
                 return Err(Error::Index {

--- a/rust/lance/src/index/vector/traits.rs
+++ b/rust/lance/src/index/vector/traits.rs
@@ -18,6 +18,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use arrow_array::{types::Float32Type, FixedSizeListArray, RecordBatch};
+use arrow_schema::Field as ArrowField;
 use async_trait::async_trait;
 
 use lance_core::Result;
@@ -90,6 +91,11 @@ pub trait VectorIndex: Send + Sync + std::fmt::Debug + Index {
     /// If an old row id is not in the mapping then it should be
     /// left alone.
     fn remap(&mut self, mapping: &HashMap<u64, Option<u64>>) -> Result<()>;
+
+    /// Transform the index in place to be for a different data type.
+    /// 
+    /// This can be used, for example, to transform a float32 index to a float16 index.
+    fn cast(&mut self, to: &ArrowField) -> Result<()>;
 
     /// The metric type of this vector index.
     fn metric_type(&self) -> MetricType;

--- a/rust/lance/src/index/vector/traits.rs
+++ b/rust/lance/src/index/vector/traits.rs
@@ -93,7 +93,7 @@ pub trait VectorIndex: Send + Sync + std::fmt::Debug + Index {
     fn remap(&mut self, mapping: &HashMap<u64, Option<u64>>) -> Result<()>;
 
     /// Transform the index in place to be for a different data type.
-    /// 
+    ///
     /// This can be used, for example, to transform a float32 index to a float16 index.
     fn cast(&mut self, to: &ArrowField) -> Result<()>;
 


### PR DESCRIPTION
When a user calls `alter_columns()` to change the data type of a vector column, we can attempt to migrate the vector index to the new data type as part of the same transaction. This will allow users to easily migrate from f32-based vectors to f16 ones.

Closes #1978