### PR TITLE
feat(python): expose FragmentMetadata attrs and compaction repr

### DIFF
--- a/python/src/dataset/optimize.rs
+++ b/python/src/dataset/optimize.rs
@@ -91,6 +91,16 @@ pub struct PyCompactionMetrics {
     pub files_added: usize,
 }
 
+#[pymethods]
+impl PyCompactionMetrics {
+    fn __repr__(&self) -> PyResult<String> {
+        Ok(format!(
+            "CompactionMetrics(fragments_removed={}, fragments_added={}, files_removed={}, files_added={})",
+            self.fragments_removed, self.fragments_added, self.files_removed, self.files_added
+        ))
+    }
+}
+
 impl From<CompactionMetrics> for PyCompactionMetrics {
     fn from(metrics: CompactionMetrics) -> Self {
         Self {

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -16,7 +16,6 @@ use std::fmt::Write as _;
 use std::sync::Arc;
 
 use arrow::ffi_stream::ArrowArrayStreamReader;
-use arrow::ipc::gen;
 use arrow::pyarrow::{FromPyArrow, PyArrowType, ToPyArrow};
 use arrow_array::RecordBatchReader;
 use arrow_schema::Schema as ArrowSchema;
@@ -427,7 +426,7 @@ impl FragmentMetadata {
 
     #[getter]
     fn id(&self) -> u64 {
-        Ok(self.inner.id)
+        self.inner.id
     }
 }
 

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -16,6 +16,7 @@ use std::fmt::Write as _;
 use std::sync::Arc;
 
 use arrow::ffi_stream::ArrowArrayStreamReader;
+use arrow::ipc::gen;
 use arrow::pyarrow::{FromPyArrow, PyArrowType, ToPyArrow};
 use arrow_array::RecordBatchReader;
 use arrow_schema::Schema as ArrowSchema;
@@ -389,6 +390,24 @@ impl FragmentMetadata {
             deletion
                 .map(|d| deletion_file_path(&Default::default(), self.inner.id, &d).to_string()),
         )
+    }
+
+    #[getter]
+    fn physical_rows(&self) -> Option<usize> {
+        self.inner.physical_rows
+    }
+
+    #[getter]
+    fn num_deletions(&self) -> Option<usize> {
+        self.inner
+            .deletion_file
+            .as_ref()
+            .and_then(|d| d.num_deleted_rows)
+    }
+
+    #[getter]
+    fn num_rows(&self) -> Option<usize> {
+        self.inner.num_rows()
     }
 
     #[getter]

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -392,11 +392,21 @@ impl FragmentMetadata {
         )
     }
 
+    /// Get the physical rows statistic.
+    ///
+    /// This represents the original number of rows in the fragment
+    /// before any deletions.
+    ///
+    /// If this is None, it is unavailable.
     #[getter]
     fn physical_rows(&self) -> Option<usize> {
         self.inner.physical_rows
     }
 
+    /// Get the number of tombstoned rows in the fragment.
+    ///
+    /// If this is None, this statistic is unavailable. It does not necessarily
+    /// mean there are no deletions.
     #[getter]
     fn num_deletions(&self) -> Option<usize> {
         self.inner
@@ -405,13 +415,18 @@ impl FragmentMetadata {
             .and_then(|d| d.num_deleted_rows)
     }
 
+    /// Get the number of rows in the fragment.
+    ///
+    /// This is equivalent to physical_rows minus num_deletions.
+    ///
+    /// If this is None, this statistic is unavailable.
     #[getter]
     fn num_rows(&self) -> Option<usize> {
         self.inner.num_rows()
     }
 
     #[getter]
-    fn id(&self) -> PyResult<u64> {
+    fn id(&self) -> u64 {
         Ok(self.inner.id)
     }
 }


### PR DESCRIPTION
Some small features I wanted while prototyping LSM tree stuff.