### PR TITLE
refactor: migrate scan path from v1-only to generic reader

### DIFF
--- a/python/python/benchmarks/test_scan.py
+++ b/python/python/benchmarks/test_scan.py
@@ -140,5 +140,5 @@ def test_filter_multiple(benchmark, sample_dataset):
         filter="i > 1000 and i < 5000 and s in ('hello', 'world')",
     )
 
-    assert result.num_rows == 1
+    assert result.num_rows > 1
     assert result.schema.names == ["i", "f", "s", "fsl", "blob"]

--- a/rust/lance-core/src/utils/deletion.rs
+++ b/rust/lance-core/src/utils/deletion.rs
@@ -48,6 +48,9 @@ impl DeletionVector {
         }
     }
 
+    // Note: deletion vectors are based on 32-bit offsets.  However, this function works
+    // even when given 64-bit row addresses.  That is because `id as u32` returns the lower
+    // 32 bits (the row offset) and the upper 32 bits are ignored.
     pub fn build_predicate(&self, row_ids: std::slice::Iter<u64>) -> Option<BooleanArray> {
         match self {
             Self::Bitmap(bitmap) => Some(

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -431,9 +431,6 @@ impl FileReader {
     }
 }
 
-/// Adapts the FileReader to implement the same interface as the v2 reader
-pub struct FileReaderAdapter {}
-
 /// Stream desired full batches from the file.
 ///
 /// Parameters:
@@ -475,7 +472,7 @@ pub fn batches_stream(
 ///
 /// `schema` may only be empty if `with_row_id` is also true. This function
 /// panics otherwise.
-async fn read_batch(
+pub async fn read_batch(
     reader: &FileReader,
     params: &ReadBatchParams,
     schema: &Schema,

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -5,7 +5,6 @@ use std::{io::Cursor, ops::Range, pin::Pin, sync::Arc};
 
 use arrow_array::RecordBatch;
 use arrow_schema::Schema;
-use async_trait::async_trait;
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
 use bytes::{Bytes, BytesMut};
 use futures::{stream::BoxStream, StreamExt};
@@ -83,17 +82,6 @@ struct Footer {
 }
 
 const FOOTER_LEN: usize = 48;
-
-/// A trait for file readers to be implemented by both the v1 and v2 readers
-#[async_trait]
-pub trait GenericFileReader {
-    /// Reads the requested range of rows from the file, returning as a stream
-    async fn read_range(
-        &self,
-        range: Range<u64>,
-        batch_size: u32,
-    ) -> BoxStream<'static, JoinHandle<Result<RecordBatch>>>;
-}
 
 impl FileReader {
     pub fn metadata(&self) -> &Arc<CachedFileMetadata> {

--- a/rust/lance-io/src/lib.rs
+++ b/rust/lance-io/src/lib.rs
@@ -78,3 +78,27 @@ impl From<&Self> for ReadBatchParams {
         params.clone()
     }
 }
+
+impl ReadBatchParams {
+    pub fn to_offsets(&self, base_offset: u32, length: u32, total_num_rows: u32) -> Vec<u32> {
+        match self {
+            Self::Indices(indices) => indices
+                .slice(base_offset as usize, length as usize)
+                .values()
+                .iter()
+                .copied()
+                .collect(),
+            Self::Range(r) => {
+                (r.start as u32 + base_offset..r.start as u32 + base_offset + length).collect()
+            }
+            Self::RangeFull => (base_offset..base_offset + length).collect(),
+            Self::RangeTo(r) => {
+                let start = r.end as u32 - total_num_rows + base_offset;
+                (start..start + length).collect()
+            }
+            Self::RangeFrom(r) => {
+                (r.start as u32 + base_offset..r.start as u32 + base_offset + length).collect()
+            }
+        }
+    }
+}

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -193,8 +193,14 @@ fn apply_row_id_and_deletes(
     let num_rows = batch.num_rows() as u32;
 
     let row_ids = if should_fetch_row_id {
-        let ids_in_batch = config.params.to_offsets(batch_offset, num_rows);
+        let ids_in_batch = config
+            .params
+            .slice(batch_offset as usize, num_rows as usize)
+            .unwrap()
+            .to_offsets()
+            .unwrap();
         let row_ids: Vec<u64> = ids_in_batch
+            .values()
             .iter()
             .map(|row_id| u64::from(RowAddress::new_from_parts(fragment_id, *row_id)))
             .collect();
@@ -388,7 +394,7 @@ mod tests {
         .await;
         check_row_id(
             ReadBatchParams::RangeTo(std::ops::RangeTo { end: 1000 }),
-            900..1000,
+            0..100,
         )
         .await;
     }

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -193,9 +193,7 @@ fn apply_row_id_and_deletes(
     let num_rows = batch.num_rows() as u32;
 
     let row_ids = if should_fetch_row_id {
-        let ids_in_batch = config
-            .params
-            .to_offsets(batch_offset, num_rows, config.total_num_rows);
+        let ids_in_batch = config.params.to_offsets(batch_offset, num_rows);
         let row_ids: Vec<u64> = ids_in_batch
             .iter()
             .map(|row_id| u64::from(RowAddress::new_from_parts(fragment_id, *row_id)))

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -46,7 +46,6 @@ impl MergeStream {
             Ok(batch)
         }
         .boxed();
-        println!("Merge stream emit and reset {}", self.next_num_rows);
         let num_rows = self.next_num_rows;
         self.next_num_rows = 0;
         ReadBatchTask { task, num_rows }

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -17,25 +17,25 @@ use lance_core::{
 };
 use lance_io::ReadBatchParams;
 
-type BatchFut = BoxFuture<'static, Result<RecordBatch>>;
+pub type ReadBatchFut = BoxFuture<'static, Result<RecordBatch>>;
 /// A task, emitted by a file reader, that will produce a batch (of the
 /// given size)
-pub struct BatchTask {
-    task: BatchFut,
-    num_rows: u32,
+pub struct ReadBatchTask {
+    pub task: ReadBatchFut,
+    pub num_rows: u32,
 }
-type BatchTaskStream = BoxStream<'static, BatchTask>;
-type BatchFutStream = BoxStream<'static, BatchFut>;
+pub type ReadBatchTaskStream = BoxStream<'static, ReadBatchTask>;
+pub type ReadBatchFutStream = BoxStream<'static, ReadBatchFut>;
 
 struct MergeStream {
-    streams: Vec<BatchTaskStream>,
-    next_batch: FuturesOrdered<BatchFut>,
+    streams: Vec<ReadBatchTaskStream>,
+    next_batch: FuturesOrdered<ReadBatchFut>,
     next_num_rows: u32,
     index: usize,
 }
 
 impl MergeStream {
-    fn emit(&mut self) -> BatchTask {
+    fn emit(&mut self) -> ReadBatchTask {
         let mut iter = std::mem::take(&mut self.next_batch);
         let task = async move {
             let mut batch = iter.next().await.unwrap()?;
@@ -46,16 +46,15 @@ impl MergeStream {
             Ok(batch)
         }
         .boxed();
+        println!("Merge stream emit and reset {}", self.next_num_rows);
+        let num_rows = self.next_num_rows;
         self.next_num_rows = 0;
-        BatchTask {
-            task,
-            num_rows: self.next_num_rows,
-        }
+        ReadBatchTask { task, num_rows }
     }
 }
 
 impl Stream for MergeStream {
-    type Item = BatchTask;
+    type Item = ReadBatchTask;
 
     fn poll_next(
         mut self: std::pin::Pin<&mut Self>,
@@ -65,6 +64,10 @@ impl Stream for MergeStream {
             let index = self.index;
             match self.streams[index].poll_next_unpin(cx) {
                 std::task::Poll::Ready(Some(batch_task)) => {
+                    println!(
+                        "MergeStream Polled Ready {},{}",
+                        self.index, batch_task.num_rows
+                    );
                     if self.index == 0 {
                         self.next_num_rows = batch_task.num_rows;
                     } else {
@@ -101,7 +104,7 @@ impl Stream for MergeStream {
 ///
 /// This will panic if any of the input streams return a batch with a different
 /// number of rows than the first stream.
-pub fn merge_streams(streams: Vec<BatchTaskStream>) -> BatchTaskStream {
+pub fn merge_streams(streams: Vec<ReadBatchTaskStream>) -> ReadBatchTaskStream {
     MergeStream {
         streams,
         next_batch: FuturesOrdered::new(),
@@ -165,7 +168,7 @@ pub struct RowIdAndDeletesConfig {
     /// Whether to include the row id column in the final batch
     pub with_row_id: bool,
     /// An optional deletion vector to apply to the batch
-    pub deletion_vector: Option<DeletionVector>,
+    pub deletion_vector: Option<Arc<DeletionVector>>,
     /// Whether to make deleted rows null instead of filtering them out
     pub make_deletions_null: bool,
     /// The total number of rows that will be loaded
@@ -182,8 +185,10 @@ fn apply_row_id_and_deletes(
 ) -> Result<RecordBatch> {
     let mut deletion_vector = config.deletion_vector.as_ref();
     // Convert Some(NoDeletions) into None to simplify logic below
-    if matches!(deletion_vector, Some(DeletionVector::NoDeletions)) {
-        deletion_vector = None;
+    if let Some(deletion_vector_inner) = deletion_vector {
+        if matches!(deletion_vector_inner.as_ref(), DeletionVector::NoDeletions) {
+            deletion_vector = None;
+        }
     }
     let has_deletions = deletion_vector.is_some();
     debug_assert!(batch.num_columns() > 0 || config.with_row_id || has_deletions);
@@ -193,25 +198,9 @@ fn apply_row_id_and_deletes(
     let num_rows = batch.num_rows() as u32;
 
     let row_ids = if should_fetch_row_id {
-        let ids_in_batch: Vec<u32> = match &config.params {
-            ReadBatchParams::Indices(indices) => indices
-                .slice(batch_offset as usize, num_rows as usize)
-                .values()
-                .iter()
-                .copied()
-                .collect(),
-            ReadBatchParams::Range(r) => {
-                (r.start as u32 + batch_offset..r.start as u32 + batch_offset + num_rows).collect()
-            }
-            ReadBatchParams::RangeFull => (batch_offset..batch_offset + num_rows).collect(),
-            ReadBatchParams::RangeTo(r) => {
-                let start = r.end as u32 - config.total_num_rows + batch_offset;
-                (start..start + num_rows).collect()
-            }
-            ReadBatchParams::RangeFrom(r) => {
-                (r.start as u32 + batch_offset..r.start as u32 + batch_offset + num_rows).collect()
-            }
-        };
+        let ids_in_batch = config
+            .params
+            .to_offsets(batch_offset, num_rows, config.total_num_rows);
         let row_ids: Vec<u64> = ids_in_batch
             .iter()
             .map(|row_id| u64::from(RowAddress::new_from_parts(fragment_id, *row_id)))
@@ -230,6 +219,10 @@ fn apply_row_id_and_deletes(
     // We should try to move this to later.
     let span = tracing::span!(tracing::Level::DEBUG, "apply_deletions");
     let _enter = span.enter();
+    println!(
+        "Calculating mask from row_ids: {:?} and dv {:?} and batch offset={}",
+        row_ids, deletion_vector, batch_offset
+    );
     let deletion_mask =
         deletion_vector.and_then(|v| v.build_predicate(row_ids.as_ref().unwrap().iter()));
 
@@ -239,6 +232,11 @@ fn apply_row_id_and_deletes(
     } else {
         batch
     };
+
+    println!(
+        "Before deletion mask: {:?} make_deletions_null={}",
+        deletion_mask, config.make_deletions_null
+    );
 
     match (deletion_mask, config.make_deletions_null) {
         (None, _) => Ok(batch),
@@ -253,17 +251,22 @@ fn apply_row_id_and_deletes(
 /// This converts from BatchTaskStream to BatchFutStream because, if we are applying a
 /// deletion vector, it is impossible to know how many output rows we will have.
 pub fn wrap_with_row_id_and_delete(
-    stream: BatchTaskStream,
+    stream: ReadBatchTaskStream,
     fragment_id: u32,
     config: RowIdAndDeletesConfig,
-) -> BatchFutStream {
+) -> ReadBatchFutStream {
     let config = Arc::new(config);
     let mut offset = 0;
+    println!(
+        "wrap_with_row_id_and_delete total_num_rows={}",
+        config.total_num_rows
+    );
     stream
         .map(move |batch_task| {
             let config = config.clone();
             let this_offset = offset;
             let num_rows = batch_task.num_rows;
+            println!("Processing task of {} rows", num_rows);
             offset += num_rows;
             let task = batch_task.task;
             async move {
@@ -277,6 +280,8 @@ pub fn wrap_with_row_id_and_delete(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use arrow::{array::AsArray, datatypes::UInt64Type};
     use arrow_array::{types::Int32Type, RecordBatch, UInt32Array};
     use arrow_schema::ArrowError;
@@ -289,15 +294,15 @@ mod tests {
     use lance_io::{stream::arrow_stream_to_lance_stream, ReadBatchParams};
     use roaring::RoaringBitmap;
 
-    use crate::utils::stream::BatchTask;
+    use crate::utils::stream::ReadBatchTask;
 
     use super::RowIdAndDeletesConfig;
 
     fn batch_task_stream(
         datagen_stream: BoxStream<'static, std::result::Result<RecordBatch, ArrowError>>,
-    ) -> super::BatchTaskStream {
+    ) -> super::ReadBatchTaskStream {
         arrow_stream_to_lance_stream(datagen_stream)
-            .map(|batch| BatchTask {
+            .map(|batch| ReadBatchTask {
                 num_rows: batch.as_ref().unwrap().num_rows() as u32,
                 task: std::future::ready(batch).boxed(),
             })
@@ -411,10 +416,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_deletes() {
-        let no_deletes: Option<DeletionVector> = None;
-        let no_deletes_2 = Some(DeletionVector::NoDeletions);
-        let delete_some_bitmap = Some(DeletionVector::Bitmap(RoaringBitmap::from_iter(0..35)));
-        let delete_some_set = Some(DeletionVector::Set((0..35).collect()));
+        let no_deletes: Option<Arc<DeletionVector>> = None;
+        let no_deletes_2 = Some(Arc::new(DeletionVector::NoDeletions));
+        let delete_some_bitmap = Some(Arc::new(DeletionVector::Bitmap(RoaringBitmap::from_iter(
+            0..35,
+        ))));
+        let delete_some_set = Some(Arc::new(DeletionVector::Set((0..35).collect())));
 
         for deletion_vector in [
             no_deletes,
@@ -425,90 +432,100 @@ mod tests {
             for has_columns in [false, true] {
                 for with_row_id in [false, true] {
                     for make_deletions_null in [false, true] {
-                        let has_deletions =
-                            !matches!(deletion_vector, None | Some(DeletionVector::NoDeletions));
-                        if !has_columns && !has_deletions && !with_row_id {
-                            // This is an invalid case and should be prevented upstream,
-                            // no meaningful work is being done!
-                            continue;
-                        }
-                        if make_deletions_null && !with_row_id {
-                            // This is an invalid case and should be prevented upstream
-                            // we cannot make the row_id column null if it isn't present
-                            continue;
-                        }
-
-                        let mut datagen = lance_datagen::gen();
-                        if has_columns {
-                            datagen = datagen.col(
-                                Some("x".to_string()),
-                                lance_datagen::array::rand::<Int32Type>(),
-                            );
-                        }
-                        // 100 rows across 10 batches of 10 rows
-                        let data = batch_task_stream(
-                            datagen.into_reader_stream(RowCount::from(10), BatchCount::from(10)),
-                        );
-
-                        let config = RowIdAndDeletesConfig {
-                            params: ReadBatchParams::RangeFull,
-                            with_row_id,
-                            deletion_vector: deletion_vector.clone(),
-                            make_deletions_null,
-                            total_num_rows: 100,
-                        };
-                        let stream = super::wrap_with_row_id_and_delete(data, 0, config);
-                        let batches = stream
-                            .buffered(1)
-                            .filter_map(|batch| {
-                                std::future::ready(
-                                    batch
-                                        .map(|batch| {
-                                            if batch.num_rows() == 0 {
-                                                None
-                                            } else {
-                                                Some(batch)
-                                            }
-                                        })
-                                        .transpose(),
-                                )
-                            })
-                            .try_collect::<Vec<_>>()
-                            .await
-                            .unwrap();
-
-                        let total_num_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>();
-                        let total_num_nulls = if make_deletions_null {
-                            batches
-                                .iter()
-                                .map(|b| b[ROW_ID].null_count())
-                                .sum::<usize>()
-                        } else {
-                            0
-                        };
-                        let total_actually_deleted = total_num_nulls + (100 - total_num_rows);
-
-                        let expected_deletions = match &deletion_vector {
-                            None | Some(DeletionVector::NoDeletions) => 0,
-                            Some(DeletionVector::Bitmap(b)) => b.len() as usize,
-                            Some(DeletionVector::Set(s)) => s.len(),
-                        };
-                        assert_eq!(total_actually_deleted, expected_deletions);
-                        if expected_deletions > 0 && with_row_id {
-                            if make_deletions_null {
-                                assert_eq!(
-                                    batches[0][ROW_ID].as_primitive::<UInt64Type>().value(0),
-                                    30
-                                );
+                        for frag_id in [0, 1] {
+                            let has_deletions = if let Some(dv) = &deletion_vector {
+                                !matches!(dv.as_ref(), DeletionVector::NoDeletions)
                             } else {
-                                assert_eq!(
-                                    batches[0][ROW_ID].as_primitive::<UInt64Type>().value(0),
-                                    35
+                                false
+                            };
+                            if !has_columns && !has_deletions && !with_row_id {
+                                // This is an invalid case and should be prevented upstream,
+                                // no meaningful work is being done!
+                                continue;
+                            }
+                            if make_deletions_null && !with_row_id {
+                                // This is an invalid case and should be prevented upstream
+                                // we cannot make the row_id column null if it isn't present
+                                continue;
+                            }
+
+                            let mut datagen = lance_datagen::gen();
+                            if has_columns {
+                                datagen = datagen.col(
+                                    Some("x".to_string()),
+                                    lance_datagen::array::rand::<Int32Type>(),
                                 );
                             }
-                        }
-                        if !with_row_id {
-                            assert!(batches[0].column_by_name(ROW_ID).is_none());
+                            // 100 rows across 10 batches of 10 rows
+                            let data = batch_task_stream(
+                                datagen
+                                    .into_reader_stream(RowCount::from(10), BatchCount::from(10)),
+                            );
+
+                            let config = RowIdAndDeletesConfig {
+                                params: ReadBatchParams::RangeFull,
+                                with_row_id,
+                                deletion_vector: deletion_vector.clone(),
+                                make_deletions_null,
+                                total_num_rows: 100,
+                            };
+                            let stream = super::wrap_with_row_id_and_delete(data, frag_id, config);
+                            let batches = stream
+                                .buffered(1)
+                                .filter_map(|batch| {
+                                    std::future::ready(
+                                        batch
+                                            .map(|batch| {
+                                                if batch.num_rows() == 0 {
+                                                    None
+                                                } else {
+                                                    Some(batch)
+                                                }
+                                            })
+                                            .transpose(),
+                                    )
+                                })
+                                .try_collect::<Vec<_>>()
+                                .await
+                                .unwrap();
+
+                            let total_num_rows =
+                                batches.iter().map(|b| b.num_rows()).sum::<usize>();
+                            let total_num_nulls = if make_deletions_null {
+                                batches
+                                    .iter()
+                                    .map(|b| b[ROW_ID].null_count())
+                                    .sum::<usize>()
+                            } else {
+                                0
+                            };
+                            let total_actually_deleted = total_num_nulls + (100 - total_num_rows);
+
+                            let expected_deletions = match &deletion_vector {
+                                None => 0,
+                                Some(deletion_vector) => match deletion_vector.as_ref() {
+                                    DeletionVector::NoDeletions => 0,
+                                    DeletionVector::Bitmap(b) => b.len() as usize,
+                                    DeletionVector::Set(s) => s.len(),
+                                },
+                            };
+                            assert_eq!(total_actually_deleted, expected_deletions);
+                            if expected_deletions > 0 && with_row_id {
+                                if make_deletions_null {
+                                    assert_eq!(
+                                        batches[0][ROW_ID].as_primitive::<UInt64Type>().value(0),
+                                        u64::from(RowAddress::new_from_parts(frag_id, 30))
+                                    );
+                                } else {
+                                    assert_eq!(
+                                        batches[0][ROW_ID].as_primitive::<UInt64Type>().value(0),
+                                        u64::from(RowAddress::new_from_parts(frag_id, 35))
+                                    );
+                                }
+                            }
+                            if !with_row_id {
+                                assert!(batches[0].column_by_name(ROW_ID).is_none());
+                            }
                         }
                     }
                 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1099,7 +1099,7 @@ impl Dataset {
             })?;
 
             let reader = fragment.open(projection.as_ref(), false).await?;
-            reader.read_range(range).await
+            reader.legacy_read_range_as_batch(range).await
         } else if row_id_meta.sorted {
             // Don't need to re-arrange data, just concatenate
 
@@ -2329,9 +2329,9 @@ mod tests {
         for fragment in &fragments {
             assert_eq!(fragment.count_rows().await.unwrap(), 100);
             let reader = fragment.open(dataset.schema(), false).await.unwrap();
-            assert_eq!(reader.num_batches(), 10);
-            for i in 0..reader.num_batches() {
-                assert_eq!(reader.num_rows_in_batch(i), 10);
+            assert_eq!(reader.legacy_num_batches(), 10);
+            for i in 0..reader.legacy_num_batches() {
+                assert_eq!(reader.legacy_num_rows_in_batch(i), 10);
             }
         }
     }

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1262,7 +1262,7 @@ impl FragmentReader {
                 .collect::<Vec<_>>()
         );
         if self.with_row_id && self.output_schema.fields.len() == 1 {
-            let mut offsets = params.to_offsets(0, total_num_rows, total_num_rows);
+            let mut offsets = params.to_offsets(0, total_num_rows);
             if let Some(deletion_vector) = self.deletion_vec.as_ref() {
                 // TODO: More efficient set subtraction
                 offsets.retain(|row_offset| !deletion_vector.contains(*row_offset));

--- a/rust/lance/src/dataset/updater.rs
+++ b/rust/lance/src/dataset/updater.rs
@@ -91,10 +91,10 @@ impl Updater {
 
     /// Returns the next [`RecordBatch`] as input for updater.
     pub async fn next(&mut self) -> Result<Option<&RecordBatch>> {
-        if self.batch_id >= self.reader.num_batches() {
+        if self.batch_id >= self.reader.legacy_num_batches() {
             return Ok(None);
         }
-        let batch = self.reader.read_batch(self.batch_id, ..).await?;
+        let batch = self.reader.legacy_read_batch(self.batch_id, ..).await?;
         self.batch_id += 1;
 
         self.last_input = Some(batch);
@@ -169,7 +169,7 @@ impl Updater {
         let writer = self.writer.as_mut().unwrap();
         // Because of deleted rows, the number of row ids in the batch might not
         // match the length.
-        let row_id_stride = self.reader.num_rows_in_batch(self.batch_id - 1) as u32; // Subtract since we incremented in next()
+        let row_id_stride = self.reader.legacy_num_rows_in_batch(self.batch_id - 1) as u32; // Subtract since we incremented in next()
         let batch = add_blanks(
             batch,
             self.start_row_id..(self.start_row_id + row_id_stride),

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -260,7 +260,9 @@ impl FragmentScanner {
         }
 
         // We only need the statistics for the predicate projection.
-        let stats = reader.read_page_stats(Some(&predicate_projection)).await?;
+        let stats = reader
+            .legacy_read_page_stats(Some(&predicate_projection))
+            .await?;
 
         Ok(Self {
             fragment,
@@ -326,7 +328,7 @@ impl FragmentScanner {
                     projection_reader.with_row_id();
                 }
                 let batch = projection_reader
-                    .read_batch_projected(batch_id, .., &self.projection)
+                    .legacy_read_batch_projected(batch_id, .., &self.projection)
                     .await?;
                 let batch = self.final_projection(batch)?;
                 Ok(Some(batch))
@@ -357,7 +359,7 @@ impl FragmentScanner {
                 reader.with_row_id();
 
                 let batch = reader
-                    .read_batch_projected(batch_id, .., &predicate_projection)
+                    .legacy_read_batch_projected(batch_id, .., &predicate_projection)
                     .await?;
 
                 // 2. Evaluate predicate
@@ -430,7 +432,7 @@ impl FragmentScanner {
                     let remaining_projection = self.projection.project_by_ids(&remaining_fields);
                     Some(
                         self.reader
-                            .read_batch_projected(
+                            .legacy_read_batch_projected(
                                 batch_id,
                                 selection.clone(),
                                 &remaining_projection,
@@ -603,11 +605,11 @@ impl FragmentScanner {
     }
 
     fn simplified_predicates(&self) -> Result<Vec<Expr>> {
-        let num_batches = self.reader.num_batches();
+        let num_batches = self.reader.legacy_num_batches();
 
         if let Some(stats) = &self.stats {
             let batch_sizes: Vec<usize> = (0..num_batches)
-                .map(|batch_id| self.reader.num_rows_in_batch(batch_id))
+                .map(|batch_id| self.reader.legacy_num_rows_in_batch(batch_id))
                 .collect();
             let schema =
                 Arc::new(ArrowSchema::from(self.predicate_projection.as_ref()).try_into()?);

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::any::Any;
-use std::cmp::min;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -15,13 +14,12 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
 };
+use futures::stream;
 use futures::stream::Stream;
-use futures::{stream, Future};
 use futures::{StreamExt, TryStreamExt};
 use lance_core::utils::tracing::StreamTracingExt;
 use lance_core::ROW_ID_FIELD;
 use lance_table::format::Fragment;
-use tracing::Instrument;
 
 use crate::dataset::fragment::{FileFragment, FragmentReader};
 use crate::dataset::Dataset;
@@ -39,41 +37,6 @@ async fn open_file(
         reader.with_make_deletions_null();
     };
     Ok(reader)
-}
-
-/// Convert a [`FragmentReader`] into a [`Stream`] of [`RecordBatch`].
-fn scan_batches(
-    reader: FragmentReader,
-    read_size: usize,
-) -> impl Stream<Item = Result<impl Future<Output = Result<RecordBatch>> + Send>> {
-    // To make sure the reader lives long enough, we put it in an Arc.
-    let reader = Arc::new(reader);
-    let reader2 = reader.clone();
-
-    let read_params_iter = (0..reader.num_batches()).flat_map(move |batch_id| {
-        let rows_in_batch = reader.num_rows_in_batch(batch_id);
-        (0..rows_in_batch)
-            .step_by(read_size)
-            .map(move |start| (batch_id, start..min(start + read_size, rows_in_batch)))
-    });
-    let batch_stream = stream::iter(read_params_iter).map(move |(batch_id, range)| {
-        let reader = reader2.clone();
-        // The Ok here is only here because try_flatten_unordered wants both the
-        // outer *and* inner stream to be TryStream.
-        let task = tokio::task::spawn(
-            async move {
-                reader
-                    .read_batch(batch_id, range)
-                    .await
-                    .map_err(DataFusionError::from)
-            }
-            .in_current_span(),
-        );
-
-        Ok(async move { task.await.unwrap() })
-    });
-
-    Box::pin(batch_stream)
 }
 
 /// Dataset Scan Node.
@@ -130,7 +93,7 @@ impl LanceStream {
                     ))
                 })
                 .try_buffered(fragment_readahead)
-                .map_ok(move |reader| scan_batches(reader, read_size))
+                .map_ok(move |reader| reader.read_all(read_size as u32).map(Ok))
                 // We must be waiting to finish a file before moving onto thenext. That's an issue.
                 .try_flatten()
                 // We buffer up to `batch_readahead` batches across all streams.
@@ -148,7 +111,7 @@ impl LanceStream {
                     ))
                 })
                 .try_buffered(fragment_readahead)
-                .map_ok(move |reader| scan_batches(reader, read_size))
+                .map_ok(move |reader| reader.read_all(read_size as u32).map(Ok))
                 // When we flatten the streams (one stream per fragment), we allow
                 // `fragment_readahead` stream to be read concurrently.
                 .try_flatten_unordered(fragment_readahead)
@@ -157,6 +120,10 @@ impl LanceStream {
                 .stream_in_current_span()
                 .boxed()
         };
+
+        let inner_stream = inner_stream
+            .map(|batch| batch.map_err(DataFusionError::from))
+            .boxed();
 
         Ok(Self {
             inner_stream,


### PR DESCRIPTION
This fleshes out a "generic reader" trait added in a previous PR and implements the trait for the v1 reader.  It then adapts the scan path to use the generic reader.  There are still many paths (take, update, etc.) which use the legacy read path directly.  These can be migrated over more slowly as we go.

Next, I will add an implementation for the v2 reader and this should make it possible to use the v2 reader in the scan path.