### PR TITLE
ci: automate release notes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,12 +9,12 @@ labels:
 - label: breaking-change
   title: "^[^:]+!:.*"
 - label: enhancement
-  title: "^feat(\(.+\))?!?:.*"
+  title: "^feat(\\(.+\\))?!?:.*"
 - label: bug
-  title: "^fix(\(.+\))?!?:.*"
+  title: "^fix(\\(.+\\))?!?:.*"
 - label: documentation
-  title: "^docs(\(.+\))?!?:.*"
+  title: "^docs(\\(.+\\))?!?:.*"
 - label: performance
-  title: "^perf(\(.+\))?!?:.*"
+  title: "^perf(\\(.+\\))?!?:.*"
 - label: ci
-  title: "^ci(\(.+\))?!?:.*"
+  title: "^ci(\\(.+\\))?!?:.*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,6 +8,8 @@ labels:
 # For example, `feat!: add new feature` will be considered a breaking change
 - label: breaking-change
   title: "^[^:]+!:.*"
+- label: breaking-change
+  body: "BREAKING CHANGE:"
 - label: enhancement
   title: "^feat(\\(.+\\))?!?:.*"
 - label: bug
@@ -18,3 +20,5 @@ labels:
   title: "^perf(\\(.+\\))?!?:.*"
 - label: ci
   title: "^ci(\\(.+\\))?!?:.*"
+- label: chore
+  title: "^(chore|test|build|style)(\\(.+\\))?!?:.*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,20 @@
+version: 1
+appendOnly: true
+# Labels are applied based on conventional commits standard
+# https://www.conventionalcommits.org/en/v1.0.0/
+# These labels are later used in release notes. See .github/release.yml
+labels:
+# If the PR title has an ! before the : it will be considered a breaking change
+# For example, `feat!: add new feature` will be considered a breaking change
+- label: breaking-change
+  title: "^[^:]+!:.*"
+- label: enhancement
+  title: "^feat(\(.+\))?!?:.*"
+- label: bug
+  title: "^fix(\(.+\))?!?:.*"
+- label: documentation
+  title: "^docs(\(.+\))?!?:.*"
+- label: performance
+  title: "^perf(\(.+\))?!?:.*"
+- label: ci
+  title: "^ci(\(.+\))?!?:.*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -9,7 +9,7 @@ labels:
 - label: breaking-change
   title: "^[^:]+!:.*"
 - label: breaking-change
-  body: "BREAKING CHANGE:"
+  body: "BREAKING CHANGE"
 - label: enhancement
   title: "^feat(\\(.+\\))?!?:.*"
 - label: bug

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,7 @@ changelog:
   exclude:
     labels:
       - ci
+      - chore
   categories:
     - title: Breaking Changes 🛠
       labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - ci
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+    - title: Documentation 📚
+      labels:
+        - documentation
+    - title: Performance Improvements 🚀
+      labels:
+        - performance
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -10,6 +10,8 @@ concurrency:
 
 jobs:
   labeler:
+    permissions:
+      pull-requests: write
     name: Label PR
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,4 +1,4 @@
-name: PR Title Check
+name: PR Checks
 
 on:
   pull_request_target:
@@ -9,6 +9,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  labeler:
+    name: Label PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: srvaroa/labeler@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   commitlint:
     permissions:
       pull-requests: write


### PR DESCRIPTION
We make contributors categorize their PRs with the conventional commits titles. Right now, I manually separate different kinds of changes into sections in the release notes. This PR automates that process.

We use a labeler action to add PR labels based on the title. Then `.github/release.yml` will use those labels to create section headers. See docs here: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#example-configurations

This is similar to how polars does their releases: https://github.com/pola-rs/polars/releases