### PR TITLE
feat: row id index structures (experimental)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ chrono = { version = "0.4.25", default-features = false, features = [
     "std",
     "now",
 ] }
-criterion = { version = "0.5", features = ["async", "async_tokio"] }
+criterion = { version = "0.5", features = ["async", "async_tokio", "html_reports"] }
 crossbeam-queue = "0.3"
 datafusion = { version = "37.1", default-features = false, features = [
     "array_expressions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ prost = "0.12.2"
 prost-build = "0.12.2"
 prost-types = "0.12.2"
 rand = { version = "0.8.3", features = ["small_rng"] }
+rangemap = { version = "1.0" }
 rayon = "1.10"
 roaring = "0.10.1"
 rustc_version = "0.4"

--- a/protos/rowids.proto
+++ b/protos/rowids.proto
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+syntax = "proto3";
+
+package lance.table;
+// TODO: what would it take to store this in a LanceV2 file?
+// Or would flatbuffers be better for this?
+
+/// A sequence of row IDs. This is split up into one or more segments,
+/// each of which can be encoded in different ways. The encodings are optimized
+/// for values that are sorted, which will often be the case with row ids.
+/// They also have optimized forms depending on how sparse the values are.
+message RowIdSequence {
+    repeated U64Segment segments = 1;
+}
+
+/// Different ways to encode a sequence of u64 values.
+message U64Segment {
+    /// A range of u64 values.
+    message Range {
+        /// The start of the range, inclusive.
+        uint64 start = 1;
+        /// The enc of the range, exclusive.
+        uint64 end = 2;
+    }
+
+    /// A range of u64 values with holes.
+    message RangeWithHoles {
+        /// The start of the range, inclusive.
+        uint64 start = 1;
+        /// The end of the range, exclusive.
+        uint64 end = 2;
+        /// The holes in the range, as a sorted array of values;
+        /// Binary search can be used to check whether a value is a hole and should
+        /// be skipped. This can also be used to count the number of holes before a
+        /// given value, if you need to find the logical offset of a value in the
+        /// segment.
+        EncodedU64Array holes = 3;
+    }
+
+    /// A range of u64 values with a bitmap.
+    message RangeWithBitmap {
+        /// The start of the range, inclusive.
+        uint64 start = 1;
+        /// The enc of the range, exclusive.
+        uint64 end = 2;
+        /// A bitmap of the values in the range. The bitmap is a sequence of bytes,
+        /// where each byte represents 8 values. The first byte represents values
+        /// start to start + 7, the second byte represents values start + 8 to
+        /// start + 15, and so on. The most significant bit of each byte represents
+        /// the first value in the range, and the least significant bit represents
+        /// the last value in the range. If the bit is set, the value is in the
+        /// range; if it is not set, the value is not in the range.
+        bytes bitmap = 3;
+    }
+
+    oneof segment {
+        /// When the values are sorted and contiguous.
+        Range range = 1;
+        /// When the values are sorted but have a few gaps.
+        RangeWithHoles range_with_holes = 2;
+        /// When the values are sorted but have many gaps.
+        RangeWithBitmap range_with_bitmap = 3;
+        /// When the values are sorted but are sparse.
+        EncodedU64Array sorted_array = 4;
+        /// A general array of values, which is not sorted.
+        EncodedU64Array array = 5;
+    }
+}
+
+/// A basic bitpacked array of u64 values.
+message EncodedU64Array {
+    message U16Array {
+        uint64 base = 1;
+        /// The deltas are stored as 16-bit unsigned integers.
+        /// (protobuf doesn't support 16-bit integers, so we use bytes instead)
+        bytes offsets = 2;
+    }
+
+    message U32Array {
+        uint64 base = 1;
+        /// The deltas are stored as 32-bit unsigned integers.
+        /// (we use bytes instead of uint32 to avoid overhead of varint encoding)
+        bytes offsets = 2;
+    }
+
+    message U64Array {
+        /// (We use bytes instead of uint64 to avoid overhead of varint encoding)
+        bytes values = 2;
+    }
+
+    oneof array {
+        U16Array u16_array = 1;
+        U32Array u32_array = 2;
+        U64Array u64_array = 3;
+    }
+}

--- a/rust/lance-core/src/utils/address.rs
+++ b/rust/lance-core/src/utils/address.rs
@@ -3,6 +3,7 @@
 
 use std::ops::Range;
 
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RowAddress(u64);
 
 impl RowAddress {

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -35,6 +35,7 @@ object_store.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 rand.workspace = true
+rangemap.workspace = true
 roaring.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -46,6 +46,7 @@ uuid.workspace = true
 
 [dev-dependencies]
 arrow-schema.workspace = true
+pretty_assertions.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -49,6 +49,10 @@ uuid.workspace = true
 arrow-schema.workspace = true
 criterion.workspace = true
 pretty_assertions.workspace = true
+proptest.workspace = true
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+pprof = { workspace = true }
 
 [build-dependencies]
 prost-build.workspace = true

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -47,6 +47,7 @@ uuid.workspace = true
 
 [dev-dependencies]
 arrow-schema.workspace = true
+criterion.workspace = true
 pretty_assertions.workspace = true
 
 [build-dependencies]
@@ -55,3 +56,7 @@ prost-build.workspace = true
 [features]
 dynamodb = ["aws-sdk-dynamodb", "lazy_static"]
 dynamodb_tests = ["dynamodb"]
+
+[[bench]]
+name = "row_id_index"
+harness = false

--- a/rust/lance-table/benches/row_id_index.rs
+++ b/rust/lance-table/benches/row_id_index.rs
@@ -77,7 +77,7 @@ struct SizeStatsFile {
 
 impl SizeStatsFile {
     fn new() -> Self {
-        if let Some(path) = std::env::var("BENCH_SIZE_STATS_FILE").ok() {
+        if let Ok(path) = std::env::var("BENCH_SIZE_STATS_FILE") {
             let mut file = std::fs::File::create(path).unwrap();
             // Header row
             writeln!(file, "structure,percent_deletions,size").unwrap();
@@ -110,7 +110,7 @@ fn bench_creation(c: &mut Criterion) {
             &percent_deletions,
             |b, _| {
                 b.iter(|| {
-                    let index = RowIdIndex::new(&sequences).unwrap();
+                    let _index = RowIdIndex::new(&sequences).unwrap();
                 });
             },
         );

--- a/rust/lance-table/benches/row_id_index.rs
+++ b/rust/lance-table/benches/row_id_index.rs
@@ -16,7 +16,11 @@
 // How can I write out the file? Where should I put it?
 // How can I take a argument to set the size of the index?
 
-use std::{collections::{BTreeMap, HashMap}, io::Write, ops::Range};
+use std::{
+    collections::{BTreeMap, HashMap},
+    io::Write,
+    ops::Range,
+};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
@@ -60,7 +64,9 @@ fn make_frag_sequences(
 // https://bheisler.github.io/criterion.rs/book/user_guide/benchmarking_with_inputs.html
 
 fn num_rows() -> u64 {
-    std::env::var("BENCH_NUM_ROWS").map(|s| s.parse().unwrap()).unwrap_or(1_000_000)
+    std::env::var("BENCH_NUM_ROWS")
+        .map(|s| s.parse().unwrap())
+        .unwrap_or(1_000_000)
 }
 
 struct SizeStats {
@@ -87,7 +93,12 @@ impl SizeStatsFile {
 
     fn write_row(&mut self, stats: SizeStats) {
         if let Some(file) = &mut self.file {
-            writeln!(file, "\"{}\",{},{}", stats.structure, stats.percent_deletions, stats.size).unwrap();
+            writeln!(
+                file,
+                "\"{}\",{},{}",
+                stats.structure, stats.percent_deletions, stats.size
+            )
+            .unwrap();
         }
     }
 }
@@ -123,7 +134,6 @@ fn bench_creation(c: &mut Criterion) {
             stats_file.write_row(stats);
         }
 
-
         // TODO: we should compare tombstoned vs compacted. We don't mind the
         // regression in the tombstoned case, but we want to see the improvement
         // in the compacted case.
@@ -145,7 +155,10 @@ fn bench_creation(c: &mut Criterion) {
             .collect::<Vec<_>>();
 
         // Size of flat data is just 16 bytes per row
-        let size = flat_data.iter().map(|(ids, _addresses)| ids.len() * 16).sum::<usize>() as u64;
+        let size = flat_data
+            .iter()
+            .map(|(ids, _addresses)| ids.len() * 16)
+            .sum::<usize>() as u64;
         let stats = SizeStats {
             structure: "FlatData".to_string(),
             percent_deletions,
@@ -220,13 +233,14 @@ fn bench_get_single(c: &mut Criterion) {
             })
             .collect::<Vec<_>>();
 
-        let index = {
-            let mut index = HashMap::new();
-            index.extend(flat_data.iter().flat_map(|(ids, addresses)| {
-                ids.iter().copied().zip(addresses.iter().copied())
-            }));
-            index
-        };
+        let index =
+            {
+                let mut index = HashMap::new();
+                index.extend(flat_data.iter().flat_map(|(ids, addresses)| {
+                    ids.iter().copied().zip(addresses.iter().copied())
+                }));
+                index
+            };
 
         group.bench_with_input(
             BenchmarkId::new("GetHashMap", percent_deletions),
@@ -240,11 +254,12 @@ fn bench_get_single(c: &mut Criterion) {
             },
         );
 
-        let index = {
-            BTreeMap::from_iter(flat_data.iter().flat_map(|(ids, addresses)| {
-                ids.iter().copied().zip(addresses.iter().copied())
-            }))
-        };
+        let index =
+            {
+                BTreeMap::from_iter(flat_data.iter().flat_map(|(ids, addresses)| {
+                    ids.iter().copied().zip(addresses.iter().copied())
+                }))
+            };
 
         group.bench_with_input(
             BenchmarkId::new("GetBTreeMap", percent_deletions),
@@ -260,7 +275,6 @@ fn bench_get_single(c: &mut Criterion) {
     }
 
     group.finish();
-
 }
 
 criterion_group!(benches, bench_creation, bench_get_single);

--- a/rust/lance-table/benches/row_id_index.rs
+++ b/rust/lance-table/benches/row_id_index.rs
@@ -25,7 +25,7 @@ use std::{
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use lance_core::utils::address::RowAddress;
-use lance_table::rowids::{serde::write_row_ids, RowIdIndex, RowIdSequence};
+use lance_table::rowids::{write_row_ids, RowIdIndex, RowIdSequence};
 
 fn make_sequence(row_id_range: Range<u64>, deletions: usize) -> RowIdSequence {
     let mut sequence = RowIdSequence::from(row_id_range);
@@ -121,11 +121,10 @@ fn bench_creation(c: &mut Criterion) {
 
         // Measure size of index
         {
-            let mut serialized = Vec::new();
+            let mut size = 0;
             for (_frag_id, sequence) in &sequences {
-                write_row_ids(sequence, &mut serialized).unwrap();
+                size += write_row_ids(sequence).len() as u64;
             }
-            let size = serialized.len() as u64;
             let stats = SizeStats {
                 structure: "RowIdIndex".to_string(),
                 percent_deletions,

--- a/rust/lance-table/benches/row_id_index.rs
+++ b/rust/lance-table/benches/row_id_index.rs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+// TODO:
+// - [x] Create base cases with BTreeMap and HashMap
+// - [x] Create on-disk size measurement
+// - [x] Create different cases for the index. Ideal, 25% deletions, 80% deletions + compaction.
+// - [ ] Create a benchmark for the get method
+//   - [x] Average over all valid values
+//   - [ ] Time to get a value that is not in the index
+// - [ ] Create a benchmark for the new method (building the in-memory index)
+// Optional:
+// - [ ] Create in-memory size measurement (if possible)
+
+// Questions:
+// How can I write out the file? Where should I put it?
+// How can I take a argument to set the size of the index?
+
+use std::{collections::{BTreeMap, HashMap}, io::Write, ops::Range};
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use lance_core::utils::address::RowAddress;
+use lance_table::rowids::{serde::write_row_ids, RowIdIndex, RowIdSequence};
+
+fn make_sequence(row_id_range: Range<u64>, deletions: usize) -> RowIdSequence {
+    let mut sequence = RowIdSequence::from(row_id_range);
+
+    // Delete every other row
+    let delete_ids = sequence
+        .iter()
+        .step_by(2)
+        .take(deletions)
+        .collect::<Vec<_>>();
+    sequence.delete(delete_ids);
+
+    sequence
+}
+
+fn make_frag_sequences(
+    num_rows: u64,
+    num_frags: u64,
+    percent_deletion: f32,
+) -> Vec<(u32, RowIdSequence)> {
+    let rows_per_frag = num_rows / num_frags;
+    let mut start = 0;
+    (0..num_frags)
+        .map(|i| {
+            let sequence = make_sequence(
+                start..(start + rows_per_frag),
+                (rows_per_frag as f32 * percent_deletion) as usize,
+            );
+            start += rows_per_frag;
+            (i as u32, sequence)
+        })
+        .collect()
+}
+
+// For range of values
+// https://bheisler.github.io/criterion.rs/book/user_guide/benchmarking_with_inputs.html
+
+fn num_rows() -> u64 {
+    std::env::var("BENCH_NUM_ROWS").map(|s| s.parse().unwrap()).unwrap_or(1_000_000)
+}
+
+struct SizeStats {
+    structure: String,
+    percent_deletions: f32,
+    size: u64,
+}
+
+struct SizeStatsFile {
+    file: Option<std::fs::File>,
+}
+
+impl SizeStatsFile {
+    fn new() -> Self {
+        if let Some(path) = std::env::var("BENCH_SIZE_STATS_FILE").ok() {
+            let mut file = std::fs::File::create(path).unwrap();
+            // Header row
+            writeln!(file, "structure,percent_deletions,size").unwrap();
+            Self { file: Some(file) }
+        } else {
+            Self { file: None }
+        }
+    }
+
+    fn write_row(&mut self, stats: SizeStats) {
+        if let Some(file) = &mut self.file {
+            writeln!(file, "\"{}\",{},{}", stats.structure, stats.percent_deletions, stats.size).unwrap();
+        }
+    }
+}
+
+fn bench_creation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("row_id_index_creation");
+    let mut stats_file = SizeStatsFile::new();
+
+    for percent_deletions in [0.0, 0.25, 0.5] {
+        let sequences = make_frag_sequences(num_rows(), 100, percent_deletions);
+        group.bench_with_input(
+            BenchmarkId::new("BuildIndex", percent_deletions),
+            &percent_deletions,
+            |b, _| {
+                b.iter(|| {
+                    let index = RowIdIndex::new(&sequences).unwrap();
+                });
+            },
+        );
+
+        // Measure size of index
+        {
+            let mut serialized = Vec::new();
+            for (_frag_id, sequence) in &sequences {
+                write_row_ids(sequence, &mut serialized).unwrap();
+            }
+            let size = serialized.len() as u64;
+            let stats = SizeStats {
+                structure: "RowIdIndex".to_string(),
+                percent_deletions,
+                size,
+            };
+            stats_file.write_row(stats);
+        }
+
+
+        // TODO: we should compare tombstoned vs compacted. We don't mind the
+        // regression in the tombstoned case, but we want to see the improvement
+        // in the compacted case.
+
+        // TODO: collect size of sequences when serialized
+
+        // TODO: also show building a BTreeMap and HashMap
+
+        let flat_data = sequences
+            .iter()
+            .map(|(frag_id, sequence)| {
+                let row_ids = sequence.iter().collect::<Vec<_>>();
+                let row_addresses = (0..sequence.len())
+                    .map(|i| RowAddress::new_from_parts(*frag_id, i as u32))
+                    .map(u64::from)
+                    .collect::<Vec<_>>();
+                (row_ids, row_addresses)
+            })
+            .collect::<Vec<_>>();
+
+        // Size of flat data is just 16 bytes per row
+        let size = flat_data.iter().map(|(ids, _addresses)| ids.len() * 16).sum::<usize>() as u64;
+        let stats = SizeStats {
+            structure: "FlatData".to_string(),
+            percent_deletions,
+            size,
+        };
+        stats_file.write_row(stats);
+
+        group.bench_with_input(
+            BenchmarkId::new("BuildHashMap", percent_deletions),
+            &percent_deletions,
+            |b, _| {
+                b.iter(|| {
+                    let mut index = HashMap::new();
+                    index.extend(flat_data.iter().flat_map(|(ids, addresses)| {
+                        ids.iter().copied().zip(addresses.iter().copied())
+                    }));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("BuildBTreeMap", percent_deletions),
+            &percent_deletions,
+            |b, _| {
+                b.iter(|| {
+                    BTreeMap::from_iter(flat_data.iter().flat_map(|(ids, addresses)| {
+                        ids.iter().copied().zip(addresses.iter().copied())
+                    }));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_get_single(c: &mut Criterion) {
+    let mut group = c.benchmark_group("row_id_index_get_single");
+
+    for percent_deletions in [0.0, 0.25, 0.5] {
+        let sequences = make_frag_sequences(num_rows(), 100, percent_deletions);
+        let index = RowIdIndex::new(&sequences).unwrap();
+
+        let mut i = 0;
+        let total_rows: u64 = num_rows();
+        let mut next_id = || {
+            let id = i;
+            i += 241861;
+            i %= total_rows;
+            id
+        };
+
+        group.bench_with_input(
+            BenchmarkId::new("GetIndex", percent_deletions),
+            &percent_deletions,
+            |b, _| {
+                b.iter(|| {
+                    let _ = index.get(next_id());
+                });
+            },
+        );
+
+        let flat_data = sequences
+            .iter()
+            .map(|(frag_id, sequence)| {
+                let row_ids = sequence.iter().collect::<Vec<_>>();
+                let row_addresses = (0..sequence.len())
+                    .map(|i| RowAddress::new_from_parts(*frag_id, i as u32))
+                    .map(u64::from)
+                    .collect::<Vec<_>>();
+                (row_ids, row_addresses)
+            })
+            .collect::<Vec<_>>();
+
+        let index = {
+            let mut index = HashMap::new();
+            index.extend(flat_data.iter().flat_map(|(ids, addresses)| {
+                ids.iter().copied().zip(addresses.iter().copied())
+            }));
+            index
+        };
+
+        group.bench_with_input(
+            BenchmarkId::new("GetHashMap", percent_deletions),
+            &percent_deletions,
+            |b, _| {
+                b.iter(|| {
+                    for i in 0..num_rows() {
+                        let _ = index.get(&i);
+                    }
+                });
+            },
+        );
+
+        let index = {
+            BTreeMap::from_iter(flat_data.iter().flat_map(|(ids, addresses)| {
+                ids.iter().copied().zip(addresses.iter().copied())
+            }))
+        };
+
+        group.bench_with_input(
+            BenchmarkId::new("GetBTreeMap", percent_deletions),
+            &percent_deletions,
+            |b, _| {
+                b.iter(|| {
+                    for i in 0..num_rows() {
+                        let _ = index.get(&i);
+                    }
+                });
+            },
+        );
+    }
+
+    group.finish();
+
+}
+
+criterion_group!(benches, bench_creation, bench_get_single);
+criterion_main!(benches);

--- a/rust/lance-table/build.rs
+++ b/rust/lance-table/build.rs
@@ -10,7 +10,11 @@ fn main() -> Result<()> {
     prost_build.extern_path(".lance.file", "::lance_file::format::pb");
     prost_build.protoc_arg("--experimental_allow_proto3_optional");
     prost_build.compile_protos(
-        &["./protos/table.proto", "./protos/transaction.proto"],
+        &[
+            "./protos/table.proto",
+            "./protos/transaction.proto",
+            "./protos/rowids.proto",
+        ],
         &["./protos"],
     )?;
 

--- a/rust/lance-table/src/lib.rs
+++ b/rust/lance-table/src/lib.rs
@@ -3,5 +3,5 @@
 
 pub mod format;
 pub mod io;
-pub mod utils;
 pub mod rowids;
+pub mod utils;

--- a/rust/lance-table/src/lib.rs
+++ b/rust/lance-table/src/lib.rs
@@ -4,3 +4,4 @@
 pub mod format;
 pub mod io;
 pub mod utils;
+pub mod rowids;

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -13,6 +13,8 @@
 //! representation, to avoid unnecessary deserialization.
 use std::ops::Range;
 
+// TODO: replace this with Arrow BooleanBuffer.
+
 // These are all internal data structures, and are private.
 mod bitmap;
 mod encoded_array;

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -1,0 +1,423 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{collections::HashSet, ops::{Range, RangeInclusive}};
+
+use snafu::{location, Location};
+
+use lance_core::{Error, Result};
+
+use self::encoded_array::EncodedU64Array;
+
+mod encoded_array;
+
+/// A row ID is a unique identifier for a row in a table.
+///
+/// The will be initially assigned as an incrementing id.
+///
+/// When a row is deleted, the row id will be marked as a tombstone.
+pub struct RowId;
+
+impl RowId {
+    pub fn new_range(max_row_id: Option<u64>, nrows: u64) -> Result<Range<u64>> {
+        if let Some(max_row_id) = max_row_id {
+            let start = max_row_id + 1;
+            let end = start
+                .checked_add(nrows)
+                .ok_or_else(|| Error::invalid_input("Ran out of row IDs", location!()))?;
+            Ok(start..end)
+        } else {
+            Ok(0..nrows)
+        }
+    }
+
+    /// Returns the tombstone row id. This is u64::MAX.
+    pub fn tombstone() -> u64 {
+        u64::MAX
+    }
+}
+
+/// A sequence of row ids.
+/// 
+/// Row ids are u64s that:
+/// 
+/// 1. Are **unique** within a table (except for tombstones)
+/// 2. Are *often* but not always sorted and/or contiguous.
+///
+/// This sequence of row ids is optimized to be compact when the row ids are
+/// contiguous and sorted. However, it does not require that the row ids are
+/// contiguous or sorted.
+/// 
+/// We can make optimizations that assume uniqueness.
+#[derive(Debug)]
+pub struct RowIdSequence(Vec<U64Segment>);
+
+impl std::fmt::Display for RowIdSequence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut iter = self.iter();
+        let mut first_10 = Vec::new();
+        let mut last_10 = Vec::new();
+        while let Some(row_id) = iter.next() {
+            first_10.push(row_id);
+            if first_10.len() > 10 {
+                break;
+            }
+        }
+
+        while let Some(row_id) = iter.next_back() {
+            last_10.push(row_id);
+            if last_10.len() > 10 {
+                break;
+            }
+        }
+        last_10.reverse();
+
+        let theres_more = iter.next().is_some();
+
+        write!(f, "[")?;
+        for row_id in first_10 {
+            write!(f, "{}", row_id)?;
+        }
+        if theres_more {
+            write!(f, ", ...")?;
+        }
+        for row_id in last_10 {
+            write!(f, ", {}", row_id)?;
+        }
+        write!(f, "]")
+    }
+}
+
+impl From<Range<u64>> for RowIdSequence {
+    fn from(range: Range<u64>) -> Self {
+        RowIdSequence(vec![U64Segment::Range(range)])
+    }
+}
+
+impl RowIdSequence {
+    fn iter(&self) -> impl DoubleEndedIterator<Item = u64> + '_ {
+        self.0.iter().flat_map(|segment| segment.iter())
+    }
+
+    pub fn len(&self) -> u64 {
+        self.iter().count() as u64
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Combines this row id sequence with another row id sequence.
+    pub fn extend(&mut self, other: RowIdSequence) {
+        // If the last element of this sequence and the first element of next
+        // sequence are ranges, we might be able to combine them into a single
+        // range.
+        if let (Some(U64Segment::Range(range1)), Some(U64Segment::Range(range2))) =
+            (self.0.last(), other.0.first())
+        {
+            if range1.end == range2.start {
+                let new_range = U64Segment::Range(range1.start..range2.end);
+                self.0.pop();
+                self.0.push(new_range);
+                self.0.extend(other.0.into_iter().skip(1));
+                return;
+            }
+        }
+        self.0.extend(other.0);
+    }
+
+    /// Mark a set of row ids as deleted. Their value will be replaced with tombstones.
+    pub fn delete(&mut self, row_ids: impl IntoIterator<Item = u64>) {
+        // Order the row ids by position in which they appear in the sequence.
+        let mut positions = self.find_ids(row_ids);
+        positions.sort_by_key(|(_, pos)| pos.clone());
+
+        let capacity = self.0.capacity();
+        let old_segments = std::mem::replace(&mut self.0, Vec::with_capacity(capacity));
+        let mut remaining_segments = old_segments.as_slice();
+
+        let mut positions_iter = positions.into_iter().peekable();
+        let mut position = if let Some(pos) = positions_iter.next() {
+            pos
+        } else {
+            // No row ids to delete.
+            self.0 = old_segments;
+            return;
+        };
+        let mut position_batch = Vec::new();
+        loop {
+            // Add all segments up to the segment containing the row id.
+            let segments_handled = old_segments.len() - remaining_segments.len();
+            let segments_to_add = position.1.0 - segments_handled;
+            self.0.extend_from_slice(&remaining_segments[..segments_to_add]);
+            remaining_segments = &remaining_segments[segments_to_add..];
+
+            let segment;
+            (segment, remaining_segments) = remaining_segments.split_first().unwrap();
+
+            // Handle all positions for this segment now.
+            position_batch.push(position.1.1);
+            while let Some(next_position) = positions_iter.peek() {
+                if next_position.1.0 != position.1.0 {
+                    position = positions_iter.next().unwrap();
+                    break;
+                }
+                position_batch.push(next_position.1.1);
+                position = positions_iter.next().unwrap();
+            }
+
+            Self::delete_from_segment(&mut self.0, segment, &position_batch);
+            position_batch.clear();
+
+            if positions_iter.peek().is_none() {
+                break;
+            }
+        }
+
+        // Add the remaining segments.
+        self.0.extend_from_slice(&remaining_segments);
+    }
+
+    /// Find the row ids in the sequence.
+    /// 
+    /// Returns the row ids and, if found, the position of the segment containing
+    /// it and the offset within the segment.
+    fn find_ids(&self, row_ids: impl IntoIterator<Item = u64>) -> Vec<(u64, (usize, usize))> {
+        // Often, the row ids will already be provided in the order they appear.
+        // So the optimal way to search will be to cycle through rather than
+        // restarting the search from the beginning each time.
+        let mut segment_iter = self.0.iter().enumerate().cycle();
+
+        row_ids.into_iter()
+            .filter_map(|row_id| {
+                let mut i = 0;
+                // If we've cycled through all segments, we know the row id is not in the sequence.
+                while i < self.0.len() {
+                    let (segment_idx, segment) = segment_iter.next().unwrap();
+                    if segment.range().map_or(false, |range| range.contains(&row_id)) {
+                        let offset = match segment {
+                            U64Segment::Tombstones(_) => unreachable!("Tombstones should not be in the sequence"),
+                            U64Segment::Range(range) => Some((row_id - range.start) as usize),
+                            U64Segment::SortedArray(array) => {
+                                array.binary_search(row_id).ok()
+                            },
+                            U64Segment::Array(array) => {
+                                array.iter().position(|v| v == row_id)
+                            },
+                        };
+                        if let Some(offset) = offset {
+                            return Some((row_id, (segment_idx, offset)));
+                        }
+                        // The row id was not found it the segment. It might be in a later segment.
+                    }
+                    i += 1;
+                }
+                None
+            })
+            .collect()
+    }
+
+    /// Replace the positions in the segment with tombstones, pushing the new
+    /// segments onto the destination vector.
+    /// 
+    /// This might involve splitting the segment into multiple segments.
+    /// It also might increment the tombstone count of the previous segment.
+    fn delete_from_segment(
+        dest: &mut Vec<U64Segment>,
+        segment: &U64Segment,
+        positions: &[usize],
+    ) {
+        // Offset to the first position in segment that we haven't added to dest.
+        let mut offset = 0;
+        for &position in positions {
+            // Add portio of segment up to the position.
+            if position > offset {
+                dest.push(segment.slice(offset, position - offset));
+            }
+            
+            // Add the tombstone. If the last segment is a tombstone, increment the count
+            // instead of appending a new tombstone segment.
+            match dest.last_mut() {
+                Some(U64Segment::Tombstones(count)) => *count += 1,
+                _ => dest.push(U64Segment::Tombstones(1)),
+            }
+
+            offset = position + 1;
+        }
+        
+        // Add the remaining slice of the segment.
+        if offset < segment.len() {
+            dest.push(segment.slice(offset, segment.len() - offset));
+        }
+    }
+}
+
+/// An index of row ids
+pub struct RowIdIndex {}
+
+/// Different ways to represent a sequence of u64s.
+///
+/// This is designed to be especially efficient for sequences that are sorted,
+/// but not meaningfully larger than a Vec<u64> in the worst case.
+#[derive(Debug, PartialEq, Eq, Clone)]
+enum U64Segment {
+    /// A contiguous sequence of tombstones. This is the only way to represent
+    /// tombstones. All other segments are assumed to not contain tombstones.
+    Tombstones(u64),
+    Range(Range<u64>),
+    SortedArray(EncodedU64Array),
+    Array(EncodedU64Array),
+}
+
+impl U64Segment {
+    fn iter(&self) -> Box<dyn DoubleEndedIterator<Item = u64> + '_> {
+        match self {
+            U64Segment::Tombstones(count) => Box::new((0..*count).map(|_| RowId::tombstone())),
+            U64Segment::Range(range) => Box::new(range.clone()),
+            U64Segment::SortedArray(array) => Box::new(array.iter()),
+            U64Segment::Array(array) => Box::new(array.iter()),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            U64Segment::Tombstones(count) => *count as usize,
+            U64Segment::Range(range) => (range.end - range.start) as usize,
+            U64Segment::SortedArray(array) => array.len(),
+            U64Segment::Array(array) => array.len(),
+        }
+    }
+
+    /// Get the min and max value of the segment, excluding tombstones.
+    fn range(&self) -> Option<RangeInclusive<u64>> {
+        match self {
+            U64Segment::Tombstones(_) => None,
+            U64Segment::Range(range) => Some(range.start..=(range.end - 1)),
+            U64Segment::SortedArray(array) => {
+                // We can assume that the array is sorted.
+                let min_value = array.first().unwrap();
+                let max_value = array.last().unwrap();
+                Some(min_value..=max_value)
+            },
+            U64Segment::Array(array) => {
+                let min_value = array.min().unwrap();
+                let max_value = array.max().unwrap();
+                Some(min_value..=max_value)
+            },
+        }
+    }
+
+    fn slice(&self, offset: usize, len: usize) -> Self {
+        match self {
+            U64Segment::Tombstones(_) => U64Segment::Tombstones(len as u64),
+            U64Segment::Range(range) => {
+                let start = range.start + offset as u64;
+                U64Segment::Range(start..(start + len as u64))
+            },
+            U64Segment::SortedArray(array) => {
+                // TODO: this could be optimized.
+                U64Segment::SortedArray(array.slice(offset, len))
+            },
+            U64Segment::Array(array) => {
+                U64Segment::Array(array.slice(offset, len))
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test_row_id_new_range() {
+        let range = RowId::new_range(None, 10).unwrap();
+        assert_eq!(range, 0..10);
+
+        let range = RowId::new_range(Some(10), 10).unwrap();
+        assert_eq!(range, 11..21);
+
+        let range = RowId::new_range(Some(u64::MAX - 10), 8).unwrap();
+        assert_eq!(range, (u64::MAX - 9)..(u64::MAX - 1));
+
+        let range = RowId::new_range(Some(u64::MAX - 10), 11);
+        assert!(range.is_err());
+        assert!(
+            matches!(range.unwrap_err(), Error::InvalidInput { source, .. } if source.to_string().contains("Ran out of row IDs"))
+        );
+    }
+
+    #[test]
+    fn test_row_id_sequence_from_range() {
+        let sequence = RowIdSequence::from(0..10);
+        assert_eq!(sequence.len(), 10);
+        assert_eq!(sequence.is_empty(), false);
+
+        let iter = sequence.iter();
+        assert_eq!(iter.collect::<Vec<_>>(), (0..10).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn test_row_id_sequence_extend() {
+        let mut sequence = RowIdSequence::from(0..10);
+        sequence.extend(RowIdSequence::from(10..20));
+        assert_eq!(sequence.0, vec![U64Segment::Range(0..20)]);
+
+        let mut sequence = RowIdSequence::from(0..10);
+        sequence.extend(RowIdSequence::from(20..30));
+        assert_eq!(
+            sequence.0,
+            vec![U64Segment::Range(0..10), U64Segment::Range(20..30)]
+        );
+    }
+
+    #[test]
+    fn test_row_id_sequence_delete() {
+        let mut sequence = RowIdSequence::from(0..10);
+        sequence.delete(vec![1, 3, 5, 7, 9]);
+        assert_eq!(
+            sequence.0,
+            vec![
+                U64Segment::Range(0..1),
+                U64Segment::Tombstones(1),
+                U64Segment::Range(2..3),
+                U64Segment::Tombstones(1),
+                U64Segment::Range(4..5),
+                U64Segment::Tombstones(1),
+                U64Segment::Range(6..7),
+                U64Segment::Tombstones(1),
+                U64Segment::Range(8..9),
+                U64Segment::Tombstones(1),
+            ]
+        );
+
+        let mut sequence = RowIdSequence::from(0..10);
+        sequence.extend(RowIdSequence::from(12..20));
+        sequence.delete(vec![0, 9, 10, 11, 12, 13]);
+        assert_eq!(
+            sequence.0,
+            vec![
+                U64Segment::Tombstones(1),
+                U64Segment::Range(1..9),
+                U64Segment::Tombstones(3),
+                U64Segment::Range(14..20),
+            ]
+        );
+
+        let mut sequence = RowIdSequence::from(0..10);
+        sequence.delete(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        assert_eq!(
+            sequence.0,
+            vec![U64Segment::Tombstones(10)]
+        );
+
+        let mut sequence = RowIdSequence::from(0..10);
+        sequence.delete(vec![9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
+        assert_eq!(
+            sequence.0,
+            vec![U64Segment::Tombstones(10)]
+        );
+    }
+}

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::{collections::HashSet, ops::{Range, RangeInclusive}};
+use std::ops::{Range, RangeInclusive};
 
 use snafu::{location, Location};
 
@@ -10,6 +10,10 @@ use lance_core::{Error, Result};
 use self::encoded_array::EncodedU64Array;
 
 mod encoded_array;
+pub mod serde;
+mod index;
+
+pub use index::RowIdIndex;
 
 /// A row ID is a unique identifier for a row in a table.
 ///
@@ -38,16 +42,16 @@ impl RowId {
 }
 
 /// A sequence of row ids.
-/// 
+///
 /// Row ids are u64s that:
-/// 
+///
 /// 1. Are **unique** within a table (except for tombstones)
 /// 2. Are *often* but not always sorted and/or contiguous.
 ///
 /// This sequence of row ids is optimized to be compact when the row ids are
 /// contiguous and sorted. However, it does not require that the row ids are
 /// contiguous or sorted.
-/// 
+///
 /// We can make optimizations that assume uniqueness.
 #[derive(Debug)]
 pub struct RowIdSequence(Vec<U64Segment>);
@@ -148,21 +152,22 @@ impl RowIdSequence {
         loop {
             // Add all segments up to the segment containing the row id.
             let segments_handled = old_segments.len() - remaining_segments.len();
-            let segments_to_add = position.1.0 - segments_handled;
-            self.0.extend_from_slice(&remaining_segments[..segments_to_add]);
+            let segments_to_add = position.1 .0 - segments_handled;
+            self.0
+                .extend_from_slice(&remaining_segments[..segments_to_add]);
             remaining_segments = &remaining_segments[segments_to_add..];
 
             let segment;
             (segment, remaining_segments) = remaining_segments.split_first().unwrap();
 
             // Handle all positions for this segment now.
-            position_batch.push(position.1.1);
+            position_batch.push(position.1 .1);
             while let Some(next_position) = positions_iter.peek() {
-                if next_position.1.0 != position.1.0 {
+                if next_position.1 .0 != position.1 .0 {
                     position = positions_iter.next().unwrap();
                     break;
                 }
-                position_batch.push(next_position.1.1);
+                position_batch.push(next_position.1 .1);
                 position = positions_iter.next().unwrap();
             }
 
@@ -179,7 +184,7 @@ impl RowIdSequence {
     }
 
     /// Find the row ids in the sequence.
-    /// 
+    ///
     /// Returns the row ids and, if found, the position of the segment containing
     /// it and the offset within the segment.
     fn find_ids(&self, row_ids: impl IntoIterator<Item = u64>) -> Vec<(u64, (usize, usize))> {
@@ -188,22 +193,24 @@ impl RowIdSequence {
         // restarting the search from the beginning each time.
         let mut segment_iter = self.0.iter().enumerate().cycle();
 
-        row_ids.into_iter()
+        row_ids
+            .into_iter()
             .filter_map(|row_id| {
                 let mut i = 0;
                 // If we've cycled through all segments, we know the row id is not in the sequence.
                 while i < self.0.len() {
                     let (segment_idx, segment) = segment_iter.next().unwrap();
-                    if segment.range().map_or(false, |range| range.contains(&row_id)) {
+                    if segment
+                        .range()
+                        .map_or(false, |range| range.contains(&row_id))
+                    {
                         let offset = match segment {
-                            U64Segment::Tombstones(_) => unreachable!("Tombstones should not be in the sequence"),
+                            U64Segment::Tombstones(_) => {
+                                unreachable!("Tombstones should not be in the sequence")
+                            }
                             U64Segment::Range(range) => Some((row_id - range.start) as usize),
-                            U64Segment::SortedArray(array) => {
-                                array.binary_search(row_id).ok()
-                            },
-                            U64Segment::Array(array) => {
-                                array.iter().position(|v| v == row_id)
-                            },
+                            U64Segment::SortedArray(array) => array.binary_search(row_id).ok(),
+                            U64Segment::Array(array) => array.iter().position(|v| v == row_id),
                         };
                         if let Some(offset) = offset {
                             return Some((row_id, (segment_idx, offset)));
@@ -219,14 +226,10 @@ impl RowIdSequence {
 
     /// Replace the positions in the segment with tombstones, pushing the new
     /// segments onto the destination vector.
-    /// 
+    ///
     /// This might involve splitting the segment into multiple segments.
     /// It also might increment the tombstone count of the previous segment.
-    fn delete_from_segment(
-        dest: &mut Vec<U64Segment>,
-        segment: &U64Segment,
-        positions: &[usize],
-    ) {
+    fn delete_from_segment(dest: &mut Vec<U64Segment>, segment: &U64Segment, positions: &[usize]) {
         // Offset to the first position in segment that we haven't added to dest.
         let mut offset = 0;
         for &position in positions {
@@ -234,7 +237,7 @@ impl RowIdSequence {
             if position > offset {
                 dest.push(segment.slice(offset, position - offset));
             }
-            
+
             // Add the tombstone. If the last segment is a tombstone, increment the count
             // instead of appending a new tombstone segment.
             match dest.last_mut() {
@@ -244,16 +247,13 @@ impl RowIdSequence {
 
             offset = position + 1;
         }
-        
+
         // Add the remaining slice of the segment.
         if offset < segment.len() {
             dest.push(segment.slice(offset, segment.len() - offset));
         }
     }
 }
-
-/// An index of row ids
-pub struct RowIdIndex {}
 
 /// Different ways to represent a sequence of u64s.
 ///
@@ -298,12 +298,12 @@ impl U64Segment {
                 let min_value = array.first().unwrap();
                 let max_value = array.last().unwrap();
                 Some(min_value..=max_value)
-            },
+            }
             U64Segment::Array(array) => {
                 let min_value = array.min().unwrap();
                 let max_value = array.max().unwrap();
                 Some(min_value..=max_value)
-            },
+            }
         }
     }
 
@@ -313,14 +313,12 @@ impl U64Segment {
             U64Segment::Range(range) => {
                 let start = range.start + offset as u64;
                 U64Segment::Range(start..(start + len as u64))
-            },
+            }
             U64Segment::SortedArray(array) => {
                 // TODO: this could be optimized.
                 U64Segment::SortedArray(array.slice(offset, len))
-            },
-            U64Segment::Array(array) => {
-                U64Segment::Array(array.slice(offset, len))
-            },
+            }
+            U64Segment::Array(array) => U64Segment::Array(array.slice(offset, len)),
         }
     }
 }
@@ -408,16 +406,10 @@ mod test {
 
         let mut sequence = RowIdSequence::from(0..10);
         sequence.delete(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-        assert_eq!(
-            sequence.0,
-            vec![U64Segment::Tombstones(10)]
-        );
+        assert_eq!(sequence.0, vec![U64Segment::Tombstones(10)]);
 
         let mut sequence = RowIdSequence::from(0..10);
         sequence.delete(vec![9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
-        assert_eq!(
-            sequence.0,
-            vec![U64Segment::Tombstones(10)]
-        );
+        assert_eq!(sequence.0, vec![U64Segment::Tombstones(10)]);
     }
 }

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -229,7 +229,7 @@ mod test {
     fn test_row_id_sequence_delete() {
         let mut sequence = RowIdSequence::from(0..10);
         sequence.delete(vec![1, 3, 5, 7, 9]);
-        let mut expected_bitmap = Bitmap::new(9);
+        let mut expected_bitmap = Bitmap::new_empty(9);
         for i in vec![0, 2, 4, 8] {
             expected_bitmap.set(i as usize);
         }

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -89,7 +89,7 @@ impl RowIdSequence {
     }
 
     pub fn len(&self) -> u64 {
-        self.iter().count() as u64
+        self.0.iter().map(|segment| segment.len() as u64).sum()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -112,6 +112,7 @@ impl RowIdSequence {
                 return;
             }
         }
+        // TODO: add other optimizations, such as combining two RangeWithHoles.
         self.0.extend(other.0);
     }
 

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -230,7 +230,7 @@ mod test {
         let mut sequence = RowIdSequence::from(0..10);
         sequence.delete(vec![1, 3, 5, 7, 9]);
         let mut expected_bitmap = Bitmap::new_empty(9);
-        for i in [0, 2, 4, 8] {
+        for i in [0, 2, 4, 6, 8] {
             expected_bitmap.set(i as usize);
         }
         assert_eq!(
@@ -251,6 +251,6 @@ mod test {
 
         let mut sequence = RowIdSequence::from(0..10);
         sequence.delete(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-        assert_eq!(sequence.0, vec![]);
+        assert_eq!(sequence.0, vec![U64Segment::Range(0..0)]);
     }
 }

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -230,7 +230,7 @@ mod test {
         let mut sequence = RowIdSequence::from(0..10);
         sequence.delete(vec![1, 3, 5, 7, 9]);
         let mut expected_bitmap = Bitmap::new_empty(9);
-        for i in vec![0, 2, 4, 8] {
+        for i in [0, 2, 4, 8] {
             expected_bitmap.set(i as usize);
         }
         assert_eq!(

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -1,6 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
-
+//! Indices for mapping row ids to their corresponding addresses.
+//! 
+//! Each fragment in a table has a [RowIdSequence] that contains the row ids
+//! in the order they appear in the fragment. The [RowIdIndex] aggregates these
+//! sequences and maps row ids to their corresponding addresses across the
+//! whole dataset.
+//! 
+//! [RowIdSequence]s are serialized individually and stored in the fragment
+//! metadata. Use [read_row_ids] and [write_row_ids] to read and write these
+//! sequences. The on-disk format is designed to align well with the in-memory
+//! representation, to avoid unnecessary deserialization.
 use std::ops::Range;
 
 // These are all internal data structures, and are private.

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 //! Indices for mapping row ids to their corresponding addresses.
-//! 
+//!
 //! Each fragment in a table has a [RowIdSequence] that contains the row ids
 //! in the order they appear in the fragment. The [RowIdIndex] aggregates these
 //! sequences and maps row ids to their corresponding addresses across the
 //! whole dataset.
-//! 
+//!
 //! [RowIdSequence]s are serialized individually and stored in the fragment
 //! metadata. Use [read_row_ids] and [write_row_ids] to read and write these
 //! sequences. The on-disk format is designed to align well with the in-memory

--- a/rust/lance-table/src/rowids/bitmap.rs
+++ b/rust/lance-table/src/rowids/bitmap.rs
@@ -75,7 +75,7 @@ impl Bitmap {
 
 impl From<&[bool]> for Bitmap {
     fn from(slice: &[bool]) -> Self {
-        let mut bitmap = Bitmap::new_empty(slice.len());
+        let mut bitmap = Self::new_empty(slice.len());
         for (i, &b) in slice.iter().enumerate() {
             if b {
                 bitmap.set(i);

--- a/rust/lance-table/src/rowids/bitmap.rs
+++ b/rust/lance-table/src/rowids/bitmap.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+#[derive(PartialEq, Eq, Clone)]
+pub struct Bitmap {
+    pub data: Vec<u8>,
+    pub len: usize,
+}
+
+impl std::fmt::Debug for Bitmap {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Bitmap {{ data: ")?;
+        for i in 0..self.len {
+            write!(f, "{}", if self.get(i) { "1" } else { "0" })?;
+        }
+        write!(f, ", len: {} }}", self.len)
+    }
+}
+
+impl Bitmap {
+    pub fn new(len: usize) -> Self {
+        let data = vec![0; (len + 7) / 8];
+        Self { data, len }
+    }
+
+    pub fn set(&mut self, i: usize) {
+        self.data[i / 8] |= 1 << (i % 8);
+    }
+
+    pub fn clear(&mut self, i: usize) {
+        self.data[i / 8] &= !(1 << (i % 8));
+    }
+
+    pub fn get(&self, i: usize) -> bool {
+        self.data[i / 8] & (1 << (i % 8)) != 0
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn slice(&self, start: usize, len: usize) -> Self {
+        let mut data = vec![0; (len + 7) / 8];
+        for i in 0..len {
+            if self.get(start + i) {
+                data[i / 8] |= 1 << (i % 8);
+            }
+        }
+        Self { data, len }
+    }
+
+    pub fn count_ones(&self) -> usize {
+        self.data.iter().map(|&x| x.count_ones() as usize).sum()
+    }
+}
+
+impl From<&[bool]> for Bitmap {
+    fn from(slice: &[bool]) -> Self {
+        let mut bitmap = Bitmap::new(slice.len());
+        for (i, &b) in slice.iter().enumerate() {
+            if b {
+                bitmap.set(i);
+            }
+        }
+        bitmap
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bitmap() {
+        let mut bitmap = Bitmap::new(10);
+        assert_eq!(bitmap.len(), 10);
+        assert_eq!(bitmap.count_ones(), 0);
+
+        bitmap.set(0);
+        bitmap.set(1);
+        bitmap.set(4);
+        bitmap.set(5);
+        bitmap.set(9);
+        assert_eq!(bitmap.count_ones(), 5);
+        assert_eq!(
+            format!("{:?}", bitmap),
+            "Bitmap { data: 1100100010, len: 10 }"
+        );
+
+        bitmap.clear(1);
+        bitmap.clear(4);
+        assert_eq!(bitmap.count_ones(), 3);
+        assert_eq!(
+            format!("{:?}", bitmap),
+            "Bitmap { data: 1000000010, len: 10 }"
+        );
+
+        bitmap.slice(5, 5);
+        assert_eq!(bitmap.count_ones(), 1);
+        assert_eq!(format!("{:?}", bitmap), "Bitmap { data: 00010, len: 5 }");
+    }
+}

--- a/rust/lance-table/src/rowids/encoded_array.rs
+++ b/rust/lance-table/src/rowids/encoded_array.rs
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::ops::Range;
+
+/// Encoded array of u64 values.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EncodedU64Array {
+    /// u64 values represented as u16 offset from a base value.
+    ///
+    /// Useful when the min and max value are within u16 range (0..65535).
+    /// Only space saving when there are more than 2 values.
+    U16 { base: u64, offsets: Vec<u16> },
+    /// u64 values represented as u32 offset from a base value.
+    ///
+    /// Useful when the min and max value are within u32 range (0..~4 billion).
+    U32 { base: u64, offsets: Vec<u32> },
+    /// Just a plain vector of u64 values.
+    ///
+    /// For when the values cover a wide range.
+    U64(Vec<u64>),
+}
+
+impl EncodedU64Array {
+    pub fn len(&self) -> usize {
+        match self {
+            EncodedU64Array::U16 { offsets, .. } => offsets.len(),
+            EncodedU64Array::U32 { offsets, .. } => offsets.len(),
+            EncodedU64Array::U64(values) => values.len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn iter(&self) -> Box<dyn DoubleEndedIterator<Item = u64> + '_> {
+        match self {
+            EncodedU64Array::U16 { base, offsets } => {
+                Box::new(offsets.iter().cloned().map(move |o| base + o as u64))
+            }
+            EncodedU64Array::U32 { base, offsets } => {
+                Box::new(offsets.iter().cloned().map(move |o| base + o as u64))
+            }
+            EncodedU64Array::U64(values) => Box::new(values.iter().cloned()),
+        }
+    }
+
+    pub fn min(&self) -> Option<u64> {
+        match self {
+            EncodedU64Array::U16 { base, offsets } => {
+                if offsets.is_empty() {
+                    None
+                } else {
+                    Some(*base)
+                }
+            }
+            EncodedU64Array::U32 { base, offsets } => {
+                if offsets.is_empty() {
+                    None
+                } else {
+                    Some(*base)
+                }
+            }
+            EncodedU64Array::U64(values) => values.iter().copied().min(),
+        }
+    }
+
+    pub fn max(&self) -> Option<u64> {
+        match self {
+            EncodedU64Array::U16 { base, offsets } => {
+                if offsets.is_empty() {
+                    None
+                } else {
+                    Some(*base + *offsets.last().unwrap() as u64)
+                }
+            }
+            EncodedU64Array::U32 { base, offsets } => {
+                if offsets.is_empty() {
+                    None
+                } else {
+                    Some(*base + *offsets.last().unwrap() as u64)
+                }
+            }
+            EncodedU64Array::U64(values) => values.iter().copied().max(),
+        }
+    }
+
+    pub fn first(&self) -> Option<u64> {
+        match self {
+            EncodedU64Array::U16 { base, offsets } => {
+                if offsets.is_empty() {
+                    None
+                } else {
+                    Some(*base + *offsets.first().unwrap() as u64)
+                }
+            }
+            EncodedU64Array::U32 { base, offsets } => {
+                if offsets.is_empty() {
+                    None
+                } else {
+                    Some(*base + *offsets.first().unwrap() as u64)
+                }
+            }
+            EncodedU64Array::U64(values) => values.first().copied(),
+        }
+    }
+
+    pub fn last(&self) -> Option<u64> {
+        match self {
+            EncodedU64Array::U16 { base, offsets } => {
+                if offsets.is_empty() {
+                    None
+                } else {
+                    Some(*base + *offsets.last().unwrap() as u64)
+                }
+            }
+            EncodedU64Array::U32 { base, offsets } => {
+                if offsets.is_empty() {
+                    None
+                } else {
+                    Some(*base + *offsets.last().unwrap() as u64)
+                }
+            }
+            EncodedU64Array::U64(values) => values.last().copied(),
+        }
+    }
+
+    pub fn binary_search(&self, val: u64) -> std::result::Result<usize, usize> {
+        match self {
+            EncodedU64Array::U16 { base, offsets } => {
+                let u16 = val as u16;
+                let base = *base as u16;
+                offsets.binary_search(&(u16 - base))
+            }
+            EncodedU64Array::U32 { base, offsets } => {
+                let u32 = val as u32;
+                let base = *base as u32;
+                offsets.binary_search(&(u32 - base))
+            }
+            EncodedU64Array::U64(values) => values.binary_search(&val),
+        }
+    }
+
+    pub fn slice(&self, offset: usize, len: usize) -> Self {
+        match self {
+            EncodedU64Array::U16 { base, offsets } => {
+                offsets[offset..(offset + len)].iter().map(|o| *base + *o as u64).collect()
+            }
+            EncodedU64Array::U32 { base, offsets } => {
+                offsets[offset..(offset + len)].iter().map(|o| *base + *o as u64).collect()
+            }
+            EncodedU64Array::U64(values) => {
+                let values = values[offset..(offset + len)].to_vec();
+                EncodedU64Array::U64(values)
+            }
+        }
+    }
+}
+
+impl From<Vec<u64>> for EncodedU64Array {
+    fn from(values: Vec<u64>) -> Self {
+        let min = values.iter().copied().min().unwrap_or(0);
+        let max = values.iter().copied().max().unwrap_or(0);
+        let range = max - min;
+        if range < u16::MAX as u64 {
+            let base = min;
+            let offsets = values.iter().map(|v| (*v - base) as u16).collect();
+            EncodedU64Array::U16 { base, offsets }
+        } else if range < u32::MAX as u64 {
+            let base = min;
+            let offsets = values.iter().map(|v| (*v - base) as u32).collect();
+            EncodedU64Array::U32 { base, offsets }
+        } else {
+            EncodedU64Array::U64(values)
+        }
+    }
+}
+
+impl From<Range<u64>> for EncodedU64Array {
+    fn from(range: Range<u64>) -> Self {
+        let min = range.start;
+        let max = range.end;
+        let range = max - min;
+        if range < u16::MAX as u64 {
+            let base = min;
+            let offsets = (0..range as u16).collect();
+            EncodedU64Array::U16 { base, offsets }
+        } else if range < u32::MAX as u64 {
+            let base = min;
+            let offsets = (0..range as u32).collect();
+            EncodedU64Array::U32 { base, offsets }
+        } else {
+            EncodedU64Array::U64((min..max).collect())
+        }
+    }
+}
+
+impl FromIterator<u64> for EncodedU64Array {
+    fn from_iter<I: IntoIterator<Item = u64>>(iter: I) -> Self {
+        let values: Vec<u64> = iter.into_iter().collect();
+        let min = values.iter().copied().min().unwrap_or(0);
+        let max = values.iter().copied().max().unwrap_or(0);
+        let range = max - min;
+        if range < u16::MAX as u64 {
+            let base = min;
+            let offsets = values.iter().map(|v| (*v - base) as u16).collect();
+            EncodedU64Array::U16 { base, offsets }
+        } else if range < u32::MAX as u64 {
+            let base = min;
+            let offsets = values.iter().map(|v| (*v - base) as u32).collect();
+            EncodedU64Array::U32 { base, offsets }
+        } else {
+            EncodedU64Array::U64(values)
+        }
+    }
+}
+
+impl IntoIterator for EncodedU64Array {
+    type Item = u64;
+    type IntoIter = Box<dyn DoubleEndedIterator<Item = u64>>;
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            EncodedU64Array::U16 { base, offsets } => {
+                Box::new(offsets.into_iter().map(move |o| base + o as u64))
+            }
+            EncodedU64Array::U32 { base, offsets } => {
+                Box::new(offsets.into_iter().map(move |o| base + o as u64))
+            }
+            EncodedU64Array::U64(values) => Box::new(values.into_iter()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_encoded_array_from_vec() {
+        // u16 version
+        let values = [42, 43, 99, u16::MAX as u64]
+            .map(|v| v + 2 * u16::MAX as u64)
+            .to_vec();
+        let encoded = EncodedU64Array::from(values.clone());
+        let expected_base = 42 + 2 * u16::MAX as u64;
+        assert!(matches!(
+            encoded,
+            EncodedU64Array::U16 {
+                base,
+                ..
+            } if base == expected_base
+        ));
+        let roundtripped = encoded.into_iter().collect::<Vec<_>>();
+        assert_eq!(values, roundtripped);
+
+        // u32 version
+        let values = [42, 43, 99, u32::MAX as u64]
+            .map(|v| v + 2 * u32::MAX as u64)
+            .to_vec();
+        let encoded = EncodedU64Array::from(values.clone());
+        let expected_base = 42 + 2 * u32::MAX as u64;
+        assert!(matches!(
+            encoded,
+            EncodedU64Array::U32 {
+                base,
+                ..
+            } if base == expected_base
+        ));
+        let roundtripped = encoded.into_iter().collect::<Vec<_>>();
+        assert_eq!(values, roundtripped);
+
+        // u64 version
+        let values = [42, 43, 99, u64::MAX].to_vec();
+        let encoded = EncodedU64Array::from(values.clone());
+        assert!(matches!(encoded, EncodedU64Array::U64(_)));
+        let roundtripped = encoded.into_iter().collect::<Vec<_>>();
+        assert_eq!(values, roundtripped);
+
+        // empty one
+        let values = Vec::<u64>::new();
+        let encoded = EncodedU64Array::from(values.clone());
+        assert_eq!(encoded.len(), 0);
+        let roundtripped = encoded.into_iter().collect::<Vec<_>>();
+        assert_eq!(values, roundtripped);
+    }
+
+    #[test]
+    fn test_encoded_array_from_range() {
+        // u16 version
+        let range = (2 * u16::MAX as u64)..(40 + 2 * u16::MAX as u64);
+        let encoded = EncodedU64Array::from(range.clone());
+        let expected_base = 2 * u16::MAX as u64;
+        assert!(matches!(
+            encoded,
+            EncodedU64Array::U16 {
+                base,
+                ..
+            } if base == expected_base
+        ), "{:?}", encoded);
+        let roundtripped = encoded.into_iter().collect::<Vec<_>>();
+        assert_eq!(range.collect::<Vec<_>>(), roundtripped);
+
+        // u32 version
+        let range = (2 * u32::MAX as u64)..(u16::MAX as u64 + 10 + 2 * u32::MAX as u64);
+        let encoded = EncodedU64Array::from(range.clone());
+        let expected_base = 2 * u32::MAX as u64;
+        assert!(matches!(
+            encoded,
+            EncodedU64Array::U32 {
+                base,
+                ..
+            } if base == expected_base
+        ));
+        let roundtripped = encoded.into_iter().collect::<Vec<_>>();
+        assert_eq!(range.collect::<Vec<_>>(), roundtripped);
+
+        // We'll skip u64 since it would take a lot of memory.
+    
+        // Empty one
+        let range = 42..42;
+        let encoded = EncodedU64Array::from(range.clone());
+        assert_eq!(encoded.len(), 0);
+    }
+}

--- a/rust/lance-table/src/rowids/encoded_array.rs
+++ b/rust/lance-table/src/rowids/encoded_array.rs
@@ -144,12 +144,14 @@ impl EncodedU64Array {
 
     pub fn slice(&self, offset: usize, len: usize) -> Self {
         match self {
-            EncodedU64Array::U16 { base, offsets } => {
-                offsets[offset..(offset + len)].iter().map(|o| *base + *o as u64).collect()
-            }
-            EncodedU64Array::U32 { base, offsets } => {
-                offsets[offset..(offset + len)].iter().map(|o| *base + *o as u64).collect()
-            }
+            EncodedU64Array::U16 { base, offsets } => offsets[offset..(offset + len)]
+                .iter()
+                .map(|o| *base + *o as u64)
+                .collect(),
+            EncodedU64Array::U32 { base, offsets } => offsets[offset..(offset + len)]
+                .iter()
+                .map(|o| *base + *o as u64)
+                .collect(),
             EncodedU64Array::U64(values) => {
                 let values = values[offset..(offset + len)].to_vec();
                 EncodedU64Array::U64(values)
@@ -291,13 +293,17 @@ mod test {
         let range = (2 * u16::MAX as u64)..(40 + 2 * u16::MAX as u64);
         let encoded = EncodedU64Array::from(range.clone());
         let expected_base = 2 * u16::MAX as u64;
-        assert!(matches!(
-            encoded,
-            EncodedU64Array::U16 {
-                base,
-                ..
-            } if base == expected_base
-        ), "{:?}", encoded);
+        assert!(
+            matches!(
+                encoded,
+                EncodedU64Array::U16 {
+                    base,
+                    ..
+                } if base == expected_base
+            ),
+            "{:?}",
+            encoded
+        );
         let roundtripped = encoded.into_iter().collect::<Vec<_>>();
         assert_eq!(range.collect::<Vec<_>>(), roundtripped);
 
@@ -316,7 +322,7 @@ mod test {
         assert_eq!(range.collect::<Vec<_>>(), roundtripped);
 
         // We'll skip u64 since it would take a lot of memory.
-    
+
         // Empty one
         let range = 42..42;
         let encoded = EncodedU64Array::from(range.clone());

--- a/rust/lance-table/src/rowids/encoded_array.rs
+++ b/rust/lance-table/src/rowids/encoded_array.rs
@@ -90,14 +90,14 @@ impl EncodedU64Array {
                 if offsets.is_empty() {
                     None
                 } else {
-                    Some(*base + *offsets.last().unwrap() as u64)
+                    Some(*base + offsets.iter().copied().max().unwrap() as u64)
                 }
             }
             Self::U32 { base, offsets } => {
                 if offsets.is_empty() {
                     None
                 } else {
-                    Some(*base + *offsets.last().unwrap() as u64)
+                    Some(*base + offsets.iter().copied().max().unwrap() as u64)
                 }
             }
             Self::U64(values) => values.iter().copied().max(),
@@ -292,7 +292,7 @@ mod test {
 
         // u16 version, it can start beyong the u16 range, but the
         // relative values must be within u16 range.
-        let relative_values = [0, 42, 43, 99, u16::MAX as u64];
+        let relative_values = [42, 0, 43, u16::MAX as u64, 99];
         let values = relative_values.map(|v| v + 2 * u16::MAX as u64).to_vec();
         let expected = EncodedU64Array::U16 {
             base: 2 * u16::MAX as u64,
@@ -301,7 +301,7 @@ mod test {
         roundtrip_array(values, &expected);
 
         // u32 version
-        let relative_values = [0, 42, 43, 99, u32::MAX as u64];
+        let relative_values = [42, 0, 43, u32::MAX as u64, 99];
         let values = relative_values.map(|v| v + 2 * u32::MAX as u64).to_vec();
         let expected = EncodedU64Array::U32 {
             base: 2 * u32::MAX as u64,
@@ -310,7 +310,7 @@ mod test {
         roundtrip_array(values, &expected);
 
         // u64 version
-        let values = [42, 43, 99, u64::MAX].to_vec();
+        let values = [42, 0, 43, u64::MAX, 99].to_vec();
         let expected = EncodedU64Array::U64(values.clone());
         roundtrip_array(values, &expected);
     }

--- a/rust/lance-table/src/rowids/index.rs
+++ b/rust/lance-table/src/rowids/index.rs
@@ -1,31 +1,49 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::{collections::BTreeMap, ops::{Range, RangeInclusive}};
+use std::ops::RangeInclusive;
 
 use lance_core::utils::address::RowAddress;
-use rangemap::{RangeInclusiveMap, RangeMap};
+use lance_core::{Error, Result};
+use rangemap::RangeInclusiveMap;
+use snafu::{location, Location};
 
 use super::{RowIdSequence, U64Segment};
 
 /// An index of row ids
-/// 
+///
 /// This index is used to map row ids to their corresponding addresses.
-/// 
+///
 /// This is structured as a B tree, where the keys and values can either
 /// be a single value or a range.
 pub struct RowIdIndex(RangeInclusiveMap<u64, (U64Segment, U64Segment)>);
 
 impl RowIdIndex {
     /// Create a new index from a list of fragment ids and their corresponding row id sequences.
-    pub fn new(fragment_indices: &[(u32, RowIdSequence)]) -> Self {
+    pub fn new(fragment_indices: &[(u32, RowIdSequence)]) -> Result<Self> {
         let mut pieces = fragment_indices
             .iter()
             .flat_map(|(fragment_id, sequence)| decompose_sequence(*fragment_id, sequence))
             .collect::<Vec<_>>();
         pieces.sort_by_key(|(range, _)| *range.start());
-        todo!("Handle overlapping ranges")
-        
+
+        // Check for overlapping ranges and if found, return a NotImplementedError.
+        // We don't expect this pattern yet.
+        if pieces.windows(2).any(|w| w[0].0.end() >= w[1].0.start()) {
+            return Err(Error::NotSupported {
+                source: "".into(),
+                location: location!(),
+            });
+        }
+
+        Ok(Self(RangeInclusiveMap::from_iter(pieces)))
+    }
+
+    pub fn get(&self, row_id: u64) -> Option<RowAddress> {
+        let (row_id_segment, address_segment) = self.0.get(&row_id)?;
+        let pos = row_id_segment.position(row_id)?;
+        let address = address_segment.get(pos)?;
+        Some(RowAddress::new_from_id(address))
     }
 }
 
@@ -34,16 +52,88 @@ fn decompose_sequence(
     sequence: &RowIdSequence,
 ) -> Vec<(RangeInclusive<u64>, (U64Segment, U64Segment))> {
     let mut start_address: u64 = RowAddress::first_row(fragment_id).into();
-    sequence.0
+    sequence
+        .0
         .iter()
         .filter_map(|segment| {
             let segment_len = segment.len() as u64;
-            let address_segment = U64Segment::Range(start_address..(start_address as u64 + segment_len));
-            start_address += segment_len as u64;
+            let address_segment = U64Segment::Range(start_address..(start_address + segment_len));
+            start_address += segment_len;
 
             let coverage = segment.range()?;
-            
+
             Some((coverage, (segment.clone(), address_segment)))
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn address_range(frag_id: u32, offset_start: u64, offset_end: u64) -> U64Segment {
+        let start = u64::from(RowAddress::first_row(frag_id)) + offset_start;
+        let end = start + (offset_end - offset_start) + 1;
+        U64Segment::Range(start..end)
+    }
+
+    #[test]
+    fn test_decompose_sequence() {
+        let fragment_id = 10;
+        let sequence = RowIdSequence(vec![
+            U64Segment::Range(0..10),
+            U64Segment::Tombstones(10),
+            U64Segment::SortedArray(vec![20, 25, 30].into()),
+            U64Segment::Array(vec![40, 50, 60].into()),
+        ]);
+
+        let pieces = decompose_sequence(fragment_id, &sequence);
+
+        // Row id ranges
+        assert_eq!(pieces.len(), 3);
+        assert_eq!(pieces[0].0, 0..=9);
+        // Tombstones are not included in the address range
+        assert_eq!(pieces[1].0, 20..=30);
+        assert_eq!(pieces[2].0, 40..=60);
+
+        // Sequences
+        assert_eq!(&pieces[0].1 .0, &sequence.0[0]);
+        assert_eq!(&pieces[1].1 .0, &sequence.0[2]);
+        assert_eq!(&pieces[2].1 .0, &sequence.0[3]);
+
+        // Row address ranges
+        assert_eq!(pieces[0].1 .1, address_range(fragment_id, 0, 9));
+        // Tombstones are not included in the index, but their addresses should
+        // be skipped.
+        assert_eq!(pieces[1].1 .1, address_range(fragment_id, 20, 22));
+        assert_eq!(pieces[2].1 .1, address_range(fragment_id, 23, 25));
+    }
+
+    #[test]
+    fn test_new_index() {
+        let fragment_indices = vec![
+            (
+                10,
+                RowIdSequence(vec![
+                    U64Segment::Range(0..10),
+                    U64Segment::Tombstones(10),
+                    U64Segment::SortedArray(vec![20, 25, 30].into()),
+                ]),
+            ),
+            (
+                20,
+                RowIdSequence(vec![U64Segment::Array(vec![40, 50, 60].into())]),
+            ),
+        ];
+
+        let index = RowIdIndex::new(&fragment_indices).unwrap();
+
+        // Check various queries.
+        assert_eq!(index.get(0), Some(RowAddress::new_from_parts(10, 0)));
+        assert_eq!(index.get(15), None);
+        assert_eq!(index.get(25), Some(RowAddress::new_from_parts(10, 21)));
+        assert_eq!(index.get(40), Some(RowAddress::new_from_parts(20, 0)));
+        assert_eq!(index.get(60), Some(RowAddress::new_from_parts(20, 2)));
+        assert_eq!(index.get(61), None);
+    }
 }

--- a/rust/lance-table/src/rowids/index.rs
+++ b/rust/lance-table/src/rowids/index.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{collections::BTreeMap, ops::{Range, RangeInclusive}};
+
+use lance_core::utils::address::RowAddress;
+use rangemap::{RangeInclusiveMap, RangeMap};
+
+use super::{RowIdSequence, U64Segment};
+
+/// An index of row ids
+/// 
+/// This index is used to map row ids to their corresponding addresses.
+/// 
+/// This is structured as a B tree, where the keys and values can either
+/// be a single value or a range.
+pub struct RowIdIndex(RangeInclusiveMap<u64, (U64Segment, U64Segment)>);
+
+impl RowIdIndex {
+    /// Create a new index from a list of fragment ids and their corresponding row id sequences.
+    pub fn new(fragment_indices: &[(u32, RowIdSequence)]) -> Self {
+        let mut pieces = fragment_indices
+            .iter()
+            .flat_map(|(fragment_id, sequence)| decompose_sequence(*fragment_id, sequence))
+            .collect::<Vec<_>>();
+        pieces.sort_by_key(|(range, _)| *range.start());
+        todo!("Handle overlapping ranges")
+        
+    }
+}
+
+fn decompose_sequence(
+    fragment_id: u32,
+    sequence: &RowIdSequence,
+) -> Vec<(RangeInclusive<u64>, (U64Segment, U64Segment))> {
+    let mut start_address: u64 = RowAddress::first_row(fragment_id).into();
+    sequence.0
+        .iter()
+        .filter_map(|segment| {
+            let segment_len = segment.len() as u64;
+            let address_segment = U64Segment::Range(start_address..(start_address as u64 + segment_len));
+            start_address += segment_len as u64;
+
+            let coverage = segment.range()?;
+            
+            Some((coverage, (segment.clone(), address_segment)))
+        })
+        .collect()
+}

--- a/rust/lance-table/src/rowids/index.rs
+++ b/rust/lance-table/src/rowids/index.rs
@@ -31,7 +31,7 @@ impl RowIdIndex {
         // We don't expect this pattern yet.
         if pieces.windows(2).any(|w| w[0].0.end() >= w[1].0.start()) {
             return Err(Error::NotSupported {
-                source: "".into(),
+                source: "Overlapping ranges are not yet supported".into(),
                 location: location!(),
             });
         }

--- a/rust/lance-table/src/rowids/index.rs
+++ b/rust/lance-table/src/rowids/index.rs
@@ -71,12 +71,6 @@ fn decompose_sequence(
 mod tests {
     use super::*;
 
-    fn address_range(frag_id: u32, offset_start: u64, offset_end: u64) -> U64Segment {
-        let start = u64::from(RowAddress::first_row(frag_id)) + offset_start;
-        let end = start + (offset_end - offset_start) + 1;
-        U64Segment::Range(start..end)
-    }
-
     #[test]
     fn test_new_index() {
         let fragment_indices = vec![

--- a/rust/lance-table/src/rowids/segment.rs
+++ b/rust/lance-table/src/rowids/segment.rs
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::ops::{Range, RangeInclusive};
+
+use super::{bitmap::Bitmap, encoded_array::EncodedU64Array};
+
+/// Different ways to represent a sequence of u64s.
+///
+/// This is designed to be especially efficient for sequences that are sorted,
+/// but not meaningfully larger than a Vec<u64> in the worst case.
+///
+/// The representation is chosen based on the properties of the sequence:
+///                                                           
+///  Sorted?───►Yes ───►Contiguous?─► Yes─► Range            
+///    │                ▼                                 
+///    │                No                                
+///    │                ▼                                 
+///    │              Dense?─────► Yes─► RangeWithBitmap/RangeWithHoles
+///    │                ▼                                 
+///    │                No─────────────► SortedArray      
+///    ▼                                                    
+///    No──────────────────────────────► Array            
+///
+/// "Dense" is decided based on ____.
+///
+/// Size of RangeWithBitMap for N values:
+///     8 bytes + 8 bytes + ceil((max - min) / 8) bytes
+/// Size of SortedArray for N values (assuming u16 packed):
+///     8 bytes + 8 bytes + 8 bytes + 2 bytes * N
+///
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum U64Segment {
+    /// A contiguous sorted range of row ids.
+    ///
+    /// Total size: 16 bytes
+    Range(Range<u64>),
+    /// A sorted range of row ids, that is mostly contiguous.
+    ///
+    /// Total size: 24 bytes + n_holes * 4 bytes
+    /// Use when: 32 * n_holes < max - min
+    RangeWithHoles {
+        range: Range<u64>,
+        /// Bitmap of offsets from the start of the range that are holes.
+        /// This is sorted, so binary search can be used. It's typically
+        /// relatively small.
+        holes: EncodedU64Array,
+    },
+    /// A sorted range of row ids, that is mostly contiguous.
+    ///
+    /// Total size: 24 bytes + ceil((max - min) / 8) bytes
+    /// Use when: max - min > 16 * len
+    RangeWithBitmap { range: Range<u64>, bitmap: Bitmap },
+    /// A sorted array of row ids, that is sparse.
+    ///
+    /// Total size: 24 bytes + 2 * n_values bytes
+    SortedArray(EncodedU64Array),
+    /// An array of row ids, that is not sorted.
+    Array(EncodedU64Array),
+}
+
+/// Statistics about a segment of u64s.
+struct SegmentStats {
+    /// Min value in the segment.
+    min: u64,
+    /// Max value in the segment
+    max: u64,
+    /// Total number of values in the segment
+    count: u64,
+    /// Whether the segment is sorted
+    sorted: bool,
+}
+
+impl SegmentStats {
+    fn n_holes(&self) -> u64 {
+        debug_assert!(self.sorted);
+        self.max - self.min - self.count + 1
+    }
+}
+
+impl U64Segment {
+    /// Return the values that are missing from the slice.
+    fn holes_in_slice<'a>(
+        range: RangeInclusive<u64>,
+        existing: impl IntoIterator<Item = u64> + 'a,
+    ) -> impl Iterator<Item = u64> + 'a {
+        let mut existing = existing.into_iter().peekable();
+        range.clone().filter(move |val| {
+            if let Some(&existing_val) = existing.peek() {
+                if existing_val == *val {
+                    existing.next();
+                    return false;
+                }
+            }
+            true
+        })
+    }
+
+    fn compute_stats(values: impl IntoIterator<Item = u64>) -> SegmentStats {
+        let mut sorted = true;
+        let mut min = u64::MAX;
+        let mut max = 0;
+        let mut count = 0;
+
+        for val in values {
+            count += 1;
+            if val < min {
+                min = val;
+            }
+            if val > max {
+                max = val;
+            }
+            if sorted && count > 1 && val < max {
+                sorted = false;
+            }
+        }
+
+        SegmentStats {
+            min,
+            max,
+            count,
+            sorted,
+        }
+    }
+
+    fn from_stats_and_sequence(
+        stats: SegmentStats,
+        sequence: impl IntoIterator<Item = u64>,
+    ) -> Self {
+        let n_holes = stats.n_holes();
+
+        if stats.sorted {
+            if n_holes == 0 {
+                Self::Range(stats.min..stats.max)
+            } else if 32 * n_holes < stats.max - stats.min {
+                let range = stats.min..(stats.max + 1);
+
+                let mut holes =
+                    Self::holes_in_slice(stats.min..=stats.max, sequence).collect::<Vec<_>>();
+                holes.sort_unstable();
+                let holes = EncodedU64Array::from(holes);
+
+                Self::RangeWithHoles { range, holes }
+            } else if stats.max - stats.min > 16 * stats.count {
+                let range = stats.min..(stats.max + 1);
+                let mut bitmap = Bitmap::new((stats.max - stats.min) as usize);
+
+                for hole in Self::holes_in_slice(stats.min..=stats.max, sequence.into_iter()) {
+                    let offset = (hole - stats.min) as usize;
+                    bitmap.set(offset);
+                }
+
+                Self::RangeWithBitmap { range, bitmap }
+            } else {
+                // Must use array, but at least it's sorted
+                Self::SortedArray(EncodedU64Array::from_iter(sequence))
+            }
+        } else {
+            // Must use array
+            Self::Array(EncodedU64Array::from_iter(sequence))
+        }
+    }
+
+    pub fn from_slice(slice: &[u64]) -> Self {
+        let stats = Self::compute_stats(slice.iter().copied());
+        let n_holes = stats.n_holes();
+
+        Self::from_stats_and_sequence(stats, slice.iter().copied())
+    }
+}
+
+impl U64Segment {
+    pub fn iter(&self) -> Box<dyn DoubleEndedIterator<Item = u64> + '_> {
+        match self {
+            Self::Range(range) => Box::new(range.clone()),
+            Self::RangeWithHoles { range, holes } => {
+                Box::new((range.start..range.end).filter(move |&val| {
+                    // TODO: we could write a more optimal version of this
+                    // iterator, but would need special handling to make it
+                    // double ended.
+                    holes.binary_search(val).is_err()
+                }))
+            }
+            Self::RangeWithBitmap { range, bitmap } => {
+                Box::new((range.start..range.end).filter_map(|val| {
+                    let offset = (val - range.start) as usize;
+                    if bitmap.get(offset - 1) {
+                        Some(val)
+                    } else {
+                        None
+                    }
+                }))
+            }
+            Self::SortedArray(array) => Box::new(array.iter()),
+            Self::Array(array) => Box::new(array.iter()),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Range(range) => (range.end - range.start) as usize,
+            Self::RangeWithHoles { range, holes } => {
+                let holes = holes.iter().count();
+                (range.end - range.start) as usize - holes
+            }
+            Self::RangeWithBitmap { range, bitmap } => {
+                let holes = bitmap.count_ones();
+                (range.end - range.start) as usize - holes as usize
+            }
+            Self::SortedArray(array) => array.len(),
+            Self::Array(array) => array.len(),
+        }
+    }
+
+    /// Get the min and max value of the segment, excluding tombstones.
+    pub fn range(&self) -> Option<RangeInclusive<u64>> {
+        match self {
+            Self::Range(range)
+            | Self::RangeWithBitmap { range, .. }
+            | Self::RangeWithHoles { range, .. } => Some(range.start..=(range.end - 1)),
+            Self::SortedArray(array) => {
+                // We can assume that the array is sorted.
+                let min_value = array.first().unwrap();
+                let max_value = array.last().unwrap();
+                Some(min_value..=max_value)
+            }
+            Self::Array(array) => {
+                let min_value = array.min().unwrap();
+                let max_value = array.max().unwrap();
+                Some(min_value..=max_value)
+            }
+        }
+    }
+
+    pub fn slice(&self, offset: usize, len: usize) -> Self {
+        match self {
+            Self::Range(range) => {
+                let start = range.start + offset as u64;
+                Self::Range(start..(start + len as u64))
+            }
+            Self::RangeWithHoles { range, holes } => {
+                let start = range.start + offset as u64;
+                let end = start + len as u64;
+
+                let start = holes.binary_search(start).unwrap_or_else(|x| x) as u64;
+                let end = holes.binary_search(end).unwrap_or_else(|x| x) as u64;
+                let holes_len = end - start;
+
+                if holes_len == 0 {
+                    Self::Range(start..end)
+                } else {
+                    let holes = holes.slice(start as usize, holes_len as usize);
+                    Self::RangeWithHoles {
+                        range: start..end,
+                        holes,
+                    }
+                }
+            }
+            Self::RangeWithBitmap { range, bitmap } => {
+                let start = range.start + offset as u64;
+                let end = start + len as u64;
+
+                let bitmap = bitmap.slice(offset, len);
+                if bitmap.count_ones() == len {
+                    // Bitmap no longer serves a purpose
+                    Self::Range(start..end)
+                    // TODO: could also have a case where we switch back to RangeWithHoles
+                } else {
+                    Self::RangeWithBitmap {
+                        range: start..end,
+                        bitmap,
+                    }
+                }
+            }
+            Self::SortedArray(array) => Self::SortedArray(array.slice(offset, len)),
+            Self::Array(array) => Self::Array(array.slice(offset, len)),
+        }
+    }
+
+    pub fn position(&self, val: u64) -> Option<usize> {
+        match self {
+            Self::Range(range) => {
+                if range.contains(&val) {
+                    Some((val - range.start) as usize)
+                } else {
+                    None
+                }
+            }
+            Self::RangeWithHoles { range, holes } => {
+                if range.contains(&val) && holes.binary_search(val).is_err() {
+                    let offset = (val - range.start) as usize;
+                    let holes = holes.iter().take_while(|&hole| hole < val).count();
+                    Some(offset - holes)
+                } else {
+                    None
+                }
+            }
+            Self::RangeWithBitmap { range, bitmap } => {
+                if range.contains(&val) && !bitmap.get((val - range.start) as usize) {
+                    let offset = (val - range.start) as usize;
+                    let num_zeros = bitmap.len() - bitmap.slice(0, offset).count_ones();
+                    Some(offset - num_zeros)
+                } else {
+                    None
+                }
+            }
+            Self::SortedArray(array) => array.binary_search(val).ok(),
+            Self::Array(array) => array.iter().position(|v| v == val),
+        }
+    }
+
+    pub fn get(&self, i: usize) -> Option<u64> {
+        match self {
+            Self::Range(range) => match range.start.checked_add(i as u64) {
+                Some(val) if val < range.end => Some(val),
+                _ => None,
+            },
+            Self::RangeWithHoles { range, holes } => {
+                let val = range.start + i as u64;
+                if holes.binary_search(val).is_err() {
+                    Some(val)
+                } else {
+                    None
+                }
+            }
+            Self::RangeWithBitmap { range, bitmap } => {
+                let val = range.start + i as u64;
+                if !bitmap.get(i) {
+                    Some(val)
+                } else {
+                    None
+                }
+            }
+            Self::SortedArray(array) => array.get(i),
+            Self::Array(array) => array.get(i),
+        }
+    }
+
+    /// Delete a set of row ids from the segment.
+    /// The row ids are assumed to be in the segment. (within the range, not
+    /// already deleted.)
+    /// They are also assumed to be sorted.
+    pub fn delete(&self, vals: &[u64]) -> Self {
+        // Collect some stats
+
+        // Then just use Self::From_stats_and_sequence
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test_segment() {
+        todo!()
+    }
+
+    #[test]
+    fn test_segment_iterator() {
+        todo!("validate double ended iterator");
+    }
+}

--- a/rust/lance-table/src/rowids/segment.rs
+++ b/rust/lance-table/src/rowids/segment.rs
@@ -163,8 +163,7 @@ impl U64Segment {
                 if min_size == &sizes[0] {
                     let range = stats.min..(stats.max + 1);
                     let mut holes =
-                        Self::holes_in_slice(stats.min..=stats.max, sequence.into_iter())
-                            .collect::<Vec<_>>();
+                        Self::holes_in_slice(stats.min..=stats.max, sequence).collect::<Vec<_>>();
                     holes.sort_unstable();
                     let holes = EncodedU64Array::from(holes);
 
@@ -173,7 +172,7 @@ impl U64Segment {
                     let range = stats.min..(stats.max + 1);
                     let mut bitmap = Bitmap::new_full((stats.max - stats.min) as usize + 1);
 
-                    for hole in Self::holes_in_slice(stats.min..=stats.max, sequence.into_iter()) {
+                    for hole in Self::holes_in_slice(stats.min..=stats.max, sequence) {
                         let offset = (hole - stats.min) as usize;
                         bitmap.clear(offset);
                     }

--- a/rust/lance-table/src/rowids/segment.rs
+++ b/rust/lance-table/src/rowids/segment.rs
@@ -22,7 +22,7 @@ use super::{bitmap::Bitmap, encoded_array::EncodedU64Array};
 ///    ▼                                                    
 ///    No──────────────────────────────► Array            
 ///
-/// "Dense" is decided based on ____.
+/// "Dense" is decided based on the estimated byte size of the representation.
 ///
 /// Size of RangeWithBitMap for N values:
 ///     8 bytes + 8 bytes + ceil((max - min) / 8) bytes

--- a/rust/lance-table/src/rowids/segment.rs
+++ b/rust/lance-table/src/rowids/segment.rs
@@ -292,7 +292,7 @@ impl U64Segment {
                 } else {
                     Self::RangeWithBitmap {
                         range: start..end,
-                        bitmap,
+                        bitmap: bitmap.into(),
                     }
                 }
             }

--- a/rust/lance-table/src/rowids/serde.rs
+++ b/rust/lance-table/src/rowids/serde.rs
@@ -8,27 +8,27 @@ use super::{encoded_array::EncodedU64Array, RowIdSequence, U64Segment};
 /// Serialize a rowid sequence to a writer.
 pub fn write_row_ids<W: Write>(sequence: &RowIdSequence, writer: &mut W) -> std::io::Result<()> {
     // First, write number of segmens
-    writer.write(&(sequence.0.len() as u64).to_le_bytes())?;
+    writer.write_all(&(sequence.0.len() as u64).to_le_bytes())?;
 
     // Then write each segment
     for segment in &sequence.0 {
         match segment {
             U64Segment::Tombstones(n) => {
-                writer.write(&0u8.to_le_bytes())?;
-                writer.write(&n.to_le_bytes())?;
+                writer.write_all(&0u8.to_le_bytes())?;
+                writer.write_all(&n.to_le_bytes())?;
             }
             U64Segment::Range(range) => {
-                writer.write(&1u8.to_le_bytes())?;
-                writer.write(&range.start.to_le_bytes())?;
-                writer.write(&range.end.to_le_bytes())?;
+                writer.write_all(&1u8.to_le_bytes())?;
+                writer.write_all(&range.start.to_le_bytes())?;
+                writer.write_all(&range.end.to_le_bytes())?;
             }
             U64Segment::SortedArray(array) => {
-                writer.write(&2u8.to_le_bytes())?;
-                write_array(&array, writer)?;
+                writer.write_all(&2u8.to_le_bytes())?;
+                write_array(array, writer)?;
             }
             U64Segment::Array(array) => {
-                writer.write(&3u8.to_le_bytes())?;
-                write_array(&array, writer)?;
+                writer.write_all(&3u8.to_le_bytes())?;
+                write_array(array, writer)?;
             }
         }
     }
@@ -38,26 +38,26 @@ pub fn write_row_ids<W: Write>(sequence: &RowIdSequence, writer: &mut W) -> std:
 
 fn write_array<W: Write>(array: &EncodedU64Array, writer: &mut W) -> std::io::Result<()> {
     // length
-    writer.write(&array.len().to_le_bytes())?;
+    writer.write_all(&array.len().to_le_bytes())?;
     match array {
         EncodedU64Array::U16 { offsets, base } => {
-            writer.write(&16u8.to_le_bytes())?;
-            writer.write(&base.to_le_bytes())?;
+            writer.write_all(&16u8.to_le_bytes())?;
+            writer.write_all(&base.to_le_bytes())?;
             for &value in offsets {
-                writer.write(&value.to_le_bytes())?;
+                writer.write_all(&value.to_le_bytes())?;
             }
         }
         EncodedU64Array::U32 { offsets, base } => {
-            writer.write(&32u8.to_le_bytes())?;
-            writer.write(&base.to_le_bytes())?;
+            writer.write_all(&32u8.to_le_bytes())?;
+            writer.write_all(&base.to_le_bytes())?;
             for &value in offsets {
-                writer.write(&value.to_le_bytes())?;
+                writer.write_all(&value.to_le_bytes())?;
             }
         }
         EncodedU64Array::U64(offsets) => {
-            writer.write(&64u8.to_le_bytes())?;
+            writer.write_all(&64u8.to_le_bytes())?;
             for &value in offsets {
-                writer.write(&value.to_le_bytes())?;
+                writer.write_all(&value.to_le_bytes())?;
             }
         }
     }

--- a/rust/lance-table/src/rowids/serde.rs
+++ b/rust/lance-table/src/rowids/serde.rs
@@ -192,13 +192,13 @@ impl From<EncodedU64Array> for pb::EncodedU64Array {
     }
 }
 
-/// Serialize a rowid sequence to a writer.
+/// Serialize a rowid sequence to a buffer.
 pub fn write_row_ids(sequence: &RowIdSequence) -> Vec<u8> {
     let pb_sequence = pb::RowIdSequence::from(sequence.clone());
     pb_sequence.encode_to_vec()
 }
 
-/// Deserialize a rowid sequence from a reader.
+/// Deserialize a rowid sequence from some bytes.
 pub fn read_row_ids(reader: &[u8]) -> Result<RowIdSequence> {
     let pb_sequence = pb::RowIdSequence::decode(reader)?;
     RowIdSequence::try_from(pb_sequence)

--- a/rust/lance-table/src/rowids/serde.rs
+++ b/rust/lance-table/src/rowids/serde.rs
@@ -221,7 +221,7 @@ mod test {
         });
         sequence.0.push(U64Segment::RangeWithBitmap {
             range: 200..300,
-            bitmap: Bitmap::new(100),
+            bitmap: Bitmap::new_empty(100),
         });
         sequence
             .0

--- a/rust/lance-table/src/rowids/serde.rs
+++ b/rust/lance-table/src/rowids/serde.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::io::{Read, Write};
+
+use super::{encoded_array::EncodedU64Array, RowIdSequence, U64Segment};
+
+/// Serialize a rowid sequence to a writer.
+pub fn write_row_ids<W: Write>(sequence: &RowIdSequence, writer: &mut W) -> std::io::Result<()> {
+    // First, write number of segmens
+    writer.write(&(sequence.0.len() as u64).to_le_bytes())?;
+
+    // Then write each segment
+    for segment in &sequence.0 {
+        match segment {
+            U64Segment::Tombstones(n) => {
+                writer.write(&0u8.to_le_bytes())?;
+                writer.write(&n.to_le_bytes())?;
+            }
+            U64Segment::Range(range) => {
+                writer.write(&1u8.to_le_bytes())?;
+                writer.write(&range.start.to_le_bytes())?;
+                writer.write(&range.end.to_le_bytes())?;
+            }
+            U64Segment::SortedArray(array) => {
+                writer.write(&2u8.to_le_bytes())?;
+                write_array(&array, writer)?;
+            }
+            U64Segment::Array(array) => {
+                writer.write(&3u8.to_le_bytes())?;
+                write_array(&array, writer)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn write_array<W: Write>(array: &EncodedU64Array, writer: &mut W) -> std::io::Result<()> {
+    // length
+    writer.write(&array.len().to_le_bytes())?;
+    match array {
+        EncodedU64Array::U16 { offsets, base } => {
+            writer.write(&16u8.to_le_bytes())?;
+            writer.write(&base.to_le_bytes())?;
+            for &value in offsets {
+                writer.write(&value.to_le_bytes())?;
+            }
+        }
+        EncodedU64Array::U32 { offsets, base } => {
+            writer.write(&32u8.to_le_bytes())?;
+            writer.write(&base.to_le_bytes())?;
+            for &value in offsets {
+                writer.write(&value.to_le_bytes())?;
+            }
+        }
+        EncodedU64Array::U64(offsets) => {
+            writer.write(&64u8.to_le_bytes())?;
+            for &value in offsets {
+                writer.write(&value.to_le_bytes())?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Deserialize a rowid sequence from a reader.
+pub fn read_row_ids<R: Read>(reader: &mut R) -> std::io::Result<RowIdSequence> {
+    let mut size_buf = [0u8; 8];
+    reader.read_exact(&mut size_buf)?;
+    let size = u64::from_le_bytes(size_buf);
+
+    let mut segments = Vec::with_capacity(size as usize);
+
+    for _ in 0..size {
+        let mut segment_type_buf = [0u8; 1];
+        reader.read_exact(&mut segment_type_buf)?;
+        let segment_type = segment_type_buf[0];
+
+        match segment_type {
+            0 => {
+                let mut n_buf = [0u8; 8];
+                reader.read_exact(&mut n_buf)?;
+                let n = u64::from_le_bytes(n_buf);
+                segments.push(U64Segment::Tombstones(n));
+            }
+            1 => {
+                let mut start_buf = [0u8; 8];
+                reader.read_exact(&mut start_buf)?;
+                let start = u64::from_le_bytes(start_buf);
+
+                let mut end_buf = [0u8; 8];
+                reader.read_exact(&mut end_buf)?;
+                let end = u64::from_le_bytes(end_buf);
+
+                segments.push(U64Segment::Range(start..end));
+            }
+            2 => {
+                let array = read_array(reader)?;
+                segments.push(U64Segment::SortedArray(array));
+            }
+            3 => {
+                let array = read_array(reader)?;
+                segments.push(U64Segment::Array(array));
+            }
+            _ => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "Invalid segment type",
+                ));
+            }
+        }
+    }
+
+    Ok(RowIdSequence(segments))
+}
+
+fn read_array<R: Read>(reader: &mut R) -> std::io::Result<EncodedU64Array> {
+    let mut size_buf = [0u8; 8];
+    reader.read_exact(&mut size_buf)?;
+    let size = u64::from_le_bytes(size_buf);
+
+    let mut array_buf = [0u8; 1];
+    reader.read_exact(&mut array_buf)?;
+    let array_type = array_buf[0];
+
+    match array_type {
+        16 => {
+            let mut base_buf = [0u8; 8];
+            reader.read_exact(&mut base_buf)?;
+            let base = u64::from_le_bytes(base_buf);
+
+            let mut offsets = Vec::with_capacity(size as usize);
+            for _ in 0..size {
+                let mut offset_buf = [0u8; 2];
+                reader.read_exact(&mut offset_buf)?;
+                let offset = u16::from_le_bytes(offset_buf);
+                offsets.push(offset);
+            }
+
+            Ok(EncodedU64Array::U16 { offsets, base })
+        }
+        32 => {
+            let mut base_buf = [0u8; 8];
+            reader.read_exact(&mut base_buf)?;
+            let base = u64::from_le_bytes(base_buf);
+
+            let mut offsets = Vec::with_capacity(size as usize);
+            for _ in 0..size {
+                let mut offset_buf = [0u8; 4];
+                reader.read_exact(&mut offset_buf)?;
+                let offset = u32::from_le_bytes(offset_buf);
+                offsets.push(offset);
+            }
+
+            Ok(EncodedU64Array::U32 { offsets, base })
+        }
+        64 => {
+            let mut offsets = Vec::with_capacity(size as usize);
+            for _ in 0..size {
+                let mut offset_buf = [0u8; 8];
+                reader.read_exact(&mut offset_buf)?;
+                let offset = u64::from_le_bytes(offset_buf);
+                offsets.push(offset);
+            }
+
+            Ok(EncodedU64Array::U64(offsets))
+        }
+        _ => Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Invalid array type",
+        )),
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_write_read_row_ids() {
+        let mut sequence = RowIdSequence::from(0..20);
+        sequence.0.push(U64Segment::Tombstones(10));
+        sequence.0.push(U64Segment::Range(30..100));
+        sequence
+            .0
+            .push(U64Segment::SortedArray(EncodedU64Array::U16 {
+                base: 200,
+                offsets: vec![1, 2, 3],
+            }));
+        sequence
+            .0
+            .push(U64Segment::Array(EncodedU64Array::U64(vec![1, 2, 3])));
+
+        let mut writer = Cursor::new(Vec::new());
+        write_row_ids(&sequence, &mut writer).unwrap();
+
+        let mut reader = Cursor::new(writer.into_inner());
+        let sequence2 = read_row_ids(&mut reader).unwrap();
+
+        assert_eq!(sequence.0, sequence2.0);
+    }
+}


### PR DESCRIPTION
These are experimental indices to map from stable row ids to row addresses. It's possible there are some improvements to serialization format or performance we will make before stabilizing, but I'd like to defer that work so we can unblock work with the stable row ids.

These row id indices are optimized for storage size (in-memory and on-disk) and access speed.

Closes: #2308