### PR TITLE
fix: fix ray test broken on windows

### DIFF
--- a/python/python/tests/test_ray.py
+++ b/python/python/tests/test_ray.py
@@ -24,7 +24,8 @@ def test_ray_sink(tmp_path: Path):
 
     ds = lance.dataset(tmp_path)
     ds.count_rows() == 10
-    assert ds.schema == schema
+    assert ds.schema.names == schema.names
+
     tbl = ds.to_table()
     assert sorted(tbl["id"].to_pylist()) == list(range(10))
     assert set(tbl["str"].to_pylist()) == set([f"str-{i}" for i in range(10)])
@@ -39,3 +40,12 @@ def test_ray_sink(tmp_path: Path):
     tbl = ds.to_table()
     assert sorted(tbl["id"].to_pylist()) == list(range(20))
     assert set(tbl["str"].to_pylist()) == set([f"str-{i}" for i in range(20)])
+
+    sink = LanceDatasink(tmp_path, schema=schema, mode="overwrite")
+    ray.data.range(10).map(
+        lambda x: {"id": x["id"], "str": f"str-{x['id']}"}
+    ).write_datasink(sink)
+
+    ds = lance.dataset(tmp_path)
+    ds.count_rows() == 10
+    assert ds.schema == schema


### PR DESCRIPTION
The test assumes that ray will infer the range as int64.  However, it uses numpy to do the inference and numpy's integer inference is platform dependent: https://github.com/numpy/numpy/issues/9464