### PR TITLE
feat: replace `LanceFragment.add_columns` with `merge_columns`

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1852,9 +1852,9 @@ class LanceOperation:
         ...     return pa.record_batch([doubled], ["a_doubled"])
         >>> fragments = []
         >>> for fragment in dataset.get_fragments():
-        ...     new_fragment = fragment.add_columns(double_a, columns=['a'])
+        ...     new_fragment, new_schema = fragment.merge_columns(double_a,
+        ...                                                       columns=['a'])
         ...     fragments.append(new_fragment)
-        >>> new_schema = table.schema.append(pa.field("a_doubled", pa.int64()))
         >>> operation = lance.LanceOperation.Merge(fragments, new_schema)
         >>> dataset = lance.LanceDataset.commit("example", operation,
         ...                                     read_version=dataset.version)
@@ -1867,7 +1867,7 @@ class LanceOperation:
         """
 
         fragments: Iterable[FragmentMetadata]
-        schema: LanceSchema
+        schema: LanceSchema | pa.Schema
 
         def __post_init__(self):
             LanceOperation._validate_fragments(self.fragments)

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -52,6 +52,7 @@ from .lance import (
 from .lance import CompactionMetrics as CompactionMetrics
 from .lance import __version__ as __version__
 from .optimize import Compaction
+from .schema import LanceSchema
 from .util import td_to_micros
 
 if TYPE_CHECKING:
@@ -59,7 +60,6 @@ if TYPE_CHECKING:
 
     from .commit import CommitLock
     from .progress import FragmentWriteProgress
-    from .schema import LanceSchema
 
     ReaderLike = Union[
         pd.Timestamp,
@@ -1820,8 +1820,9 @@ class LanceOperation:
         ----------
         fragments: iterable of FragmentMetadata
             The fragments that make up the new dataset.
-        schema: pyarrow.Schema
-            The schema of the new dataset.
+        schema: LanceSchema or pyarrow.Schema
+            The schema of the new dataset. Passing a LanceSchema is preferred,
+            and passing a pyarrow.Schema is deprecated.
 
         Warning
         -------
@@ -1866,13 +1867,20 @@ class LanceOperation:
         """
 
         fragments: Iterable[FragmentMetadata]
-        schema: pa.Schema
+        schema: LanceSchema
 
         def __post_init__(self):
             LanceOperation._validate_fragments(self.fragments)
 
         def _to_inner(self):
             raw_fragments = [f._metadata for f in self.fragments]
+            if isinstance(self.schema, pa.Schema):
+                warnings.warn(
+                    "Passing a pyarrow.Schema to Merge is deprecated. "
+                    "Please use a LanceSchema instead.",
+                    DeprecationWarning,
+                )
+                self.schema = LanceSchema.from_pyarrow(self.schema)
             return _Operation.merge(raw_fragments, self.schema)
 
     @dataclass

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -59,6 +59,7 @@ if TYPE_CHECKING:
 
     from .commit import CommitLock
     from .progress import FragmentWriteProgress
+    from .schema import LanceSchema
 
     ReaderLike = Union[
         pd.Timestamp,
@@ -327,6 +328,13 @@ class LanceDataset(pa.dataset.Dataset):
         The pyarrow Schema for this dataset
         """
         return self._ds.schema
+
+    @property
+    def lance_schema(self) -> "LanceSchema":
+        """
+        The LanceSchema for this dataset
+        """
+        return self._ds.lance_schema
 
     def to_table(
         self,

--- a/python/python/lance/debug.pyi
+++ b/python/python/lance/debug.pyi
@@ -12,7 +12,7 @@ def format_schema(dataset: LanceDataset) -> str:
 def format_manifest(dataset: LanceDataset) -> str:
     pass
 
-def format_fragment(fragment: FragmentMetadata) -> str:
+def format_fragment(fragment: FragmentMetadata, dataset: LanceDataset) -> str:
     pass
 
 def list_transactions(

--- a/python/python/lance/schema.py
+++ b/python/python/lance/schema.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 
 import pyarrow as pa
 
+from .lance import LanceSchema as LanceSchema
 from .lance import _json_to_schema, _schema_to_json
 
 

--- a/python/python/lance/schema.pyi
+++ b/python/python/lance/schema.pyi
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+import pyarrow as pa
+
+class LanceSchema:
+    def to_pyarrow(self) -> pa.Schema: ...
+    def from_pyarrow(schema: pa.Schema) -> "LanceSchema": ...

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -523,7 +523,7 @@ def test_add_columns(tmp_path: Path):
         c_array = pa.compute.multiply(batch.column(0), 2)
         return pa.RecordBatch.from_arrays([c_array], names=["c"])
 
-    fragment_metadata, schema = fragment.add_columns(adder, columns=["a"])
+    fragment_metadata, schema = fragment.merge_columns(adder, columns=["a"])
 
     operation = lance.LanceOperation.Overwrite(schema.to_pyarrow(), [fragment_metadata])
     dataset = lance.LanceDataset.commit(base_dir, operation)
@@ -655,15 +655,22 @@ def test_merge_with_commit(tmp_path: Path):
     lance.write_dataset(table, base_dir)
 
     fragment = lance.dataset(base_dir).get_fragments()[0]
-    merged, schema = fragment.add_columns(
-        lambda _: pa.RecordBatch.from_pydict({"c": range(100)})
-    )
+    # add_columns is deprecated, but we can make sure it still work
+    # for now.
+    with pytest.deprecated_call():
+        merged = fragment.add_columns(
+            lambda _: pa.RecordBatch.from_pydict({"c": range(100)})
+        )
 
-    merge = lance.LanceOperation.Merge([merged], schema)
-    dataset = lance.LanceDataset.commit(base_dir, merge, read_version=1)
+    expected = pa.Table.from_pydict({"a": range(100), "b": range(100), "c": range(100)})
+
+    # PyArrow schema is deprecated, but should still work for now.
+    with pytest.deprecated_call():
+        merge = lance.LanceOperation.Merge([merged], expected.schema)
+        dataset = lance.LanceDataset.commit(base_dir, merge, read_version=1)
 
     tbl = dataset.to_table()
-    expected = pa.Table.from_pydict({"a": range(100), "b": range(100), "c": range(100)})
+
     assert tbl == expected
 
 
@@ -679,7 +686,7 @@ def test_merge_with_schema_holes(tmp_path: Path):
     dataset.drop_columns(["b"])
 
     fragment = dataset.get_fragments()[0]
-    merged, schema = fragment.add_columns(
+    merged, schema = fragment.merge_columns(
         lambda _: pa.RecordBatch.from_pydict({"d": range(10, 20)})
     )
 

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -655,7 +655,7 @@ def test_merge_with_commit(tmp_path: Path):
     lance.write_dataset(table, base_dir)
 
     fragment = lance.dataset(base_dir).get_fragments()[0]
-    # add_columns is deprecated, but we can make sure it still work
+    # add_columns is deprecated, but we can make sure it still works
     # for now.
     with pytest.deprecated_call():
         merged = fragment.add_columns(
@@ -675,8 +675,6 @@ def test_merge_with_commit(tmp_path: Path):
 
 
 def test_merge_with_schema_holes(tmp_path: Path):
-    import lance.debug
-
     # Create table with 3 cols
     table = pa.table({"a": range(10)})
     dataset = lance.write_dataset(table, tmp_path)

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -523,12 +523,11 @@ def test_add_columns(tmp_path: Path):
         c_array = pa.compute.multiply(batch.column(0), 2)
         return pa.RecordBatch.from_arrays([c_array], names=["c"])
 
-    fragment_metadata = fragment.add_columns(adder, columns=["a"])
-    schema = dataset.schema.append(pa.field("c", pa.int64()))
+    fragment_metadata, schema = fragment.add_columns(adder, columns=["a"])
 
-    operation = lance.LanceOperation.Overwrite(schema, [fragment_metadata])
+    operation = lance.LanceOperation.Overwrite(schema.to_pyarrow(), [fragment_metadata])
     dataset = lance.LanceDataset.commit(base_dir, operation)
-    assert dataset.schema == schema
+    assert dataset.schema == schema.to_pyarrow()
 
     tbl = dataset.to_table()
     assert tbl == pa.Table.from_pydict({
@@ -656,16 +655,15 @@ def test_merge_with_commit(tmp_path: Path):
     lance.write_dataset(table, base_dir)
 
     fragment = lance.dataset(base_dir).get_fragments()[0]
-    merged = fragment.add_columns(
+    merged, schema = fragment.add_columns(
         lambda _: pa.RecordBatch.from_pydict({"c": range(100)})
     )
 
-    expected = pa.Table.from_pydict({"a": range(100), "b": range(100), "c": range(100)})
-
-    merge = lance.LanceOperation.Merge([merged], expected.schema)
+    merge = lance.LanceOperation.Merge([merged], schema)
     dataset = lance.LanceDataset.commit(base_dir, merge, read_version=1)
 
     tbl = dataset.to_table()
+    expected = pa.Table.from_pydict({"a": range(100), "b": range(100), "c": range(100)})
     assert tbl == expected
 
 
@@ -681,21 +679,21 @@ def test_merge_with_schema_holes(tmp_path: Path):
     dataset.drop_columns(["b"])
 
     fragment = dataset.get_fragments()[0]
-    merged = fragment.add_columns(
+    merged, schema = fragment.add_columns(
         lambda _: pa.RecordBatch.from_pydict({"d": range(10, 20)})
     )
-    expected = pa.table({
-        "a": range(10),
-        "c": range(2, 12),
-        "d": range(10, 20),
-    })
 
-    merge = lance.LanceOperation.Merge([merged], expected.schema)
+    merge = lance.LanceOperation.Merge([merged], schema)
     dataset = lance.LanceDataset.commit(tmp_path, merge, read_version=dataset.version)
 
     dataset.validate()
 
     tbl = dataset.to_table()
+    expected = pa.table({
+        "a": range(10),
+        "c": range(2, 12),
+        "d": range(10, 20),
+    })
     assert tbl == expected
 
 

--- a/python/python/tests/test_debug.py
+++ b/python/python/tests/test_debug.py
@@ -61,7 +61,7 @@ def test_format_fragment(tmp_path: Path):
 
     fragment = dataset.get_fragments()[0].metadata
 
-    output = format_fragment(fragment)
+    output = format_fragment(fragment, dataset)
 
     assert output.startswith("PrettyPrintableFragment {")
     assert "files: [" in output

--- a/python/python/tests/test_schema.py
+++ b/python/python/tests/test_schema.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+import pickle
+from pathlib import Path
+
+import lance
+import pyarrow as pa
+
+
+def test_lance_schema(tmp_path: Path):
+    data = pa.table({"x": range(2)})
+    dataset = lance.write_dataset(data, tmp_path)
+
+    schema = dataset.lance_schema
+
+    assert repr(schema).startswith("Schema {")
+
+    dumped = pickle.dumps(schema)
+    loaded = pickle.loads(dumped)
+    assert schema == loaded

--- a/python/python/tests/test_schema.py
+++ b/python/python/tests/test_schema.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import lance
 import pyarrow as pa
+from lance.schema import LanceSchema
 
 
 def test_lance_schema(tmp_path: Path):
@@ -19,3 +20,6 @@ def test_lance_schema(tmp_path: Path):
     dumped = pickle.dumps(schema)
     loaded = pickle.loads(dumped)
     assert schema == loaded
+
+    assert schema.to_pyarrow() == data.schema
+    assert LanceSchema.from_pyarrow(data.schema) == schema

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -64,6 +64,7 @@ use pyo3::{
 use snafu::{location, Location};
 
 use crate::fragment::{FileFragment, FragmentMetadata};
+use crate::schema::LanceSchema;
 use crate::RT;
 use crate::{LanceReader, Scanner};
 
@@ -244,8 +245,8 @@ impl Operation {
     }
 
     #[staticmethod]
-    fn merge(fragments: Vec<FragmentMetadata>, schema: PyArrowType<ArrowSchema>) -> PyResult<Self> {
-        let schema = convert_schema(&schema.0)?;
+    fn merge(fragments: Vec<FragmentMetadata>, schema: LanceSchema) -> PyResult<Self> {
+        let schema = schema.0;
         let fragments = into_fragments(fragments);
         let op = LanceOperation::Merge { fragments, schema };
         Ok(Self(op))
@@ -322,6 +323,11 @@ impl Dataset {
     fn schema(self_: PyRef<'_, Self>) -> PyResult<PyObject> {
         let arrow_schema = ArrowSchema::from(self_.ds.schema());
         arrow_schema.to_pyarrow(self_.py())
+    }
+
+    #[getter(lance_schema)]
+    fn lance_schema(self_: PyRef<'_, Self>) -> LanceSchema {
+        LanceSchema(self_.ds.schema().clone())
     }
 
     /// Get index statistics

--- a/python/src/debug.rs
+++ b/python/src/debug.rs
@@ -75,12 +75,16 @@ impl PrettyPrintableFragment {
 
 /// Debug print a LanceFragment.
 #[pyfunction]
-pub fn format_fragment(fragment: &PyAny) -> PyResult<String> {
+pub fn format_fragment(fragment: &PyAny, dataset: &PyAny) -> PyResult<String> {
     let py = fragment.py();
     let fragment = fragment
         .getattr("_metadata")?
         .extract::<Py<FragmentMetadata>>()?;
-    let schema = &fragment.as_ref(py).borrow().schema;
+
+    let dataset = dataset.getattr("_ds")?.extract::<Py<Dataset>>()?;
+    let dataset_ref = &dataset.as_ref(py).borrow().ds;
+    let schema = dataset_ref.schema();
+
     let meta = fragment.as_ref(py).borrow().inner.clone();
     let pp_meta = PrettyPrintableFragment::new(&meta, schema);
     Ok(format!("{:#?}", pp_meta))

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -112,14 +112,10 @@ impl FileFragment {
 
         reader.py().allow_threads(|| {
             RT.runtime.block_on(async move {
-                let schema = batches.schema().clone();
-
                 let metadata =
                     LanceFragment::create(dataset_uri, fragment_id.unwrap_or(0), batches, params)
                         .await
                         .map_err(|err| PyIOError::new_err(err.to_string()))?;
-                let schema = Schema::try_from(schema.as_ref())
-                    .map_err(|err| PyValueError::new_err(err.to_string()))?;
 
                 Ok(FragmentMetadata::new(metadata))
             })

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -431,10 +431,6 @@ pub fn write_fragments(
 ) -> PyResult<Vec<FragmentMetadata>> {
     let batches = convert_reader(reader)?;
 
-    let schema = batches.schema();
-    let schema =
-        Schema::try_from(schema.as_ref()).map_err(|err| PyValueError::new_err(err.to_string()))?;
-
     let params = kwargs
         .and_then(|params| get_write_params(params).ok().flatten())
         .unwrap_or_default();

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -58,6 +58,7 @@ pub(crate) mod file;
 pub(crate) mod fragment;
 pub(crate) mod reader;
 pub(crate) mod scanner;
+pub(crate) mod schema;
 pub(crate) mod tracing;
 pub(crate) mod updater;
 pub(crate) mod utils;
@@ -127,6 +128,7 @@ fn lance(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyRewriteResult>()?;
     m.add_class::<PyCompactionMetrics>()?;
     m.add_class::<TraceGuard>()?;
+    m.add_class::<schema::LanceSchema>()?;
     m.add_wrapped(wrap_pyfunction!(bfloat16_array))?;
     m.add_wrapped(wrap_pyfunction!(write_dataset))?;
     m.add_wrapped(wrap_pyfunction!(write_fragments))?;

--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -80,10 +80,7 @@ impl LanceSchema {
             })?;
             fields.push(Field::from(&field));
         }
-        let schema = Schema {
-            fields: fields,
-            metadata: metadata,
-        };
+        let schema = Schema { fields, metadata };
         Ok(Self(schema))
     }
 }

--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use arrow::pyarrow::PyArrowType;
+use arrow_schema::Schema as ArrowSchema;
+use lance::datatypes::{Field, Schema};
+use lance_file::datatypes::Fields;
+use lance_file::format::pb;
+use prost::Message;
+use pyo3::{
+    basic::CompareOp,
+    exceptions::{PyNotImplementedError, PyValueError},
+    prelude::*,
+    types::PyTuple,
+};
+
+/// A Lance Schema.
+///
+/// This is valid for a particular dataset. It contains the field ids for each
+/// column in the dataset.
+#[pyclass(name = "LanceSchema", module = "lance.schema")]
+#[derive(Clone)]
+pub struct LanceSchema(pub Schema);
+
+#[pymethods]
+impl LanceSchema {
+    pub fn __repr__(&self) -> PyResult<String> {
+        // TODO: we should make a more succinct representation
+        Ok(format!("{:?}", self.0))
+    }
+
+    pub fn __richcmp__(&self, other: LanceSchema, op: CompareOp) -> PyResult<bool> {
+        match op {
+            CompareOp::Eq => Ok(self.0 == other.0),
+            CompareOp::Ne => Ok(self.0 != other.0),
+            _ => Err(PyNotImplementedError::new_err(
+                "Only == and != are supported",
+            )),
+        }
+    }
+
+    pub fn to_pyarrow(&self) -> PyArrowType<ArrowSchema> {
+        PyArrowType(ArrowSchema::from(&self.0))
+    }
+
+    pub fn __reduce__(&self, py: Python<'_>) -> PyResult<(PyObject, PyObject)> {
+        // Each field is a protobuf message
+        let mut states = Vec::new();
+
+        let fields = Fields::from(&self.0);
+        for field in fields.0.iter() {
+            states.push(field.encode_to_vec());
+        }
+        // The metadata is its own JSON object
+        let metadata_str = serde_json::to_string(&self.0.metadata)
+            .map_err(|e| PyErr::new::<PyValueError, _>(format!("{}", e)))?;
+        states.push(metadata_str.as_bytes().to_vec());
+
+        let state = PyTuple::new(py, states).extract()?;
+        let from_json = PyModule::import(py, "lance.schema")?
+            .getattr("LanceSchema")?
+            .getattr("_from_protos")?
+            .extract()?;
+        Ok((from_json, state))
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (*args))]
+    pub fn _from_protos(mut args: Vec<Vec<u8>>) -> PyResult<Self> {
+        let metadata = args
+            .pop()
+            .ok_or_else(|| PyValueError::new_err("Must have at least two arguments"))?;
+        let metadata = serde_json::from_slice(&metadata)
+            .map_err(|err| PyValueError::new_err(format!("Failed to parse metadata: {}", err)))?;
+
+        let mut fields = Vec::new();
+        for arg in args {
+            let field = pb::Field::decode(arg.as_slice()).map_err(|e| {
+                PyValueError::new_err(format!("Failed to parse field proto: {}", e))
+            })?;
+            fields.push(Field::from(&field));
+        }
+        let schema = Schema {
+            fields: fields,
+            metadata: metadata,
+        };
+        Ok(Self(schema))
+    }
+}

--- a/python/src/schema.rs
+++ b/python/src/schema.rs
@@ -39,8 +39,20 @@ impl LanceSchema {
         }
     }
 
+    /// Convert the schema to a PyArrow schema.
     pub fn to_pyarrow(&self) -> PyArrowType<ArrowSchema> {
         PyArrowType(ArrowSchema::from(&self.0))
+    }
+
+    /// Create a Lance schema from a PyArrow schema.
+    ///
+    /// This will assign field ids in depth-first order. Be aware this may not
+    /// match the correct schema for a particular table.
+    #[staticmethod]
+    pub fn from_pyarrow(schema: PyArrowType<ArrowSchema>) -> PyResult<Self> {
+        let schema = Schema::try_from(&schema.0)
+            .map_err(|err| PyValueError::new_err(format!("Failed to convert schema: {}", err)))?;
+        Ok(Self(schema))
     }
 
     pub fn __reduce__(&self, py: Python<'_>) -> PyResult<(PyObject, PyObject)> {

--- a/python/src/updater.rs
+++ b/python/src/updater.rs
@@ -62,9 +62,6 @@ impl Updater {
                 .map_err(|e| PyIOError::new_err(e.to_string()))
         })??;
 
-        Ok(FragmentMetadata::new(
-            fragment,
-            self.inner.schema().unwrap().clone(),
-        ))
+        Ok(FragmentMetadata::new(fragment))
     }
 }

--- a/python/src/updater.rs
+++ b/python/src/updater.rs
@@ -18,7 +18,7 @@ use pyo3::{exceptions::*, prelude::*};
 
 use lance::dataset::updater::Updater as LanceUpdater;
 
-use crate::{fragment::FragmentMetadata, RT};
+use crate::{fragment::FragmentMetadata, schema::LanceSchema, RT};
 
 #[pyclass(name = "_Updater", module = "_lib")]
 pub struct Updater {
@@ -63,5 +63,9 @@ impl Updater {
         })??;
 
         Ok(FragmentMetadata::new(fragment))
+    }
+
+    fn schema(&self) -> Option<LanceSchema> {
+        self.inner.schema().map(|s| LanceSchema(s.clone()))
     }
 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -706,6 +706,8 @@ impl Dataset {
     ///
     /// This method can be used to commit this change to the dataset's manifest.  This method will
     /// not verify that the provided fragments exist and correct, that is the caller's responsibility.
+    /// Some validation can be performed using the function
+    /// [crate::dataset::transaction::validate_operation].
     ///
     /// If this commit is a change to an existing dataset then it will often need to be based on an
     /// existing version of the dataset.  For example, if this change is a `delete` operation then

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -981,14 +981,15 @@ pub fn validate_operation(manifest: Option<&Manifest>, operation: &Operation) ->
 /// It is not required that the schema contains all fields in the fragment.
 /// There may be masked fields.
 fn schema_fragments_valid(schema: &Schema, fragments: &[Fragment]) -> Result<()> {
+    // TODO: add additional validation. Consider consolidating with various
+    // validate() methods in the codebase.
     for fragment in fragments {
         for field in schema.fields_pre_order() {
-            if fragment
+            if !fragment
                 .files
                 .iter()
                 .flat_map(|f| f.fields.iter())
-                .find(|&f_id| f_id == &field.id)
-                .is_none()
+                .any(|f_id| f_id == &field.id)
             {
                 return Err(Error::invalid_input(
                     format!(

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -936,7 +936,24 @@ impl From<&RewriteGroup> for pb::transaction::rewrite::RewriteGroup {
 }
 
 /// Validate the operation is valid for the given manifest.
-pub fn validate_operation(manifest: &Manifest, operation: &Operation) -> Result<()> {
+pub fn validate_operation(manifest: Option<&Manifest>, operation: &Operation) -> Result<()> {
+    let manifest = match (manifest, operation) {
+        (None, Operation::Overwrite { .. }) => {
+            // TODO: validate overwrite
+            return Ok(());
+        }
+        (Some(manifest), _) => manifest,
+        (None, _) => {
+            return Err(Error::invalid_input(
+                format!(
+                    "Cannot apply operation {} to non-existent dataset",
+                    operation.name()
+                ),
+                location!(),
+            ));
+        }
+    };
+
     match operation {
         Operation::Append { fragments } => {
             // Fragments must contain all fields in the schema

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -938,8 +938,10 @@ impl From<&RewriteGroup> for pb::transaction::rewrite::RewriteGroup {
 /// Validate the operation is valid for the given manifest.
 pub fn validate_operation(manifest: Option<&Manifest>, operation: &Operation) -> Result<()> {
     let manifest = match (manifest, operation) {
-        (None, Operation::Overwrite { .. }) => {
-            // TODO: validate overwrite
+        (None, Operation::Overwrite { fragments, schema }) => {
+            // Validate here because we are going to return early.
+            schema_fragments_valid(schema, fragments)?;
+
             return Ok(());
         }
         (Some(manifest), _) => manifest,


### PR DESCRIPTION
`LanceFragment.add_columns()` is broken for schemas with complex row id sequences. It needs to return the actual Lance schema used, rather than allowing the user to pass a PyArrow schema. PyArrow schemas are problematic because they assume field ids are contiguous and sequential, but they often are not. So we introduce a method `LanceFragment.merge_columns()` which returns both the new fragment and the actual Lance schema.

* Added new `lance.schema.LanceSchema` class, representing a Lance schema.
* Added `LanceDataset.lance_schema` property that returns a `LanceSchema`.
* Deprecated `LanceFragment.add_columns()` in favor of `LanceFragment.merge_columns()`, which returns `Tuple[FragmentMetadata, LanceSchema]`.
  * Also motivating this change: I'd like to later re-introduce `LanceFragment.add_columns()` with a signature in line with the `LanceDataset.add_columns()`.
* `LanceOperation.Merge()` now accepts `LanceSchema` in the `schema` argument. `pa.Schema` is still accepted for now but issues a `DeprecationWarning`.
* `lance.debug.format_fragment()` now requires `LanceDataset` as its second argument.
  * This is a brand-new debug API, so I think it's fine if we change it.
* Changed some fragment methods to use `FragmentMetadata.from_metadata()` instead of `FragmentMetadata(frag.json())` to avoid silly JSON roundtrip.
* `LanceDataset.commit()` now runs basic validation on fragments to prevent some corruption. I will add more checks like this in the near future.
* `FragmentMetadata` no longer holds a schema. pickle/JSON serialization didn't preserve it, so support for it was already broken. It didn't seem to be relied upon by anything.