### PR TITLE
chore: bump minimal python version to 39

### DIFF
--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -3,7 +3,7 @@ name: build-linux-wheel
 description: "Build a manylinux wheel for lance"
 inputs:
   python-minor-version:
-    description: "8, 9, 10, 11, 12"
+    description: "9, 10, 11, 12"
     required: true
   args:
     description: "--release"

--- a/.github/workflows/build_mac_wheel/action.yml
+++ b/.github/workflows/build_mac_wheel/action.yml
@@ -3,7 +3,7 @@ name: build_wheel
 description: "Build a lance wheel"
 inputs:
   python-minor-version:
-    description: "8, 9, 10, 11"
+    description: "9, 10, 11, 12"
     required: true
   args:
     description: "--release"

--- a/.github/workflows/build_windows_wheel/action.yml
+++ b/.github/workflows/build_windows_wheel/action.yml
@@ -3,7 +3,7 @@ name: build_wheel
 description: "Build a lance wheel"
 inputs:
   python-minor-version:
-    description: "8, 9, 10, 11"
+    description: "9, 10, 11, 12"
     required: true
   args:
     description: "--release"

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -10,7 +10,7 @@ jobs:
     name: Python Linux 3.${{ matrix.python-minor-version }} ${{ matrix.config.platform }} manylinux${{ matrix.config.manylinux }}
     strategy:
       matrix:
-        python-minor-version: [ "8" ]
+        python-minor-version: [ "9" ]
         config:
           - platform: x86_64
             manylinux: "2_17"
@@ -21,7 +21,7 @@ jobs:
           - platform: aarch64
             manylinux: "2_24"
             extra_args: ""
-          # We don't build fp16 kernels for aarch64, because it uses 
+          # We don't build fp16 kernels for aarch64, because it uses
           # cross compilation image, which doesn't have a new enough compiler.
     runs-on: "ubuntu-22.04"
     steps:
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ matrix.config.runner }}
     strategy:
       matrix:
-        python-minor-version: ["8"]
+        python-minor-version: ["9"]
         config:
           - target: x86_64-apple-darwin
             runner: macos-13
@@ -80,7 +80,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-minor-version: ["8"]
+        python-minor-version: ["9"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -83,7 +83,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       matrix:
-        python-minor-version: [ "8", "12" ]
+        python-minor-version: [ "9", "12" ]
     name: "Python Linux 3.${{ matrix.python-minor-version }} x86_64"
     runs-on: "ubuntu-22.04"
     defaults:

--- a/.github/workflows/run_tests/action.yml
+++ b/.github/workflows/run_tests/action.yml
@@ -4,7 +4,7 @@ description: "Install lance wheel and run unit tests"
 inputs:
   python-minor-version:
     required: true
-    description: "8 9 10 11 12"
+    description: "9 10 11 12"
 runs:
   using: "composite"
   steps:

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -41,7 +41,7 @@ lance-table = { path = "../rust/lance-table" }
 lazy_static = "1"
 log = "0.4"
 prost = "0.12.2"
-pyo3 = { version = "0.20", features = ["extension-module", "abi3-py38"] }
+pyo3 = { version = "0.20", features = ["extension-module", "abi3-py39"] }
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 uuid = "1.3.0"
 serde_json = "1"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "Lance Devs", email = "dev@lancedb.com" }]
 license = { file = "LICENSE" }
 repository = "https://github.com/eto-ai/lance"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = [
     "data-format",
     "data-science",
@@ -29,7 +29,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -74,7 +73,7 @@ lint.select = ["F", "E", "W", "I", "G", "TCH", "PERF", "B019"]
 "*.pyi" = ["E301", "E302"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 check_untyped_defs = true
 warn_redundant_casts = true
 warn_unused_ignores = true


### PR DESCRIPTION
BREAKING CHANGE: minimal python version is set to Python 3.9