### PR TITLE
feat: add v2 nullability for primitive / fsl

### DIFF
--- a/protos/encodings.proto
+++ b/protos/encodings.proto
@@ -51,33 +51,6 @@ message Buffer {
     BufferType buffer_type = 2;
 }
 
-// Encodings that decode into a single buffer of values
-message BufferEncoding {
-  oneof buffer_encoding {
-      Flat flat = 1;
-      Bitmap bitmap = 2;
-      // TODO: Constant, RunEnd, Dictionary, BitPacking
-      //       FoR, ...
-  }
-}
-
-// A buffer encoding where each row is a fixed number of bytes
-message Flat {
-    // The buffer of values
-    Buffer buffer = 1;
-    // The number of bytes per value
-    uint64 bytes_per_value = 2;
-}
-
-// A buffer encoding for boolean data where each row is 1 bit
-// 
-// The data is stored with bit-endianess (e.g. what Arrow uses for validity
-// bitmaps and boolean arrays)
-message Bitmap {
-    // The buffer of values
-    Buffer buffer = 1;
-}
-
 // An encoding that adds nullability to another array encoding
 //
 // This can wrap any array encoding and add nullability information
@@ -87,7 +60,7 @@ message Nullable {
   }
   message AllNull {}
   message SomeNull {
-    BufferEncoding validity = 1;
+    ArrayEncoding validity = 1;
     ArrayEncoding values = 2;
   }
   oneof nullability {
@@ -136,10 +109,13 @@ message FixedSizeList {
   ArrayEncoding items = 2;
 }
 
-// An encoding for arrays that fit in a single buffer
-message Value {
+// Fixed width items placed contiguously in a buffer
+message Flat {
+  // the number of bits per value, must be greater than 0, does
+  // not need to be a multiple of 8
+  uint64 bits_per_value = 1;
   // the buffer of values
-  BufferEncoding buffer = 1;
+  Buffer buffer = 2;
 }
 
 // An array encoding for shredded structs that will never be null
@@ -152,7 +128,7 @@ message SimpleStruct {}
 // Encodings that decode into an Arrow array
 message ArrayEncoding {
     oneof array_encoding {
-        Value value = 1;
+        Flat flat = 1;
         Nullable nullable = 2;
         FixedSizeList fixed_size_list = 3;
         List list = 4;

--- a/protos/encodings.proto
+++ b/protos/encodings.proto
@@ -54,7 +54,7 @@ message Buffer {
 // Encodings that decode into a single buffer of values
 message BufferEncoding {
   oneof buffer_encoding {
-      Value value = 1;
+      Flat flat = 1;
       Bitmap bitmap = 2;
       // TODO: Constant, RunEnd, Dictionary, BitPacking
       //       FoR, ...
@@ -62,7 +62,7 @@ message BufferEncoding {
 }
 
 // A buffer encoding where each row is a fixed number of bytes
-message Value {
+message Flat {
     // The buffer of values
     Buffer buffer = 1;
     // The number of bytes per value
@@ -78,21 +78,17 @@ message Bitmap {
     Buffer buffer = 1;
 }
 
-// An array encoding for primitive fields where the validity information
-// is stored in a separate bitmap
+// An encoding that adds nullability to another array encoding
 //
-// "primitive" fields are any field which can be represented in Arrow by
-// a fixed-size buffer of values and a validity buffer.  This includes
-// the fields you would expect (integers, floats, temporal types) as
-// well as null, boolean, and fixed size list/string/binary types.
-message Basic {
+// This can wrap any array encoding and add nullability information
+message Nullable {
   message NoNull {
-    BufferEncoding values = 1;
+    ArrayEncoding values = 1;
   }
   message AllNull {}
   message SomeNull {
     BufferEncoding validity = 1;
-    BufferEncoding values = 2;
+    ArrayEncoding values = 2;
   }
   oneof nullability {
     // The array has no nulls and there is a single buffer needed
@@ -140,6 +136,12 @@ message FixedSizeList {
   ArrayEncoding items = 2;
 }
 
+// An encoding for arrays that fit in a single buffer
+message Value {
+  // the buffer of values
+  BufferEncoding buffer = 1;
+}
+
 // An array encoding for shredded structs that will never be null
 //
 // There is no actual data in this column.
@@ -150,9 +152,10 @@ message SimpleStruct {}
 // Encodings that decode into an Arrow array
 message ArrayEncoding {
     oneof array_encoding {
-        Basic basic = 1;
-        FixedSizeList fixed_size_list = 2;
-        List list = 3;
-        SimpleStruct struct = 4;
+        Value value = 1;
+        Nullable nullable = 2;
+        FixedSizeList fixed_size_list = 3;
+        List list = 4;
+        SimpleStruct struct = 5;
     }
 }

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -659,6 +659,7 @@ pub trait PhysicalPageDecoder: Send + Sync {
     /// * `num_rows` - how many rows to decode
     /// * `dest_buffers` - the output buffers to decode into
     fn decode_into(&self, rows_to_skip: u32, num_rows: u32, dest_buffers: &mut [BytesMut]);
+    fn num_buffers(&self) -> u32;
 }
 
 /// A scheduler for single-column encodings of primitive data

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -647,7 +647,14 @@ pub trait PhysicalPageDecoder: Send + Sync {
     /// * `rows_to_skip` - how many rows to skip (within the page) before decoding
     /// * `num_rows` - how many rows to decode
     /// * `buffers` - A mutable slice of "capacities" (as described above), one per buffer
-    fn update_capacity(&self, rows_to_skip: u32, num_rows: u32, buffers: &mut [(u64, bool)]);
+    /// * `all_null` - A mutable bool, set to true if a decoder determines all values are null
+    fn update_capacity(
+        &self,
+        rows_to_skip: u32,
+        num_rows: u32,
+        buffers: &mut [(u64, bool)],
+        all_null: &mut bool,
+    );
     /// Decodes the data into the requested buffers.
     ///
     /// You can assume that the capacity will have already been configured on the `BytesMut`

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -10,6 +10,7 @@ use lance_core::Result;
 use crate::{
     encodings::logical::{
         list::ListFieldEncoder, primitive::PrimitiveFieldEncoder, r#struct::StructFieldEncoder,
+        utf8::Utf8FieldEncoder,
     },
     format::pb,
 };
@@ -224,6 +225,14 @@ impl BatchEncoder {
                 Ok(Box::new(StructFieldEncoder::new(
                     children_encoders,
                     header_col_idx,
+                )))
+            }
+            DataType::Utf8 => {
+                let my_col_idx = *col_idx;
+                *col_idx += 2;
+                Ok(Box::new(Utf8FieldEncoder::new(
+                    cache_bytes_per_column,
+                    my_col_idx,
                 )))
             }
             _ => todo!("Implement encoding for data type {}", field.data_type()),

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -6,25 +6,16 @@ use arrow_buffer::Buffer;
 use arrow_schema::{DataType, Field, Schema};
 use futures::future::BoxFuture;
 use lance_core::Result;
-use std::sync::Arc;
 
 use crate::{
-    encodings::{
-        logical::{list::ListFieldEncoder, primitive::PrimitiveFieldEncoder},
-        physical::basic::BasicEncoder,
+    encodings::logical::{
+        list::ListFieldEncoder, primitive::PrimitiveFieldEncoder, r#struct::StructFieldEncoder,
     },
     format::pb,
 };
 
 /// An encoded buffer
 pub struct EncodedBuffer {
-    /// If true, the buffer should be stored as "data"
-    /// If false, the buffer should be stored as "metadata"
-    ///
-    /// Metadata buffers are typically small buffers that should be cached.  For example,
-    /// this might be a small dictionary when data has been dictionary encoded.  Or it might
-    /// contain a skip block when data has been RLE encoded.
-    pub is_data: bool,
     /// Buffers that make up the encoded buffer
     ///
     /// All of these buffers should be written to the file as one contiguous buffer
@@ -34,28 +25,59 @@ pub struct EncodedBuffer {
     /// For example, if we are asked to write 3 primitive arrays of 1000 rows and we can write them all
     /// as one page then this will be the value buffers from the 3 primitive arrays
     pub parts: Vec<Buffer>,
+    /// A description of the encoding used to encode the buffer
+    pub encoding: pb::BufferEncoding,
 }
 
 // Custom impl because buffers shouldn't be included in debug output
 impl std::fmt::Debug for EncodedBuffer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EncodedBuffer")
-            .field("is_data", &self.is_data)
             .field("len", &self.parts.iter().map(|p| p.len()).sum::<usize>())
             .finish()
     }
 }
 
+pub struct EncodedArrayBuffer {
+    /// The data making up the buffer
+    pub parts: Vec<Buffer>,
+    /// The index of the buffer in the page
+    pub index: u32,
+}
+
+// Custom impl because buffers shouldn't be included in debug output
+impl std::fmt::Debug for EncodedArrayBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncodedBuffer")
+            .field("len", &self.parts.iter().map(|p| p.len()).sum::<usize>())
+            .field("index", &self.index)
+            .finish()
+    }
+}
+
+/// An encoded array
+///
+/// Maps to a single Arrow array
+///
+/// This may contain multiple buffers.  For example, a nullable int32 array will contain two buffers,
+/// one for the null bitmap and one for the values
+#[derive(Debug)]
+pub struct EncodedArray {
+    /// The encoded buffers
+    pub buffers: Vec<EncodedArrayBuffer>,
+    /// A description of the encoding used to encode the array
+    pub encoding: pb::ArrayEncoding,
+}
+
 /// An encoded page of data
 ///
-/// This maps to an Arrow Array and may contain multiple buffers
-/// For example, a nullable int32 page will contain two buffers, one for the null bitmap and one for the values
+/// Maps to a top-level array
+///
+/// For example, FixedSizeList<Int32> will have two EncodedArray instances and one EncodedPage
 #[derive(Debug)]
 pub struct EncodedPage {
-    /// The encoded buffers
-    pub buffers: Vec<EncodedBuffer>,
-    /// A description of the encoding used to encode the column
-    pub encoding: pb::ArrayEncoding,
+    // The encoded array data
+    pub array: EncodedArray,
     /// The number of rows in the encoded page
     pub num_rows: u32,
     /// The index of the column
@@ -69,7 +91,12 @@ pub trait BufferEncoder: std::fmt::Debug + Send + Sync {
     /// This method may receive multiple chunks and should encode them all into
     /// a single EncodedBuffer (though that buffer may have multiple parts).  All
     /// parts will be written to the file as one contiguous block.
-    fn encode(&self, arrays: &[ArrayRef]) -> Result<EncodedBuffer>;
+    fn encode(
+        &self,
+        arrays: &[ArrayRef],
+        buffer_index: u32,
+        buffer_type: pb::buffer::BufferType,
+    ) -> Result<EncodedBuffer>;
 }
 
 /// Encodes data from Arrow format into some kind of on-disk format
@@ -96,7 +123,7 @@ pub trait ArrayEncoder: std::fmt::Debug + Send + Sync {
     ///
     /// The result should contain a description of the encoding that was chosen.
     /// This can be used to decode the data later.
-    fn encode(&self, arrays: &[ArrayRef]) -> Result<EncodedPage>;
+    fn encode(&self, arrays: &[ArrayRef], buffer_index: &mut u32) -> Result<EncodedArray>;
 }
 
 /// Top level encoding trait to code any Arrow array type into one or more pages.
@@ -136,7 +163,7 @@ pub struct BatchEncoder {
 }
 
 impl BatchEncoder {
-    fn get_encoder_for_field(
+    pub(crate) fn get_encoder_for_field(
         field: &Field,
         cache_bytes_per_column: u64,
         col_idx: &mut u32,
@@ -164,13 +191,15 @@ impl BatchEncoder {
             | DataType::UInt16
             | DataType::UInt32
             | DataType::UInt64
-            | DataType::UInt8 => {
+            | DataType::UInt8
+            | DataType::FixedSizeList(_, _) => {
                 let my_col_idx = *col_idx;
                 *col_idx += 1;
-                Ok(Box::new(PrimitiveFieldEncoder::new(
+                Ok(Box::new(PrimitiveFieldEncoder::try_new(
                     cache_bytes_per_column,
-                    Arc::new(BasicEncoder::new(my_col_idx)),
-                )))
+                    field.data_type(),
+                    my_col_idx,
+                )?))
             }
             DataType::List(inner_type) => {
                 let my_col_idx = *col_idx;
@@ -183,7 +212,21 @@ impl BatchEncoder {
                     my_col_idx,
                 )))
             }
-            _ => todo!("Implement encoding for field type: {:?}", field.data_type()),
+            DataType::Struct(fields) => {
+                let header_col_idx = *col_idx;
+                *col_idx += 1;
+                let children_encoders = fields
+                    .iter()
+                    .map(|field| {
+                        Self::get_encoder_for_field(field, cache_bytes_per_column, col_idx)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                Ok(Box::new(StructFieldEncoder::new(
+                    children_encoders,
+                    header_col_idx,
+                )))
+            }
+            _ => todo!("Implement encoding for data type {}", field.data_type()),
         }
     }
 

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -26,8 +26,6 @@ pub struct EncodedBuffer {
     /// For example, if we are asked to write 3 primitive arrays of 1000 rows and we can write them all
     /// as one page then this will be the value buffers from the 3 primitive arrays
     pub parts: Vec<Buffer>,
-    /// A description of the encoding used to encode the buffer
-    pub encoding: pb::BufferEncoding,
 }
 
 // Custom impl because buffers shouldn't be included in debug output
@@ -92,12 +90,7 @@ pub trait BufferEncoder: std::fmt::Debug + Send + Sync {
     /// This method may receive multiple chunks and should encode them all into
     /// a single EncodedBuffer (though that buffer may have multiple parts).  All
     /// parts will be written to the file as one contiguous block.
-    fn encode(
-        &self,
-        arrays: &[ArrayRef],
-        buffer_index: u32,
-        buffer_type: pb::buffer::BufferType,
-    ) -> Result<EncodedBuffer>;
+    fn encode(&self, arrays: &[ArrayRef]) -> Result<EncodedBuffer>;
 }
 
 /// Encodes data from Arrow format into some kind of on-disk format

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -18,8 +18,7 @@ use lance_core::Result;
 
 use crate::{
     decoder::{DecodeArrayTask, LogicalPageDecoder, LogicalPageScheduler, NextDecodeTask},
-    encoder::{EncodedPage, FieldEncoder},
-    encodings::physical::basic::BasicEncoder,
+    encoder::{EncodedArray, EncodedPage, FieldEncoder},
     format::pb,
     EncodingsIo,
 };
@@ -429,10 +428,12 @@ impl ListFieldEncoder {
         column_index: u32,
     ) -> Self {
         Self {
-            indices_encoder: PrimitiveFieldEncoder::new(
+            indices_encoder: PrimitiveFieldEncoder::try_new(
                 cache_bytes_per_columns,
-                Arc::new(BasicEncoder::new(column_index)),
-            ),
+                &DataType::Int32,
+                column_index,
+            )
+            .unwrap(),
             items_encoder,
         }
     }
@@ -456,17 +457,20 @@ impl ListFieldEncoder {
                 .map(|page_task| {
                     async move {
                         let page = page_task.await?;
-                        Ok(EncodedPage {
-                            buffers: page.buffers,
-                            column_idx: page.column_idx,
-                            num_rows: page.num_rows,
+                        let array = EncodedArray {
+                            buffers: page.array.buffers,
                             encoding: pb::ArrayEncoding {
                                 array_encoding: Some(pb::array_encoding::ArrayEncoding::List(
                                     Box::new(pb::List {
-                                        offsets: Some(Box::new(page.encoding)),
+                                        offsets: Some(Box::new(page.array.encoding)),
                                     }),
                                 )),
                             },
+                        };
+                        Ok(EncodedPage {
+                            array,
+                            column_idx: page.column_idx,
+                            num_rows: page.num_rows,
                         })
                     }
                     .boxed()
@@ -522,23 +526,12 @@ mod tests {
 
     use arrow_schema::{DataType, Field};
 
-    use crate::{
-        encodings::{
-            logical::{list::ListFieldEncoder, primitive::PrimitiveFieldEncoder},
-            physical::basic::BasicEncoder,
-        },
-        testing::check_round_trip_field_encoding,
-    };
+    use crate::testing::check_round_trip_encoding;
 
     #[test_log::test(tokio::test)]
     async fn test_simple_list() {
         let data_type = DataType::List(Arc::new(Field::new("item", DataType::Int32, true)));
-        let items_encoder = Box::new(PrimitiveFieldEncoder::new(
-            4096,
-            Arc::new(BasicEncoder::new(1)),
-        ));
-        let encoder = ListFieldEncoder::new(items_encoder, 4096, 0);
         let field = Field::new("", data_type, false);
-        check_round_trip_field_encoding(encoder, field).await;
+        check_round_trip_encoding(field).await;
     }
 }

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -467,11 +467,7 @@ impl ListFieldEncoder {
                                 )),
                             },
                         };
-                        Ok(EncodedPage {
-                            array,
-                            column_idx: page.column_idx,
-                            num_rows: page.num_rows,
-                        })
+                        Ok(EncodedPage { array, ..page })
                     }
                     .boxed()
                 })

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -139,11 +139,18 @@ impl DecodeArrayTask for PrimitiveFieldDecodeTask {
         // There are two buffers, the validity buffer and the values buffer
         // We start by assuming the validity buffer will not be required
         let mut capacities = vec![(0, false); self.physical_decoder.num_buffers() as usize];
+        let mut all_null = false;
         self.physical_decoder.update_capacity(
             self.rows_to_skip,
             self.rows_to_take,
             &mut capacities,
+            &mut all_null,
         );
+
+        if all_null {
+            return Ok(new_null_array(&self.data_type, self.rows_to_take as usize));
+        }
+
         // At this point we know the size needed for each buffer
         let mut bufs = capacities
             .into_iter()

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -136,8 +136,9 @@ struct PrimitiveFieldDecodeTask {
 
 impl DecodeArrayTask for PrimitiveFieldDecodeTask {
     fn decode(self: Box<Self>) -> Result<ArrayRef> {
-        // There are two buffers, the validity buffer and the values buffer
-        // We start by assuming the validity buffer will not be required
+        // We start by assuming that no buffers are required.  The number of buffers needed is based
+        // on the data type.  Most data types need two buffers but each layer of fixed-size-list, for
+        // example, adds another validity buffer
         let mut capacities = vec![(0, false); self.physical_decoder.num_buffers() as usize];
         let mut all_null = false;
         self.physical_decoder.update_capacity(

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -32,7 +32,10 @@ use crate::{
         PhysicalPageDecoder, PhysicalPageScheduler,
     },
     encoder::{ArrayEncoder, EncodedPage, FieldEncoder},
-    encodings::physical::{decoder_from_array_encoding, ColumnBuffers, PageBuffers},
+    encodings::physical::{
+        basic::BasicEncoder, decoder_from_array_encoding, fixed_size_list::FslEncoder,
+        value::ValueEncoder, ColumnBuffers, PageBuffers,
+    },
     EncodingsIo,
 };
 
@@ -135,7 +138,7 @@ impl DecodeArrayTask for PrimitiveFieldDecodeTask {
     fn decode(self: Box<Self>) -> Result<ArrayRef> {
         // There are two buffers, the validity buffer and the values buffer
         // We start by assuming the validity buffer will not be required
-        let mut capacities = [(0, false), (0, true)];
+        let mut capacities = vec![(0, false); self.physical_decoder.num_buffers() as usize];
         self.physical_decoder.update_capacity(
             self.rows_to_skip,
             self.rows_to_take,
@@ -196,6 +199,19 @@ impl PrimitiveFieldDecodeTask {
         )
     }
 
+    fn bytes_to_validity(bytes: BytesMut, num_rows: u32) -> Option<NullBuffer> {
+        if bytes.is_empty() {
+            None
+        } else {
+            let null_buffer = bytes.freeze().into();
+            Some(NullBuffer::new(BooleanBuffer::new(
+                Buffer::from_bytes(null_buffer),
+                0,
+                num_rows as usize,
+            )))
+        }
+    }
+
     fn primitive_array_from_buffers(
         data_type: &DataType,
         buffers: Vec<BytesMut>,
@@ -205,16 +221,7 @@ impl PrimitiveFieldDecodeTask {
             DataType::Boolean => {
                 let mut buffer_iter = buffers.into_iter();
                 let null_buffer = buffer_iter.next().unwrap();
-                let null_buffer = if null_buffer.is_empty() {
-                    None
-                } else {
-                    let null_buffer = null_buffer.freeze().into();
-                    Some(NullBuffer::new(BooleanBuffer::new(
-                        Buffer::from_bytes(null_buffer),
-                        0,
-                        num_rows as usize,
-                    )))
-                };
+                let null_buffer = Self::bytes_to_validity(null_buffer, num_rows);
 
                 let data_buffer = buffer_iter.next().unwrap().freeze();
                 let data_buffer = Buffer::from(data_buffer);
@@ -334,16 +341,21 @@ impl PrimitiveFieldDecodeTask {
                 buffers, num_rows, data_type,
             )),
             DataType::FixedSizeList(items, dimension) => {
+                let mut buffers_iter = buffers.into_iter();
+                let fsl_validity = buffers_iter.next().unwrap();
+                let fsl_nulls = Self::bytes_to_validity(fsl_validity, num_rows);
+
+                let remaining_buffers = buffers_iter.collect::<Vec<_>>();
                 let items_array = Self::primitive_array_from_buffers(
                     items.data_type(),
-                    buffers,
+                    remaining_buffers,
                     num_rows * (*dimension as u32),
                 )?;
                 Ok(Arc::new(FixedSizeListArray::new(
                     items.clone(),
                     *dimension,
                     items_array,
-                    None,
+                    fsl_nulls,
                 )))
             }
             _ => Err(Error::IO {
@@ -413,16 +425,32 @@ pub struct PrimitiveFieldEncoder {
     buffered_arrays: Vec<ArrayRef>,
     current_bytes: u64,
     encoder: Arc<dyn ArrayEncoder>,
+    column_index: u32,
 }
 
 impl PrimitiveFieldEncoder {
-    pub fn new(cache_bytes: u64, encoder: Arc<dyn ArrayEncoder>) -> Self {
-        Self {
+    fn array_encoder_from_data_type(data_type: &DataType) -> Result<Box<dyn ArrayEncoder>> {
+        match data_type {
+            DataType::FixedSizeList(inner, dimension) => {
+                Ok(Box::new(BasicEncoder::new(Box::new(FslEncoder::new(
+                    Self::array_encoder_from_data_type(inner.data_type())?,
+                    *dimension as u32,
+                )))))
+            }
+            _ => Ok(Box::new(BasicEncoder::new(Box::new(
+                ValueEncoder::try_new(data_type)?,
+            )))),
+        }
+    }
+
+    pub fn try_new(cache_bytes: u64, data_type: &DataType, column_index: u32) -> Result<Self> {
+        Ok(Self {
             cache_bytes,
+            column_index,
             buffered_arrays: Vec::with_capacity(8),
             current_bytes: 0,
-            encoder,
-        }
+            encoder: Arc::from(Self::array_encoder_from_data_type(data_type)?),
+        })
     }
 
     // Creates an encode task, consuming all buffered data
@@ -431,10 +459,20 @@ impl PrimitiveFieldEncoder {
         std::mem::swap(&mut arrays, &mut self.buffered_arrays);
         self.current_bytes = 0;
         let encoder = self.encoder.clone();
+        let column_idx = self.column_index;
 
-        tokio::task::spawn(async move { encoder.encode(&arrays) })
-            .map(|res_res| res_res.unwrap())
-            .boxed()
+        tokio::task::spawn(async move {
+            let num_rows = arrays.iter().map(|arr| arr.len() as u32).sum();
+            let mut buffer_index = 0;
+            let array = encoder.encode(&arrays, &mut buffer_index)?;
+            Ok(EncodedPage {
+                array,
+                num_rows,
+                column_idx,
+            })
+        })
+        .map(|res_res| res_res.unwrap())
+        .boxed()
     }
 }
 

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -39,11 +39,6 @@ impl SimpleStructScheduler {
         debug_assert!(!children.is_empty());
         let num_rows = children[0].iter().map(|page| page.num_rows()).sum();
         // Ensure that all the children have the same number of rows
-        debug_assert!(children.iter().all(|col| col
-            .iter()
-            .map(|page| page.num_rows())
-            .sum::<u32>()
-            == num_rows));
         Self {
             children,
             child_fields,

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -11,7 +11,7 @@ use tokio::sync::mpsc;
 
 use crate::{
     decoder::{DecodeArrayTask, LogicalPageDecoder, LogicalPageScheduler, NextDecodeTask},
-    encoder::{EncodedPage, FieldEncoder},
+    encoder::{EncodedArray, EncodedPage, FieldEncoder},
     format::pb,
     EncodingsIo,
 };
@@ -403,10 +403,6 @@ impl ChildState {
             // It's possible that we loaded more rows than asked for so need to calculate
             // newly_avail this way (we do this above too)
             let newly_avail = decoder.avail() - previously_avail;
-            println!(
-                "prev_avail: {}, newly_avail: {}",
-                previously_avail, newly_avail
-            );
             self.awaited.push_back(decoder);
             self.rows_available += newly_avail;
             self.rows_unawaited -= newly_avail;
@@ -544,7 +540,7 @@ impl DecodeArrayTask for SimpleStructDecodeTask {
     }
 }
 
-struct StructFieldEncoder {
+pub struct StructFieldEncoder {
     children: Vec<Box<dyn FieldEncoder>>,
     column_index: u32,
     num_rows_seen: u32,
@@ -590,11 +586,13 @@ impl FieldEncoder for StructFieldEncoder {
         // the very end which covers the entire struct.
         child_tasks.push(
             std::future::ready(Ok(EncodedPage {
-                buffers: vec![],
-                encoding: pb::ArrayEncoding {
-                    array_encoding: Some(pb::array_encoding::ArrayEncoding::Struct(
-                        pb::SimpleStruct {},
-                    )),
+                array: EncodedArray {
+                    buffers: vec![],
+                    encoding: pb::ArrayEncoding {
+                        array_encoding: Some(pb::array_encoding::ArrayEncoding::Struct(
+                            pb::SimpleStruct {},
+                        )),
+                    },
                 },
                 num_rows: num_rows_seen,
                 column_idx: column_index,
@@ -612,18 +610,9 @@ impl FieldEncoder for StructFieldEncoder {
 #[cfg(test)]
 mod tests {
 
-    use std::sync::Arc;
-
     use arrow_schema::{DataType, Field, Fields};
 
-    use crate::{
-        encoder::FieldEncoder,
-        encodings::{
-            logical::{primitive::PrimitiveFieldEncoder, r#struct::StructFieldEncoder},
-            physical::basic::BasicEncoder,
-        },
-        testing::check_round_trip_field_encoding,
-    };
+    use crate::testing::check_round_trip_encoding;
 
     #[test_log::test(tokio::test)]
     async fn test_simple_struct() {
@@ -631,18 +620,7 @@ mod tests {
             Field::new("a", DataType::Int32, false),
             Field::new("b", DataType::Int32, false),
         ]));
-        let child_encoders = vec![
-            Box::new(PrimitiveFieldEncoder::new(
-                4096,
-                Arc::new(BasicEncoder::new(1)),
-            )) as Box<dyn FieldEncoder>,
-            Box::new(PrimitiveFieldEncoder::new(
-                4096,
-                Arc::new(BasicEncoder::new(2)),
-            )) as Box<dyn FieldEncoder>,
-        ];
-        let encoder = StructFieldEncoder::new(child_encoders, 0);
         let field = Field::new("", data_type, false);
-        check_round_trip_field_encoding(encoder, field).await;
+        check_round_trip_encoding(field).await;
     }
 }

--- a/rust/lance-encoding/src/encodings/physical.rs
+++ b/rust/lance-encoding/src/encodings/physical.rs
@@ -85,7 +85,9 @@ pub fn decoder_from_array_encoding(
                         decoder_from_array_encoding(some_nulls.values.as_ref().unwrap(), buffers),
                     ))
                 }
-                pb::nullable::Nullability::AllNulls(_) => todo!(),
+                pb::nullable::Nullability::AllNulls(_) => {
+                    Box::new(BasicPageScheduler::new_all_null())
+                }
             }
         }
         pb::array_encoding::ArrayEncoding::Value(value) => {

--- a/rust/lance-encoding/src/encodings/physical/bitmap.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitmap.rs
@@ -3,9 +3,7 @@
 
 use std::ops::Range;
 
-use arrow_array::{cast::AsArray, ArrayRef};
 use arrow_buffer::BooleanBufferBuilder;
-use arrow_schema::DataType;
 use bytes::{Bytes, BytesMut};
 
 use futures::{future::BoxFuture, FutureExt};
@@ -14,7 +12,6 @@ use log::trace;
 
 use crate::{
     decoder::{PhysicalPageDecoder, PhysicalPageScheduler},
-    encoder::{BufferEncoder, EncodedBuffer},
     EncodingsIo,
 };
 
@@ -97,7 +94,7 @@ struct BitmapDecoder {
 impl PhysicalPageDecoder for BitmapDecoder {
     fn update_capacity(&self, _rows_to_skip: u32, num_rows: u32, buffers: &mut [(u64, bool)]) {
         buffers[0].0 = arrow_buffer::bit_util::ceil(num_rows as usize, 8) as u64;
-        // This decoder has no concept of "optional" buffers
+        buffers[0].1 = true;
     }
 
     fn decode_into(&self, rows_to_skip: u32, num_rows: u32, dest_buffers: &mut [BytesMut]) {
@@ -138,39 +135,9 @@ impl PhysicalPageDecoder for BitmapDecoder {
         // It's a moot point at the moment since we don't support page bridging
         dest_buffers[0].copy_from_slice(bool_buffer.as_slice());
     }
-}
 
-// Encoder for writing boolean arrays as dense bitmaps
-#[derive(Debug, Default)]
-pub struct BitmapEncoder {}
-
-impl BufferEncoder for BitmapEncoder {
-    fn encode(&self, arrays: &[ArrayRef]) -> Result<EncodedBuffer> {
-        debug_assert!(arrays
-            .iter()
-            .all(|arr| *arr.data_type() == DataType::Boolean));
-        let num_rows: u32 = arrays.iter().map(|arr| arr.len() as u32).sum();
-        // Empty pages don't make sense, this should be prevented before we
-        // get here
-        debug_assert_ne!(num_rows, 0);
-        // We can't just write the inner value buffers one after the other because
-        // bitmaps can have junk padding at the end (e.g. a boolean array with 12
-        // values will be 2 bytes but the last four bits of the second byte are
-        // garbage).  So we go ahead and pay the cost of a copy (we could avoid this
-        // if we really needed to, at the expense of more complicated code and a slightly
-        // larger encoded size but writer cost generally doesn't matter as much as reader cost)
-        let mut builder = BooleanBufferBuilder::new(num_rows as usize);
-        for arr in arrays {
-            let bool_arr = arr.as_boolean();
-            builder.append_buffer(bool_arr.values());
-        }
-        let buffer = builder.finish().into_inner();
-        let parts = vec![buffer];
-        let buffer = EncodedBuffer {
-            is_data: true,
-            parts,
-        };
-        Ok(buffer)
+    fn num_buffers(&self) -> u32 {
+        1
     }
 }
 
@@ -180,18 +147,15 @@ mod tests {
     use bytes::{Bytes, BytesMut};
 
     use crate::decoder::PhysicalPageDecoder;
-    use crate::encodings::physical::basic::BasicEncoder;
     use crate::encodings::physical::bitmap::BitmapData;
-    use crate::testing::check_round_trip_array_encoding;
+    use crate::testing::check_round_trip_encoding;
 
     use super::BitmapDecoder;
 
     #[test_log::test(tokio::test)]
     async fn test_bitmap_boolean() {
-        let encoder = BasicEncoder::new(0);
         let field = Field::new("", DataType::Boolean, false);
-
-        check_round_trip_array_encoding(encoder, field).await;
+        check_round_trip_encoding(field).await;
     }
 
     #[test]

--- a/rust/lance-encoding/src/encodings/physical/bitmap.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitmap.rs
@@ -92,7 +92,13 @@ struct BitmapDecoder {
 }
 
 impl PhysicalPageDecoder for BitmapDecoder {
-    fn update_capacity(&self, _rows_to_skip: u32, num_rows: u32, buffers: &mut [(u64, bool)]) {
+    fn update_capacity(
+        &self,
+        _rows_to_skip: u32,
+        num_rows: u32,
+        buffers: &mut [(u64, bool)],
+        _all_null: &mut bool,
+    ) {
         buffers[0].0 = arrow_buffer::bit_util::ceil(num_rows as usize, 8) as u64;
         buffers[0].1 = true;
     }

--- a/rust/lance-encoding/src/encodings/physical/buffers.rs
+++ b/rust/lance-encoding/src/encodings/physical/buffers.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
 use arrow_array::{cast::AsArray, ArrayRef};
 
 use arrow_buffer::BooleanBufferBuilder;

--- a/rust/lance-encoding/src/encodings/physical/buffers.rs
+++ b/rust/lance-encoding/src/encodings/physical/buffers.rs
@@ -1,0 +1,87 @@
+use arrow_array::{cast::AsArray, ArrayRef};
+
+use arrow_buffer::BooleanBufferBuilder;
+use arrow_schema::DataType;
+use lance_arrow::DataTypeExt;
+use lance_core::Result;
+
+use crate::{
+    encoder::{BufferEncoder, EncodedBuffer},
+    format::pb,
+};
+
+#[derive(Debug, Default)]
+pub struct FlatBufferEncoder {}
+
+impl BufferEncoder for FlatBufferEncoder {
+    fn encode(
+        &self,
+        arrays: &[ArrayRef],
+        buffer_index: u32,
+        buffer_type: pb::buffer::BufferType,
+    ) -> Result<EncodedBuffer> {
+        let bytes_per_value = arrays[0].data_type().byte_width() as u64;
+        let parts = arrays
+            .iter()
+            .map(|arr| arr.to_data().buffers()[0].clone())
+            .collect::<Vec<_>>();
+        Ok(EncodedBuffer {
+            parts,
+            encoding: pb::BufferEncoding {
+                buffer_encoding: Some(pb::buffer_encoding::BufferEncoding::Flat(pb::Flat {
+                    buffer: Some(pb::Buffer {
+                        buffer_index,
+                        buffer_type: buffer_type as i32,
+                    }),
+                    bytes_per_value,
+                })),
+            },
+        })
+    }
+}
+
+// Encoder for writing boolean arrays as dense bitmaps
+#[derive(Debug, Default)]
+pub struct BitmapBufferEncoder {}
+
+impl BufferEncoder for BitmapBufferEncoder {
+    fn encode(
+        &self,
+        arrays: &[ArrayRef],
+        buffer_index: u32,
+        buffer_type: pb::buffer::BufferType,
+    ) -> Result<EncodedBuffer> {
+        debug_assert!(arrays
+            .iter()
+            .all(|arr| *arr.data_type() == DataType::Boolean));
+        let num_rows: u32 = arrays.iter().map(|arr| arr.len() as u32).sum();
+        // Empty pages don't make sense, this should be prevented before we
+        // get here
+        debug_assert_ne!(num_rows, 0);
+        // We can't just write the inner value buffers one after the other because
+        // bitmaps can have junk padding at the end (e.g. a boolean array with 12
+        // values will be 2 bytes but the last four bits of the second byte are
+        // garbage).  So we go ahead and pay the cost of a copy (we could avoid this
+        // if we really needed to, at the expense of more complicated code and a slightly
+        // larger encoded size but writer cost generally doesn't matter as much as reader cost)
+        let mut builder = BooleanBufferBuilder::new(num_rows as usize);
+        for arr in arrays {
+            let bool_arr = arr.as_boolean();
+            builder.append_buffer(bool_arr.values());
+        }
+        let buffer = builder.finish().into_inner();
+        let parts = vec![buffer];
+        let buffer = EncodedBuffer {
+            parts,
+            encoding: pb::BufferEncoding {
+                buffer_encoding: Some(pb::buffer_encoding::BufferEncoding::Bitmap(pb::Bitmap {
+                    buffer: Some(pb::Buffer {
+                        buffer_index,
+                        buffer_type: buffer_type as i32,
+                    }),
+                })),
+            },
+        };
+        Ok(buffer)
+    }
+}

--- a/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
@@ -70,11 +70,17 @@ pub struct FixedListDecoder {
 }
 
 impl PhysicalPageDecoder for FixedListDecoder {
-    fn update_capacity(&self, rows_to_skip: u32, num_rows: u32, buffers: &mut [(u64, bool)]) {
+    fn update_capacity(
+        &self,
+        rows_to_skip: u32,
+        num_rows: u32,
+        buffers: &mut [(u64, bool)],
+        all_null: &mut bool,
+    ) {
         let rows_to_skip = rows_to_skip * self.dimension;
         let num_rows = num_rows * self.dimension;
         self.items_decoder
-            .update_capacity(rows_to_skip, num_rows, buffers);
+            .update_capacity(rows_to_skip, num_rows, buffers, all_null);
     }
 
     fn decode_into(&self, rows_to_skip: u32, num_rows: u32, dest_buffers: &mut [bytes::BytesMut]) {

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -82,7 +82,13 @@ struct ValuePageDecoder {
 }
 
 impl PhysicalPageDecoder for ValuePageDecoder {
-    fn update_capacity(&self, _rows_to_skip: u32, num_rows: u32, buffers: &mut [(u64, bool)]) {
+    fn update_capacity(
+        &self,
+        _rows_to_skip: u32,
+        num_rows: u32,
+        buffers: &mut [(u64, bool)],
+        _all_null: &mut bool,
+    ) {
         buffers[0].0 = self.bytes_per_value * num_rows as u64;
         buffers[0].1 = true;
     }

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -130,11 +130,11 @@ impl ValueEncoder {
     pub fn try_new(data_type: &DataType) -> Result<Self> {
         if data_type.is_primitive() {
             Ok(Self {
-                buffer_encoder: Box::new(FlatBufferEncoder::default()),
+                buffer_encoder: Box::<FlatBufferEncoder>::default(),
             })
         } else if *data_type == DataType::Boolean {
             Ok(Self {
-                buffer_encoder: Box::new(BitmapBufferEncoder::default()),
+                buffer_encoder: Box::<BitmapBufferEncoder>::default(),
             })
         } else {
             Err(Error::invalid_input(

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -39,11 +39,6 @@ impl SimulatedScheduler {
     }
 
     fn satisfy_request(&self, req: Range<u64>) -> Bytes {
-        println!(
-            "Satisfy request {:?} from bytes of size {}",
-            req,
-            self.data.len()
-        );
         self.data.slice(req.start as usize..req.end as usize)
     }
 }
@@ -105,7 +100,7 @@ fn supports_nulls(data_type: &DataType) -> bool {
 }
 
 async fn check_round_trip_field_encoding(mut encoder: Box<dyn FieldEncoder>, field: Field) {
-    for null_rate in [None, Some(0.5)] {
+    for null_rate in [None, Some(0.5), Some(1.0)] {
         let field = if null_rate.is_some() {
             if !supports_nulls(field.data_type()) {
                 continue;

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -4,7 +4,7 @@
 use std::{ops::Range, sync::Arc};
 
 use arrow_array::{Array, UInt32Array};
-use arrow_schema::{Field, Schema};
+use arrow_schema::{DataType, Field, Schema};
 use bytes::{Bytes, BytesMut};
 use futures::{future::BoxFuture, FutureExt, StreamExt};
 use log::trace;
@@ -15,8 +15,7 @@ use lance_datagen::{array, gen, RowCount};
 
 use crate::{
     decoder::{BatchDecodeStream, ColumnInfo, DecodeBatchScheduler, LogicalPageDecoder, PageInfo},
-    encoder::{ArrayEncoder, EncodedPage, FieldEncoder},
-    encodings::logical::primitive::PrimitiveFieldEncoder,
+    encoder::{BatchEncoder, EncodedPage, FieldEncoder},
     EncodingsIo,
 };
 
@@ -27,8 +26,8 @@ pub(crate) struct SimulatedScheduler {
 impl SimulatedScheduler {
     pub fn new(data: Vec<EncodedPage>) -> Self {
         let mut bytes = BytesMut::new();
-        for arr in data.into_iter() {
-            for buf in arr.buffers.into_iter() {
+        for page in data.into_iter() {
+            for buf in page.array.buffers {
                 for part in buf.parts.into_iter() {
                     bytes.extend(part.iter())
                 }
@@ -40,6 +39,11 @@ impl SimulatedScheduler {
     }
 
     fn satisfy_request(&self, req: Range<u64>) -> Bytes {
+        println!(
+            "Satisfy request {:?} from bytes of size {}",
+            req,
+            self.data.len()
+        );
         self.data.slice(req.start as usize..req.end as usize)
     }
 }
@@ -51,14 +55,6 @@ impl EncodingsIo for SimulatedScheduler {
             .map(|range| self.satisfy_request(range))
             .collect::<Vec<_>>()))
         .boxed()
-    }
-}
-
-pub async fn check_round_trip_array_encoding(encoder: impl ArrayEncoder + 'static, field: Field) {
-    let array_encoder = Arc::new(encoder);
-    for page_size_bytes in [1024, 4 * 1024, 1024 * 1024] {
-        let field_encoder = PrimitiveFieldEncoder::new(page_size_bytes, array_encoder.clone());
-        check_round_trip_field_encoding(field_encoder, field.clone()).await
     }
 }
 
@@ -93,128 +89,159 @@ async fn test_decode(
     }
 }
 
-pub async fn check_round_trip_field_encoding(mut encoder: impl FieldEncoder, field: Field) {
-    let data = gen()
-        .col(None, array::rand_type(field.data_type()))
-        .into_batch_rows(RowCount::from(10000))
-        .unwrap()
-        .column(0)
-        .clone();
+pub async fn check_round_trip_encoding(field: Field) {
+    let mut col_idx = 0;
+    let encoder = BatchEncoder::get_encoder_for_field(&field, 4096, &mut col_idx).unwrap();
+    check_round_trip_field_encoding(encoder, field).await
+}
 
-    let num_rows = data.len();
+fn supports_nulls(data_type: &DataType) -> bool {
+    // We don't yet have nullability support for all types.  Don't test nullability for the
+    // types we don't support.
+    match data_type {
+        DataType::List(_) | DataType::Struct(_) => false,
+        _ => true,
+    }
+}
 
-    for num_ingest_batches in [1, 5, 10] {
-        let rows_per_batch = num_rows / num_ingest_batches;
-        trace!(
-            "Testing with {} rows divided across {} batches for {} rows per batch",
-            num_rows,
-            num_ingest_batches,
-            rows_per_batch
-        );
+async fn check_round_trip_field_encoding(mut encoder: Box<dyn FieldEncoder>, field: Field) {
+    for null_rate in [None, Some(0.5)] {
+        let field = if null_rate.is_some() {
+            if !supports_nulls(field.data_type()) {
+                continue;
+            }
+            field.clone().with_nullable(true)
+        } else {
+            field.clone().with_nullable(false)
+        };
+        let mut generator = gen().col(None, array::rand_type(field.data_type()));
+        if let Some(null_rate) = null_rate {
+            generator.with_random_nulls(null_rate);
+        }
+        let data = generator
+            .into_batch_rows(RowCount::from(10000))
+            .unwrap()
+            .column(0)
+            .clone();
 
-        let mut offset = 0;
-        let mut all_encoded_pages = Vec::new();
-        let mut page_infos: Vec<Vec<Arc<PageInfo>>> =
-            vec![Vec::new(); encoder.num_columns() as usize];
-        let mut buffer_offset = 0;
+        let num_rows = data.len();
 
-        let mut simulate_write = |encoded_page: EncodedPage| {
-            trace!("Encoded page {:?}", encoded_page);
-            let buffer_offsets = encoded_page
-                .buffers
-                .iter()
-                .map(|buf| {
-                    let offset = buffer_offset;
-                    buffer_offset += buf.parts.iter().map(|part| part.len() as u64).sum::<u64>();
-                    offset
-                })
-                .collect::<Vec<_>>();
+        for num_ingest_batches in [1, 5, 10] {
+            let rows_per_batch = num_rows / num_ingest_batches;
+            trace!(
+                "Testing with {} rows divided across {} batches for {} rows per batch",
+                num_rows,
+                num_ingest_batches,
+                rows_per_batch
+            );
 
-            let page_info = PageInfo {
-                num_rows: encoded_page.num_rows,
-                encoding: encoded_page.encoding.clone(),
-                buffer_offsets: Arc::new(buffer_offsets.clone()),
+            let mut offset = 0;
+            let mut all_encoded_pages = Vec::new();
+            let mut page_infos: Vec<Vec<Arc<PageInfo>>> =
+                vec![Vec::new(); encoder.num_columns() as usize];
+            let mut buffer_offset = 0;
+
+            let mut simulate_write = |mut encoded_page: EncodedPage| {
+                trace!("Encoded page {:?}", encoded_page);
+                encoded_page.array.buffers.sort_by_key(|b| b.index);
+                let buffer_offsets = encoded_page
+                    .array
+                    .buffers
+                    .iter()
+                    .map(|buf| {
+                        let offset = buffer_offset;
+                        buffer_offset +=
+                            buf.parts.iter().map(|part| part.len() as u64).sum::<u64>();
+                        offset
+                    })
+                    .collect::<Vec<_>>();
+
+                let page_info = PageInfo {
+                    num_rows: encoded_page.num_rows,
+                    encoding: encoded_page.array.encoding.clone(),
+                    buffer_offsets: Arc::new(buffer_offsets.clone()),
+                };
+
+                let col_idx = encoded_page.column_idx as usize;
+                all_encoded_pages.push(encoded_page);
+                page_infos[col_idx].push(Arc::new(page_info));
             };
 
-            let col_idx = encoded_page.column_idx as usize;
-            all_encoded_pages.push(encoded_page);
-            page_infos[col_idx].push(Arc::new(page_info));
-        };
+            for _ in 0..num_ingest_batches {
+                let data = data.slice(offset, rows_per_batch);
 
-        for _ in 0..num_ingest_batches {
-            let data = data.slice(offset, rows_per_batch);
+                for encode_task in encoder.maybe_encode(data).unwrap() {
+                    let encoded_page = encode_task.await.unwrap();
+                    simulate_write(encoded_page);
+                }
 
-            for encode_task in encoder.maybe_encode(data).unwrap() {
+                offset += rows_per_batch;
+            }
+
+            for encode_task in encoder.flush().unwrap() {
                 let encoded_page = encode_task.await.unwrap();
                 simulate_write(encoded_page);
             }
 
-            offset += rows_per_batch;
-        }
+            let scheduler =
+                Arc::new(SimulatedScheduler::new(all_encoded_pages)) as Arc<dyn EncodingsIo>;
 
-        for encode_task in encoder.flush().unwrap() {
-            let encoded_page = encode_task.await.unwrap();
-            simulate_write(encoded_page);
-        }
+            let column_infos = page_infos
+                .into_iter()
+                .map(|page_infos| ColumnInfo::new(page_infos, Vec::new()))
+                .collect::<Vec<_>>();
+            let schema = Schema::new(vec![field.clone()]);
 
-        let scheduler =
-            Arc::new(SimulatedScheduler::new(all_encoded_pages)) as Arc<dyn EncodingsIo>;
+            // Test range scheduling
+            for range in [0..500, 100..1100, 8000..8500] {
+                let range = range.start as u64..range.end as u64;
+                let num_rows = range.end - range.start;
+                let expected = data.slice(range.start as usize, num_rows as usize);
+                let scheduler = scheduler.clone();
+                test_decode(
+                    num_rows,
+                    &schema,
+                    &column_infos,
+                    expected,
+                    |mut decode_scheduler, tx| {
+                        async move { decode_scheduler.schedule_range(range, tx, &scheduler).await }
+                            .boxed()
+                    },
+                )
+                .await;
+            }
 
-        let column_infos = page_infos
-            .into_iter()
-            .map(|page_infos| ColumnInfo::new(page_infos, Vec::new()))
-            .collect::<Vec<_>>();
-        let schema = Schema::new(vec![field.clone()]);
-
-        // Test range scheduling
-        for range in [0..500, 100..1100, 8000..8500] {
-            let range = range.start as u64..range.end as u64;
-            let num_rows = range.end - range.start;
-            let expected = data.slice(range.start as usize, num_rows as usize);
-            let scheduler = scheduler.clone();
-            test_decode(
-                num_rows,
-                &schema,
-                &column_infos,
-                expected,
-                |mut decode_scheduler, tx| {
-                    async move { decode_scheduler.schedule_range(range, tx, &scheduler).await }
+            // Test take scheduling
+            for indices in [
+                vec![100],
+                vec![0],
+                vec![9999],
+                vec![100, 1100, 5000],
+                vec![1000, 2000, 3000],
+                vec![2000, 2001, 2002, 2003, 2004],
+                // Big take that spans multiple pages and generates multiple output batches
+                (100..500).map(|i| i * 3).collect::<Vec<_>>(),
+            ] {
+                let num_rows = indices.len() as u64;
+                let indices_arr = UInt32Array::from(indices.clone());
+                let expected = arrow_select::take::take(&data, &indices_arr, None).unwrap();
+                let scheduler = scheduler.clone();
+                test_decode(
+                    num_rows,
+                    &schema,
+                    &column_infos,
+                    expected,
+                    |mut decode_scheduler, tx| {
+                        async move {
+                            decode_scheduler
+                                .schedule_take(&indices, tx, &scheduler)
+                                .await
+                        }
                         .boxed()
-                },
-            )
-            .await;
-        }
-
-        // Test take scheduling
-        for indices in [
-            vec![100],
-            vec![0],
-            vec![9999],
-            vec![100, 1100, 5000],
-            vec![1000, 2000, 3000],
-            vec![2000, 2001, 2002, 2003, 2004],
-            // Big take that spans multiple pages and generates multiple output batches
-            (100..500).map(|i| i * 3).collect::<Vec<_>>(),
-        ] {
-            let num_rows = indices.len() as u64;
-            let indices_arr = UInt32Array::from(indices.clone());
-            let expected = arrow_select::take::take(&data, &indices_arr, None).unwrap();
-            let scheduler = scheduler.clone();
-            test_decode(
-                num_rows,
-                &schema,
-                &column_infos,
-                expected,
-                |mut decode_scheduler, tx| {
-                    async move {
-                        decode_scheduler
-                            .schedule_take(&indices, tx, &scheduler)
-                            .await
-                    }
-                    .boxed()
-                },
-            )
-            .await;
+                    },
+                )
+                .await;
+            }
         }
     }
 }

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -93,10 +93,10 @@ pub async fn check_round_trip_encoding(field: Field) {
 fn supports_nulls(data_type: &DataType) -> bool {
     // We don't yet have nullability support for all types.  Don't test nullability for the
     // types we don't support.
-    match data_type {
-        DataType::List(_) | DataType::Struct(_) | DataType::Utf8 => false,
-        _ => true,
-    }
+    !matches!(
+        data_type,
+        DataType::List(_) | DataType::Struct(_) | DataType::Utf8
+    )
 }
 
 async fn check_round_trip_field_encoding(mut encoder: Box<dyn FieldEncoder>, field: Field) {

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -94,7 +94,7 @@ fn supports_nulls(data_type: &DataType) -> bool {
     // We don't yet have nullability support for all types.  Don't test nullability for the
     // types we don't support.
     match data_type {
-        DataType::List(_) | DataType::Struct(_) => false,
+        DataType::List(_) | DataType::Struct(_) | DataType::Utf8 => false,
         _ => true,
     }
 }

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -82,9 +82,9 @@ impl FileWriter {
     }
 
     async fn write_page(&mut self, encoded_page: EncodedPage) -> Result<()> {
-        let mut buffer_offsets = Vec::with_capacity(encoded_page.buffers.len());
-        let mut buffer_sizes = Vec::with_capacity(encoded_page.buffers.len());
-        for buffer in encoded_page.buffers {
+        let mut buffer_offsets = Vec::with_capacity(encoded_page.array.buffers.len());
+        let mut buffer_sizes = Vec::with_capacity(encoded_page.array.buffers.len());
+        for buffer in encoded_page.array.buffers {
             buffer_offsets.push(self.writer.tell().await? as u64);
             buffer_sizes.push(
                 buffer
@@ -101,7 +101,7 @@ impl FileWriter {
                 self.writer.write_all(part).await?;
             }
         }
-        let encoded_encoding = Any::from_msg(&encoded_page.encoding)?;
+        let encoded_encoding = Any::from_msg(&encoded_page.array.encoding)?;
         let page = pbfile::column_metadata::Page {
             buffer_offsets,
             buffer_sizes,


### PR DESCRIPTION
Struct and list will come later.  This PR was getting large enough as it was.

There is some refactoring that is happening as part of this PR also.  The basic encoder was previously and array encoder that took in two buffer encodings.  However, this meant we couldn't use the basic encoder to encode FSL since FSL is an array encoder.  So I changed the basic encoder to be an encoder that takes an encoder for validity and an array encoder for values.

I then also created the "value encoder" as an array encoder and renamed the existing value encoder (a buffer encoder) to the flat encoder.

In addition there was some minor refactoring needed to keep track of buffer indices.  Previously array encodings always mapped to 2 buffers.  Now they might map to more than 2 buffers (e.g. FSL with its own nullability is 3 buffers).