### PR TITLE
chore: use VectorStorage in HNSWBuilder

### DIFF
--- a/rust/lance-index/src/vector/graph/memory.rs
+++ b/rust/lance-index/src/vector/graph/memory.rs
@@ -29,13 +29,6 @@ impl InMemoryVectorStorage {
     pub fn vector(&self, id: u32) -> &[f32] {
         self.vectors.row(id as usize).unwrap()
     }
-
-    /// Distance between two vectors.
-    pub fn distance_between(&self, a: u32, b: u32) -> f32 {
-        let vector1 = self.vectors.row(a as usize).unwrap();
-        let vector2 = self.vectors.row(b as usize).unwrap();
-        self.metric_type.func()(vector1, vector2)
-    }
 }
 
 impl VectorStorage for InMemoryVectorStorage {
@@ -61,6 +54,21 @@ impl VectorStorage for InMemoryVectorStorage {
             query: query.to_vec(),
             metric_type: self.metric_type,
         })
+    }
+
+    fn dist_calculator_from_id(&self, id: u32) -> Box<dyn DistCalculator> {
+        Box::new(InMemoryDistanceCal {
+            vectors: self.vectors.clone(),
+            query: self.vectors.row(id as usize).unwrap().to_vec(),
+            metric_type: self.metric_type,
+        })
+    }
+
+    /// Distance between two vectors.
+    fn distance_between(&self, a: u32, b: u32) -> f32 {
+        let vector1 = self.vectors.row(a as usize).unwrap();
+        let vector2 = self.vectors.row(b as usize).unwrap();
+        self.metric_type.func()(vector1, vector2)
     }
 }
 

--- a/rust/lance-index/src/vector/graph/storage.rs
+++ b/rust/lance-index/src/vector/graph/storage.rs
@@ -36,4 +36,8 @@ pub trait VectorStorage: Send + Sync {
     /// Using dist calcualtor can be more efficient as it can pre-compute some
     /// values.
     fn dist_calculator(&self, query: &[f32]) -> Box<dyn DistCalculator>;
+
+    fn dist_calculator_from_id(&self, id: u32) -> Box<dyn DistCalculator>;
+
+    fn distance_between(&self, a: u32, b: u32) -> f32;
 }

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -420,6 +420,14 @@ impl VectorStorage for ProductQuantizationStorage {
             self.metric_type(),
         ))
     }
+
+    fn dist_calculator_from_id(&self, _: u32) -> Box<dyn DistCalculator> {
+        todo!("distance_between not implemented for PQ storage")
+    }
+
+    fn distance_between(&self, _: u32, _: u32) -> f32 {
+        todo!("distance_between not implemented for PQ storage")
+    }
 }
 
 /// Distance calculator backed by PQ code.

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -219,6 +219,20 @@ impl VectorStorage for ScalarQuantizationStorage {
             self.bounds.clone(),
         ))
     }
+
+    fn dist_calculator_from_id(&self, id: u32) -> Box<dyn DistCalculator> {
+        Box::new(SQDistCalculator {
+            query_sq_code: get_sq_code(&self.sq_codes, id).to_vec(),
+            sq_codes: self.sq_codes.clone(),
+        })
+    }
+
+    fn distance_between(&self, a: u32, b: u32) -> f32 {
+        l2_distance_uint_scalar(
+            get_sq_code(&self.sq_codes, a),
+            get_sq_code(&self.sq_codes, b),
+        )
+    }
 }
 
 struct SQDistCalculator {


### PR DESCRIPTION
1/n -- trying to unify `HNSWBuilder` and `HNSWIndex`

move build time vector distance API to `VectorStorage` trait so we can pass in abstracted `VectorStorage`