### PR TITLE
chore: remove --preview from ruff invocations

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,8 +58,8 @@ jobs:
         pip install torch --index-url https://download.pytorch.org/whl/cpu
     - name: Lint Python
       run: |
-        ruff format --preview --check python
-        ruff check --preview python
+        ruff format --check python
+        ruff check python
     - name: Install dependencies
       run: |
         sudo apt update

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,6 @@ repos:
     rev: v0.2.2
     hooks:
       - id: ruff
-        args: [--preview, --fix, --exit-non-zero-on-fix]
+        args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
-        args: [--preview]
+

--- a/python/Makefile
+++ b/python/Makefile
@@ -17,16 +17,16 @@ format: format-python
 .PHONY: format
 
 format-python:
-	ruff format --preview python
-	ruff --preview --fix python
+	ruff format python
+	ruff --fix python
 .PHONY: format-python
 
 lint: lint-python lint-rust
 .PHONY: lint
 
 lint-python:
-	ruff format --preview --check python
-	ruff --preview python
+	ruff format --check python
+	ruff python
 .PHONY: lint-python
 
 lint-rust:

--- a/python/python/benchmarks/test_bulk_write.py
+++ b/python/python/benchmarks/test_bulk_write.py
@@ -16,11 +16,13 @@ GiB = 1024 * MiB
 
 # Mostly vector data.  One id column, a caption, and an embedding vector
 def create_captioned_image_data(num_bytes):
-    schema = pa.schema([
-        pa.field("int32", pa.int32()),
-        pa.field("text", pa.utf8()),
-        pa.field("vector", pa.list_(pa.float32(), N_DIMS)),
-    ])
+    schema = pa.schema(
+        [
+            pa.field("int32", pa.int32()),
+            pa.field("text", pa.utf8()),
+            pa.field("vector", pa.list_(pa.float32(), N_DIMS)),
+        ]
+    )
     return schema, rand_batches(
         schema, num_batches=8, batch_size_bytes=int(num_bytes / 8)
     )
@@ -28,24 +30,26 @@ def create_captioned_image_data(num_bytes):
 
 # Purely scalar data (schema based on TPC-H lineitem table)
 def create_scalar_data(num_bytes):
-    schema = pa.schema([
-        pa.field("l_orderkey", pa.int64()),
-        pa.field("l_partkey", pa.int64()),
-        pa.field("l_suppkey", pa.int64()),
-        pa.field("l_linenumber", pa.int64()),
-        pa.field("l_quantity", pa.float64()),
-        pa.field("l_extendedprice", pa.float64()),
-        pa.field("l_discount", pa.float64()),
-        pa.field("l_tax", pa.float64()),
-        pa.field("l_returnflag", pa.utf8()),
-        pa.field("l_linestatus", pa.utf8()),
-        pa.field("l_shipdate", pa.date32()),
-        pa.field("l_commitdate", pa.date32()),
-        pa.field("l_receiptdate", pa.date32()),
-        pa.field("l_shipinstruct", pa.utf8()),
-        pa.field("l_shipmode", pa.utf8()),
-        pa.field("l_comment", pa.utf8()),
-    ])
+    schema = pa.schema(
+        [
+            pa.field("l_orderkey", pa.int64()),
+            pa.field("l_partkey", pa.int64()),
+            pa.field("l_suppkey", pa.int64()),
+            pa.field("l_linenumber", pa.int64()),
+            pa.field("l_quantity", pa.float64()),
+            pa.field("l_extendedprice", pa.float64()),
+            pa.field("l_discount", pa.float64()),
+            pa.field("l_tax", pa.float64()),
+            pa.field("l_returnflag", pa.utf8()),
+            pa.field("l_linestatus", pa.utf8()),
+            pa.field("l_shipdate", pa.date32()),
+            pa.field("l_commitdate", pa.date32()),
+            pa.field("l_receiptdate", pa.date32()),
+            pa.field("l_shipinstruct", pa.utf8()),
+            pa.field("l_shipmode", pa.utf8()),
+            pa.field("l_comment", pa.utf8()),
+        ]
+    )
     return schema, rand_batches(
         schema, num_batches=8, batch_size_bytes=int(num_bytes / 8)
     )

--- a/python/python/benchmarks/test_scan.py
+++ b/python/python/benchmarks/test_scan.py
@@ -46,28 +46,32 @@ def test_scan_integer(tmp_path: Path, benchmark, array_factory):
 @pytest.fixture(scope="module")
 def sample_dataset(tmpdir_factory):
     tmp_path = Path(tmpdir_factory.mktemp("data"))
-    table = pa.table({
-        "i": pa.array(range(NUM_ROWS), type=pa.int32()),
-        "f": pc.random(NUM_ROWS).cast(pa.float32()),
-        "s": pa.array(
-            [random.choice(["hello", "world", "today"]) for _ in range(NUM_ROWS)],
-            type=pa.string(),
-        ),
-        "fsl": pa.FixedSizeListArray.from_arrays(
-            pc.random(NUM_ROWS * 128).cast(pa.float32()), 128
-        ),
-        "blob": pa.array(
-            [
-                random.choice([
-                    random.randbytes(100 * 1024),
-                    random.randbytes(100 * 1024),
-                    random.randbytes(100 * 1024),
-                ])
-                for _ in range(NUM_ROWS)
-            ],
-            type=pa.binary(),
-        ),
-    })
+    table = pa.table(
+        {
+            "i": pa.array(range(NUM_ROWS), type=pa.int32()),
+            "f": pc.random(NUM_ROWS).cast(pa.float32()),
+            "s": pa.array(
+                [random.choice(["hello", "world", "today"]) for _ in range(NUM_ROWS)],
+                type=pa.string(),
+            ),
+            "fsl": pa.FixedSizeListArray.from_arrays(
+                pc.random(NUM_ROWS * 128).cast(pa.float32()), 128
+            ),
+            "blob": pa.array(
+                [
+                    random.choice(
+                        [
+                            random.randbytes(100 * 1024),
+                            random.randbytes(100 * 1024),
+                            random.randbytes(100 * 1024),
+                        ]
+                    )
+                    for _ in range(NUM_ROWS)
+                ],
+                type=pa.binary(),
+            ),
+        }
+    )
 
     return lance.write_dataset(table, tmp_path)
 

--- a/python/python/lance/arrow.py
+++ b/python/python/lance/arrow.py
@@ -370,9 +370,9 @@ class EncodedImageArray(ImageArray):
 
                 from PIL import Image
 
-                return np.stack([
-                    Image.open(io.BytesIO(img)) for img in images.to_pylist()
-                ])
+                return np.stack(
+                    [Image.open(io.BytesIO(img)) for img in images.to_pylist()]
+                )
 
             def tensorflow_decoder(images):
                 import tensorflow as tf

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1203,10 +1203,12 @@ class LanceDataset(pa.dataset.Dataset):
 
         index_type = index_type.upper()
         if index_type != "BTREE":
-            raise NotImplementedError((
-                'Only "BTREE" is supported for ',
-                f"index_type.  Received {index_type}",
-            ))
+            raise NotImplementedError(
+                (
+                    'Only "BTREE" is supported for ',
+                    f"index_type.  Received {index_type}",
+                )
+            )
 
         self._ds.create_index([column], index_type, name, replace)
 

--- a/python/python/lance/progress.py
+++ b/python/python/lance/progress.py
@@ -199,10 +199,12 @@ class FileSystemFragmentWriteProgress(FragmentWriteProgress):
                     fragment_metadata = FragmentMetadata.from_json(
                         f.read().decode("utf-8")
                     )
-                objects.append((
-                    fragment_metadata.data_files()[0].path(),
-                    progress_data["multipart_id"],
-                ))
+                objects.append(
+                    (
+                        fragment_metadata.data_files()[0].path(),
+                        progress_data["multipart_id"],
+                    )
+                )
 
         _cleanup_partial_writes(dataset_uri, objects)
 

--- a/python/python/lance/ray/sink.py
+++ b/python/python/lance/ray/sink.py
@@ -239,10 +239,12 @@ class LanceFragmentWriter:
             max_rows_per_file=self.max_rows_per_file,
             max_rows_per_group=self.max_rows_per_group,
         )
-        return pa.Table.from_pydict({
-            "fragment": [pickle.dumps(fragment) for fragment, _ in fragments],
-            "schema": [pickle.dumps(schema) for _, schema in fragments],
-        })
+        return pa.Table.from_pydict(
+            {
+                "fragment": [pickle.dumps(fragment) for fragment, _ in fragments],
+                "schema": [pickle.dumps(schema) for _, schema in fragments],
+            }
+        )
 
 
 class LanceCommitter(_BaseLanceDatasink):

--- a/python/python/lance/tf/data.py
+++ b/python/python/lance/tf/data.py
@@ -253,9 +253,9 @@ def lance_fragments(dataset: Union[str, Path, LanceDataset]) -> tf.data.Dataset:
     """
     if not isinstance(dataset, LanceDataset):
         dataset = lance.dataset(dataset)
-    return tf.data.Dataset.from_tensor_slices([
-        f.fragment_id for f in dataset.get_fragments()
-    ])
+    return tf.data.Dataset.from_tensor_slices(
+        [f.fragment_id for f in dataset.get_fragments()]
+    )
 
 
 def _ith_batch(i: int, batch_size: int, total_size: int) -> Tuple[int, int]:

--- a/python/python/lance/torch/bench_utils.py
+++ b/python/python/lance/torch/bench_utils.py
@@ -132,9 +132,9 @@ def recall(expected: np.ndarray, actual: np.ndarray) -> np.ndarray:
         The ANN results
     """
     assert expected.shape == actual.shape
-    recalls = np.array([
-        np.isin(exp, act).sum() / exp.shape[0] for exp, act in zip(expected, actual)
-    ])
+    recalls = np.array(
+        [np.isin(exp, act).sum() / exp.shape[0] for exp, act in zip(expected, actual)]
+    )
     return recalls
 
 

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -221,10 +221,12 @@ def compute_partitions(
         with_row_id=True,
         columns=[column],
     )
-    output_schema = pa.schema([
-        pa.field("row_id", pa.uint64()),
-        pa.field("partition", pa.uint32()),
-    ])
+    output_schema = pa.schema(
+        [
+            pa.field("row_id", pa.uint64()),
+            pa.field("partition", pa.uint32()),
+        ]
+    )
 
     def _partition_assignment() -> Iterable[pa.RecordBatch]:
         with torch.no_grad():

--- a/python/python/tests/test_arrow.py
+++ b/python/python/tests/test_arrow.py
@@ -163,11 +163,13 @@ def test_bf16_roundtrip(tmp_path: Path):
     tensors = pa.ExtensionArray.from_storage(
         pa.fixed_shape_tensor(values.type, [3]), vectors
     )
-    data = pa.table({
-        "values": values.slice(0, 3),
-        "vector": vectors,
-        "tensors": tensors,
-    })
+    data = pa.table(
+        {
+            "values": values.slice(0, 3),
+            "vector": vectors,
+            "tensors": tensors,
+        }
+    )
     ds = lance.write_dataset(data, tmp_path)
     assert ds.schema == data.schema
     assert ds.to_table() == data

--- a/python/python/tests/test_datagen.py
+++ b/python/python/tests/test_datagen.py
@@ -20,10 +20,12 @@ def test_import_error():
 def test_rand_batches():
     import lance._datagen as datagen
 
-    schema = pa.schema([
-        pa.field("int", pa.int64()),
-        pa.field("vector", pa.list_(pa.float32(), 128)),
-    ])
+    schema = pa.schema(
+        [
+            pa.field("int", pa.int64()),
+            pa.field("vector", pa.list_(pa.float32(), 128)),
+        ]
+    )
 
     batches = datagen.rand_batches(schema, batch_size_bytes=16 * 1024, num_batches=10)
 

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -44,10 +44,12 @@ input_data = [
     (
         input_schema,
         iter(
-            pa.table({
-                "a": [1.0, 2.0],
-                "b": pa.array([20, 30], pa.int32()),
-            }).to_batches()
+            pa.table(
+                {
+                    "a": [1.0, 2.0],
+                    "b": pa.array([20, 30], pa.int32()),
+                }
+            ).to_batches()
         ),
     ),
 ]
@@ -61,18 +63,22 @@ def test_input_data(tmp_path: Path, schema, data):
 
 
 def test_roundtrip_types(tmp_path: Path):
-    table = pa.table({
-        "dict": pa.array(["a", "b", "a"], pa.dictionary(pa.int8(), pa.string())),
-        # PyArrow doesn't support creating large_string dictionaries easily.
-        "large_dict": pa.DictionaryArray.from_arrays(
-            pa.array([0, 1, 1], pa.int8()),
-            pa.array(["foo", "bar"], pa.large_string()),
-        ),
-        "list": pa.array([["a", "b"], ["c", "d"], ["e", "f"]], pa.list_(pa.string())),
-        "large_list": pa.array(
-            [["a", "b"], ["c", "d"], ["e", "f"]], pa.large_list(pa.string())
-        ),
-    })
+    table = pa.table(
+        {
+            "dict": pa.array(["a", "b", "a"], pa.dictionary(pa.int8(), pa.string())),
+            # PyArrow doesn't support creating large_string dictionaries easily.
+            "large_dict": pa.DictionaryArray.from_arrays(
+                pa.array([0, 1, 1], pa.int8()),
+                pa.array(["foo", "bar"], pa.large_string()),
+            ),
+            "list": pa.array(
+                [["a", "b"], ["c", "d"], ["e", "f"]], pa.list_(pa.string())
+            ),
+            "large_list": pa.array(
+                [["a", "b"], ["c", "d"], ["e", "f"]], pa.large_list(pa.string())
+            ),
+        }
+    )
 
     dataset = lance.write_dataset(table, tmp_path)
     assert dataset.schema == table.schema
@@ -121,10 +127,12 @@ def test_dataset_from_record_batch_iterable(tmp_path: Path):
     ]
 
     # define schema
-    schema = pa.schema([
-        pa.field("colA", pa.string()),
-        pa.field("colB", pa.int64()),
-    ])
+    schema = pa.schema(
+        [
+            pa.field("colA", pa.string()),
+            pa.field("colB", pa.int64()),
+        ]
+    )
 
     # write dataset with iterator
     lance.write_dataset(iter(batches), base_dir, schema)
@@ -391,9 +399,9 @@ def test_list_from_parquet(tmp_path: Path):
     # This is a regression for GH-1482, the parquet reader creates
     # list fields with the name 'element' instead of 'item'.  We should
     # ignore that
-    tab = pa.Table.from_pydict({
-        "x": pa.array([[1, 2], [3, 4]], pa.list_(pa.float32(), 2))
-    })
+    tab = pa.Table.from_pydict(
+        {"x": pa.array([[1, 2], [3, 4]], pa.list_(pa.float32(), 2))}
+    )
     pq.write_table(tab, tmp_path / "foo.parquet")
     tab = pq.read_table(tmp_path / "foo.parquet")
     lance.write_dataset(tab, tmp_path / "foo.lance")
@@ -412,11 +420,13 @@ def test_pickle(tmp_path: Path):
 
 def test_polar_scan(tmp_path: Path):
     some_structs = [{"x": counter, "y": counter} for counter in range(100)]
-    table = pa.Table.from_pydict({
-        "a": range(100),
-        "b": range(100),
-        "struct": some_structs,
-    })
+    table = pa.Table.from_pydict(
+        {
+            "a": range(100),
+            "b": range(100),
+            "struct": some_structs,
+        }
+    )
     base_dir = tmp_path / "test"
     lance.write_dataset(table, base_dir)
 
@@ -530,11 +540,13 @@ def test_add_columns(tmp_path: Path):
     assert dataset.schema == schema.to_pyarrow()
 
     tbl = dataset.to_table()
-    assert tbl == pa.Table.from_pydict({
-        "a": range(100),
-        "b": range(100),
-        "c": pa.array(range(0, 200, 2), pa.int64()),
-    })
+    assert tbl == pa.Table.from_pydict(
+        {
+            "a": range(100),
+            "b": range(100),
+            "c": pa.array(range(0, 200, 2), pa.int64()),
+        }
+    )
 
 
 def test_cleanup_old_versions(tmp_path):
@@ -595,10 +607,12 @@ def test_append_with_commit(tmp_path: Path):
 
     tbl = dataset.to_table()
 
-    expected = pa.Table.from_pydict({
-        "a": list(range(100)) + list(range(100)),
-        "b": list(range(100)) + list(range(100)),
-    })
+    expected = pa.Table.from_pydict(
+        {
+            "a": list(range(100)) + list(range(100)),
+            "b": list(range(100)) + list(range(100)),
+        }
+    )
     assert tbl == expected
 
 
@@ -694,11 +708,13 @@ def test_merge_with_schema_holes(tmp_path: Path):
     dataset.validate()
 
     tbl = dataset.to_table()
-    expected = pa.table({
-        "a": range(10),
-        "c": range(2, 12),
-        "d": range(10, 20),
-    })
+    expected = pa.table(
+        {
+            "a": range(10),
+            "c": range(2, 12),
+            "d": range(10, 20),
+        }
+    )
     assert tbl == expected
 
 
@@ -814,22 +830,26 @@ def test_merge_data(tmp_path: Path):
     new_tab = pa.table({"a": range(100), "c": range(100)})
     dataset.merge(new_tab, "a")
     assert dataset.version == 2
-    assert dataset.to_table() == pa.table({
-        "a": range(100),
-        "b": range(100),
-        "c": range(100),
-    })
+    assert dataset.to_table() == pa.table(
+        {
+            "a": range(100),
+            "b": range(100),
+            "c": range(100),
+        }
+    )
 
     # accepts a partial for string
     new_tab = pa.table({"a2": range(5), "d": ["a", "b", "c", "d", "e"]})
     dataset.merge(new_tab, left_on="a", right_on="a2")
     assert dataset.version == 3
-    expected = pa.table({
-        "a": range(100),
-        "b": range(100),
-        "c": range(100),
-        "d": ["a", "b", "c", "d", "e"] + [None] * 95,
-    })
+    expected = pa.table(
+        {
+            "a": range(100),
+            "b": range(100),
+            "c": range(100),
+            "d": ["a", "b", "c", "d", "e"] + [None] * 95,
+        }
+    )
     assert dataset.to_table() == expected
     # Verify we can also load from fresh instance
     dataset = lance.dataset(tmp_path / "dataset")
@@ -845,19 +865,23 @@ def test_merge_from_dataset(tmp_path: Path):
 
     ds1.merge(ds2.to_batches(), "a", schema=ds2.schema)
     assert ds1.version == 2
-    assert ds1.to_table() == pa.table({
-        "a": range(100),
-        "b": range(100),
-        "c": range(100),
-    })
+    assert ds1.to_table() == pa.table(
+        {
+            "a": range(100),
+            "b": range(100),
+            "c": range(100),
+        }
+    )
 
 
 def test_delete_data(tmp_path: Path):
     # We pass schema explicitly since we want b to be non-nullable.
-    schema = pa.schema([
-        pa.field("a", pa.int64()),
-        pa.field("b", pa.int64(), nullable=False),
-    ])
+    schema = pa.schema(
+        [
+            pa.field("a", pa.int64()),
+            pa.field("b", pa.int64(), nullable=False),
+        ]
+    )
     tab = pa.table({"a": range(100), "b": range(100)}, schema=schema)
     lance.write_dataset(tab, tmp_path / "dataset", mode="append")
 
@@ -892,21 +916,25 @@ def test_delete_data(tmp_path: Path):
 
 def test_merge_insert(tmp_path: Path):
     nrows = 1000
-    table = pa.Table.from_pydict({
-        "a": range(nrows),
-        "b": [1 for _ in range(nrows)],
-        "c": [x % 2 for x in range(nrows)],
-    })
+    table = pa.Table.from_pydict(
+        {
+            "a": range(nrows),
+            "b": [1 for _ in range(nrows)],
+            "c": [x % 2 for x in range(nrows)],
+        }
+    )
     dataset = lance.write_dataset(
         table, tmp_path / "dataset", mode="create", max_rows_per_file=100
     )
     version = dataset.version
 
-    new_table = pa.Table.from_pydict({
-        "a": range(300, 300 + nrows),
-        "b": [2 for _ in range(nrows)],
-        "c": [0 for _ in range(nrows)],
-    })
+    new_table = pa.Table.from_pydict(
+        {
+            "a": range(300, 300 + nrows),
+            "b": [2 for _ in range(nrows)],
+            "c": [0 for _ in range(nrows)],
+        }
+    )
 
     is_new = pc.field("b") == 2
 
@@ -966,18 +994,22 @@ def test_merge_insert(tmp_path: Path):
 
 
 def test_merge_insert_conditional_upsert_example(tmp_path: Path):
-    table = pa.Table.from_pydict({
-        "id": [1, 2, 3, 4, 5],
-        "txNumber": [1, 1, 2, 2, 3],
-        "vector": pa.array([[1.0, 1.0] for _ in range(5)], pa.list_(pa.float32())),
-    })
+    table = pa.Table.from_pydict(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "txNumber": [1, 1, 2, 2, 3],
+            "vector": pa.array([[1.0, 1.0] for _ in range(5)], pa.list_(pa.float32())),
+        }
+    )
     dataset = lance.write_dataset(table, tmp_path / "dataset", mode="create")
 
-    new_table = pa.Table.from_pydict({
-        "id": [1, 2, 3, 4, 5],
-        "txNumber": [1, 2, 1, 2, 5],
-        "vector": pa.array([[2.0, 2.0] for _ in range(5)], pa.list_(pa.float32())),
-    })
+    new_table = pa.Table.from_pydict(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "txNumber": [1, 2, 1, 2, 5],
+            "vector": pa.array([[2.0, 2.0] for _ in range(5)], pa.list_(pa.float32())),
+        }
+    )
 
     dataset.merge_insert("id").when_matched_update_all(
         "target.txNumber < source.txNumber"
@@ -985,24 +1017,28 @@ def test_merge_insert_conditional_upsert_example(tmp_path: Path):
 
     table = dataset.to_table()
 
-    expected = pa.Table.from_pydict({
-        "id": [1, 2, 3, 4, 5],
-        "txNumber": [1, 2, 2, 2, 5],
-        "vector": pa.array(
-            [[1.0, 1.0], [2.0, 2.0], [1.0, 1.0], [1.0, 1.0], [2.0, 2.0]],
-            pa.list_(pa.float32()),
-        ),
-    })
+    expected = pa.Table.from_pydict(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "txNumber": [1, 2, 2, 2, 5],
+            "vector": pa.array(
+                [[1.0, 1.0], [2.0, 2.0], [1.0, 1.0], [1.0, 1.0], [2.0, 2.0]],
+                pa.list_(pa.float32()),
+            ),
+        }
+    )
 
     assert table.sort_by("id") == expected
 
     # No matches
 
-    new_table = pa.Table.from_pydict({
-        "id": [1, 2, 3, 4, 5],
-        "txNumber": [0, 0, 0, 0, 0],
-        "vector": pa.array([[2.0, 2.0] for _ in range(5)], pa.list_(pa.float32())),
-    })
+    new_table = pa.Table.from_pydict(
+        {
+            "id": [1, 2, 3, 4, 5],
+            "txNumber": [0, 0, 0, 0, 0],
+            "vector": pa.array([[2.0, 2.0] for _ in range(5)], pa.list_(pa.float32())),
+        }
+    )
 
     dataset.merge_insert("id").when_matched_update_all(
         "target.txNumber < source.txNumber"
@@ -1017,10 +1053,12 @@ def test_merge_insert_source_is_dataset(tmp_path: Path):
     )
     version = dataset.version
 
-    new_table = pa.Table.from_pydict({
-        "a": range(300, 300 + nrows),
-        "b": [2 for _ in range(nrows)],
-    })
+    new_table = pa.Table.from_pydict(
+        {
+            "a": range(300, 300 + nrows),
+            "b": [2 for _ in range(nrows)],
+        }
+    )
     new_dataset = lance.write_dataset(
         new_table, tmp_path / "dataset2", mode="create", max_rows_per_file=80
     )
@@ -1050,11 +1088,13 @@ def test_merge_insert_multiple_keys(tmp_path: Path):
     # a - [0, 1, 2, ..., 999]
     # b - [1, 1, 1, ..., 1]
     # c - [0, 1, 0, ..., 1]
-    table = pa.Table.from_pydict({
-        "a": range(nrows),
-        "b": [1 for _ in range(nrows)],
-        "c": [i % 2 for i in range(nrows)],
-    })
+    table = pa.Table.from_pydict(
+        {
+            "a": range(nrows),
+            "b": [1 for _ in range(nrows)],
+            "c": [i % 2 for i in range(nrows)],
+        }
+    )
     dataset = lance.write_dataset(
         table, tmp_path / "dataset", mode="create", max_rows_per_file=100
     )
@@ -1062,11 +1102,13 @@ def test_merge_insert_multiple_keys(tmp_path: Path):
     # a - [300, 301, 302, ..., 1299]
     # b - [2, 2, 2, ..., 2]
     # c - [0, 0, 0, ..., 0]
-    new_table = pa.Table.from_pydict({
-        "a": range(300, 300 + nrows),
-        "b": [2 for _ in range(nrows)],
-        "c": [0 for _ in range(nrows)],
-    })
+    new_table = pa.Table.from_pydict(
+        {
+            "a": range(300, 300 + nrows),
+            "b": [2 for _ in range(nrows)],
+            "c": [0 for _ in range(nrows)],
+        }
+    )
 
     is_new = pc.field("b") == 2
 
@@ -1078,47 +1120,57 @@ def test_merge_insert_multiple_keys(tmp_path: Path):
 
 def test_merge_insert_incompatible_schema(tmp_path: Path):
     nrows = 1000
-    table = pa.Table.from_pydict({
-        "a": range(nrows),
-        "b": [1 for _ in range(nrows)],
-    })
+    table = pa.Table.from_pydict(
+        {
+            "a": range(nrows),
+            "b": [1 for _ in range(nrows)],
+        }
+    )
     dataset = lance.write_dataset(
         table, tmp_path / "dataset", mode="create", max_rows_per_file=100
     )
 
-    new_table = pa.Table.from_pydict({
-        "a": range(300, 300 + nrows),
-    })
+    new_table = pa.Table.from_pydict(
+        {
+            "a": range(300, 300 + nrows),
+        }
+    )
 
     with pytest.raises(OSError):
         dataset.merge_insert("a").when_matched_update_all().execute(new_table)
 
 
 def test_merge_insert_vector_column(tmp_path: Path):
-    table = pa.Table.from_pydict({
-        "vec": pa.array([[1, 2, 3], [4, 5, 6]], pa.list_(pa.float32(), 3)),
-        "key": [1, 2],
-    })
+    table = pa.Table.from_pydict(
+        {
+            "vec": pa.array([[1, 2, 3], [4, 5, 6]], pa.list_(pa.float32(), 3)),
+            "key": [1, 2],
+        }
+    )
 
-    new_table = pa.Table.from_pydict({
-        "vec": pa.array([[7, 8, 9], [10, 11, 12]], pa.list_(pa.float32(), 3)),
-        "key": [2, 3],
-    })
+    new_table = pa.Table.from_pydict(
+        {
+            "vec": pa.array([[7, 8, 9], [10, 11, 12]], pa.list_(pa.float32(), 3)),
+            "key": [2, 3],
+        }
+    )
 
     dataset = lance.write_dataset(
         table, tmp_path / "dataset", mode="create", max_rows_per_file=100
     )
 
-    dataset.merge_insert([
-        "key"
-    ]).when_not_matched_insert_all().when_matched_update_all().execute(new_table)
+    dataset.merge_insert(
+        ["key"]
+    ).when_not_matched_insert_all().when_matched_update_all().execute(new_table)
 
-    expected = pa.Table.from_pydict({
-        "vec": pa.array(
-            [[1, 2, 3], [7, 8, 9], [10, 11, 12]], pa.list_(pa.float32(), 3)
-        ),
-        "key": [1, 2, 3],
-    })
+    expected = pa.Table.from_pydict(
+        {
+            "vec": pa.array(
+                [[1, 2, 3], [7, 8, 9], [10, 11, 12]], pa.list_(pa.float32(), 3)
+            ),
+            "key": [1, 2, 3],
+        }
+    )
 
     assert dataset.to_table().sort_by("key") == expected
 
@@ -1138,36 +1190,44 @@ def test_update_dataset(tmp_path: Path):
     assert dataset.to_table(columns=["a", "b"]) == expected
 
     dataset.update(dict(a="a * 2"), where="a < 50")
-    expected = pa.table({
-        "a": [x * 2 if x < 50 else x for x in range(100)],
-        "b": range(1, 101),
-    })
+    expected = pa.table(
+        {
+            "a": [x * 2 if x < 50 else x for x in range(100)],
+            "b": range(1, 101),
+        }
+    )
     assert dataset.to_table(columns=["a", "b"]).sort_by("b") == expected
 
     dataset.update(dict(vec="[42.0, 43.0]"))
-    expected = pa.table({
-        "b": range(1, 101),
-        "vec": pa.array([[42.0, 43.0] for _ in range(100)], pa.list_(pa.float32(), 2)),
-    })
+    expected = pa.table(
+        {
+            "b": range(1, 101),
+            "vec": pa.array(
+                [[42.0, 43.0] for _ in range(100)], pa.list_(pa.float32(), 2)
+            ),
+        }
+    )
     assert dataset.to_table(columns=["b", "vec"]).sort_by("b") == expected
 
 
 def test_update_dataset_all_types(tmp_path: Path):
-    table = pa.table({
-        "int32": pa.array([1], pa.int32()),
-        "int64": pa.array([1], pa.int64()),
-        "uint32": pa.array([1], pa.uint32()),
-        "string": pa.array(["foo"], pa.string()),
-        "large_string": pa.array(["foo"], pa.large_string()),
-        "float32": pa.array([1.0], pa.float32()),
-        "float64": pa.array([1.0], pa.float64()),
-        "bool": pa.array([True], pa.bool_()),
-        "date32": pa.array([date(2021, 1, 1)], pa.date32()),
-        "timestamp_ns": pa.array([datetime(2021, 1, 1)], pa.timestamp("ns")),
-        "timestamp_ms": pa.array([datetime(2021, 1, 1)], pa.timestamp("ms")),
-        "vec_f32": pa.array([[1.0, 2.0]], pa.list_(pa.float32(), 2)),
-        "vec_f64": pa.array([[1.0, 2.0]], pa.list_(pa.float64(), 2)),
-    })
+    table = pa.table(
+        {
+            "int32": pa.array([1], pa.int32()),
+            "int64": pa.array([1], pa.int64()),
+            "uint32": pa.array([1], pa.uint32()),
+            "string": pa.array(["foo"], pa.string()),
+            "large_string": pa.array(["foo"], pa.large_string()),
+            "float32": pa.array([1.0], pa.float32()),
+            "float64": pa.array([1.0], pa.float64()),
+            "bool": pa.array([True], pa.bool_()),
+            "date32": pa.array([date(2021, 1, 1)], pa.date32()),
+            "timestamp_ns": pa.array([datetime(2021, 1, 1)], pa.timestamp("ns")),
+            "timestamp_ms": pa.array([datetime(2021, 1, 1)], pa.timestamp("ms")),
+            "vec_f32": pa.array([[1.0, 2.0]], pa.list_(pa.float32(), 2)),
+            "vec_f64": pa.array([[1.0, 2.0]], pa.list_(pa.float64(), 2)),
+        }
+    )
 
     dataset = lance.write_dataset(table, tmp_path)
 
@@ -1189,21 +1249,23 @@ def test_update_dataset_all_types(tmp_path: Path):
             vec_f64="[3.0, 4.0]",
         )
     )
-    expected = pa.table({
-        "int32": pa.array([2], pa.int32()),
-        "int64": pa.array([2], pa.int64()),
-        "uint32": pa.array([2], pa.uint32()),
-        "string": pa.array(["bar"], pa.string()),
-        "large_string": pa.array(["bar"], pa.large_string()),
-        "float32": pa.array([2.0], pa.float32()),
-        "float64": pa.array([2.0], pa.float64()),
-        "bool": pa.array([False], pa.bool_()),
-        "date32": pa.array([date(2021, 1, 2)], pa.date32()),
-        "timestamp_ns": pa.array([datetime(2021, 1, 2)], pa.timestamp("ns")),
-        "timestamp_ms": pa.array([datetime(2021, 1, 2)], pa.timestamp("ms")),
-        "vec_f32": pa.array([[3.0, 4.0]], pa.list_(pa.float32(), 2)),
-        "vec_f64": pa.array([[3.0, 4.0]], pa.list_(pa.float64(), 2)),
-    })
+    expected = pa.table(
+        {
+            "int32": pa.array([2], pa.int32()),
+            "int64": pa.array([2], pa.int64()),
+            "uint32": pa.array([2], pa.uint32()),
+            "string": pa.array(["bar"], pa.string()),
+            "large_string": pa.array(["bar"], pa.large_string()),
+            "float32": pa.array([2.0], pa.float32()),
+            "float64": pa.array([2.0], pa.float64()),
+            "bool": pa.array([False], pa.bool_()),
+            "date32": pa.array([date(2021, 1, 2)], pa.date32()),
+            "timestamp_ns": pa.array([datetime(2021, 1, 2)], pa.timestamp("ns")),
+            "timestamp_ms": pa.array([datetime(2021, 1, 2)], pa.timestamp("ms")),
+            "vec_f32": pa.array([[3.0, 4.0]], pa.list_(pa.float32(), 2)),
+            "vec_f64": pa.array([[3.0, 4.0]], pa.list_(pa.float64(), 2)),
+        }
+    )
     assert dataset.to_table() == expected
 
 
@@ -1220,11 +1282,13 @@ def test_create_update_empty_dataset(tmp_path: Path, provide_pandas: bool):
     dataset = lance.write_dataset(tab, base_dir)
 
     assert dataset.count_rows() == 0
-    expected_schema = pa.schema([
-        pa.field("a", pa.string()),
-        pa.field("b", pa.int64()),
-        pa.field("c", pa.float64()),
-    ])
+    expected_schema = pa.schema(
+        [
+            pa.field("a", pa.string()),
+            pa.field("b", pa.int64()),
+            pa.field("c", pa.float64()),
+        ]
+    )
     assert dataset.schema == expected_schema
     assert dataset.to_table() == pa.table(
         {"a": [], "b": [], "c": []}, schema=expected_schema
@@ -1274,11 +1338,13 @@ def test_scan_prefilter(tmp_path: Path):
     vecs = pa.array(
         [[1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 6]], type=pa.list_(pa.float32(), 2)
     )
-    df = pa.Table.from_pydict({
-        "index": [1, 2, 3, 4, 5, 6],
-        "type": ["a", "a", "a", "b", "b", "b"],
-        "vecs": vecs,
-    })
+    df = pa.Table.from_pydict(
+        {
+            "index": [1, 2, 3, 4, 5, 6],
+            "type": ["a", "a", "a", "b", "b", "b"],
+            "vecs": vecs,
+        }
+    )
     dataset = lance.write_dataset(df, base_dir)
     query = pa.array([1, 1], pa.float32())
     args = {
@@ -1529,11 +1595,13 @@ def test_sharded_iterator_batches(tmp_path: Path):
         granularity="batch",
     )
     batches = pa.concat_arrays([b["a"] for b in shard_datast])
-    assert batches == pa.array([
-        j
-        for i in range(RANK * BATCH_SIZE, 1000, WORLD_SIZE * BATCH_SIZE)
-        for j in range(i, i + BATCH_SIZE)
-    ])
+    assert batches == pa.array(
+        [
+            j
+            for i in range(RANK * BATCH_SIZE, 1000, WORLD_SIZE * BATCH_SIZE)
+            for j in range(i, i + BATCH_SIZE)
+        ]
+    )
 
 
 def test_sharded_iterator_non_full_batch(tmp_path: Path):

--- a/python/python/tests/test_debug.py
+++ b/python/python/tests/test_debug.py
@@ -14,11 +14,13 @@ from lance.debug import (
 
 
 def test_format_schema(tmp_path: Path):
-    schema = pa.schema({
-        "a": pa.int64(),
-        "b": pa.string(),
-        "c": pa.bool_(),
-    })
+    schema = pa.schema(
+        {
+            "a": pa.int64(),
+            "b": pa.string(),
+            "c": pa.bool_(),
+        }
+    )
     table = pa.Table.from_batches([], schema)
     dataset = lance.write_dataset(table, tmp_path)
 

--- a/python/python/tests/test_filter.py
+++ b/python/python/tests/test_filter.py
@@ -167,9 +167,9 @@ def test_escaped_name(tmp_path: Path, provide_pandas: bool):
         result, pd.DataFrame([{"ALLCAPSNAME": 1, "other": 3}])
     )
 
-    table = pa.table({
-        "Nested with Space": pa.array([{"Inner With Caps": i} for i in range(3)])
-    })
+    table = pa.table(
+        {"Nested with Space": pa.array([{"Inner With Caps": i} for i in range(3)])}
+    )
     _ = lance.write_dataset(table, tmp_path / "test_escaped_name_nested_and_capped")
 
     dataset = lance.dataset(tmp_path / "test_escaped_name_nested_and_capped")
@@ -183,9 +183,9 @@ def test_escaped_name(tmp_path: Path, provide_pandas: bool):
 
 def test_functions(tmp_path: Path):
     # Ensure that we can use complex functions
-    table = pa.table({
-        "genres": [["action", "comedy"], ["anime", "drama"], ["adventure"]]
-    })
+    table = pa.table(
+        {"genres": [["action", "comedy"], ["anime", "drama"], ["adventure"]]}
+    )
     expected = table.slice(1, 2)
     dataset = lance.write_dataset(table, tmp_path / "test_neg_expr")
     assert (

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -86,9 +86,11 @@ def test_scan_fragment_with_dynamic_projection(tmp_path: Path):
 
 def test_write_fragments(tmp_path: Path):
     # This will be split across two files if we set the max_bytes_per_file to 1024
-    tab = pa.table({
-        "a": pa.array(range(1024)),
-    })
+    tab = pa.table(
+        {
+            "a": pa.array(range(1024)),
+        }
+    )
     progress = ProgressForTest()
     fragments = write_fragments(
         tab,

--- a/python/python/tests/test_lance.py
+++ b/python/python/tests/test_lance.py
@@ -171,10 +171,12 @@ def _create_dataset(uri, num_batches=1):
 
 
 def test_schema_to_json():
-    schema = pa.schema([
-        pa.field("embedding", pa.list_(pa.float32(), 32), False),
-        pa.field("id", pa.int64(), True),
-    ])
+    schema = pa.schema(
+        [
+            pa.field("embedding", pa.list_(pa.float32(), 32), False),
+            pa.field("id", pa.int64(), True),
+        ]
+    )
     json_schema = lance.schema_to_json(schema)
     assert json_schema == {
         "fields": [
@@ -211,15 +213,19 @@ def sample_data_all_types():
     storage = pa.FixedSizeListArray.from_arrays(inner, 6)
     tensor_array = pa.ExtensionArray.from_storage(tensor_type, storage)
 
-    return pa.table({
-        # TODO: add remaining types
-        "str": pa.array([str(i) for i in range(nrows)]),
-        "float16": pa.array(
-            [np.float16(1.0 + i / 10) for i in range(nrows)], pa.float16()
-        ),
-        "bfloat16": lance.arrow.bfloat16_array([1.0 + i / 10 for i in range(nrows)]),
-        "tensor": tensor_array,
-    })
+    return pa.table(
+        {
+            # TODO: add remaining types
+            "str": pa.array([str(i) for i in range(nrows)]),
+            "float16": pa.array(
+                [np.float16(1.0 + i / 10) for i in range(nrows)], pa.float16()
+            ),
+            "bfloat16": lance.arrow.bfloat16_array(
+                [1.0 + i / 10 for i in range(nrows)]
+            ),
+            "tensor": tensor_array,
+        }
+    )
 
 
 def test_roundtrip_types(tmp_path, sample_data_all_types):

--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -40,10 +40,12 @@ def create_table(min, max, nvec, ndim=8):
     mat = np.random.uniform(min, max, (nvec, ndim))
     tbl = vec_to_table(data=mat)
     # Add id column for filtering
-    tbl = pa.Table.from_pydict({
-        "vector": tbl.column(0).chunk(0),
-        "id": np.arange(0, nvec),
-    })
+    tbl = pa.Table.from_pydict(
+        {
+            "vector": tbl.column(0).chunk(0),
+            "id": np.arange(0, nvec),
+        }
+    )
     return tbl
 
 

--- a/python/python/tests/test_s3_ddb.py
+++ b/python/python/tests/test_s3_ddb.py
@@ -163,9 +163,9 @@ def test_s3_ddb_concurrent_commit(
     assert len(lance.dataset(table_dir).versions()) == 6
     assert lance.dataset(table_dir).count_rows() == 6
 
-    assert sorted([
-        item["a"] for item in lance.dataset(table_dir).to_table().to_pylist()
-    ]) == [-1, 0, 1, 2, 3, 4]
+    assert sorted(
+        [item["a"] for item in lance.dataset(table_dir).to_table().to_pylist()]
+    ) == [-1, 0, 1, 2, 3, 4]
 
 
 @pytest.mark.integration

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -86,12 +86,14 @@ def test_temporal_index(tmp_path):
     # Timestamps
     now = datetime.now()
     today = date.today()
-    table = pa.Table.from_pydict({
-        "ts": [now - timedelta(days=i) for i in range(100)],
-        "date": [today - timedelta(days=i) for i in range(100)],
-        "time": pa.array([i for i in range(100)], type=pa.time32("s")),
-        "id": [i for i in range(100)],
-    })
+    table = pa.Table.from_pydict(
+        {
+            "ts": [now - timedelta(days=i) for i in range(100)],
+            "date": [today - timedelta(days=i) for i in range(100)],
+            "time": pa.array([i for i in range(100)], type=pa.time32("s")),
+            "id": [i for i in range(100)],
+        }
+    )
     dataset = lance.write_dataset(table, tmp_path)
     dataset.create_scalar_index("ts", index_type="BTREE")
     dataset.create_scalar_index("date", index_type="BTREE")

--- a/python/python/tests/test_schema_evolution.py
+++ b/python/python/tests/test_schema_evolution.py
@@ -17,20 +17,24 @@ def test_drop_columns(tmp_path: Path):
     dims = 32
     nrows = 512
     values = pc.random(nrows * dims).cast("float32")
-    table = pa.table({
-        "a": pa.FixedSizeListArray.from_arrays(values, dims),
-        "b": range(nrows),
-        "c": range(nrows),
-    })
+    table = pa.table(
+        {
+            "a": pa.FixedSizeListArray.from_arrays(values, dims),
+            "b": range(nrows),
+            "c": range(nrows),
+        }
+    )
     dataset = lance.write_dataset(table, tmp_path)
     dataset.create_index("a", "IVF_PQ", num_partitions=2, num_sub_vectors=1)
 
     # Drop a column, index is kept
     dataset.drop_columns(["b"])
-    assert dataset.schema == pa.schema({
-        "a": pa.list_(pa.float32(), dims),
-        "c": pa.int64(),
-    })
+    assert dataset.schema == pa.schema(
+        {
+            "a": pa.list_(pa.float32(), dims),
+            "c": pa.int64(),
+        }
+    )
     assert len(dataset.list_indices()) == 1
 
     # Drop vector column, index is dropped
@@ -84,10 +88,12 @@ def test_add_columns_udf(tmp_path):
 
 
 def test_add_columns_udf_caching(tmp_path):
-    tab = pa.table({
-        "a": range(100),
-        "b": range(100),
-    })
+    tab = pa.table(
+        {
+            "a": range(100),
+            "b": range(100),
+        }
+    )
     dataset = lance.write_dataset(tab, tmp_path, max_rows_per_file=20)
 
     @lance.batch_udf(checkpoint_file=tmp_path / "cache.sqlite")
@@ -132,16 +138,20 @@ def test_add_many_columns(tmp_path: Path):
 
 def test_query_after_merge(tmp_path):
     # https://github.com/lancedb/lance/issues/1905
-    tab = pa.table({
-        "id": range(100),
-        "vec": pa.FixedShapeTensorArray.from_numpy_ndarray(
-            np.random.rand(100, 128).astype("float32")
-        ),
-    })
-    tab2 = pa.table({
-        "id": range(100),
-        "data": range(100, 200),
-    })
+    tab = pa.table(
+        {
+            "id": range(100),
+            "vec": pa.FixedShapeTensorArray.from_numpy_ndarray(
+                np.random.rand(100, 128).astype("float32")
+            ),
+        }
+    )
+    tab2 = pa.table(
+        {
+            "id": range(100),
+            "data": range(100, 200),
+        }
+    )
     dataset = lance.write_dataset(tab, tmp_path)
 
     dataset.merge(tab2, left_on="id")
@@ -152,10 +162,12 @@ def test_query_after_merge(tmp_path):
 
 
 def test_alter_columns(tmp_path: Path):
-    schema = pa.schema([
-        pa.field("a", pa.int64(), nullable=False),
-        pa.field("b", pa.string(), nullable=False),
-    ])
+    schema = pa.schema(
+        [
+            pa.field("a", pa.int64(), nullable=False),
+            pa.field("b", pa.string(), nullable=False),
+        ]
+    )
     tab = pa.table(
         {"a": pa.array([1, 2, 1024]), "b": pa.array(["a", "b", "c"])}, schema=schema
     )
@@ -167,10 +179,12 @@ def test_alter_columns(tmp_path: Path):
         {"path": "b", "name": "y"},
     )
 
-    expected_schema = pa.schema([
-        pa.field("x", pa.int64()),
-        pa.field("y", pa.string(), nullable=False),
-    ])
+    expected_schema = pa.schema(
+        [
+            pa.field("x", pa.int64()),
+            pa.field("y", pa.string(), nullable=False),
+        ]
+    )
     assert dataset.schema == expected_schema
 
     expected_tab = pa.table(
@@ -183,10 +197,12 @@ def test_alter_columns(tmp_path: Path):
         {"path": "x", "data_type": pa.int32()},
         {"path": "y", "data_type": pa.large_string()},
     )
-    expected_schema = pa.schema([
-        pa.field("x", pa.int32()),
-        pa.field("y", pa.large_string(), nullable=False),
-    ])
+    expected_schema = pa.schema(
+        [
+            pa.field("x", pa.int32()),
+            pa.field("y", pa.large_string(), nullable=False),
+        ]
+    )
     assert dataset.schema == expected_schema
 
     expected_tab = pa.table(

--- a/python/python/tests/test_tf.py
+++ b/python/python/tests/test_tf.py
@@ -35,17 +35,21 @@ from lance.tf.tfrecord import infer_tfrecord_schema, read_tfrecord
 
 @pytest.fixture
 def tf_dataset(tmp_path):
-    df = pd.DataFrame({
-        "a": range(10000),
-        "s": [f"val-{i}" for i in range(10000)],
-        "vec": [[i * 0.2] * 128 for i in range(10000)],
-    })
+    df = pd.DataFrame(
+        {
+            "a": range(10000),
+            "s": [f"val-{i}" for i in range(10000)],
+            "vec": [[i * 0.2] * 128 for i in range(10000)],
+        }
+    )
 
-    schema = pa.schema([
-        pa.field("a", pa.int64()),
-        pa.field("s", pa.string()),
-        pa.field("vec", pa.list_(pa.float32(), 128)),
-    ])
+    schema = pa.schema(
+        [
+            pa.field("a", pa.int64()),
+            pa.field("s", pa.string()),
+            pa.field("vec", pa.list_(pa.float32(), 128)),
+        ]
+    )
     tbl = pa.Table.from_pandas(df, schema=schema)
     uri = tmp_path / "dataset.lance"
     lance.write_dataset(
@@ -191,15 +195,19 @@ def test_take_dataset(tf_dataset):
 
 def test_var_length_list(tmp_path):
     """Treat var length list as RaggedTensor."""
-    df = pd.DataFrame({
-        "a": range(200),
-        "l": [[i] * (i % 5 + 1) for i in range(200)],
-    })
+    df = pd.DataFrame(
+        {
+            "a": range(200),
+            "l": [[i] * (i % 5 + 1) for i in range(200)],
+        }
+    )
 
-    schema = pa.schema([
-        pa.field("a", pa.int64()),
-        pa.field("l", pa.list_(pa.int32())),
-    ])
+    schema = pa.schema(
+        [
+            pa.field("a", pa.int64()),
+            pa.field("l", pa.list_(pa.int32())),
+        ]
+    )
     tbl = pa.Table.from_pandas(df, schema=schema)
 
     uri = tmp_path / "dataset.lance"
@@ -226,18 +234,22 @@ def test_var_length_list(tmp_path):
 
 
 def test_nested_struct(tmp_path):
-    table = pa.table({
-        "x": pa.array([
-            {
-                "a": 1,
-                "json": {"b": "hello", "x": b"abc"},
-            },
-            {
-                "a": 24,
-                "json": {"b": "world", "x": b"def"},
-            },
-        ])
-    })
+    table = pa.table(
+        {
+            "x": pa.array(
+                [
+                    {
+                        "a": 1,
+                        "json": {"b": "hello", "x": b"abc"},
+                    },
+                    {
+                        "a": 24,
+                        "json": {"b": "world", "x": b"def"},
+                    },
+                ]
+            )
+        }
+    )
     uri = tmp_path / "dataset.lance"
     dataset = lance.write_dataset(table, uri)
 
@@ -275,11 +287,13 @@ def test_image_types(tmp_path):
     uris = ImageArray.from_array(path * 3)
     encoded_images = uris.read_uris()
     tensors = encoded_images.to_tensor()
-    table = pa.table({
-        "uris": uris,
-        "encoded_images": encoded_images,
-        "tensor_images": tensors,
-    })
+    table = pa.table(
+        {
+            "uris": uris,
+            "encoded_images": encoded_images,
+            "tensor_images": tensors,
+        }
+    )
 
     uri = tmp_path / "dataset.lance"
     dataset = lance.write_dataset(table, uri)
@@ -349,35 +363,39 @@ def test_tfrecord_parsing(tmp_path, sample_tf_example):
 
     inferred_schema = infer_tfrecord_schema(str(path))
 
-    assert inferred_schema == pa.schema({
-        "1_int": pa.int64(),
-        "2_int_list": pa.list_(pa.int64()),
-        "3_float": pa.float32(),
-        "4_float_list": pa.list_(pa.float32()),
-        "5_bytes": pa.binary(),
-        "6_bytes_list": pa.list_(pa.binary()),
-        # tensors and strings assumed binary
-        "7_string": pa.binary(),
-        "8_tensor": pa.binary(),
-        "9_tensor_bf16": pa.binary(),
-    })
+    assert inferred_schema == pa.schema(
+        {
+            "1_int": pa.int64(),
+            "2_int_list": pa.list_(pa.int64()),
+            "3_float": pa.float32(),
+            "4_float_list": pa.list_(pa.float32()),
+            "5_bytes": pa.binary(),
+            "6_bytes_list": pa.list_(pa.binary()),
+            # tensors and strings assumed binary
+            "7_string": pa.binary(),
+            "8_tensor": pa.binary(),
+            "9_tensor_bf16": pa.binary(),
+        }
+    )
 
     inferred_schema = infer_tfrecord_schema(
         str(path),
         tensor_features=["8_tensor", "9_tensor_bf16"],
         string_features=["7_string"],
     )
-    assert inferred_schema == pa.schema({
-        "1_int": pa.int64(),
-        "2_int_list": pa.list_(pa.int64()),
-        "3_float": pa.float32(),
-        "4_float_list": pa.list_(pa.float32()),
-        "5_bytes": pa.binary(),
-        "6_bytes_list": pa.list_(pa.binary()),
-        "7_string": pa.string(),
-        "8_tensor": pa.fixed_shape_tensor(pa.float32(), [2, 3]),
-        "9_tensor_bf16": pa.fixed_shape_tensor(BFloat16Type(), [2, 3]),
-    })
+    assert inferred_schema == pa.schema(
+        {
+            "1_int": pa.int64(),
+            "2_int_list": pa.list_(pa.int64()),
+            "3_float": pa.float32(),
+            "4_float_list": pa.list_(pa.float32()),
+            "5_bytes": pa.binary(),
+            "6_bytes_list": pa.list_(pa.binary()),
+            "7_string": pa.string(),
+            "8_tensor": pa.fixed_shape_tensor(pa.float32(), [2, 3]),
+            "9_tensor_bf16": pa.fixed_shape_tensor(BFloat16Type(), [2, 3]),
+        }
+    )
 
     reader = read_tfrecord(str(path), inferred_schema)
     assert reader.schema == inferred_schema
@@ -395,17 +413,19 @@ def test_tfrecord_parsing(tmp_path, sample_tf_example):
     storage = pa.FixedSizeListArray.from_arrays(bf16_array, 6)
     bf16_array = pa.ExtensionArray.from_storage(tensor_type, storage)
 
-    expected_data = pa.table({
-        "1_int": pa.array([1]),
-        "2_int_list": pa.array([[1, 2, 3]]),
-        "3_float": pa.array([1.0], pa.float32()),
-        "4_float_list": pa.array([[1.0, 2.0, 3.0]], pa.list_(pa.float32())),
-        "5_bytes": pa.array([b"Hello, TensorFlow!"]),
-        "6_bytes_list": pa.array([[b"Hello, TensorFlow!", b"Hello, Lance!"]]),
-        "7_string": pa.array(["Hello, TensorFlow!"]),
-        "8_tensor": f32_array,
-        "9_tensor_bf16": bf16_array,
-    })
+    expected_data = pa.table(
+        {
+            "1_int": pa.array([1]),
+            "2_int_list": pa.array([[1, 2, 3]]),
+            "3_float": pa.array([1.0], pa.float32()),
+            "4_float_list": pa.array([[1.0, 2.0, 3.0]], pa.list_(pa.float32())),
+            "5_bytes": pa.array([b"Hello, TensorFlow!"]),
+            "6_bytes_list": pa.array([[b"Hello, TensorFlow!", b"Hello, Lance!"]]),
+            "7_string": pa.array(["Hello, TensorFlow!"]),
+            "8_tensor": f32_array,
+            "9_tensor_bf16": bf16_array,
+        }
+    )
 
     assert table == expected_data
 
@@ -470,12 +490,14 @@ def test_tfrecord_parsing_nulls(tmp_path):
             writer.write(serialized)
 
     inferred_schema = infer_tfrecord_schema(str(path), tensor_features=["d"])
-    assert inferred_schema == pa.schema({
-        "a": pa.int64(),
-        "b": pa.list_(pa.int64()),
-        "c": pa.float32(),
-        "d": pa.fixed_shape_tensor(pa.float32(), [2, 3]),
-    })
+    assert inferred_schema == pa.schema(
+        {
+            "a": pa.int64(),
+            "b": pa.list_(pa.int64()),
+            "c": pa.float32(),
+            "d": pa.fixed_shape_tensor(pa.float32(), [2, 3]),
+        }
+    )
 
     tensor_type = pa.fixed_shape_tensor(pa.float32(), [2, 3])
     inner = pa.array([float(x) for x in range(1, 7)] + [None] * 12, pa.float32())
@@ -483,24 +505,30 @@ def test_tfrecord_parsing_nulls(tmp_path):
     f32_array = pa.ExtensionArray.from_storage(tensor_type, storage)
 
     data = read_tfrecord(str(path), inferred_schema).read_all()
-    expected = pa.table({
-        "a": pa.array([1, 1, 1]),
-        "b": pa.array([[1], [], [1, 2, 3]]),
-        "c": pa.array([1.0, None, 1.0], pa.float32()),
-        "d": f32_array,
-    })
+    expected = pa.table(
+        {
+            "a": pa.array([1, 1, 1]),
+            "b": pa.array([[1], [], [1, 2, 3]]),
+            "c": pa.array([1.0, None, 1.0], pa.float32()),
+            "d": f32_array,
+        }
+    )
 
     assert data == expected
 
     # can do projection
-    read_schema = pa.schema({
-        "a": pa.int64(),
-        "c": pa.float32(),
-    })
-    expected = pa.table({
-        "a": pa.array([1, 1, 1]),
-        "c": pa.array([1.0, None, 1.0], pa.float32()),
-    })
+    read_schema = pa.schema(
+        {
+            "a": pa.int64(),
+            "c": pa.float32(),
+        }
+    )
+    expected = pa.table(
+        {
+            "a": pa.array([1, 1, 1]),
+            "c": pa.array([1.0, None, 1.0], pa.float32()),
+        }
+    )
 
     data = read_tfrecord(str(path), read_schema).read_all()
     assert data == expected

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -451,10 +451,12 @@ def create_uniform_table(min, max, nvec, offset, ndim=8):
     mat = np.random.uniform(min, max, (nvec, ndim))
     # rowid = np.arange(offset, offset + nvec)
     tbl = vec_to_table(data=mat)
-    tbl = pa.Table.from_pydict({
-        "vector": tbl.column(0).chunk(0),
-        "filterable": np.arange(offset, offset + nvec),
-    })
+    tbl = pa.Table.from_pydict(
+        {
+            "vector": tbl.column(0).chunk(0),
+            "filterable": np.arange(offset, offset + nvec),
+        }
+    )
     return tbl
 
 
@@ -522,10 +524,12 @@ def test_knn_with_deletions(tmp_path):
     values = pa.array(
         [x for val in range(50) for x in [float(val)] * 5], type=pa.float32()
     )
-    tbl = pa.Table.from_pydict({
-        "vector": pa.FixedSizeListArray.from_arrays(values, dims),
-        "filterable": pa.array(range(50)),
-    })
+    tbl = pa.Table.from_pydict(
+        {
+            "vector": pa.FixedSizeListArray.from_arrays(values, dims),
+            "filterable": pa.array(range(50)),
+        }
+    )
     dataset = lance.write_dataset(tbl, tmp_path, max_rows_per_group=10)
 
     dataset.delete("not (filterable % 5 == 0)")

--- a/python/python/tests/torch_tests/test_data.py
+++ b/python/python/tests/torch_tests/test_data.py
@@ -189,10 +189,12 @@ def test_sample_batches(tmp_path: Path):
 
 def test_sample_batches_with_filter(tmp_path: Path):
     NUM_ROWS = 10000
-    tbl = pa.Table.from_pydict({
-        "id": range(NUM_ROWS),
-        "filterme": [i % 2 for i in range(NUM_ROWS)],
-    })
+    tbl = pa.Table.from_pydict(
+        {
+            "id": range(NUM_ROWS),
+            "filterme": [i % 2 for i in range(NUM_ROWS)],
+        }
+    )
 
     lance.write_dataset(tbl, tmp_path, max_rows_per_file=2000)
 


### PR DESCRIPTION
We had originally added --preview to our ruff invocations because it was required to enforce rule CPY001 which checks for a copyright header.  We have since moved that check to a dedicated tool and removed the ruff rule so we can safely remove --preview.

The --preview flag was a problem because IDEs and manual invocation would often leave it off and it turns out that the formatting changes based on the presence of `--preview` (it doesn't just enable / disable rules but actually changes the behavior of rules too).

By removing --preview we should make it easier for developers because there will be less configuration of their development environment required.