### PR TITLE
feat: add create_index to vector index extensions

### DIFF
--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -58,7 +58,7 @@ pub trait Index: Send + Sync {
 }
 
 /// Index Type
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Hash, Clone)]
 pub enum IndexType {
     // Preserve 0-100 for simple indices.
     Scalar = 0,
@@ -78,6 +78,10 @@ impl std::fmt::Display for IndexType {
 
 pub trait IndexParams: Send + Sync {
     fn as_any(&self) -> &dyn Any;
+
+    fn index_type(&self) -> IndexType;
+
+    fn index_name(&self) -> &str;
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -9,11 +9,14 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use lance_datafusion::{chunker::chunk_concat_stream, exec::LanceExecutionOptions};
-use lance_index::scalar::{
-    btree::{train_btree_index, BTreeIndex, BtreeTrainingSource},
-    flat::FlatIndexMetadata,
-    lance_format::LanceIndexStore,
-    ScalarIndex,
+use lance_index::{
+    scalar::{
+        btree::{train_btree_index, BTreeIndex, BtreeTrainingSource},
+        flat::FlatIndexMetadata,
+        lance_format::LanceIndexStore,
+        ScalarIndex,
+    },
+    IndexType,
 };
 use snafu::{location, Location};
 use tracing::instrument;
@@ -24,12 +27,22 @@ use crate::{dataset::scanner::ColumnOrdering, Dataset};
 
 use super::IndexParams;
 
+pub const LANCE_SCALAR_INDEX: &str = "__lance_scalar_index";
+
 #[derive(Default)]
 pub struct ScalarIndexParams {}
 
 impl IndexParams for ScalarIndexParams {
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+
+    fn index_type(&self) -> IndexType {
+        IndexType::Scalar
+    }
+
+    fn index_name(&self) -> &str {
+        LANCE_SCALAR_INDEX
     }
 }
 

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -6,12 +6,13 @@ use std::sync::Arc;
 
 use lance_core::cache::FileMetadataCache;
 use lance_core::{Error, Result};
+use lance_index::IndexType;
 use snafu::{location, Location};
 
 use crate::dataset::{DEFAULT_INDEX_CACHE_SIZE, DEFAULT_METADATA_CACHE_SIZE};
 use crate::index::cache::IndexCache;
 
-use self::index_extension::VectorIndexExtension;
+use self::index_extension::IndexExtension;
 
 pub mod index_extension;
 
@@ -24,7 +25,7 @@ pub struct Session {
     /// Cache for file metadata
     pub(crate) file_metadata_cache: FileMetadataCache,
 
-    pub(crate) vector_index_extensions: HashMap<String, Arc<dyn VectorIndexExtension>>,
+    pub(crate) index_extensions: HashMap<(IndexType, String), Arc<dyn IndexExtension>>,
 }
 
 impl std::fmt::Debug for Session {
@@ -43,22 +44,52 @@ impl Session {
         Self {
             index_cache: IndexCache::new(index_cache_size),
             file_metadata_cache: FileMetadataCache::new(metadata_cache_size),
-            vector_index_extensions: HashMap::new(),
+            index_extensions: HashMap::new(),
         }
     }
 
-    pub fn register_vector_index_extension(
+    /// Register a new index extension.
+    ///
+    /// A name can only be registered once per type of index extension.
+    ///
+    /// Parameters:
+    ///
+    /// - ***name***: the name of the extension.
+    /// - ***extension***: the extension to register.
+    pub fn register_index_extension(
         &mut self,
         name: String,
-        extension: Arc<dyn VectorIndexExtension>,
+        extension: Arc<dyn IndexExtension>,
     ) -> Result<()> {
-        if self.vector_index_extensions.contains_key(&name) {
-            return Err(Error::invalid_input(
-                format!("{name} is already registered"),
-                location!(),
-            ));
+        match extension.index_type() {
+            IndexType::Scalar => {
+                return Err(Error::invalid_input(
+                    "scalar index extension is not support yet".to_string(),
+                    location!(),
+                ));
+            }
+            IndexType::Vector => {
+                if self
+                    .index_extensions
+                    .contains_key(&(IndexType::Vector, name.clone()))
+                {
+                    return Err(Error::invalid_input(
+                        format!("{name} is already registered"),
+                        location!(),
+                    ));
+                }
+
+                if let Some(ext) = extension.to_vector() {
+                    self.index_extensions
+                        .insert((IndexType::Vector, name), ext.to_generic());
+                } else {
+                    return Err(Error::invalid_input(
+                        format!("{name} is not a vector index extension"),
+                        location!(),
+                    ));
+                }
+            }
         }
-        self.vector_index_extensions.insert(name, extension);
 
         Ok(())
     }
@@ -69,7 +100,7 @@ impl Default for Session {
         Self {
             index_cache: IndexCache::new(DEFAULT_INDEX_CACHE_SIZE),
             file_metadata_cache: FileMetadataCache::new(DEFAULT_METADATA_CACHE_SIZE),
-            vector_index_extensions: HashMap::new(),
+            index_extensions: HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
This PR gives vector index extension the ability to create index

changes:
* add `IndexExtension` and `ScalarIndexExtension` -- `ScalarIndexExtension` does nothing and has no API for now
* add `index_type` and `index_name` to `IndexParams` trait -- this is used to route `create_index` call to the correct handler
* `s/register_vector_index_extension/register_index_extension/`
* add test for index roundtrip -- create + load

Next PR will add index append API.