### PR TITLE
chore: refine the IVF_HNSW index building path

### DIFF
--- a/rust/lance-index/src/vector/ivf.rs
+++ b/rust/lance-index/src/vector/ivf.rs
@@ -41,6 +41,7 @@ use crate::vector::{
     transform::Transformer,
 };
 
+use super::quantizer::Quantizer;
 use super::sq::transform::SQTransformer;
 use super::sq::ScalarQuantizer;
 use super::{PART_ID_COLUMN, PQ_CODE_COLUMN, RESIDUAL_COLUMN, SQ_CODE_COLUMN};
@@ -233,6 +234,24 @@ fn new_ivf_with_sq_impl<T: ArrowFloatType + Dot + Cosine + L2 + ArrowPrimitiveTy
         sq,
         range,
     ))
+}
+
+pub fn new_ivf_with_quantizer(
+    centroids: &dyn Array,
+    dimension: usize,
+    metric_type: MetricType,
+    vector_column: &str,
+    quantizer: Quantizer,
+    range: Option<Range<u32>>,
+) -> Result<Arc<dyn Ivf>> {
+    match quantizer {
+        Quantizer::Product(pq) => {
+            new_ivf_with_pq(centroids, dimension, metric_type, vector_column, pq, range)
+        }
+        Quantizer::Scalar(sq) => {
+            new_ivf_with_sq(centroids, dimension, metric_type, vector_column, sq, range)
+        }
+    }
 }
 
 /// IVF - IVF file partition

--- a/rust/lance-index/src/vector/ivf.rs
+++ b/rust/lance-index/src/vector/ivf.rs
@@ -42,7 +42,7 @@ use crate::vector::{
 };
 
 use super::quantizer::Quantizer;
-use super::transform::RemoveColumn;
+use super::transform::DropColumn;
 use super::{PART_ID_COLUMN, PQ_CODE_COLUMN, RESIDUAL_COLUMN};
 
 pub mod builder;
@@ -407,7 +407,7 @@ impl<T: ArrowFloatType + Dot + L2 + ArrowPrimitiveType> IvfImpl<T> {
 
         // For SQ we will transofrm the vector to SQ code while building the index,
         // so simply drop the vector column now.
-        transforms.push(Arc::new(RemoveColumn::new(vector_column)));
+        transforms.push(Arc::new(DropColumn::new(vector_column)));
         Self {
             centroids: centroids.clone(),
             metric_type,

--- a/rust/lance-index/src/vector/ivf.rs
+++ b/rust/lance-index/src/vector/ivf.rs
@@ -41,10 +41,9 @@ use crate::vector::{
     transform::Transformer,
 };
 
-use super::quantizer::Quantizer;
-use super::sq::transform::SQTransformer;
 use super::sq::ScalarQuantizer;
-use super::{PART_ID_COLUMN, PQ_CODE_COLUMN, RESIDUAL_COLUMN, SQ_CODE_COLUMN};
+use super::transform::RemoveColumn;
+use super::{PART_ID_COLUMN, PQ_CODE_COLUMN, RESIDUAL_COLUMN};
 
 pub mod builder;
 pub mod shuffler;
@@ -231,7 +230,6 @@ fn new_ivf_with_sq_impl<T: ArrowFloatType + Dot + Cosine + L2 + ArrowPrimitiveTy
         mat,
         metric_type,
         vector_column,
-        sq,
         range,
     ))
 }
@@ -389,7 +387,6 @@ impl<T: ArrowFloatType + Dot + L2 + ArrowPrimitiveType> IvfImpl<T> {
         centroids: MatrixView<T>,
         metric_type: MetricType,
         vector_column: &str,
-        sq: ScalarQuantizer,
         range: Option<Range<u32>>,
     ) -> Self {
         let mut transforms: Vec<Arc<dyn Transformer>> = vec![];
@@ -413,11 +410,9 @@ impl<T: ArrowFloatType + Dot + L2 + ArrowPrimitiveType> IvfImpl<T> {
             )));
         }
 
-        transforms.push(Arc::new(SQTransformer::<T>::new(
-            sq,
-            vector_column.to_owned(),
-            SQ_CODE_COLUMN.to_owned(),
-        )));
+        // For SQ we will transofrm the vector to SQ code while building the index,
+        // so simply drop the vector column now.
+        transforms.push(Arc::new(RemoveColumn::new(vector_column)));
         Self {
             centroids: centroids.clone(),
             metric_type,

--- a/rust/lance-index/src/vector/ivf.rs
+++ b/rust/lance-index/src/vector/ivf.rs
@@ -41,7 +41,7 @@ use crate::vector::{
     transform::Transformer,
 };
 
-use super::sq::ScalarQuantizer;
+use super::quantizer::Quantizer;
 use super::transform::RemoveColumn;
 use super::{PART_ID_COLUMN, PQ_CODE_COLUMN, RESIDUAL_COLUMN};
 
@@ -175,7 +175,6 @@ pub fn new_ivf_with_sq(
     dimension: usize,
     metric_type: MetricType,
     vector_column: &str,
-    sq: ScalarQuantizer,
     range: Option<Range<u32>>,
 ) -> Result<Arc<dyn Ivf>> {
     let ivf = match centroids.data_type() {
@@ -184,7 +183,6 @@ pub fn new_ivf_with_sq(
             dimension,
             metric_type,
             vector_column,
-            sq,
             range,
         ),
         DataType::Float32 => new_ivf_with_sq_impl::<Float32Type>(
@@ -192,7 +190,6 @@ pub fn new_ivf_with_sq(
             dimension,
             metric_type,
             vector_column,
-            sq,
             range,
         ),
         DataType::Float64 => new_ivf_with_sq_impl::<Float64Type>(
@@ -200,7 +197,6 @@ pub fn new_ivf_with_sq(
             dimension,
             metric_type,
             vector_column,
-            sq,
             range,
         ),
         _ => {
@@ -222,7 +218,6 @@ fn new_ivf_with_sq_impl<T: ArrowFloatType + Dot + Cosine + L2 + ArrowPrimitiveTy
     dimension: usize,
     metric_type: MetricType,
     vector_column: &str,
-    sq: ScalarQuantizer,
     range: Option<Range<u32>>,
 ) -> Arc<dyn Ivf> {
     let mat = MatrixView::<T>::new(Arc::new(centroids.clone()), dimension);
@@ -246,8 +241,8 @@ pub fn new_ivf_with_quantizer(
         Quantizer::Product(pq) => {
             new_ivf_with_pq(centroids, dimension, metric_type, vector_column, pq, range)
         }
-        Quantizer::Scalar(sq) => {
-            new_ivf_with_sq(centroids, dimension, metric_type, vector_column, sq, range)
+        Quantizer::Scalar(_) => {
+            new_ivf_with_sq(centroids, dimension, metric_type, vector_column, range)
         }
     }
 }

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -221,6 +221,9 @@ impl ProductQuantizationStorage {
         })
     }
 
+    pub fn batch(&self) -> &RecordBatch {
+        &self.batch
+    }
     /// Build a PQ storage from ProductQuantizer and a RecordBatch.
     ///
     /// Parameters

--- a/rust/lance-index/src/vector/quantizer.rs
+++ b/rust/lance-index/src/vector/quantizer.rs
@@ -47,9 +47,25 @@ pub trait Quantization {
     type Metadata: QuantizerMetadata + Send + Sync;
     type Storage: QuantizerStorage<Metadata = Self::Metadata> + VectorStorage;
 
+    fn code_dim(&self) -> usize;
     fn column(&self) -> &'static str;
     fn metadata_key(&self) -> &'static str;
-    fn quantization_type(&self) -> String;
+    fn quantization_type(&self) -> QuantizationType;
+    fn metadata(&self, _: Option<QuantizationMetadata>) -> Result<serde_json::Value>;
+}
+
+pub enum QuantizationType {
+    Product,
+    Scalar,
+}
+
+impl std::fmt::Display for QuantizationType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Product => write!(f, "PQ"),
+            Self::Scalar => write!(f, "SQ"),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -80,7 +96,7 @@ impl Quantizer {
         }
     }
 
-    pub fn typ(&self) -> String {
+    pub fn quantization_type(&self) -> QuantizationType {
         match self {
             Self::Product(pq) => pq.quantization_type(),
             Self::Scalar(sq) => sq.quantization_type(),
@@ -88,29 +104,10 @@ impl Quantizer {
     }
 
     pub fn metadata(&self, args: Option<QuantizationMetadata>) -> Result<serde_json::Value> {
-        let args = args.unwrap_or_default();
-        let value = match self {
-            Self::Product(pq) => {
-                let codebook_position = args.codebook_position.ok_or(Error::Index {
-                    message: "codebook_position not found".to_owned(),
-                    location: location!(),
-                })?;
-                serde_json::to_value(ProductQuantizationMetadata {
-                    codebook_position,
-                    num_bits: pq.num_bits(),
-                    num_sub_vectors: pq.num_sub_vectors(),
-                    dimension: pq.dimension(),
-                    codebook: args.codebook,
-                })?
-            }
-
-            Self::Scalar(sq) => serde_json::to_value(ScalarQuantizationMetadata {
-                num_bits: sq.num_bits(),
-                bounds: sq.bounds(),
-            })?,
-        };
-
-        Ok(value)
+        match self {
+            Self::Product(pq) => pq.metadata(args),
+            Self::Scalar(sq) => sq.metadata(args),
+        }
     }
 }
 
@@ -142,6 +139,10 @@ impl Quantization for ScalarQuantizer {
     type Metadata = ScalarQuantizationMetadata;
     type Storage = ScalarQuantizationStorage;
 
+    fn code_dim(&self) -> usize {
+        self.dim
+    }
+
     fn column(&self) -> &'static str {
         SQ_CODE_COLUMN
     }
@@ -150,8 +151,15 @@ impl Quantization for ScalarQuantizer {
         SQ_METADATA_KEY
     }
 
-    fn quantization_type(&self) -> String {
-        "SQ".to_owned()
+    fn quantization_type(&self) -> QuantizationType {
+        QuantizationType::Scalar
+    }
+
+    fn metadata(&self, _: Option<QuantizationMetadata>) -> Result<serde_json::Value> {
+        Ok(serde_json::to_value(ScalarQuantizationMetadata {
+            num_bits: self.num_bits(),
+            bounds: self.bounds(),
+        })?)
     }
 }
 
@@ -159,6 +167,10 @@ impl Quantization for dyn ProductQuantizer {
     type Metadata = ProductQuantizationMetadata;
     type Storage = ProductQuantizationStorage;
 
+    fn code_dim(&self) -> usize {
+        self.num_sub_vectors()
+    }
+
     fn column(&self) -> &'static str {
         PQ_CODE_COLUMN
     }
@@ -167,14 +179,34 @@ impl Quantization for dyn ProductQuantizer {
         PQ_METADTA_KEY
     }
 
-    fn quantization_type(&self) -> String {
-        "PQ".to_owned()
+    fn quantization_type(&self) -> QuantizationType {
+        QuantizationType::Product
+    }
+
+    fn metadata(&self, args: Option<QuantizationMetadata>) -> Result<serde_json::Value> {
+        let args = args.unwrap_or_default();
+
+        let codebook_position = args.codebook_position.ok_or(Error::Index {
+            message: "codebook_position not found".to_owned(),
+            location: location!(),
+        })?;
+        Ok(serde_json::to_value(ProductQuantizationMetadata {
+            codebook_position,
+            num_bits: self.num_bits(),
+            num_sub_vectors: self.num_sub_vectors(),
+            dimension: self.dimension(),
+            codebook: args.codebook,
+        })?)
     }
 }
 
-impl<T: ArrowFloatType + Dot + L2> Quantization for ProductQuantizerImpl<T> {
+impl<T: ArrowFloatType + Dot + L2 + 'static> Quantization for ProductQuantizerImpl<T> {
     type Metadata = ProductQuantizationMetadata;
     type Storage = ProductQuantizationStorage;
+
+    fn code_dim(&self) -> usize {
+        self.num_sub_vectors()
+    }
 
     fn column(&self) -> &'static str {
         PQ_CODE_COLUMN
@@ -184,8 +216,24 @@ impl<T: ArrowFloatType + Dot + L2> Quantization for ProductQuantizerImpl<T> {
         PQ_METADTA_KEY
     }
 
-    fn quantization_type(&self) -> String {
-        "PQ".to_owned()
+    fn quantization_type(&self) -> QuantizationType {
+        QuantizationType::Product
+    }
+
+    fn metadata(&self, args: Option<QuantizationMetadata>) -> Result<serde_json::Value> {
+        let args = args.unwrap_or_default();
+
+        let codebook_position = args.codebook_position.ok_or(Error::Index {
+            message: "codebook_position not found".to_owned(),
+            location: location!(),
+        })?;
+        Ok(serde_json::to_value(ProductQuantizationMetadata {
+            codebook_position,
+            num_bits: self.num_bits(),
+            num_sub_vectors: self.num_sub_vectors(),
+            dimension: self.dimension(),
+            codebook: args.codebook,
+        })?)
     }
 }
 

--- a/rust/lance-index/src/vector/quantizer.rs
+++ b/rust/lance-index/src/vector/quantizer.rs
@@ -121,7 +121,6 @@ pub struct QuantizationMetadata {
     pub codebook: Option<FixedSizeListArray>,
 }
 
-
 #[async_trait]
 pub trait QuantizerMetadata: Clone + Sized {
     async fn load(reader: &FileReader) -> Result<Self>;

--- a/rust/lance-index/src/vector/quantizer.rs
+++ b/rust/lance-index/src/vector/quantizer.rs
@@ -14,6 +14,7 @@
 
 use std::sync::Arc;
 
+use arrow_array::FixedSizeListArray;
 use async_trait::async_trait;
 use lance_arrow::ArrowFloatType;
 use lance_core::{Error, Result};
@@ -25,23 +26,101 @@ use snafu::{location, Location};
 
 use crate::{IndexMetadata, INDEX_METADATA_SCHEMA_KEY};
 
+use super::pq::storage::PQ_METADTA_KEY;
+use super::pq::ProductQuantizer;
+use super::sq::storage::SQ_METADATA_KEY;
 use super::{
     graph::VectorStorage,
     ivf::storage::IvfData,
     pq::{
         storage::{ProductQuantizationMetadata, ProductQuantizationStorage},
-        ProductQuantizer, ProductQuantizerImpl,
+        ProductQuantizerImpl,
     },
     sq::{
         storage::{ScalarQuantizationMetadata, ScalarQuantizationStorage},
         ScalarQuantizer,
     },
 };
+use super::{PQ_CODE_COLUMN, SQ_CODE_COLUMN};
 
-pub trait Quantizer {
+pub trait Quantization {
     type Metadata: QuantizerMetadata + Send + Sync;
     type Storage: QuantizerStorage<Metadata = Self::Metadata> + VectorStorage;
+
+    fn column(&self) -> &'static str;
+    fn metadata_key(&self) -> &'static str;
+    fn quantization_type(&self) -> String;
 }
+
+#[derive(Debug, Clone)]
+pub enum Quantizer {
+    Product(Arc<dyn ProductQuantizer>),
+    Scalar(ScalarQuantizer),
+}
+
+impl Quantizer {
+    pub fn code_dim(&self) -> usize {
+        match self {
+            Self::Product(pq) => pq.num_sub_vectors(),
+            Self::Scalar(sq) => sq.dim,
+        }
+    }
+
+    pub fn column(&self) -> &'static str {
+        match self {
+            Self::Product(pq) => pq.column(),
+            Self::Scalar(sq) => sq.column(),
+        }
+    }
+
+    pub fn metadata_key(&self) -> &'static str {
+        match self {
+            Self::Product(pq) => pq.metadata_key(),
+            Self::Scalar(sq) => sq.metadata_key(),
+        }
+    }
+
+    pub fn typ(&self) -> String {
+        match self {
+            Self::Product(pq) => pq.quantization_type(),
+            Self::Scalar(sq) => sq.quantization_type(),
+        }
+    }
+
+    pub fn metadata(&self, args: Option<QuantizationMetadata>) -> Result<serde_json::Value> {
+        let args = args.unwrap_or_default();
+        let value = match self {
+            Self::Product(pq) => {
+                let codebook_position = args.codebook_position.ok_or(Error::Index {
+                    message: "codebook_position not found".to_owned(),
+                    location: location!(),
+                })?;
+                serde_json::to_value(ProductQuantizationMetadata {
+                    codebook_position,
+                    num_bits: pq.num_bits(),
+                    num_sub_vectors: pq.num_sub_vectors(),
+                    dimension: pq.dimension(),
+                    codebook: args.codebook,
+                })?
+            }
+
+            Self::Scalar(sq) => serde_json::to_value(ScalarQuantizationMetadata {
+                num_bits: sq.num_bits(),
+                bounds: sq.bounds(),
+            })?,
+        };
+
+        Ok(value)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct QuantizationMetadata {
+    // For PQ
+    pub codebook_position: Option<usize>,
+    pub codebook: Option<FixedSizeListArray>,
+}
+
 
 #[async_trait]
 pub trait QuantizerMetadata: Clone + Sized {
@@ -60,23 +139,59 @@ pub trait QuantizerStorage: Clone + Sized {
     ) -> Result<Self>;
 }
 
-impl Quantizer for ScalarQuantizer {
+impl Quantization for ScalarQuantizer {
     type Metadata = ScalarQuantizationMetadata;
     type Storage = ScalarQuantizationStorage;
+
+    fn column(&self) -> &'static str {
+        SQ_CODE_COLUMN
+    }
+
+    fn metadata_key(&self) -> &'static str {
+        SQ_METADATA_KEY
+    }
+
+    fn quantization_type(&self) -> String {
+        "SQ".to_owned()
+    }
 }
 
-impl Quantizer for dyn ProductQuantizer {
+impl Quantization for dyn ProductQuantizer {
     type Metadata = ProductQuantizationMetadata;
     type Storage = ProductQuantizationStorage;
+
+    fn column(&self) -> &'static str {
+        PQ_CODE_COLUMN
+    }
+
+    fn metadata_key(&self) -> &'static str {
+        PQ_METADTA_KEY
+    }
+
+    fn quantization_type(&self) -> String {
+        "PQ".to_owned()
+    }
 }
 
-impl<T: ArrowFloatType + Dot + L2> Quantizer for ProductQuantizerImpl<T> {
+impl<T: ArrowFloatType + Dot + L2> Quantization for ProductQuantizerImpl<T> {
     type Metadata = ProductQuantizationMetadata;
     type Storage = ProductQuantizationStorage;
+
+    fn column(&self) -> &'static str {
+        PQ_CODE_COLUMN
+    }
+
+    fn metadata_key(&self) -> &'static str {
+        PQ_METADTA_KEY
+    }
+
+    fn quantization_type(&self) -> String {
+        "PQ".to_owned()
+    }
 }
 
 /// Loader to load partitioned PQ storage from disk.
-pub struct IvfQuantizationStorage<Q: Quantizer> {
+pub struct IvfQuantizationStorage<Q: Quantization> {
     reader: FileReader,
 
     metric_type: MetricType,
@@ -85,7 +200,7 @@ pub struct IvfQuantizationStorage<Q: Quantizer> {
     ivf: IvfData,
 }
 
-impl<Q: Quantizer> Clone for IvfQuantizationStorage<Q> {
+impl<Q: Quantization> Clone for IvfQuantizationStorage<Q> {
     fn clone(&self) -> Self {
         Self {
             reader: self.reader.clone(),
@@ -97,7 +212,7 @@ impl<Q: Quantizer> Clone for IvfQuantizationStorage<Q> {
 }
 
 #[allow(dead_code)]
-impl<Q: Quantizer> IvfQuantizationStorage<Q> {
+impl<Q: Quantization> IvfQuantizationStorage<Q> {
     /// Open a Loader.
     ///
     ///

--- a/rust/lance-index/src/vector/sq.rs
+++ b/rust/lance-index/src/vector/sq.rs
@@ -100,7 +100,7 @@ impl ScalarQuantizer {
         Ok(self.bounds.clone())
     }
 
-    async fn transform<T: ArrowFloatType>(&self, data: &dyn Array) -> Result<ArrayRef> {
+    pub fn transform<T: ArrowFloatType>(&self, data: &dyn Array) -> Result<ArrayRef> {
         let fsl = data
             .as_fixed_size_list_opt()
             .ok_or(Error::Index {
@@ -184,7 +184,7 @@ mod tests {
             float_values.last().cloned().unwrap().to_f64()
         );
 
-        let sq_code = sq.transform::<Float16Type>(&vectors).await.unwrap();
+        let sq_code = sq.transform::<Float16Type>(&vectors).unwrap();
         let sq_values = sq_code
             .as_fixed_size_list()
             .values()
@@ -213,7 +213,7 @@ mod tests {
             float_values.last().cloned().unwrap().to_f64().unwrap()
         );
 
-        let sq_code = sq.transform::<Float32Type>(&vectors).await.unwrap();
+        let sq_code = sq.transform::<Float32Type>(&vectors).unwrap();
         let sq_values = sq_code
             .as_fixed_size_list()
             .values()
@@ -239,7 +239,7 @@ mod tests {
         assert_eq!(sq.bounds.start, float_values[0]);
         assert_eq!(sq.bounds.end, float_values.last().cloned().unwrap());
 
-        let sq_code = sq.transform::<Float64Type>(&vectors).await.unwrap();
+        let sq_code = sq.transform::<Float64Type>(&vectors).unwrap();
         let sq_values = sq_code
             .as_fixed_size_list()
             .values()

--- a/rust/lance-index/src/vector/sq.rs
+++ b/rust/lance-index/src/vector/sq.rs
@@ -26,7 +26,6 @@ use snafu::{location, Location};
 
 pub mod builder;
 pub mod storage;
-pub mod transform;
 
 /// Scalar Quantization, optimized for [Apache Arrow] buffer memory layout.
 ///

--- a/rust/lance-index/src/vector/sq/transform.rs
+++ b/rust/lance-index/src/vector/sq/transform.rs
@@ -72,7 +72,7 @@ impl<T: ArrowFloatType> Transformer for SQTransformer<T> {
             })?;
         let batch = batch.drop_column(&self.input_column)?;
 
-        let sq_code = self.quantizer.transform::<T>(input).await?;
+        let sq_code = self.quantizer.transform::<T>(input)?;
         let sq_field = Field::new(&self.output_column, sq_code.data_type().clone(), false);
         let batch = batch.try_with_column(sq_field, Arc::new(sq_code))?;
         Ok(batch)

--- a/rust/lance-index/src/vector/transform.rs
+++ b/rust/lance-index/src/vector/transform.rs
@@ -187,7 +187,6 @@ impl Transformer for RemoveColumn {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/lance-index/src/vector/transform.rs
+++ b/rust/lance-index/src/vector/transform.rs
@@ -167,6 +167,27 @@ impl Transformer for KeepFiniteVectors {
     }
 }
 
+#[derive(Debug)]
+pub struct RemoveColumn {
+    column: String,
+}
+
+impl RemoveColumn {
+    pub fn new(column: &str) -> Self {
+        Self {
+            column: column.to_owned(),
+        }
+    }
+}
+
+#[async_trait]
+impl Transformer for RemoveColumn {
+    async fn transform(&self, batch: &RecordBatch) -> Result<RecordBatch> {
+        Ok(batch.drop_column(&self.column)?)
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/lance/src/index/vector/hnsw.rs
+++ b/rust/lance/src/index/vector/hnsw.rs
@@ -31,7 +31,7 @@ use lance_index::{
         graph::NEIGHBORS_FIELD,
         hnsw::{HnswMetadata, HNSW, VECTOR_ID_FIELD},
         ivf::storage::IVF_PARTITION_KEY,
-        quantizer::{IvfQuantizationStorage, Quantizer},
+        quantizer::{IvfQuantizationStorage, Quantization},
         Query, DIST_COL,
     },
     Index, IndexType,
@@ -55,7 +55,7 @@ pub(crate) struct HNSWIndexOptions {
 }
 
 #[derive(Clone)]
-pub(crate) struct HNSWIndex<Q: Quantizer> {
+pub(crate) struct HNSWIndex<Q: Quantization> {
     hnsw: HNSW,
 
     // TODO: move these into IVFIndex after the refactor is complete
@@ -65,13 +65,13 @@ pub(crate) struct HNSWIndex<Q: Quantizer> {
     options: HNSWIndexOptions,
 }
 
-impl<Q: Quantizer> Debug for HNSWIndex<Q> {
+impl<Q: Quantization> Debug for HNSWIndex<Q> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.hnsw.fmt(f)
     }
 }
 
-impl<Q: Quantizer> HNSWIndex<Q> {
+impl<Q: Quantization> HNSWIndex<Q> {
     pub async fn try_new(
         hnsw: HNSW,
         reader: Arc<dyn Reader>,
@@ -109,7 +109,7 @@ impl<Q: Quantizer> HNSWIndex<Q> {
 }
 
 #[async_trait]
-impl<Q: Quantizer + Send + Sync + 'static> Index for HNSWIndex<Q> {
+impl<Q: Quantization + Send + Sync + 'static> Index for HNSWIndex<Q> {
     /// Cast to [Any].
     fn as_any(&self) -> &dyn Any {
         self
@@ -143,7 +143,7 @@ impl<Q: Quantizer + Send + Sync + 'static> Index for HNSWIndex<Q> {
 }
 
 #[async_trait]
-impl<Q: Quantizer + Send + Sync + 'static> VectorIndex for HNSWIndex<Q> {
+impl<Q: Quantization + Send + Sync + 'static> VectorIndex for HNSWIndex<Q> {
     #[instrument(level = "debug", skip_all, name = "HNSWIndex::search")]
     async fn search(&self, query: &Query, pre_filter: Arc<PreFilter>) -> Result<RecordBatch> {
         let row_ids = self.hnsw.storage().row_ids();

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -1289,7 +1289,7 @@ async fn write_ivf_hnsw_file(
     writer.add_metadata(
         INDEX_METADATA_SCHEMA_KEY,
         json!(IndexMetadata {
-            index_type: format!("IVF_HNSW_{}", quantizer.typ()),
+            index_type: format!("IVF_HNSW_{}", quantizer.quantization_type()),
             distance_type: distance_type.to_string(),
         })
         .to_string()
@@ -1318,7 +1318,7 @@ async fn write_ivf_hnsw_file(
     aux_writer.add_metadata(
         INDEX_METADATA_SCHEMA_KEY,
         json!(IndexMetadata {
-            index_type: quantizer.typ(),
+            index_type: quantizer.quantization_type().to_string(),
             distance_type: distance_type.to_string(),
         })
         .to_string()

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -52,13 +52,8 @@ use lance_index::{
             storage::{IvfData, IVF_PARTITION_KEY},
             IvfBuildParams,
         },
-        pq::{
-            PQBuildParams, ProductQuantizer,
-        },
-        sq::{
-            builder::SQBuildParams,
-            ScalarQuantizer,
-        },
+        pq::{PQBuildParams, ProductQuantizer},
+        sq::{builder::SQBuildParams, ScalarQuantizer},
         Query, DIST_COL,
     },
     Index, IndexMetadata, IndexType, INDEX_AUXILIARY_FILE_NAME, INDEX_METADATA_SCHEMA_KEY,

--- a/rust/lance/src/index/vector/ivf/builder.rs
+++ b/rust/lance/src/index/vector/ivf/builder.rs
@@ -141,6 +141,13 @@ pub(super) async fn build_hnsw_partitions(
         });
     }
 
+    if metric_type == MetricType::Dot {
+        return Err(Error::Index {
+            message: "HNSW index does not support dot product distance".to_string(),
+            location: location!(),
+        });
+    }
+
     let ivf_model = lance_index::vector::ivf::new_ivf_with_quantizer(
         ivf.centroids.values(),
         dim,

--- a/rust/lance/src/index/vector/ivf/builder.rs
+++ b/rust/lance/src/index/vector/ivf/builder.rs
@@ -16,7 +16,14 @@ use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
 
+use arrow::array::AsArray;
+use arrow::datatypes::Float32Type;
+use arrow_array::Array;
 use lance_file::writer::FileWriter;
+use lance_index::vector::graph::memory::InMemoryVectorStorage;
+use lance_index::vector::hnsw::{HNSWBuilder, HNSW};
+use lance_index::vector::quantizer::Quantizer;
+use lance_linalg::MatrixView;
 use lance_table::io::manifest::ManifestDescribing;
 use object_store::path::Path;
 use snafu::{location, Location};
@@ -27,7 +34,6 @@ use lance_index::vector::{
     hnsw::{builder::HnswBuildParams, HnswMetadata},
     ivf::{shuffler::shuffle_dataset, storage::IvfData},
     pq::ProductQuantizer,
-    sq::ScalarQuantizer,
 };
 use lance_io::{stream::RecordBatchStream, traits::Writer};
 use lance_linalg::distance::MetricType;
@@ -37,7 +43,7 @@ use crate::{
     Dataset,
 };
 
-use super::io::{write_hnsw_pq_index_partitions, write_hnsw_sq_index_partitions};
+use super::io::write_hnsw_quantization_index_partitions;
 
 /// Build specific partitions of IVF index.
 ///
@@ -102,87 +108,15 @@ pub(super) async fn build_partitions(
 ///
 ///
 #[allow(clippy::too_many_arguments)]
-#[instrument(level = "debug", skip(writer, auxiliary_writer, data, ivf, pq))]
-pub(super) async fn build_hnsw_pq_partitions(
+#[instrument(level = "debug", skip(writer, auxiliary_writer, data, ivf, quantizer))]
+pub(super) async fn build_hnsw_partitions(
     dataset: &Dataset,
     writer: &mut FileWriter<ManifestDescribing>,
     auxiliary_writer: Option<&mut FileWriter<ManifestDescribing>>,
     data: impl RecordBatchStream + Unpin + 'static,
     column: &str,
     ivf: &mut Ivf,
-    pq: Arc<dyn ProductQuantizer>,
-    metric_type: MetricType,
-    hnsw_params: &HnswBuildParams,
-    part_range: Range<u32>,
-    precomputed_partitons: Option<HashMap<u64, u32>>,
-    shuffle_partition_batches: usize,
-    shuffle_partition_concurrency: usize,
-    precomputed_shuffle_buffers: Option<(Path, Vec<String>)>,
-) -> Result<(Vec<HnswMetadata>, IvfData)> {
-    let schema = data.schema();
-    if schema.column_with_name(column).is_none() {
-        return Err(Error::Schema {
-            message: format!("column {} does not exist in data stream", column),
-            location: location!(),
-        });
-    }
-    if schema.column_with_name(ROW_ID).is_none() {
-        return Err(Error::Schema {
-            message: "ROW ID is not set when building index partitions".to_string(),
-            location: location!(),
-        });
-    }
-
-    let ivf_model = lance_index::vector::ivf::new_ivf_with_pq(
-        ivf.centroids.values(),
-        ivf.centroids.value_length() as usize,
-        metric_type,
-        column,
-        pq.clone(),
-        Some(part_range),
-    )?;
-
-    let stream = shuffle_dataset(
-        data,
-        column,
-        ivf_model,
-        precomputed_partitons,
-        ivf.num_partitions() as u32,
-        pq.num_sub_vectors(),
-        shuffle_partition_batches,
-        shuffle_partition_concurrency,
-        precomputed_shuffle_buffers,
-    )
-    .await?;
-
-    write_hnsw_pq_index_partitions(
-        dataset,
-        column,
-        metric_type,
-        hnsw_params,
-        writer,
-        auxiliary_writer,
-        ivf,
-        pq,
-        Some(stream),
-        None,
-    )
-    .await
-}
-
-/// Build specific partitions of IVF index.
-///
-///
-#[allow(clippy::too_many_arguments)]
-#[instrument(level = "debug", skip(writer, auxiliary_writer, data, ivf, sq))]
-pub(super) async fn build_hnsw_sq_partitions(
-    dataset: &Dataset,
-    writer: &mut FileWriter<ManifestDescribing>,
-    auxiliary_writer: Option<&mut FileWriter<ManifestDescribing>>,
-    data: impl RecordBatchStream + Unpin + 'static,
-    column: &str,
-    ivf: &mut Ivf,
-    sq: ScalarQuantizer,
+    quantizer: Quantizer,
     metric_type: MetricType,
     hnsw_params: &HnswBuildParams,
     part_range: Range<u32>,
@@ -207,12 +141,12 @@ pub(super) async fn build_hnsw_sq_partitions(
         });
     }
 
-    let ivf_model = lance_index::vector::ivf::new_ivf_with_sq(
+    let ivf_model = lance_index::vector::ivf::new_ivf_with_quantizer(
         ivf.centroids.values(),
         dim,
         metric_type,
         column,
-        sq.clone(),
+        quantizer.clone(),
         Some(part_range),
     )?;
 
@@ -229,7 +163,7 @@ pub(super) async fn build_hnsw_sq_partitions(
     )
     .await?;
 
-    write_hnsw_sq_index_partitions(
+    write_hnsw_quantization_index_partitions(
         dataset,
         column,
         metric_type,
@@ -237,9 +171,31 @@ pub(super) async fn build_hnsw_sq_partitions(
         writer,
         auxiliary_writer,
         ivf,
-        sq,
+        quantizer,
         Some(stream),
         None,
     )
     .await
+}
+
+pub fn build_hnsw_model(
+    metric_type: MetricType,
+    hnsw_params: HnswBuildParams,
+    vector_array: Vec<Arc<dyn Array>>,
+) -> Result<(HNSW, Arc<dyn Array>)> {
+    let vector_arrs = vector_array
+        .iter()
+        .map(|arr| arr.as_ref())
+        .collect::<Vec<_>>();
+    let fsl = arrow_select::concat::concat(&vector_arrs)?;
+    std::mem::drop(vector_array);
+
+    let mat = Arc::new(MatrixView::<Float32Type>::try_from(
+        fsl.as_fixed_size_list(),
+    )?);
+    let vec_store = Arc::new(InMemoryVectorStorage::new(mat.clone(), metric_type));
+    let mut hnsw_builder = HNSWBuilder::with_params(hnsw_params, vec_store);
+    let hnsw = hnsw_builder.build()?;
+
+    Ok((hnsw, fsl))
 }

--- a/rust/lance/src/index/vector/ivf/builder.rs
+++ b/rust/lance/src/index/vector/ivf/builder.rs
@@ -179,7 +179,6 @@ pub(super) async fn build_hnsw_partitions(
 }
 
 pub fn build_hnsw_model(
-    metric_type: MetricType,
     hnsw_params: HnswBuildParams,
     vector_array: Vec<Arc<dyn Array>>,
 ) -> Result<(HNSW, Arc<dyn Array>)> {
@@ -193,7 +192,9 @@ pub fn build_hnsw_model(
     let mat = Arc::new(MatrixView::<Float32Type>::try_from(
         fsl.as_fixed_size_list(),
     )?);
-    let vec_store = Arc::new(InMemoryVectorStorage::new(mat.clone(), metric_type));
+
+    // We have normalized the vectors if the metric type is cosine, so we can use the L2 distance
+    let vec_store = Arc::new(InMemoryVectorStorage::new(mat.clone(), MetricType::L2));
     let mut hnsw_builder = HNSWBuilder::with_params(hnsw_params, vec_store);
     let hnsw = hnsw_builder.build()?;
 

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -107,7 +107,10 @@ async fn merge_streams(
             let codes = Arc::new(
                 batch
                     .column_by_name(column)
-                    .expect(format!("code column {} not found", column).as_str())
+                    .ok_or_else(|| Error::Index {
+                        message: format!("code column {} not found", column),
+                        location: location!(),
+                    })?
                     .as_fixed_size_list()
                     .clone(),
             );

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -31,23 +31,18 @@ use lance_file::reader::FileReader;
 use lance_file::writer::FileWriter;
 use lance_index::scalar::IndexWriter;
 use lance_index::vector::hnsw::builder::HNSW_METADATA_KEY;
-use lance_index::vector::hnsw::HNSW;
+use lance_index::vector::hnsw::{builder::HnswBuildParams, HnswMetadata};
 use lance_index::vector::ivf::storage::IvfData;
 use lance_index::vector::pq::storage::ProductQuantizationStorage;
-use lance_index::vector::pq::ProductQuantizer;
+use lance_index::vector::quantizer::{Quantization as _, Quantizer};
 use lance_index::vector::sq::storage::ScalarQuantizationStorage;
 use lance_index::vector::sq::ScalarQuantizer;
-use lance_index::vector::SQ_CODE_COLUMN;
-use lance_index::vector::{
-    graph::memory::InMemoryVectorStorage,
-    hnsw::{builder::HnswBuildParams, HNSWBuilder, HnswMetadata},
-    PART_ID_COLUMN, PQ_CODE_COLUMN,
-};
+use lance_index::vector::{PART_ID_COLUMN, PQ_CODE_COLUMN};
 use lance_io::encodings::plain::PlainEncoder;
 use lance_io::object_store::ObjectStore;
 use lance_io::traits::Writer;
 use lance_io::ReadBatchParams;
-use lance_linalg::{distance::MetricType, MatrixView};
+use lance_linalg::distance::MetricType;
 use lance_table::format::SelfDescribingFileReader;
 use lance_table::io::manifest::ManifestDescribing;
 use object_store::path::Path;
@@ -55,6 +50,7 @@ use snafu::{location, Location};
 use tempfile::TempDir;
 use tokio::sync::Semaphore;
 
+use super::builder::build_hnsw_model;
 use super::{IVFIndex, Ivf};
 use crate::index::vector::pq::PQIndex;
 use crate::{dataset::ROW_ID, Dataset};
@@ -247,7 +243,7 @@ pub(super) async fn write_pq_partitions(
 }
 
 #[allow(clippy::too_many_arguments)]
-pub(super) async fn write_hnsw_pq_index_partitions(
+pub(super) async fn write_hnsw_quantization_index_partitions(
     dataset: &Dataset,
     column: &str,
     metric_type: MetricType,
@@ -255,293 +251,7 @@ pub(super) async fn write_hnsw_pq_index_partitions(
     writer: &mut FileWriter<ManifestDescribing>,
     mut auxiliary_writer: Option<&mut FileWriter<ManifestDescribing>>,
     ivf: &mut Ivf,
-    pq: Arc<dyn ProductQuantizer>,
-    streams: Option<Vec<impl Stream<Item = Result<RecordBatch>>>>,
-    _existing_indices: Option<&[&IVFIndex]>,
-) -> Result<(Vec<HnswMetadata>, IvfData)> {
-    let dataset = Arc::new(dataset.clone());
-    let column = Arc::new(column.to_owned());
-    let hnsw_params = Arc::new(hnsw_params.clone());
-
-    let mut streams_heap = BinaryHeap::new();
-    let mut new_streams = vec![];
-    if let Some(streams) = streams {
-        for stream in streams {
-            let mut stream = Box::pin(stream.peekable());
-
-            match stream.as_mut().peek().await {
-                Some(Ok(batch)) => {
-                    let part_ids: &UInt32Array = batch
-                        .column_by_name(PART_ID_COLUMN)
-                        .expect("part id column not found")
-                        .as_primitive();
-                    let part_id = part_ids.values()[0];
-                    streams_heap.push((Reverse(part_id), new_streams.len()));
-                    new_streams.push(stream);
-                }
-                Some(Err(e)) => {
-                    return Err(Error::IO {
-                        message: format!("failed to read batch: {}", e),
-                        location: location!(),
-                    });
-                }
-                None => {
-                    return Err(Error::IO {
-                        message: "failed to read batch: end of stream".to_string(),
-                        location: location!(),
-                    });
-                }
-            }
-        }
-    }
-
-    let object_store = ObjectStore::local();
-    let mut part_files = Vec::with_capacity(ivf.num_partitions());
-    let mut aux_part_files = Vec::with_capacity(ivf.num_partitions());
-    let tmp_part_dir = Path::from_filesystem_path(TempDir::new()?)?;
-    let mut tasks = Vec::with_capacity(ivf.num_partitions());
-    let sem = Arc::new(Semaphore::new(HNSW_PARTITIONS_BUILD_PARRALLEL));
-    for part_id in 0..ivf.num_partitions() {
-        part_files.push(tmp_part_dir.child(format!("hnsw_part_{}", part_id)));
-        aux_part_files.push(tmp_part_dir.child(format!("hnsw_part_aux_{}", part_id)));
-
-        let mut pq_array: Vec<Arc<dyn Array>> = vec![];
-        let mut row_id_array: Vec<Arc<dyn Array>> = vec![];
-        merge_streams(
-            &mut streams_heap,
-            &mut new_streams,
-            part_id as u32,
-            PQ_CODE_COLUMN,
-            &mut pq_array,
-            &mut row_id_array,
-        )
-        .await?;
-
-        let (part_file, aux_part_file) = (&part_files[part_id], &aux_part_files[part_id]);
-        let part_writer = FileWriter::<ManifestDescribing>::try_new(
-            &object_store,
-            part_file,
-            Schema::try_from(writer.schema())?,
-            &Default::default(),
-        )
-        .await?;
-
-        let aux_part_writer = match auxiliary_writer.as_ref() {
-            Some(writer) => Some(
-                FileWriter::<ManifestDescribing>::try_new(
-                    &object_store,
-                    aux_part_file,
-                    Schema::try_from(writer.schema())?,
-                    &Default::default(),
-                )
-                .await?,
-            ),
-            None => None,
-        };
-
-        let dataset = dataset.clone();
-        let column = column.clone();
-        let hnsw_params = hnsw_params.clone();
-        let pq = pq.clone();
-        let sem = sem.clone();
-        tasks.push(tokio::spawn(async move {
-            let _permit = sem.acquire().await.expect("semaphore error");
-
-            log::debug!("Building HNSW partition {}", part_id);
-            let result = build_hnsw_partition(
-                dataset,
-                column,
-                metric_type,
-                hnsw_params,
-                part_writer,
-                aux_part_writer,
-                pq,
-                row_id_array,
-                pq_array,
-            )
-            .await;
-            log::debug!("Finished building HNSW partition {}", part_id);
-            result
-        }));
-    }
-
-    let mut aux_ivf = IvfData::empty();
-    let mut hnsw_metadata = Vec::with_capacity(ivf.num_partitions());
-    for (part_id, task) in tasks.into_iter().enumerate() {
-        let length = task.await??;
-
-        let (part_file, aux_part_file) = (&part_files[part_id], &aux_part_files[part_id]);
-        let part_reader =
-            FileReader::try_new_self_described(&object_store, part_file, None).await?;
-
-        let offset = writer.tell().await?;
-        let batches = futures::stream::iter(0..part_reader.num_batches())
-            .map(|batch_id| {
-                part_reader.read_batch(
-                    batch_id as i32,
-                    ReadBatchParams::RangeFull,
-                    part_reader.schema(),
-                    None,
-                )
-            })
-            .buffered(num_cpus::get())
-            .try_collect::<Vec<_>>()
-            .await?;
-        writer.write(&batches).await?;
-        ivf.add_partition(offset, length as u32);
-        hnsw_metadata.push(serde_json::from_str(
-            part_reader.schema().metadata[HNSW_METADATA_KEY].as_str(),
-        )?);
-
-        if let Some(aux_writer) = auxiliary_writer.as_mut() {
-            let aux_part_reader =
-                FileReader::try_new_self_described(&object_store, aux_part_file, None).await?;
-
-            let batches = futures::stream::iter(0..aux_part_reader.num_batches())
-                .map(|batch_id| {
-                    aux_part_reader.read_batch(
-                        batch_id as i32,
-                        ReadBatchParams::RangeFull,
-                        aux_part_reader.schema(),
-                        None,
-                    )
-                })
-                .buffered(num_cpus::get())
-                .try_collect::<Vec<_>>()
-                .await?;
-
-            let num_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
-            aux_writer.write(&batches).await?;
-            aux_ivf.add_partition(num_rows as u32);
-        }
-    }
-
-    Ok((hnsw_metadata, aux_ivf))
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn build_hnsw_partition(
-    dataset: Arc<Dataset>,
-    column: Arc<String>,
-    metric_type: MetricType,
-    hnsw_params: Arc<HnswBuildParams>,
-    mut writer: FileWriter<ManifestDescribing>,
-    mut aux_writer: Option<FileWriter<ManifestDescribing>>,
-    pq: Arc<dyn ProductQuantizer>,
-    row_id_array: Vec<Arc<dyn Array>>,
-    pq_array: Vec<Arc<dyn Array>>,
-) -> Result<usize> {
-    let projection = Arc::new(dataset.schema().project(&[column.as_ref()])?);
-    let mut vector_batches = Vec::with_capacity(row_id_array.len());
-    for row_ids in row_id_array.iter() {
-        let array = dataset
-            .take_rows(row_ids.as_primitive::<UInt64Type>().values(), &projection)
-            .await?
-            .column_by_name(column.as_ref())
-            .expect("row id column not found")
-            .clone();
-        vector_batches.push(array);
-    }
-
-    let pq = pq.clone();
-    let build_with_pq = aux_writer.is_some();
-
-    let (hnsw, pq_storage) = utils::tokio::spawn_cpu(move || {
-        build_hnsw_index(
-            metric_type,
-            (*hnsw_params).clone(),
-            row_id_array,
-            pq_array,
-            vector_batches,
-            build_with_pq,
-            pq,
-        )
-    })
-    .await?;
-
-    writer.add_metadata(
-        HNSW_METADATA_KEY,
-        serde_json::to_string(&hnsw.metadata())?.as_str(),
-    );
-    let length = hnsw.write_levels(&mut writer).await?;
-    writer.finish().await?;
-
-    if let Some(pq_storage) = pq_storage {
-        let aux_writer = aux_writer.as_mut().unwrap();
-        pq_storage.write_partition(aux_writer).await?;
-        aux_writer.finish().await?;
-    }
-
-    Ok(length)
-}
-
-fn build_hnsw_index(
-    metric_type: MetricType,
-    hnsw_params: HnswBuildParams,
-    row_ids_array: Vec<Arc<dyn Array>>,
-    pq_array: Vec<Arc<dyn Array>>,
-    vector_array: Vec<Arc<dyn Array>>,
-    build_with_pq: bool,
-    pq: Arc<dyn ProductQuantizer>,
-) -> Result<(HNSW, Option<ProductQuantizationStorage>)> {
-    let vector_arrs = vector_array
-        .iter()
-        .map(|arr| arr.as_ref())
-        .collect::<Vec<_>>();
-    let fsl = arrow_select::concat::concat(&vector_arrs)?;
-    std::mem::drop(vector_array);
-
-    let mat = Arc::new(MatrixView::<Float32Type>::try_from(
-        fsl.as_fixed_size_list(),
-    )?);
-    let vec_store = Arc::new(InMemoryVectorStorage::new(mat.clone(), metric_type));
-    let mut hnsw_builder = HNSWBuilder::with_params(hnsw_params, vec_store);
-    let hnsw = hnsw_builder.build()?;
-
-    let pq_storage = if build_with_pq {
-        let pq_arrs = pq_array.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
-        let pq_column = concat(&pq_arrs)?;
-        std::mem::drop(pq_array);
-
-        let row_ids_arrs = row_ids_array.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
-        let row_ids_column = concat(&row_ids_arrs)?;
-        std::mem::drop(row_ids_array);
-
-        let pq_batch = RecordBatch::try_from_iter_with_nullable(vec![
-            (ROW_ID, row_ids_column, true),
-            (PQ_CODE_COLUMN, pq_column, false),
-        ])?;
-        let pq_store = ProductQuantizationStorage::new(
-            pq.codebook_as_fsl()
-                .values()
-                .as_primitive::<Float32Type>()
-                .clone()
-                .into(),
-            pq_batch.clone(),
-            pq.num_bits(),
-            pq.num_sub_vectors(),
-            pq.dimension(),
-            metric_type,
-        )?;
-
-        Some(pq_store)
-    } else {
-        None
-    };
-
-    Ok((hnsw, pq_storage))
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(super) async fn write_hnsw_sq_index_partitions(
-    dataset: &Dataset,
-    column: &str,
-    metric_type: MetricType,
-    hnsw_params: &HnswBuildParams,
-    writer: &mut FileWriter<ManifestDescribing>,
-    mut auxiliary_writer: Option<&mut FileWriter<ManifestDescribing>>,
-    ivf: &mut Ivf,
-    sq: ScalarQuantizer,
+    quantizer: Quantizer,
     streams: Option<Vec<impl Stream<Item = Result<RecordBatch>>>>,
     _existing_indices: Option<&[&IVFIndex]>,
 ) -> Result<(Vec<HnswMetadata>, IvfData)> {
@@ -597,7 +307,7 @@ pub(super) async fn write_hnsw_sq_index_partitions(
             &mut streams_heap,
             &mut new_streams,
             part_id as u32,
-            SQ_CODE_COLUMN,
+            quantizer.column(),
             &mut code_array,
             &mut row_id_array,
         )
@@ -628,20 +338,20 @@ pub(super) async fn write_hnsw_sq_index_partitions(
         let dataset = dataset.clone();
         let column = column.clone();
         let hnsw_params = hnsw_params.clone();
-        let sq = sq.clone();
+        let quantizer = quantizer.clone();
         let sem = sem.clone();
         tasks.push(tokio::spawn(async move {
             let _permit = sem.acquire().await.expect("semaphore error");
 
             log::debug!("Building HNSW partition {}", part_id);
-            let result = build_hnsw_sq_partition(
+            let result = build_hnsw_quantization_partition(
                 dataset,
                 column,
                 metric_type,
                 hnsw_params,
                 part_writer,
                 aux_part_writer,
-                sq,
+                quantizer,
                 row_id_array,
                 code_array,
             )
@@ -706,20 +416,20 @@ pub(super) async fn write_hnsw_sq_index_partitions(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn build_hnsw_sq_partition(
+async fn build_hnsw_quantization_partition(
     dataset: Arc<Dataset>,
     column: Arc<String>,
     metric_type: MetricType,
     hnsw_params: Arc<HnswBuildParams>,
     mut writer: FileWriter<ManifestDescribing>,
     mut aux_writer: Option<FileWriter<ManifestDescribing>>,
-    sq: ScalarQuantizer,
-    row_id_array: Vec<Arc<dyn Array>>,
+    quantizer: Quantizer,
+    row_ids_array: Vec<Arc<dyn Array>>,
     code_array: Vec<Arc<dyn Array>>,
 ) -> Result<usize> {
     let projection = Arc::new(dataset.schema().project(&[column.as_ref()])?);
-    let mut vector_batches = Vec::with_capacity(row_id_array.len());
-    for row_ids in row_id_array.iter() {
+    let mut vector_batches = Vec::with_capacity(row_ids_array.len());
+    for row_ids in row_ids_array.iter() {
         let array = dataset
             .take_rows(row_ids.as_primitive::<UInt64Type>().values(), &projection)
             .await?
@@ -730,16 +440,8 @@ async fn build_hnsw_sq_partition(
     }
 
     let build_with_aux = aux_writer.is_some();
-    let (hnsw, sq_storage) = utils::tokio::spawn_cpu(move || {
-        build_hnsw_sq_index(
-            metric_type,
-            (*hnsw_params).clone(),
-            row_id_array,
-            code_array,
-            vector_batches,
-            build_with_aux,
-            sq,
-        )
+    let (hnsw, fsl) = utils::tokio::spawn_cpu(move || {
+        build_hnsw_model(metric_type, (*hnsw_params).clone(), vector_batches)
     })
     .await?;
 
@@ -749,11 +451,49 @@ async fn build_hnsw_sq_partition(
     );
     let length = hnsw.write_levels(&mut writer).await?;
     writer.finish().await?;
+    std::mem::drop(hnsw);
 
-    if let Some(code_storage) = sq_storage {
+    let quantization_storage_batch = match quantizer {
+        Quantizer::Product(pq) => {
+            let pq_arrs = code_array.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
+            let pq_column = concat(&pq_arrs)?;
+            std::mem::drop(code_array);
+
+            let row_ids_arrs = row_ids_array.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
+            let row_ids_column = concat(&row_ids_arrs)?;
+            std::mem::drop(row_ids_array);
+
+            let pq_batch = RecordBatch::try_from_iter_with_nullable(vec![
+                (ROW_ID, row_ids_column, true),
+                (pq.column(), pq_column, false),
+            ])?;
+            let pq_store = ProductQuantizationStorage::new(
+                pq.codebook_as_fsl()
+                    .values()
+                    .as_primitive::<Float32Type>()
+                    .clone()
+                    .into(),
+                pq_batch.clone(),
+                pq.num_bits(),
+                pq.num_sub_vectors(),
+                pq.dimension(),
+                metric_type,
+            )?;
+            pq_store.batch().clone()
+        }
+        Quantizer::Scalar(sq) => {
+            let sq_storage = utils::tokio::spawn_cpu(move || {
+                build_sq_storage(metric_type, row_ids_array, fsl, sq)
+            })
+            .await?;
+            sq_storage.batch().clone()
+        }
+    };
+
+    if build_with_aux {
         let aux_writer = aux_writer.as_mut().unwrap();
         aux_writer
-            .write_record_batch(code_storage.batch().clone())
+            .write_record_batch(quantization_storage_batch)
             .await?;
         aux_writer.finish().await?;
     }
@@ -761,51 +501,26 @@ async fn build_hnsw_sq_partition(
     Ok(length)
 }
 
-fn build_hnsw_sq_index(
+fn build_sq_storage(
     metric_type: MetricType,
-    hnsw_params: HnswBuildParams,
     row_ids_array: Vec<Arc<dyn Array>>,
-    code_array: Vec<Arc<dyn Array>>,
-    vector_array: Vec<Arc<dyn Array>>,
-    build_with_aux: bool,
+    vectors: Arc<dyn Array>,
     sq: ScalarQuantizer,
-) -> Result<(HNSW, Option<ScalarQuantizationStorage>)> {
-    let vector_arrs = vector_array
-        .iter()
-        .map(|arr| arr.as_ref())
-        .collect::<Vec<_>>();
-    let fsl = arrow_select::concat::concat(&vector_arrs)?;
-    std::mem::drop(vector_array);
+) -> Result<ScalarQuantizationStorage> {
+    let code_column = sq.transform::<Float32Type>(vectors.as_ref())?;
+    std::mem::drop(vectors);
 
-    let mat = Arc::new(MatrixView::<Float32Type>::try_from(
-        fsl.as_fixed_size_list(),
-    )?);
-    let vec_store = Arc::new(InMemoryVectorStorage::new(mat.clone(), metric_type));
-    let mut hnsw_builder = HNSWBuilder::with_params(hnsw_params, vec_store);
-    let hnsw = hnsw_builder.build()?;
+    let row_ids_arrs = row_ids_array.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
+    let row_ids_column = concat(&row_ids_arrs)?;
+    std::mem::drop(row_ids_array);
 
-    let pq_storage = if build_with_aux {
-        let code_arrs = code_array.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
-        let code_column = concat(&code_arrs)?;
-        std::mem::drop(code_array);
+    let pq_batch = RecordBatch::try_from_iter_with_nullable(vec![
+        (ROW_ID, row_ids_column, true),
+        (sq.column(), code_column, false),
+    ])?;
+    let store = ScalarQuantizationStorage::new(sq.num_bits(), metric_type, sq.bounds(), pq_batch)?;
 
-        let row_ids_arrs = row_ids_array.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
-        let row_ids_column = concat(&row_ids_arrs)?;
-        std::mem::drop(row_ids_array);
-
-        let pq_batch = RecordBatch::try_from_iter_with_nullable(vec![
-            (ROW_ID, row_ids_column, true),
-            (SQ_CODE_COLUMN, code_column, false),
-        ])?;
-        let pq_store =
-            ScalarQuantizationStorage::new(sq.num_bits(), metric_type, sq.bounds(), pq_batch)?;
-
-        Some(pq_store)
-    } else {
-        None
-    };
-
-    Ok((hnsw, pq_storage))
+    Ok(store)
 }
 
 #[cfg(test)]

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -58,7 +58,9 @@ use crate::{dataset::ROW_ID, Dataset};
 use crate::{utils, Result};
 
 // TODO: make it configurable, limit by the number of CPU cores & memory
-const HNSW_PARTITIONS_BUILD_PARRALLEL: usize = 16;
+lazy_static::lazy_static! {
+    static ref HNSW_PARTITIONS_BUILD_PARALLEL: usize = num_cpus::get();
+}
 
 /// Merge streams with the same partition id and collect PQ codes and row IDs.
 async fn merge_streams(
@@ -300,7 +302,7 @@ pub(super) async fn write_hnsw_quantization_index_partitions(
     let mut aux_part_files = Vec::with_capacity(ivf.num_partitions());
     let tmp_part_dir = Path::from_filesystem_path(TempDir::new()?)?;
     let mut tasks = Vec::with_capacity(ivf.num_partitions());
-    let sem = Arc::new(Semaphore::new(HNSW_PARTITIONS_BUILD_PARRALLEL));
+    let sem = Arc::new(Semaphore::new(*HNSW_PARTITIONS_BUILD_PARALLEL));
     for part_id in 0..ivf.num_partitions() {
         part_files.push(tmp_part_dir.child(format!("hnsw_part_{}", part_id)));
         aux_part_files.push(tmp_part_dir.child(format!("hnsw_part_aux_{}", part_id)));

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -43,7 +43,7 @@ use lance_io::object_store::ObjectStore;
 use lance_io::traits::Writer;
 use lance_io::ReadBatchParams;
 use lance_linalg::distance::MetricType;
-use lance_linalg::kernels::{normalize_arrow, normalize_fsl};
+use lance_linalg::kernels::normalize_fsl;
 use lance_table::format::SelfDescribingFileReader;
 use lance_table::io::manifest::ManifestDescribing;
 use object_store::path::Path;


### PR DESCRIPTION
- refactor the index building path of IVF_HNSW_PQ & IVF_HNSW_SQ
- remove SQ transformer, make the building much faster
- reduce memory footprint while building (about 2x less)
- fix the graph was trained with cosine distance type