### PR TITLE
fix: copy arrays when placing them in the v2 writer's accumulation queue

### DIFF
--- a/python/python/lance/file.py
+++ b/python/python/lance/file.py
@@ -129,8 +129,7 @@ class LanceFileWriter:
         path: str,
         schema: pa.Schema,
         *,
-        data_cache_bytes: int,
-        keep_original_array: bool,
+        data_cache_bytes: int = None,
         **kwargs,
     ):
         """

--- a/python/python/lance/file.py
+++ b/python/python/lance/file.py
@@ -124,7 +124,15 @@ class LanceFileWriter:
     Lance datasets then you should use the LanceDataset class instead.
     """
 
-    def __init__(self, path: str, schema: pa.Schema, **kwargs):
+    def __init__(
+        self,
+        path: str,
+        schema: pa.Schema,
+        *,
+        data_cache_bytes: int,
+        keep_original_array: bool,
+        **kwargs,
+    ):
         """
         Create a new LanceFileWriter to write to the given path
 
@@ -135,8 +143,13 @@ class LanceFileWriter:
             or a URI for remote storage.
         schema: pa.Schema
             The schema of data that will be written
+        data_cache_bytes: int
+            How many bytes (per column) to cache before writing a page.  The
+            default is an appropriate value based on the filesystem.
         """
-        self._writer = _LanceFileWriter(path, schema, **kwargs)
+        self._writer = _LanceFileWriter(
+            path, schema, data_cache_bytes=data_cache_bytes, **kwargs
+        )
         self.closed = False
 
     def write_batch(self, batch: Union[pa.RecordBatch, pa.Table]) -> None:

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -34,7 +34,13 @@ class CompactionMetrics:
     files_added: int
 
 class LanceFileWriter:
-    def __init__(self, path: str, schema: pa.Schema): ...
+    def __init__(
+        self,
+        path: str,
+        schema: pa.Schema,
+        data_cache_bytes: int,
+        keep_original_array: bool,
+    ): ...
     def write_batch(self, batch: pa.RecordBatch) -> None: ...
     def finish(self) -> int: ...
 

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -168,7 +168,12 @@ pub struct LanceFileWriter {
 }
 
 impl LanceFileWriter {
-    async fn open(uri_or_path: String, schema: PyArrowType<ArrowSchema>) -> PyResult<Self> {
+    async fn open(
+        uri_or_path: String,
+        schema: PyArrowType<ArrowSchema>,
+        data_cache_bytes: Option<u64>,
+        keep_original_array: Option<bool>,
+    ) -> PyResult<Self> {
         let (object_store, path) = object_store_from_uri_or_path(uri_or_path).await?;
         let object_writer = object_store.create(&path).await.infer_error()?;
         let lance_schema = lance_core::datatypes::Schema::try_from(&schema.0).infer_error()?;
@@ -176,7 +181,10 @@ impl LanceFileWriter {
             object_writer,
             path.to_string(),
             lance_schema,
-            FileWriterOptions::default(),
+            FileWriterOptions {
+                data_cache_bytes,
+                keep_original_array,
+            },
         )
         .infer_error()?;
         Ok(Self {
@@ -188,8 +196,18 @@ impl LanceFileWriter {
 #[pymethods]
 impl LanceFileWriter {
     #[new]
-    pub fn new(path: String, schema: PyArrowType<ArrowSchema>) -> PyResult<Self> {
-        RT.runtime.block_on(Self::open(path, schema))
+    pub fn new(
+        path: String,
+        schema: PyArrowType<ArrowSchema>,
+        data_cache_bytes: Option<u64>,
+        keep_original_array: Option<bool>,
+    ) -> PyResult<Self> {
+        RT.runtime.block_on(Self::open(
+            path,
+            schema,
+            data_cache_bytes,
+            keep_original_array,
+        ))
     }
 
     pub fn write_batch(&mut self, batch: PyArrowType<RecordBatch>) -> PyResult<()> {

--- a/rust/lance-arrow/src/deepcopy.rs
+++ b/rust/lance-arrow/src/deepcopy.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use arrow_array::{make_array, Array, RecordBatch};
+use arrow_buffer::{Buffer, NullBuffer};
+use arrow_data::ArrayData;
+
+pub fn deep_copy_buffer(buffer: &Buffer) -> Buffer {
+    Buffer::from(Vec::from(buffer.as_slice()))
+}
+
+fn deep_copy_nulls(nulls: &NullBuffer) -> Buffer {
+    deep_copy_buffer(nulls.inner().inner())
+}
+
+pub fn deep_copy_array_data(data: &ArrayData) -> ArrayData {
+    let data_type = data.data_type().clone();
+    let len = data.len();
+    let null_count = data.null_count();
+    let null_bit_buffer = data.nulls().map(|nulls| deep_copy_nulls(nulls));
+    let offset = data.offset();
+    let buffers = data
+        .buffers()
+        .iter()
+        .map(|buf| deep_copy_buffer(buf))
+        .collect::<Vec<_>>();
+    let child_data = data
+        .child_data()
+        .iter()
+        .map(|child| deep_copy_array_data(child))
+        .collect::<Vec<_>>();
+    unsafe {
+        ArrayData::new_unchecked(
+            data_type,
+            len,
+            Some(null_count),
+            null_bit_buffer,
+            offset,
+            buffers,
+            child_data,
+        )
+    }
+}
+
+pub fn deep_copy_array(array: &dyn Array) -> Arc<dyn Array> {
+    let data = array.to_data();
+    let data = deep_copy_array_data(&data);
+    make_array(data)
+}
+
+pub fn deep_copy_batch(batch: &RecordBatch) -> crate::Result<RecordBatch> {
+    let arrays = batch
+        .columns()
+        .iter()
+        .map(|array| deep_copy_array(array))
+        .collect::<Vec<_>>();
+    Ok(RecordBatch::try_new(batch.schema().clone(), arrays)?)
+}

--- a/rust/lance-arrow/src/deepcopy.rs
+++ b/rust/lance-arrow/src/deepcopy.rs
@@ -19,17 +19,17 @@ pub fn deep_copy_array_data(data: &ArrayData) -> ArrayData {
     let data_type = data.data_type().clone();
     let len = data.len();
     let null_count = data.null_count();
-    let null_bit_buffer = data.nulls().map(|nulls| deep_copy_nulls(nulls));
+    let null_bit_buffer = data.nulls().map(deep_copy_nulls);
     let offset = data.offset();
     let buffers = data
         .buffers()
         .iter()
-        .map(|buf| deep_copy_buffer(buf))
+        .map(deep_copy_buffer)
         .collect::<Vec<_>>();
     let child_data = data
         .child_data()
         .iter()
-        .map(|child| deep_copy_array_data(child))
+        .map(deep_copy_array_data)
         .collect::<Vec<_>>();
     unsafe {
         ArrayData::new_unchecked(
@@ -56,5 +56,5 @@ pub fn deep_copy_batch(batch: &RecordBatch) -> crate::Result<RecordBatch> {
         .iter()
         .map(|array| deep_copy_array(array))
         .collect::<Vec<_>>();
-    Ok(RecordBatch::try_new(batch.schema().clone(), arrays)?)
+    RecordBatch::try_new(batch.schema().clone(), arrays)
 }

--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -17,6 +17,7 @@ use arrow_schema::{ArrowError, DataType, Field, FieldRef, Fields, IntervalUnit, 
 use arrow_select::take::take;
 use rand::prelude::*;
 
+pub mod deepcopy;
 pub mod schema;
 pub use schema::*;
 pub mod bfloat16;

--- a/rust/lance-encoding/src/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/encodings/logical/binary.rs
@@ -166,10 +166,11 @@ pub struct BinaryFieldEncoder {
 }
 
 impl BinaryFieldEncoder {
-    pub fn new(cache_bytes_per_column: u64, column_index: u32) -> Self {
+    pub fn new(cache_bytes_per_column: u64, keep_original_array: bool, column_index: u32) -> Self {
         let items_encoder = Box::new(
             PrimitiveFieldEncoder::try_new(
                 cache_bytes_per_column,
+                keep_original_array,
                 &DataType::UInt8,
                 column_index + 1,
             )
@@ -179,6 +180,7 @@ impl BinaryFieldEncoder {
             varbin_encoder: Box::new(ListFieldEncoder::new(
                 items_encoder,
                 cache_bytes_per_column,
+                keep_original_array,
                 column_index,
             )),
         }

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -487,6 +487,7 @@ impl ListFieldEncoder {
     pub fn new(
         items_encoder: Box<dyn FieldEncoder>,
         cache_bytes_per_columns: u64,
+        keep_original_array: bool,
         column_index: u32,
     ) -> Self {
         let inner_encoder =
@@ -497,6 +498,7 @@ impl ListFieldEncoder {
         Self {
             offsets_encoder: PrimitiveFieldEncoder::new_with_encoder(
                 cache_bytes_per_columns,
+                keep_original_array,
                 column_index,
                 offsets_encoder,
             ),

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -447,7 +447,6 @@ impl ArrayEncoder for ListOffsetsEncoder {
             // Nothing to patch, don't incur a copy
             return self.inner.encode(arrays, buffer_index);
         }
-        println!("Stitching offsets {:?}", arrays);
         let num_offsets =
             arrays.iter().map(|array| array.len()).sum::<usize>() - (arrays.len() - 1);
         let mut offsets = Vec::with_capacity(num_offsets);
@@ -472,7 +471,6 @@ impl ArrayEncoder for ListOffsetsEncoder {
                     .map(|&v| v + last_prev_offset - first_curr_offset),
             );
         }
-        println!("Stitched offsets {:?}", offsets);
         self.inner
             .encode(&[Arc::new(Int32Array::from(offsets))], buffer_index)
     }

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -96,6 +96,7 @@ pub async fn check_round_trip_encoding_random(field: Field) {
             BatchEncoder::get_encoder_for_field(
                 &lance_field,
                 page_size,
+                /*keep_original_array=*/ true,
                 &mut col_idx,
                 &mut field_id_to_col_index,
             )
@@ -149,6 +150,7 @@ pub async fn check_round_trip_encoding_of_data(data: Vec<Arc<dyn Array>>, test_c
         let encoder = BatchEncoder::get_encoder_for_field(
             &lance_field,
             page_size,
+            /*keep_original=*/ true,
             &mut col_idx,
             &mut field_id_to_col_index,
         )

--- a/rust/lance-file/Cargo.toml
+++ b/rust/lance-file/Cargo.toml
@@ -19,6 +19,7 @@ lance-io.workspace = true
 arrow-arith.workspace = true
 arrow-array.workspace = true
 arrow-buffer.workspace = true
+arrow-data.workspace = true
 arrow-schema.workspace = true
 arrow-select.workspace = true
 async-recursion.workspace = true


### PR DESCRIPTION
When a record batch crosses the FFI layer we lose the ability to deallocate that batch one array at a time (every array in the batch keeps a reference counted pointer to the batch).  This is a problem for the writer because we usually want to flush some arrays to disk and keep other arrays in memory for a while longer.  However, we do want to release the arrays we flush to disk to avoid memory leaks.

This issue was highlighted in a test / demo that attempted to write video data to a lance file.  In this situation we were writing the data one row at a time.  There were only 30,000 rows in the source data but this was hundreds of GB.  None of the metadata columns would ever flush to disk (e.g. a 4 byte int column @ 30,000 rows is only 120KB).  These metadata arrays were keeping the video data alive in memory and the writer was taking up too much data.

The solution in this PR is to perform a deep copy of any data we are planning on flushing to disk.  This is unfortunate, and there is a configuration parameter to disable this copy (I have, intentionally, chosen not to expose this in the python API since data from python always crosses an FFI boundary and is susceptible to this problem).  However, copying this data by default is a much safer course of action.

In the future we could investigate alternative ways of passing the data across the FFI boundary (e.g. instead of sending the entire record batch we could send individual arrays across and then reassemble them into a record batch on the other side).  However, I don't think we need to worry too much about this until we see writer CPU performance become an issue.  In most cases the batches will probably be in the CPU cache already and so this should be a pretty quick write.  Also, writers that are writing any significant amount of data will be I/O bound.