### PR TITLE
chore: simplify the datagen API

### DIFF
--- a/rust/lance-datagen/benches/array_gen.rs
+++ b/rust/lance-datagen/benches/array_gen.rs
@@ -29,7 +29,7 @@ fn bench_gen<M: Measurement>(
     group.bench_function(id, |b| {
         b.iter(|| {
             let reader = lance_datagen::gen()
-                .col(None, gen_factory())
+                .anon_col(gen_factory())
                 .into_reader_bytes(
                     ByteCount::from(BYTES_PER_BATCH),
                     num_batches,

--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -1001,8 +1001,16 @@ impl BatchGeneratorBuilder {
     /// Adds a new column to the generator
     ///
     /// See [`crate::generator::array`] for methods to create generators
-    pub fn col(mut self, name: Option<String>, gen: Box<dyn ArrayGenerator>) -> Self {
-        self.generators.push((name, gen));
+    pub fn col(mut self, name: impl Into<String>, gen: Box<dyn ArrayGenerator>) -> Self {
+        self.generators.push((Some(name.into()), gen));
+        self
+    }
+
+    /// Adds a new column to the generator with a generated unique name
+    ///
+    /// See [`crate::generator::array`] for methods to create generators
+    pub fn anon_col(mut self, gen: Box<dyn ArrayGenerator>) -> Self {
+        self.generators.push((None, gen));
         self
     }
 
@@ -1632,10 +1640,7 @@ pub fn gen() -> BatchGeneratorBuilder {
 pub fn rand(schema: &Schema) -> BatchGeneratorBuilder {
     let mut builder = BatchGeneratorBuilder::default();
     for field in schema.fields() {
-        builder = builder.col(
-            Some(field.name().clone()),
-            array::rand_type(field.data_type()),
-        );
+        builder = builder.col(field.name(), array::rand_type(field.data_type()));
     }
     builder
 }

--- a/rust/lance-encoding/benches/decoder.rs
+++ b/rust/lance-encoding/benches/decoder.rs
@@ -52,7 +52,7 @@ fn bench_decode(c: &mut Criterion) {
     let mut group = c.benchmark_group("decode_primitive");
     for data_type in PRIMITIVE_TYPES {
         let data = lance_datagen::gen()
-            .col(None, lance_datagen::array::rand_type(&DataType::Int32))
+            .anon_col(lance_datagen::array::rand_type(&DataType::Int32))
             .into_batch_rows(lance_datagen::RowCount::from(1024 * 1024))
             .unwrap();
         let input_bytes = data.get_array_memory_size();
@@ -74,13 +74,10 @@ fn bench_decode_fsl(c: &mut Criterion) {
     let mut group = c.benchmark_group("decode_primitive_fsl");
     for data_type in PRIMITIVE_TYPES_FOR_FSL {
         let data = lance_datagen::gen()
-            .col(
-                None,
-                lance_datagen::array::rand_type(&DataType::FixedSizeList(
-                    Arc::new(Field::new("item", DataType::Int32, true)),
-                    1024,
-                )),
-            )
+            .anon_col(lance_datagen::array::rand_type(&DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Int32, true)),
+                1024,
+            )))
             .into_batch_rows(lance_datagen::RowCount::from(1024))
             .unwrap();
         let input_bytes = data.get_array_memory_size();

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -345,7 +345,7 @@ async fn check_round_trip_field_encoding_random(
                 // example, a list array sliced into smaller arrays will have arrays whose
                 // starting offset is not 0.
                 if use_slicing {
-                    let mut generator = gen().col(None, array::rand_type(field.data_type()));
+                    let mut generator = gen().anon_col(array::rand_type(field.data_type()));
                     if let Some(null_rate) = null_rate {
                         generator.with_random_nulls(null_rate);
                     }
@@ -363,7 +363,7 @@ async fn check_round_trip_field_encoding_random(
                     for i in 0..num_ingest_batches {
                         let mut generator = gen()
                             .with_seed(Seed::from(i as u64))
-                            .col(None, array::rand_type(field.data_type()));
+                            .anon_col(array::rand_type(field.data_type()));
                         if let Some(null_rate) = null_rate {
                             generator.with_random_nulls(null_rate);
                         }

--- a/rust/lance-file/benches/reader.rs
+++ b/rust/lance-file/benches/reader.rs
@@ -14,7 +14,7 @@ use lance_io::{object_store::ObjectStore, scheduler::StoreScheduler};
 fn bench_reader(c: &mut Criterion) {
     let mut group = c.benchmark_group("reader");
     let data = lance_datagen::gen()
-        .col(None, lance_datagen::array::rand_type(&DataType::Int32))
+        .anon_col(lance_datagen::array::rand_type(&DataType::Int32))
         .into_batch_rows(lance_datagen::RowCount::from(1024 * 1024))
         .unwrap();
     let rt = tokio::runtime::Runtime::new().unwrap();

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -547,7 +547,7 @@ mod tests {
         let scheduler = StoreScheduler::new(obj_store.clone(), 8);
 
         let reader = gen()
-            .col(Some("score".to_string()), array::rand::<Float64Type>())
+            .col("score", array::rand::<Float64Type>())
             .into_reader_rows(RowCount::from(1000), BatchCount::from(100));
 
         let writer = obj_store.create(&tmp_path).await.unwrap();

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -365,7 +365,7 @@ mod tests {
         let obj_store = Arc::new(ObjectStore::local());
 
         let reader = gen()
-            .col(Some("score".to_string()), array::rand::<Float64Type>())
+            .col("score", array::rand::<Float64Type>())
             .into_reader_rows(RowCount::from(1000), BatchCount::from(10));
 
         let writer = obj_store.create(&tmp_path).await.unwrap();

--- a/rust/lance-index/src/scalar/flat.rs
+++ b/rust/lance-index/src/scalar/flat.rs
@@ -269,13 +269,10 @@ mod tests {
     fn example_index() -> FlatIndex {
         let batch = gen()
             .col(
-                Some("values".to_string()),
+                "values",
                 array::cycle::<Int32Type>(vec![10, 100, 1000, 1234]),
             )
-            .col(
-                Some("ids".to_string()),
-                array::cycle::<UInt64Type>(vec![5, 0, 3, 100]),
-            )
+            .col("ids", array::cycle::<UInt64Type>(vec![5, 0, 3, 100]))
             .into_batch_rows(RowCount::from(4))
             .unwrap();
 
@@ -352,14 +349,8 @@ mod tests {
             .unwrap();
 
         let expected = gen()
-            .col(
-                Some("values".to_string()),
-                array::cycle::<Int32Type>(vec![10, 100, 1234]),
-            )
-            .col(
-                Some("ids".to_string()),
-                array::cycle::<UInt64Type>(vec![5, 2000, 100]),
-            )
+            .col("values", array::cycle::<Int32Type>(vec![10, 100, 1234]))
+            .col("ids", array::cycle::<UInt64Type>(vec![5, 2000, 100]))
             .into_batch_rows(RowCount::from(3))
             .unwrap();
         assert_eq!(remapped, expected);

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -210,8 +210,8 @@ mod tests {
         let tempdir = tempdir().unwrap();
         let index_store = test_store(&tempdir);
         let data = gen()
-            .col(Some("values".to_string()), array::step::<Int32Type>())
-            .col(Some("row_ids".to_string()), array::step::<UInt64Type>())
+            .col("values", array::step::<Int32Type>())
+            .col("row_ids", array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(4096), BatchCount::from(100));
         train_index(&index_store, data, DataType::Int32).await;
         let index = BTreeIndex::load(index_store).await.unwrap();
@@ -250,15 +250,15 @@ mod tests {
         let index_dir = tempdir().unwrap();
         let index_store = test_store(&index_dir);
         let data = gen()
-            .col(Some("values".to_string()), array::step::<Int32Type>())
-            .col(Some("row_ids".to_string()), array::step::<UInt64Type>())
+            .col("values", array::step::<Int32Type>())
+            .col("row_ids", array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(4096), BatchCount::from(100));
         train_index(&index_store, data, DataType::Int32).await;
         let index = BTreeIndex::load(index_store).await.unwrap();
 
         let data = gen()
-            .col(Some("values".to_string()), array::step::<Int32Type>())
-            .col(Some("row_ids".to_string()), array::step::<UInt64Type>())
+            .col("values", array::step::<Int32Type>())
+            .col("row_ids", array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(4096), BatchCount::from(100));
 
         let updated_index_dir = tempdir().unwrap();
@@ -295,42 +295,24 @@ mod tests {
         let tempdir = tempdir().unwrap();
         let index_store = test_store(&tempdir);
         let batch_one = gen()
-            .col(
-                Some("values".to_string()),
-                array::cycle::<Int32Type>(vec![0, 1, 4, 5]),
-            )
-            .col(
-                Some("row_ids".to_string()),
-                array::cycle::<UInt64Type>(vec![0, 1, 2, 3]),
-            )
+            .col("values", array::cycle::<Int32Type>(vec![0, 1, 4, 5]))
+            .col("row_ids", array::cycle::<UInt64Type>(vec![0, 1, 2, 3]))
             .into_batch_rows(RowCount::from(4));
         let batch_two = gen()
-            .col(
-                Some("values".to_string()),
-                array::cycle::<Int32Type>(vec![10, 11, 11, 15]),
-            )
-            .col(
-                Some("row_ids".to_string()),
-                array::cycle::<UInt64Type>(vec![40, 50, 60, 70]),
-            )
+            .col("values", array::cycle::<Int32Type>(vec![10, 11, 11, 15]))
+            .col("row_ids", array::cycle::<UInt64Type>(vec![40, 50, 60, 70]))
             .into_batch_rows(RowCount::from(4));
         let batch_three = gen()
+            .col("values", array::cycle::<Int32Type>(vec![15, 15, 15, 15]))
             .col(
-                Some("values".to_string()),
-                array::cycle::<Int32Type>(vec![15, 15, 15, 15]),
-            )
-            .col(
-                Some("row_ids".to_string()),
+                "row_ids",
                 array::cycle::<UInt64Type>(vec![400, 500, 600, 700]),
             )
             .into_batch_rows(RowCount::from(4));
         let batch_four = gen()
+            .col("values", array::cycle::<Int32Type>(vec![15, 16, 20, 20]))
             .col(
-                Some("values".to_string()),
-                array::cycle::<Int32Type>(vec![15, 16, 20, 20]),
-            )
-            .col(
-                Some("row_ids".to_string()),
+                "row_ids",
                 array::cycle::<UInt64Type>(vec![4000, 5000, 6000, 7000]),
             )
             .into_batch_rows(RowCount::from(4));
@@ -538,8 +520,8 @@ mod tests {
             let tempdir = tempdir().unwrap();
             let index_store = test_store(&tempdir);
             let data: RecordBatch = gen()
-                .col(Some("values".to_string()), array::rand_type(data_type))
-                .col(Some("row_ids".to_string()), array::step::<UInt64Type>())
+                .col("values", array::rand_type(data_type))
+                .col("row_ids", array::step::<UInt64Type>())
                 .into_batch_rows(RowCount::from(4096 * 3))
                 .unwrap();
 
@@ -596,14 +578,8 @@ mod tests {
         let tempdir = tempdir().unwrap();
         let index_store = test_store(&tempdir);
         let batch = gen()
-            .col(
-                Some("values".to_string()),
-                array::cycle::<Float32Type>(vec![0.0, f32::NAN]),
-            )
-            .col(
-                Some("row_ids".to_string()),
-                array::cycle::<UInt64Type>(vec![0, 1]),
-            )
+            .col("values", array::cycle::<Float32Type>(vec![0.0, f32::NAN]))
+            .col("row_ids", array::cycle::<UInt64Type>(vec![0, 1]))
             .into_batch_rows(RowCount::from(2));
         let batches = vec![batch];
         let schema = Arc::new(Schema::new(vec![
@@ -629,13 +605,10 @@ mod tests {
         let index_store = test_store(&tempdir);
         let batch = gen()
             .col(
-                Some("values".to_string()),
+                "values",
                 array::rand_utf8(ByteCount::from(0)).with_nulls(&[true]),
             )
-            .col(
-                Some("row_ids".to_string()),
-                array::cycle::<UInt64Type>(vec![0, 1]),
-            )
+            .col("row_ids", array::cycle::<UInt64Type>(vec![0, 1]))
             .into_batch_rows(RowCount::from(4096));
         assert_eq!(batch.as_ref().unwrap()["values"].null_count(), 4096);
         let batches = vec![batch];

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -298,18 +298,12 @@ mod tests {
     async fn test_basic_zip() {
         let left = batch_task_stream(
             lance_datagen::gen()
-                .col(
-                    Some("x".to_string()),
-                    lance_datagen::array::step::<Int32Type>(),
-                )
+                .col("x", lance_datagen::array::step::<Int32Type>())
                 .into_reader_stream(RowCount::from(100), BatchCount::from(10)),
         );
         let right = batch_task_stream(
             lance_datagen::gen()
-                .col(
-                    Some("y".to_string()),
-                    lance_datagen::array::step::<Int32Type>(),
-                )
+                .col("y", lance_datagen::array::step::<Int32Type>())
                 .into_reader_stream(RowCount::from(100), BatchCount::from(10)),
         );
 
@@ -321,14 +315,8 @@ mod tests {
             .unwrap();
 
         let expected = lance_datagen::gen()
-            .col(
-                Some("x".to_string()),
-                lance_datagen::array::step::<Int32Type>(),
-            )
-            .col(
-                Some("y".to_string()),
-                lance_datagen::array::step::<Int32Type>(),
-            )
+            .col("x", lance_datagen::array::step::<Int32Type>())
+            .col("y", lance_datagen::array::step::<Int32Type>())
             .into_reader_rows(RowCount::from(100), BatchCount::from(10))
             .collect::<Result<Vec<_>, ArrowError>>()
             .unwrap();
@@ -343,10 +331,7 @@ mod tests {
                 // 100 rows across 10 batches of 10 rows
                 let mut datagen = lance_datagen::gen();
                 if has_columns {
-                    datagen = datagen.col(
-                        Some("x".to_string()),
-                        lance_datagen::array::rand::<Int32Type>(),
-                    );
+                    datagen = datagen.col("x", lance_datagen::array::rand::<Int32Type>());
                 }
                 let data = batch_task_stream(
                     datagen.into_reader_stream(RowCount::from(10), BatchCount::from(10)),
@@ -436,10 +421,8 @@ mod tests {
 
                             let mut datagen = lance_datagen::gen();
                             if has_columns {
-                                datagen = datagen.col(
-                                    Some("x".to_string()),
-                                    lance_datagen::array::rand::<Int32Type>(),
-                                );
+                                datagen =
+                                    datagen.col("x", lance_datagen::array::rand::<Int32Type>());
                             }
                             // 100 rows across 10 batches of 10 rows
                             let data = batch_task_stream(

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -36,8 +36,8 @@ struct BenchmarkDataSource {}
 impl BenchmarkDataSource {
     fn test_data() -> impl RecordBatchReader {
         gen()
-            .col(Some("values".to_string()), array::step::<UInt32Type>())
-            .col(Some("row_ids".to_string()), array::step::<UInt64Type>())
+            .col("values", array::step::<UInt32Type>())
+            .col("row_ids", array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(1024), BatchCount::from(100 * 1024))
     }
 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3139,7 +3139,7 @@ mod tests {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
 
-        let data = gen().col(Some("int".to_string()), array::step::<Int32Type>());
+        let data = gen().col("int", array::step::<Int32Type>());
         // Write 64Ki rows.  We should get 16 4Ki pages
         let mut dataset = Dataset::write(
             data.into_reader_rows(RowCount::from(16 * 1024), BatchCount::from(4)),

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -2235,34 +2235,25 @@ mod test {
         let test_uri = test_dir.path().to_str().unwrap();
 
         let data = gen()
+            .col("int", array::cycle::<Int32Type>(vec![5, 4, 1, 2, 3]))
             .col(
-                Some("int".to_string()),
-                array::cycle::<Int32Type>(vec![5, 4, 1, 2, 3]),
-            )
-            .col(
-                Some("str".to_string()),
+                "str",
                 array::cycle_utf8_literals(&["a", "b", "c", "e", "d"]),
             );
 
         let sorted_by_int = gen()
+            .col("int", array::cycle::<Int32Type>(vec![1, 2, 3, 4, 5]))
             .col(
-                Some("int".to_string()),
-                array::cycle::<Int32Type>(vec![1, 2, 3, 4, 5]),
-            )
-            .col(
-                Some("str".to_string()),
+                "str",
                 array::cycle_utf8_literals(&["c", "e", "d", "b", "a"]),
             )
             .into_batch_rows(RowCount::from(5))
             .unwrap();
 
         let sorted_by_str = gen()
+            .col("int", array::cycle::<Int32Type>(vec![5, 4, 1, 3, 2]))
             .col(
-                Some("int".to_string()),
-                array::cycle::<Int32Type>(vec![5, 4, 1, 3, 2]),
-            )
-            .col(
-                Some("str".to_string()),
+                "str",
                 array::cycle_utf8_literals(&["a", "b", "c", "d", "e"]),
             )
             .into_batch_rows(RowCount::from(5))
@@ -2327,22 +2318,16 @@ mod test {
         let test_uri = test_dir.path().to_str().unwrap();
 
         let data = gen()
+            .col("int", array::cycle::<Int32Type>(vec![5, 5, 1, 1, 3]))
             .col(
-                Some("int".to_string()),
-                array::cycle::<Int32Type>(vec![5, 5, 1, 1, 3]),
-            )
-            .col(
-                Some("float".to_string()),
+                "float",
                 array::cycle::<Float32Type>(vec![7.3, -f32::NAN, f32::NAN, 4.3, f32::INFINITY]),
             );
 
         let sorted_by_int_then_float = gen()
+            .col("int", array::cycle::<Int32Type>(vec![1, 1, 3, 5, 5]))
             .col(
-                Some("int".to_string()),
-                array::cycle::<Int32Type>(vec![1, 1, 3, 5, 5]),
-            )
-            .col(
-                Some("float".to_string()),
+                "float",
                 // floats should be sorted using total order so -NAN is before all and NAN is after all
                 array::cycle::<Float32Type>(vec![4.3, f32::NAN, f32::INFINITY, -f32::NAN, 7.3]),
             )
@@ -2967,11 +2952,11 @@ mod test {
             // The first row where indexed == 75 is our deleted row (and delete query)
             let data = gen()
                 .col(
-                    Some("vector".to_string()),
+                    "vector",
                     array::rand_vec::<Float32Type>(Dimension::from(32)),
                 )
-                .col(Some("indexed".to_string()), array::step::<Int32Type>())
-                .col(Some("not_indexed".to_string()), array::step::<Int32Type>())
+                .col("indexed", array::step::<Int32Type>())
+                .col("not_indexed", array::step::<Int32Type>())
                 .into_batch_rows(RowCount::from(1000))
                 .unwrap();
 

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -1081,8 +1081,8 @@ mod tests {
 
         let data = lance_datagen::gen()
             .with_seed(Seed::from(1))
-            .col(Some("value".to_string()), array::step::<UInt32Type>())
-            .col(Some("key".to_string()), array::rand_pseduo_uuid_hex());
+            .col("value", array::step::<UInt32Type>())
+            .col("key", array::rand_pseduo_uuid_hex());
         let data = data.into_reader_rows(RowCount::from(1024), BatchCount::from(32));
         let schema = data.schema();
 
@@ -1096,8 +1096,8 @@ mod tests {
         // Create some new (unindexed) data
         let data = lance_datagen::gen()
             .with_seed(Seed::from(2))
-            .col(Some("value".to_string()), array::step::<UInt32Type>())
-            .col(Some("key".to_string()), array::rand_pseduo_uuid_hex());
+            .col("value", array::step::<UInt32Type>())
+            .col("key", array::rand_pseduo_uuid_hex());
         let data = data.into_reader_rows(RowCount::from(1024), BatchCount::from(8));
         let ds = Dataset::write(
             data,
@@ -1121,7 +1121,7 @@ mod tests {
             .unwrap();
         let some_indices = some_indices.column(0).clone();
         let some_vals = lance_datagen::gen()
-            .col(None, array::fill::<UInt32Type>(9999999))
+            .anon_col(array::fill::<UInt32Type>(9999999))
             .into_batch_rows(RowCount::from(2048))
             .unwrap();
         let some_vals = some_vals.column(0).clone();

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -199,7 +199,7 @@ mod tests {
     #[tokio::test]
     async fn test_replay() {
         let data = lance_datagen::gen()
-            .col(Some("x".to_string()), array::step::<UInt32Type>())
+            .col("x", array::step::<UInt32Type>())
             .into_reader_rows(RowCount::from(1024), BatchCount::from(16));
         let schema = data.schema().clone();
         let data = Box::pin(RecordBatchStreamAdapter::new(


### PR DESCRIPTION
Very minor change but one that has been annoying me for a while.  The datagen allows columns to be specified with or without a name ("without a name" means one is automatically generated based on the column index).  If a name is specified it must be a `String`.  The vast majority of usage does specify a name and provides it as a `&str`.  As a result we have a lot of boilerplate `Some("foo".to_string())` that I would like to avoid.

To generate a column without a name use the function `anon_col`.
When generating a column with a name the name is now provided as `impl Into<String>` instead of `Option<String>`.