### PR TITLE
refactor: rework fragment API in preparation for lance v2

### DIFF
--- a/protos/table.proto
+++ b/protos/table.proto
@@ -189,7 +189,7 @@ message DataFile {
   // nested fields (both struct and list).  Fixed size list fields have only a single
   // field id (these are not considered nested fields in Lance v1).
   //
-  // This allows column offsets to be calculated from field IDs and the input schema.
+  // This allows column indices to be calculated from field IDs and the input schema.
   //
   // In Lance v2 the field IDs generally follow the same pattern but there is no
   // way to calculate the column index from the field ID.  This is because a given

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -192,22 +192,22 @@ message DataFile {
   // This allows column offsets to be calculated from field IDs and the input schema.
   //
   // In Lance v2 the field IDs generally follow the same pattern but there is no
-  // way to calculate the column offset from the field ID.  This is because a given
+  // way to calculate the column index from the field ID.  This is because a given
   // field could be encoded in many different ways, some of which occupy a different
   // number of columns.  For example, a struct field could be encoded into N + 1 columns
-  // or it could be encoded into a single packed column.  To determine column offsets
-  // the column_offsets property should be used instead.
+  // or it could be encoded into a single packed column.  To determine column indices
+  // the column_indices property should be used instead.
   //
   // In Lance v1 these ids must be sorted and contiguous.
   repeated int32 fields = 2;
-  // The top-level offsets of the columns in the file.
+  // The top-level column indices for each field in the file.
   //
-  // If the data file is version 1 then the offsets will be empty
+  // If the data file is version 1 then this property will be empty
   //
   // Otherwise there must be one entry for each field in `fields`.
   //
   // Some fields may not correspond to a top-level column in the file.  In these cases
-  // the offset will -1.
+  // the index will -1.
   //
   // For example, consider the schema:
   //
@@ -222,7 +222,7 @@ message DataFile {
   //     - margin: fp64 (7)
   //     - padding: fp64 (8)
   //
-  // One possible column offsets array could be:
+  // One possible column indices array could be:
   // [0, -1, -1, 1, 3, 4, 5, 6, 7]
   //
   // This reflects quite a few phenomenon:
@@ -233,8 +233,8 @@ message DataFile {
   //   is not "FSL column"
   // - The borders field actually does have an "FSL column"
   //
-  // The column offsets table may not have duplicates (other than -1)
-  repeated int32 column_offsets = 3;
+  // The column indices table may not have duplicates (other than -1)
+  repeated int32 column_indices = 3;
   // The major file version used to create the file
   uint32 file_major_version = 4;
   // The minor file version used to create the file

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -179,13 +179,46 @@ message DataFile {
   string path = 1;
   // The ids of the fields/columns in this file.
   //
-  // IDs are assigned based on position in the file, offset by the max existing
-  // field id in the table (if any already). So when a fragment is first created
-  // with one file of N columns, the field ids will be 1, 2, ..., N. If a second,
-  // fragment is created with M columns, the field ids will be N+1, N+2, ..., N+M.
+  // In Lance v1 IDs are assigned based on position in the file, offset by the max
+  // existing field id in the table (if any already). So when a fragment is first
+  // created with one file of N columns, the field ids will be 1, 2, ..., N. If a
+  // second, fragment is created with M columns, the field ids will be N+1, N+2,
+  // ..., N+M.
   //
-  // These ids must be sorted and contiguous.
+  // In Lance v1 there is one field for each field in the input schema, this includes
+  // nested fields (both struct and list).  Fixed size list fields have only a single
+  // field id (these are not considered nested fields in Lance v1).
+  //
+  // This allows column offsets to be calculated from field IDs and the input schema.
+  //
+  // In Lance v2 the field IDs generally follow the same pattern but there is no
+  // way to calculate the column offset from the field ID.  This is because a given
+  // field could be encoded in many different ways, some of which occupy a different
+  // number of columns.  For example, a struct field could be encoded into N + 1 columns
+  // or it could be encoded into a single packed column.  To determine column offsets
+  // the column_offsets property should be used instead.
+  //
+  // In Lance v2 a nested field may or may not have its field id recorded here.  In the
+  // "packed struct" example above a nested field would not have a field id recorded here.
+  // If a nested field is not listed here then it is not possible for that field to be
+  // projected / individually loaded and the entire parent field must be loaded instead (this
+  // is the downside of the packed struct)
+  //
+  // In Lance v1 these ids must be sorted and contiguous.
   repeated int32 fields = 2;
+  // The offsets of the columns in the file.
+  //
+  // If the data file is version 1 then the offsets will be empty
+  //
+  // Otherwise there must be one entry for each field in `fields`.
+  repeated uint32 column_offsets = 3;
+  // The major file version used to create the file
+  uint32 file_major_version = 4;
+  // The minor file version used to create the file
+  //
+  // If both `file_major_version` and `file_minor_version` are set to 0,
+  // then this is a version 0.1 or version 0.2 file.
+  uint32 file_minor_version = 5;
 } // DataFile
 
 // Deletion File

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -207,7 +207,7 @@ message DataFile {
   // Otherwise there must be one entry for each field in `fields`.
   //
   // Some fields may not correspond to a top-level column in the file.  In these cases
-  // the offset will be top-level column of the ancestor containing the field.
+  // the offset will -1.
   //
   // For example, consider the schema:
   //
@@ -223,7 +223,7 @@ message DataFile {
   //     - padding: fp64 (8)
   //
   // One possible column offsets array could be:
-  // [0, 0, 0, 1, 3, 4, 5, 6, 7]
+  // [0, -1, -1, 1, 3, 4, 5, 6, 7]
   //
   // This reflects quite a few phenomenon:
   // - The packed struct is encoded into a single column and there is no top-level column
@@ -233,7 +233,7 @@ message DataFile {
   //   is not "FSL column"
   // - The borders field actually does have an "FSL column"
   //
-  // Hopefully it is clear that the column offsets may have duplicates and gaps.
+  // The column offsets table may not have duplicates (other than -1)
   repeated int32 column_offsets = 3;
   // The major file version used to create the file
   uint32 file_major_version = 4;

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -198,20 +198,43 @@ message DataFile {
   // or it could be encoded into a single packed column.  To determine column offsets
   // the column_offsets property should be used instead.
   //
-  // In Lance v2 a nested field may or may not have its field id recorded here.  In the
-  // "packed struct" example above a nested field would not have a field id recorded here.
-  // If a nested field is not listed here then it is not possible for that field to be
-  // projected / individually loaded and the entire parent field must be loaded instead (this
-  // is the downside of the packed struct)
-  //
   // In Lance v1 these ids must be sorted and contiguous.
   repeated int32 fields = 2;
-  // The offsets of the columns in the file.
+  // The top-level offsets of the columns in the file.
   //
   // If the data file is version 1 then the offsets will be empty
   //
   // Otherwise there must be one entry for each field in `fields`.
-  repeated uint32 column_offsets = 3;
+  //
+  // Some fields may not correspond to a top-level column in the file.  In these cases
+  // the offset will be top-level column of the ancestor containing the field.
+  //
+  // For example, consider the schema:
+  //
+  // - dimension: packed-struct (0):
+  //   - x: u32 (1)
+  //   - y: u32 (2)
+  // - path: string (3)
+  // - embedding: fsl<768> (4)
+  //   - fp64
+  // - borders: fsl<4> (5)
+  //   - simple-struct (6)
+  //     - margin: fp64 (7)
+  //     - padding: fp64 (8)
+  //
+  // One possible column offsets array could be:
+  // [0, 0, 0, 1, 3, 4, 5, 6, 7]
+  //
+  // This reflects quite a few phenomenon:
+  // - The packed struct is encoded into a single column and there is no top-level column
+  //   for the x or y fields
+  // - The string is encoded into two columns
+  // - The embedding is encoded into a single column (common for FSL of primitive) and there
+  //   is not "FSL column"
+  // - The borders field actually does have an "FSL column"
+  //
+  // Hopefully it is clear that the column offsets may have duplicates and gaps.
+  repeated int32 column_offsets = 3;
   // The major file version used to create the file
   uint32 file_major_version = 4;
   // The minor file version used to create the file

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -186,7 +186,7 @@ def test_dataset_progress(tmp_path: Path):
 
 
 def test_fragment_meta():
-    # Intentionally leaving off column_offsets / version fields to make sure
+    # Intentionally leaving off column_indices / version fields to make sure
     # we can handle backwards compatibility (though not clear we need to)
     data = {
         "id": 0,
@@ -206,8 +206,8 @@ def test_fragment_meta():
 
     assert repr(meta) == (
         'Fragment { id: 0, files: [DataFile { path: "0.lance", fields: [0], '
-        "column_offsets: [], file_major_version: 0, file_minor_version: 0 }, "
-        'DataFile { path: "1.lance", fields: [1], column_offsets: [], '
+        "column_indices: [], file_major_version: 0, file_minor_version: 0 }, "
+        'DataFile { path: "1.lance", fields: [1], column_indices: [], '
         "file_major_version: 0, file_minor_version: 0 }], deletion_file: None, "
         "physical_rows: Some(100) }"
     )

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -186,6 +186,8 @@ def test_dataset_progress(tmp_path: Path):
 
 
 def test_fragment_meta():
+    # Intentionally leaving off column_offsets / version fields to make sure
+    # we can handle backwards compatibility (though not clear we need to)
     data = {
         "id": 0,
         "files": [
@@ -203,7 +205,9 @@ def test_fragment_meta():
     assert meta.data_files()[1].path() == "1.lance"
 
     assert repr(meta) == (
-        'Fragment { id: 0, files: [DataFile { path: "0.lance", fields: [0] },'
-        ' DataFile { path: "1.lance", fields: [1] }], deletion_file: None,'
-        " physical_rows: Some(100) }"
+        'Fragment { id: 0, files: [DataFile { path: "0.lance", fields: [0], '
+        "column_offsets: [], file_major_version: 0, file_minor_version: 0 }, "
+        'DataFile { path: "1.lance", fields: [1], column_offsets: [], '
+        "file_major_version: 0, file_minor_version: 0 }], deletion_file: None, "
+        "physical_rows: Some(100) }"
     )

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -339,6 +339,10 @@ impl Schema {
             })
     }
 
+    pub fn top_level_field_ids(&self) -> Vec<i32> {
+        self.fields.iter().map(|f| f.id).collect()
+    }
+
     // Recursively collect all the field IDs, in pre-order traversal order.
     // TODO: pub(crate)
     pub fn field_ids(&self) -> Vec<i32> {

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -431,6 +431,9 @@ impl FileReader {
     }
 }
 
+/// Adapts the FileReader to implement the same interface as the v2 reader
+pub struct FileReaderAdapter {}
+
 /// Stream desired full batches from the file.
 ///
 /// Parameters:

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -5,6 +5,7 @@ use std::{io::Cursor, ops::Range, pin::Pin, sync::Arc};
 
 use arrow_array::RecordBatch;
 use arrow_schema::Schema;
+use async_trait::async_trait;
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
 use bytes::{Bytes, BytesMut};
 use futures::{stream::BoxStream, StreamExt};
@@ -82,6 +83,17 @@ struct Footer {
 }
 
 const FOOTER_LEN: usize = 48;
+
+/// A trait for file readers to be implemented by both the v1 and v2 readers
+#[async_trait]
+pub trait GenericFileReader {
+    /// Reads the requested range of rows from the file, returning as a stream
+    async fn read_range(
+        &self,
+        range: Range<u64>,
+        batch_size: u32,
+    ) -> BoxStream<'static, JoinHandle<Result<RecordBatch>>>;
+}
 
 impl FileReader {
     pub fn metadata(&self) -> &Arc<CachedFileMetadata> {

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -345,7 +345,7 @@ mod tests {
             json!({
                 "id": 123,
                 "files":[
-                    {"path": "foobar.lance", "fields": [0]}],
+                    {"path": "foobar.lance", "fields": [0], "column_offsets": [], "file_major_version": 0, "file_minor_version": 0}],
                      "deletion_file": {"read_version": 123, "id": 456, "file_type": "array",
                                        "num_deleted_rows": 10},
                 "physical_rows": None::<usize>}),

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::collections::BTreeSet;
-
+use lance_core::Error;
+use object_store::path::Path;
 use serde::{Deserialize, Serialize};
+use snafu::{location, Location};
 
 use crate::format::pb;
 
@@ -17,20 +18,66 @@ use lance_core::error::Result;
 pub struct DataFile {
     /// Relative path of the data file to dataset root.
     pub path: String,
-    /// The Ids of fields in this file.
+    /// The ids of fields in this file.
     pub fields: Vec<i32>,
+    /// The offsets of the fields listed in `fields`, empty in v1 files
+    pub column_offsets: Vec<u32>,
+    /// The major version of the file format used to write this file.
+    pub file_major_version: u32,
+    /// The minor version of the file format used to write this file.
+    pub file_minor_version: u32,
 }
 
 impl DataFile {
-    pub(crate) fn new(path: &str, schema: &Schema) -> Self {
+    fn new(
+        path: impl Into<String>,
+        fields: Vec<i32>,
+        column_offsets: Vec<u32>,
+        file_major_version: u32,
+        file_minor_version: u32,
+    ) -> Self {
         Self {
-            path: path.to_string(),
-            fields: schema.field_ids(),
+            path: path.into(),
+            fields,
+            column_offsets,
+            file_major_version,
+            file_minor_version,
         }
+    }
+
+    pub fn new_legacy_from_fields(path: impl Into<String>, fields: Vec<i32>) -> Self {
+        Self::new(path, fields, vec![], 0, 0)
+    }
+
+    pub(crate) fn new_legacy(path: impl Into<String>, schema: &Schema) -> Self {
+        Self::new(path, schema.field_ids(), vec![], 0, 0)
     }
 
     pub fn schema(&self, full_schema: &Schema) -> Schema {
         full_schema.project_by_ids(&self.fields)
+    }
+
+    pub fn is_legacy_file(&self) -> bool {
+        self.file_major_version == 0 && self.file_minor_version < 3
+    }
+
+    pub fn validate(&self, base_path: &Path) -> Result<()> {
+        if self.is_legacy_file() {
+            if !self.fields.windows(2).all(|w| w[0] < w[1]) {
+                return Err(Error::corrupt_file(
+                    base_path.child(self.path.clone()),
+                    "contained unsorted or duplicate field ids",
+                    location!(),
+                ));
+            }
+        } else if self.fields.len() != self.column_offsets.len() {
+            return Err(Error::corrupt_file(
+                base_path.child(self.path.clone()),
+                "contained an unequal number of fields / column_offsets",
+                location!(),
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -39,16 +86,22 @@ impl From<&DataFile> for pb::DataFile {
         Self {
             path: df.path.clone(),
             fields: df.fields.clone(),
+            column_offsets: df.column_offsets.clone(),
+            file_major_version: df.file_major_version,
+            file_minor_version: df.file_minor_version,
         }
     }
 }
 
 impl From<&pb::DataFile> for DataFile {
     fn from(proto: &pb::DataFile) -> Self {
-        Self {
-            path: proto.path.clone(),
-            fields: proto.fields.clone(),
-        }
+        Self::new(
+            &proto.path,
+            proto.fields.clone(),
+            proto.column_offsets.clone(),
+            proto.file_major_version,
+            proto.file_minor_version,
+        )
     }
 }
 
@@ -155,25 +208,23 @@ impl Fragment {
     }
 
     /// Create a `Fragment` with one DataFile
-    pub fn with_file(id: u64, path: &str, schema: &Schema, physical_rows: Option<usize>) -> Self {
+    pub fn with_file_legacy(
+        id: u64,
+        path: &str,
+        schema: &Schema,
+        physical_rows: Option<usize>,
+    ) -> Self {
         Self {
             id,
-            files: vec![DataFile::new(path, schema)],
+            files: vec![DataFile::new_legacy(path, schema)],
             deletion_file: None,
             physical_rows,
         }
     }
 
     /// Add a new [`DataFile`] to this fragment.
-    pub fn add_file(&mut self, path: &str, schema: &Schema) {
-        self.files.push(DataFile::new(path, schema));
-    }
-
-    /// Get all field IDs from this fragment, sorted.
-    pub fn field_ids(&self) -> Vec<i32> {
-        BTreeSet::from_iter(self.files.iter().flat_map(|f| f.fields.clone()))
-            .into_iter()
-            .collect()
+    pub fn add_file_legacy(&mut self, path: &str, schema: &Schema) {
+        self.files.push(DataFile::new_legacy(path, schema));
     }
 }
 
@@ -240,16 +291,15 @@ mod tests {
             ArrowField::new("bool", DataType::Boolean, true),
         ]);
         let schema = Schema::try_from(&arrow_schema).unwrap();
-        let fragment = Fragment::with_file(123, path, &schema, Some(10));
+        let fragment = Fragment::with_file_legacy(123, path, &schema, Some(10));
 
         assert_eq!(123, fragment.id);
-        assert_eq!(fragment.field_ids(), [0, 1, 2, 3]);
         assert_eq!(
             fragment.files,
-            vec![DataFile {
-                path: path.to_string(),
-                fields: vec![0, 1, 2, 3]
-            }]
+            vec![DataFile::new_legacy_from_fields(
+                path.to_string(),
+                vec![0, 1, 2, 3],
+            )]
         )
     }
 
@@ -257,7 +307,7 @@ mod tests {
     fn test_roundtrip_fragment() {
         let mut fragment = Fragment::new(123);
         let schema = ArrowSchema::new(vec![ArrowField::new("x", DataType::Float16, true)]);
-        fragment.add_file("foobar.lance", &Schema::try_from(&schema).unwrap());
+        fragment.add_file_legacy("foobar.lance", &Schema::try_from(&schema).unwrap());
         fragment.deletion_file = Some(DeletionFile {
             read_version: 123,
             id: 456,
@@ -279,7 +329,7 @@ mod tests {
     fn test_to_json() {
         let mut fragment = Fragment::new(123);
         let schema = ArrowSchema::new(vec![ArrowField::new("x", DataType::Float16, true)]);
-        fragment.add_file("foobar.lance", &Schema::try_from(&schema).unwrap());
+        fragment.add_file_legacy("foobar.lance", &Schema::try_from(&schema).unwrap());
         fragment.deletion_file = Some(DeletionFile {
             read_version: 123,
             id: 456,

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -21,10 +21,13 @@ pub struct DataFile {
     /// The ids of fields in this file.
     pub fields: Vec<i32>,
     /// The offsets of the fields listed in `fields`, empty in v1 files
+    #[serde(default)]
     pub column_offsets: Vec<u32>,
     /// The major version of the file format used to write this file.
+    #[serde(default)]
     pub file_major_version: u32,
     /// The minor version of the file format used to write this file.
+    #[serde(default)]
     pub file_minor_version: u32,
 }
 

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -512,9 +512,9 @@ mod tests {
         )]);
         let schema = Schema::try_from(&arrow_schema).unwrap();
         let fragments = vec![
-            Fragment::with_file(0, "path1", &schema, Some(10)),
-            Fragment::with_file(1, "path2", &schema, Some(15)),
-            Fragment::with_file(2, "path3", &schema, Some(20)),
+            Fragment::with_file_legacy(0, "path1", &schema, Some(10)),
+            Fragment::with_file_legacy(1, "path2", &schema, Some(15)),
+            Fragment::with_file_legacy(2, "path3", &schema, Some(20)),
         ];
         let manifest = Manifest::new(schema, Arc::new(fragments));
 
@@ -561,24 +561,15 @@ mod tests {
         let fragments = vec![
             Fragment {
                 id: 0,
-                files: vec![DataFile {
-                    path: "path1".to_string(),
-                    fields: vec![0, 1, 2],
-                }],
+                files: vec![DataFile::new_legacy_from_fields("path1", vec![0, 1, 2])],
                 deletion_file: None,
                 physical_rows: None,
             },
             Fragment {
                 id: 1,
                 files: vec![
-                    DataFile {
-                        path: "path2".to_string(),
-                        fields: vec![0, 1, 43],
-                    },
-                    DataFile {
-                        path: "path3".to_string(),
-                        fields: vec![2],
-                    },
+                    DataFile::new_legacy_from_fields("path2", vec![0, 1, 43]),
+                    DataFile::new_legacy_from_fields("path3", vec![2]),
                 ],
                 deletion_file: None,
                 physical_rows: None,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1857,6 +1857,21 @@ impl Dataset {
                 )
                 .await?;
 
+            // Some data files may no longer contain any columns in the dataset (e.g. if every
+            // remaining column has been altered into a different data file) and so we remove them
+            let schema_field_ids = new_schema.field_ids().into_iter().collect::<Vec<_>>();
+            let fragments = fragments
+                .into_iter()
+                .map(|mut frag| {
+                    frag.files.retain(|f| {
+                        f.fields
+                            .iter()
+                            .any(|field| schema_field_ids.contains(field))
+                    });
+                    frag
+                })
+                .collect::<Vec<_>>();
+
             Transaction::new(
                 self.manifest.version,
                 Operation::Merge {
@@ -4841,9 +4856,9 @@ mod tests {
         let indices = dataset.load_indices().await?;
         assert_eq!(indices.len(), 0);
 
-        // Each fragment gains a file with the new columns
+        // Each fragment gains a file with the new columns, but then the original file is dropped
         dataset.fragments().iter().for_each(|f| {
-            assert_eq!(f.files.len(), 5);
+            assert_eq!(f.files.len(), 4);
         });
 
         let expected_data = RecordBatch::try_new(

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -80,7 +80,7 @@ impl FileFragment {
 
         let (object_store, base_path) = ObjectStore::from_uri(dataset_uri).await?;
         let filename = format!("{}.lance", Uuid::new_v4());
-        let mut fragment = Fragment::with_file(id as u64, &filename, &schema, None);
+        let mut fragment = Fragment::with_file_legacy(id as u64, &filename, &schema, None);
         let full_path = base_path.child(DATA_DIR).child(filename.clone());
         let mut writer = FileWriter::<ManifestDescribing>::try_new(
             &object_store,
@@ -111,7 +111,8 @@ impl FileFragment {
         fragment_id: usize,
         physical_rows: Option<usize>,
     ) -> Result<Fragment> {
-        let fragment = Fragment::with_file(fragment_id as u64, filename, schema, physical_rows);
+        let fragment =
+            Fragment::with_file_legacy(fragment_id as u64, filename, schema, physical_rows);
         Ok(fragment)
     }
 
@@ -181,20 +182,20 @@ impl FileFragment {
         data_file.fields.first().copied().unwrap_or(0) as u32
     }
 
-    async fn open_readers(
+    async fn open_reader(
         &self,
-        projection: &Schema,
+        data_file: &DataFile,
+        projection: Option<&Schema>,
         with_row_id: bool,
-    ) -> Result<Vec<(FileReader, Schema)>> {
-        let full_schema = self.dataset.schema();
+    ) -> Result<Option<(FileReader, Schema)>> {
+        if data_file.is_legacy_file() {
+            let full_schema = self.dataset.schema();
 
-        let mut opened_files = vec![];
-        for (i, data_file) in self.metadata.files.iter().enumerate() {
             let data_file_schema = data_file.schema(full_schema);
+            let projection = projection.unwrap_or(full_schema);
             let schema_per_file = data_file_schema.intersection(projection)?;
-            let add_row_id = with_row_id && i == 0;
             let num_fields = data_file.fields.len() as u32;
-            if add_row_id || !schema_per_file.fields.is_empty() {
+            if with_row_id || !schema_per_file.fields.is_empty() {
                 let path = self.dataset.data_dir().child(data_file.path.as_str());
                 let field_id_offset = Self::get_field_id_offset(data_file);
                 let mut reader = FileReader::try_new_with_fragment_id(
@@ -207,9 +208,30 @@ impl FileFragment {
                     Some(&self.dataset.session.file_metadata_cache),
                 )
                 .await?;
-                reader.with_row_id(add_row_id);
+                reader.with_row_id(with_row_id);
                 let initialized_schema = reader.schema().project_by_schema(&schema_per_file)?;
-                opened_files.push((reader, initialized_schema));
+                Ok(Some((reader, initialized_schema)))
+            } else {
+                Ok(None)
+            }
+        } else {
+            todo!()
+        }
+    }
+
+    async fn open_readers(
+        &self,
+        projection: &Schema,
+        with_row_id: bool,
+    ) -> Result<Vec<(FileReader, Schema)>> {
+        let mut opened_files = vec![];
+        for (i, data_file) in self.metadata.files.iter().enumerate() {
+            let with_row_id = with_row_id && i == 0;
+            if let Some((reader, schema)) = self
+                .open_reader(data_file, Some(projection), with_row_id)
+                .await?
+            {
+                opened_files.push((reader, schema));
             }
         }
 
@@ -300,18 +322,16 @@ impl FileFragment {
 
         // Just open any file. All of them should have same size.
         let some_file = &self.metadata.files[0];
-        let path = self.dataset.data_dir().child(some_file.path.as_str());
-        let num_fields = some_file.fields.len() as u32;
-        let reader = FileReader::try_new_with_fragment_id(
-            &self.dataset.object_store,
-            &path,
-            self.schema().clone(),
-            self.id() as u32,
-            Self::get_field_id_offset(some_file),
-            num_fields,
-            Some(&self.dataset.session.file_metadata_cache),
-        )
-        .await?;
+        let (reader, _) = self
+            .open_reader(some_file, None, false)
+            .await?
+            .ok_or_else(|| Error::Internal {
+                message: format!(
+                    "The data file {} did not have any fields contained in the dataset schema",
+                    some_file.path
+                ),
+                location: location!(),
+            })?;
 
         Ok(reader.len())
     }
@@ -342,29 +362,23 @@ impl FileFragment {
             }
         }
 
-        let get_lengths = self
-            .metadata
-            .files
-            .iter()
-            .map(|data_file| {
-                let path = self.dataset.data_dir().child(data_file.path.as_str());
-                let field_id_offset = Self::get_field_id_offset(data_file);
-                let num_fields = data_file.fields.len() as u32;
-                (path, field_id_offset, num_fields)
-            })
-            .map(|(path, field_id_offset, num_fields)| async move {
-                let reader = FileReader::try_new_with_fragment_id(
-                    &self.dataset.object_store,
-                    &path,
-                    self.schema().clone(),
-                    self.id() as u32,
-                    field_id_offset,
-                    num_fields,
-                    Some(&self.dataset.session.file_metadata_cache),
-                )
-                .await?;
-                Result::Ok(reader.len())
-            });
+        for data_file in &self.metadata.files {
+            data_file.validate(&self.dataset.data_dir())?;
+        }
+
+        let get_lengths = self.metadata.files.iter().map(|data_file| async move {
+            let (reader, _) = self
+                .open_reader(data_file, None, false)
+                .await?
+                .ok_or_else(|| {
+                    Error::corrupt_file(
+                        self.dataset.data_dir().child(data_file.path.clone()),
+                        "did not have any fields in common with the dataset schema",
+                        location!(),
+                    )
+                })?;
+            Result::Ok(reader.len())
+        });
         let get_lengths = try_join_all(get_lengths);
 
         let deletion_vector = read_deletion_file(

--- a/rust/lance/src/dataset/updater.rs
+++ b/rust/lance/src/dataset/updater.rs
@@ -111,7 +111,7 @@ impl Updater {
     /// Internal use only.
     async fn new_writer(&mut self, schema: Schema) -> Result<FileWriter<ManifestDescribing>> {
         let file_name = format!("{}.lance", Uuid::new_v4());
-        self.fragment.metadata.add_file(&file_name, &schema);
+        self.fragment.metadata.add_file_legacy(&file_name, &schema);
 
         let full_path = self.fragment.dataset().data_dir().child(file_name.as_str());
 

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -210,7 +210,7 @@ impl WriterGenerator {
 
         // Use temporary ID 0; will assign ID later.
         let mut fragment = Fragment::new(0);
-        fragment.add_file(&data_file_path, &self.schema);
+        fragment.add_file_legacy(&data_file_path, &self.schema);
 
         let full_path = self.base_dir.child(DATA_DIR).child(data_file_path);
         let writer = FileWriter::try_new(

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -852,14 +852,8 @@ mod tests {
             Fragment {
                 id: 0,
                 files: vec![
-                    DataFile {
-                        path: "path1".to_string(),
-                        fields: vec![0, 1, 2],
-                    },
-                    DataFile {
-                        path: "unused".to_string(),
-                        fields: vec![9],
-                    },
+                    DataFile::new_legacy_from_fields("path1", vec![0, 1, 2]),
+                    DataFile::new_legacy_from_fields("unused", vec![9]),
                 ],
                 deletion_file: None,
                 physical_rows: None,
@@ -867,14 +861,8 @@ mod tests {
             Fragment {
                 id: 1,
                 files: vec![
-                    DataFile {
-                        path: "path2".to_string(),
-                        fields: vec![0, 1, 2],
-                    },
-                    DataFile {
-                        path: "path3".to_string(),
-                        fields: vec![2],
-                    },
+                    DataFile::new_legacy_from_fields("path2", vec![0, 1, 2]),
+                    DataFile::new_legacy_from_fields("path3", vec![2]),
                 ],
                 deletion_file: None,
                 physical_rows: None,
@@ -900,24 +888,15 @@ mod tests {
         let expected_fragments = vec![
             Fragment {
                 id: 0,
-                files: vec![DataFile {
-                    path: "path1".to_string(),
-                    fields: vec![0, 1, 10],
-                }],
+                files: vec![DataFile::new_legacy_from_fields("path1", vec![0, 1, 10])],
                 deletion_file: None,
                 physical_rows: None,
             },
             Fragment {
                 id: 1,
                 files: vec![
-                    DataFile {
-                        path: "path2".to_string(),
-                        fields: vec![0, 1, 2],
-                    },
-                    DataFile {
-                        path: "path3".to_string(),
-                        fields: vec![10],
-                    },
+                    DataFile::new_legacy_from_fields("path2", vec![0, 1, 2]),
+                    DataFile::new_legacy_from_fields("path3", vec![10]),
                 ],
                 deletion_file: None,
                 physical_rows: None,


### PR DESCRIPTION
Refactor the file opening code in fragment to use common paths.

Add validation logic for data files.

Fix alter_columns so that it drops data files that are no longer referenced.

Put in groundwork for new fragment info for v2.