### PR TITLE
fix: relax 'take out of bounds' check which could cause failure if flat searching deleted rows

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -994,6 +994,25 @@ def test_merge_insert(tmp_path: Path):
         dataset.merge_insert("a").execute(new_table)
 
 
+def test_flat_vector_search_with_delete(tmp_path: Path):
+    table = pa.Table.from_pydict(
+        {
+            "id": [i for i in range(10)],
+            "vector": pa.array(
+                [[1.0, 1.0] for _ in range(10)], pa.list_(pa.float32(), 2)
+            ),
+        }
+    )
+    dataset = lance.write_dataset(table, tmp_path / "dataset", mode="create")
+    dataset.delete("id = 0")
+    assert (
+        dataset.scanner(nearest={"column": "vector", "k": 10, "q": [1.0, 1.0]})
+        .to_table()
+        .num_rows
+        == 9
+    )
+
+
 def test_merge_insert_conditional_upsert_example(tmp_path: Path):
     table = pa.Table.from_pydict(
         {

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -366,12 +366,12 @@ impl FileReader {
             .map(|batch| async move {
                 if batch.batch_id >= num_batches as i32 {
                     Err(Error::InvalidInput {
-                        source: format!("batch_id: {} if out of bound", batch.batch_id).into(),
+                        source: format!("batch_id: {} out of bounds", batch.batch_id).into(),
                         location: location!(),
                     })
                 } else if *batch.offsets.last().expect("got empty batch") > num_rows {
                     Err(Error::InvalidInput {
-                        source: format!("indices: {:?} if out of bound", batch.offsets).into(),
+                        source: format!("indices: {:?} out of bounds", batch.offsets).into(),
                         location: location!(),
                     })
                 } else {

--- a/rust/lance-io/src/lib.rs
+++ b/rust/lance-io/src/lib.rs
@@ -84,6 +84,17 @@ impl From<&Self> for ReadBatchParams {
 }
 
 impl ReadBatchParams {
+    /// Validate that the selection is valid given the length of the batch
+    pub fn valid_given_len(&self, len: usize) -> bool {
+        match self {
+            Self::Indices(indices) => indices.iter().all(|i| i.unwrap_or(0) < len as u32),
+            Self::Range(r) => r.start < len && r.end <= len,
+            Self::RangeFull => true,
+            Self::RangeTo(r) => r.end <= len,
+            Self::RangeFrom(r) => r.start < len,
+        }
+    }
+
     /// Slice the selection
     ///
     /// For example, given ReadBatchParams::RangeFull and slice(10, 20), the output will be

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2885,7 +2885,7 @@ mod tests {
         let indices = &[(1 << 32) - 1];
         let err = ds.take_rows(indices, ds.schema()).await.unwrap_err();
         assert!(
-            err.to_string().contains("out of bound"),
+            err.to_string().contains("Invalid read params"),
             "{}",
             err.to_string()
         );
@@ -2894,7 +2894,7 @@ mod tests {
         let indices = &[(1 << 32) - 3, (1 << 32) - 1];
         let err = ds.take_rows(indices, ds.schema()).await.unwrap_err();
         assert!(
-            err.to_string().contains("out of bound"),
+            err.to_string().contains("out of bounds"),
             "{}",
             err.to_string()
         );
@@ -2903,7 +2903,7 @@ mod tests {
         let indices = &[(1 << 32) - 1, (1 << 32) - 3];
         let err = ds.take_rows(indices, ds.schema()).await.unwrap_err();
         assert!(
-            err.to_string().contains("out of bound"),
+            err.to_string().contains("out of bounds"),
             "{}",
             err.to_string()
         );

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1355,9 +1355,8 @@ impl FragmentReader {
     ) -> Result<ReadBatchFutStream> {
         let total_num_rows = self.readers[0].0.len();
         // Note that the fragment length might be considerably smaller if there are deleted rows.
-        // E.g. if a fragment has 100 rows but rows 90..100 are deleted we still need to make
-        // sure it is valid to read / take 0..100.  This is because some index paths might take
-        // deleted rows (e.g. when doing KNN without an index)
+        // E.g. if a fragment has 100 rows but rows 0..10 are deleted we still need to make
+        // sure it is valid to read / take 0..100
         if !params.valid_given_len(total_num_rows as usize) {
             return Err(Error::invalid_input(
                 format!(

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1354,6 +1354,19 @@ impl FragmentReader {
         read_fn: impl Fn(&dyn GenericFileReader, &Arc<Schema>) -> Result<ReadBatchTaskStream>,
     ) -> Result<ReadBatchFutStream> {
         let total_num_rows = self.readers[0].0.len();
+        // Note that the fragment length might be considerably smaller if there are deleted rows.
+        // E.g. if a fragment has 100 rows but rows 90..100 are deleted we still need to make
+        // sure it is valid to read / take 0..100.  This is because some index paths might take
+        // deleted rows (e.g. when doing KNN without an index)
+        if !params.valid_given_len(total_num_rows as usize) {
+            return Err(Error::invalid_input(
+                format!(
+                    "Invalid read params {:?} for fragment with {} addressible rows",
+                    params, total_num_rows
+                ),
+                location!(),
+            ));
+        }
         // If just the row id there is no need to actually read any data
         // and we don't need to involve the readers at all.
         //
@@ -1474,15 +1487,6 @@ impl FragmentReader {
     //
     // TODO: Move away from this by changing callers to support consuming a stream
     pub async fn legacy_read_range_as_batch(&self, range: Range<usize>) -> Result<RecordBatch> {
-        if range.start >= self.num_rows || range.end > self.num_rows {
-            return Err(Error::invalid_input(
-                format!(
-                    "range {:?} is out of bounds for fragment {} with {} rows",
-                    range, self.fragment_id, self.num_rows
-                ),
-                location!(),
-            ));
-        }
         let batches = self
             .read_range(
                 range.start as u32..range.end as u32,
@@ -1662,6 +1666,35 @@ mod tests {
             batches[1].column_by_name("i").unwrap().as_ref(),
             &Int32Array::from_iter_values(100..120)
         );
+    }
+
+    #[tokio::test]
+    async fn test_out_of_range() {
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+        // Creates 400 rows in 10 fragments
+        let mut dataset = create_dataset(test_uri).await;
+        // Delete last 20 rows in first fragment
+        dataset.delete("i >= 20").await.unwrap();
+        // Last fragment has 20 rows but 40 addressible rows
+        let fragment = &dataset.get_fragments()[0];
+        assert_eq!(fragment.metadata.num_rows().unwrap(), 20);
+
+        for with_row_id in [false, true] {
+            let reader = fragment.open(fragment.schema(), with_row_id).await.unwrap();
+            for valid_range in [0..40, 20..40] {
+                reader
+                    .read_range(valid_range, 100)
+                    .unwrap()
+                    .buffered(1)
+                    .try_collect::<Vec<_>>()
+                    .await
+                    .unwrap();
+            }
+            for invalid_range in [0..41, 41..42] {
+                assert!(reader.read_range(invalid_range, 100).is_err());
+            }
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Taking row offset 100 might be valid even if a fragment only has 10 rows.  This is because that fragment might have once had 1000 rows and 990 of them were deleted.  We need to make sure we do the bounds check on the addressible range and not the materialized range.  This means that some takes might return empty / deleted (id == null) rows and this is ok.