### PR TITLE
feat: raise GCS object size limit to 2.5TB

### DIFF
--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -42,12 +42,12 @@ tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 path_abs.workspace = true
+rand.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
 parquet.workspace = true
 pprof.workspace = true
-rand.workspace = true
 tempfile.workspace = true
 
 [build-dependencies]

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -56,3 +56,6 @@ prost-build.workspace = true
 [[bench]]
 name = "scheduler"
 harness = false
+
+[features]
+gcs-test = []

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -719,7 +719,7 @@ async fn configure_store(url: &str, options: ObjectStoreParams) -> Result<Object
 
         "gs" => {
             storage_options.with_env_gcs();
-            let mut builder = GoogleCloudStorageBuilder::new();
+            let mut builder = GoogleCloudStorageBuilder::new().with_url(url.as_ref());
             for (key, value) in storage_options.as_gcs_options() {
                 builder = builder.with_config(key, value);
             }

--- a/rust/lance-io/src/object_store/gcs_wrapper.rs
+++ b/rust/lance-io/src/object_store/gcs_wrapper.rs
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Wrappers around object_store that apply tracing
+
+use std::io;
+use std::ops::Range;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Poll;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use futures::stream::{BoxStream, FuturesUnordered};
+use futures::{FutureExt, StreamExt};
+use object_store::gcp::GoogleCloudStorage;
+use object_store::multipart::{MultiPartStore, PartId};
+use object_store::path::Path;
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartId, ObjectMeta, ObjectStore, PutOptions, PutResult,
+    Result as OSResult,
+};
+use tokio::io::AsyncWrite;
+
+/// Wrapper around GoogleCloudStorage with a larger maximum upload size.
+///
+/// This will be obsolete once object_store 0.10.0 is released.
+#[derive(Debug)]
+pub struct PatchedGoogleCloudStorage(pub Arc<GoogleCloudStorage>);
+
+impl std::fmt::Display for PatchedGoogleCloudStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "PatchedGoogleCloudStorage({})", self.0)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for PatchedGoogleCloudStorage {
+    async fn put(&self, location: &Path, bytes: Bytes) -> OSResult<PutResult> {
+        self.0.put(location, bytes).await
+    }
+
+    async fn put_opts(
+        &self,
+        location: &Path,
+        bytes: Bytes,
+        opts: PutOptions,
+    ) -> OSResult<PutResult> {
+        self.0.put_opts(location, bytes, opts).await
+    }
+
+    async fn put_multipart(
+        &self,
+        location: &Path,
+    ) -> OSResult<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)> {
+        // We don't return a real multipart id here. This will be addressed
+        // in object_store 0.10.0.
+        Upload::new(self.0.clone(), location.clone())
+            .map(|upload| (MultipartId::default(), Box::new(upload) as _))
+    }
+
+    async fn abort_multipart(&self, location: &Path, multipart_id: &MultipartId) -> OSResult<()> {
+        MultiPartStore::abort_multipart(self.0.as_ref(), location, multipart_id).await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+        self.0.get_opts(location, options).await
+    }
+
+    async fn get_range(&self, location: &Path, range: Range<usize>) -> OSResult<Bytes> {
+        self.0.get_range(location, range).await
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> OSResult<Vec<Bytes>> {
+        self.0.get_ranges(location, ranges).await
+    }
+
+    async fn head(&self, location: &Path) -> OSResult<ObjectMeta> {
+        self.0.head(location).await
+    }
+
+    async fn delete(&self, location: &Path) -> OSResult<()> {
+        self.0.delete(location).await
+    }
+
+    fn delete_stream<'a>(
+        &'a self,
+        locations: BoxStream<'a, OSResult<Path>>,
+    ) -> BoxStream<'a, OSResult<Path>> {
+        self.0.delete_stream(locations)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, OSResult<ObjectMeta>> {
+        self.0.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+        self.0.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> OSResult<()> {
+        self.0.copy(from, to).await
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> OSResult<()> {
+        self.0.rename(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
+        self.0.copy_if_not_exists(from, to).await
+    }
+}
+
+enum UploadState {
+    Pending,
+    CreatingUpload(BoxFuture<'static, OSResult<MultipartId>>),
+    InProgress {
+        multipart_id: Arc<MultipartId>,
+        part_idx: u16,
+        futures: FuturesUnordered<BoxFuture<'static, OSResult<(u16, PartId)>>>,
+        part_ids: Vec<Option<PartId>>,
+    },
+    PuttingSingle(BoxFuture<'static, OSResult<()>>),
+    Completing(BoxFuture<'static, OSResult<()>>),
+    Done,
+}
+
+/// Start at 5MB.
+const INITIAL_UPLOAD_SIZE: usize = 1024 * 1024 * 5;
+
+struct Upload {
+    store: Arc<GoogleCloudStorage>,
+    path: Arc<Path>,
+    buffer: Vec<u8>,
+    state: UploadState,
+}
+
+impl Upload {
+    fn new(store: Arc<GoogleCloudStorage>, path: Path) -> OSResult<Self> {
+        Ok(Self {
+            store,
+            path: Arc::new(path),
+            buffer: Vec::with_capacity(INITIAL_UPLOAD_SIZE),
+            state: UploadState::Pending,
+        })
+    }
+
+    fn poll_tasks(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Result<(), io::Error> {
+        loop {
+            match &mut self.state {
+                UploadState::Pending | UploadState::Done => break,
+                UploadState::CreatingUpload(ref mut fut) => match fut.poll_unpin(cx) {
+                    Poll::Ready(Ok(multipart_id)) => {
+                        self.state = UploadState::InProgress {
+                            multipart_id: Arc::new(multipart_id),
+                            part_idx: 0,
+                            futures: FuturesUnordered::new(),
+                            part_ids: Vec::new(),
+                        };
+                    }
+                    Poll::Ready(Err(e)) => {
+                        return Err(std::io::Error::new(std::io::ErrorKind::Other, e))
+                    }
+                    Poll::Pending => break,
+                },
+                UploadState::InProgress {
+                    futures, part_ids, ..
+                } => {
+                    while let Poll::Ready(Some(res)) = futures.poll_next_unpin(cx) {
+                        let (part_idx, part_id) = res?;
+                        let total_parts = part_ids.len();
+                        part_ids.resize(total_parts.max(part_idx as usize + 1), None);
+                        part_ids[part_idx as usize] = Some(part_id);
+                    }
+                }
+                UploadState::PuttingSingle(ref mut fut) | UploadState::Completing(ref mut fut) => {
+                    match fut.poll_unpin(cx) {
+                        Poll::Ready(Ok(())) => self.state = UploadState::Done,
+                        Poll::Ready(Err(e)) => {
+                            return Err(std::io::Error::new(std::io::ErrorKind::Other, e))
+                        }
+                        Poll::Pending => break,
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl AsyncWrite for Upload {
+    fn poll_write(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<Result<usize, std::io::Error>> {
+        self.as_mut().poll_tasks(cx)?;
+
+        // Fill buffer up to remaining capacity.
+        let remaining_capacity = self.buffer.capacity() - self.buffer.len();
+        let bytes_to_write = std::cmp::min(remaining_capacity, buf.len());
+        self.buffer.extend_from_slice(&buf[..bytes_to_write]);
+
+        // Rust needs a little help to borrow self mutably and immutably at the same time
+        // through a Pin.
+        let mut_self = &mut *self;
+        let state_ref = &mut mut_self.state;
+        let buffer_ref = &mut mut_self.buffer;
+        let store_ref = &mut_self.store;
+        let path_ref = &mut_self.path;
+
+        // Instantiate next request, if available.
+        if buffer_ref.capacity() == buffer_ref.len() {
+            match state_ref {
+                UploadState::Pending => {
+                    let store = self.store.clone();
+                    let path = self.path.clone();
+                    let fut = Box::pin(async move { store.create_multipart(path.as_ref()).await });
+                    self.state = UploadState::CreatingUpload(fut);
+                }
+                UploadState::InProgress {
+                    multipart_id,
+                    part_idx,
+                    futures,
+                    ..
+                } => {
+                    // TODO: Make max concurrency configurable.
+                    if buffer_ref.len() >= buffer_ref.capacity() && futures.len() < 10 {
+                        // Increase the upload size every 100 parts. This gives maximum part size of 2.5TB.
+                        let new_capacity = ((*part_idx / 100) as usize + 1) * INITIAL_UPLOAD_SIZE;
+                        let new_buffer = Vec::with_capacity(new_capacity);
+                        let part = std::mem::replace(buffer_ref, new_buffer);
+                        let part = Bytes::from(part);
+
+                        let part_idx_clone = *part_idx;
+                        let store = store_ref.clone();
+                        let multipart_id = multipart_id.clone();
+                        let path = path_ref.clone();
+                        let fut = Box::pin(async move {
+                            let part_id = store
+                                .put_part(
+                                    path.as_ref(),
+                                    multipart_id.as_ref(),
+                                    part_idx_clone as usize,
+                                    part,
+                                )
+                                .await?;
+                            Ok((part_idx_clone, part_id))
+                        });
+                        futures.push(fut);
+                        *part_idx += 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        self.poll_tasks(cx)?;
+
+        match bytes_to_write {
+            0 => Poll::Pending,
+            _ => Poll::Ready(Ok(bytes_to_write)),
+        }
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        self.as_mut().poll_tasks(cx)?;
+
+        match &self.state {
+            UploadState::Pending | UploadState::Done => Poll::Ready(Ok(())),
+            UploadState::CreatingUpload(_)
+            | UploadState::Completing(_)
+            | UploadState::PuttingSingle(_) => Poll::Pending,
+            UploadState::InProgress { futures, .. } => {
+                if futures.is_empty() {
+                    Poll::Ready(Ok(()))
+                } else {
+                    Poll::Pending
+                }
+            }
+        }
+    }
+
+    fn poll_shutdown(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), std::io::Error>> {
+        self.as_mut().poll_tasks(cx)?;
+
+        // Rust needs a little help to borrow self mutably and immutably at the same time
+        // through a Pin.
+        let mut_self = &mut *self;
+        let state_ref = &mut mut_self.state;
+        let buffer_ref = &mut mut_self.buffer;
+        let store_ref = &mut_self.store;
+        let path_ref = &mut_self.path;
+
+        match state_ref {
+            UploadState::Done => Poll::Ready(Ok(())),
+            UploadState::CreatingUpload(_)
+            | UploadState::PuttingSingle(_)
+            | UploadState::Completing(_) => Poll::Pending,
+            UploadState::Pending => {
+                // If we didn't start a multipart upload, we can just do a single put.
+                let part = Bytes::from(std::mem::take(buffer_ref));
+                let path = path_ref.clone();
+                let store = store_ref.clone();
+                let fut = Box::pin(async move {
+                    store.put(&path, part).await?;
+                    Ok(())
+                });
+                self.state = UploadState::PuttingSingle(fut);
+                self.as_mut().poll_tasks(cx)?;
+                // Just in case the put immediately finishes, we recurse here.
+                self.poll_shutdown(cx)
+            }
+            UploadState::InProgress {
+                futures,
+                part_ids,
+                multipart_id,
+                ..
+            } => {
+                // We handle the transition from in progress to completing here.
+                if futures.is_empty() {
+                    let part_ids = std::mem::take(part_ids)
+                        .into_iter()
+                        .map(|maybe_id| {
+                            maybe_id.ok_or_else(|| {
+                                io::Error::new(io::ErrorKind::Other, "missing part id")
+                            })
+                        })
+                        .collect::<io::Result<Vec<_>>>()?;
+                    let path = path_ref.clone();
+                    let store = store_ref.clone();
+                    let multipart_id = multipart_id.clone();
+                    let fut = Box::pin(async move {
+                        store
+                            .complete_multipart(&path, &multipart_id, part_ids)
+                            .await?;
+                        Ok(())
+                    });
+                    self.state = UploadState::Completing(fut);
+                    self.as_mut().poll_tasks(cx)?;
+                    // Just in case the completion immediately finishes, we recurse here.
+                    self.poll_shutdown(cx)
+                } else {
+                    Poll::Pending
+                }
+            }
+        }
+    }
+}

--- a/rust/lance-io/src/object_store/tracing.rs
+++ b/rust/lance-io/src/object_store/tracing.rs
@@ -132,6 +132,14 @@ impl object_store::ObjectStore for TracedObjectStore {
         self.target.delete(location).await
     }
 
+    #[instrument(level = "debug", skip_all)]
+    fn delete_stream<'a>(
+        &'a self,
+        locations: BoxStream<'a, OSResult<Path>>,
+    ) -> BoxStream<'a, OSResult<Path>> {
+        self.target.delete_stream(locations)
+    }
+
     #[instrument(level = "debug", skip(self))]
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, OSResult<ObjectMeta>> {
         self.target.list(prefix)

--- a/rust/lance-io/tests/gcs_integration.rs
+++ b/rust/lance-io/tests/gcs_integration.rs
@@ -4,6 +4,8 @@
 //! They do not work against any local emulator right now.
 #![cfg(feature = "gcs-test")]
 
+// TODO: Once we re-use this logic for S3, we can instead use tests against
+// Minio to validate the multipart upload logic.
 use lance_io::object_store::ObjectStore;
 use object_store::path::Path;
 use tokio::io::AsyncWriteExt;

--- a/rust/lance-io/tests/gcs_integration.rs
+++ b/rust/lance-io/tests/gcs_integration.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
-//! These integration tests can be run against a real GCS bucket.
+//! These integration tests can only be run against a real GCS bucket.  
 //! They do not work against any local emulator right now.
 #![cfg(feature = "gcs-test")]
 
@@ -75,7 +75,7 @@ async fn test_large_upload() {
         .await
         .unwrap();
 
-    // Write a 40MB buffers
+    // Write a 40MB buffer
     writer
         .write_all(&vec![b'e'; 40 * 1024 * 1024])
         .await

--- a/rust/lance-io/tests/gcs_integration.rs
+++ b/rust/lance-io/tests/gcs_integration.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+//! These integration tests can be run against a real GCS bucket.
+//! They do not work against any local emulator right now.
+#![cfg(feature = "gcs-test")]
+
+use lance_io::object_store::ObjectStore;
+use object_store::path::Path;
+use tokio::io::AsyncWriteExt;
+
+async fn get_store() -> ObjectStore {
+    let bucket_name = std::env::var("OBJECT_STORE_BUCKET").unwrap_or_else(|_| "test-bucket".into());
+    ObjectStore::from_uri(&format!("gs://{}/object", bucket_name))
+        .await
+        .unwrap()
+        .0
+}
+
+#[tokio::test]
+async fn test_small_upload() {
+    let store = get_store().await;
+
+    let path = Path::from("test_small_upload");
+    if store.exists(&path).await.unwrap() {
+        store.delete(&path).await.unwrap();
+    }
+
+    // Write an empty file.
+    let mut writer = store.create(&path).await.unwrap();
+    writer.shutdown().await.unwrap();
+    let meta = store.inner.head(&path).await.unwrap();
+    assert_eq!(meta.size, 0);
+    store.delete(&path).await.unwrap();
+
+    // Write a small file, with two small writes.
+    let mut writer = store.create(&path).await.unwrap();
+    writer.write_all(b"hello").await.unwrap();
+    writer.write_all(b"world").await.unwrap();
+    writer.shutdown().await.unwrap();
+    let meta = store.inner.head(&path).await.unwrap();
+    assert_eq!(meta.size, 10);
+    store.delete(&path).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_large_upload() {
+    let store = get_store().await;
+
+    let path = Path::from("test_large_upload");
+    if store.exists(&path).await.unwrap() {
+        store.delete(&path).await.unwrap();
+    }
+
+    let mut writer = store.create(&path).await.unwrap();
+
+    // Write a few 3MB buffers
+    writer
+        .write_all(&vec![b'a'; 3 * 1024 * 1024])
+        .await
+        .unwrap();
+    writer
+        .write_all(&vec![b'b'; 3 * 1024 * 1024])
+        .await
+        .unwrap();
+    writer
+        .write_all(&vec![b'c'; 3 * 1024 * 1024])
+        .await
+        .unwrap();
+    writer
+        .write_all(&vec![b'd'; 3 * 1024 * 1024])
+        .await
+        .unwrap();
+
+    // Write a 40MB buffers
+    writer
+        .write_all(&vec![b'e'; 40 * 1024 * 1024])
+        .await
+        .unwrap();
+
+    writer.flush().await.unwrap();
+    writer.shutdown().await.unwrap();
+
+    let meta = store.inner.head(&path).await.unwrap();
+    assert_eq!(meta.size, 52 * 1024 * 1024);
+
+    let data = store.inner.get(&path).await.unwrap().bytes().await.unwrap();
+    assert_eq!(data.len(), 52 * 1024 * 1024);
+    assert_eq!(data[0], b'a');
+    assert_eq!(data[3 * 1024 * 1024], b'b');
+    assert_eq!(data[6 * 1024 * 1024], b'c');
+    assert_eq!(data[9 * 1024 * 1024], b'd');
+    assert_eq!(data[12 * 1024 * 1024], b'e');
+}

--- a/rust/lance-io/tests/gcs_integration.rs
+++ b/rust/lance-io/tests/gcs_integration.rs
@@ -18,6 +18,7 @@ async fn get_store() -> ObjectStore {
         .0
 }
 
+#[ignore = "Must be run manually on GCS"]
 #[tokio::test]
 async fn test_small_upload() {
     let store = get_store().await;
@@ -44,6 +45,7 @@ async fn test_small_upload() {
     store.delete(&path).await.unwrap();
 }
 
+#[ignore = "Must be run manually on GCS"]
 #[tokio::test]
 async fn test_large_upload() {
     let store = get_store().await;


### PR DESCRIPTION
This is an interim fix for just GCS to solve https://github.com/lancedb/lance/issues/2247

Because of the challenges of casting between `&dyn ObjectStore` and `&dyn MultiPartStore`, it's not easy in the current version of `object_store` to implement this generically over all stores. However, in the next version of `object_store` (0.10.0), there is a new API for `put_multipart()` that will make it easy to extend this implementation to all stores.