### PR TITLE
chore: fix formatting in test_schema.py

### DIFF
--- a/python/python/tests/test_schema.py
+++ b/python/python/tests/test_schema.py
@@ -11,11 +11,13 @@ from lance.schema import LanceSchema
 
 def test_lance_schema(tmp_path: Path):
     # Include nested fields to test the reconstruction of the schema
-    data = pa.table({
-        "x": range(2),
-        "s": [{"a": 1, "b": "hello"}, {"a": 2, "b": "world"}],
-        "y": [[1.0, 2.0], [3.0, 4.0]],
-    })
+    data = pa.table(
+        {
+            "x": range(2),
+            "s": [{"a": 1, "b": "hello"}, {"a": 2, "b": "world"}],
+            "y": [[1.0, 2.0], [3.0, 4.0]],
+        }
+    )
     dataset = lance.write_dataset(data, tmp_path)
 
     schema = dataset.lance_schema


### PR DESCRIPTION
I suspect this snuck in during a recent PR that was concurrent with the PR to remove `--preview` from `ruff format`.