### PR TITLE
ci: make sure the tests run if only the root cargo file is updated

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
       - rust/**
       - protos/**
       - .github/workflows/rust.yml
+      - Cargo.toml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
https://github.com/lancedb/lance/pull/2281 did not trigger CI runs.