### PR TITLE
feat(python): expose storage options

### DIFF
--- a/docs/read_and_write.rst
+++ b/docs/read_and_write.rst
@@ -482,6 +482,10 @@ and Google Cloud Storage. Which object store to use is determined by the URI sch
 the dataset path. For example, ``s3://bucket/path`` will use S3, ``az://bucket/path``
 will use Azure, and ``gs://bucket/path`` will use GCS.
 
+.. versionadded:: 0.10.7
+
+  Passing options directly to storage options.
+
 These object stores take additional configuration objects. There are two ways to
 specify these configurations: by setting environment variables or by passing them
 to the ``storage_options`` parameter of :py:meth:`lance.dataset` and
@@ -531,11 +535,22 @@ These options apply to all object stores.
    * - ``proxy_ca_certificate``
      - PEM-formatted CA certificate for proxy connections
    * - ``proxy_excludes``
-     - List of hosts that bypass proxy
+     - List of hosts that bypass proxy. This is a comma separated list of domains
+       and IP masks. Any subdomain of the provided domain will be bypassed. For 
+       example, ``example.com, 192.168.1.0/24`` would bypass ``https://api.example.com``,
+       ``https://www.example.com``, and any IP in the range ``192.168.1.0/24``.
 
 
 S3 Configuration
 ~~~~~~~~~~~~~~~~
+
+S3 (and S3-compatible stores) have additional configuration options that configure
+authorization and S3-specific features (such as server-side encryption). Region
+is a required parameter.
+
+AWS credentials can be set in the environment variables ``AWS_ACCESS_KEY_ID``,
+``AWS_SECRET_ACCESS_KEY``, and ``AWS_SESSION_TOKEN``. Alternatively, they can be
+passed as parameters to the ``storage_options`` parameter:
 
 .. code-block:: python
 
@@ -553,7 +568,8 @@ S3 Configuration
 If you are using AWS SSO, you can specify the ``AWS_PROFILE`` environment variable.
 It cannot be specified in the ``storage_options`` parameter.
 
-These keys can be used as both environment variables or keys in the ``storage_options`` parameter:
+The following keys can be used as both environment variables or keys in the
+``storage_options`` parameter:
 
 .. list-table::
    :widths: 30 70
@@ -578,7 +594,7 @@ These keys can be used as both environment variables or keys in the ``storage_op
      - Whether to use S3 Express One Zone endpoints. Default, ``False``. See more
        details below.
    * - ``aws_server_side_encryption``
-     - The server-side encryption algorithm to use. Must be one of "AES256",
+     - The server-side encryption algorithm to use. Must be one of ``"AES256"``,
        ``"aws:kms"``, or ``"aws:kms:dsse"``. Default, ``None``.
    * - ``aws_sse_kms_key_id``
      - The KMS key ID to use for server-side encryption. If set,
@@ -709,6 +725,10 @@ For details on how this feature works, please see :ref:`external-manifest-store`
 Google Cloud Storage Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+GCS credentials are configured by setting the ``GOOGLE_SERVICE_ACCOUNT`` environment
+variable to the path of a JSON file containing the service account credentials.
+Alternatively, you can pass the path to the JSON file in the ``storage_options``
+
 .. code-block:: python
 
   import lance
@@ -726,7 +746,8 @@ Google Cloud Storage Configuration
   you can set the environment variable ``HTTP1_ONLY`` to ``false``.
 
 
-These keys can be used as both environment variables or keys in the ``storage_options`` parameter:
+The following keys can be used as both environment variables or keys in the
+``storage_options`` parameter:
 
 .. source: https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html
 
@@ -746,6 +767,10 @@ These keys can be used as both environment variables or keys in the ``storage_op
 
 Azure Blob Storage Configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Azure Blob Storage credentials can be configured by setting the ``AZURE_STORAGE_ACCOUNT_NAME``
+and ``AZURE_STORAGE_ACCOUNT_KEY`` environment variables. Alternatively, you can pass
+the account name and key in the ``storage_options`` parameter:
 
 .. code-block:: python
 

--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 from .dataset import (
     LanceDataset,
@@ -62,6 +62,7 @@ def dataset(
     block_size: Optional[int] = None,
     commit_lock: Optional[CommitLock] = None,
     index_cache_size: Optional[int] = None,
+    storage_options: Optional[Dict[str, str]] = None,
 ) -> LanceDataset:
     """
     Opens the Lance dataset from the address specified.
@@ -92,6 +93,9 @@ def dataset(
         and the row ids (``nd.array([n], dtype=uint64)``).
         Approximately, ``n = Total Rows / number of IVF partitions``.
         ``pq = number of PQ sub-vectors``.
+    storage_options : optional, dict
+        Extra options that make sense for a particular storage connection. This is
+        used to store connection parameters like credentials, endpoint, etc.
     """
     ds = LanceDataset(
         uri,
@@ -99,6 +103,7 @@ def dataset(
         block_size,
         commit_lock=commit_lock,
         index_cache_size=index_cache_size,
+        storage_options=storage_options,
     )
     if version is None and asof is not None:
         ts_cutoff = sanitize_ts(asof)

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -167,11 +167,18 @@ class LanceDataset(pa.dataset.Dataset):
         index_cache_size: Optional[int] = None,
         metadata_cache_size: Optional[int] = None,
         commit_lock: Optional[CommitLock] = None,
+        storage_options: Optional[Dict[str, str]] = None,
     ):
         uri = os.fspath(uri) if isinstance(uri, Path) else uri
         self._uri = uri
         self._ds = _Dataset(
-            uri, version, block_size, index_cache_size, metadata_cache_size, commit_lock
+            uri,
+            version,
+            block_size,
+            index_cache_size,
+            metadata_cache_size,
+            commit_lock,
+            storage_options,
         )
 
     def __reduce__(self):
@@ -628,8 +635,10 @@ class LanceDataset(pa.dataset.Dataset):
     def alter_columns(self, *alterations: Iterable[Dict[str, Any]]):
         """Alter column name, data type, and nullability.
 
-        Columns that are renamed can keep any indices that are on them. However, if
-        the column is cast to a different type, its indices will be dropped.
+        Columns that are renamed can keep any indices that are on them. If a
+        column has an IVF_PQ index, it can be kept if the column is casted to
+        another type. However, other index types don't support casting at this
+        time.
 
         Column types can be upcasted (such as int32 to int64) or downcasted
         (such as int64 to int32). However, downcasting will fail if there are
@@ -2321,6 +2330,7 @@ def write_dataset(
     max_bytes_per_file: int = 90 * 1024 * 1024 * 1024,
     commit_lock: Optional[CommitLock] = None,
     progress: Optional[FragmentWriteProgress] = None,
+    storage_options: Optional[Dict[str, str]] = None,
 ) -> LanceDataset:
     """Write a given data_obj to the given uri
 
@@ -2357,6 +2367,9 @@ def write_dataset(
         *Experimental API*. Progress tracking for writing the fragment. Pass
         a custom class that defines hooks to be called when each fragment is
         starting to write and finishing writing.
+    storage_options : optional, dict
+        Extra options that make sense for a particular storage connection. This is
+        used to store connection parameters like credentials, endpoint, etc.
     """
     if _check_for_hugging_face(data_obj):
         # Huggingface datasets
@@ -2377,6 +2390,7 @@ def write_dataset(
         "max_rows_per_group": max_rows_per_group,
         "max_bytes_per_file": max_bytes_per_file,
         "progress": progress,
+        "storage_options": storage_options,
     }
 
     if commit_lock:
@@ -2385,8 +2399,12 @@ def write_dataset(
         params["commit_handler"] = commit_lock
 
     uri = os.fspath(uri) if isinstance(uri, Path) else uri
-    _write_dataset(reader, uri, params)
-    return LanceDataset(uri)
+    inner_ds = _write_dataset(reader, uri, params)
+
+    ds = LanceDataset.__new__(LanceDataset)
+    ds._ds = inner_ds
+    ds._uri = uri
+    return ds
 
 
 def _coerce_reader(


### PR DESCRIPTION
This allows users to pass object storage configuration in Lance in Python. Previously, users could only configure these settings through environment variables.

Closes #1930