### PR TITLE
fix: set prost to minimum 0.12.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,9 +109,9 @@ parquet = "49.0"
 pin-project = "1.0"
 pprof = { version = "0.13", features = ["flamegraph", "criterion"] }
 proptest = "1.3.1"
-prost = "0.12"
-prost-build = "0.12"
-prost-types = "0.12"
+prost = "0.12.2"
+prost-build = "0.12.2"
+prost-types = "0.12.2"
 rand = { version = "0.8.3", features = ["small_rng"] }
 roaring = "0.10.1"
 rustc_version = "0.4"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -36,7 +36,7 @@ lance-linalg = { path = "../rust/lance-linalg" }
 lance-table = { path = "../rust/lance-table" }
 lazy_static = "1"
 log = "0.4"
-prost = "0.12"
+prost = "0.12.2"
 pyo3 = { version = "0.20", features = ["extension-module", "abi3-py38"] }
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 uuid = "1.3.0"


### PR DESCRIPTION
this is required because we need Config `enable_type_names` method.

Fixes issue when installing python:
```
$ maturin develop

error[E0599]: no method named `enable_type_names` found for struct `Config` in the current scope
 --> /Users/albertlockett/Development/sophon/src/lance/rust/lance-encoding/build.rs:8:17
  |
8 |     prost_build.enable_type_names();
  |                 ^^^^^^^^^^^^^^^^^ method not found in `Config`
  ```