### PR TITLE
feat: debug functions

### DIFF
--- a/python/python/lance/debug.py
+++ b/python/python/lance/debug.py
@@ -5,7 +5,7 @@ Debug utilities for Lance.
 """
 
 # re-export from the native module.
+from .lance import format_fragment as format_fragment
+from .lance import format_manifest as format_manifest
+from .lance import format_schema as format_schema
 from .lance import list_transactions as list_transactions
-from .lance import print_fragment as print_fragment
-from .lance import print_manifest as print_manifest
-from .lance import print_schema as print_schema

--- a/python/python/lance/debug.py
+++ b/python/python/lance/debug.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+"""
+Debug utilities for Lance.
+"""
+
+# re-export from the native module.
+from .lance import (
+    list_transactions as list_transactions,
+)
+from .lance import (
+    print_manifest as print_manifest,
+)
+from .lance import (
+    print_schema as print_schema,
+)

--- a/python/python/lance/debug.py
+++ b/python/python/lance/debug.py
@@ -5,13 +5,7 @@ Debug utilities for Lance.
 """
 
 # re-export from the native module.
-from .lance import (
-    list_transactions as list_transactions,
-)
+from .lance import list_transactions as list_transactions
 from .lance import print_fragment as print_fragment
-from .lance import (
-    print_manifest as print_manifest,
-)
-from .lance import (
-    print_schema as print_schema,
-)
+from .lance import print_manifest as print_manifest
+from .lance import print_schema as print_schema

--- a/python/python/lance/debug.py
+++ b/python/python/lance/debug.py
@@ -8,6 +8,7 @@ Debug utilities for Lance.
 from .lance import (
     list_transactions as list_transactions,
 )
+from .lance import print_fragment as print_fragment
 from .lance import (
     print_manifest as print_manifest,
 )

--- a/python/python/lance/debug.pyi
+++ b/python/python/lance/debug.pyi
@@ -6,13 +6,13 @@ from typing import List
 from lance import LanceDataset
 from lance.fragment import FragmentMetadata
 
-def print_schema(dataset: LanceDataset) -> None:
+def format_schema(dataset: LanceDataset) -> str:
     pass
 
-def print_manifest(dataset: LanceDataset) -> None:
+def format_manifest(dataset: LanceDataset) -> str:
     pass
 
-def print_fragment(fragment: FragmentMetadata) -> None:
+def format_fragment(fragment: FragmentMetadata) -> str:
     pass
 
 def list_transactions(

--- a/python/python/lance/debug.pyi
+++ b/python/python/lance/debug.pyi
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+from typing import List
+
+from lance import LanceDataset
+
+def print_schema(dataset: LanceDataset) -> None:
+    pass
+
+def print_manifest(dataset: LanceDataset) -> None:
+    pass
+
+def list_transactions(
+    dataset: LanceDataset,
+    max_transactions: int = 10,
+) -> List[str]:
+    pass

--- a/python/python/lance/debug.pyi
+++ b/python/python/lance/debug.pyi
@@ -4,11 +4,15 @@
 from typing import List
 
 from lance import LanceDataset
+from lance.fragment import FragmentMetadata
 
 def print_schema(dataset: LanceDataset) -> None:
     pass
 
 def print_manifest(dataset: LanceDataset) -> None:
+    pass
+
+def print_fragment(fragment: FragmentMetadata) -> None:
     pass
 
 def list_transactions(

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -40,6 +40,12 @@ class FragmentMetadata:
         """
         self._metadata = _FragmentMetadata.from_json(metadata)
 
+    @classmethod
+    def from_metadata(cls, metadata: _FragmentMetadata):
+        instance = cls.__new__(cls)
+        instance._metadata = metadata
+        return instance
+
     def __repr__(self):
         return self._metadata.__repr__()
 
@@ -428,7 +434,7 @@ class LanceFragment(pa.dataset.Fragment):
         -------
         FragmentMetadata
         """
-        return FragmentMetadata(self._fragment.metadata().json())
+        return FragmentMetadata.from_metadata(self._fragment.metadata())
 
 
 def write_fragments(

--- a/python/python/tests/test_debug.py
+++ b/python/python/tests/test_debug.py
@@ -5,10 +5,15 @@ from pathlib import Path
 
 import lance
 import pyarrow as pa
-from lance.debug import list_transactions, print_fragment, print_manifest, print_schema
+from lance.debug import (
+    format_fragment,
+    format_manifest,
+    format_schema,
+    list_transactions,
+)
 
 
-def test_print_schema(capfd, tmp_path: Path):
+def test_format_schema(tmp_path: Path):
     schema = pa.schema({
         "a": pa.int64(),
         "b": pa.string(),
@@ -17,54 +22,50 @@ def test_print_schema(capfd, tmp_path: Path):
     table = pa.Table.from_batches([], schema)
     dataset = lance.write_dataset(table, tmp_path)
 
-    print_schema(dataset)
-    captured = capfd.readouterr()
-    assert captured.out.startswith("Schema")
+    output = format_schema(dataset)
+    assert output.startswith("Schema")
     assert (
         'Field {\n            name: "a",\n            id: 0,\n            parent_id:'
         ' -1,\n            logical_type: LogicalType(\n                "int64"'
-        in captured.out
+        in output
     )
     assert (
         'Field {\n            name: "b",\n            id: 1,\n            parent_id:'
         ' -1,\n            logical_type: LogicalType(\n                "string"'
-        in captured.out
+        in output
     )
     assert (
         'Field {\n            name: "c",\n            id: 2,\n            parent_id:'
-        ' -1,\n            logical_type: LogicalType(\n                "bool"'
-        in captured.out
+        ' -1,\n            logical_type: LogicalType(\n                "bool"' in output
     )
 
 
-def test_print_manifest(capfd, tmp_path: Path):
+def test_format_manifest(tmp_path: Path):
     table = pa.table({"x": range(10)})
     dataset = lance.write_dataset(table, tmp_path)
 
-    print_manifest(dataset)
-    captured = capfd.readouterr()
-    assert captured.out.startswith("Manifest {")
-    assert "Schema {" in captured.out
+    output = format_manifest(dataset)
+    assert output.startswith("Manifest {")
+    assert "Schema {" in output
     assert (
         'writer_version: Some(\n        WriterVersion {\n            library: "lance"'
-        in captured.out
+        in output
     )
-    assert "fragments: [\n        Fragment {" in captured.out
+    assert "fragments: [\n        Fragment {" in output
 
 
-def test_print_fragment(capfd, tmp_path: Path):
+def test_format_fragment(tmp_path: Path):
     table = pa.table({"x": range(10)})
     dataset = lance.write_dataset(table, tmp_path)
     dataset.add_columns({"y": "x + 1", "z": "'hello'"})
 
     fragment = dataset.get_fragments()[0].metadata
 
-    print_fragment(fragment)
-    captured = capfd.readouterr()
+    output = format_fragment(fragment)
 
-    assert captured.out.startswith("PrettyPrintableFragment {")
-    assert "files: [" in captured.out
-    assert "schema: Schema {" in captured.out
+    assert output.startswith("PrettyPrintableFragment {")
+    assert "files: [" in output
+    assert "schema: Schema {" in output
 
 
 def test_list_transactions(tmp_path: Path):

--- a/python/python/tests/test_debug.py
+++ b/python/python/tests/test_debug.py
@@ -19,7 +19,6 @@ def test_print_schema(capfd, tmp_path: Path):
 
     print_schema(dataset)
     captured = capfd.readouterr()
-    # breakpoint()
     assert captured.out.startswith("Schema")
     assert (
         'Field {\n            name: "a",\n            id: 0,\n            parent_id:'

--- a/python/python/tests/test_debug.py
+++ b/python/python/tests/test_debug.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+from pathlib import Path
+
+import lance
+import pyarrow as pa
+from lance.debug import list_transactions, print_manifest, print_schema
+
+
+def test_print_schema(capfd, tmp_path: Path):
+    schema = pa.schema({
+        "a": pa.int64(),
+        "b": pa.string(),
+        "c": pa.bool_(),
+    })
+    table = pa.Table.from_batches([], schema)
+    dataset = lance.write_dataset(table, tmp_path)
+
+    print_schema(dataset)
+    captured = capfd.readouterr()
+    # breakpoint()
+    assert captured.out.startswith("Schema")
+    assert (
+        'Field { name: "a", id: 0, parent_id: -1, logical_type: LogicalType("int64")'
+        in captured.out
+    )
+    assert (
+        'Field { name: "b", id: 1, parent_id: -1, logical_type: LogicalType("string")'
+        in captured.out
+    )
+    assert (
+        'Field { name: "c", id: 2, parent_id: -1, logical_type: LogicalType("bool")'
+        in captured.out
+    )
+
+
+def test_print_manifest(capfd, tmp_path: Path):
+    table = pa.table({"x": range(10)})
+    dataset = lance.write_dataset(table, tmp_path)
+
+    print_manifest(dataset)
+    captured = capfd.readouterr()
+    assert captured.out.startswith("Manifest {")
+    assert "Schema {" in captured.out
+    assert 'writer_version: Some(WriterVersion { library: "lance"' in captured.out
+    assert "fragments: [Fragment { id: 0," in captured.out
+
+
+def test_list_transactions(tmp_path: Path):
+    table = pa.table({"x": range(10)})
+    dataset = lance.write_dataset(table, tmp_path)
+    dataset = lance.write_dataset(table, tmp_path, mode="append")
+    dataset.delete("x = 5")
+    dataset.update({"x": "1"}, where="x = 2")
+
+    results = list_transactions(dataset)
+    assert len(results) == 4
+    assert all(r.startswith("Transaction {") for r in results)
+    assert "operation: Update {" in results[0]
+    assert "operation: Delete {" in results[1]
+    assert "operation: Append {" in results[2]
+    assert "operation: Overwrite {" in results[3]
+
+    results_2 = list_transactions(dataset, max_transactions=2)
+    assert len(results_2) == 2
+    assert results_2 == results[:2]

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -154,8 +154,12 @@ def test_dataset_progress(tmp_path: Path):
 
     assert metadata["id"] == 0
     assert len(metadata["files"]) == 1
-
-    assert fragment == FragmentMetadata.from_json(json.dumps(metadata))
+    # Fragments aren't exactly equal, because the file was written before
+    # physical_rows was known.
+    assert (
+        fragment.data_files()
+        == FragmentMetadata.from_json(json.dumps(metadata)).data_files()
+    )
 
     ctx = multiprocessing.get_context("spawn")
     p = ctx.Process(target=failing_write, args=(progress_uri, dataset_uri))

--- a/python/src/debug.rs
+++ b/python/src/debug.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use lance::Error;
+use pyo3::{exceptions::PyIOError, prelude::*};
+
+use crate::{Dataset, RT};
+
+/// Print the Lance schema of a dataset.
+///
+/// This can be used to view the field ids and types in the schema.
+#[pyfunction]
+pub fn print_schema(dataset: &PyAny) -> PyResult<()> {
+    let py = dataset.py();
+    let dataset = dataset.getattr("_ds")?.extract::<Py<Dataset>>()?;
+    let dataset_ref = &dataset.as_ref(py).borrow().ds;
+    let schema = dataset_ref.schema();
+    println!("{:?}", schema);
+    Ok(())
+}
+
+/// Print the full Lance manifest of the dataset.
+#[pyfunction]
+pub fn print_manifest(dataset: &PyAny) -> PyResult<()> {
+    let py = dataset.py();
+    let dataset = dataset.getattr("_ds")?.extract::<Py<Dataset>>()?;
+    let dataset_ref = &dataset.as_ref(py).borrow().ds;
+    let manifest = dataset_ref.manifest();
+    println!("{:?}", manifest);
+    Ok(())
+}
+
+/// Return a string representation of each transaction in the dataset, in
+/// reverse chronological order.
+///
+/// If `max_transactions` is provided, only the most recent `max_transactions`
+/// transactions will be returned. Defaults to 10.
+#[pyfunction]
+#[pyo3(signature = (dataset, /, max_transactions = 10))]
+pub fn list_transactions(
+    dataset: &PyAny,
+    max_transactions: usize,
+) -> PyResult<Vec<Option<String>>> {
+    let py = dataset.py();
+    let dataset = dataset.getattr("_ds")?.extract::<Py<Dataset>>()?;
+    let mut dataset = dataset.as_ref(py).borrow().ds.clone();
+
+    RT.block_on(Some(py), async move {
+        let mut transactions = vec![];
+
+        loop {
+            let transaction = dataset.read_transaction().await.map_err(|err| {
+                PyIOError::new_err(format!("Failed to read transaction file: {:?}", err))
+            })?;
+            if let Some(transaction) = transaction {
+                transactions.push(Some(format!("{:?}", transaction)));
+            } else {
+                transactions.push(None);
+            }
+
+            if transactions.len() >= max_transactions {
+                break;
+            } else {
+                match dataset
+                    .checkout_version(dataset.version().version - 1)
+                    .await
+                {
+                    Ok(ds) => dataset = Arc::new(ds),
+                    Err(Error::DatasetNotFound { .. }) => break,
+                    Err(err) => {
+                        return Err(PyIOError::new_err(format!(
+                            "Failed to checkout version: {:?}",
+                            err
+                        )))
+                    }
+                }
+            }
+        }
+
+        Ok(transactions)
+    })?
+}

--- a/python/src/debug.rs
+++ b/python/src/debug.rs
@@ -9,28 +9,26 @@ use pyo3::{exceptions::PyIOError, prelude::*};
 
 use crate::{Dataset, FragmentMetadata, RT};
 
-/// Print the Lance schema of a dataset.
+/// Format the Lance schema of a dataset as a string.
 ///
 /// This can be used to view the field ids and types in the schema.
 #[pyfunction]
-pub fn print_schema(dataset: &PyAny) -> PyResult<()> {
+pub fn format_schema(dataset: &PyAny) -> PyResult<String> {
     let py = dataset.py();
     let dataset = dataset.getattr("_ds")?.extract::<Py<Dataset>>()?;
     let dataset_ref = &dataset.as_ref(py).borrow().ds;
     let schema = dataset_ref.schema();
-    println!("{:#?}", schema);
-    Ok(())
+    Ok(format!("{:#?}", schema))
 }
 
 /// Print the full Lance manifest of the dataset.
 #[pyfunction]
-pub fn print_manifest(dataset: &PyAny) -> PyResult<()> {
+pub fn format_manifest(dataset: &PyAny) -> PyResult<String> {
     let py = dataset.py();
     let dataset = dataset.getattr("_ds")?.extract::<Py<Dataset>>()?;
     let dataset_ref = &dataset.as_ref(py).borrow().ds;
     let manifest = dataset_ref.manifest();
-    println!("{:#?}", manifest);
-    Ok(())
+    Ok(format!("{:#?}", manifest))
 }
 
 // These are dead code because they just exist for the debug impl.
@@ -77,7 +75,7 @@ impl PrettyPrintableFragment {
 
 /// Debug print a LanceFragment.
 #[pyfunction]
-pub fn print_fragment(fragment: &PyAny) -> PyResult<()> {
+pub fn format_fragment(fragment: &PyAny) -> PyResult<String> {
     let py = fragment.py();
     let fragment = fragment
         .getattr("_metadata")?
@@ -85,8 +83,7 @@ pub fn print_fragment(fragment: &PyAny) -> PyResult<()> {
     let schema = &fragment.as_ref(py).borrow().schema;
     let meta = fragment.as_ref(py).borrow().inner.clone();
     let pp_meta = PrettyPrintableFragment::new(&meta, schema);
-    println!("{:#?}", pp_meta);
-    Ok(())
+    Ok(format!("{:#?}", pp_meta))
 }
 
 /// Return a string representation of each transaction in the dataset, in

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -374,6 +374,7 @@ impl FragmentMetadata {
     }
 
     fn __repr__(&self) -> String {
+        dbg!(&self.schema);
         format!("{:?}", self.inner)
     }
 
@@ -385,6 +386,7 @@ impl FragmentMetadata {
                     PyValueError::new_err(format!("Unable to unpickle FragmentMetadata: {}", e))
                 })?;
                 self.schema = Schema::from(&Fields(manifest.fields));
+                dbg!(&self.schema);
                 self.inner = LanceFragmentMetadata::from(&manifest.fragments[0]);
                 Ok(())
             }

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -322,6 +322,16 @@ impl DataFile {
     fn field_ids(&self) -> Vec<i32> {
         self.inner.fields.clone()
     }
+
+    fn __richcmp__(&self, other: &Self, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Eq => Ok(self.inner == other.inner),
+            CompareOp::Ne => Ok(self.inner != other.inner),
+            _ => Err(PyNotImplementedError::new_err(
+                "Only == and != are supported for DataFile",
+            )),
+        }
+    }
 }
 
 #[pyclass(name = "_FragmentMetadata", module = "lance")]

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -366,7 +366,7 @@ impl FragmentMetadata {
         match op {
             CompareOp::Lt => Ok(self.inner.id < other.inner.id),
             CompareOp::Le => Ok(self.inner.id <= other.inner.id),
-            CompareOp::Eq => Ok(self.inner.id == other.inner.id && self.schema == other.schema),
+            CompareOp::Eq => Ok(self.inner == other.inner),
             CompareOp::Ne => self.__richcmp__(other, CompareOp::Eq).map(|v| !v),
             CompareOp::Gt => self.__richcmp__(other, CompareOp::Le).map(|v| !v),
             CompareOp::Ge => self.__richcmp__(other, CompareOp::Lt).map(|v| !v),

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -328,7 +328,7 @@ impl DataFile {
 #[derive(Clone, Debug)]
 pub struct FragmentMetadata {
     pub(crate) inner: LanceFragmentMetadata,
-    schema: Schema,
+    pub(crate) schema: Schema,
 }
 
 impl FragmentMetadata {

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -374,7 +374,6 @@ impl FragmentMetadata {
     }
 
     fn __repr__(&self) -> String {
-        dbg!(&self.schema);
         format!("{:?}", self.inner)
     }
 
@@ -386,7 +385,6 @@ impl FragmentMetadata {
                     PyValueError::new_err(format!("Unable to unpickle FragmentMetadata: {}", e))
                 })?;
                 self.schema = Schema::from(&Fields(manifest.fields));
-                dbg!(&self.schema);
                 self.inner = LanceFragmentMetadata::from(&manifest.fragments[0]);
                 Ok(())
             }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -139,9 +139,9 @@ fn lance(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(manifest_needs_migration))?;
     m.add_wrapped(wrap_pyfunction!(build_sq_storage))?;
     // Debug functions
-    m.add_wrapped(wrap_pyfunction!(debug::print_schema))?;
-    m.add_wrapped(wrap_pyfunction!(debug::print_manifest))?;
-    m.add_wrapped(wrap_pyfunction!(debug::print_fragment))?;
+    m.add_wrapped(wrap_pyfunction!(debug::format_schema))?;
+    m.add_wrapped(wrap_pyfunction!(debug::format_manifest))?;
+    m.add_wrapped(wrap_pyfunction!(debug::format_fragment))?;
     m.add_wrapped(wrap_pyfunction!(debug::list_transactions))?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     register_datagen(py, m)?;

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -141,6 +141,7 @@ fn lance(py: Python, m: &PyModule) -> PyResult<()> {
     // Debug functions
     m.add_wrapped(wrap_pyfunction!(debug::print_schema))?;
     m.add_wrapped(wrap_pyfunction!(debug::print_manifest))?;
+    m.add_wrapped(wrap_pyfunction!(debug::print_fragment))?;
     m.add_wrapped(wrap_pyfunction!(debug::list_transactions))?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     register_datagen(py, m)?;

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -51,6 +51,7 @@ pub(crate) mod arrow;
 #[cfg(feature = "datagen")]
 pub(crate) mod datagen;
 pub(crate) mod dataset;
+pub(crate) mod debug;
 pub(crate) mod error;
 pub(crate) mod executor;
 pub(crate) mod file;
@@ -137,6 +138,10 @@ fn lance(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(trace_to_chrome))?;
     m.add_wrapped(wrap_pyfunction!(manifest_needs_migration))?;
     m.add_wrapped(wrap_pyfunction!(build_sq_storage))?;
+    // Debug functions
+    m.add_wrapped(wrap_pyfunction!(debug::print_schema))?;
+    m.add_wrapped(wrap_pyfunction!(debug::print_manifest))?;
+    m.add_wrapped(wrap_pyfunction!(debug::list_transactions))?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     register_datagen(py, m)?;
     Ok(())

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -605,10 +605,12 @@ impl Dataset {
         self.append_impl(batches, params).await
     }
 
+    /// Get the base URI of the dataset.
     pub fn uri(&self) -> &Path {
         &self.base
     }
 
+    /// Get the full manifest of the dataset version.
     pub fn manifest(&self) -> &Manifest {
         &self.manifest
     }
@@ -624,6 +626,10 @@ impl Dataset {
         .await
     }
 
+    /// Read the transaction file for this version of the dataset.
+    ///
+    /// If there was no transaction file written for this version of the dataset
+    /// then this will return None.
     pub async fn read_transaction(&self) -> Result<Option<Transaction>> {
         let path = match &self.manifest.transaction_file {
             Some(path) => self.base.child("_transactions").child(path.as_str()),

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -33,6 +33,7 @@ use lance_table::io::commit::{commit_handler_from_url, CommitError, CommitHandle
 use lance_table::io::manifest::{read_manifest, write_manifest};
 use log::warn;
 use object_store::path::Path;
+use prost::Message;
 use snafu::{location, Location};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Range;
@@ -604,6 +605,14 @@ impl Dataset {
         self.append_impl(batches, params).await
     }
 
+    pub fn uri(&self) -> &Path {
+        &self.base
+    }
+
+    pub fn manifest(&self) -> &Manifest {
+        &self.manifest
+    }
+
     pub async fn latest_manifest(&self) -> Result<Manifest> {
         read_manifest(
             &self.object_store,
@@ -613,6 +622,16 @@ impl Dataset {
                 .await?,
         )
         .await
+    }
+
+    pub async fn read_transaction(&self) -> Result<Option<Transaction>> {
+        let path = match &self.manifest.transaction_file {
+            Some(path) => self.base.child("_transactions").child(path.as_str()),
+            None => return Ok(None),
+        };
+        let data = self.object_store.inner.get(&path).await?.bytes().await?;
+        let transaction = lance_table::format::pb::Transaction::decode(data)?;
+        Transaction::try_from(&transaction).map(Some)
     }
 
     /// Restore the currently checked out version of the dataset as the latest version.


### PR DESCRIPTION
These functions provide debug printing on various important structures. They are mainly useful for debugging issues on the dataset.

Since they are mainly for debugging, they are free function in a submodule instead of easily discoverable methods on respective classes.

Also, this includes a drive-by fix: fixes #2174

As dicussed in https://github.com/lancedb/lance/issues/2186