### PR TITLE
feat: add core traits for encoders & decoders in the v2 format

### DIFF
--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -1,0 +1,348 @@
+//! Utilities and traits for decoding data
+//!
+//! There are two types of decoders, logical decoders and physical decoders.
+//! In addition, decoding data is broken into two steps, scheduling the I/O
+//! and decoding the returned data.
+//!
+//! # Physical vs. Logical Decoding
+//!
+//! The physical traits are [`self::PhysicalPageScheduler`] and
+//! [`self::PhysicalPageDecoder`].  These are lower level encodings.  They
+//! have a few advantages:
+//!
+//!  * They do not need to decode into an Arrow array and so they don't need
+//!    to be enveloped into the Arrow filesystem (e.g. Arrow doesn't have a
+//!    bit-packed type.  We can use variable-length binary but that is kind
+//!    of overkill)
+//!  * They can decode into existing storage.  This can allow for "page
+//!    bridging".  If we are trying to decode into a batch of 1024 rows and
+//!    the rows 0..1024 are spread across two pages then we can avoid a memory
+//!    copy by allocating once and decoding each page into the outer allocation.
+//!
+//! However, there are some limitations too:
+//!
+//!  * They are constrained to a single column
+//!  * The API is more complex
+//!
+//! The logical traits are [`self::LogicalPageScheduler`] and [`self::LogicalPageDecoder`]
+//! These are designed to map from Arrow fields into one or more columns of Lance
+//! data.  They do not decode into existing buffers and instead they return an Arrow Array.
+//!
+//! Encodings are typically nested into each other to form a tree.  The top of the tree is
+//! the user requested schema.  Each field in that schema is assigned to one top-level logical
+//! encoding.  That encoding can then contain other logical encodings or physical encodings.
+//! Physical encodings can also contain other physical encodings.
+//!
+//! So, for example, a single field in the Arrow schema might have the type List<UInt32>
+//!
+//! The encoding tree could then be:
+//!
+//! root: List (logical encoding)
+//!  - indices: Primitive (logical encoding)
+//!    - column: Basic (physical encoding)
+//!      - validity: Bitmap (physical encoding)
+//!      - values: RLE (physical encoding)
+//!        - runs: Value (physical encoding)
+//!        - values: Value (physical encoding)
+//!  - items: Primitive (logical encoding)
+//!    - column: Basic (physical encoding)
+//!      - values: Value (phsyical encoding)
+//!
+//! Note that, in this example, root.items.column does not have a validity because there were
+//! no nulls in the page.
+//!
+//! Note that the decoding API is not symmetric with the encoding API.  The encoding API contains
+//! buffer encoders, array encoders, and field encoders.  Physical decoders correspond to both
+//! buffer encoders and array encoders.  Logical decoders correspond to both array encoders and
+//! field encoders.
+//!
+//! ## Multiple buffers or multiple columns?
+//!
+//! Note that there are many different ways we can write encodings.  For example, we might
+//! store primitive fields in a single column with two buffers (one for validity and one for
+//! values)
+//!
+//! On the other hand, we could also store a primitive field as two different columns.  One
+//! that yields a non-nullable boolean array and one that yields a non-nullable array of items.
+//! Then we could combine these two arrays into a single array where the boolean array is the
+//! bitmap.  There are a few subtle differences between the approaches:
+//!
+//! * Storing things as multiple buffers within the same column is generally more efficient and
+//!   easier to schedule.  For example, in-batch coalescing is very easy but can only be done
+//!   on data that is in the same page.
+//! * When things are stored in multiple columns you have to worry about their pages not being
+//!   in sync.  In our previous validity / values example this means we might have to do some
+//!   memory copies to get the validity array and values arrays to be the same length as
+//!   decode.
+//! * When things are stored in a single column, projection is impossible.  For example, if we
+//!   tried to store all the struct fields in a single column with lots of buffers then we wouldn't
+//!   be able to read back individual fields of the struct.
+//! * When things are stored in a single column they must have the same length.  This is an issue
+//!   for list fields.  The items column does not usually have the same length as the parent list
+//!   column (in most cases it is much longer).
+//!
+//! The fixed size list decoding is an interesting example because it is actually both a physical
+//! encoding and a logical encoding.  A fixed size list of a physical encoding is, itself, a physical
+//! encoding (e.g. a fixed size list of doubles).  However, a fixed size list of a logical encoding
+//! is a logical encoding (e.g. a fixed size list of structs).
+//!
+//! # The scheduling loop
+//!
+//! Reading a Lance file involves both scheduling and decoding.  Its generally expected that these
+//! will run as two separate threads.
+//!
+//! ```text
+//!
+//!                                    I/O PARALLELISM
+//!                       Issues
+//!                       Requests   ┌─────────────────┐
+//!                                  │                 │        Wait for
+//!                       ┌──────────►   I/O Service   ├─────►  Enough I/O ◄─┐
+//!                       │          │                 │        For batch    │
+//!                       │          └─────────────────┘             │3      │
+//!                       │                                          │       │
+//!                       │                                          │       │2
+//! ┌─────────────────────┴─┐                              ┌─────────▼───────┴┐
+//! │                       │                              │                  │Poll
+//! │       Batch Decode    │ Decode tasks sent via channel│   Batch Decode   │1
+//! │       Scheduler       ├─────────────────────────────►│   Stream         ◄─────
+//! │                       │                              │                  │
+//! └─────▲─────────────┬───┘                              └─────────┬────────┘
+//!       │             │                                            │4
+//!       │             │                                            │
+//!       └─────────────┘                                   ┌────────┴────────┐
+//!  Caller of schedule_range                Buffer polling │                 │
+//!  will be scheduler thread                to achieve CPU │ Decode Batch    ├────►
+//!  and schedule one decode                 parallelism    │ Task            │
+//!  task (and all needed I/O)               (thread per    │                 │
+//!  per logical page                         batch)        └─────────────────┘
+//! ```
+//!
+//! The scheduling thread will work through the file from the
+//! start to the end as quickly as possible.  Data is scheduled one page at a time in a row-major
+//! fashion.  For example, imagine we have a file with the following page structure:
+//!
+//! ```text
+//! Score (Float32)     | C0P0 |
+//! Id (16-byte UUID)   | C1P0 | C1P1 | C1P2 | C1P3 |
+//! Vector (4096 bytes) | C2P0 | C2P1 | C2P2 | C2P3 | .. | C2P1024 |
+//! ```
+//!
+//! This would be quite common as each of these pages has the same number of bytes.  Let's pretend
+//! each page is 1MiB and so there are 256Ki rows of data.  Each page of `Score` has 256Ki rows.
+//! Each page of `Id` has 64Ki rows.  Each page of `Vector` has 256 rows.  The scheduler would then
+//! schedule in the following order:
+//!
+//! C0 P0
+//! C1 P0
+//! C2 P0
+//! C2 P1
+//! ... (254 pages omitted)
+//! C2 P255
+//! C1 P1
+//! C2 P256
+//! ... (254 pages omitted)
+//! C2 P511
+//! C1 P2
+//! C2 P512
+//! ... (254 pages omitted)
+//! C2 P767
+//! C1 P3
+//! C2 P768
+//! ... (254 pages omitted)
+//! C2 P1024
+//!
+//! This is the ideal scheduling order because it means we can decode complete rows as quickly as possible.
+//! Note that the scheduler thread does not need to wait for I/O to happen at any point.  As soon as it starts
+//! it will start scheduling one page of I/O after another until it has scheduled the entire file's worth of
+//! I/O.  This is slightly different than other file readers which have "row group parallelism" and will
+//! typically only schedule X row groups worth of reads at a time.
+//!
+//! In the near future there will be a backpressure mechanism and so it may need to stop/pause if the compute
+//! falls behind.
+//!
+//! ## Indirect I/O
+//!
+//! Regrettably, there are times where we cannot know exactly what data we need until we have partially decoded
+//! the file.  This happens when we have variable sized list data.  In that case the scheduling task for that
+//! page will only schedule the first part of the read (loading the list offsets).  It will then immediately
+//! spawn a new tokio task to wait for that I/O and decode the list offsets.  That follow-up task is not part
+//! of the scheduling loop or the decode loop.  It is a free task.  Once the list offsets are decoded we submit
+//! a follow-up I/O task.  This task is scheduled at a high priority because the decoder is going to need it soon.
+//!
+//! # The decode loop
+//!
+//! As soon as the scheduler starts we can start decoding.  Each time we schedule a page we
+//! push a decoder for that page's data into a channel.  The decode loop
+//! ([`BatchDecodeStream`]) reads from that channel.  Each time it receives a decoder it
+//! waits until the decoder has all of its data.  Then it grabs the next decoder.  Once it has
+//! enough loaded decoders to complete a batch worth of rows it will spawn a "decode batch task".
+//!
+//! These batch decode tasks perform the actual CPU work of decoding the loaded data into Arrow
+//! arrays.  This may involve signifciant CPU processing like decompression or arithmetic in order
+//! to restore the data to its correct in-memory representation.
+//!
+//! ## Batch size
+//!
+//! The `BatchDecodeStream` is configured with a batch size.  This does not need to have any
+//! relation to the page size(s) used to write the data.  This keeps our compute work completely
+//! independent of our I/O work.  We suggest using small batch sizes:
+//!
+//!  * Batches should fit in CPU cache (at least L3)
+//!  * More batches means more opportunity for parallelism
+//!  * The "batch overhead" is very small in Lance compared to other formats because it has no
+//!    relation to the way the data is stored.
+
+use std::{ops::Range, sync::Arc};
+
+use arrow_array::ArrayRef;
+use bytes::BytesMut;
+use futures::future::BoxFuture;
+use tokio::sync::mpsc;
+
+use lance_core::Result;
+
+use crate::EncodingsIo;
+
+/// A decoder for single-column encodings of primitive data (this includes fixed size
+/// lists of primitive data)
+///
+/// Physical decoders are able to decode into existing buffers for zero-copy operation.
+///
+/// Instances should be stateless and `Send` / `Sync`.  This is because multiple decode
+/// tasks could reference the same page.  For example, imagine a page covers rows 0-2000
+/// and the decoder stream has a batch size of 1024.  The decoder will be needed by both
+/// the decode task for batch 0 and the decode task for batch 1.
+///
+/// See [`crate::decoder`] for more information
+pub trait PhysicalPageDecoder: Send + Sync {
+    /// Calculates and updates the capacity required to represent the requested data
+    ///
+    /// Capacity is stored as a tuple of (num_bytes: u64, is_needed: bool).  The `is_needed`
+    /// portion only needs to be updated if the encoding has some concept of an "optional"
+    /// buffer.
+    ///
+    /// The decoder should look at `rows_to_skip` and `num_rows` and then calculate how
+    /// many bytes of data are needed.  It should then update the first part of the tuple.
+    ///
+    /// Note: Most encodings deal with a single buffer.  They may have multiple input buffers
+    /// but they only have a single output buffer.  The current exception to this rule is the
+    /// `basic` encoding which has an output "validity" buffer and an output "values" buffers.
+    /// We may find there are other such exceptions.
+    ///
+    /// # Arguments
+    ///
+    /// * `rows_to_skip` - how many rows to skip (within the page) before decoding
+    /// * `num_rows` - how many rows to decode
+    /// * `buffers` - A mutable slice of "capacities" (as described above), one per buffer
+    fn update_capacity(&self, rows_to_skip: u32, num_rows: u32, buffers: &mut [(u64, bool)]);
+    /// Decodes the data into the requested buffers.
+    ///
+    /// You can assume that the capacity will have already been configured on the `BytesMut`
+    /// according to the capacity calculated in [`Self::update_capacity`]
+    ///
+    /// # Arguments
+    ///
+    /// * `rows_to_skip` - how many rows to skip (within the page) before decoding
+    /// * `num_rows` - how many rows to decode
+    /// * `dest_buffers` - the output buffers to decode into
+    fn decode_into(&self, rows_to_skip: u32, num_rows: u32, dest_buffers: &mut [BytesMut]);
+}
+
+/// A scheduler for single-column encodings of primitive data
+///
+/// The scheduler is responsible for calculating what I/O is needed for the requested rows
+///
+/// Instances should be stateless and `Send` and `Sync`.  This is because instances can
+/// be shared in follow-up I/O tasks.
+///
+/// See [`crate::decoder`] for more information
+pub trait PhysicalPageScheduler: Send + Sync + std::fmt::Debug {
+    /// Schedules a batch of I/O to load the data needed for the requested range
+    ///
+    /// Returns a future that will yield a decoder once the data has been loaded
+    ///
+    /// # Arguments
+    ///
+    /// * `range` - the range of row offsets (relative to start of page) requested
+    /// * `scheduler` - a scheduler to submit the I/O request to
+    fn schedule_range(
+        &self,
+        range: Range<u32>,
+        scheduler: &dyn EncodingsIo,
+    ) -> BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>>;
+}
+
+/// A scheduler for a field's worth of data
+///
+/// Each page of incoming data maps to one `LogicalPageScheduler` instance.  However, this
+/// page may map to many pages transitively.  For example, one page of struct data may cover
+/// many pages of primitive child data.  In fact, the entire file is treated as one page
+/// of SimpleStruct data.
+///
+/// The scheduler is responsible for calculating the neccesary I/O.  One schedule_range
+/// request could trigger mulitple batches of I/O across multiple columns.  The scheduler
+/// should emit decoders into the sink as quickly as possible.
+///
+/// As soon as a batch of data that can decoded then the scheduler should emit a decoder
+/// in the "unloaded" state.  The decode stream will pull the decoder and start decoding.
+///
+/// The order in which decoders are emitted is important.  Pages should be emitted in
+/// row-major order allowing decode of complete rows as quickly as possible.
+///
+/// The `LogicalPageScheduler` should be stateless and `Send` and `Sync`.  This is
+/// because it might need to be shared.  For example, a list page has a reference to
+/// the page schedulers for its items column.  This is shared with the follow-up I/O
+/// task created when the offsets are loaded.
+///
+/// See [`crate::decoder`] for more information
+pub trait LogicalPageScheduler: Send + Sync + std::fmt::Debug {
+    /// Schedules I/O for the requested portion of the page.
+    fn schedule_range(
+        &self,
+        range: Range<u32>,
+        scheduler: &Arc<dyn EncodingsIo>,
+        sink: &mpsc::UnboundedSender<Box<dyn LogicalPageDecoder>>,
+    ) -> Result<()>;
+    /// The number of rows covered by this page
+    fn num_rows(&self) -> u32;
+}
+
+/// A trait for tasks that decode data into an Arrow array
+pub trait DecodeArrayTask: Send {
+    /// Decodes the data into an Arrow array
+    fn decode(self: Box<Self>) -> Result<ArrayRef>;
+}
+
+/// A task to decode data into an Arrow array
+pub struct NextDecodeTask {
+    /// The decode task itself
+    pub task: Box<dyn DecodeArrayTask>,
+    /// The number of rows that will be created
+    pub num_rows: u32,
+    /// Whether or not the decoder that created this still has more rows to decode
+    pub has_more: bool,
+}
+
+/// A decoder for a field's worth of data
+///
+/// The decoder is initially "unloaded" (doesn't have all its data).  The [`Self::wait`]
+/// method should be called to wait for the needed I/O data before attempting to decode
+/// any further.
+///
+/// Unlike the other decoder types it is assumed that `LogicalPageDecoder` is stateful
+/// and only `Send`.  This is why we don't need a `rows_to_skip` argument in [`Self::drain`]
+pub trait LogicalPageDecoder: Send {
+    /// Waits for enough data to be loaded to decode `num_rows` of data
+    fn wait<'a>(
+        &'a mut self,
+        num_rows: u32,
+        source: &'a mut mpsc::UnboundedReceiver<Box<dyn LogicalPageDecoder>>,
+    ) -> BoxFuture<'a, Result<()>>;
+    /// Creates a task to decode `num_rows` of data into an array
+    fn drain(&mut self, num_rows: u32) -> Result<NextDecodeTask>;
+    /// The number of rows that are in the page but haven't yet been "waited"
+    fn unawaited(&self) -> u32;
+    /// The number of rows that have been "waited" but not yet decoded
+    fn avail(&self) -> u32;
+}

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -1,0 +1,122 @@
+use arrow_array::ArrayRef;
+use arrow_buffer::Buffer;
+
+use futures::future::BoxFuture;
+use lance_core::Result;
+
+use crate::format::pb;
+
+/// An encoded buffer
+pub struct EncodedBuffer {
+    /// If true, the buffer should be stored as "data"
+    /// If false, the buffer should be stored as "metadata"
+    ///
+    /// Metadata buffers are typically small buffers that should be cached.  For example,
+    /// this might be a small dictionary when data has been dictionary encoded.  Or it might
+    /// contain a skip block when data has been RLE encoded.
+    pub is_data: bool,
+    /// Buffers that make up the encoded buffer
+    ///
+    /// All of these buffers should be written to the file as one contiguous buffer
+    ///
+    /// This is a Vec to allow for zero-copy
+    ///
+    /// For example, if we are asked to write 3 primitive arrays of 1000 rows and we can write them all
+    /// as one page then this will be the value buffers from the 3 primitive arrays
+    pub parts: Vec<Buffer>,
+}
+
+// Custom impl because buffers shouldn't be included in debug output
+impl std::fmt::Debug for EncodedBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncodedBuffer")
+            .field("is_data", &self.is_data)
+            .field("len", &self.parts.iter().map(|p| p.len()).sum::<usize>())
+            .finish()
+    }
+}
+
+/// An encoded page of data
+///
+/// This maps to an Arrow Array and may contain multiple buffers
+/// For example, a nullable int32 page will contain two buffers, one for the null bitmap and one for the values
+#[derive(Debug)]
+pub struct EncodedPage {
+    /// The encoded buffers
+    pub buffers: Vec<EncodedBuffer>,
+    /// A description of the encoding used to encode the column
+    pub encoding: pb::ArrayEncoding,
+    /// The number of rows in the encoded page
+    pub num_rows: u32,
+    /// The index of the column
+    pub column_idx: u32,
+}
+
+/// Encodes data into a single buffer
+pub trait BufferEncoder: std::fmt::Debug + Send + Sync {
+    /// Encode data
+    ///
+    /// This method may receive multiple chunks and should encode them all into
+    /// a single EncodedBuffer (though that buffer may have multiple parts).  All
+    /// parts will be written to the file as one contiguous block.
+    fn encode(&self, arrays: &[ArrayRef]) -> Result<EncodedBuffer>;
+}
+
+/// Encodes data from Arrow format into some kind of on-disk format
+///
+/// The encoder is responsible for looking at the incoming data and determining
+/// which encoding is most appropriate.  This may involve calculating statistics,
+/// etc.  It then needs to actually encode that data according to the chosen encoding.
+///
+/// The encoder may even encode the statistics as well (typically in the column
+/// metadata) so that the statistics can be used for filtering later.
+///
+/// The array encoder must be Send + Sync.  Encoding is always done on its own
+/// thread task in the background and there could potentially be multiple encode
+/// tasks running for a column at once.
+///
+/// Note: not all Arrow arrays can be encoded using an ArrayEncoder.  Some arrays
+/// will be econded into several Lance columns.  For example, a list array or a
+/// struct array.  See [FieldEncoder] for the top-level encoding entry point
+pub trait ArrayEncoder: std::fmt::Debug + Send + Sync {
+    /// Encode data
+    ///
+    /// This method may receive multiple chunks and should encode them into a
+    /// single EncodedPage.
+    ///
+    /// The result should contain a description of the encoding that was chosen.
+    /// This can be used to decode the data later.
+    fn encode(&self, arrays: &[ArrayRef]) -> Result<EncodedPage>;
+}
+
+/// Top level encoding trait to code any Arrow array type into one or more pages.
+///
+/// The field encoder implements buffering and encoding of a single input column
+/// but it may map to multiple output columns.  For example, a list array or struct
+/// array will be encoded into multiple columns.
+///
+/// Also, fields may be encoded at different speeds.  For example, given a struct
+/// column with three fields (a boolean field, an int32 field, and a 4096-dimension
+/// tensor field) the tensor field is likely to emit encoded pages much more frequently
+/// than the boolean field.
+pub trait FieldEncoder {
+    /// Buffer the data and, if there is enough data in the buffer to form a page, return
+    /// an encoding task to encode the data.
+    ///
+    /// This may return more than one task because a single column may be mapped to multiple
+    /// output columns.  For example, if encoding a struct column with three children then
+    /// up to three tasks may be returned from each call to maybe_encode.
+    ///
+    /// It may also return multiple tasks for a single column if the input array is larger
+    /// than a single disk page.
+    ///
+    /// It could also return an empty Vec if there is not enough data yet to encode any pages.
+    fn maybe_encode(
+        &mut self,
+        array: ArrayRef,
+    ) -> Result<Vec<BoxFuture<'static, Result<EncodedPage>>>>;
+    /// Flush any remaining data from the buffers into encoding tasks
+    fn flush(&mut self) -> Result<Vec<BoxFuture<'static, Result<EncodedPage>>>>;
+    /// The number of output columns this encoding will create
+    fn num_columns(&self) -> u32;
+}

--- a/rust/lance-encoding/src/lib.rs
+++ b/rust/lance-encoding/src/lib.rs
@@ -19,6 +19,8 @@ use futures::future::BoxFuture;
 
 use lance_core::Result;
 
+pub mod decoder;
+pub mod encoder;
 pub mod format;
 
 /// A trait for an I/O service


### PR DESCRIPTION
This adds several traits.  On the encode side we have `BufferEncoder`, `ArrayEncoder`, and `FieldEncoder`.  On the decode side we have `PhysicalPageDecoder`, `LogicalPageDecoder`, `PhysicalPageScheduler`, and `LogicalPageScheduler`.

Prereqs:

 - [x] https://github.com/lancedb/lance/pull/2137
 - [x] https://github.com/lancedb/lance/pull/2139