### PR TITLE
feat: don't load all list items before returning a batch

### DIFF
--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -264,8 +264,8 @@ impl LanceFileReader {
     async fn open(uri_or_path: String, schema: PyArrowType<ArrowSchema>) -> PyResult<Self> {
         let (object_store, path) = object_store_from_uri_or_path(uri_or_path).await?;
         let io_parallelism = std::env::var("IO_THREADS")
-        .map(|val| val.parse::<u32>().unwrap_or(8))
-        .unwrap_or(8);
+            .map(|val| val.parse::<u32>().unwrap_or(8))
+            .unwrap_or(8);
         let scheduler = StoreScheduler::new(Arc::new(object_store), io_parallelism);
         let file = scheduler.open_file(&path).await.infer_error()?;
         let inner = FileReader::try_open(file, schema.0.clone())

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -263,7 +263,10 @@ pub struct LanceFileReader {
 impl LanceFileReader {
     async fn open(uri_or_path: String, schema: PyArrowType<ArrowSchema>) -> PyResult<Self> {
         let (object_store, path) = object_store_from_uri_or_path(uri_or_path).await?;
-        let scheduler = StoreScheduler::new(Arc::new(object_store), 8);
+        let io_parallelism = std::env::var("IO_THREADS")
+        .map(|val| val.parse::<u32>().unwrap_or(8))
+        .unwrap_or(8);
+        let scheduler = StoreScheduler::new(Arc::new(object_store), io_parallelism);
         let file = scheduler.open_file(&path).await.infer_error()?;
         let inner = FileReader::try_open(file, schema.0.clone())
             .await

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -559,7 +559,7 @@ impl LogicalPageDecoder for ListPageDecoder {
                     "List decoder waiting on a new page that has {} items unawaited",
                     unawaited
                 );
-                let to_await = items_needed.min(unawaited as u64) as u32;
+                let to_await = items_needed.min(unawaited) as u32;
                 // TODO: Seems like this will fail in List<Struct> case
                 next_item_decoder.wait(to_await, source).await?;
                 // Might end up loading more items than needed so use saturating_sub

--- a/rust/lance-io/src/object_reader.rs
+++ b/rust/lance-io/src/object_reader.rs
@@ -9,6 +9,7 @@ use bytes::Bytes;
 use futures::future::BoxFuture;
 use lance_core::Result;
 use object_store::{path::Path, ObjectStore};
+use tracing::instrument;
 
 use crate::traits::Reader;
 
@@ -75,6 +76,7 @@ impl Reader for CloudObjectReader {
         Ok(meta.size)
     }
 
+    #[instrument(level = "debug", skip(self))]
     async fn get_range(&self, range: Range<usize>) -> Result<Bytes> {
         self.do_with_retry(|| self.object_store.get_range(&self.path, range.clone()))
             .await


### PR DESCRIPTION
Previously we were requiring that all items referenced by a page of offsets be loaded before any batches were returned.  This can be a problem when a list offsets page has many rows (e.g. a million) spread across many list item pages (hundreds).  In this case we can start emitting batches as soon as the first item page(s) have loaded.  That is what this PR does.