### PR TITLE
feat: extend datagen to cover more types

### DIFF
--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -24,7 +24,7 @@ use arrow_array::{
     UInt8Array,
 };
 use arrow_data::ArrayDataBuilder;
-use arrow_schema::{ArrowError, DataType, Field, FieldRef, Fields, Schema};
+use arrow_schema::{ArrowError, DataType, Field, FieldRef, Fields, IntervalUnit, Schema};
 use arrow_select::take::take;
 use rand::prelude::*;
 
@@ -131,6 +131,11 @@ impl DataTypeExt for DataType {
             Self::Duration(_) => 8,
             Self::Decimal128(_, _) => 16,
             Self::Decimal256(_, _) => 32,
+            Self::Interval(unit) => match unit {
+                IntervalUnit::YearMonth => 4,
+                IntervalUnit::DayTime => 8,
+                IntervalUnit::MonthDayNano => 16,
+            },
             Self::FixedSizeBinary(s) => *s as usize,
             Self::FixedSizeList(dt, s) => *s as usize * dt.data_type().byte_width(),
             _ => panic!("Does not support get byte width on type {self}"),

--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -545,8 +545,6 @@ impl<T: ArrowPrimitiveType + Send + Sync> ArrayGenerator for RandomBytesGenerato
     }
 
     fn element_size_bytes(&self) -> Option<ByteCount> {
-        // We can't say 1/8th of a byte and 1 byte would be a pretty extreme over-count so let's leave
-        // it at None until someone needs this.  Then we can probably special case this (e.g. make a ByteCount::ONE_BIT)
         Self::byte_width().map(ByteCount::from).ok()
     }
 }


### PR DESCRIPTION
This allows for random generation of float16, decimals, intervals, durations, and structs.