### PR TITLE
chore: `half` dependency unpin and bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ async-trait = "0.1"
 aws-config = "0.56"
 aws-credential-types = "0.56"
 aws-sdk-dynamodb = "0.34"
-half = { "version" = "=2.3.1", default-features = false, features = [
+half = { "version" = "2.4.1", default-features = false, features = [
     "num-traits",
     "std",
 ] }


### PR DESCRIPTION
closes https://github.com/lancedb/lance/issues/2279