### PR TITLE
fix: creating IVF_HNSW index fails with cosine metric type

### DIFF
--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -49,7 +49,7 @@ impl Default for HnswBuildParams {
             max_level: 7,
             m: 20,
             m_max: 40,
-            ef_construction: 100,
+            ef_construction: 150,
             use_select_heuristic: true,
             parallel_limit: None,
         }

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -223,8 +223,6 @@ impl VectorStorage for ScalarQuantizationStorage {
 
 struct SQDistCalculator {
     query_sq_code: Vec<u8>,
-
-    // flatten sq codes
     sq_codes: Arc<FixedSizeListArray>,
 }
 

--- a/rust/lance-testing/src/datagen.rs
+++ b/rust/lance-testing/src/datagen.rs
@@ -208,7 +208,7 @@ pub fn generate_random_array(n: usize) -> Float32Array {
 /// Create a random float32 array where each element is uniformly distributed a
 /// given range.
 pub fn generate_random_array_with_range(n: usize, range: Range<f32>) -> Float32Array {
-    let mut rng = rand::thread_rng();
+    let mut rng = StdRng::from_seed([13; 32]);
     let distribution = Uniform::new(range.start, range.end);
     Float32Array::from_iter_values(repeat_with(|| distribution.sample(&mut rng)).take(n))
 }

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -2235,7 +2235,7 @@ mod tests {
         let pq_params = PQBuildParams::default();
         let hnsw_params = HnswBuildParams::default();
         let params = VectorIndexParams::with_ivf_hnsw_pq_params(
-            MetricType::Cosine,
+            MetricType::L2,
             ivf_params,
             hnsw_params,
             pq_params,
@@ -2303,7 +2303,7 @@ mod tests {
             .to_vec();
 
         let results = dists.into_iter().zip(row_ids.into_iter()).collect_vec();
-        let gt = ground_truth(&mat, query.values(), k, DistanceType::Cosine);
+        let gt = ground_truth(&mat, query.values(), k, DistanceType::L2);
 
         let results_set = results.iter().map(|r| r.1).collect::<HashSet<_>>();
         let gt_set = gt.iter().map(|r| r.1).collect::<HashSet<_>>();

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -2320,7 +2320,7 @@ mod tests {
         let sq_params = SQBuildParams::default();
         let hnsw_params = HnswBuildParams::default();
         let params = VectorIndexParams::with_ivf_hnsw_sq_params(
-            MetricType::L2,
+            MetricType::Cosine,
             ivf_params,
             hnsw_params,
             sq_params,

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -2255,7 +2255,7 @@ mod tests {
         query: &[f32],
         k: usize,
         distance_type: DistanceType,
-    ) -> HashSet<u32> {
+    ) -> Vec<(f32, u32)> {
         let mut dists = vec![];
         for i in 0..mat.num_rows() {
             let dist = distance_type.func()(query, mat.row_ref(i).unwrap());

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -2207,15 +2207,20 @@ mod tests {
         );
     }
 
-    fn ground_truth(mat: &MatrixView<Float32Type>, query: &[f32], k: usize) -> HashSet<u32> {
+    fn ground_truth(
+        mat: &MatrixView<Float32Type>,
+        query: &[f32],
+        k: usize,
+        distance_type: DistanceType,
+    ) -> Vec<(f32, u32)> {
         let mut dists = vec![];
         for i in 0..mat.num_rows() {
-            let dist = lance_linalg::distance::l2_distance(query, mat.row(i).unwrap());
+            let dist = distance_type.func()(query, mat.row(i).unwrap());
             dists.push((dist, i as u32));
         }
         dists.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
         dists.truncate(k);
-        dists.into_iter().map(|(_, i)| i).collect()
+        dists
     }
 
     #[tokio::test]
@@ -2226,15 +2231,11 @@ mod tests {
         let nlist = 4;
         let (mut dataset, vector_array) = generate_test_dataset(test_uri, 0.0..1.0).await;
 
-        let centroids = generate_random_array(nlist * DIM);
-        let ivf_centroids = FixedSizeListArray::try_new_from_values(centroids, DIM as i32).unwrap();
-        let ivf_params =
-            IvfBuildParams::try_with_centroids(nlist, Arc::new(ivf_centroids)).unwrap();
-
+        let ivf_params = IvfBuildParams::new(nlist);
         let pq_params = PQBuildParams::default();
         let hnsw_params = HnswBuildParams::default();
         let params = VectorIndexParams::with_ivf_hnsw_pq_params(
-            MetricType::L2,
+            MetricType::Cosine,
             ivf_params,
             hnsw_params,
             pq_params,
@@ -2283,7 +2284,7 @@ mod tests {
         assert_eq!(1, results.len());
         assert_eq!(k, results[0].num_rows());
 
-        let results = results[0]
+        let row_ids = results[0]
             .column_by_name(ROW_ID)
             .unwrap()
             .as_any()
@@ -2291,16 +2292,29 @@ mod tests {
             .unwrap()
             .iter()
             .map(|v| v.unwrap() as u32)
-            .collect::<HashSet<_>>();
+            .collect::<Vec<_>>();
+        let dists = results[0]
+            .column_by_name("_distance")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .unwrap()
+            .values()
+            .to_vec();
 
-        let gt = ground_truth(&mat, query.values(), k);
-        let recall = results.intersection(&gt).count() as f32 / k as f32;
+        let results = dists.into_iter().zip(row_ids.into_iter()).collect_vec();
+        let gt = ground_truth(&mat, query.values(), k, DistanceType::L2);
+
+        let results_set = results.iter().map(|r| r.1).collect::<HashSet<_>>();
+        let gt_set = gt.iter().map(|r| r.1).collect::<HashSet<_>>();
+
+        let recall = results_set.intersection(&gt_set).count() as f32 / k as f32;
         assert!(
-            recall >= 0.8,
+            recall >= 0.9,
             "recall: {}\n results: {:?}\n\ngt: {:?}",
             recall,
-            results.iter().sorted().collect_vec(),
-            gt.iter().sorted().collect_vec()
+            results,
+            gt,
         );
     }
 
@@ -2312,11 +2326,7 @@ mod tests {
         let nlist = 4;
         let (mut dataset, vector_array) = generate_test_dataset(test_uri, 0.0..1.0).await;
 
-        let centroids = generate_random_array(nlist * DIM);
-        let ivf_centroids = FixedSizeListArray::try_new_from_values(centroids, DIM as i32).unwrap();
-        let ivf_params =
-            IvfBuildParams::try_with_centroids(nlist, Arc::new(ivf_centroids)).unwrap();
-
+        let ivf_params = IvfBuildParams::new(nlist);
         let sq_params = SQBuildParams::default();
         let hnsw_params = HnswBuildParams::default();
         let params = VectorIndexParams::with_ivf_hnsw_sq_params(
@@ -2369,7 +2379,7 @@ mod tests {
         assert_eq!(1, results.len());
         assert_eq!(k, results[0].num_rows());
 
-        let results = results[0]
+        let row_ids = results[0]
             .column_by_name(ROW_ID)
             .unwrap()
             .as_any()
@@ -2377,16 +2387,29 @@ mod tests {
             .unwrap()
             .iter()
             .map(|v| v.unwrap() as u32)
-            .collect::<HashSet<_>>();
+            .collect::<Vec<_>>();
+        let dists = results[0]
+            .column_by_name("_distance")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .unwrap()
+            .values()
+            .to_vec();
 
-        let gt = ground_truth(&mat, query.values(), k);
-        let recall = results.intersection(&gt).count() as f32 / k as f32;
+        let results = dists.into_iter().zip(row_ids.into_iter()).collect_vec();
+        let gt = ground_truth(&mat, query.values(), k, DistanceType::Cosine);
+
+        let results_set = results.iter().map(|r| r.1).collect::<HashSet<_>>();
+        let gt_set = gt.iter().map(|r| r.1).collect::<HashSet<_>>();
+
+        let recall = results_set.intersection(&gt_set).count() as f32 / k as f32;
         assert!(
             recall >= 0.9,
             "recall: {}\n results: {:?}\n\ngt: {:?}",
             recall,
-            results.iter().sorted().collect_vec(),
-            gt.iter().sorted().collect_vec()
+            results,
+            gt,
         );
     }
 

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -2303,7 +2303,7 @@ mod tests {
             .to_vec();
 
         let results = dists.into_iter().zip(row_ids.into_iter()).collect_vec();
-        let gt = ground_truth(&mat, query.values(), k, DistanceType::L2);
+        let gt = ground_truth(&mat, query.values(), k, DistanceType::Cosine);
 
         let results_set = results.iter().map(|r| r.1).collect::<HashSet<_>>();
         let gt_set = gt.iter().map(|r| r.1).collect::<HashSet<_>>();

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -392,6 +392,8 @@ pub(super) async fn write_hnsw_quantization_index_partitions(
         hnsw_metadata.push(serde_json::from_str(
             part_reader.schema().metadata[HNSW_METADATA_KEY].as_str(),
         )?);
+        std::mem::drop(part_reader);
+        object_store.delete(part_file).await?;
 
         if let Some(aux_writer) = auxiliary_writer.as_mut() {
             let aux_part_reader =
@@ -409,6 +411,8 @@ pub(super) async fn write_hnsw_quantization_index_partitions(
                 .buffered(num_cpus::get())
                 .try_collect::<Vec<_>>()
                 .await?;
+            std::mem::drop(aux_part_reader);
+            object_store.delete(aux_part_file).await?;
 
             let num_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
             aux_writer.write(&batches).await?;

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -31,7 +31,7 @@ use lance_io::object_store::ObjectStore;
 use lance_io::traits::Writer;
 use lance_io::ReadBatchParams;
 use lance_linalg::distance::MetricType;
-use lance_linalg::kernels::normalize_arrow;
+use lance_linalg::kernels::normalize_fsl;
 use lance_table::format::SelfDescribingFileReader;
 use lance_table::io::manifest::ManifestDescribing;
 use object_store::path::Path;
@@ -446,7 +446,8 @@ async fn build_hnsw_quantization_partition(
     let mut metric_type = metric_type;
     if metric_type == MetricType::Cosine {
         // Normalize vectors for cosine similarity
-        vectors = normalize_arrow(&vectors)?;
+        vectors =
+            Arc::new(spawn_cpu(move || Ok(normalize_fsl(vectors.as_fixed_size_list())?)).await?);
         metric_type = MetricType::L2;
     }
 

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -451,8 +451,7 @@ async fn build_hnsw_quantization_partition(
         metric_type = MetricType::L2;
     }
 
-    let fsl = vectors.clone();
-    let build_hnsw = build_and_write_hnsw((*hnsw_params).clone(), fsl, writer);
+    let build_hnsw = build_and_write_hnsw((*hnsw_params).clone(), vectors.clone(), writer);
 
     let build_store = match quantizer {
         Quantizer::Product(pq) => tokio::spawn(build_and_write_pq_storage(


### PR DESCRIPTION
- normalize vectors by `normalize_fsl`
- change the default HNSW build params `ef_constrction: 100 -> 150`
- fix the ground truth for cosine