### PR TITLE
feat: add nullability and u64 support to list codec

### DIFF
--- a/protos/encodings.proto
+++ b/protos/encodings.proto
@@ -83,27 +83,67 @@ message List {
     // If the list at index i is not null then offsets[i] will
     // contain `base + len(list)` where `base` is defined as:
     //   i == 0: 0
-    //   i >  0: (offsets[i-1] % first_invalid_offset)
+    //   i >  0: (offsets[i-1] % null_offset_adjustment)
     //
-    // If the incoming list at index i is null then offsets[i+1] will
-    // contain `base + len(list) + first_invalid_offset` where `base`
+    // To help understand we can consider the following example list:
+    // [ [A, B], null, [], [C, D, E] ]
+    //
+    // The offsets will be [2, ?, 2, 5]
+    //
+    // If the incoming list at index i IS null then offsets[i] will
+    // contain `base + len(list) + null_offset_adjustment` where `base`
     // is defined the same as above.
     //
-    // Reading a list at index i only needs the offsets at
-    // index i and index i-1 (if i > 0).
+    // To complete the above example let's assume that `null_offset_adjustment`
+    // is 7.  Then the offsets will be [2, 9, 2, 5]
     //
-    // If the offset at index i is greater than first_invalid_offset
-    //   then the list at index i is null.
+    // If there are no nulls then the offsets we write here are exactly the
+    // same as the offsets in an Arrow list array (except we omit the leading
+    // 0 which is redundant)
+    //
+    // The reason we do this is so that reading a single list at index i only
+    // requires us to load the indices at i and i-1.
+    //
+    // If the offset at index i is greater than `null_offset_adjustment``
+    // then the list at index i is null.
+    //
     // Otherwise the length of the list is `offsets[i] - base` where
     // base is defined the same as above.
     //
+    // Let's consider our example offsets: [2, 9, 2, 5]
+    //
+    // We can take any range of lists and determine how many list items are
+    // referenced by the sublist.
+    //
+    // 0..3: [_, 5] -> items 0..5 (base = 0* and end is 5)
+    // 0..2: [_, 2] -> items 0..2 (base = 0* and end is 2)
+    // 0..1: [_, 9] -> items 0..2 (base = 0* and end is 9 % 7)
+    // 1..3: [2, 5] -> items 2..5 (base = 2 and end is 5)
+    // 1..2: [2, 2] -> items 2..2 (base = 2 and end is 2)
+    // 2..3: [9, 5] -> items 2..5 (base = 9 % 7 and end is 5)
+    //
+    // * When the start of our range is the 0th item the base is always 0 and we only
+    //   need to load a single index from disk to determine the range.
+    //
     // The data type of the offsets array is flexible and does not need
-    // to match the data type of the destination array.  However, this array is an
-    // unsigned integer array with range [0, 2 * num_items] and so it should
-    // be bit packed accordingly.
+    // to match the data type of the destination array.  Please note that the offsets
+    // array is very likely to be efficiently encoded by bit packing deltas.
     ArrayEncoding offsets = 1;
-    // All valid offsets will be less than this value.
-    uint64 first_invalid_offset = 2;
+    // If a list is null then we add this value to the offset
+    //
+    // This value must be greater than the length of the items so that
+    // (offset + null_offset_adjustment) is never used by a non-null list.
+    //
+    // Note that this value cannot be equal to the length of the items
+    // because then a page with a single list would store [ X ] and we
+    // couldn't know if that is a null list or a list with X items.
+    //
+    // Therefore, the best choice for this value is 1 + # of items.
+    // Choosing this will maximize the bit packing that we can apply to the offsets.
+    uint64 null_offset_adjustment = 2;
+    // How many items are referenced by these offsets.  This is needed in
+    // order to determine which items pages map to this offsets page.
+    uint64 num_items = 3;
 }
 
 // An array encoding for fixed-size list fields

--- a/protos/encodings.proto
+++ b/protos/encodings.proto
@@ -89,7 +89,7 @@ message List {
     // contain `base + len(list) + first_invalid_offset` where `base`
     // is defined the same as above.
     //
-    // When reading a list at index i only only needs the offsets at
+    // When reading a list at index i only needs the offsets at
     // index i and index i-1 (if i > 0).
     //
     // If the offset at index i is greater than first_invalid_offset

--- a/protos/encodings.proto
+++ b/protos/encodings.proto
@@ -89,7 +89,7 @@ message List {
     // contain `base + len(list) + first_invalid_offset` where `base`
     // is defined the same as above.
     //
-    // When reading a list at index i only needs the offsets at
+    // Reading a list at index i only needs the offsets at
     // index i and index i-1 (if i > 0).
     //
     // If the offset at index i is greater than first_invalid_offset

--- a/protos/encodings.proto
+++ b/protos/encodings.proto
@@ -77,28 +77,33 @@ message Nullable {
 message List {
     // An array containing the offsets into an items array.
     //
-    // This array will have (num_rows + 1), will have a data
-    // type of uint64, and will never have nulls.
+    // This array will have num_rows items and will never
+    // have nulls.
     //
-    // offsets[0] will always be 0.
-    //
-    // If the incoming list at index i is not null then offsets[i+1]
-    // will contain offsets[i] + len(list)
+    // If the list at index i is not null then offsets[i] will
+    // contain `base + len(list)` where `base` is defined as:
+    //   i == 0: 0
+    //   i >  0: (offsets[i-1] % first_invalid_offset)
     //
     // If the incoming list at index i is null then offsets[i+1] will
-    // contain offsets[i] + num_items
+    // contain `base + len(list) + first_invalid_offset` where `base`
+    // is defined the same as above.
     //
-    // The length of the list at index i can then be found from
-    // the calculation (offsets[i+1] - offsets[i]) % num_items.  If
-    // the length is 0 the list is:
-    //   * offsets[i+1] == offsets[i] -> empty list
-    //   * offsets[i+1] == num_items + offsets[i+1] -> null list
+    // When reading a list at index i only only needs the offsets at
+    // index i and index i-1 (if i > 0).
     //
-    // The offsets array is always a uint64 array (even if the arrow type it
-    // maps to is using int32 or int64 offsets).  However, this array is an
+    // If the offset at index i is greater than first_invalid_offset
+    //   then the list at index i is null.
+    // Otherwise the length of the list is `offsets[i] - base` where
+    // base is defined the same as above.
+    //
+    // The data type of the offsets array is flexible and does not need
+    // to match the data type of the destination array.  However, this array is an
     // unsigned integer array with range [0, 2 * num_items] and so it should
     // be bit packed accordingly.
     ArrayEncoding offsets = 1;
+    // All valid offsets will be less than this value.
+    uint64 first_invalid_offset = 2;
 }
 
 // An array encoding for fixed-size list fields

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -428,10 +428,15 @@ impl DecodeBatchScheduler {
                                 offsets_column_buffers,
                             ))
                                 as Box<dyn LogicalPageScheduler>;
-                            let mut num_items = list_encoding.first_invalid_offset;
                             let mut items_schedulers = Vec::new();
+                            let mut num_items = list_encoding.num_items;
                             while num_items > 0 {
                                 let next_items_page = items.next().unwrap();
+                                println!(
+                                    "num_items = {} and next_items_page.num_rows() = {}",
+                                    num_items,
+                                    next_items_page.num_rows() as u64
+                                );
                                 num_items -= next_items_page.num_rows() as u64;
                                 items_schedulers.push(next_items_page);
                             }
@@ -440,7 +445,7 @@ impl DecodeBatchScheduler {
                                 items_schedulers,
                                 items_field.data_type().clone(),
                                 DataType::Int32,
-                                list_encoding.first_invalid_offset,
+                                list_encoding.null_offset_adjustment,
                             )) as Box<dyn LogicalPageScheduler>
                         } else {
                             // TODO: Should probably return Err here

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -295,7 +295,7 @@ impl DecodeBatchScheduler {
         }
     }
 
-    fn create_primitive_scheduler<'a>(
+    fn create_primitive_scheduler(
         data_type: &DataType,
         column: &ColumnInfo,
         buffers: FileBuffers,

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -297,11 +297,10 @@ impl DecodeBatchScheduler {
 
     fn create_primitive_scheduler<'a>(
         data_type: &DataType,
-        column_infos: &mut impl Iterator<Item = &'a ColumnInfo>,
+        column: &ColumnInfo,
         buffers: FileBuffers,
     ) -> Vec<Box<dyn LogicalPageScheduler>> {
         // Primitive fields map to a single column
-        let column = column_infos.next().unwrap();
         let column_buffers = ColumnBuffers {
             file_buffers: buffers,
             positions: &column.buffer_offsets,
@@ -385,14 +384,16 @@ impl DecodeBatchScheduler {
         buffers: FileBuffers,
     ) -> Vec<Box<dyn LogicalPageScheduler>> {
         if Self::is_primitive(data_type) {
-            return Self::create_primitive_scheduler(data_type, column_infos, buffers);
+            let primitive_col = column_infos.next().unwrap();
+            return Self::create_primitive_scheduler(data_type, primitive_col, buffers);
         }
         match data_type {
             DataType::FixedSizeList(inner, dimension) => {
                 // A fixed size list column could either be a physical or a logical decoder
                 // depending on the child data type.
                 if Self::is_primitive(inner.data_type()) {
-                    Self::create_primitive_scheduler(data_type, column_infos, buffers)
+                    let primitive_col = column_infos.next().unwrap();
+                    Self::create_primitive_scheduler(data_type, primitive_col, buffers)
                 } else {
                     let inner_schedulers =
                         Self::create_field_scheduler(inner.data_type(), column_infos, buffers);
@@ -406,21 +407,45 @@ impl DecodeBatchScheduler {
                 }
             }
             DataType::List(items_field) => {
-                let offsets = Self::create_field_scheduler(&DataType::Int32, column_infos, buffers);
+                let offsets_column = column_infos.next().unwrap();
+                let offsets_column_buffers = ColumnBuffers {
+                    file_buffers: buffers,
+                    positions: &offsets_column.buffer_offsets,
+                };
                 let items =
                     Self::create_field_scheduler(items_field.data_type(), column_infos, buffers);
-                // TODO: This may need to be more flexible in the future if an items page can
-                // be shared by multiple offsets pages.
-                offsets
-                    .into_iter()
-                    .zip(items)
-                    .map(|(offsets_page, items_page)| {
-                        Box::new(ListPageScheduler::new(
-                            offsets_page,
-                            vec![items_page],
-                            items_field.data_type().clone(),
-                            DataType::Int32,
-                        )) as Box<dyn LogicalPageScheduler>
+                let mut items = items.into_iter();
+                offsets_column
+                    .page_infos
+                    .iter()
+                    .map(|offsets_page| {
+                        if let Some(pb::array_encoding::ArrayEncoding::List(list_encoding)) =
+                            &offsets_page.encoding.array_encoding
+                        {
+                            let inner = Box::new(PrimitivePageScheduler::new(
+                                DataType::UInt64,
+                                offsets_page.clone(),
+                                offsets_column_buffers,
+                            ))
+                                as Box<dyn LogicalPageScheduler>;
+                            let mut num_items = list_encoding.first_invalid_offset;
+                            let mut items_schedulers = Vec::new();
+                            while num_items > 0 {
+                                let next_items_page = items.next().unwrap();
+                                num_items -= next_items_page.num_rows() as u64;
+                                items_schedulers.push(next_items_page);
+                            }
+                            Box::new(ListPageScheduler::new(
+                                inner,
+                                items_schedulers,
+                                items_field.data_type().clone(),
+                                DataType::Int32,
+                                list_encoding.first_invalid_offset,
+                            )) as Box<dyn LogicalPageScheduler>
+                        } else {
+                            // TODO: Should probably return Err here
+                            panic!("Expected a list column");
+                        }
                     })
                     .collect::<Vec<_>>()
             }

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -151,6 +151,9 @@ pub trait FieldEncoder: Send {
     /// It could also return an empty Vec if there is not enough data yet to encode any pages.
     fn maybe_encode(&mut self, array: ArrayRef) -> Result<Vec<EncodeTask>>;
     /// Flush any remaining data from the buffers into encoding tasks
+    ///
+    /// This may be called intermittently throughout encoding but will always be called
+    /// once at the end of encoding.
     fn flush(&mut self) -> Result<Vec<EncodeTask>>;
     /// The number of output columns this encoding will create
     fn num_columns(&self) -> u32;

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -137,7 +137,7 @@ impl ListPageScheduler {
                 let first_offset_idx = 0_usize;
                 let num_offsets = num_lists as usize;
                 let items_start = 0;
-                let mut items_end = offsets_values[num_offsets as usize - 1];
+                let mut items_end = offsets_values[num_offsets - 1];
                 // Repair any null value
                 if items_end > last_valid_offset {
                     items_end = items_end - last_valid_offset - 1;

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -978,7 +978,7 @@ impl FieldEncoder for ListFieldEncoder {
             .offsets_encoder
             .maybe_encode_offsets_and_validity(array.as_ref())
             .map(|task| vec![task])
-            .unwrap_or_else(|| Vec::default());
+            .unwrap_or_default();
         let mut item_tasks = self.items_encoder.maybe_encode(items)?;
         if !offsets_tasks.is_empty() && item_tasks.is_empty() {
             // An items page cannot currently be shared by two different offsets pages.  This is
@@ -996,7 +996,7 @@ impl FieldEncoder for ListFieldEncoder {
             .offsets_encoder
             .flush()
             .map(|task| vec![task])
-            .unwrap_or_else(|| Vec::default());
+            .unwrap_or_default();
         let item_tasks = self.items_encoder.flush()?;
         Self::combine_tasks(offsets_tasks, item_tasks)
     }

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -58,7 +58,7 @@ async fn test_decode(
     num_rows: u64,
     schema: &Schema,
     column_infos: &[ColumnInfo],
-    expected: Arc<dyn Array>,
+    expected: Option<Arc<dyn Array>>,
     schedule_fn: impl FnOnce(
         DecodeBatchScheduler,
         UnboundedSender<Box<dyn LogicalPageDecoder>>,
@@ -76,11 +76,14 @@ async fn test_decode(
     let mut offset = 0;
     while let Some(batch) = decode_stream.next().await {
         let batch = batch.task.await.unwrap();
-        let actual = batch.column(0);
-        let expected_size = (BATCH_SIZE as usize).min(expected.len() - offset);
-        let expected = expected.slice(offset, expected_size);
-        assert_eq!(expected.data_type(), actual.data_type());
-        assert_eq!(&expected, actual);
+        assert_eq!(batch.num_rows() as u32, BATCH_SIZE);
+        if let Some(expected) = expected.as_ref() {
+            let actual = batch.column(0);
+            let expected_size = (BATCH_SIZE as usize).min(expected.len() - offset);
+            let expected = expected.slice(offset, expected_size);
+            assert_eq!(expected.data_type(), actual.data_type());
+            assert_eq!(&expected, actual);
+        }
         offset += BATCH_SIZE as usize;
     }
 }
@@ -109,10 +112,7 @@ pub async fn check_round_trip_encoding_random(field: Field) {
 fn supports_nulls(data_type: &DataType) -> bool {
     // We don't yet have nullability support for all types.  Don't test nullability for the
     // types we don't support.
-    !matches!(
-        data_type,
-        DataType::List(_) | DataType::Struct(_) | DataType::Utf8 | DataType::Binary
-    )
+    !matches!(data_type, DataType::Struct(_))
 }
 
 // The default will just test the full read
@@ -120,6 +120,7 @@ fn supports_nulls(data_type: &DataType) -> bool {
 pub struct TestCases {
     ranges: Vec<Range<u64>>,
     indices: Vec<Vec<u32>>,
+    skip_validation: bool,
 }
 
 impl TestCases {
@@ -130,6 +131,11 @@ impl TestCases {
 
     pub fn with_indices(mut self, indices: Vec<u32>) -> Self {
         self.indices.push(indices);
+        self
+    }
+
+    pub fn without_validation(mut self) -> Self {
+        self.skip_validation = true;
         self
     }
 }
@@ -215,11 +221,15 @@ async fn check_round_trip_encoding_inner(
         .collect::<Vec<_>>();
     let schema = Schema::new(vec![field.clone()]);
 
-    let concat_data = concat(&data.iter().map(|arr| arr.as_ref()).collect::<Vec<_>>()).unwrap();
+    let num_rows = data.iter().map(|arr| arr.len() as u64).sum::<u64>();
+    let concat_data = if test_cases.skip_validation {
+        None
+    } else {
+        Some(concat(&data.iter().map(|arr| arr.as_ref()).collect::<Vec<_>>()).unwrap())
+    };
 
     // We always try a full decode, regardless of the test cases provided
     debug!("Testing full decode");
-    let num_rows = concat_data.len() as u64;
     let scheduler_copy = scheduler.clone();
     test_decode(
         num_rows,
@@ -241,7 +251,9 @@ async fn check_round_trip_encoding_inner(
     for range in &test_cases.ranges {
         debug!("Testing decode of range {:?}", range);
         let num_rows = range.end - range.start;
-        let expected = concat_data.slice(range.start as usize, num_rows as usize);
+        let expected = concat_data
+            .as_ref()
+            .map(|concat_data| concat_data.slice(range.start as usize, num_rows as usize));
         let scheduler = scheduler.clone();
         let range = range.clone();
         test_decode(
@@ -270,7 +282,9 @@ async fn check_round_trip_encoding_inner(
         }
         let num_rows = indices.len() as u64;
         let indices_arr = UInt32Array::from(indices.clone());
-        let expected = arrow_select::take::take(&concat_data, &indices_arr, None).unwrap();
+        let expected = concat_data
+            .as_ref()
+            .map(|concat_data| arrow_select::take::take(&concat_data, &indices_arr, None).unwrap());
         let scheduler = scheduler.clone();
         let indices = indices.clone();
         test_decode(

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -76,7 +76,6 @@ async fn test_decode(
     let mut offset = 0;
     while let Some(batch) = decode_stream.next().await {
         let batch = batch.task.await.unwrap();
-        assert_eq!(batch.num_rows() as u32, BATCH_SIZE);
         if let Some(expected) = expected.as_ref() {
             let actual = batch.column(0);
             let expected_size = (BATCH_SIZE as usize).min(expected.len() - offset);


### PR DESCRIPTION
This adds support for nulls in lists and adds support for lists that contain more than i32::MAX items (note: this is a lot more common since we write offset pages much slower than item pages)