### PR TITLE
chore: bump to ruff 0.4.1

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -54,7 +54,7 @@ jobs:
         workspaces: python
     - name: Install linting tools
       run: |
-        pip install ruff==0.2.2 maturin tensorflow tqdm ray[data]
+        pip install ruff==0.4.1 maturin tensorflow tqdm ray[data]
         pip install torch --index-url https://download.pytorch.org/whl/cpu
     - name: Lint Python
       run: |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -62,7 +62,7 @@ tests = [
     "h5py<3.11",
     "tqdm",
 ]
-dev = ["ruff==0.2.2"]
+dev = ["ruff==0.4.1"]
 benchmarks = ["pytest-benchmark"]
 torch = ["torch"]
 ray = ["ray[data]; python_version<'3.12'"]


### PR DESCRIPTION
`ruff` 0.4.1 works with our current code base.