### PR TITLE
feat: easier and consistent S3 configuration

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -206,14 +206,6 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ACCESSKEY
           AWS_SECRET_ACCESS_KEY: SECRETKEY
-    env:
-      AWS_ACCESS_KEY_ID: ACCESSKEY
-      AWS_SECRET_ACCESS_KEY: SECRETKEY
-      AWS_REGION: us-west-2
-      # this one is for s3
-      AWS_ENDPOINT: http://localhost:9000
-      # this one is for dynamodb
-      DYNAMODB_ENDPOINT: http://localhost:8000
     steps:
     - uses: actions/checkout@v4
       with:
@@ -223,16 +215,6 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.12"
-    - name: create s3
-      run: aws s3 mb s3://lance-integtest --endpoint http://localhost:9000
-    - name: create ddb
-      run: |
-        aws dynamodb create-table \
-          --table-name lance-integtest \
-          --attribute-definitions '[{"AttributeName": "base_uri", "AttributeType": "S"}, {"AttributeName": "version", "AttributeType": "N"}]' \
-          --key-schema '[{"AttributeName": "base_uri", "KeyType": "HASH"}, {"AttributeName": "version", "KeyType": "RANGE"}]' \
-          --provisioned-throughput '{"ReadCapacityUnits": 10, "WriteCapacityUnits": 10}' \
-          --endpoint-url http://localhost:8000
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: python

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+services:
+  minio:
+    image: lazybit/minio
+    ports:
+      - 9000:9000
+    environment:
+      - MINIO_ACCESS_KEY=ACCESSKEY
+      - MINIO_SECRET_KEY=SECRETKEY
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:9000/minio/health/live" ]
+      interval: 5s
+      retries: 3
+      start_period: 10s
+  dynamodb-local:
+    image: amazon/dynamodb-local
+    ports:
+      - 8000:8000
+    environment:
+      - AWS_ACCESS_KEY_ID=ACCESSKEY
+      - AWS_SECRET_ACCESS_KEY=SECRETKEY

--- a/docs/read_and_write.rst
+++ b/docs/read_and_write.rst
@@ -545,8 +545,7 @@ S3 Configuration
 ~~~~~~~~~~~~~~~~
 
 S3 (and S3-compatible stores) have additional configuration options that configure
-authorization and S3-specific features (such as server-side encryption). Region
-is a required parameter.
+authorization and S3-specific features (such as server-side encryption).
 
 AWS credentials can be set in the environment variables ``AWS_ACCESS_KEY_ID``,
 ``AWS_SECRET_ACCESS_KEY``, and ``AWS_SESSION_TOKEN``. Alternatively, they can be
@@ -558,7 +557,6 @@ passed as parameters to the ``storage_options`` parameter:
   ds = lance.dataset(
       "s3://bucket/path",
       storage_options={
-          "region": "us-east-1",
           "access_key_id": "my-access-key",
           "secret_access_key": "my-secret-key",
           "session_token": "my-session-token",
@@ -578,7 +576,8 @@ The following keys can be used as both environment variables or keys in the
    * - Key
      - Description
    * - ``aws_region`` / ``region``
-     - The AWS region to use. This is currently required.
+     - The AWS region the bucket is in. This can be automatically detected when
+       using AWS S3, but must be specified for S3-compatible stores.
    * - ``aws_access_key_id`` / ``access_key_id``
      - The AWS access key ID to use.
    * - ``aws_secret_access_key`` / ``secret_access_key``

--- a/python/DEVELOPMENT.md
+++ b/python/DEVELOPMENT.md
@@ -245,6 +245,21 @@ As a result, a single instrumented async method may appear as many different
 spans in the UI.
 
 
+## Running S3 Integration tests
+
+The integration tests run against local minio and local dynamodb. To start the
+services, run
+
+```shell
+docker compose up
+```
+
+Then you can run the tests with
+
+```shell
+pytest --run-integration python/tests/test_s3_ddb.py
+```
+
 ## Building wheels locally
 
 ### Linux

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -85,6 +85,8 @@ markers = [
 filterwarnings = [
     'error::FutureWarning',
     'error::DeprecationWarning',
+    # Boto3
+    'ignore:.*datetime\.datetime\.utcnow\(\) is deprecated.*:DeprecationWarning',
     # Pandas 2.2 on Python 2.12
     'ignore:.*datetime\.datetime\.utcfromtimestamp\(\) is deprecated.*:DeprecationWarning',
     # Pytorch 2.2 on Python 2.12

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -47,6 +47,7 @@ build-backend = "maturin"
 
 [project.optional-dependencies]
 tests = [
+    "boto3",
     "datasets",
     "duckdb; python_version<'3.12'", # TODO: remove when duckdb supports 3.12
     "ml_dtypes",

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -169,6 +169,7 @@ class LanceDataset(pa.dataset.Dataset):
         commit_lock: Optional[CommitLock] = None,
         storage_options: Optional[Dict[str, str]] = None,
     ):
+        breakpoint()
         uri = os.fspath(uri) if isinstance(uri, Path) else uri
         self._uri = uri
         self._ds = _Dataset(
@@ -190,6 +191,12 @@ class LanceDataset(pa.dataset.Dataset):
     def __setstate__(self, state):
         self._uri, version = state
         self._ds = _Dataset(self._uri, version)
+
+    def __copy__(self):
+        ds = LanceDataset.__new__(LanceDataset)
+        ds._uri = self._uri
+        ds._ds = copy.copy(self._ds)
+        return ds
 
     def __len__(self):
         return self.count_rows()

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -169,7 +169,6 @@ class LanceDataset(pa.dataset.Dataset):
         commit_lock: Optional[CommitLock] = None,
         storage_options: Optional[Dict[str, str]] = None,
     ):
-        breakpoint()
         uri = os.fspath(uri) if isinstance(uri, Path) else uri
         self._uri = uri
         self._ds = _Dataset(

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import os
 import sys
 
 import pytest
@@ -22,16 +21,6 @@ def provide_pandas(request, monkeypatch):
     if not request.param:
         monkeypatch.setitem(sys.modules, "pd", None)
     return request.param
-
-
-@pytest.fixture
-def s3_bucket() -> str:
-    return os.environ.get("TEST_S3_BUCKET", "lance-integtest")
-
-
-@pytest.fixture
-def ddb_table() -> str:
-    return os.environ.get("TEST_DDB_TABLE", "lance-integtest")
 
 
 def disable_items_with_mark(items, mark, reason):

--- a/python/python/tests/test_s3_ddb.py
+++ b/python/python/tests/test_s3_ddb.py
@@ -11,7 +11,14 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+"""
+Integration tests with S3 and DynamoDB.
 
+See DEVELOPMENT.md under heading "Integration Tests" for more information.
+"""
+
+import copy
+import time
 import uuid
 from concurrent import futures
 from concurrent.futures import ThreadPoolExecutor
@@ -21,32 +28,113 @@ import lance
 import pyarrow as pa
 import pytest
 
+# These are all keys that are accepted by storage_options
+CONFIG = {
+    "allow_http": "true",
+    "aws_access_key_id": "ACCESSKEY",
+    "aws_secret_access_key": "SECRETKEY",
+    "aws_endpoint": "http://localhost:9000",
+    "dynamodb_endpoint": "http://localhost:8000",
+    "aws_region": "us-west-2",
+}
+
+
+def get_boto3_client(*args, **kwargs):
+    import boto3
+
+    return boto3.client(
+        *args,
+        region_name=CONFIG["aws_region"],
+        aws_access_key_id=CONFIG["aws_access_key_id"],
+        aws_secret_access_key=CONFIG["aws_secret_access_key"],
+        **kwargs,
+    )
+
+
+@pytest.fixture(scope="module")
+def s3_bucket():
+    s3 = get_boto3_client("s3", endpoint_url=CONFIG["aws_endpoint"])
+    bucket_name = "lance-integtest"
+    # if bucket exists, delete it
+    try:
+        # Delete all objects first
+        for obj in s3.list_objects(Bucket=bucket_name).get("Contents", []):
+            s3.delete_object(Bucket=bucket_name, Key=obj["Key"])
+        s3.delete_bucket(Bucket=bucket_name)
+    except s3.exceptions.NoSuchBucket:
+        pass
+    s3.create_bucket(Bucket=bucket_name)
+    yield bucket_name
+    s3.delete_bucket(Bucket=bucket_name)
+
+
+@pytest.fixture(scope="module")
+def ddb_table():
+    dynamodb = get_boto3_client("dynamodb", endpoint_url=CONFIG["dynamodb_endpoint"])
+    table_name = "lance-integtest"
+    # if table exists, delete it
+    try:
+        dynamodb.delete_table(TableName=table_name)
+        # smh dynamodb is async
+        time.sleep(0.5)
+    except dynamodb.exceptions.ResourceNotFoundException:
+        pass
+    dynamodb.create_table(
+        TableName=table_name,
+        KeySchema=[
+            {"AttributeName": "base_uri", "KeyType": "HASH"},
+            {"AttributeName": "version", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "base_uri", "AttributeType": "S"},
+            {"AttributeName": "version", "AttributeType": "N"},
+        ],
+        ProvisionedThroughput={"ReadCapacityUnits": 10, "WriteCapacityUnits": 10},
+    )
+
+    time.sleep(1)
+    yield table_name
+    dynamodb.delete_table(TableName=table_name)
+
 
 @pytest.mark.integration
-def test_s3_ddb_create_and_append(s3_bucket: str, ddb_table: str):
+@pytest.mark.parametrize("use_env", [True, False])
+def test_s3_ddb_create_and_append(
+    s3_bucket: str, ddb_table: str, use_env: bool, monkeypatch
+):
+    storage_options = copy.deepcopy(CONFIG)
+    if use_env:
+        for key, value in storage_options.items():
+            monkeypatch.setenv(key.upper(), value)
+        storage_options = None
+
     table1 = pa.Table.from_pylist([{"a": 1, "b": 2}, {"a": 10, "b": 20}])
     table_name = uuid.uuid4().hex
     table_dir = f"s3+ddb://{s3_bucket}/{table_name}?ddbTableName={ddb_table}"
-    lance.write_dataset(table1, table_dir)
-    assert len(lance.dataset(table_dir).versions()) == 1
+    ds = lance.write_dataset(table1, table_dir, storage_options=storage_options)
+    assert len(ds.versions()) == 1
 
     table2 = pa.Table.from_pylist([{"a": 100, "b": 2000}])
 
     # can detect existing dataset
     with pytest.raises(OSError, match="Dataset already exists"):
-        lance.write_dataset(table2, table_dir)
+        lance.write_dataset(table2, table_dir, storage_options=storage_options)
 
-    lance.write_dataset(table2, table_dir, mode="append")
+    ds = lance.write_dataset(
+        table2, table_dir, mode="append", storage_options=storage_options
+    )
 
-    assert len(lance.dataset(table_dir).versions()) == 2
-    assert lance.dataset(table_dir).count_rows() == 3
+    assert len(ds.versions()) == 2
+    assert ds.count_rows() == 3
 
     # can checkout
-    assert lance.dataset(table_dir, version=1).count_rows() == 2
-    assert lance.dataset(table_dir, version=2).count_rows() == 3
+    ds = ds.checkout_version(1)
+    assert ds.count_rows() == 2
+    ds = ds.checkout_version(2)
+    assert ds.count_rows() == 3
 
     with pytest.raises(ValueError, match="Not found"):
-        lance.dataset(table_dir, version=3)
+        ds.checkout_version(3)
 
 
 @pytest.mark.integration

--- a/python/python/tests/test_s3_ddb.py
+++ b/python/python/tests/test_s3_ddb.py
@@ -218,3 +218,17 @@ def test_s3_ddb_concurrent_commit_more_than_five(
 
     assert len(lance.dataset(table_dir).versions()) == expected_version
     assert lance.dataset(table_dir).count_rows() == expected_version * 2
+
+
+@pytest.mark.integration
+def test_s3_unsafe(s3_bucket: str):
+    storage_options = copy.deepcopy(CONFIG)
+    del storage_options["dynamodb_endpoint"]
+
+    uri = f"s3://{s3_bucket}/test_unsafe"
+    data = pa.table({"x": [1, 2, 3]})
+    ds = lance.write_dataset(data, uri, storage_options=storage_options)
+
+    assert len(ds.versions()) == 1
+    assert ds.count_rows() == 3
+    assert ds.to_table() == data

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -311,7 +311,6 @@ impl Dataset {
     }
 
     pub fn __copy__(&self) -> Self {
-        println!("hello world!");
         self.clone()
     }
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -310,6 +310,11 @@ impl Dataset {
         }
     }
 
+    pub fn __copy__(&self) -> Self {
+        println!("hello world!");
+        self.clone()
+    }
+
     #[getter(schema)]
     fn schema(self_: PyRef<'_, Self>) -> PyResult<PyObject> {
         let arrow_schema = ArrowSchema::from(self_.ds.schema());
@@ -815,7 +820,10 @@ impl Dataset {
     fn checkout_version(&self, version: u64) -> PyResult<Self> {
         let ds = RT
             .block_on(None, self.ds.checkout_version(version))?
-            .map_err(|err| PyIOError::new_err(err.to_string()))?;
+            .map_err(|err| match err {
+                lance::Error::NotFound { .. } => PyValueError::new_err(err.to_string()),
+                _ => PyIOError::new_err(err.to_string()),
+            })?;
         Ok(Self {
             ds: Arc::new(ds),
             uri: self.uri.clone(),

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -212,7 +212,7 @@ async fn resolve_s3_region(
         let mut client_options = ClientOptions::default();
         for (key, value) in storage_options {
             if let AmazonS3ConfigKey::Client(client_key) = key {
-                client_options = client_options.with_config(client_key.clone(), value.clone());
+                client_options = client_options.with_config(*client_key, value.clone());
             }
         }
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -627,6 +627,7 @@ async fn configure_store(url: &str, options: ObjectStoreParams) -> Result<Object
         "s3" | "s3+ddb" => {
             storage_options.with_env_s3();
             let storage_options = storage_options.as_s3_options();
+            dbg!(&storage_options);
 
             // if url.scheme() == "s3+ddb" && options.commit_handler.is_some() {
             //     return Err(Error::InvalidInput {

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -372,6 +372,7 @@ pub async fn commit_handler_from_url(
             let (aws_creds, region) = build_aws_credential(
                 options.s3_credentials_refresh_offset,
                 options.aws_credentials.clone(),
+                Some(&storage_options),
                 region,
             )
             .await?;
@@ -395,6 +396,7 @@ pub async fn commit_handler_from_url(
     }
 }
 
+#[cfg(feature = "dynamodb")]
 fn get_dynamodb_endpoint(storage_options: &StorageOptions) -> Option<String> {
     if let Some(endpoint) = storage_options.0.get("dynamodb_endpoint") {
         Some(endpoint.to_string())

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -324,6 +324,8 @@ pub async fn commit_handler_from_url(
     };
 
     match url.scheme() {
+        // TODO: for Cloudflare R2 and Minio, we can provide a PutIfNotExist commit handler
+        // See: https://docs.rs/object_store/latest/object_store/aws/enum.S3ConditionalPut.html#variant.ETagMatch
         "s3" => Ok(Arc::new(UnsafeCommitHandler)),
         #[cfg(not(feature = "dynamodb"))]
         "s3+ddb" => Err(Error::InvalidInput {


### PR DESCRIPTION
This PR makes several changes:

1. Fixes an issue where `StorageOptions` would be bypassed in favor of `DefaultCredentialsChain` for the commit lock.
2. Makes credentials in `storage_options` take precedence over `DefaultCredentialsChain`. This way credentials passed in through function parameters will actually be used. Closes #1155
3. Fixes an issue were `Dataset.checkout_version()` would cause the dataset to lose it's storage configurations.
4. Refactored the integration tests so they are easier to run locally. `pytest` now handles the setup and teardown of buckets and dynamodb tables. Users just have to run `docker compose up`. Also, this is now documented in the `DEVELOPMENT.md`.
5. Bucket region is now automatically detected when using AWS S3.
6. We no longer hardcode allowing insecure connections to S3 (`allow_http(true)`). Users can set this themselves if they want it.
