### PR TITLE
feat: add v2 support to fragment merge / update paths

### DIFF
--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -250,6 +250,12 @@ impl Fragment {
     pub fn add_file_legacy(&mut self, path: &str, schema: &Schema) {
         self.files.push(DataFile::new_legacy(path, schema));
     }
+
+    // True if this fragment is made up of legacy v1 files, false otherwise
+    pub fn has_legacy_files(&self) -> bool {
+        // If any file in a fragment is legacy then all files in the fragment must be
+        self.files[0].is_legacy_file()
+    }
 }
 
 impl From<&pb::DataFragment> for Fragment {

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -95,6 +95,7 @@ lance-testing = { workspace = true }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 env_logger = "0.10.0"
 tracing-chrome = "0.7.1"
+rstest = "0.19.0"
 
 [features]
 fp16kernels = ["lance-linalg/fp16kernels"]

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2343,8 +2343,8 @@ mod tests {
             assert_eq!(fragment.count_rows().await.unwrap(), 100);
             let reader = fragment.open(dataset.schema(), false).await.unwrap();
             assert_eq!(reader.legacy_num_batches(), 10);
-            for i in 0..reader.legacy_num_batches() {
-                assert_eq!(reader.legacy_num_rows_in_batch(i), 10);
+            for i in 0..reader.legacy_num_batches() as u32 {
+                assert_eq!(reader.legacy_num_rows_in_batch(i).unwrap(), 10);
             }
         }
     }
@@ -3385,117 +3385,124 @@ mod tests {
 
     #[tokio::test]
     async fn test_merge() {
-        let schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("i", DataType::Int32, false),
-            Field::new("x", DataType::Float32, false),
-        ]));
-        let batch1 = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2])),
-                Arc::new(Float32Array::from(vec![1.0, 2.0])),
-            ],
-        )
-        .unwrap();
-        let batch2 = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(Int32Array::from(vec![3, 2])),
-                Arc::new(Float32Array::from(vec![3.0, 4.0])),
-            ],
-        )
-        .unwrap();
-
-        let test_dir = tempdir().unwrap();
-        let test_uri = test_dir.path().to_str().unwrap();
-
-        let write_params = WriteParams {
-            mode: WriteMode::Append,
-            ..Default::default()
-        };
-
-        let batches = RecordBatchIterator::new(vec![batch1].into_iter().map(Ok), schema.clone());
-        Dataset::write(batches, test_uri, Some(write_params.clone()))
-            .await
-            .unwrap();
-
-        let batches = RecordBatchIterator::new(vec![batch2].into_iter().map(Ok), schema.clone());
-        Dataset::write(batches, test_uri, Some(write_params.clone()))
-            .await
-            .unwrap();
-
-        let dataset = Dataset::open(test_uri).await.unwrap();
-        assert_eq!(dataset.fragments().len(), 2);
-        assert_eq!(dataset.manifest.max_fragment_id(), Some(1));
-
-        let right_schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("i2", DataType::Int32, false),
-            Field::new("y", DataType::Utf8, true),
-        ]));
-        let right_batch1 = RecordBatch::try_new(
-            right_schema.clone(),
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2])),
-                Arc::new(StringArray::from(vec!["a", "b"])),
-            ],
-        )
-        .unwrap();
-
-        let batches =
-            RecordBatchIterator::new(vec![right_batch1].into_iter().map(Ok), right_schema.clone());
-        let mut dataset = Dataset::open(test_uri).await.unwrap();
-        dataset.merge(batches, "i", "i2").await.unwrap();
-        dataset.validate().await.unwrap();
-
-        assert_eq!(dataset.version().version, 3);
-        assert_eq!(dataset.fragments().len(), 2);
-        assert_eq!(dataset.fragments()[0].files.len(), 2);
-        assert_eq!(dataset.fragments()[1].files.len(), 2);
-        assert_eq!(dataset.manifest.max_fragment_id(), Some(1));
-
-        let actual_batches = dataset
-            .scan()
-            .try_into_stream()
-            .await
-            .unwrap()
-            .try_collect::<Vec<_>>()
-            .await
-            .unwrap();
-        let actual = concat_batches(&actual_batches[0].schema(), &actual_batches).unwrap();
-        let expected = RecordBatch::try_new(
-            Arc::new(ArrowSchema::new(vec![
+        for use_v2_format in [true, false] {
+            let schema = Arc::new(ArrowSchema::new(vec![
                 Field::new("i", DataType::Int32, false),
                 Field::new("x", DataType::Float32, false),
-                Field::new("y", DataType::Utf8, true),
-            ])),
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2, 3, 2])),
-                Arc::new(Float32Array::from(vec![1.0, 2.0, 3.0, 4.0])),
-                Arc::new(StringArray::from(vec![
-                    Some("a"),
-                    Some("b"),
-                    None,
-                    Some("b"),
-                ])),
-            ],
-        )
-        .unwrap();
-
-        assert_eq!(actual, expected);
-
-        // Validate we can still read after re-instantiating dataset, which
-        // clears the cache.
-        let dataset = Dataset::open(test_uri).await.unwrap();
-        let actual_batches = dataset
-            .scan()
-            .try_into_stream()
-            .await
-            .unwrap()
-            .try_collect::<Vec<_>>()
-            .await
+            ]));
+            let batch1 = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from(vec![1, 2])),
+                    Arc::new(Float32Array::from(vec![1.0, 2.0])),
+                ],
+            )
             .unwrap();
-        let actual = concat_batches(&actual_batches[0].schema(), &actual_batches).unwrap();
-        assert_eq!(actual, expected);
+            let batch2 = RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from(vec![3, 2])),
+                    Arc::new(Float32Array::from(vec![3.0, 4.0])),
+                ],
+            )
+            .unwrap();
+
+            let test_dir = tempdir().unwrap();
+            let test_uri = test_dir.path().to_str().unwrap();
+
+            let write_params = WriteParams {
+                mode: WriteMode::Append,
+                use_experimental_writer: use_v2_format,
+                ..Default::default()
+            };
+
+            let batches =
+                RecordBatchIterator::new(vec![batch1].into_iter().map(Ok), schema.clone());
+            Dataset::write(batches, test_uri, Some(write_params.clone()))
+                .await
+                .unwrap();
+
+            let batches =
+                RecordBatchIterator::new(vec![batch2].into_iter().map(Ok), schema.clone());
+            Dataset::write(batches, test_uri, Some(write_params.clone()))
+                .await
+                .unwrap();
+
+            let dataset = Dataset::open(test_uri).await.unwrap();
+            assert_eq!(dataset.fragments().len(), 2);
+            assert_eq!(dataset.manifest.max_fragment_id(), Some(1));
+
+            let right_schema = Arc::new(ArrowSchema::new(vec![
+                Field::new("i2", DataType::Int32, false),
+                Field::new("y", DataType::Utf8, true),
+            ]));
+            let right_batch1 = RecordBatch::try_new(
+                right_schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from(vec![1, 2])),
+                    Arc::new(StringArray::from(vec!["a", "b"])),
+                ],
+            )
+            .unwrap();
+
+            let batches = RecordBatchIterator::new(
+                vec![right_batch1].into_iter().map(Ok),
+                right_schema.clone(),
+            );
+            let mut dataset = Dataset::open(test_uri).await.unwrap();
+            dataset.merge(batches, "i", "i2").await.unwrap();
+            dataset.validate().await.unwrap();
+
+            assert_eq!(dataset.version().version, 3);
+            assert_eq!(dataset.fragments().len(), 2);
+            assert_eq!(dataset.fragments()[0].files.len(), 2);
+            assert_eq!(dataset.fragments()[1].files.len(), 2);
+            assert_eq!(dataset.manifest.max_fragment_id(), Some(1));
+
+            let actual_batches = dataset
+                .scan()
+                .try_into_stream()
+                .await
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            let actual = concat_batches(&actual_batches[0].schema(), &actual_batches).unwrap();
+            let expected = RecordBatch::try_new(
+                Arc::new(ArrowSchema::new(vec![
+                    Field::new("i", DataType::Int32, false),
+                    Field::new("x", DataType::Float32, false),
+                    Field::new("y", DataType::Utf8, true),
+                ])),
+                vec![
+                    Arc::new(Int32Array::from(vec![1, 2, 3, 2])),
+                    Arc::new(Float32Array::from(vec![1.0, 2.0, 3.0, 4.0])),
+                    Arc::new(StringArray::from(vec![
+                        Some("a"),
+                        Some("b"),
+                        None,
+                        Some("b"),
+                    ])),
+                ],
+            )
+            .unwrap();
+
+            assert_eq!(actual, expected);
+
+            // Validate we can still read after re-instantiating dataset, which
+            // clears the cache.
+            let dataset = Dataset::open(test_uri).await.unwrap();
+            let actual_batches = dataset
+                .scan()
+                .try_into_stream()
+                .await
+                .unwrap()
+                .try_collect::<Vec<_>>()
+                .await
+                .unwrap();
+            let actual = concat_batches(&actual_batches[0].schema(), &actual_batches).unwrap();
+            assert_eq!(actual, expected);
+        }
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -641,6 +641,18 @@ impl FileFragment {
             }
         }
 
+        if self.metadata.files.iter().any(|f| f.is_legacy_file())
+            != self.metadata.files.iter().all(|f| f.is_legacy_file())
+        {
+            return Err(Error::corrupt_file(
+                self.dataset
+                    .data_dir()
+                    .child(self.metadata.files[0].path.as_str()),
+                "Fragment contains a mix of v1 and v2 data files".to_string(),
+                location!(),
+            ));
+        }
+
         for field in self.schema().fields_pre_order() {
             if !seen_fields.contains(&field.id) {
                 return Err(Error::corrupt_file(
@@ -926,7 +938,7 @@ impl FileFragment {
         let reader = reader?;
         let deletion_vector = deletion_vector?.unwrap_or_default();
 
-        Ok(Updater::new(self.clone(), reader, deletion_vector, schemas))
+        Updater::try_new(self.clone(), reader, deletion_vector, schemas)
     }
 
     pub(crate) async fn merge(mut self, join_column: &str, joiner: &HashJoiner) -> Result<Self> {
@@ -1225,9 +1237,16 @@ impl FragmentReader {
         num_batches
     }
 
-    pub(crate) fn legacy_num_rows_in_batch(&self, batch_id: usize) -> usize {
-        let legacy_reader = self.readers[0].0.as_legacy();
-        legacy_reader.num_rows_in_batch(batch_id as i32)
+    pub(crate) fn legacy_num_rows_in_batch(&self, batch_id: u32) -> Option<u32> {
+        if let Some(legacy_reader) = self.readers[0].0.as_legacy_opt() {
+            if batch_id < legacy_reader.num_batches() as u32 {
+                Some(legacy_reader.num_rows_in_batch(batch_id as i32) as u32)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
     }
 
     /// Read the page statistics of the fragment for the specified fields.
@@ -1270,6 +1289,7 @@ impl FragmentReader {
         Ok(merge_batches(&batches)?.project_by_schema(&self.output_schema)?)
     }
 
+    #[cfg(test)]
     pub(crate) async fn legacy_read_batch(
         &self,
         batch_id: usize,
@@ -1517,12 +1537,13 @@ mod tests {
     use arrow_array::{ArrayRef, Int32Array, RecordBatchIterator, StringArray};
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
     use pretty_assertions::assert_eq;
+    use rstest::rstest;
     use tempfile::tempdir;
 
     use super::*;
     use crate::dataset::transaction::Operation;
 
-    async fn create_dataset(test_uri: &str) -> Dataset {
+    async fn create_dataset(test_uri: &str, use_experimental_writer: bool) -> Dataset {
         let schema = Arc::new(ArrowSchema::new(vec![
             ArrowField::new("i", DataType::Int32, true),
             ArrowField::new("s", DataType::Utf8, true),
@@ -1546,6 +1567,7 @@ mod tests {
         let write_params = WriteParams {
             max_rows_per_file: 40,
             max_rows_per_group: 10,
+            use_experimental_writer,
             ..Default::default()
         };
         let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
@@ -1591,7 +1613,7 @@ mod tests {
     async fn test_fragment_scan() {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
-        let dataset = create_dataset(test_uri).await;
+        let dataset = create_dataset(test_uri, false).await;
         let fragment = &dataset.get_fragments()[2];
         let mut scanner = fragment.scan();
         let batches = scanner
@@ -1700,7 +1722,7 @@ mod tests {
     async fn test_fragment_scan_deletions() {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
-        let mut dataset = create_dataset(test_uri).await;
+        let mut dataset = create_dataset(test_uri, false).await;
         dataset.delete("i >= 0 and i < 15").await.unwrap();
 
         let fragment = &dataset.get_fragments()[0];
@@ -1731,7 +1753,7 @@ mod tests {
     async fn test_fragment_take_indices() {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
-        let mut dataset = create_dataset(test_uri).await;
+        let mut dataset = create_dataset(test_uri, false).await;
         let fragment = dataset
             .get_fragments()
             .into_iter()
@@ -1779,7 +1801,7 @@ mod tests {
     async fn test_fragment_take_rows() {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
-        let mut dataset = create_dataset(test_uri).await;
+        let mut dataset = create_dataset(test_uri, false).await;
         let fragment = dataset
             .get_fragments()
             .into_iter()
@@ -1844,7 +1866,7 @@ mod tests {
     async fn test_recommit_from_file() {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
-        let dataset = create_dataset(test_uri).await;
+        let dataset = create_dataset(test_uri, false).await;
         let schema = dataset.schema();
         let dataset_rows = dataset.count_rows(None).await.unwrap();
 
@@ -1886,11 +1908,12 @@ mod tests {
         }
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_fragment_count() {
+    async fn test_fragment_count(#[values(false, true)] use_experimental_writer: bool) {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
-        let dataset = create_dataset(test_uri).await;
+        let dataset = create_dataset(test_uri, use_experimental_writer).await;
         let fragment = dataset.get_fragments().pop().unwrap();
 
         assert_eq!(fragment.count_rows().await.unwrap(), 40);
@@ -1914,12 +1937,13 @@ mod tests {
         );
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_append_new_columns() {
+    async fn test_append_new_columns(#[values(false, true)] use_experimental_writer: bool) {
         for with_delete in [true, false] {
             let test_dir = tempdir().unwrap();
             let test_uri = test_dir.path().to_str().unwrap();
-            let mut dataset = create_dataset(test_uri).await;
+            let mut dataset = create_dataset(test_uri, use_experimental_writer).await;
             dataset.validate().await.unwrap();
             assert_eq!(dataset.count_rows(None).await.unwrap(), 200);
 
@@ -1975,6 +1999,7 @@ mod tests {
 
             let stream = dataset
                 .scan()
+                .batch_size(10)
                 .project(&["i", "double_i"])
                 .unwrap()
                 .try_into_stream()
@@ -2001,11 +2026,12 @@ mod tests {
         }
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_merge_fragment() {
+    async fn test_merge_fragment(#[values(false, true)] use_experimental_writer: bool) {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
-        let mut dataset = create_dataset(test_uri).await;
+        let mut dataset = create_dataset(test_uri, use_experimental_writer).await;
         dataset.validate().await.unwrap();
         assert_eq!(dataset.count_rows(None).await.unwrap(), 200);
 

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1694,7 +1694,7 @@ mod tests {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
         // Creates 400 rows in 10 fragments
-        let mut dataset = create_dataset(test_uri).await;
+        let mut dataset = create_dataset(test_uri, false).await;
         // Delete last 20 rows in first fragment
         dataset.delete("i >= 20").await.unwrap();
         // Last fragment has 20 rows but 40 addressible rows

--- a/rust/lance/src/dataset/updater.rs
+++ b/rust/lance/src/dataset/updater.rs
@@ -131,7 +131,7 @@ impl Updater {
         open_writer(
             &self.fragment.dataset().object_store,
             &schema,
-            &self.fragment.dataset().data_dir(),
+            &self.fragment.dataset().base,
             !is_legacy,
         )
         .await

--- a/rust/lance/src/dataset/updater.rs
+++ b/rust/lance/src/dataset/updater.rs
@@ -1,20 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::ops::Range;
-
 use arrow_array::{RecordBatch, UInt32Array};
+use futures::StreamExt;
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::{datatypes::Schema, Error, Result};
-use lance_file::writer::FileWriter;
 use lance_table::format::Fragment;
-use lance_table::io::manifest::ManifestDescribing;
+use lance_table::utils::stream::ReadBatchFutStream;
 use snafu::{location, Location};
-use uuid::Uuid;
 
 use super::fragment::FragmentReader;
+use super::write::{open_writer, GenericWriter};
 use super::Dataset;
 use crate::dataset::FileFragment;
+
 /// Update or insert a new column.
 ///
 /// To use, call [`Updater::next`] to get the next [`RecordBatch`] as input,
@@ -29,11 +28,12 @@ pub struct Updater {
     fragment: FileFragment,
 
     /// The reader over the [`Fragment`]
-    reader: FragmentReader,
+    input_stream: ReadBatchFutStream,
 
+    /// The last batch read from the file, with deleted rows removed
     last_input: Option<RecordBatch>,
 
-    writer: Option<FileWriter<ManifestDescribing>>,
+    writer: Option<Box<dyn GenericWriter>>,
 
     /// The final schema of the fragment after the update.
     final_schema: Option<Schema>,
@@ -41,11 +41,9 @@ pub struct Updater {
     /// The schema the new files will be written in. This only contains new columns.
     write_schema: Option<Schema>,
 
-    batch_id: usize,
+    finished: bool,
 
-    start_row_id: u32,
-
-    deletion_vector: DeletionVector,
+    deletion_restorer: DeletionRestorer,
 }
 
 impl Updater {
@@ -56,29 +54,32 @@ impl Updater {
     ///
     /// If the schemas are not known, they can be None and will be inferred from
     /// the first batch of results.
-    pub(super) fn new(
+    pub(super) fn try_new(
         fragment: FileFragment,
         reader: FragmentReader,
         deletion_vector: DeletionVector,
         schemas: Option<(Schema, Schema)>,
-    ) -> Self {
+    ) -> Result<Self> {
         let (write_schema, final_schema) = if let Some((write_schema, final_schema)) = schemas {
             (Some(write_schema), Some(final_schema))
         } else {
             (None, None)
         };
 
-        Self {
+        let batch_size = reader.legacy_num_rows_in_batch(0);
+
+        let input_stream = reader.read_all(1024)?;
+
+        Ok(Self {
             fragment,
-            reader,
+            input_stream,
             last_input: None,
             writer: None,
             write_schema,
             final_schema,
-            batch_id: 0,
-            start_row_id: 0,
-            deletion_vector,
-        }
+            finished: false,
+            deletion_restorer: DeletionRestorer::new(deletion_vector, batch_size),
+        })
     }
 
     pub fn fragment(&self) -> &FileFragment {
@@ -91,14 +92,28 @@ impl Updater {
 
     /// Returns the next [`RecordBatch`] as input for updater.
     pub async fn next(&mut self) -> Result<Option<&RecordBatch>> {
-        if self.batch_id >= self.reader.legacy_num_batches() {
+        if self.finished {
             return Ok(None);
         }
-        let batch = self.reader.legacy_read_batch(self.batch_id, ..).await?;
-        self.batch_id += 1;
-
-        self.last_input = Some(batch);
-        Ok(self.last_input.as_ref())
+        let batch = self.input_stream.next().await;
+        match batch {
+            None => {
+                if !self.deletion_restorer.is_exhausted() {
+                    // This can happen only if there is a batch size (e.g. v1 file) and the
+                    // last batch(es) are entirely deleted.
+                    return Err(Error::NotSupported {
+                        source: "Missing too many rows in merge, run compaction to materialize deletions first".into(),
+                        location: location!(),
+                    });
+                }
+                self.finished = true;
+                Ok(None)
+            }
+            Some(batch) => {
+                self.last_input = Some(batch.await?);
+                Ok(self.last_input.as_ref())
+            }
+        }
     }
 
     /// Create a new Writer for new columns.
@@ -109,17 +124,15 @@ impl Updater {
     /// It is the caller's responsibility to close the [`FileWriter`].
     ///
     /// Internal use only.
-    async fn new_writer(&mut self, schema: Schema) -> Result<FileWriter<ManifestDescribing>> {
-        let file_name = format!("{}.lance", Uuid::new_v4());
-        self.fragment.metadata.add_file_legacy(&file_name, &schema);
+    async fn new_writer(&mut self, schema: Schema) -> Result<Box<dyn GenericWriter>> {
+        // Look at some file in the fragment to determine if it is a v2 file or not
+        let is_legacy = self.fragment.metadata.files[0].is_legacy_file();
 
-        let full_path = self.fragment.dataset().data_dir().child(file_name.as_str());
-
-        FileWriter::try_new(
-            self.fragment.dataset().object_store.as_ref(),
-            &full_path,
-            schema,
-            &Default::default(),
+        open_writer(
+            &self.fragment.dataset().object_store,
+            &schema,
+            &self.fragment.dataset().data_dir(),
+            !is_legacy,
         )
         .await
     }
@@ -144,6 +157,9 @@ impl Updater {
             });
         };
 
+        // Add back in deleted rows
+        let batch = self.deletion_restorer.restore(batch)?;
+
         if self.writer.is_none() {
             if self.write_schema.is_none() {
                 // Need to infer the schema.
@@ -167,29 +183,8 @@ impl Updater {
         }
 
         let writer = self.writer.as_mut().unwrap();
-        // Because of deleted rows, the number of row ids in the batch might not
-        // match the length.
-        let row_id_stride = self.reader.legacy_num_rows_in_batch(self.batch_id - 1) as u32; // Subtract since we incremented in next()
-        let batch = add_blanks(
-            batch,
-            self.start_row_id..(self.start_row_id + row_id_stride),
-            &self.deletion_vector,
-        )?;
-        // validation just in case
-        if batch.num_rows() != row_id_stride as usize {
-            return Err(Error::Internal {
-                message: format!(
-                    "Fragment Updater: batch size mismatch: {} != {}",
-                    batch.num_rows(),
-                    row_id_stride
-                ),
-                location: location!(),
-            });
-        }
 
         writer.write(&[batch]).await?;
-
-        self.start_row_id += row_id_stride;
 
         Ok(())
     }
@@ -197,7 +192,8 @@ impl Updater {
     /// Finish updating this fragment, and returns the updated [`Fragment`].
     pub async fn finish(&mut self) -> Result<Fragment> {
         if let Some(writer) = self.writer.as_mut() {
-            writer.finish().await?;
+            let (_, data_file) = writer.finish().await?;
+            self.fragment.metadata.files.push(data_file);
         }
 
         Ok(self.fragment.metadata().clone())
@@ -213,17 +209,139 @@ impl Updater {
     }
 }
 
+/// Restores deleted rows.
+///
+/// All data files in a fragment must have the same # of rows (including deleted rows)
+/// When we run the update process the next/update methods don't actually calculate on
+/// deleted rows.  This means the updated batches will have fewer rows than the original
+/// data files.  This struct restores the deleted rows, inserting arbitrary values into the
+/// batches where the deleted rows should be.
+///
+/// To do this we scan through the deletion vector in sorted order, merging deleted rows
+/// in as appropriate.
+struct DeletionRestorer {
+    current_row_id: u32,
+
+    /// Number of rows in each batch, only used in legacy files for validation
+    batch_size: Option<u32>,
+
+    deletion_vector_iter: Option<Box<dyn Iterator<Item = u32> + Send>>,
+
+    last_deleted_row_id: Option<u32>,
+}
+
+impl DeletionRestorer {
+    fn new(deletion_vector: DeletionVector, batch_size: Option<u32>) -> Self {
+        Self {
+            current_row_id: 0,
+            batch_size,
+            deletion_vector_iter: Some(deletion_vector.into_sorted_iter()),
+            last_deleted_row_id: None,
+        }
+    }
+
+    fn is_exhausted(&self) -> bool {
+        self.deletion_vector_iter.is_none()
+    }
+
+    fn is_full(batch_size: Option<u32>, num_rows: u32) -> bool {
+        if let Some(batch_size) = batch_size {
+            // We should never encounter the case that `batch_size < num_rows` because
+            // that would mean we have a v1 writer and it generated a batch with more rows
+            // than expected
+            debug_assert!(batch_size >= num_rows);
+            batch_size == num_rows
+        } else {
+            false
+        }
+    }
+
+    /// Given a batch of `num_rows`, walk through the deletion vector, and figure out where blanks
+    /// should be inserted.
+    ///
+    /// For example, if self.current_row_id is 10 and the deletion vector is [11, 12, 19, 25] and
+    /// num_rows is 7 then this function will at least return [1, 2] and the batch will at least
+    /// span row ids 10..18.
+    ///
+    /// Then, in the example we need to choose whether the returned batch should include
+    /// row 19 (and have 10 rows) or not (and have 9 rows).  This is only a concern in v1 files
+    /// where we want to match the original row group size (which is the batch size).  If the
+    /// batch size is 9 then we do not include 19 and return as above.
+    ///
+    /// If the batch size is 10 (or unset) then we do include 19 and the return will be [1, 2, 9]
+    ///
+    /// In v2 files, since the batch size will be unset, we will always include as many deleted
+    /// rows at the end as we can.
+    fn deleted_batch_offsets_in_range(&mut self, mut num_rows: u32) -> Vec<u32> {
+        let mut deleted = Vec::new();
+        let first_row_id = self.current_row_id;
+        // The last row id (exclusive) in the batch
+        let mut last_row_id = first_row_id + num_rows;
+        // If there are zero deleted rows then the range covered will be first_row_id..last_row_id
+        if self.deletion_vector_iter.is_none() {
+            return deleted;
+        }
+        let deletion_vector_iter = self.deletion_vector_iter.as_mut().unwrap();
+
+        // Now we need to walk through our deletion vector and figure out where to insert blanks
+        let mut next_deleted_id = if self.last_deleted_row_id.is_some() {
+            self.last_deleted_row_id
+        } else {
+            deletion_vector_iter.next()
+        };
+        loop {
+            if let Some(next_deleted_id) = next_deleted_id {
+                if next_deleted_id > last_row_id
+                    || (next_deleted_id == last_row_id && Self::is_full(self.batch_size, num_rows))
+                {
+                    // Either the next deleted id is out of range or it is the next row but
+                    // we are full.  Either way, stash it and return
+                    self.last_deleted_row_id = Some(next_deleted_id);
+                    return deleted;
+                }
+                // Otherwise, the deleted row is in range, and we have space in our batch
+                // and so we include it
+                deleted.push(next_deleted_id - first_row_id);
+                last_row_id += 1;
+                num_rows += 1;
+            } else {
+                // Deleted row ids iterator is exhausted
+                self.deletion_vector_iter = None;
+                return deleted;
+            }
+            next_deleted_id = deletion_vector_iter.next();
+        }
+    }
+
+    fn restore(&mut self, batch: RecordBatch) -> Result<RecordBatch> {
+        // Because of deleted rows, the number of row ids in the batch might not
+        // match the length.
+        let deleted_batch_offsets = self.deleted_batch_offsets_in_range(batch.num_rows() as u32);
+        let batch = add_blanks(batch, &deleted_batch_offsets)?;
+
+        // validation just in case
+        if let Some(batch_size) = self.batch_size {
+            if batch.num_rows() != batch_size as usize {
+                return Err(Error::Internal {
+                    message: format!(
+                        "Fragment Updater: batch size mismatch: {} != {}",
+                        batch.num_rows(),
+                        batch_size
+                    ),
+                    location: location!(),
+                });
+            }
+        }
+
+        self.current_row_id += batch.num_rows() as u32;
+        Ok(batch)
+    }
+}
+
 /// Add blank rows where there are deleted rows
-pub(crate) fn add_blanks(
-    batch: RecordBatch,
-    row_id_range: Range<u32>,
-    deletion_vector: &DeletionVector,
-) -> Result<RecordBatch> {
+pub(crate) fn add_blanks(batch: RecordBatch, batch_offsets: &[u32]) -> Result<RecordBatch> {
     // Fast early return
-    if !row_id_range
-        .clone()
-        .any(|row_id| deletion_vector.contains(row_id))
-    {
+    if batch_offsets.is_empty() {
         return Ok(batch);
     }
 
@@ -231,24 +349,25 @@ pub(crate) fn add_blanks(
         // TODO: implement adding blanks for an empty batch.
         // This is difficult because we need to create a batch for arbitrary schemas.
         return Err(Error::NotSupported {
-            source: "Missing many rows in merge".into(),
+            source: "Missing too many rows in merge, run compaction to materialize deletions first"
+                .into(),
             location: location!(),
         });
     }
 
-    let mut array_i = 0;
-    let selection_vector: Vec<u32> = row_id_range
-        .map(move |row_id| {
-            if deletion_vector.contains(row_id) {
-                // For simplicity, we just use the first value for deleted rows
-                // TODO: optimize this to use small value for each column.
-                0
-            } else {
-                array_i += 1;
-                array_i - 1
-            }
-        })
-        .collect();
+    let mut selection_vector = Vec::<u32>::with_capacity(batch.num_rows() + batch_offsets.len());
+    let mut batch_pos = 0;
+    let mut next_id = 0;
+    for batch_offset in batch_offsets {
+        let num_rows = *batch_offset - next_id;
+        selection_vector.extend(batch_pos..batch_pos + num_rows);
+        // For simplicity, we just use the first value for deleted rows
+        // TODO: optimize this to use small value for each column.
+        selection_vector.push(0);
+        next_id = *batch_offset + 1;
+        batch_pos += num_rows;
+    }
+    selection_vector.extend(batch_pos..batch.num_rows() as u32);
     let selection_vector = UInt32Array::from(selection_vector);
 
     let arrays = batch
@@ -267,4 +386,85 @@ pub(crate) fn add_blanks(
     let batch = RecordBatch::try_new(batch.schema(), arrays)?;
 
     Ok(batch)
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::{array::AsArray, datatypes::Int32Type};
+    use lance_datagen::RowCount;
+
+    use super::add_blanks;
+
+    #[test]
+    fn test_restore_deletes() {
+        for batch_size in &[None, Some(10)] {
+            let mut restorer = super::DeletionRestorer::new(
+                vec![11, 12, 19, 20, 25].into_iter().collect(),
+                *batch_size,
+            );
+
+            let batch = lance_datagen::gen()
+                .col("x", lance_datagen::array::step::<Int32Type>())
+                .into_batch_rows(RowCount::from(10))
+                .unwrap();
+            // First batch is rows ids 0..9 so nothing is restored
+            let restored = restorer.restore(batch.clone()).unwrap();
+            assert_eq!(restored, batch);
+
+            let batch = lance_datagen::gen()
+                .col("x", lance_datagen::array::step::<Int32Type>())
+                .into_batch_rows(RowCount::from(7))
+                .unwrap();
+            // Next batch is rows ids 10..16 so we need to restore 11, 12
+            // 19, and maybe 20 (depends on batch size)
+            let restored = restorer.restore(batch).unwrap();
+            let values = restored.column(0).as_primitive::<Int32Type>();
+            assert_eq!(values.value(0), 0);
+            assert_eq!(values.value(1), 0);
+            assert_eq!(values.value(2), 0);
+            assert_eq!(values.value(3), 1);
+            assert_eq!(values.value(4), 2);
+            assert_eq!(values.value(5), 3);
+            assert_eq!(values.value(6), 4);
+            assert_eq!(values.value(7), 5);
+            assert_eq!(values.value(8), 6);
+            assert_eq!(values.value(9), 0);
+            if *batch_size == Some(10) {
+                assert_eq!(values.len(), 10);
+            } else {
+                assert_eq!(values.value(10), 0);
+                assert_eq!(values.len(), 11);
+            }
+        }
+    }
+
+    #[test]
+    fn test_add_blanks() {
+        let batch = lance_datagen::gen()
+            .col("x", lance_datagen::array::step::<Int32Type>())
+            .into_batch_rows(RowCount::from(10))
+            .unwrap();
+
+        let with_blanks = add_blanks(batch.clone(), &[5, 7]).unwrap();
+
+        assert_eq!(with_blanks.num_rows(), 12);
+        let values = with_blanks.column(0).as_primitive::<Int32Type>();
+        for i in 0..5 {
+            assert_eq!(values.value(i), i as i32);
+        }
+        assert_eq!(values.value(5), 0);
+        assert_eq!(values.value(6), 5);
+        assert_eq!(values.value(7), 0);
+        for i in 8..12 {
+            assert_eq!(values.value(i), (i - 2) as i32);
+        }
+
+        let with_blanks = add_blanks(batch, &[0, 11]).unwrap();
+        let values = with_blanks.column(0).as_primitive::<Int32Type>();
+        assert_eq!(values.value(0), 0);
+        for i in 1..11 {
+            assert_eq!(values.value(i), (i - 1) as i32);
+        }
+        assert_eq!(values.value(11), 0);
+    }
 }

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -618,8 +618,13 @@ impl FragmentScanner {
         let num_batches = self.reader.legacy_num_batches();
 
         if let Some(stats) = &self.stats {
-            let batch_sizes: Vec<usize> = (0..num_batches)
-                .map(|batch_id| self.reader.legacy_num_rows_in_batch(batch_id))
+            let batch_sizes: Vec<usize> = (0..num_batches as u32)
+                .map(|batch_id| {
+                    self.reader
+                        .legacy_num_rows_in_batch(batch_id)
+                        .expect("Operation does not yet support v2 fragments")
+                        as usize
+                })
                 .collect();
             let schema =
                 Arc::new(ArrowSchema::from(self.predicate_projection.as_ref()).try_into()?);


### PR DESCRIPTION
The old implementation depended on the batch size of the file to determine the deleted row ids.  This implementation does not but will respect the batch size, if given.