### PR TITLE
chore: drop data after copied to reduce memory footprint

### DIFF
--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -466,7 +466,7 @@ async fn build_hnsw_partition(
 fn build_hnsw_index(
     metric_type: MetricType,
     hnsw_params: HnswBuildParams,
-    row_id_array: Vec<Arc<dyn Array>>,
+    row_ids_array: Vec<Arc<dyn Array>>,
     pq_array: Vec<Arc<dyn Array>>,
     vector_array: Vec<Arc<dyn Array>>,
     build_with_pq: bool,
@@ -477,6 +477,8 @@ fn build_hnsw_index(
         .map(|arr| arr.as_ref())
         .collect::<Vec<_>>();
     let fsl = arrow_select::concat::concat(&vector_arrs)?;
+    std::mem::drop(vector_array);
+
     let mat = Arc::new(MatrixView::<Float32Type>::try_from(
         fsl.as_fixed_size_list(),
     )?);
@@ -485,10 +487,14 @@ fn build_hnsw_index(
     let hnsw = hnsw_builder.build()?;
 
     let pq_storage = if build_with_pq {
-        let pq_array = pq_array.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
-        let row_id_array = row_id_array.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
-        let pq_column = concat(&pq_array)?;
-        let row_ids_column = concat(&row_id_array)?;
+        let pq_arrs = pq_array.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
+        let pq_column = concat(&pq_arrs)?;
+        std::mem::drop(pq_array);
+
+        let row_ids_arrs = row_ids_array.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
+        let row_ids_column = concat(&row_ids_arrs)?;
+        std::mem::drop(row_ids_array);
+
         let pq_batch = RecordBatch::try_from_iter_with_nullable(vec![
             (ROW_ID, row_ids_column, true),
             (PQ_CODE_COLUMN, pq_column, false),


### PR DESCRIPTION
this reduces the memory footprint about 2X less