### PR TITLE
feat: allow loading extension vector index

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1487,6 +1487,146 @@ impl From<DatasetRecordBatchStream> for SendableRecordBatchStream {
 }
 
 #[cfg(test)]
+pub mod test_dataset {
+
+    use super::*;
+
+    use std::vec;
+
+    use arrow_array::{ArrayRef, FixedSizeListArray, Int32Array, RecordBatchIterator, StringArray};
+    use arrow_schema::ArrowError;
+    use lance_index::IndexType;
+    use tempfile::{tempdir, TempDir};
+
+    use crate::arrow::*;
+    use crate::dataset::WriteParams;
+    use crate::index::scalar::ScalarIndexParams;
+    use crate::index::vector::VectorIndexParams;
+
+    // Creates a dataset with 5 batches where each batch has 80 rows
+    //
+    // The dataset has the following columns:
+    //
+    //  i   - i32      : [0, 1, ..., 399]
+    //  s   - &str     : ["s-0", "s-1", ..., "s-399"]
+    //  vec - [f32; 32]: [[0, 1, ... 31], [32, ..., 63], ... [..., (80 * 5 * 32) - 1]]
+    //
+    // An IVF-PQ index with 2 partitions is trained on this data
+    pub struct TestVectorDataset {
+        pub tmp_dir: TempDir,
+        pub schema: Arc<ArrowSchema>,
+        pub dataset: Dataset,
+    }
+
+    impl TestVectorDataset {
+        pub async fn new() -> Result<Self> {
+            let tmp_dir = tempdir()?;
+            let path = tmp_dir.path().to_str().unwrap();
+
+            // Make sure the schema has metadata so it tests all paths that re-construct the schema along the way
+            let metadata: HashMap<String, String> =
+                vec![("dataset".to_string(), "vector".to_string())]
+                    .into_iter()
+                    .collect();
+
+            let schema = Arc::new(ArrowSchema::new_with_metadata(
+                vec![
+                    ArrowField::new("i", DataType::Int32, true),
+                    ArrowField::new("s", DataType::Utf8, true),
+                    ArrowField::new(
+                        "vec",
+                        DataType::FixedSizeList(
+                            Arc::new(ArrowField::new("item", DataType::Float32, true)),
+                            32,
+                        ),
+                        true,
+                    ),
+                ],
+                metadata,
+            ));
+
+            let batches: Vec<RecordBatch> = (0..5)
+                .map(|i| {
+                    let vector_values: Float32Array = (0..32 * 80).map(|v| v as f32).collect();
+                    let vectors =
+                        FixedSizeListArray::try_new_from_values(vector_values, 32).unwrap();
+                    RecordBatch::try_new(
+                        schema.clone(),
+                        vec![
+                            Arc::new(Int32Array::from_iter_values(i * 80..(i + 1) * 80)),
+                            Arc::new(StringArray::from_iter_values(
+                                (i * 80..(i + 1) * 80).map(|v| format!("s-{}", v)),
+                            )),
+                            Arc::new(vectors),
+                        ],
+                    )
+                })
+                .collect::<std::result::Result<Vec<_>, ArrowError>>()?;
+
+            let params = WriteParams {
+                max_rows_per_group: 10,
+                ..Default::default()
+            };
+            let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+
+            let dataset = Dataset::write(reader, path, Some(params)).await?;
+
+            Ok(Self {
+                tmp_dir,
+                schema,
+                dataset,
+            })
+        }
+
+        pub async fn make_vector_index(&mut self) -> Result<()> {
+            let params = VectorIndexParams::ivf_pq(2, 8, 2, false, MetricType::L2, 2);
+            self.dataset
+                .create_index(
+                    &["vec"],
+                    IndexType::Vector,
+                    Some("idx".to_string()),
+                    &params,
+                    true,
+                )
+                .await
+        }
+
+        pub async fn make_scalar_index(&mut self) -> Result<()> {
+            self.dataset
+                .create_index(
+                    &["i"],
+                    IndexType::Scalar,
+                    None,
+                    &ScalarIndexParams::default(),
+                    true,
+                )
+                .await
+        }
+
+        pub async fn append_new_data(&mut self) -> Result<()> {
+            let vector_values: Float32Array =
+                (0..10).flat_map(|i| [i as f32; 32].into_iter()).collect();
+            let new_vectors = FixedSizeListArray::try_new_from_values(vector_values, 32).unwrap();
+            let new_data: Vec<ArrayRef> = vec![
+                Arc::new(Int32Array::from_iter_values(400..410)), // 5 * 80
+                Arc::new(StringArray::from_iter_values(
+                    (400..410).map(|v| format!("s-{}", v)),
+                )),
+                Arc::new(new_vectors),
+            ];
+            let reader = RecordBatchIterator::new(
+                vec![RecordBatch::try_new(self.schema.clone(), new_data).unwrap()]
+                    .into_iter()
+                    .map(Ok),
+                self.schema.clone(),
+            );
+            self.dataset.append(reader, None).await?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
 mod test {
 
     use std::collections::BTreeSet;
@@ -1501,7 +1641,6 @@ mod test {
         RecordBatchIterator, StringArray, StructArray,
     };
     use arrow_ord::sort::sort_to_indices;
-    use arrow_schema::ArrowError;
     use arrow_select::take;
     use datafusion::logical_expr::{col, lit};
     use half::f16;
@@ -1513,6 +1652,7 @@ mod test {
     use super::*;
     use crate::arrow::*;
     use crate::dataset::optimize::{compact_files, CompactionOptions};
+    use crate::dataset::scanner::test_dataset::TestVectorDataset;
     use crate::dataset::WriteMode;
     use crate::dataset::WriteParams;
     use crate::index::scalar::ScalarIndexParams;
@@ -1615,128 +1755,6 @@ mod test {
 
         assert_eq!(actual, full_data);
         Ok(())
-    }
-
-    // Creates a dataset with 5 batches where each batch has 80 rows
-    //
-    // The dataset has the following columns:
-    //
-    //  i   - i32      : [0, 1, ..., 399]
-    //  s   - &str     : ["s-0", "s-1", ..., "s-399"]
-    //  vec - [f32; 32]: [[0, 1, ... 31], [32, ..., 63], ... [..., (80 * 5 * 32) - 1]]
-    //
-    // An IVF-PQ index with 2 partitions is trained on this data
-    struct TestVectorDataset {
-        _tmp_dir: TempDir,
-        pub schema: Arc<ArrowSchema>,
-        pub dataset: Dataset,
-    }
-
-    impl TestVectorDataset {
-        async fn new() -> Result<Self> {
-            let tmp_dir = tempdir()?;
-            let path = tmp_dir.path().to_str().unwrap();
-
-            // Make sure the schema has metadata so it tests all paths that re-construct the schema along the way
-            let metadata: HashMap<String, String> =
-                vec![("dataset".to_string(), "vector".to_string())]
-                    .into_iter()
-                    .collect();
-
-            let schema = Arc::new(ArrowSchema::new_with_metadata(
-                vec![
-                    ArrowField::new("i", DataType::Int32, true),
-                    ArrowField::new("s", DataType::Utf8, true),
-                    ArrowField::new(
-                        "vec",
-                        DataType::FixedSizeList(
-                            Arc::new(ArrowField::new("item", DataType::Float32, true)),
-                            32,
-                        ),
-                        true,
-                    ),
-                ],
-                metadata,
-            ));
-
-            let batches: Vec<RecordBatch> = (0..5)
-                .map(|i| {
-                    let vector_values: Float32Array = (0..32 * 80).map(|v| v as f32).collect();
-                    let vectors =
-                        FixedSizeListArray::try_new_from_values(vector_values, 32).unwrap();
-                    RecordBatch::try_new(
-                        schema.clone(),
-                        vec![
-                            Arc::new(Int32Array::from_iter_values(i * 80..(i + 1) * 80)),
-                            Arc::new(StringArray::from_iter_values(
-                                (i * 80..(i + 1) * 80).map(|v| format!("s-{}", v)),
-                            )),
-                            Arc::new(vectors),
-                        ],
-                    )
-                })
-                .collect::<std::result::Result<Vec<_>, ArrowError>>()?;
-
-            let params = WriteParams {
-                max_rows_per_group: 10,
-                ..Default::default()
-            };
-            let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-
-            let dataset = Dataset::write(reader, path, Some(params)).await?;
-
-            Ok(Self {
-                _tmp_dir: tmp_dir,
-                schema,
-                dataset,
-            })
-        }
-
-        async fn make_vector_index(&mut self) -> Result<()> {
-            let params = VectorIndexParams::ivf_pq(2, 8, 2, false, MetricType::L2, 2);
-            self.dataset
-                .create_index(
-                    &["vec"],
-                    IndexType::Vector,
-                    Some("idx".to_string()),
-                    &params,
-                    true,
-                )
-                .await
-        }
-
-        async fn make_scalar_index(&mut self) -> Result<()> {
-            self.dataset
-                .create_index(
-                    &["i"],
-                    IndexType::Scalar,
-                    None,
-                    &ScalarIndexParams::default(),
-                    true,
-                )
-                .await
-        }
-
-        async fn append_new_data(&mut self) -> Result<()> {
-            let vector_values: Float32Array =
-                (0..10).flat_map(|i| [i as f32; 32].into_iter()).collect();
-            let new_vectors = FixedSizeListArray::try_new_from_values(vector_values, 32).unwrap();
-            let new_data: Vec<ArrayRef> = vec![
-                Arc::new(Int32Array::from_iter_values(400..410)), // 5 * 80
-                Arc::new(StringArray::from_iter_values(
-                    (400..410).map(|v| format!("s-{}", v)),
-                )),
-                Arc::new(new_vectors),
-            ];
-            let reader = RecordBatchIterator::new(
-                vec![RecordBatch::try_new(self.schema.clone(), new_data).unwrap()]
-                    .into_iter()
-                    .map(Ok),
-                self.schema.clone(),
-            );
-            self.dataset.append(reader, None).await?;
-            Ok(())
-        }
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -424,14 +424,14 @@ pub(crate) async fn open_vector_index_v2(
     let index_metadata: lance_index::IndexMetadata = serde_json::from_str(index_metadata)?;
     let distance_type = DistanceType::try_from(index_metadata.distance_type.as_str())?;
 
-    let aux_path = dataset
-        .indices_dir()
-        .child(uuid)
-        .child(INDEX_AUXILIARY_FILE_NAME);
-    let aux_reader = dataset.object_store().open(&aux_path).await?;
-
     let index: Arc<dyn VectorIndex> = match index_metadata.index_type.as_str() {
         "IVF_HNSW_PQ" => {
+            let aux_path = dataset
+                .indices_dir()
+                .child(uuid)
+                .child(INDEX_AUXILIARY_FILE_NAME);
+            let aux_reader = dataset.object_store().open(&aux_path).await?;
+
             let ivf_data = IvfData::load(&reader).await?;
             let options = HNSWIndexOptions { use_residual: true };
             let hnsw = HNSWIndex::<ProductQuantizerImpl<Float32Type>>::try_new(
@@ -455,6 +455,12 @@ pub(crate) async fn open_vector_index_v2(
         }
 
         "IVF_HNSW_SQ" => {
+            let aux_path = dataset
+                .indices_dir()
+                .child(uuid)
+                .child(INDEX_AUXILIARY_FILE_NAME);
+            let aux_reader = dataset.object_store().open(&aux_path).await?;
+
             let ivf_data = IvfData::load(&reader).await?;
             let options = HNSWIndexOptions {
                 use_residual: false,
@@ -479,11 +485,16 @@ pub(crate) async fn open_vector_index_v2(
             )?)
         }
 
-        _ => {
-            return Err(Error::Index {
-                message: format!("Unsupported index type: {}", index_metadata.index_type),
-                location: location!(),
-            })
+        index_type => {
+            if let Some(ext) = dataset.session.vector_index_extensions.get(index_type) {
+                ext.load_index(dataset.clone(), column, uuid, reader)
+                    .await?
+            } else {
+                return Err(Error::Index {
+                    message: format!("Unsupported index type: {}", index_metadata.index_type),
+                    location: location!(),
+                });
+            }
         }
     };
 

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -1,10 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use lance_core::cache::FileMetadataCache;
+use lance_core::{Error, Result};
+use snafu::{location, Location};
 
 use crate::dataset::{DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE};
 use crate::index::cache::IndexCache;
+
+use self::index_extension::VectorIndexExtension;
+
+pub mod index_extension;
 
 /// A user session tracks the runtime state.
 #[derive(Clone)]
@@ -14,6 +23,8 @@ pub struct Session {
 
     /// Cache for file metadata
     pub(crate) file_metadata_cache: FileMetadataCache,
+
+    pub(crate) vector_index_extensions: HashMap<String, Arc<dyn VectorIndexExtension>>,
 }
 
 impl std::fmt::Debug for Session {
@@ -32,7 +43,24 @@ impl Session {
         Self {
             index_cache: IndexCache::new(index_cache_size),
             file_metadata_cache: FileMetadataCache::new(metadata_cache_size),
+            vector_index_extensions: HashMap::new(),
         }
+    }
+
+    pub fn register_vector_index_extension(
+        &mut self,
+        name: String,
+        extension: Arc<dyn VectorIndexExtension>,
+    ) -> Result<()> {
+        if self.vector_index_extensions.contains_key(&name) {
+            return Err(Error::invalid_input(
+                format!("{name} is already registered"),
+                location!(),
+            ));
+        }
+        self.vector_index_extensions.insert(name, extension);
+
+        Ok(())
     }
 }
 
@@ -41,6 +69,7 @@ impl Default for Session {
         Self {
             index_cache: IndexCache::new(DEFAULT_INDEX_CACHE_SIZE),
             file_metadata_cache: FileMetadataCache::new(DEFAULT_METADATA_CACHE_SIZE),
+            vector_index_extensions: HashMap::new(),
         }
     }
 }

--- a/rust/lance/src/session/index_extension.rs
+++ b/rust/lance/src/session/index_extension.rs
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use lance_core::Result;
+use lance_file::reader::FileReader;
+
+use crate::{index::vector::VectorIndex, Dataset};
+
+#[async_trait::async_trait]
+pub trait VectorIndexExtension: Send + Sync {
+    /// TODO: add create_index and optimize_index methods
+
+    /// Load a vector index from a file.
+    async fn load_index(
+        &self,
+        dataset: Arc<Dataset>,
+        column: &str,
+        uuid: &str,
+        reader: FileReader,
+    ) -> Result<Arc<dyn VectorIndex>>;
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        dataset::{
+            builder::DatasetBuilder,
+            scanner::test_dataset::TestVectorDataset,
+            transaction::{Operation, Transaction},
+        },
+        index::{DatasetIndexInternalExt, PreFilter},
+        io::commit::commit_transaction,
+        session::Session,
+    };
+
+    use super::*;
+
+    use std::{any::Any, collections::HashMap, sync::Arc};
+
+    use arrow_array::RecordBatch;
+    use arrow_schema::Schema;
+    use lance_file::writer::{FileWriter, FileWriterOptions};
+    use lance_index::{
+        vector::{hnsw::VECTOR_ID_FIELD, Query},
+        DatasetIndexExt, Index, IndexMetadata, IndexType, INDEX_FILE_NAME,
+        INDEX_METADATA_SCHEMA_KEY,
+    };
+    use lance_io::traits::Reader;
+    use lance_linalg::distance::MetricType;
+    use lance_table::io::manifest::ManifestDescribing;
+    use roaring::RoaringBitmap;
+    use serde_json::json;
+    use uuid::Uuid;
+
+    #[derive(Debug)]
+    struct MockIndex;
+
+    #[async_trait::async_trait]
+    impl Index for MockIndex {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+            self
+        }
+
+        fn statistics(&self) -> Result<serde_json::Value> {
+            Ok(json!(()))
+        }
+
+        fn index_type(&self) -> IndexType {
+            IndexType::Vector
+        }
+
+        async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {
+            Ok(RoaringBitmap::new())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl VectorIndex for MockIndex {
+        async fn search(&self, _: &Query, _: Arc<PreFilter>) -> Result<RecordBatch> {
+            todo!("panic")
+        }
+
+        fn is_loadable(&self) -> bool {
+            true
+        }
+
+        fn use_residual(&self) -> bool {
+            true
+        }
+
+        fn check_can_remap(&self) -> Result<()> {
+            Ok(())
+        }
+
+        async fn load(
+            &self,
+            _: Arc<dyn Reader>,
+            _: usize,
+            _: usize,
+        ) -> Result<Box<dyn VectorIndex>> {
+            todo!("panic")
+        }
+
+        fn remap(&mut self, _: &HashMap<u64, Option<u64>>) -> Result<()> {
+            Ok(())
+        }
+
+        fn metric_type(&self) -> MetricType {
+            MetricType::L2
+        }
+    }
+
+    struct MockIndexExtension {}
+
+    #[async_trait::async_trait]
+    impl VectorIndexExtension for MockIndexExtension {
+        async fn load_index(
+            &self,
+            _dataset: Arc<Dataset>,
+            _column: &str,
+            _uuid: &str,
+            _reader: FileReader,
+        ) -> Result<Arc<dyn VectorIndex>> {
+            Ok(Arc::new(MockIndex))
+        }
+    }
+
+    async fn make_empty_index(
+        dataset: &mut Dataset,
+        index_type: &str,
+        index_uuid: &Uuid,
+        column: &str,
+    ) {
+        // write an index
+        let store = dataset.object_store.clone();
+        let path = dataset
+            .indices_dir()
+            .child(index_uuid.to_string())
+            .child(INDEX_FILE_NAME);
+        let writer = store.create(&path).await.unwrap();
+
+        let arrow_schema = Arc::new(Schema::new(vec![VECTOR_ID_FIELD.clone()]));
+        let schema = lance_core::datatypes::Schema::try_from(arrow_schema.as_ref()).unwrap();
+        let mut writer: FileWriter<ManifestDescribing> =
+            FileWriter::with_object_writer(writer, schema, &FileWriterOptions::default()).unwrap();
+        writer.add_metadata(
+            INDEX_METADATA_SCHEMA_KEY,
+            json!(IndexMetadata {
+                index_type: index_type.to_string(),
+                distance_type: "cosine".to_string(),
+            })
+            .to_string()
+            .as_str(),
+        );
+
+        writer
+            .write(&[RecordBatch::new_empty(arrow_schema)])
+            .await
+            .unwrap();
+        writer.finish().await.unwrap();
+
+        // check in the metadat to point at the index
+
+        let field = dataset.schema().field(column).unwrap();
+
+        let new_idx = lance_table::format::Index {
+            uuid: *index_uuid,
+            name: "test".to_string(),
+            fields: vec![field.id],
+            dataset_version: dataset.manifest.version,
+            fragment_bitmap: Some(
+                dataset
+                    .get_fragments()
+                    .iter()
+                    .map(|f| f.id() as u32)
+                    .collect(),
+            ),
+        };
+
+        let transaction = Transaction::new(
+            dataset.manifest.version,
+            Operation::CreateIndex {
+                new_indices: vec![new_idx],
+                removed_indices: vec![],
+            },
+            None,
+        );
+
+        let new_manifest = commit_transaction(
+            dataset,
+            dataset.object_store(),
+            dataset.commit_handler.as_ref(),
+            &transaction,
+            &Default::default(),
+            &Default::default(),
+        )
+        .await
+        .unwrap();
+
+        dataset.manifest = Arc::new(new_manifest);
+    }
+
+    #[tokio::test]
+    async fn test_vector_index_extension() {
+        // make dataset and index that is not supported natively
+        let mut test_ds = TestVectorDataset::new().await.unwrap();
+
+        let idx = test_ds.dataset.load_indices().await.unwrap();
+        assert_eq!(idx.len(), 0);
+
+        let index_uuid = Uuid::new_v4();
+
+        make_empty_index(&mut test_ds.dataset, "TEST", &index_uuid, "vec").await;
+
+        let idx = test_ds.dataset.load_indices().await.unwrap();
+        assert_eq!(idx.len(), 1);
+
+        // trying to open the index should fail as there is no extension loader
+        assert!(test_ds
+            .dataset
+            .open_vector_index("vec", &index_uuid.to_string())
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("Unsupported index type: TEST"));
+
+        // make a session with extension loader
+        let mut session = Session::default();
+        session
+            .register_vector_index_extension("TEST".into(), Arc::new(MockIndexExtension {}))
+            .unwrap();
+
+        let ds_with_extension = DatasetBuilder::from_uri(test_ds.tmp_dir.path().to_str().unwrap())
+            .with_session(Arc::new(session))
+            .load()
+            .await
+            .unwrap();
+
+        let vector_index = ds_with_extension
+            .open_vector_index("vec", &index_uuid.to_string())
+            .await
+            .unwrap();
+
+        // should be able to downcast to the mock index
+        let _downcasted = vector_index.as_any().downcast_ref::<MockIndex>().unwrap();
+    }
+}


### PR DESCRIPTION
Add support for loading vector index types that are not natively supported in lance. This is done by registering a `VectorIndexExtension` in `Session`. During index loading, if the index type is not well known, we will check if there is an extension for it. This only works for `v0.2` index.

This PR omits extensions points for creating and appending to the index to keep the change small. I will add create and append in following PRs.

This PR also extracted `TestVectorDataset` in `scanner::test` to `scanner::test_dataset`, which is `pub` and guarded under `#[cfg(test)]`