### PR TITLE
fix: use 1/ln(m) as the `mL` value for better performance

### DIFF
--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -246,7 +246,7 @@ impl HNSWBuilderInner {
     /// See paper `Algorithm 1`
     fn random_level(&self) -> u16 {
         let mut rng = thread_rng();
-        let ml = self.params.m as f32;
+        let ml = 1.0 / (self.params.m as f32).ln();
         min(
             (-rng.gen::<f32>().ln() * ml) as u16,
             self.params.max_level - 1,


### PR DESCRIPTION
I forgot to change the value when changed the formulation to calculate the level