### PR TITLE
fix: add env variables to bypass/configure spill pool size

### DIFF
--- a/rust/lance-datafusion/Cargo.toml
+++ b/rust/lance-datafusion/Cargo.toml
@@ -22,6 +22,7 @@ datafusion-substrait = { version = "36.0", optional = true }
 futures.workspace = true
 lance-arrow.workspace = true
 lance-core = { workspace = true, features = ["datafusion"] }
+log.workspace = true
 prost.workspace = true
 snafu.workspace = true
 tokio.workspace = true

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -139,19 +139,10 @@ impl ExecutionPlan for OneShotExec {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Default, Clone)]
 pub struct LanceExecutionOptions {
     pub use_spilling: bool,
     pub mem_pool_size: Option<u64>,
-}
-
-impl Default for LanceExecutionOptions {
-    fn default() -> Self {
-        Self {
-            use_spilling: false,
-            mem_pool_size: None,
-        }
-    }
 }
 
 const DEFAULT_LANCE_MEM_POOL_SIZE: u64 = 100 * 1024 * 1024;


### PR DESCRIPTION
I'm not sure if we will want these long term so I don't want to expose them programmatically.  I'm hoping we can fix datafusion's out of core sort and so these won't need to be configurable.