### PR TITLE
ci: full python 3.12 ci

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -79,7 +79,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        python-minor-version: [ "8", "11", "12" ] # 3.11 because tensorflow does not support 3.12 yet.
+        python-minor-version: [ "8", "12" ]
     name: "Python Linux 3.${{ matrix.python-minor-version }} x86_64"
     runs-on: "ubuntu-22.04"
     defaults:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -49,13 +49,13 @@ build-backend = "maturin"
 tests = [
     "boto3",
     "datasets",
-    "duckdb; python_version<'3.12'", # TODO: remove when duckdb supports 3.12
+    "duckdb",
     "ml_dtypes",
     "pillow",
     "pandas",
     "polars[pyarrow,pandas]",
     "pytest",
-    "tensorflow; python_version<'3.12'", # TODO: remove when tensorflow supports 3.12
+    "tensorflow",
     "tqdm",
 ]
 dev = ["ruff==0.2.2"]


### PR DESCRIPTION
Remove python 3.11 CI because we can run full CI with python 3.12 now.