### PR TITLE
feat: add encoders/decoders for basic types

### DIFF
--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -1078,10 +1078,12 @@ const MS_PER_DAY: i64 = 86400000;
 
 pub mod array {
 
+    use arrow::datatypes::{
+        Int16Type, Int64Type, Int8Type, IntervalDayTimeType, IntervalMonthDayNanoType,
+    };
     use arrow_array::types::{
         Decimal128Type, Decimal256Type, DurationMicrosecondType, DurationMillisecondType,
         DurationNanosecondType, DurationSecondType, Float16Type, Float32Type, Float64Type,
-        Int16Type, Int32Type, Int64Type, Int8Type, IntervalDayTimeType, IntervalMonthDayNanoType,
         IntervalYearMonthType, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
     };
     use arrow_array::{
@@ -1091,7 +1093,6 @@ pub mod array {
     };
     use arrow_schema::{IntervalUnit, TimeUnit};
     use chrono::Utc;
-    use rand::distributions::Uniform;
     use rand::prelude::Distribution;
 
     use super::*;
@@ -1621,10 +1622,8 @@ pub fn rand(schema: &Schema) -> BatchGeneratorBuilder {
 #[cfg(test)]
 mod tests {
 
-    use arrow_array::{
-        types::{Float32Type, Int16Type, Int32Type, Int8Type, UInt32Type},
-        BooleanArray, Float32Array, Int16Array, Int32Array, Int8Array, UInt32Array,
-    };
+    use arrow::datatypes::{Float32Type, Int16Type, Int8Type, UInt32Type};
+    use arrow_array::{BooleanArray, Float32Array, Int16Array, Int32Array, Int8Array, UInt32Array};
 
     use super::*;
 

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -276,32 +276,15 @@ pub struct DecodeBatchScheduler {
 
 impl DecodeBatchScheduler {
     fn is_primitive(data_type: &DataType) -> bool {
-        match data_type {
-            DataType::Boolean
-            | DataType::Date32
-            | DataType::Date64
-            | DataType::Decimal128(_, _)
-            | DataType::Decimal256(_, _)
-            | DataType::Duration(_)
-            | DataType::Float16
-            | DataType::Float32
-            | DataType::Float64
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::Int8
-            | DataType::Interval(_)
-            | DataType::Null
-            | DataType::RunEndEncoded(_, _)
-            | DataType::Time32(_)
-            | DataType::Time64(_)
-            | DataType::Timestamp(_, _)
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::UInt8 => true,
-            DataType::FixedSizeList(inner, _) => Self::is_primitive(inner.data_type()),
-            _ => false,
+        if data_type.is_primitive() {
+            true
+        } else {
+            match data_type {
+                // DataType::is_primitive doesn't consider these primitive but we do
+                DataType::Boolean | DataType::Null => true,
+                DataType::FixedSizeList(inner, _) => Self::is_primitive(inner.data_type()),
+                _ => false,
+            }
         }
     }
 

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -195,14 +195,395 @@
 
 use std::{ops::Range, sync::Arc};
 
-use arrow_array::ArrayRef;
+use arrow_array::cast::AsArray;
+use arrow_array::{ArrayRef, RecordBatch};
+use arrow_schema::{DataType, Schema};
 use bytes::BytesMut;
 use futures::future::BoxFuture;
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use log::trace;
+use snafu::{location, Location};
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
-use lance_core::Result;
+use lance_core::{Error, Result};
 
+use crate::encodings::logical::fixed_size_list::FslPageScheduler;
+use crate::encodings::logical::list::ListPageScheduler;
+use crate::encodings::logical::primitive::PrimitivePageScheduler;
+use crate::encodings::logical::r#struct::SimpleStructScheduler;
+use crate::encodings::physical::{ColumnBuffers, FileBuffers};
+use crate::format::pb;
 use crate::EncodingsIo;
+
+/// Metadata describing a page in a file
+///
+/// This is typically created by reading the metadata section of a Lance file
+#[derive(Debug)]
+pub struct PageInfo {
+    /// The number of rows in the page
+    pub num_rows: u32,
+    /// The encoding that explains the buffers in the page
+    pub encoding: pb::ArrayEncoding,
+    /// The offsets of the buffers in the file
+    pub buffer_offsets: Arc<Vec<u64>>,
+}
+
+/// Metadata describing a column in a file
+///
+/// This is typically created by reading the metadata section of a Lance file
+pub struct ColumnInfo {
+    /// The metadata for each page in the column
+    pub page_infos: Vec<Arc<PageInfo>>,
+    pub buffer_offsets: Vec<u64>,
+}
+
+impl ColumnInfo {
+    /// Create a new instance
+    pub fn new(page_infos: Vec<Arc<PageInfo>>, buffer_offsets: Vec<u64>) -> Self {
+        Self {
+            page_infos,
+            buffer_offsets,
+        }
+    }
+}
+
+/// The scheduler for decoding batches
+///
+/// Lance decoding is done in two steps, scheduling, and decoding.  The
+/// scheduling tends to be lightweight and should quickly figure what data
+/// is needed from the disk issue the appropriate I/O requests.  A decode task is
+/// created to eventually decode the data (once it is loaded) and scheduling
+/// moves on to scheduling the next page.
+///
+/// Meanwhile, it's expected that a decode stream will be setup to run at the
+/// same time.  Decode tasks take the data that is loaded and turn it into
+/// Arrow arrays.
+///
+/// This approach allows us to keep our I/O parallelism and CPU parallelism
+/// completely separate since those are often two very different values.
+///
+/// Backpressure should be achieved via the I/O service.  Requests that are
+/// issued will pile up if the decode stream is not polling quickly enough.
+/// The [`crate::EncodingsIo::submit_request`] function should return a pending
+/// future once there are too many I/O requests in flight.
+///
+/// TODO: Implement backpressure
+pub struct DecodeBatchScheduler {
+    root_scheduler: SimpleStructScheduler,
+}
+
+impl DecodeBatchScheduler {
+    fn is_primitive(data_type: &DataType) -> bool {
+        match data_type {
+            DataType::Boolean
+            | DataType::Date32
+            | DataType::Date64
+            | DataType::Decimal128(_, _)
+            | DataType::Decimal256(_, _)
+            | DataType::Duration(_)
+            | DataType::Float16
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::Int8
+            | DataType::Interval(_)
+            | DataType::Null
+            | DataType::RunEndEncoded(_, _)
+            | DataType::Time32(_)
+            | DataType::Time64(_)
+            | DataType::Timestamp(_, _)
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::UInt8 => true,
+            DataType::FixedSizeList(inner, _) => Self::is_primitive(inner.data_type()),
+            _ => false,
+        }
+    }
+
+    fn create_primitive_scheduler<'a>(
+        data_type: &DataType,
+        column_infos: &mut impl Iterator<Item = &'a ColumnInfo>,
+        buffers: FileBuffers,
+    ) -> Vec<Box<dyn LogicalPageScheduler>> {
+        // Primitive fields map to a single column
+        let column = column_infos.next().unwrap();
+        let column_buffers = ColumnBuffers {
+            file_buffers: buffers,
+            positions: &column.buffer_offsets,
+        };
+        column
+            .page_infos
+            .iter()
+            .cloned()
+            .map(|page_info| {
+                Box::new(PrimitivePageScheduler::new(
+                    data_type.clone(),
+                    page_info,
+                    column_buffers,
+                )) as Box<dyn LogicalPageScheduler>
+            })
+            .collect::<Vec<_>>()
+    }
+
+    fn check_simple_struct(column_info: &ColumnInfo) -> Result<()> {
+        if !column_info.page_infos.len() == 1 {
+            return Err(Error::InvalidInput { source: format!("Due to schema we expected a struct column but we received a column with {} pages and right now we only support struct columns with 1 page", column_info.page_infos.len()).into(), location: location!() });
+        }
+        let encoding = &column_info.page_infos[0].encoding;
+        match encoding.array_encoding.as_ref().unwrap() {
+            pb::array_encoding::ArrayEncoding::Struct(_) => Ok(()),
+            _ => Err(Error::InvalidInput { source: format!("Expected a struct encoding because we have a struct field in the schema but got the encoding {:?}", encoding).into(), location: location!() }),
+        }
+    }
+    // This function is where the all important mapping from Arrow schema
+    // to decoders happens.  Note that the decoders can only be figured out
+    // using both the schema AND the column metadata.  In theory, one could
+    // infer the decoder / column type using only the column metadata.  However,
+    // field nullability would be missing / incorrect and its also not as easy
+    // as it sounds since pages can have different encodings and those encodings
+    // often have various layers.  Also, sometimes the inference is just impossible.
+    // For example, both Timestamp, Float64, Int64, and UInt64 will be encoded
+    // as 8-byte value encoding.  The only way to know the data type is to look
+    // at the schema.
+    //
+    // We also can't just guess the encoding based on the schema.  This is because
+    // there may be multiple different ways to encode a field and it may even
+    // change on a page-by-page basis.
+    //
+    // For example, if a field is a struct field then we expect a header
+    // column that could have one of a few different encodings.
+    //
+    // This could be encoded with "simple struct" and an empty header column
+    // followed by the shredded child columns.  It could be encoded as a nullable
+    // struct where the nulls are in a dense bitmap.  It could even be encoded
+    // as a packed (row-major) struct where there is only a single column containing
+    // all of the data!
+    //
+    // TODO: Still lots of research to do here in different ways that
+    // we can map schemas to buffers.
+    //
+    // Example: repetition levels - the validity bitmaps for nested
+    // fields are fatter (more than one bit per row) and contain
+    // validity information about parent fields (e.g. is this a
+    // struct-struct-null or struct-null-null or null-null-null?)
+    //
+    // Examples: sentinel-shredding - instead of creating a wider
+    // validity bitmap we assign more sentinels to each column.  So
+    // if the values of an int32 array have a max of 1000 then we can
+    // use 1001 to mean null int32 and 1002 to mean null parent.
+    //
+    // Examples: Sparse structs - the struct column has a validity
+    // bitmap that must be read if you plan on reading the struct
+    // or any nested field.  However, this could be a compressed
+    // bitmap stored in metadata.  A perk for this approach is that
+    // the child fields can then have a smaller size than the parent
+    // field.  E.g. if a struct is 1000 rows and 900 of them are
+    // null then there is one validity bitmap of length 1000 and
+    // 100 rows of each of the children.
+    //
+    // TODO: In the future, this will need to be more flexible if
+    // we want to allow custom encodings.  E.g. if the field's encoding
+    // is not an encoding we expect then we should delegate to a plugin.
+    fn create_field_scheduler<'a>(
+        data_type: &DataType,
+        column_infos: &mut impl Iterator<Item = &'a ColumnInfo>,
+        buffers: FileBuffers,
+    ) -> Vec<Box<dyn LogicalPageScheduler>> {
+        if Self::is_primitive(data_type) {
+            return Self::create_primitive_scheduler(data_type, column_infos, buffers);
+        }
+        match data_type {
+            DataType::FixedSizeList(inner, dimension) => {
+                // A fixed size list column could either be a physical or a logical decoder
+                // depending on the child data type.
+                if Self::is_primitive(inner.data_type()) {
+                    Self::create_primitive_scheduler(data_type, column_infos, buffers)
+                } else {
+                    let inner_schedulers =
+                        Self::create_field_scheduler(inner.data_type(), column_infos, buffers);
+                    inner_schedulers
+                        .into_iter()
+                        .map(|inner| {
+                            Box::new(FslPageScheduler::new(inner, *dimension as u32))
+                                as Box<dyn LogicalPageScheduler>
+                        })
+                        .collect::<Vec<_>>()
+                }
+            }
+            DataType::List(items_field) => {
+                let offsets = Self::create_field_scheduler(&DataType::Int32, column_infos, buffers);
+                let items =
+                    Self::create_field_scheduler(items_field.data_type(), column_infos, buffers);
+                // TODO: This may need to be more flexible in the future if an items page can
+                // be shared by multiple offsets pages.
+                offsets
+                    .into_iter()
+                    .zip(items)
+                    .map(|(offsets_page, items_page)| {
+                        Box::new(ListPageScheduler::new(
+                            offsets_page,
+                            vec![items_page],
+                            DataType::Int32,
+                        )) as Box<dyn LogicalPageScheduler>
+                    })
+                    .collect::<Vec<_>>()
+            }
+            DataType::Struct(fields) => {
+                let column_info = column_infos.next().unwrap();
+                Self::check_simple_struct(column_info).unwrap();
+                let child_schedulers = fields
+                    .iter()
+                    .map(|field| {
+                        Self::create_field_scheduler(field.data_type(), column_infos, buffers)
+                    })
+                    .collect::<Vec<_>>();
+                // For now, we don't record nullability for structs.  As a result, there is always
+                // only one "page" of struct data.  In the future, this will change.  A null-aware
+                // struct scheduler will need to first calculate how many rows are in the struct page
+                // and then find the child pages that overlap.  This should be doable.
+                vec![Box::new(SimpleStructScheduler::new(
+                    child_schedulers,
+                    fields.clone(),
+                ))]
+            }
+            _ => todo!(),
+        }
+    }
+
+    /// Creates a new decode scheduler with the expected schema and the column
+    /// metadata of the file.
+    ///
+    /// TODO: How does this work when doing projection?  Need to add tests.  Can
+    /// probably take care of this in lance-file by only passing in the appropriate
+    /// columns with the projected schema.
+    pub fn new(
+        schema: &Schema,
+        column_infos: &[ColumnInfo],
+        file_buffer_positions: &Vec<u64>,
+    ) -> Self {
+        let mut col_info_iter = column_infos.iter();
+        let buffers = FileBuffers {
+            positions: file_buffer_positions,
+        };
+        let field_schedulers = schema
+            .fields
+            .iter()
+            .map(|field| {
+                Self::create_field_scheduler(field.data_type(), &mut col_info_iter, buffers)
+            })
+            .collect::<Vec<_>>();
+        let root_scheduler = SimpleStructScheduler::new(field_schedulers, schema.fields.clone());
+        Self { root_scheduler }
+    }
+
+    /// Schedules the load of a range of rows
+    ///
+    /// # Arguments
+    ///
+    /// * `range` - The range of rows to load
+    /// * `sink` - A channel to send the decode tasks
+    /// * `scheduler` An I/O scheduler to issue I/O requests
+    pub async fn schedule_range(
+        &mut self,
+        range: Range<u64>,
+        sink: mpsc::UnboundedSender<Box<dyn LogicalPageDecoder>>,
+        scheduler: &Arc<dyn EncodingsIo>,
+    ) -> Result<()> {
+        let rows_to_read = range.end - range.start;
+        trace!("Scheduling range {:?} ({} rows)", range, rows_to_read);
+
+        let range = range.start as u32..range.end as u32;
+
+        self.root_scheduler
+            .schedule_range(range.clone(), scheduler, &sink)?;
+
+        trace!("Finished scheduling of range {:?}", range);
+        Ok(())
+    }
+}
+
+/// A stream that takes scheduled jobs and generates decode tasks from them.
+pub struct BatchDecodeStream {
+    scheduled: mpsc::UnboundedReceiver<Box<dyn LogicalPageDecoder>>,
+    current: Option<Box<dyn LogicalPageDecoder>>,
+    rows_remaining: u64,
+    rows_per_batch: u32,
+}
+
+impl BatchDecodeStream {
+    /// Create a new instance of a batch decode stream
+    ///
+    /// # Arguments
+    ///
+    /// * `scheduled` - an incoming stream of decode tasks from a
+    ///   [`crate::decode::DecodeBatchScheduler`]
+    /// * `schema` - the scheam of the data to create
+    /// * `rows_per_batch` the number of rows to create before making a batch
+    /// * `num_rows` the total number of rows scheduled
+    /// * `num_columns` the total number of columns in the file
+    pub fn new(
+        scheduled: mpsc::UnboundedReceiver<Box<dyn LogicalPageDecoder>>,
+        rows_per_batch: u32,
+        num_rows: u64,
+    ) -> Self {
+        Self {
+            scheduled,
+            current: None,
+            rows_remaining: num_rows,
+            rows_per_batch,
+        }
+    }
+
+    async fn next_batch_task(&mut self) -> Result<Option<NextDecodeTask>> {
+        trace!("Draining batch task");
+        if self.rows_remaining == 0 {
+            return Ok(None);
+        }
+
+        let to_take = self.rows_remaining.min(self.rows_per_batch as u64) as u32;
+        self.rows_remaining -= to_take as u64;
+
+        if self.current.is_none() {
+            trace!("Loading new top-level page");
+            self.current = Some(self.scheduled.recv().await.unwrap());
+        }
+        let current = self.current.as_mut().unwrap();
+        let avail = current.avail();
+        trace!("Top level page has {} rows already available", avail);
+        if avail < to_take {
+            current.wait(to_take, &mut self.scheduled).await?;
+        }
+        let next_task = current.drain(to_take)?;
+        if !next_task.has_more {
+            self.current = None;
+        }
+        Ok(Some(next_task))
+    }
+
+    fn task_to_batch(task: NextDecodeTask) -> Result<RecordBatch> {
+        let struct_arr = task.task.decode()?;
+        Ok(RecordBatch::from(struct_arr.as_struct()))
+    }
+
+    pub fn into_stream(self) -> BoxStream<'static, JoinHandle<Result<RecordBatch>>> {
+        let stream = futures::stream::unfold(self, |mut slf| async move {
+            let next_task = slf.next_batch_task().await;
+            let next_task = next_task.transpose().map(|next_task| {
+                tokio::spawn(async move {
+                    let next_task = next_task?;
+                    Self::task_to_batch(next_task)
+                })
+            });
+            next_task.map(|next_task| (next_task, slf))
+        });
+        stream.boxed()
+    }
+}
 
 /// A decoder for single-column encodings of primitive data (this includes fixed size
 /// lists of primitive data)

--- a/rust/lance-encoding/src/encodings.rs
+++ b/rust/lance-encoding/src/encodings.rs
@@ -1,0 +1,2 @@
+pub mod logical;
+pub mod physical;

--- a/rust/lance-encoding/src/encodings/logical.rs
+++ b/rust/lance-encoding/src/encodings/logical.rs
@@ -1,0 +1,4 @@
+pub mod fixed_size_list;
+pub mod list;
+pub mod primitive;
+pub mod r#struct;

--- a/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
@@ -1,0 +1,128 @@
+use std::{ops::Range, sync::Arc};
+
+use arrow_array::{ArrayRef, FixedSizeListArray};
+use arrow_schema::Field;
+use futures::future::BoxFuture;
+use log::trace;
+use tokio::sync::mpsc;
+
+use crate::{
+    decoder::{DecodeArrayTask, LogicalPageDecoder, LogicalPageScheduler, NextDecodeTask},
+    EncodingsIo,
+};
+use lance_core::Result;
+
+// The Fsl decoder relies on the fact that the inner child decoder will never split a list across two
+// pages.  As a result, each child page of X rows can map to an FSL page with X / DIM rows.
+//
+// This is simpler than the List case where a single List page may have multiple child pages.
+//
+// Nulls are not supported yet.  This means that an Fsl page has zero buffers of its own.  In the future
+// this may need to change as there is no guarantee that an FSL will always have a sentinel (e.g. imagine
+// an FSL of [u8; 2] that covers every 2^16 possible values and all combinations of NULL),  This could
+// fit within a single page.
+
+// Note: The fixed size list encoding is both a logical and a physical encoding.  This file contains the
+// logical encoding which is only used when the inner type is, itself, a logical encoding.  For example,
+// a fixed-size-list<struct<...>> would use this encoding.
+
+// TODO: There are no tests for this yet.
+
+#[derive(Debug)]
+pub struct FslPageScheduler {
+    items_scheduler: Box<dyn LogicalPageScheduler>,
+    dimension: u32,
+}
+
+impl FslPageScheduler {
+    pub fn new(items_scheduler: Box<dyn LogicalPageScheduler>, dimension: u32) -> Self {
+        debug_assert_eq!(items_scheduler.num_rows() % dimension, 0);
+        Self {
+            items_scheduler,
+            dimension,
+        }
+    }
+}
+
+impl LogicalPageScheduler for FslPageScheduler {
+    fn schedule_range(
+        &self,
+        range: Range<u32>,
+        scheduler: &Arc<dyn EncodingsIo>,
+        sink: &mpsc::UnboundedSender<Box<dyn LogicalPageDecoder>>,
+    ) -> Result<()> {
+        let expanded_range = (range.start * self.dimension)..(range.end * self.dimension);
+        trace!("Scheduling range {:?} from items scheduler", expanded_range);
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        self.items_scheduler
+            .schedule_range(expanded_range, scheduler, &tx)?;
+        let inner_page_decoder = rx.blocking_recv().unwrap();
+        sink.send(Box::new(FslPageDecoder {
+            inner: inner_page_decoder,
+            dimension: self.dimension,
+        }))
+        .unwrap();
+        Ok(())
+    }
+
+    fn num_rows(&self) -> u32 {
+        self.items_scheduler.num_rows() / self.dimension
+    }
+}
+
+struct FslPageDecoder {
+    inner: Box<dyn LogicalPageDecoder>,
+    dimension: u32,
+}
+
+impl LogicalPageDecoder for FslPageDecoder {
+    fn wait<'a>(
+        &'a mut self,
+        num_rows: u32,
+        source: &'a mut mpsc::UnboundedReceiver<Box<dyn LogicalPageDecoder>>,
+    ) -> BoxFuture<'a, Result<()>> {
+        self.inner.wait(num_rows * self.dimension, source)
+    }
+
+    fn unawaited(&self) -> u32 {
+        self.inner.unawaited() / self.dimension
+    }
+
+    fn drain(&mut self, num_rows: u32) -> Result<NextDecodeTask> {
+        self.inner
+            .drain(num_rows * self.dimension)
+            .map(|inner_task| {
+                let task = Box::new(FslDecodeTask {
+                    inner: inner_task.task,
+                    dimension: self.dimension,
+                });
+                NextDecodeTask {
+                    task,
+                    num_rows: inner_task.num_rows / self.dimension,
+                    has_more: inner_task.has_more,
+                }
+            })
+    }
+
+    fn avail(&self) -> u32 {
+        self.inner.avail() / self.dimension
+    }
+}
+
+struct FslDecodeTask {
+    inner: Box<dyn DecodeArrayTask>,
+    dimension: u32,
+}
+
+impl DecodeArrayTask for FslDecodeTask {
+    fn decode(self: Box<Self>) -> Result<ArrayRef> {
+        let child_array = self.inner.decode()?;
+        Ok(Arc::new(FixedSizeListArray::new(
+            Arc::new(Field::new("item", child_array.data_type().clone(), true)),
+            self.dimension as i32,
+            child_array,
+            // TODO: Support nullable FSL
+            None,
+        )))
+    }
+}

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -1,0 +1,491 @@
+use std::{collections::VecDeque, sync::Arc};
+
+use arrow_array::{
+    cast::AsArray,
+    types::{Int32Type, Int64Type},
+    ArrayRef, Int32Array, Int64Array, LargeListArray, ListArray,
+};
+use arrow_buffer::OffsetBuffer;
+use arrow_schema::{DataType, Field};
+use futures::{future::BoxFuture, FutureExt};
+use log::trace;
+use snafu::{location, Location};
+use tokio::{sync::mpsc, task::JoinHandle};
+
+use lance_core::{Error, Result};
+
+use crate::{
+    decoder::{DecodeArrayTask, LogicalPageDecoder, LogicalPageScheduler, NextDecodeTask},
+    encoder::{EncodedPage, FieldEncoder},
+    encodings::physical::basic::BasicEncoder,
+    format::pb,
+    EncodingsIo,
+};
+
+use super::primitive::PrimitiveFieldEncoder;
+
+/// A page scheduler for list fields that encodes offsets in one field and items in another
+///
+/// TODO: Implement list nullability
+///
+/// The list scheduler is somewhat unique because it requires indirect I/O.  We cannot know the
+/// ranges we need simply by looking at the metadata.  This means that list scheduling doesn't
+/// fit neatly into the two-thread schedule-loop / decode-loop model.  To handle this, when a
+/// list page is scheduled, we only schedule the I/O for the offsets and then we immediately
+/// launch a new tokio task.  This new task waits for the offsets, decodes them, and then
+/// schedules the I/O for the items.  Keep in mind that list items can be lists themselves.  If
+/// that is the case then this indirection will continue.  The decode task that is returned will
+/// only finish `wait`ing when all of the I/O has completed.
+///
+/// Whenever we schedule follow-up I/O like this the priority is based on the top-level row
+/// index.  This helps ensure that earlier rows get finished completely (including follow up
+/// tasks) before we perform I/O for later rows.
+///
+/// TODO: Actually implement the priority system described above
+///
+/// Note: The length of the list page is 1 less than the length of the offsets page
+// TODO: Right now we are assuming that list offsets and list items are written at the same time.
+// As a result, we know which item pages correspond to which index page and there are no item
+// pages which overlap two different index pages.
+//
+// In the metadata for the page we store only the u64 num_items referenced by the page.
+//
+// We could relax this constraint.  Either each index page could store the u64 offset into
+// the total range of item pages or each index page could store a u64 num_items and a u32
+// first_item_page_offset.
+#[derive(Debug)]
+pub struct ListPageScheduler {
+    offsets_scheduler: Box<dyn LogicalPageScheduler>,
+    items_schedulers: Arc<Vec<Box<dyn LogicalPageScheduler>>>,
+    offset_type: DataType,
+}
+
+impl ListPageScheduler {
+    // Create a new ListPageScheduler
+    pub fn new(
+        offsets_scheduler: Box<dyn LogicalPageScheduler>,
+        items_schedulers: Vec<Box<dyn LogicalPageScheduler>>,
+        // Should be int32 or int64
+        offset_type: DataType,
+    ) -> Self {
+        match &offset_type {
+            DataType::Int32 | DataType::Int64 => {}
+            _ => panic!(),
+        }
+        Self {
+            offsets_scheduler,
+            items_schedulers: Arc::new(items_schedulers),
+            offset_type,
+        }
+    }
+}
+
+impl LogicalPageScheduler for ListPageScheduler {
+    fn schedule_range(
+        &self,
+        range: std::ops::Range<u32>,
+        scheduler: &Arc<dyn EncodingsIo>,
+        sink: &mpsc::UnboundedSender<Box<dyn LogicalPageDecoder>>,
+    ) -> Result<()> {
+        trace!("Scheduling list offsets range: {:?}", range);
+        let num_rows = range.end - range.start;
+        let num_offsets = num_rows + 1;
+        let offsets_range = range.start..(range.end + 1);
+        // Create a channel for the internal schedule / decode loop that is unique
+        // to this page.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        self.offsets_scheduler
+            .schedule_range(offsets_range, scheduler, &tx)?;
+        let mut scheduled_offsets = rx.recv().now_or_never().unwrap().unwrap();
+        let items_schedulers = self.items_schedulers.clone();
+        let scheduler = scheduler.clone();
+
+        // First we schedule, as normal, the I/O for the offsets.  Then we immediately spawn
+        // a task to decode those offsets and schedule the I/O for the items.  If we wait until
+        // the decode task has launched then we will be delaying the I/O for the items until we
+        // need them which is not good.  Better to spend some eager CPU and start loading the
+        // items immediately.
+        let indirect_fut = tokio::task::spawn(async move {
+            // We know the offsets are a primitive array and thus will not need additional
+            // pages.  We can use a dummy receiver to match the decoder API
+            let (_, mut dummy_rx) = mpsc::unbounded_channel();
+            scheduled_offsets.wait(num_rows, &mut dummy_rx).await?;
+            let decode_task = scheduled_offsets.drain(num_offsets)?;
+            let offsets = decode_task.task.decode()?;
+            let numeric_offsets = offsets.as_primitive::<Int32Type>();
+            let start = numeric_offsets.values()[0] as u32;
+            let end = numeric_offsets.values()[numeric_offsets.len() - 1] as u32;
+            trace!(
+                "List offsets range of {:?} maps to item range {:?}..{:?}",
+                range,
+                start,
+                end
+            );
+
+            let mut rows_to_take = end - start;
+            let mut rows_to_skip = start;
+            let (tx, mut rx) = mpsc::unbounded_channel();
+
+            trace!(
+                "Indirectly scheduling items from {} list items pages",
+                items_schedulers.len()
+            );
+            for item_scheduler in items_schedulers.as_ref() {
+                if item_scheduler.num_rows() < rows_to_skip {
+                    rows_to_skip -= item_scheduler.num_rows()
+                } else {
+                    let rows_avail = item_scheduler.num_rows() - rows_to_skip;
+                    let to_take = rows_to_take.min(rows_avail);
+                    let page_range = rows_to_skip..(rows_to_skip + to_take);
+                    // Note that, if we have List<List<...>> then this call will schedule yet another round
+                    // of I/O :)
+                    item_scheduler.schedule_range(page_range, &scheduler, &tx)?;
+                    rows_to_skip = 0;
+                    rows_to_take -= to_take;
+                }
+            }
+            let mut item_decoders = Vec::new();
+            drop(tx);
+            while let Some(item_decoder) = rx.recv().now_or_never().unwrap() {
+                item_decoders.push(item_decoder);
+            }
+
+            Ok(IndirectlyLoaded {
+                offsets,
+                item_decoders,
+            })
+        });
+        sink.send(Box::new(ListPageDecoder {
+            offsets: None,
+            unawaited: VecDeque::new(),
+            item_decoders: VecDeque::new(),
+            num_rows,
+            rows_drained: 0,
+            unloaded: Some(indirect_fut),
+            offset_type: self.offset_type.clone(),
+        }))
+        .unwrap();
+        Ok(())
+    }
+
+    // A list page's length is one less than the length of the offsets
+    fn num_rows(&self) -> u32 {
+        self.offsets_scheduler.num_rows() - 1
+    }
+}
+
+/// As soon as the first call to decode comes in we wait for all indirect I/O to
+/// complete.  TODO: We could potentially be lazier here, to investigate.
+///
+/// Once the indirect I/O is finished we pull items out of `unawaited`, wait them
+/// (this wait should return immedately) and then push them into `item_decoders`.
+///
+/// We then drain from `item_decoders`, popping item pages off as we finish with
+/// them.
+///
+/// TODO: Test the case where a single list page has multiple items pages
+struct ListPageDecoder {
+    unloaded: Option<JoinHandle<Result<IndirectlyLoaded>>>,
+    unawaited: VecDeque<Box<dyn LogicalPageDecoder>>,
+    // offsets will have already been decoded as part of the indirect I/O
+    // and so we store ArrayRef and not Box<dyn LogicalPageDecoder>
+    offsets: Option<ArrayRef>,
+    // Items will not yet be decoded, we at least try and do that part
+    // on the decode thread
+    item_decoders: VecDeque<Box<dyn LogicalPageDecoder>>,
+    num_rows: u32,
+    rows_drained: u32,
+    offset_type: DataType,
+}
+
+impl ListPageDecoder {
+    fn rows_immediately_available(&self) -> u32 {
+        self.item_decoders.iter().map(|d| d.avail()).sum()
+    }
+}
+
+struct ListDecodeTask {
+    offsets: ArrayRef,
+    items: Vec<Box<dyn DecodeArrayTask>>,
+    offset_type: DataType,
+}
+
+impl DecodeArrayTask for ListDecodeTask {
+    fn decode(self: Box<Self>) -> Result<ArrayRef> {
+        let offsets = self.offsets;
+        let items = self
+            .items
+            .into_iter()
+            .map(|task| task.decode())
+            .collect::<Result<Vec<_>>>()?;
+        let item_refs = items.iter().map(|item| item.as_ref()).collect::<Vec<_>>();
+        // TODO: could maybe try and "page bridge" these at some point
+        // (assuming item type is primitive) to avoid the concat
+        let items = arrow_select::concat::concat(&item_refs)?;
+        let nulls = offsets.nulls().cloned();
+        // TODO: we default to nullable true here, should probably use the nullability given to
+        // us from the input schema
+        let item_field = Arc::new(Field::new("item", items.data_type().clone(), true));
+
+        // The offsets are already decoded but they need to be shifted back to 0
+        // TODO: Can these branches be simplified?
+        match &self.offset_type {
+            DataType::Int32 => {
+                let offsets = arrow_cast::cast(&offsets, &DataType::Int32)?;
+                let offsets_i32 = offsets.as_primitive::<Int32Type>();
+                let min_offset = Int32Array::new_scalar(offsets_i32.value(0));
+                let offsets = arrow_arith::numeric::sub(&offsets_i32, &min_offset)?;
+                let offsets_i32 = offsets.as_primitive::<Int32Type>();
+                let offsets = OffsetBuffer::new(offsets_i32.values().clone());
+
+                Ok(Arc::new(ListArray::try_new(
+                    item_field, offsets, items, nulls,
+                )?))
+            }
+            DataType::Int64 => {
+                let offsets = arrow_cast::cast(&offsets, &DataType::Int64)?;
+                let offsets_i64 = offsets.as_primitive::<Int64Type>();
+                let min_offset = Int64Array::new_scalar(offsets_i64.value(0));
+                let offsets = arrow_arith::numeric::sub(&offsets_i64, &min_offset)?;
+                let offsets_i64 = offsets.as_primitive::<Int64Type>();
+                let offsets = OffsetBuffer::new(offsets_i64.values().clone());
+
+                Ok(Arc::new(LargeListArray::try_new(
+                    item_field, offsets, items, nulls,
+                )?))
+            }
+            _ => panic!("ListDecodeTask with data type that is not i32 or i64"),
+        }
+    }
+}
+
+impl LogicalPageDecoder for ListPageDecoder {
+    fn wait<'a>(
+        &'a mut self,
+        num_rows: u32,
+        source: &'a mut mpsc::UnboundedReceiver<Box<dyn LogicalPageDecoder>>,
+    ) -> BoxFuture<'a, Result<()>> {
+        async move {
+            // First, wait for the indirect I/O to finish, if we haven't already
+            if self.unloaded.is_some() {
+                let indirectly_loaded = self.unloaded.take().unwrap().await.unwrap()?;
+                self.offsets = Some(indirectly_loaded.offsets);
+                self.unawaited.extend(indirectly_loaded.item_decoders);
+            }
+            // Next, pull as many items as we can from decoders that have already
+            // been "awaited".
+            let avail = self.rows_immediately_available();
+            if avail >= num_rows {
+                return Ok(());
+            }
+            let mut remaining = num_rows - avail;
+            if let Some(partial) = self.item_decoders.back_mut() {
+                let rows_left_unawaited = partial.unawaited();
+                if rows_left_unawaited > 0 {
+                    let rows_to_take = rows_left_unawaited.min(remaining);
+                    partial.wait(rows_to_take, source).await?;
+                    remaining -= rows_to_take;
+                }
+            }
+            // Finally, pull items from the unawaited queue
+            while remaining > 0 {
+                let mut next_to_await = self.unawaited.pop_front().ok_or_else(|| Error::Internal { message: format!("list page was asked for {} rows but ran out of item pages before that happened", remaining), location: location!() })?;
+                let rows_to_take = next_to_await.unawaited().min(remaining);
+                next_to_await.wait(rows_to_take, source).await?;
+                remaining -= rows_to_take;
+                self.item_decoders.push_back(next_to_await);
+            }
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn unawaited(&self) -> u32 {
+        match self.unloaded {
+            None => {
+                let partial = self
+                    .item_decoders
+                    .back()
+                    .map(|d| d.unawaited())
+                    .unwrap_or(0);
+                partial + self.unawaited.iter().map(|d| d.unawaited()).sum::<u32>()
+            }
+            Some(_) => self.num_rows,
+        }
+    }
+
+    fn drain(&mut self, num_rows: u32) -> Result<NextDecodeTask> {
+        // We already have the offsets but need to drain the item pages
+        let offsets = self
+            .offsets
+            .as_ref()
+            .unwrap()
+            .slice(self.rows_drained as usize, num_rows as usize + 1);
+
+        // TODO: Support for large list, nullability, will probably change this away from Int32Type
+        let offsets_i32 = offsets.as_primitive::<Int32Type>();
+        let start = offsets_i32.values()[0];
+        let end = offsets_i32.values()[offsets_i32.len() - 1];
+        let mut num_items_to_drain = end - start;
+
+        let mut item_decodes = Vec::new();
+        while num_items_to_drain > 0 {
+            let next_item_page = self.item_decoders.front_mut().unwrap();
+            let avail = next_item_page.avail();
+            let to_take = num_items_to_drain.min(avail as i32) as u32;
+            num_items_to_drain -= to_take as i32;
+            let next_task = next_item_page.drain(to_take)?;
+
+            if !next_task.has_more {
+                self.item_decoders.pop_front();
+            }
+            item_decodes.push(next_task.task);
+        }
+
+        self.rows_drained += num_rows;
+        Ok(NextDecodeTask {
+            has_more: self.avail() > 0,
+            num_rows,
+            task: Box::new(ListDecodeTask {
+                offsets,
+                items: item_decodes,
+                offset_type: self.offset_type.clone(),
+            }) as Box<dyn DecodeArrayTask>,
+        })
+    }
+
+    fn avail(&self) -> u32 {
+        self.num_rows - self.rows_drained
+    }
+}
+
+struct IndirectlyLoaded {
+    offsets: ArrayRef,
+    item_decoders: Vec<Box<dyn LogicalPageDecoder>>,
+}
+
+pub struct ListFieldEncoder {
+    indices_encoder: PrimitiveFieldEncoder,
+    items_encoder: Box<dyn FieldEncoder>,
+}
+
+impl ListFieldEncoder {
+    pub fn new(
+        items_encoder: Box<dyn FieldEncoder>,
+        cache_bytes_per_columns: u64,
+        column_index: u32,
+    ) -> Self {
+        Self {
+            indices_encoder: PrimitiveFieldEncoder::new(
+                cache_bytes_per_columns,
+                Arc::new(BasicEncoder::new(column_index)),
+            ),
+            items_encoder,
+        }
+    }
+
+    fn combine_index_tasks(
+        index_tasks: Result<Vec<BoxFuture<'static, Result<EncodedPage>>>>,
+        item_tasks: Result<Vec<BoxFuture<'static, Result<EncodedPage>>>>,
+    ) -> Result<Vec<BoxFuture<'static, Result<EncodedPage>>>> {
+        let mut index_tasks = index_tasks?;
+        let item_tasks = item_tasks?;
+        index_tasks.extend(item_tasks);
+        Ok(index_tasks)
+    }
+
+    fn wrap_index_encode_tasks(
+        tasks: Result<Vec<BoxFuture<'static, Result<EncodedPage>>>>,
+    ) -> Result<Vec<BoxFuture<'static, Result<EncodedPage>>>> {
+        tasks.map(|tasks| {
+            tasks
+                .into_iter()
+                .map(|page_task| {
+                    async move {
+                        let page = page_task.await?;
+                        Ok(EncodedPage {
+                            buffers: page.buffers,
+                            column_idx: page.column_idx,
+                            num_rows: page.num_rows,
+                            encoding: pb::ArrayEncoding {
+                                array_encoding: Some(pb::array_encoding::ArrayEncoding::List(
+                                    Box::new(pb::List {
+                                        offsets: Some(Box::new(page.encoding)),
+                                    }),
+                                )),
+                            },
+                        })
+                    }
+                    .boxed()
+                })
+                .collect::<Vec<_>>()
+        })
+    }
+}
+
+impl FieldEncoder for ListFieldEncoder {
+    fn maybe_encode(
+        &mut self,
+        array: ArrayRef,
+    ) -> Result<Vec<BoxFuture<'static, Result<EncodedPage>>>> {
+        let items = match array.data_type() {
+            DataType::List(_) => array.as_list::<i32>().values().clone(),
+            DataType::LargeList(_) => array.as_list::<i64>().values().clone(),
+            _ => panic!(),
+        };
+        let offsets = match array.data_type() {
+            DataType::List(_) => {
+                let offsets = array.as_list::<i32>().offsets().clone();
+                Arc::new(Int32Array::new(offsets.into_inner(), None)) as ArrayRef
+            }
+            DataType::LargeList(_) => {
+                let offsets = array.as_list::<i64>().offsets().clone();
+                Arc::new(Int64Array::new(offsets.into_inner(), None)) as ArrayRef
+            }
+            _ => panic!(),
+        };
+        let index_tasks = self.indices_encoder.maybe_encode(offsets);
+        let index_tasks = Self::wrap_index_encode_tasks(index_tasks);
+        let item_tasks = self.items_encoder.maybe_encode(items);
+        Self::combine_index_tasks(index_tasks, item_tasks)
+    }
+
+    fn flush(&mut self) -> Result<Vec<BoxFuture<'static, Result<EncodedPage>>>> {
+        let index_tasks = self.indices_encoder.flush();
+        let index_tasks = Self::wrap_index_encode_tasks(index_tasks);
+        let item_tasks = self.items_encoder.flush();
+        Self::combine_index_tasks(index_tasks, item_tasks)
+    }
+
+    fn num_columns(&self) -> u32 {
+        2
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::sync::Arc;
+
+    use arrow_schema::{DataType, Field};
+
+    use crate::{
+        encodings::{
+            logical::{list::ListFieldEncoder, primitive::PrimitiveFieldEncoder},
+            physical::basic::BasicEncoder,
+        },
+        testing::check_round_trip_field_encoding,
+    };
+
+    #[test_log::test(tokio::test)]
+    async fn test_simple_list() {
+        let data_type = DataType::List(Arc::new(Field::new("item", DataType::Int32, true)));
+        let items_encoder = Box::new(PrimitiveFieldEncoder::new(
+            4096,
+            Arc::new(BasicEncoder::new(1)),
+        ));
+        let encoder = ListFieldEncoder::new(items_encoder, 4096, 0);
+        let field = Field::new("", data_type, false);
+        check_round_trip_field_encoding(encoder, field).await;
+    }
+}

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -1,0 +1,441 @@
+use std::sync::Arc;
+
+use arrow_array::{
+    new_null_array,
+    types::{
+        ArrowPrimitiveType, Date32Type, Date64Type, Decimal128Type, Decimal256Type,
+        DurationMicrosecondType, DurationMillisecondType, DurationNanosecondType,
+        DurationSecondType, Float16Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type,
+        Int8Type, IntervalDayTimeType, IntervalMonthDayNanoType, IntervalYearMonthType,
+        Time32MillisecondType, Time32SecondType, Time64MicrosecondType, Time64NanosecondType,
+        TimestampMicrosecondType, TimestampMillisecondType, TimestampNanosecondType,
+        TimestampSecondType, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
+    },
+    ArrayRef, BooleanArray, FixedSizeListArray, PrimitiveArray,
+};
+use arrow_buffer::{BooleanBuffer, Buffer, NullBuffer, ScalarBuffer};
+use arrow_schema::{DataType, IntervalUnit, TimeUnit};
+use bytes::BytesMut;
+use futures::{future::BoxFuture, FutureExt};
+use log::trace;
+use snafu::{location, Location};
+
+use lance_core::{Error, Result};
+use tokio::sync::mpsc;
+
+use crate::{
+    decoder::{
+        DecodeArrayTask, LogicalPageDecoder, LogicalPageScheduler, NextDecodeTask, PageInfo,
+        PhysicalPageDecoder, PhysicalPageScheduler,
+    },
+    encoder::{ArrayEncoder, EncodedPage, FieldEncoder},
+    encodings::physical::{decoder_from_array_encoding, ColumnBuffers, PageBuffers},
+    EncodingsIo,
+};
+
+/// A page scheduler for primitive fields
+///
+/// This maps to exactly one physical page and it assumes that the top-level
+/// encoding of the page is "basic".  The basic encoding decodes into an
+/// optional buffer of validity and a fixed-width buffer of values
+/// which is exactly what we need to create a primitive array.
+///
+/// Note: we consider booleans and fixed-size-lists of primitive types to be
+/// primitive types.  This is slightly different than arrow-rs's definition
+#[derive(Debug)]
+pub struct PrimitivePageScheduler {
+    data_type: DataType,
+    physical_decoder: Box<dyn PhysicalPageScheduler>,
+    num_rows: u32,
+}
+
+impl PrimitivePageScheduler {
+    pub fn new(data_type: DataType, page: Arc<PageInfo>, buffers: ColumnBuffers) -> Self {
+        let page_buffers = PageBuffers {
+            column_buffers: buffers,
+            positions: &page.buffer_offsets,
+        };
+        Self {
+            data_type,
+            physical_decoder: decoder_from_array_encoding(&page.encoding, &page_buffers),
+            num_rows: page.num_rows,
+        }
+    }
+}
+
+impl LogicalPageScheduler for PrimitivePageScheduler {
+    fn num_rows(&self) -> u32 {
+        self.num_rows
+    }
+
+    fn schedule_range(
+        &self,
+        range: std::ops::Range<u32>,
+        scheduler: &Arc<dyn EncodingsIo>,
+        sink: &mpsc::UnboundedSender<Box<dyn LogicalPageDecoder>>,
+    ) -> Result<()> {
+        let num_rows = range.end - range.start;
+        trace!("Scheduling range {:?} from physical page", range);
+        let physical_decoder = self
+            .physical_decoder
+            .schedule_range(range, scheduler.as_ref());
+
+        let logical_decoder = PrimitiveFieldDecoder {
+            data_type: self.data_type.clone(),
+            unloaded_physical_decoder: Some(physical_decoder),
+            physical_decoder: None,
+            rows_drained: 0,
+            num_rows,
+        };
+
+        sink.send(Box::new(logical_decoder)).unwrap();
+        Ok(())
+    }
+}
+
+struct PrimitiveFieldDecoder {
+    data_type: DataType,
+    unloaded_physical_decoder: Option<BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>>>,
+    physical_decoder: Option<Arc<dyn PhysicalPageDecoder>>,
+    num_rows: u32,
+    rows_drained: u32,
+}
+
+struct PrimitiveFieldDecodeTask {
+    rows_to_skip: u32,
+    rows_to_take: u32,
+    physical_decoder: Arc<dyn PhysicalPageDecoder>,
+    data_type: DataType,
+}
+
+impl DecodeArrayTask for PrimitiveFieldDecodeTask {
+    fn decode(self: Box<Self>) -> Result<ArrayRef> {
+        // There are two buffers, the validity buffer and the values buffer
+        // We start by assuming the validity buffer will not be required
+        let mut capacities = [(0, false), (0, true)];
+        self.physical_decoder.update_capacity(
+            self.rows_to_skip,
+            self.rows_to_take,
+            &mut capacities,
+        );
+        // At this point we know the size needed for each buffer
+        let mut bufs = capacities
+            .into_iter()
+            .map(|(num_bytes, is_needed)| {
+                // Only allocate the validity buffer if it is needed, otherwise we
+                // create an empty BytesMut (does not require allocation)
+                if is_needed {
+                    BytesMut::with_capacity(num_bytes as usize)
+                } else {
+                    BytesMut::default()
+                }
+            })
+            .collect::<Vec<_>>();
+
+        // Go ahead and fill the validity / values buffers
+        self.physical_decoder
+            .decode_into(self.rows_to_skip, self.rows_to_take, &mut bufs);
+
+        // Convert the two buffers into an Arrow array
+        Self::primitive_array_from_buffers(&self.data_type, bufs, self.rows_to_take)
+    }
+}
+
+impl PrimitiveFieldDecodeTask {
+    // TODO: Does this capability exist upstream somewhere?  I couldn't find
+    // it from a simple scan but it seems the ability to convert two buffers
+    // into a primitive array is pretty fundamental.
+    fn new_primitive_array<T: ArrowPrimitiveType>(
+        buffers: Vec<BytesMut>,
+        num_rows: u32,
+        data_type: &DataType,
+    ) -> ArrayRef {
+        let mut buffer_iter = buffers.into_iter();
+        let null_buffer = buffer_iter.next().unwrap();
+        let null_buffer = if null_buffer.is_empty() {
+            None
+        } else {
+            let null_buffer = null_buffer.freeze().into();
+            Some(NullBuffer::new(BooleanBuffer::new(
+                Buffer::from_bytes(null_buffer),
+                0,
+                num_rows as usize,
+            )))
+        };
+
+        let data_buffer = buffer_iter.next().unwrap().freeze();
+        let data_buffer = Buffer::from(data_buffer);
+        let data_buffer = ScalarBuffer::<T::Native>::new(data_buffer, 0, num_rows as usize);
+
+        // The with_data_type is needed here to recover the parameters for types like Decimal/Timestamp
+        Arc::new(
+            PrimitiveArray::<T>::new(data_buffer, null_buffer).with_data_type(data_type.clone()),
+        )
+    }
+
+    fn primitive_array_from_buffers(
+        data_type: &DataType,
+        buffers: Vec<BytesMut>,
+        num_rows: u32,
+    ) -> Result<ArrayRef> {
+        match data_type {
+            DataType::Boolean => {
+                let mut buffer_iter = buffers.into_iter();
+                let null_buffer = buffer_iter.next().unwrap();
+                let null_buffer = if null_buffer.is_empty() {
+                    None
+                } else {
+                    let null_buffer = null_buffer.freeze().into();
+                    Some(NullBuffer::new(BooleanBuffer::new(
+                        Buffer::from_bytes(null_buffer),
+                        0,
+                        num_rows as usize,
+                    )))
+                };
+
+                let data_buffer = buffer_iter.next().unwrap().freeze();
+                let data_buffer = Buffer::from(data_buffer);
+                let data_buffer = BooleanBuffer::new(data_buffer, 0, num_rows as usize);
+
+                Ok(Arc::new(BooleanArray::new(data_buffer, null_buffer)))
+            }
+            DataType::Date32 => Ok(Self::new_primitive_array::<Date32Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::Date64 => Ok(Self::new_primitive_array::<Date64Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::Decimal128(_, _) => Ok(Self::new_primitive_array::<Decimal128Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::Decimal256(_, _) => Ok(Self::new_primitive_array::<Decimal256Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::Duration(units) => Ok(match units {
+                TimeUnit::Second => {
+                    Self::new_primitive_array::<DurationSecondType>(buffers, num_rows, data_type)
+                }
+                TimeUnit::Microsecond => Self::new_primitive_array::<DurationMicrosecondType>(
+                    buffers, num_rows, data_type,
+                ),
+                TimeUnit::Millisecond => Self::new_primitive_array::<DurationMillisecondType>(
+                    buffers, num_rows, data_type,
+                ),
+                TimeUnit::Nanosecond => Self::new_primitive_array::<DurationNanosecondType>(
+                    buffers, num_rows, data_type,
+                ),
+            }),
+            DataType::Float16 => Ok(Self::new_primitive_array::<Float16Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::Float32 => Ok(Self::new_primitive_array::<Float32Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::Float64 => Ok(Self::new_primitive_array::<Float64Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::Int16 => Ok(Self::new_primitive_array::<Int16Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::Int32 => Ok(Self::new_primitive_array::<Int32Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::Int64 => Ok(Self::new_primitive_array::<Int64Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::Int8 => Ok(Self::new_primitive_array::<Int8Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::Interval(unit) => Ok(match unit {
+                IntervalUnit::DayTime => {
+                    Self::new_primitive_array::<IntervalDayTimeType>(buffers, num_rows, data_type)
+                }
+                IntervalUnit::MonthDayNano => {
+                    Self::new_primitive_array::<IntervalMonthDayNanoType>(
+                        buffers, num_rows, data_type,
+                    )
+                }
+                IntervalUnit::YearMonth => {
+                    Self::new_primitive_array::<IntervalYearMonthType>(buffers, num_rows, data_type)
+                }
+            }),
+            DataType::Null => Ok(new_null_array(data_type, num_rows as usize)),
+            DataType::Time32(unit) => match unit {
+                TimeUnit::Millisecond => Ok(Self::new_primitive_array::<Time32MillisecondType>(
+                    buffers, num_rows, data_type,
+                )),
+                TimeUnit::Second => Ok(Self::new_primitive_array::<Time32SecondType>(
+                    buffers, num_rows, data_type,
+                )),
+                _ => Err(Error::IO {
+                    message: format!("invalid time unit {:?} for 32-bit time type", unit),
+                    location: location!(),
+                }),
+            },
+            DataType::Time64(unit) => match unit {
+                TimeUnit::Microsecond => Ok(Self::new_primitive_array::<Time64MicrosecondType>(
+                    buffers, num_rows, data_type,
+                )),
+                TimeUnit::Nanosecond => Ok(Self::new_primitive_array::<Time64NanosecondType>(
+                    buffers, num_rows, data_type,
+                )),
+                _ => Err(Error::IO {
+                    message: format!("invalid time unit {:?} for 64-bit time type", unit),
+                    location: location!(),
+                }),
+            },
+            DataType::Timestamp(unit, _) => Ok(match unit {
+                TimeUnit::Microsecond => Self::new_primitive_array::<TimestampMicrosecondType>(
+                    buffers, num_rows, data_type,
+                ),
+                TimeUnit::Millisecond => Self::new_primitive_array::<TimestampMillisecondType>(
+                    buffers, num_rows, data_type,
+                ),
+                TimeUnit::Nanosecond => Self::new_primitive_array::<TimestampNanosecondType>(
+                    buffers, num_rows, data_type,
+                ),
+                TimeUnit::Second => {
+                    Self::new_primitive_array::<TimestampSecondType>(buffers, num_rows, data_type)
+                }
+            }),
+            DataType::UInt16 => Ok(Self::new_primitive_array::<UInt16Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::UInt32 => Ok(Self::new_primitive_array::<UInt32Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::UInt64 => Ok(Self::new_primitive_array::<UInt64Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::UInt8 => Ok(Self::new_primitive_array::<UInt8Type>(
+                buffers, num_rows, data_type,
+            )),
+            DataType::FixedSizeList(items, dimension) => {
+                let items_array = Self::primitive_array_from_buffers(
+                    items.data_type(),
+                    buffers,
+                    num_rows * (*dimension as u32),
+                )?;
+                Ok(Arc::new(FixedSizeListArray::new(
+                    items.clone(),
+                    *dimension,
+                    items_array,
+                    None,
+                )))
+            }
+            _ => Err(Error::IO {
+                message: format!(
+                    "The data type {} cannot be decoded from a primitive encoding",
+                    data_type
+                ),
+                location: location!(),
+            }),
+        }
+    }
+}
+
+impl LogicalPageDecoder for PrimitiveFieldDecoder {
+    fn wait<'a>(
+        &'a mut self,
+        _: u32,
+        _: &'a mut mpsc::UnboundedReceiver<Box<dyn LogicalPageDecoder>>,
+    ) -> BoxFuture<'a, Result<()>> {
+        async move {
+            let physical_decoder = self.unloaded_physical_decoder.take().unwrap().await?;
+            self.physical_decoder = Some(Arc::from(physical_decoder));
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn drain(&mut self, num_rows: u32) -> Result<NextDecodeTask> {
+        let rows_to_skip = self.rows_drained;
+        let rows_to_take = num_rows;
+
+        self.rows_drained += rows_to_take;
+
+        let task = Box::new(PrimitiveFieldDecodeTask {
+            rows_to_skip,
+            rows_to_take,
+            physical_decoder: self.physical_decoder.as_ref().unwrap().clone(),
+            data_type: self.data_type.clone(),
+        });
+
+        Ok(NextDecodeTask {
+            task,
+            num_rows: rows_to_take,
+            has_more: self.rows_drained != self.num_rows,
+        })
+    }
+
+    fn unawaited(&self) -> u32 {
+        if self.unloaded_physical_decoder.is_some() {
+            self.num_rows
+        } else {
+            0
+        }
+    }
+
+    fn avail(&self) -> u32 {
+        self.num_rows - self.rows_drained
+    }
+}
+
+pub struct PrimitiveFieldEncoder {
+    cache_bytes: u64,
+    buffered_arrays: Vec<ArrayRef>,
+    current_bytes: u64,
+    encoder: Arc<dyn ArrayEncoder>,
+}
+
+impl PrimitiveFieldEncoder {
+    pub fn new(cache_bytes: u64, encoder: Arc<dyn ArrayEncoder>) -> Self {
+        Self {
+            cache_bytes,
+            buffered_arrays: Vec::with_capacity(8),
+            current_bytes: 0,
+            encoder,
+        }
+    }
+
+    // Creates an encode task, consuming all buffered data
+    fn do_flush(&mut self) -> BoxFuture<'static, Result<EncodedPage>> {
+        let mut arrays = Vec::new();
+        std::mem::swap(&mut arrays, &mut self.buffered_arrays);
+        self.current_bytes = 0;
+        let encoder = self.encoder.clone();
+
+        tokio::task::spawn(async move { encoder.encode(&arrays) })
+            .map(|res_res| res_res.unwrap())
+            .boxed()
+    }
+}
+
+impl FieldEncoder for PrimitiveFieldEncoder {
+    // Buffers data, if there is enough to write a page then we create an encode task
+    fn maybe_encode(
+        &mut self,
+        array: ArrayRef,
+    ) -> Result<Vec<BoxFuture<'static, Result<EncodedPage>>>> {
+        self.current_bytes += array.get_array_memory_size() as u64;
+        self.buffered_arrays.push(array);
+        if self.current_bytes > self.cache_bytes {
+            Ok(vec![self.do_flush()])
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    // If there is any data left in the buffer then create an encode task from it
+    fn flush(&mut self) -> Result<Vec<BoxFuture<'static, Result<EncodedPage>>>> {
+        if self.current_bytes > 0 {
+            Ok(vec![self.do_flush()])
+        } else {
+            Ok(vec![])
+        }
+    }
+
+    fn num_columns(&self) -> u32 {
+        1
+    }
+}

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -1,0 +1,506 @@
+use std::{collections::VecDeque, ops::Range, sync::Arc};
+
+use arrow_array::{cast::AsArray, ArrayRef, StructArray};
+use arrow_schema::Fields;
+use futures::{future::BoxFuture, FutureExt};
+use log::trace;
+use tokio::sync::mpsc;
+
+use crate::{
+    decoder::{DecodeArrayTask, LogicalPageDecoder, LogicalPageScheduler, NextDecodeTask},
+    encoder::{EncodedPage, FieldEncoder},
+    format::pb,
+    EncodingsIo,
+};
+use lance_core::Result;
+
+/// A scheduler for structs
+///
+/// The implementation is actually a bit more tricky than one might initially think.  We can't just
+/// go through and schedule each column one after the other.  This would mean our decode can't start
+/// until nearly all the data has arrived (since we need data from each column)
+///
+/// Instead, we schedule in row-major fashion, described in detail below.
+///
+/// Note: this scheduler is the starting point for all decoding.  This is because we treat the top-level
+/// record batch as a non-nullable struct.
+#[derive(Debug)]
+pub struct SimpleStructScheduler {
+    children: Vec<Vec<Box<dyn LogicalPageScheduler>>>,
+    child_fields: Fields,
+    num_rows: u32,
+}
+
+impl SimpleStructScheduler {
+    pub fn new(children: Vec<Vec<Box<dyn LogicalPageScheduler>>>, child_fields: Fields) -> Self {
+        debug_assert!(!children.is_empty());
+        let num_rows = children[0].iter().map(|page| page.num_rows()).sum();
+        // Ensure that all the children have the same number of rows
+        debug_assert!(children.iter().all(|col| col
+            .iter()
+            .map(|page| page.num_rows())
+            .sum::<u32>()
+            == num_rows));
+        Self {
+            children,
+            child_fields,
+            num_rows,
+        }
+    }
+}
+
+// As we schedule we keep one of these per column so that we know
+// how far into the column we have already scheduled.
+#[derive(Debug, Clone, Copy)]
+struct FieldWalkStatus {
+    rows_to_skip: u32,
+    rows_to_take: u32,
+    page_offset: u32,
+    rows_queued: u32,
+}
+
+impl FieldWalkStatus {
+    fn new_from_range(range: Range<u32>) -> Self {
+        Self {
+            rows_to_skip: range.start,
+            rows_to_take: range.end - range.start,
+            page_offset: 0,
+            rows_queued: 0,
+        }
+    }
+}
+
+impl LogicalPageScheduler for SimpleStructScheduler {
+    fn schedule_range(
+        &self,
+        range: Range<u32>,
+        scheduler: &Arc<dyn EncodingsIo>,
+        sink: &mpsc::UnboundedSender<Box<dyn LogicalPageDecoder>>,
+    ) -> Result<()> {
+        let mut rows_to_read = range.end - range.start;
+        trace!(
+            "Scheduling struct decode of range {:?} ({} rows)",
+            range,
+            rows_to_read
+        );
+
+        // Before we do anything, send a struct decoder to the decode thread so it can start decoding the pages
+        // we are about to send.
+        //
+        // This will need to get a tiny bit more complicated once structs have their own nullability and that nullability
+        // information starts to span multiple pages.
+        sink.send(Box::new(SimpleStructDecoder::new(
+            self.child_fields.clone(),
+            rows_to_read,
+        )))
+        .unwrap();
+
+        let mut field_status = vec![FieldWalkStatus::new_from_range(range); self.children.len()];
+
+        // NOTE: The order in which we are scheduling tasks here is very important.  We want to schedule the I/O so that
+        // we can deliver completed rows as quickly as possible to the decoder.  This means we want to schedule in row-major
+        // order from start to the end.  E.g. if we schedule one column at a time then the decoder is going to have to wait
+        // until almost all the I/O is finished before it can return a single batch.
+        //
+        // Luckily, we can do this using a simple greedy algorithm.  We iterate through each column independently.  For each
+        // pass through the metadata we look for any column that doesn't have any "queued rows".  Once we find it we schedule
+        // the next page for that column and increase its queued rows.  After each pass we should have some data queued for
+        // each column.  We take the column with the least amount of queued data and decrement that amount from the queued
+        // rows total of all columns.
+
+        // As we schedule, we create decoders.  These decoders are immediately sent to the decode thread
+        // to allow decoding to start.
+
+        while rows_to_read > 0 {
+            let mut min_rows_added = u32::MAX;
+            for (col_idx, field_scheduler) in self.children.iter().enumerate() {
+                let status = &mut field_status[col_idx];
+                if status.rows_queued == 0 {
+                    trace!("Need additional rows for column {}", col_idx);
+                    let mut next_page = &field_scheduler[status.page_offset as usize];
+
+                    while status.rows_to_skip >= next_page.num_rows() {
+                        status.rows_to_skip -= next_page.num_rows();
+                        status.page_offset += 1;
+                        trace!("Skipping entire page of {} rows", next_page.num_rows());
+                        next_page = &field_scheduler[status.page_offset as usize];
+                    }
+
+                    let page_range_start = status.rows_to_skip as u32;
+                    let page_rows_remaining = next_page.num_rows() - page_range_start;
+                    let rows_to_take = status.rows_to_take.min(page_rows_remaining);
+                    let page_range = page_range_start..(page_range_start + rows_to_take);
+
+                    trace!(
+                        "Taking {} rows from column {} starting at page offset {} from page {:?}",
+                        rows_to_take,
+                        col_idx,
+                        page_range_start,
+                        next_page
+                    );
+                    next_page.schedule_range(page_range, scheduler, sink)?;
+
+                    status.rows_queued += rows_to_take;
+                    status.rows_to_take -= rows_to_take;
+                    status.page_offset += 1;
+                    status.rows_to_skip = 0;
+
+                    min_rows_added = min_rows_added.min(rows_to_take);
+                }
+            }
+            if min_rows_added == 0 {
+                panic!("Error in scheduling logic, panic to avoid infinite loop");
+            }
+            rows_to_read -= min_rows_added;
+            for field_status in &mut field_status {
+                field_status.rows_queued -= min_rows_added;
+            }
+        }
+        Ok(())
+    }
+
+    fn num_rows(&self) -> u32 {
+        self.num_rows
+    }
+}
+
+struct ChildState {
+    // As we decode a column we pull pages out of the channel source and into
+    // a queue for that column.  Since we await as soon as we pull the page from
+    // the source there is no need for a separate unawaited queue.
+    //
+    // Technically though, these pages are only "partially awaited"
+    //
+    // Note: This queue may have more than one page in it if the batch size is very large
+    // or pages are very small
+    // TODO: Test this case
+    //
+    // Then we drain this queue pages as we decode.
+    awaited: VecDeque<Box<dyn LogicalPageDecoder>>,
+    // Rows that should still be coming over the channel source but haven't yet been
+    // put into the awaited queue
+    rows_unawaited: u32,
+    // Rows that have been pulled out of the channel source, awaited, and are ready to
+    // be drained
+    rows_available: u32,
+}
+
+struct CompositeDecodeTask {
+    // One per child
+    tasks: Vec<Box<dyn DecodeArrayTask>>,
+    num_rows: u32,
+    has_more: bool,
+}
+
+impl CompositeDecodeTask {
+    fn decode(self) -> Result<ArrayRef> {
+        let arrays = self
+            .tasks
+            .into_iter()
+            .map(|task| task.decode())
+            .collect::<Result<Vec<_>>>()?;
+        let array_refs = arrays.iter().map(|arr| arr.as_ref()).collect::<Vec<_>>();
+        // TODO: If this is a primitive column we should be able to avoid this
+        // allocation + copy with "page bridging" which could save us a few CPU
+        // cycles.
+        //
+        // This optimization is probably most important for super fast storage like NVME
+        // where the page size can be smaller.
+        Ok(arrow_select::concat::concat(&array_refs)?)
+    }
+}
+
+impl ChildState {
+    fn new(num_rows: u32) -> Self {
+        Self {
+            awaited: VecDeque::new(),
+            rows_unawaited: num_rows,
+            rows_available: 0,
+        }
+    }
+
+    async fn wait(
+        &mut self,
+        num_rows: u32,
+        source: &mut mpsc::UnboundedReceiver<Box<dyn LogicalPageDecoder>>,
+    ) -> Result<()> {
+        trace!(
+            "Struct waiting for {} rows and {} are available already",
+            num_rows,
+            self.rows_available
+        );
+        // Note: this code is the inverse of the row-major scheduling algorithm
+        let mut remaining = num_rows.saturating_sub(self.rows_available);
+        if remaining > 0 {
+            if let Some(back) = self.awaited.back_mut() {
+                if back.unawaited() > 0 {
+                    let rows_to_wait = remaining.min(back.unawaited());
+                    trace!(
+                        "Struct await an additional {} rows from the current page",
+                        rows_to_wait
+                    );
+                    // Even though we wait for X rows we might actually end up
+                    // loading more than that
+                    let previously_avail = back.avail();
+                    back.wait(rows_to_wait, source).await?;
+                    let newly_avail = back.avail() - previously_avail;
+                    trace!("The await loaded {} rows", newly_avail);
+                    self.rows_available += newly_avail;
+                    self.rows_unawaited -= newly_avail;
+                    remaining -= rows_to_wait;
+                }
+            }
+
+            while remaining > 0 {
+                // Because we schedule in row-major fashion we know the next page
+                // will belong to this column.
+                let mut decoder = source.recv().await.unwrap();
+                let rows_to_wait = remaining.min(decoder.unawaited());
+                trace!(
+                    "Struct received new page and awaiting {} rows",
+                    rows_to_wait
+                );
+                // We might only await part of a page.  This is important for things
+                // like the struct<struct<...>> case where we have one outer page, one
+                // middle page, and then a bunch of inner pages.  If we await the entire
+                // middle page then we will have to wait for all the inner pages to arrive
+                // before we can start decoding.
+                //
+                // TODO: test this case
+                decoder.wait(rows_to_wait, source).await?;
+                let newly_avail = decoder.avail();
+                self.awaited.push_back(decoder);
+                self.rows_available += newly_avail;
+                self.rows_unawaited -= newly_avail;
+                remaining -= rows_to_wait;
+                trace!(
+                    "The new await loaded {} rows and {} are still needed",
+                    newly_avail,
+                    remaining
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn drain(&mut self, num_rows: u32) -> Result<CompositeDecodeTask> {
+        trace!("Struct draining {} rows", num_rows);
+        debug_assert!(self.rows_available >= num_rows);
+        debug_assert!(num_rows > 0);
+        self.rows_available -= num_rows;
+        let mut remaining = num_rows;
+        let mut composite = CompositeDecodeTask {
+            tasks: Vec::new(),
+            num_rows: 0,
+            has_more: true,
+        };
+        while remaining > 0 {
+            let next = self.awaited.front_mut().unwrap();
+            let rows_to_take = remaining.min(next.avail());
+            let next_task = next.drain(rows_to_take)?;
+            if next.avail() == 0 && next.unawaited() == 0 {
+                trace!("Completely drained page");
+                self.awaited.pop_front();
+            }
+            remaining -= rows_to_take;
+            composite.tasks.push(next_task.task);
+            composite.num_rows += next_task.num_rows;
+        }
+        composite.has_more = self.rows_available != 0 || self.rows_unawaited != 0;
+        Ok(composite)
+    }
+}
+
+struct SimpleStructDecoder {
+    children: Vec<ChildState>,
+    child_fields: Fields,
+}
+
+impl SimpleStructDecoder {
+    fn new(child_fields: Fields, num_rows: u32) -> Self {
+        Self {
+            children: child_fields
+                .iter()
+                .map(|_| ChildState::new(num_rows))
+                .collect(),
+            child_fields,
+        }
+    }
+}
+
+impl LogicalPageDecoder for SimpleStructDecoder {
+    fn wait<'a>(
+        &'a mut self,
+        num_rows: u32,
+        source: &'a mut mpsc::UnboundedReceiver<Box<dyn LogicalPageDecoder>>,
+    ) -> BoxFuture<'a, Result<()>> {
+        async move {
+            for child in &mut self.children {
+                child.wait(num_rows, source).await?;
+            }
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn drain(&mut self, num_rows: u32) -> Result<NextDecodeTask> {
+        let child_tasks = self
+            .children
+            .iter_mut()
+            .map(|child| child.drain(num_rows))
+            .collect::<Result<Vec<_>>>()?;
+        let num_rows = child_tasks[0].num_rows;
+        let has_more = child_tasks[0].has_more;
+        debug_assert!(child_tasks.iter().all(|task| task.num_rows == num_rows));
+        debug_assert!(child_tasks.iter().all(|task| task.has_more == has_more));
+        Ok(NextDecodeTask {
+            task: Box::new(SimpleStructDecodeTask {
+                children: child_tasks,
+                child_fields: self.child_fields.clone(),
+            }),
+            num_rows,
+            has_more,
+        })
+    }
+
+    // Rows are available only if they are available in every child column
+    fn avail(&self) -> u32 {
+        self.children
+            .iter()
+            .map(|c| c.rows_available)
+            .min()
+            .unwrap()
+    }
+
+    // Rows are unawaited if they are unawaited in any child column
+    fn unawaited(&self) -> u32 {
+        self.children
+            .iter()
+            .map(|c| c.rows_unawaited)
+            .max()
+            .unwrap()
+    }
+}
+
+struct SimpleStructDecodeTask {
+    children: Vec<CompositeDecodeTask>,
+    child_fields: Fields,
+}
+
+impl DecodeArrayTask for SimpleStructDecodeTask {
+    fn decode(self: Box<Self>) -> Result<ArrayRef> {
+        let child_arrays = self
+            .children
+            .into_iter()
+            .map(|child| child.decode())
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Arc::new(StructArray::try_new(
+            self.child_fields,
+            child_arrays,
+            None,
+        )?))
+    }
+}
+
+struct StructFieldEncoder {
+    children: Vec<Box<dyn FieldEncoder>>,
+    column_index: u32,
+    num_rows_seen: u32,
+}
+
+impl StructFieldEncoder {
+    #[allow(dead_code)]
+    pub fn new(children: Vec<Box<dyn FieldEncoder>>, column_index: u32) -> Self {
+        Self {
+            children,
+            column_index,
+            num_rows_seen: 0,
+        }
+    }
+}
+
+impl FieldEncoder for StructFieldEncoder {
+    fn maybe_encode(
+        &mut self,
+        array: ArrayRef,
+    ) -> Result<Vec<BoxFuture<'static, Result<EncodedPage>>>> {
+        self.num_rows_seen += array.len() as u32;
+        let struct_array = array.as_struct();
+        let child_tasks = self
+            .children
+            .iter_mut()
+            .zip(struct_array.columns().iter())
+            .map(|(encoder, arr)| encoder.maybe_encode(arr.clone()))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(child_tasks.into_iter().flatten().collect::<Vec<_>>())
+    }
+
+    fn flush(&mut self) -> Result<Vec<BoxFuture<'static, Result<EncodedPage>>>> {
+        let child_tasks = self
+            .children
+            .iter_mut()
+            .map(|encoder| encoder.flush())
+            .collect::<Result<Vec<_>>>()?;
+        let mut child_tasks = child_tasks.into_iter().flatten().collect::<Vec<_>>();
+        let num_rows_seen = self.num_rows_seen;
+        let column_index = self.column_index;
+        // In this "simple struct / no nulls" case we emit a single header page at
+        // the very end which covers the entire struct.
+        child_tasks.push(
+            std::future::ready(Ok(EncodedPage {
+                buffers: vec![],
+                encoding: pb::ArrayEncoding {
+                    array_encoding: Some(pb::array_encoding::ArrayEncoding::Struct(
+                        pb::SimpleStruct {},
+                    )),
+                },
+                num_rows: num_rows_seen,
+                column_idx: column_index,
+            }))
+            .boxed(),
+        );
+        Ok(child_tasks)
+    }
+
+    fn num_columns(&self) -> u32 {
+        self.children.len() as u32 + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::sync::Arc;
+
+    use arrow_schema::{DataType, Field, Fields};
+
+    use crate::{
+        encoder::FieldEncoder,
+        encodings::{
+            logical::{primitive::PrimitiveFieldEncoder, r#struct::StructFieldEncoder},
+            physical::basic::BasicEncoder,
+        },
+        testing::check_round_trip_field_encoding,
+    };
+
+    #[test_log::test(tokio::test)]
+    async fn test_simple_struct() {
+        let data_type = DataType::Struct(Fields::from(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+        ]));
+        let child_encoders = vec![
+            Box::new(PrimitiveFieldEncoder::new(
+                4096,
+                Arc::new(BasicEncoder::new(1)),
+            )) as Box<dyn FieldEncoder>,
+            Box::new(PrimitiveFieldEncoder::new(
+                4096,
+                Arc::new(BasicEncoder::new(2)),
+            )) as Box<dyn FieldEncoder>,
+        ];
+        let encoder = StructFieldEncoder::new(child_encoders, 0);
+        let field = Field::new("", data_type, false);
+        check_round_trip_field_encoding(encoder, field).await;
+    }
+}

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -126,7 +126,7 @@ impl LogicalPageScheduler for SimpleStructScheduler {
                         next_page = &field_scheduler[status.page_offset as usize];
                     }
 
-                    let page_range_start = status.rows_to_skip as u32;
+                    let page_range_start = status.rows_to_skip;
                     let page_rows_remaining = next_page.num_rows() - page_range_start;
                     let rows_to_take = status.rows_to_take.min(page_rows_remaining);
                     let page_range = page_range_start..(page_range_start + rows_to_take);

--- a/rust/lance-encoding/src/encodings/physical.rs
+++ b/rust/lance-encoding/src/encodings/physical.rs
@@ -1,0 +1,107 @@
+use crate::{decoder::PhysicalPageScheduler, format::pb};
+
+use self::{
+    basic::BasicPageScheduler, bitmap::DenseBitmapScheduler, fixed_size_list::FixedListScheduler,
+    value::ValuePageScheduler,
+};
+
+pub mod basic;
+pub mod bitmap;
+pub mod fixed_size_list;
+pub mod value;
+
+/// These contain the file buffers shared across the entire file
+#[derive(Clone, Copy, Debug)]
+pub struct FileBuffers<'a> {
+    pub positions: &'a Vec<u64>,
+}
+
+/// These contain the file buffers and also buffers specific to a column
+#[derive(Clone, Copy, Debug)]
+pub struct ColumnBuffers<'a, 'b> {
+    pub file_buffers: FileBuffers<'a>,
+    pub positions: &'b Vec<u64>,
+}
+/// These contain the file & column buffers and also buffers specific to a page
+#[derive(Clone, Copy, Debug)]
+pub struct PageBuffers<'a, 'b, 'c> {
+    pub column_buffers: ColumnBuffers<'a, 'b>,
+    pub positions: &'c Vec<u64>,
+}
+
+// Translate a protobuf buffer description into a position in the file.  This could be a page
+// buffer, a column buffer, or a file buffer.
+fn get_buffer(buffer_desc: &pb::Buffer, buffers: &PageBuffers) -> u64 {
+    match pb::buffer::BufferType::try_from(buffer_desc.buffer_type).unwrap() {
+        pb::buffer::BufferType::Page => buffers.positions[buffer_desc.buffer_index as usize],
+        pb::buffer::BufferType::Column => {
+            buffers.column_buffers.positions[buffer_desc.buffer_index as usize]
+        }
+        pb::buffer::BufferType::File => {
+            buffers.column_buffers.file_buffers.positions[buffer_desc.buffer_index as usize]
+        }
+    }
+}
+
+/// Convert a protobuf buffer encoding into a physical page scheduler
+fn decoder_from_buffer_encoding(
+    encoding: &pb::BufferEncoding,
+    buffers: &PageBuffers,
+) -> Box<dyn PhysicalPageScheduler> {
+    match encoding.buffer_encoding.as_ref().unwrap() {
+        pb::buffer_encoding::BufferEncoding::Value(value) => Box::new(ValuePageScheduler::new(
+            value.bytes_per_value,
+            get_buffer(value.buffer.as_ref().unwrap(), buffers),
+        )),
+        pb::buffer_encoding::BufferEncoding::Bitmap(bitmap) => Box::new(DenseBitmapScheduler::new(
+            get_buffer(bitmap.buffer.as_ref().unwrap(), buffers),
+        )),
+    }
+}
+
+/// Convert a protobuf array encoding into a physical page scheduler
+pub fn decoder_from_array_encoding(
+    encoding: &pb::ArrayEncoding,
+    buffers: &PageBuffers,
+) -> Box<dyn PhysicalPageScheduler> {
+    match encoding.array_encoding.as_ref().unwrap() {
+        pb::array_encoding::ArrayEncoding::Basic(basic) => {
+            match basic.nullability.as_ref().unwrap() {
+                pb::basic::Nullability::NoNulls(no_nulls) => {
+                    Box::new(BasicPageScheduler::new_non_nullable(
+                        decoder_from_buffer_encoding(no_nulls.values.as_ref().unwrap(), buffers),
+                    ))
+                }
+                pb::basic::Nullability::SomeNulls(some_nulls) => {
+                    Box::new(BasicPageScheduler::new_nullable(
+                        decoder_from_buffer_encoding(
+                            some_nulls.validity.as_ref().unwrap(),
+                            buffers,
+                        ),
+                        decoder_from_buffer_encoding(some_nulls.values.as_ref().unwrap(), buffers),
+                    ))
+                }
+                pb::basic::Nullability::AllNulls(_) => todo!(),
+            }
+        }
+        pb::array_encoding::ArrayEncoding::FixedSizeList(fixed_size_list) => {
+            let item_encoding = fixed_size_list.items.as_ref().unwrap();
+            let item_scheduler = decoder_from_array_encoding(item_encoding, buffers);
+            Box::new(FixedListScheduler::new(
+                item_scheduler,
+                fixed_size_list.dimension,
+            ))
+        }
+        // This is a column containing the list offsets.  This wrapper is superfluous at the moment
+        // since we know it is a list based on the schema.  In the future there may be different ways
+        // of storing the list offsets.
+        pb::array_encoding::ArrayEncoding::List(list) => {
+            decoder_from_array_encoding(list.offsets.as_ref().unwrap(), buffers)
+        }
+        // Currently there is no way to encode struct nullability and structs are encoded with a "header" column
+        // (that has no data).  We never actually decode that column and so this branch is never actually encountered.
+        //
+        // This will change in the future when we add support for struct nullability.
+        pb::array_encoding::ArrayEncoding::Struct(_) => unreachable!(),
+    }
+}

--- a/rust/lance-encoding/src/encodings/physical/basic.rs
+++ b/rust/lance-encoding/src/encodings/physical/basic.rs
@@ -1,0 +1,216 @@
+use arrow_array::ArrayRef;
+use arrow_schema::DataType;
+use futures::{future::BoxFuture, FutureExt};
+use lance_arrow::DataTypeExt;
+use log::trace;
+
+use crate::{
+    decoder::{PhysicalPageDecoder, PhysicalPageScheduler},
+    encoder::{ArrayEncoder, BufferEncoder, EncodedBuffer, EncodedPage},
+    format::pb,
+    EncodingsIo,
+};
+
+use lance_core::Result;
+
+use super::{bitmap::BitmapEncoder, value::ValueEncoder};
+
+enum DataValidity {
+    NoNull,
+    SomeNull(Box<dyn PhysicalPageDecoder>),
+}
+
+/// A physical scheduler for "basic" fields.  These are fields that have an optional
+/// validity bitmap and some kind of values buffer.
+///
+/// No actual decoding happens here, we are simply aggregating the two buffers.
+///
+/// If everything is null then there are no data buffers at all.
+// TODO: Add support/tests for primitive nulls
+// TODO: Add tests for the all-null case
+//
+// Right now this is always present on primitive fields.  In the future we may use a
+// sentinel encoding instead.
+#[derive(Debug)]
+pub struct BasicPageScheduler {
+    validity_decoder: PageValidity,
+    values_decoder: Box<dyn PhysicalPageScheduler>,
+}
+
+impl BasicPageScheduler {
+    /// Creates a new instance that expects a validity bitmap
+    pub fn new_nullable(
+        validity_decoder: Box<dyn PhysicalPageScheduler>,
+        values_decoder: Box<dyn PhysicalPageScheduler>,
+    ) -> Self {
+        Self {
+            validity_decoder: PageValidity::SomeNull(validity_decoder),
+            values_decoder,
+        }
+    }
+
+    /// Create a new instance that does not need a validity bitmap because no item is null
+    pub fn new_non_nullable(values_decoder: Box<dyn PhysicalPageScheduler>) -> Self {
+        Self {
+            validity_decoder: PageValidity::NoNull,
+            values_decoder,
+        }
+    }
+}
+
+impl PhysicalPageScheduler for BasicPageScheduler {
+    fn schedule_range(
+        &self,
+        range: std::ops::Range<u32>,
+        scheduler: &dyn EncodingsIo,
+    ) -> BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>> {
+        let validity_future = match &self.validity_decoder {
+            PageValidity::NoNull => None,
+            PageValidity::SomeNull(validity_decoder) => {
+                trace!("Scheduling range {:?} from validity", range);
+                Some(validity_decoder.schedule_range(range.clone(), scheduler))
+            }
+        };
+
+        trace!("Scheduling range {:?} from values", range);
+        let values_future = self.values_decoder.schedule_range(range, scheduler);
+
+        async move {
+            let validity = match validity_future {
+                None => DataValidity::NoNull,
+                Some(fut) => DataValidity::SomeNull(fut.await?),
+            };
+            let values = values_future.await?;
+            Ok(Box::new(BasicPageDecoder { validity, values }) as Box<dyn PhysicalPageDecoder>)
+        }
+        .boxed()
+    }
+}
+
+struct BasicPageDecoder {
+    validity: DataValidity,
+    values: Box<dyn PhysicalPageDecoder>,
+}
+
+impl PhysicalPageDecoder for BasicPageDecoder {
+    fn update_capacity(&self, rows_to_skip: u32, num_rows: u32, buffers: &mut [(u64, bool)]) {
+        // No need to look at the validity decoder to know the dest buffer size since it is boolean
+        buffers[0].0 = arrow_buffer::bit_util::ceil(num_rows as usize, 8) as u64;
+        // The validity buffer is only required if we have some nulls
+        buffers[0].1 = match self.validity {
+            DataValidity::NoNull => false,
+            DataValidity::SomeNull(_) => true,
+        };
+        self.values
+            .update_capacity(rows_to_skip, num_rows, &mut buffers[1..]);
+    }
+
+    fn decode_into(&self, rows_to_skip: u32, num_rows: u32, dest_buffers: &mut [bytes::BytesMut]) {
+        if let DataValidity::SomeNull(validity_decoder) = &self.validity {
+            validity_decoder.decode_into(rows_to_skip, num_rows, &mut dest_buffers[..1]);
+        }
+        self.values
+            .decode_into(rows_to_skip, num_rows, &mut dest_buffers[1..]);
+    }
+}
+
+#[derive(Debug)]
+enum PageValidity {
+    NoNull,
+    SomeNull(Box<dyn PhysicalPageScheduler>),
+}
+
+#[derive(Debug)]
+pub struct BasicEncoder {
+    column_index: u32,
+}
+
+impl BasicEncoder {
+    pub fn new(column_index: u32) -> Self {
+        Self { column_index }
+    }
+
+    fn encode_values(
+        arrays: &[ArrayRef],
+        buffer_index: u32,
+    ) -> Result<(EncodedBuffer, pb::BufferEncoding)> {
+        if *arrays[0].data_type() == DataType::Boolean {
+            let values = BitmapEncoder::default().encode(arrays)?;
+            Ok((
+                values,
+                pb::BufferEncoding {
+                    buffer_encoding: Some(pb::buffer_encoding::BufferEncoding::Bitmap(
+                        pb::Bitmap {
+                            buffer: Some(pb::Buffer {
+                                buffer_index,
+                                buffer_type: pb::buffer::BufferType::Page as i32,
+                            }),
+                        },
+                    )),
+                },
+            ))
+        } else {
+            let bytes_per_value = arrays[0].data_type().byte_width() as u64;
+            debug_assert!(bytes_per_value > 0);
+            let values = ValueEncoder::default().encode(arrays)?;
+            Ok((
+                values,
+                pb::BufferEncoding {
+                    buffer_encoding: Some(pb::buffer_encoding::BufferEncoding::Value(pb::Value {
+                        buffer: Some(pb::Buffer {
+                            buffer_index,
+                            buffer_type: pb::buffer::BufferType::Page as i32,
+                        }),
+                        bytes_per_value,
+                    })),
+                },
+            ))
+        }
+    }
+}
+
+impl ArrayEncoder for BasicEncoder {
+    fn encode(&self, arrays: &[ArrayRef]) -> Result<EncodedPage> {
+        let (null_count, row_count) = arrays
+            .iter()
+            .map(|arr| (arr.null_count() as u32, arr.len() as u32))
+            .fold((0, 0), |acc, val| (acc.0 + val.0, acc.1 + val.1));
+        let (buffers, nullability) = if null_count == 0 {
+            let (values_buffer, values_encoding) = Self::encode_values(arrays, 0)?;
+            let encoding = pb::basic::Nullability::NoNulls(pb::basic::NoNull {
+                values: Some(values_encoding),
+            });
+            (vec![values_buffer], encoding)
+        } else if null_count == row_count {
+            let encoding = pb::basic::Nullability::AllNulls(pb::basic::AllNull {});
+            (vec![], encoding)
+        } else {
+            let validity_encoding = pb::BufferEncoding {
+                buffer_encoding: Some(pb::buffer_encoding::BufferEncoding::Bitmap(pb::Bitmap {
+                    buffer: Some(pb::Buffer {
+                        buffer_index: 0,
+                        buffer_type: pb::buffer::BufferType::Page as i32,
+                    }),
+                })),
+            };
+            let (values_buffer, values_encoding) = Self::encode_values(arrays, 1)?;
+            let encoding = pb::basic::Nullability::SomeNulls(pb::basic::SomeNull {
+                validity: Some(validity_encoding),
+                values: Some(values_encoding),
+            });
+            let validity = BitmapEncoder::default().encode(arrays)?;
+            (vec![validity, values_buffer], encoding)
+        };
+
+        Ok(EncodedPage {
+            buffers,
+            encoding: pb::ArrayEncoding {
+                array_encoding: Some(pb::array_encoding::ArrayEncoding::Basic(pb::Basic {
+                    nullability: Some(nullability),
+                })),
+            },
+            num_rows: row_count,
+            column_idx: self.column_index,
+        })
+    }
+}

--- a/rust/lance-encoding/src/encodings/physical/bitmap.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitmap.rs
@@ -1,0 +1,166 @@
+use std::ops::Range;
+
+use arrow_array::{cast::AsArray, ArrayRef};
+use arrow_buffer::BooleanBufferBuilder;
+use arrow_schema::DataType;
+use bytes::{Bytes, BytesMut};
+
+use futures::{future::BoxFuture, FutureExt};
+use lance_core::Result;
+use log::trace;
+
+use crate::{
+    decoder::{PhysicalPageDecoder, PhysicalPageScheduler},
+    encoder::{BufferEncoder, EncodedBuffer},
+    EncodingsIo,
+};
+
+/// A physical scheduler for bitmap buffers encoded densely as 1 bit per value
+/// with bit-endianess (e.g. what Arrow uses for validity bitmaps and boolean arrays)
+///
+/// This decoder decodes from one buffer of disk data into one buffer of memory data
+#[derive(Debug, Clone, Copy)]
+pub struct DenseBitmapScheduler {
+    buffer_offset: u64,
+}
+
+impl DenseBitmapScheduler {
+    pub fn new(buffer_offset: u64) -> Self {
+        Self { buffer_offset }
+    }
+}
+
+impl PhysicalPageScheduler for DenseBitmapScheduler {
+    fn schedule_range(
+        &self,
+        range: Range<u32>,
+        scheduler: &dyn EncodingsIo,
+    ) -> BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>> {
+        debug_assert_ne!(range.start, range.end);
+        let start = self.buffer_offset + range.start as u64 / 8;
+        let bit_offset = range.start % 8;
+        let end = self.buffer_offset + (range.end as u64 / 8) + 1;
+        let byte_range = start..end;
+
+        trace!("Scheduling I/O for range {:?}", byte_range);
+        let bytes = scheduler.submit_request(vec![byte_range]);
+
+        async move {
+            let bytes = bytes.await?;
+            Ok(Box::new(BitmapDecoder {
+                data: bytes,
+                bit_offset,
+            }) as Box<dyn PhysicalPageDecoder>)
+        }
+        .boxed()
+    }
+}
+
+struct BitmapDecoder {
+    data: Vec<Bytes>,
+    bit_offset: u32,
+}
+
+impl PhysicalPageDecoder for BitmapDecoder {
+    fn update_capacity(&self, _rows_to_skip: u32, num_rows: u32, buffers: &mut [(u64, bool)]) {
+        buffers[0].0 = arrow_buffer::bit_util::ceil(num_rows as usize, 8) as u64;
+        // This decoder has no concept of "optional" buffers
+    }
+
+    fn decode_into(&self, rows_to_skip: u32, num_rows: u32, dest_buffers: &mut [BytesMut]) {
+        let mut bytes_to_fully_skip = rows_to_skip as u64 / 8;
+        let mut bits_to_skip = (rows_to_skip % 8) + self.bit_offset;
+        if bits_to_skip > 8 {
+            bits_to_skip -= 8;
+            bytes_to_fully_skip += 1;
+        }
+
+        let mut dest_builder = BooleanBufferBuilder::new(num_rows as usize);
+
+        let mut rows_remaining = num_rows;
+        for buf in &self.data {
+            let buf_len = buf.len() as u64;
+            if bytes_to_fully_skip > buf_len {
+                bytes_to_fully_skip -= buf_len;
+            } else {
+                let num_vals = (buf_len * 8) as u32;
+                let num_vals_to_take = rows_remaining.min(num_vals);
+                let start = (bytes_to_fully_skip * 8) as usize + bits_to_skip as usize;
+                let end = start + num_vals_to_take as usize;
+                dest_builder.append_packed_range(start..end, buf);
+                bytes_to_fully_skip = 0;
+                bits_to_skip = 0;
+                rows_remaining -= num_vals_to_take;
+            }
+        }
+
+        let bool_buffer = dest_builder.finish().into_inner();
+        unsafe { dest_buffers[0].set_len(bool_buffer.len()) }
+        // TODO: This requires an extra copy.  First we copy the data from the read buffer(s)
+        // into dest_builder (one copy is inevitable).  Then we copy the data from dest_builder
+        // into dest_buffers.  This second copy could be avoided (e.g. BooleanBufferBuilder
+        // has a new_from_buffer but that requires MutableBuffer and we can't easily get there
+        // from BytesMut [or can we?])
+        //
+        // Worst case, we vendor our own copy of BooleanBufferBuilder based on BytesMut.  We could
+        // also use MutableBuffer ourselves instead of BytesMut but arrow-rs claims MutableBuffer may
+        // be deprecated in the future (though that discussion seems to have died)
+
+        // TODO: Will this work at the boundaries?  If we have to skip 3 bits for example then the first
+        // bytes of bool_buffer.as_slice will be 000XXXXX and if we copy it on top of YYY00000 then the YYY
+        // will be clobbered.
+        //
+        // It's a moot point at the moment since we don't support page bridging
+        dest_buffers[0].copy_from_slice(bool_buffer.as_slice());
+    }
+}
+
+// Encoder for writing boolean arrays as dense bitmaps
+#[derive(Debug, Default)]
+pub struct BitmapEncoder {}
+
+impl BufferEncoder for BitmapEncoder {
+    fn encode(&self, arrays: &[ArrayRef]) -> Result<EncodedBuffer> {
+        debug_assert!(arrays
+            .iter()
+            .all(|arr| *arr.data_type() == DataType::Boolean));
+        let num_rows: u32 = arrays.iter().map(|arr| arr.len() as u32).sum();
+        // Empty pages don't make sense, this should be prevented before we
+        // get here
+        debug_assert_ne!(num_rows, 0);
+        // We can't just write the inner value buffers one after the other because
+        // bitmaps can have junk padding at the end (e.g. a boolean array with 12
+        // values will be 2 bytes but the last four bits of the second byte are
+        // garbage).  So we go ahead and pay the cost of a copy (we could avoid this
+        // if we really needed to, at the expense of more complicated code and a slightly
+        // larger encoded size but writer cost generally doesn't matter as much as reader cost)
+        let mut builder = BooleanBufferBuilder::new(num_rows as usize);
+        for arr in arrays {
+            let bool_arr = arr.as_boolean();
+            builder.append_buffer(bool_arr.values());
+        }
+        let buffer = builder.finish().into_inner();
+        let parts = vec![buffer];
+        let buffer = EncodedBuffer {
+            is_data: true,
+            parts,
+        };
+        Ok(buffer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow_schema::{DataType, Field};
+
+    use crate::encodings::physical::basic::BasicEncoder;
+    use crate::testing::check_round_trip_array_encoding;
+
+    #[test_log::test(tokio::test)]
+    async fn test_bitmap_boolean() {
+        let encoder = BasicEncoder::new(0);
+        let field = Field::new("", DataType::Boolean, false);
+
+        check_round_trip_array_encoding(encoder, field).await;
+    }
+}

--- a/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
@@ -1,0 +1,135 @@
+use arrow_array::{cast::AsArray, ArrayRef};
+use futures::{future::BoxFuture, FutureExt};
+use lance_core::Result;
+
+use crate::{
+    decoder::{PhysicalPageDecoder, PhysicalPageScheduler},
+    encoder::{ArrayEncoder, EncodedPage},
+    format::pb,
+    EncodingsIo,
+};
+
+/// A scheduler for fixed size lists of primitive values
+///
+/// This scheduler is, itself, primitive
+#[derive(Debug)]
+pub struct FixedListScheduler {
+    items_scheduler: Box<dyn PhysicalPageScheduler>,
+    dimension: u32,
+}
+
+impl FixedListScheduler {
+    pub fn new(items_scheduler: Box<dyn PhysicalPageScheduler>, dimension: u32) -> Self {
+        Self {
+            items_scheduler,
+            dimension,
+        }
+    }
+}
+
+impl PhysicalPageScheduler for FixedListScheduler {
+    fn schedule_range(
+        &self,
+        range: std::ops::Range<u32>,
+        scheduler: &dyn EncodingsIo,
+    ) -> BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>> {
+        let expanded_range = (range.start * self.dimension)..(range.end * self.dimension);
+        let inner_page_decoder = self
+            .items_scheduler
+            .schedule_range(expanded_range, scheduler);
+        let dimension = self.dimension;
+        async move {
+            let items_decoder = inner_page_decoder.await?;
+            Ok(Box::new(FixedListDecoder {
+                items_decoder,
+                dimension,
+            }) as Box<dyn PhysicalPageDecoder>)
+        }
+        .boxed()
+    }
+}
+
+pub struct FixedListDecoder {
+    items_decoder: Box<dyn PhysicalPageDecoder>,
+    dimension: u32,
+}
+
+impl PhysicalPageDecoder for FixedListDecoder {
+    fn update_capacity(&self, rows_to_skip: u32, num_rows: u32, buffers: &mut [(u64, bool)]) {
+        let rows_to_skip = rows_to_skip * self.dimension;
+        let num_rows = num_rows * self.dimension;
+        self.items_decoder
+            .update_capacity(rows_to_skip, num_rows, buffers);
+    }
+
+    fn decode_into(&self, rows_to_skip: u32, num_rows: u32, dest_buffers: &mut [bytes::BytesMut]) {
+        let rows_to_skip = rows_to_skip * self.dimension;
+        let num_rows = num_rows * self.dimension;
+        self.items_decoder
+            .decode_into(rows_to_skip, num_rows, dest_buffers);
+    }
+}
+
+#[derive(Debug)]
+pub struct FslEncoder {
+    items_encoder: Box<dyn ArrayEncoder>,
+    dimension: u32,
+}
+
+impl FslEncoder {
+    pub fn new(items_encoder: Box<dyn ArrayEncoder>, dimension: u32) -> Self {
+        Self {
+            items_encoder,
+            dimension,
+        }
+    }
+}
+
+impl ArrayEncoder for FslEncoder {
+    fn encode(&self, arrays: &[ArrayRef]) -> Result<EncodedPage> {
+        let inner_arrays = arrays
+            .iter()
+            .map(|arr| arr.as_fixed_size_list().values().clone())
+            .collect::<Vec<_>>();
+        let items_page = self.items_encoder.encode(&inner_arrays)?;
+        Ok(EncodedPage {
+            buffers: items_page.buffers,
+            num_rows: items_page.num_rows / self.dimension,
+            encoding: pb::ArrayEncoding {
+                array_encoding: Some(pb::array_encoding::ArrayEncoding::FixedSizeList(Box::new(
+                    pb::FixedSizeList {
+                        dimension: self.dimension,
+                        items: Some(Box::new(items_page.encoding)),
+                    },
+                ))),
+            },
+            column_idx: items_page.column_idx,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_schema::{DataType, Field};
+
+    use crate::encodings::physical::basic::BasicEncoder;
+    use crate::encodings::physical::fixed_size_list::FslEncoder;
+    use crate::encodings::physical::value::tests::PRIMITIVE_TYPES;
+    use crate::testing::check_round_trip_array_encoding;
+
+    #[test_log::test(tokio::test)]
+    async fn test_value_fsl_primitive() {
+        for data_type in PRIMITIVE_TYPES {
+            let encoder = FslEncoder::new(Box::new(BasicEncoder::new(0)), 16);
+            let inner_field = Field::new("item", data_type.clone(), true);
+            let field = Field::new(
+                "",
+                DataType::FixedSizeList(Arc::new(inner_field), 16),
+                false,
+            );
+            check_round_trip_array_encoding(encoder, field).await;
+        }
+    }
+}

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -1,0 +1,149 @@
+use arrow_array::ArrayRef;
+use bytes::Bytes;
+use futures::{future::BoxFuture, FutureExt};
+use log::trace;
+
+use crate::{
+    decoder::{PhysicalPageDecoder, PhysicalPageScheduler},
+    encoder::{BufferEncoder, EncodedBuffer},
+    EncodingsIo,
+};
+
+use lance_core::Result;
+
+/// Scheduler for a simple encoding where buffers of fixed-size items are stored as-is on disk
+#[derive(Debug, Clone, Copy)]
+pub struct ValuePageScheduler {
+    // TODO: do we really support values greater than 2^32 bytes per value?
+    // I think we want to, in theory, but will need to test this case.
+    bytes_per_value: u64,
+    buffer_offset: u64,
+}
+
+impl ValuePageScheduler {
+    pub fn new(bytes_per_value: u64, buffer_offset: u64) -> Self {
+        Self {
+            bytes_per_value,
+            buffer_offset,
+        }
+    }
+}
+
+impl PhysicalPageScheduler for ValuePageScheduler {
+    fn schedule_range(
+        &self,
+        range: std::ops::Range<u32>,
+        scheduler: &dyn EncodingsIo,
+    ) -> BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>> {
+        let start = self.buffer_offset + (range.start as u64 * self.bytes_per_value);
+        let end = self.buffer_offset + (range.end as u64 * self.bytes_per_value);
+        let byte_range = start..end;
+
+        trace!("Scheduling I/O for range {:?}", byte_range);
+        let bytes = scheduler.submit_request(vec![byte_range]);
+        let bytes_per_value = self.bytes_per_value;
+
+        async move {
+            let bytes = bytes.await?;
+            Ok(Box::new(ValuePageDecoder {
+                bytes_per_value,
+                data: bytes,
+            }) as Box<dyn PhysicalPageDecoder>)
+        }
+        .boxed()
+    }
+}
+
+struct ValuePageDecoder {
+    bytes_per_value: u64,
+    data: Vec<Bytes>,
+}
+
+impl PhysicalPageDecoder for ValuePageDecoder {
+    fn update_capacity(&self, _rows_to_skip: u32, num_rows: u32, buffers: &mut [(u64, bool)]) {
+        buffers[0].0 = self.bytes_per_value * num_rows as u64;
+        buffers[0].1 = true;
+    }
+
+    fn decode_into(&self, rows_to_skip: u32, num_rows: u32, dest_buffers: &mut [bytes::BytesMut]) {
+        let mut bytes_to_skip = rows_to_skip as u64 * self.bytes_per_value;
+        let mut bytes_to_take = num_rows as u64 * self.bytes_per_value;
+
+        let dest = &mut dest_buffers[0];
+
+        debug_assert!(dest.capacity() as u64 >= bytes_to_take);
+
+        for buf in &self.data {
+            let buf_len = buf.len() as u64;
+            if bytes_to_skip > buf_len {
+                bytes_to_skip -= buf_len;
+            } else {
+                let bytes_to_take_here = buf_len.min(bytes_to_take);
+                bytes_to_take -= bytes_to_take_here;
+                let start = bytes_to_skip as usize;
+                let end = start + bytes_to_take_here as usize;
+                dest.extend_from_slice(&buf.slice(start..end));
+                bytes_to_skip = 0;
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ValueEncoder {}
+
+impl BufferEncoder for ValueEncoder {
+    fn encode(&self, arrays: &[ArrayRef]) -> Result<EncodedBuffer> {
+        let parts = arrays
+            .iter()
+            .map(|arr| arr.to_data().buffers()[0].clone())
+            .collect::<Vec<_>>();
+        Ok(EncodedBuffer {
+            is_data: true,
+            parts,
+        })
+    }
+}
+
+// public tests module because we share the PRIMITIVE_TYPES constant with fixed_size_list
+#[cfg(test)]
+pub(crate) mod tests {
+
+    use arrow_schema::{DataType, Field, IntervalUnit, TimeUnit};
+
+    use crate::encodings::physical::basic::BasicEncoder;
+    use crate::testing::check_round_trip_array_encoding;
+
+    pub const PRIMITIVE_TYPES: &[DataType] = &[
+        DataType::Date32,
+        DataType::Date64,
+        DataType::Int8,
+        DataType::Int16,
+        DataType::Int32,
+        DataType::Int64,
+        DataType::UInt8,
+        DataType::UInt16,
+        DataType::UInt32,
+        DataType::UInt64,
+        DataType::Float16,
+        DataType::Float32,
+        DataType::Float64,
+        DataType::Decimal128(10, 10),
+        DataType::Decimal256(10, 10),
+        DataType::Timestamp(TimeUnit::Nanosecond, None),
+        DataType::Time32(TimeUnit::Second),
+        DataType::Time64(TimeUnit::Nanosecond),
+        DataType::Duration(TimeUnit::Second),
+        DataType::Interval(IntervalUnit::DayTime),
+    ];
+
+    #[test_log::test(tokio::test)]
+    async fn test_value_primitive() {
+        for data_type in PRIMITIVE_TYPES {
+            let encoder = BasicEncoder::new(0);
+            let field = Field::new("", data_type.clone(), false);
+
+            check_round_trip_array_encoding(encoder, field).await;
+        }
+    }
+}

--- a/rust/lance-encoding/src/lib.rs
+++ b/rust/lance-encoding/src/lib.rs
@@ -21,7 +21,10 @@ use lance_core::Result;
 
 pub mod decoder;
 pub mod encoder;
+pub mod encodings;
 pub mod format;
+#[cfg(test)]
+pub mod testing;
 
 /// A trait for an I/O service
 ///

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -1,0 +1,161 @@
+use std::{ops::Range, sync::Arc};
+
+use arrow_schema::{Field, Schema};
+use bytes::{Bytes, BytesMut};
+use futures::{future::BoxFuture, FutureExt, StreamExt};
+use log::trace;
+use tokio::sync::mpsc;
+
+use lance_core::Result;
+use lance_datagen::{array, gen, RowCount};
+
+use crate::{
+    decoder::{BatchDecodeStream, ColumnInfo, DecodeBatchScheduler, PageInfo},
+    encoder::{ArrayEncoder, EncodedPage, FieldEncoder},
+    encodings::logical::primitive::PrimitiveFieldEncoder,
+    EncodingsIo,
+};
+
+pub(crate) struct SimulatedScheduler {
+    data: Bytes,
+}
+
+impl SimulatedScheduler {
+    pub fn new(data: Vec<EncodedPage>) -> Self {
+        let mut bytes = BytesMut::new();
+        for arr in data.into_iter() {
+            for buf in arr.buffers.into_iter() {
+                for part in buf.parts.into_iter() {
+                    bytes.extend(part.iter())
+                }
+            }
+        }
+        Self {
+            data: bytes.freeze(),
+        }
+    }
+
+    fn satisfy_request(&self, req: Range<u64>) -> Bytes {
+        self.data.slice(req.start as usize..req.end as usize)
+    }
+}
+
+impl EncodingsIo for SimulatedScheduler {
+    fn submit_request(&self, ranges: Vec<Range<u64>>) -> BoxFuture<'static, Result<Vec<Bytes>>> {
+        std::future::ready(Ok(ranges
+            .into_iter()
+            .map(|range| self.satisfy_request(range))
+            .collect::<Vec<_>>()))
+        .boxed()
+    }
+}
+
+pub async fn check_round_trip_array_encoding(encoder: impl ArrayEncoder + 'static, field: Field) {
+    let array_encoder = Arc::new(encoder);
+    for page_size_bytes in [1024, 4 * 1024, 1024 * 1024] {
+        let field_encoder = PrimitiveFieldEncoder::new(page_size_bytes, array_encoder.clone());
+        check_round_trip_field_encoding(field_encoder, field.clone()).await
+    }
+}
+
+pub async fn check_round_trip_field_encoding(mut encoder: impl FieldEncoder, field: Field) {
+    let data = gen()
+        .col(None, array::rand_type(field.data_type()))
+        .into_batch_rows(RowCount::from(10000))
+        .unwrap()
+        .column(0)
+        .clone();
+
+    let num_rows = data.len();
+
+    for num_ingest_batches in [1, 5, 10] {
+        let rows_per_batch = num_rows / num_ingest_batches;
+        trace!(
+            "Testing with {} rows divided across {} batches for {} rows per batch",
+            num_rows,
+            num_ingest_batches,
+            rows_per_batch
+        );
+
+        let mut offset = 0;
+        let mut all_encoded_pages = Vec::new();
+        let mut page_infos: Vec<Vec<Arc<PageInfo>>> =
+            vec![Vec::new(); encoder.num_columns() as usize];
+        let mut buffer_offset = 0;
+
+        let mut simulate_write = |encoded_page: EncodedPage| {
+            trace!("Encoded page {:?}", encoded_page);
+            let buffer_offsets = encoded_page
+                .buffers
+                .iter()
+                .map(|buf| {
+                    let offset = buffer_offset;
+                    buffer_offset += buf.parts.iter().map(|part| part.len() as u64).sum::<u64>();
+                    offset
+                })
+                .collect::<Vec<_>>();
+
+            let page_info = PageInfo {
+                num_rows: encoded_page.num_rows,
+                encoding: encoded_page.encoding.clone(),
+                buffer_offsets: Arc::new(buffer_offsets.clone()),
+            };
+
+            let col_idx = encoded_page.column_idx as usize;
+            all_encoded_pages.push(encoded_page);
+            page_infos[col_idx].push(Arc::new(page_info));
+        };
+
+        for _ in 0..num_ingest_batches {
+            let data = data.slice(offset, rows_per_batch);
+
+            for encode_task in encoder.maybe_encode(data).unwrap() {
+                let encoded_page = encode_task.await.unwrap();
+                simulate_write(encoded_page);
+            }
+
+            offset += rows_per_batch;
+        }
+
+        for encode_task in encoder.flush().unwrap() {
+            let encoded_page = encode_task.await.unwrap();
+            simulate_write(encoded_page);
+        }
+
+        let scheduler =
+            Arc::new(SimulatedScheduler::new(all_encoded_pages)) as Arc<dyn EncodingsIo>;
+
+        let column_infos = page_infos
+            .into_iter()
+            .map(|page_infos| ColumnInfo::new(page_infos, Vec::new()))
+            .collect::<Vec<_>>();
+        let schema = Schema::new(vec![field.clone()]);
+
+        for range in [0..500, 100..1100, 8000..8500] {
+            let num_rows = range.end - range.start;
+            let schema = schema.clone();
+            let mut decode_scheduler =
+                DecodeBatchScheduler::new(&schema, &column_infos, &Vec::new());
+
+            let (tx, rx) = mpsc::unbounded_channel();
+
+            decode_scheduler
+                .schedule_range(range.clone(), tx, &scheduler)
+                .await
+                .unwrap();
+
+            const BATCH_SIZE: u32 = 100;
+            let mut decode_stream = BatchDecodeStream::new(rx, BATCH_SIZE, num_rows).into_stream();
+
+            let mut offset = range.start as usize;
+            while let Some(batch) = decode_stream.next().await {
+                let batch = batch.await.unwrap().unwrap();
+                let actual = batch.column(0);
+                let expected = data.slice(offset, BATCH_SIZE as usize);
+                assert_eq!(expected.data_type(), actual.data_type());
+                assert_eq!(&expected, actual);
+                offset += BATCH_SIZE as usize;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds encoders and decoders for non-nullable versions of all the arrow types

Prerequisites:

 - [x] https://github.com/lancedb/lance/pull/2137
 - [x] https://github.com/lancedb/lance/pull/2139
 - [x] https://github.com/lancedb/lance/pull/2141