### PR TITLE
feat: support complex schemas in append

### DIFF
--- a/protos/table.proto
+++ b/protos/table.proto
@@ -198,7 +198,7 @@ message DataFile {
   // or it could be encoded into a single packed column.  To determine column indices
   // the column_indices property should be used instead.
   //
-  // In Lance v1 these ids must be sorted. The might not always be contiguous.
+  // In Lance v1 these ids must be sorted but might not always be contiguous.
   repeated int32 fields = 2;
   // The top-level column indices for each field in the file.
   //

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -198,7 +198,7 @@ message DataFile {
   // or it could be encoded into a single packed column.  To determine column indices
   // the column_indices property should be used instead.
   //
-  // In Lance v1 these ids must be sorted and contiguous.
+  // In Lance v1 these ids must be sorted. The might not always be contiguous.
   repeated int32 fields = 2;
   // The top-level column indices for each field in the file.
   //

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -138,6 +138,7 @@ class LanceFragment(pa.dataset.Fragment):
         schema: Optional[pa.Schema] = None,
         max_rows_per_group: int = 1024,
         progress: Optional[FragmentWriteProgress] = None,
+        mode: str = "append",
     ) -> FragmentMetadata:
         """Create a :class:`FragmentMetadata` from the given data.
 
@@ -164,6 +165,10 @@ class LanceFragment(pa.dataset.Fragment):
             *Experimental API*. Progress tracking for writing the fragment. Pass
             a custom class that defines hooks to be called when each fragment is
             starting to write and finishing writing.
+        mode: str, default "append"
+            The write mode. If "append" is specified, the data will be checked
+            against the existing datasets schema. Otherwise, the schema will
+            get newly assigned field ids.
 
         See Also
         --------
@@ -201,6 +206,7 @@ class LanceFragment(pa.dataset.Fragment):
             reader,
             max_rows_per_group=max_rows_per_group,
             progress=progress,
+            mode=mode,
         )
         return FragmentMetadata(inner_meta.json())
 
@@ -442,6 +448,7 @@ def write_fragments(
     dataset_uri: Union[str, Path],
     schema: Optional[pa.Schema] = None,
     *,
+    mode: str = "append",
     max_rows_per_file: int = 1024 * 1024,
     max_rows_per_group: int = 1024,
     max_bytes_per_file: int = 90 * 1024 * 1024 * 1024,
@@ -464,6 +471,10 @@ def write_fragments(
     schema : pa.Schema, optional
         The schema of the data. If not specified, the schema will be inferred
         from the data.
+    mode : str, default "append"
+        The write mode. If "append" is specified, the data will be checked
+        against the existing datasets schema. Otherwise, the schema will get
+        newly assigned field ids.
     max_rows_per_file : int, default 1024 * 1024
         The maximum number of rows per data file.
     max_rows_per_group : int, default 1024
@@ -503,6 +514,7 @@ def write_fragments(
     fragments = _write_fragments(
         dataset_uri,
         reader,
+        mode=mode,
         max_rows_per_file=max_rows_per_file,
         max_rows_per_group=max_rows_per_group,
         max_bytes_per_file=max_bytes_per_file,

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -167,7 +167,7 @@ class LanceFragment(pa.dataset.Fragment):
             starting to write and finishing writing.
         mode: str, default "append"
             The write mode. If "append" is specified, the data will be checked
-            against the existing datasets schema. Otherwise, the schema will
+            against the existing dataset's schema. Otherwise, the schema will
             get newly assigned field ids.
 
         See Also
@@ -473,7 +473,7 @@ def write_fragments(
         from the data.
     mode : str, default "append"
         The write mode. If "append" is specified, the data will be checked
-        against the existing datasets schema. Otherwise, the schema will get
+        against the existing dataset's schema. Otherwise, the schema will get
         newly assigned field ids.
     max_rows_per_file : int, default 1024 * 1024
         The maximum number of rows per data file.

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -167,8 +167,8 @@ class LanceFragment(pa.dataset.Fragment):
             starting to write and finishing writing.
         mode: str, default "append"
             The write mode. If "append" is specified, the data will be checked
-            against the existing dataset's schema. Otherwise, the schema will
-            get newly assigned field ids.
+            against the existing dataset's schema. Otherwise, pass "create" or
+            "overwrite" to assign new field ids to the schema.
 
         See Also
         --------
@@ -473,8 +473,8 @@ def write_fragments(
         from the data.
     mode : str, default "append"
         The write mode. If "append" is specified, the data will be checked
-        against the existing dataset's schema. Otherwise, the schema will get
-        newly assigned field ids.
+        against the existing dataset's schema. Otherwise, pass "create" or
+        "overwrite" to assign new field ids to the schema.
     max_rows_per_file : int, default 1024 * 1024
         The maximum number of rows per data file.
     max_rows_per_group : int, default 1024

--- a/python/python/tests/test_ray.py
+++ b/python/python/tests/test_ray.py
@@ -30,6 +30,9 @@ def test_ray_sink(tmp_path: Path):
     ds = lance.dataset(tmp_path)
     ds.count_rows() == 10
     assert ds.schema.names == schema.names
+    # The schema is platform-dependent, because numpy uses int32 on Windows.
+    # So we observe the schema that is written and use that.
+    schema = ds.schema
 
     tbl = ds.to_table()
     assert sorted(tbl["id"].to_pylist()) == list(range(10))

--- a/rust/lance-file/Cargo.toml
+++ b/rust/lance-file/Cargo.toml
@@ -42,6 +42,7 @@ tracing.workspace = true
 rand.workspace = true
 tempfile.workspace = true
 proptest.workspace = true
+pretty_assertions.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -682,6 +682,7 @@ async fn _read_fixed_stride_array(
     page_table: &PageTable,
     params: &ReadBatchParams,
 ) -> Result<ArrayRef> {
+    dbg!(reader.fragment_id, &reader.schema, page_table);
     let page_info = get_page_info(page_table, field, batch_id)?;
     read_fixed_stride_array(
         reader.object_reader.as_ref(),

--- a/rust/lance-file/src/writer.rs
+++ b/rust/lance-file/src/writer.rs
@@ -1254,4 +1254,50 @@ mod tests {
         let batch = read_file_as_one_batch(&store, &path, schema).await;
         assert_eq!(batch.column_by_name("i").unwrap().as_ref(), &array);
     }
+
+    #[tokio::test]
+    async fn test_write_schema_with_holes() {
+        let store = ObjectStore::memory();
+        let path = Path::from("test");
+
+        let mut field0 = Field::try_from(&ArrowField::new("a", DataType::Int32, true)).unwrap();
+        field0.set_id(-1, &mut 0);
+        assert_eq!(field0.id, 0);
+        let mut field2 = Field::try_from(&ArrowField::new("b", DataType::Int32, true)).unwrap();
+        field2.set_id(-1, &mut 2);
+        assert_eq!(field2.id, 2);
+        // There is a hole at field id 1.
+        let schema = Schema {
+            fields: vec![field0, field2],
+            metadata: Default::default(),
+        };
+
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("a", DataType::Int32, true),
+            ArrowField::new("b", DataType::Int32, true),
+        ]));
+        let data = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..10)),
+                Arc::new(Int32Array::from_iter_values(10..20)),
+            ],
+        )
+        .unwrap();
+
+        let mut file_writer = FileWriter::<NotSelfDescribing>::try_new(
+            &store,
+            &path,
+            schema.clone(),
+            &Default::default(),
+        )
+        .await
+        .unwrap();
+        file_writer.write(&[data]).await.unwrap();
+        file_writer.finish().await.unwrap();
+
+        let page_table = file_writer.page_table;
+        assert!(page_table.get(0, 0).is_some());
+        assert!(page_table.get(2, 0).is_some());
+    }
 }

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -57,7 +57,9 @@ impl DataFile {
     }
 
     pub fn new_legacy(path: impl Into<String>, schema: &Schema) -> Self {
-        Self::new(path, schema.field_ids(), vec![], 0, 0)
+        let mut field_ids = schema.field_ids();
+        field_ids.sort();
+        Self::new(path, field_ids, vec![], 0, 0)
     }
 
     pub fn schema(&self, full_schema: &Schema) -> Schema {

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -453,7 +453,7 @@ impl SelfDescribingFileReader for FileReader {
         let mut manifest: Manifest = read_struct(reader.as_ref(), manifest_position).await?;
         populate_schema_dictionary(&mut manifest.schema, reader.as_ref()).await?;
         let schema = manifest.schema;
-        let num_fields = schema.max_field_id().unwrap_or_default() + 1;
+        let max_field_id = schema.max_field_id().unwrap_or_default();
         Self::try_new_from_reader(
             reader.path(),
             reader.clone(),
@@ -461,7 +461,7 @@ impl SelfDescribingFileReader for FileReader {
             schema,
             0,
             0,
-            num_fields as u32,
+            max_field_id,
             cache,
         )
         .await

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -473,9 +473,15 @@ impl Dataset {
         }
 
         let object_store = Arc::new(object_store);
-        let fragments =
-            write_fragments_internal(object_store.clone(), &base, &schema, stream, params.clone())
-                .await?;
+        let fragments = write_fragments_internal(
+            dataset.as_ref(),
+            object_store.clone(),
+            &base,
+            &schema,
+            stream,
+            params.clone(),
+        )
+        .await?;
 
         let operation = match params.mode {
             WriteMode::Create | WriteMode::Overwrite => Operation::Overwrite { schema, fragments },
@@ -565,6 +571,7 @@ impl Dataset {
         )?;
 
         let fragments = write_fragments_internal(
+            Some(self),
             self.object_store.clone(),
             &self.base,
             &schema,

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -9,7 +9,7 @@ use snafu::{location, Location};
 use tracing::instrument;
 use url::Url;
 
-use super::{ReadParams, DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE};
+use super::{ReadParams, WriteParams, DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE};
 use crate::{
     error::{Error, Result},
     session::Session,
@@ -150,6 +150,18 @@ impl DatasetBuilder {
             self.commit_handler = Some(commit_handler);
         }
 
+        self
+    }
+
+    /// Set options based on [WriteParams].
+    pub fn with_write_params(mut self, write_params: WriteParams) -> Self {
+        if let Some(options) = write_params.store_params {
+            self.options = options;
+        }
+
+        if let Some(commit_handler) = write_params.commit_handler {
+            self.commit_handler = Some(commit_handler);
+        }
         self
     }
 

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -217,7 +217,7 @@ impl FileFragment {
             let data_file_schema = data_file.schema(full_schema);
             let projection = projection.unwrap_or(full_schema);
             let schema_per_file = data_file_schema.intersection(projection)?;
-            let num_fields = data_file.fields.len() as u32;
+            let max_field_id = data_file.fields.iter().max().unwrap();
             if with_row_id || !schema_per_file.fields.is_empty() {
                 let path = self.dataset.data_dir().child(data_file.path.as_str());
                 let field_id_offset = Self::get_field_id_offset(data_file);
@@ -226,8 +226,8 @@ impl FileFragment {
                     &path,
                     self.schema().clone(),
                     self.id() as u32,
-                    field_id_offset,
-                    num_fields,
+                    field_id_offset as i32,
+                    *max_field_id,
                     Some(&self.dataset.session.file_metadata_cache),
                 )
                 .await?;

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -799,6 +799,7 @@ async fn rewrite_files(
         ..Default::default()
     };
     let mut new_fragments = write_fragments_internal(
+        Some(dataset.as_ref()),
         dataset.object_store.clone(),
         &dataset.base,
         dataset.schema(),

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -193,8 +193,6 @@ pub async fn write_fragments_internal(
     } else {
         schema
     };
-    dbg!(&params.mode);
-    dbg!(schema);
 
     // TODO: When writing v2 we could consider skipping this chunking step.  However, leaving in
     // for now as it doesn't hurt anything
@@ -203,7 +201,7 @@ pub async fn write_fragments_internal(
     let writer_generator = WriterGenerator::new(
         object_store,
         base_dir,
-        schema,
+        dbg!(schema),
         params.use_experimental_writer,
     );
     let mut writer: Option<Box<dyn GenericWriter>> = None;
@@ -503,6 +501,7 @@ mod tests {
 
         let object_store = Arc::new(ObjectStore::memory());
         let fragments = write_fragments_internal(
+            None,
             object_store,
             &Path::from("test"),
             &schema,
@@ -545,6 +544,7 @@ mod tests {
 
         let object_store = Arc::new(ObjectStore::memory());
         let fragments = write_fragments_internal(
+            None,
             object_store,
             &Path::from("test"),
             &schema,

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -382,10 +382,12 @@ impl WriterGenerator {
 mod tests {
     use super::*;
 
-    use arrow_array::Int32Array;
-    use arrow_schema::{DataType, Schema as ArrowSchema};
+    use arrow_array::{Int32Array, StructArray};
+    use arrow_schema::{DataType, Field as ArrowField, Fields, Schema as ArrowSchema};
     use datafusion::{error::DataFusionError, physical_plan::stream::RecordBatchStreamAdapter};
     use futures::TryStreamExt;
+    use lance_file::reader::FileReader;
+    use lance_io::traits::Reader;
 
     #[tokio::test]
     async fn test_chunking_large_batches() {
@@ -558,5 +560,88 @@ mod tests {
         assert_eq!(fragment.files.len(), 1);
         assert_eq!(fragment.physical_rows, Some(1024));
         assert_eq!(fragment.files[0].file_minor_version, 3);
+    }
+
+    #[tokio::test]
+    async fn test_file_v1_schema_order() {
+        // Create a schema where fields ids are not in order and contain holes.
+        // Also first field id is a struct.
+        let struct_fields = Fields::from(vec![ArrowField::new("b", DataType::Int32, false)]);
+        let arrow_schema = ArrowSchema::new(vec![
+            ArrowField::new("d", DataType::Int32, false),
+            ArrowField::new("a", DataType::Struct(struct_fields.clone()), false),
+        ]);
+        let mut schema = Schema::try_from(&arrow_schema).unwrap();
+        // Make schema:
+        // 0: a
+        // 1: a.b
+        // (hole at 2)
+        // 3: d
+        schema.mut_field_by_id(0).unwrap().id = 3;
+        schema.mut_field_by_id(1).unwrap().id = 0;
+        schema.mut_field_by_id(2).unwrap().id = 1;
+
+        let field_ids = schema.fields_pre_order().map(|f| f.id).collect::<Vec<_>>();
+        assert_eq!(field_ids, vec![3, 0, 1]);
+
+        let data = RecordBatch::try_new(
+            Arc::new(arrow_schema.clone()),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StructArray::new(
+                    struct_fields,
+                    vec![Arc::new(Int32Array::from(vec![3, 4]))],
+                    None,
+                )),
+            ],
+        )
+        .unwrap();
+
+        let write_params = WriteParams {
+            use_experimental_writer: false,
+            ..Default::default()
+        };
+        let data_stream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::new(arrow_schema),
+            futures::stream::iter(std::iter::once(Ok(data.clone()))),
+        ));
+
+        let object_store = Arc::new(ObjectStore::memory());
+        let base_path = Path::from("test");
+        let fragments = write_fragments_internal(
+            None,
+            object_store.clone(),
+            &base_path,
+            &schema,
+            data_stream,
+            write_params,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(fragments.len(), 1);
+        let fragment = &fragments[0];
+        assert_eq!(fragment.files.len(), 1);
+        assert_eq!(fragment.files[0].fields, vec![0, 1, 3]);
+
+        let path = base_path
+            .child(DATA_DIR)
+            .child(fragment.files[0].path.as_str());
+        let file_reader: Arc<dyn Reader> = object_store.open(&path).await.unwrap().into();
+        let reader = FileReader::try_new_from_reader(
+            &path,
+            file_reader,
+            None,
+            schema.clone(),
+            0,
+            0,
+            3,
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(reader.num_batches(), 1);
+        let batch = reader.read_batch(0, .., &schema, None).await.unwrap();
+        assert_eq!(batch, data);
     }
 }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -201,7 +201,7 @@ pub async fn write_fragments_internal(
     let writer_generator = WriterGenerator::new(
         object_store,
         base_dir,
-        dbg!(schema),
+        schema,
         params.use_experimental_writer,
     );
     let mut writer: Option<Box<dyn GenericWriter>> = None;

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -503,6 +503,7 @@ impl MergeInsertJob {
         let stream = RecordBatchStreamAdapter::new(schema, stream);
 
         let new_fragments = write_fragments_internal(
+            None,
             self.dataset.object_store.clone(),
             &self.dataset.base,
             self.dataset.schema(),

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -232,6 +232,7 @@ impl UpdateJob {
         let stream = RecordBatchStreamAdapter::new(schema, stream);
 
         let new_fragments = write_fragments_internal(
+            Some(&self.dataset),
             self.dataset.object_store.clone(),
             &self.dataset.base,
             self.dataset.schema(),


### PR DESCRIPTION
Fixes two bugs, both associated with schemas that have holes in the field ids:

1. `write_fragments()` and `LanceFragment.create()` assume they can derive the field ids from the Arrow schema. This is not the case if there are holes in the schema. Therefore, when the mode is `Append`, we check the existing schema of the dataset and use its field ids. Fixes #2179
2. `PageTable` assumed that there were no holes in the field ids. It was parametrized as `field_id_offset` and `num_fields`, assuming the field ids were `field_id_offset..(field_id_offset + num_fields)`. This is changed to be parametrized by the min and max field id.