### PR TITLE
feat: add priority to I/O scheduler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ http = "0.2.9"
 itertools = "0.12"
 lazy_static = "1"
 log = "0.4"
+mockall = { version = "0.12.1" }
 mock_instant = { version = "0.3.1", features = ["sync"] }
 moka = "0.11"
 num-traits = "0.2"

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -23,7 +23,7 @@ use lance_file::v2::{
     reader::{BufferDescriptor, CachedFileMetadata, FileReader},
     writer::{FileWriter, FileWriterOptions},
 };
-use lance_io::{scheduler::StoreScheduler, ReadBatchParams};
+use lance_io::{scheduler::ScanScheduler, ReadBatchParams};
 use object_store::path::Path;
 use pyo3::{
     exceptions::{PyIOError, PyRuntimeError, PyValueError},
@@ -267,7 +267,7 @@ impl LanceFileReader {
         let io_parallelism = std::env::var("IO_THREADS")
             .map(|val| val.parse::<u32>().unwrap_or(8))
             .unwrap_or(8);
-        let scheduler = StoreScheduler::new(Arc::new(object_store), io_parallelism);
+        let scheduler = ScanScheduler::new(Arc::new(object_store), io_parallelism);
         let file = scheduler.open_file(&path).await.infer_error()?;
         let inner = FileReader::try_open(file, None).await.infer_error()?;
         Ok(Self {

--- a/rust/lance-encoding/src/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/encodings/logical/binary.rs
@@ -47,11 +47,12 @@ impl LogicalPageScheduler for BinaryPageScheduler {
         ranges: &[std::ops::Range<u32>],
         scheduler: &Arc<dyn crate::EncodingsIo>,
         sink: &tokio::sync::mpsc::UnboundedSender<Box<dyn crate::decoder::LogicalPageDecoder>>,
+        top_level_row: u64,
     ) -> Result<()> {
         trace!("Scheduling binary for {} ranges", ranges.len());
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         self.varbin_scheduler
-            .schedule_ranges(ranges, scheduler, &tx)?;
+            .schedule_ranges(ranges, scheduler, &tx, top_level_row)?;
 
         while let Some(decoder) = rx.recv().now_or_never() {
             let wrapped = BinaryPageDecoder {
@@ -69,6 +70,7 @@ impl LogicalPageScheduler for BinaryPageScheduler {
         indices: &[u32],
         scheduler: &Arc<dyn crate::EncodingsIo>,
         sink: &tokio::sync::mpsc::UnboundedSender<Box<dyn crate::decoder::LogicalPageDecoder>>,
+        top_level_row: u64,
     ) -> Result<()> {
         trace!("Scheduling binary for {} indices", indices.len());
         self.schedule_ranges(
@@ -78,6 +80,7 @@ impl LogicalPageScheduler for BinaryPageScheduler {
                 .collect::<Vec<_>>(),
             scheduler,
             sink,
+            top_level_row,
         )
     }
 

--- a/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
@@ -53,6 +53,7 @@ impl LogicalPageScheduler for FslPageScheduler {
         ranges: &[Range<u32>],
         scheduler: &Arc<dyn EncodingsIo>,
         sink: &mpsc::UnboundedSender<Box<dyn LogicalPageDecoder>>,
+        top_level_row: u64,
     ) -> Result<()> {
         let expanded_ranges = ranges
             .iter()
@@ -64,7 +65,7 @@ impl LogicalPageScheduler for FslPageScheduler {
         );
         let (tx, mut rx) = mpsc::unbounded_channel();
         self.items_scheduler
-            .schedule_ranges(&expanded_ranges, scheduler, &tx)?;
+            .schedule_ranges(&expanded_ranges, scheduler, &tx, top_level_row)?;
         let inner_page_decoder = rx.blocking_recv().unwrap();
         sink.send(Box::new(FslPageDecoder {
             inner: inner_page_decoder,
@@ -79,6 +80,7 @@ impl LogicalPageScheduler for FslPageScheduler {
         indices: &[u32],
         scheduler: &Arc<dyn EncodingsIo>,
         sink: &mpsc::UnboundedSender<Box<dyn LogicalPageDecoder>>,
+        top_level_row: u64,
     ) -> Result<()> {
         self.schedule_ranges(
             &indices
@@ -87,6 +89,7 @@ impl LogicalPageScheduler for FslPageScheduler {
                 .collect::<Vec<_>>(),
             scheduler,
             sink,
+            top_level_row,
         )
     }
 

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -80,12 +80,13 @@ impl LogicalPageScheduler for PrimitivePageScheduler {
         ranges: &[std::ops::Range<u32>],
         scheduler: &Arc<dyn EncodingsIo>,
         sink: &mpsc::UnboundedSender<Box<dyn LogicalPageDecoder>>,
+        top_level_row: u64,
     ) -> Result<()> {
         let num_rows = ranges.iter().map(|r| r.end - r.start).sum();
         trace!("Scheduling ranges {:?} from physical page", ranges);
-        let physical_decoder = self
-            .physical_decoder
-            .schedule_ranges(ranges, scheduler.as_ref());
+        let physical_decoder =
+            self.physical_decoder
+                .schedule_ranges(ranges, scheduler.as_ref(), top_level_row);
 
         let logical_decoder = PrimitiveFieldDecoder {
             data_type: self.data_type.clone(),
@@ -104,6 +105,7 @@ impl LogicalPageScheduler for PrimitivePageScheduler {
         indices: &[u32],
         scheduler: &Arc<dyn EncodingsIo>,
         sink: &mpsc::UnboundedSender<Box<dyn LogicalPageDecoder>>,
+        top_level_row: u64,
     ) -> Result<()> {
         trace!(
             "Scheduling take of {} indices from physical page",
@@ -116,6 +118,7 @@ impl LogicalPageScheduler for PrimitivePageScheduler {
                 .collect::<Vec<_>>(),
             scheduler,
             sink,
+            top_level_row,
         )
     }
 }

--- a/rust/lance-encoding/src/encodings/physical/bitmap.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitmap.rs
@@ -35,6 +35,7 @@ impl PhysicalPageScheduler for DenseBitmapScheduler {
         &self,
         ranges: &[Range<u32>],
         scheduler: &dyn EncodingsIo,
+        top_level_row: u64,
     ) -> BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>> {
         let mut min = u64::MAX;
         let mut max = 0;
@@ -62,7 +63,7 @@ impl PhysicalPageScheduler for DenseBitmapScheduler {
             min,
             max
         );
-        let bytes = scheduler.submit_request(byte_ranges);
+        let bytes = scheduler.submit_request(byte_ranges, top_level_row);
 
         async move {
             let bytes = bytes.await?;

--- a/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
@@ -36,6 +36,7 @@ impl PhysicalPageScheduler for FixedListScheduler {
         &self,
         ranges: &[std::ops::Range<u32>],
         scheduler: &dyn EncodingsIo,
+        top_level_row: u64,
     ) -> BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>> {
         let expanded_ranges = ranges
             .iter()
@@ -49,9 +50,9 @@ impl PhysicalPageScheduler for FixedListScheduler {
             expanded_ranges[0].start,
             expanded_ranges[expanded_ranges.len() - 1].end
         );
-        let inner_page_decoder = self
-            .items_scheduler
-            .schedule_ranges(&expanded_ranges, scheduler);
+        let inner_page_decoder =
+            self.items_scheduler
+                .schedule_ranges(&expanded_ranges, scheduler, top_level_row);
         let dimension = self.dimension;
         async move {
             let items_decoder = inner_page_decoder.await?;

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -43,6 +43,7 @@ impl PhysicalPageScheduler for ValuePageScheduler {
         &self,
         ranges: &[std::ops::Range<u32>],
         scheduler: &dyn EncodingsIo,
+        top_level_row: u64,
     ) -> BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>> {
         let mut min = u64::MAX;
         let mut max = 0;
@@ -63,7 +64,7 @@ impl PhysicalPageScheduler for ValuePageScheduler {
             min,
             max
         );
-        let bytes = scheduler.submit_request(byte_ranges);
+        let bytes = scheduler.submit_request(byte_ranges, top_level_row);
         let bytes_per_value = self.bytes_per_value;
 
         async move {

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -45,7 +45,11 @@ impl SimulatedScheduler {
 }
 
 impl EncodingsIo for SimulatedScheduler {
-    fn submit_request(&self, ranges: Vec<Range<u64>>) -> BoxFuture<'static, Result<Vec<Bytes>>> {
+    fn submit_request(
+        &self,
+        ranges: Vec<Range<u64>>,
+        _priority: u64,
+    ) -> BoxFuture<'static, Result<Vec<Bytes>>> {
         std::future::ready(Ok(ranges
             .into_iter()
             .map(|range| self.satisfy_request(range))

--- a/rust/lance-file/benches/reader.rs
+++ b/rust/lance-file/benches/reader.rs
@@ -9,7 +9,7 @@ use lance_file::v2::{
     reader::FileReader,
     writer::{FileWriter, FileWriterOptions},
 };
-use lance_io::{object_store::ObjectStore, scheduler::StoreScheduler};
+use lance_io::{object_store::ObjectStore, scheduler::ScanScheduler};
 
 fn bench_reader(c: &mut Criterion) {
     let mut group = c.benchmark_group("reader");
@@ -44,7 +44,7 @@ fn bench_reader(c: &mut Criterion) {
             let file_path = &file_path;
             let data = &data;
             rt.block_on(async move {
-                let store_scheduler = StoreScheduler::new(Arc::new(object_store.clone()), 8);
+                let store_scheduler = ScanScheduler::new(Arc::new(object_store.clone()), 8);
                 let scheduler = store_scheduler.open_file(file_path).await.unwrap();
                 let reader = FileReader::try_open(scheduler.clone(), None).await.unwrap();
                 let mut stream = reader

--- a/rust/lance-file/src/v2/io.rs
+++ b/rust/lance-file/src/v2/io.rs
@@ -12,7 +12,8 @@ impl EncodingsIo for LanceEncodingsIo {
     fn submit_request(
         &self,
         range: Vec<std::ops::Range<u64>>,
+        priority: u64,
     ) -> BoxFuture<'static, lance_core::Result<Vec<bytes::Bytes>>> {
-        self.0.submit_request(range).boxed()
+        self.0.submit_request(range, priority).boxed()
     }
 }

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -37,18 +37,19 @@ pin-project.workspace = true
 prost.workspace = true
 shellexpand.workspace = true
 snafu.workspace = true
-tokio-stream.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 path_abs.workspace = true
 rand.workspace = true
+async-priority-channel = "0.2.0"
 
 [dev-dependencies]
 criterion.workspace = true
 parquet.workspace = true
 pprof.workspace = true
 tempfile.workspace = true
+mockall.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true

--- a/rust/lance-io/src/lib.rs
+++ b/rust/lance-io/src/lib.rs
@@ -16,6 +16,8 @@ pub mod object_store;
 pub mod object_writer;
 pub mod scheduler;
 pub mod stream;
+#[cfg(test)]
+pub mod testing;
 pub mod traits;
 pub mod utils;
 

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -364,8 +364,7 @@ mod tests {
                 let location = location.clone();
                 async move {
                     semaphore.acquire().await.unwrap().forget();
-                    let res = base_store.get_opts(&location, options).await;
-                    res
+                    base_store.get_opts(&location, options).await
                 }
                 .boxed()
             });

--- a/rust/lance-io/src/testing.rs
+++ b/rust/lance-io/src/testing.rs
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
 use std::fmt::{self, Display, Formatter};
 
 use async_trait::async_trait;

--- a/rust/lance-io/src/testing.rs
+++ b/rust/lance-io/src/testing.rs
@@ -1,0 +1,51 @@
+use std::fmt::{self, Display, Formatter};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use mockall::mock;
+use object_store::{
+    path::Path, GetOptions, GetResult, ListResult, MultipartId, ObjectMeta,
+    ObjectStore as OSObjectStore, PutOptions, PutResult, Result as OSResult,
+};
+use std::future::Future;
+use tokio::io::AsyncWrite;
+
+mock! {
+    pub ObjectStore {}
+
+    #[async_trait]
+    impl OSObjectStore for ObjectStore {
+        async fn put_opts(&self, location: &Path, bytes: Bytes, opts: PutOptions) -> OSResult<PutResult>;
+        async fn put_multipart(
+            &self,
+            location: &Path,
+        ) -> OSResult<(MultipartId, Box<dyn AsyncWrite + Unpin + Send>)>;
+        async fn abort_multipart(&self, location: &Path, multipart_id: &MultipartId) -> OSResult<()>;
+        fn get_opts<'life0, 'life1, 'async_trait>(
+            &'life0 self,
+            location: &'life1 Path,
+            options: GetOptions
+        ) -> std::pin::Pin<Box<dyn Future<Output=OSResult<GetResult> > +Send+'async_trait> > where
+        Self: 'async_trait,
+        'life0: 'async_trait,
+        'life1: 'async_trait;
+        async fn delete(&self, location: &Path) -> OSResult<()>;
+        fn list<'a>(&'a self, prefix: Option<&'a Path>) -> BoxStream<'_, OSResult<ObjectMeta>>;
+        async fn list_with_delimiter<'a, 'b>(&'a self, prefix: Option<&'b Path>) -> OSResult<ListResult>;
+        async fn copy(&self, from: &Path, to: &Path) -> OSResult<()>;
+        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()>;
+    }
+}
+
+impl std::fmt::Debug for MockObjectStore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "MockObjectStore")
+    }
+}
+
+impl Display for MockObjectStore {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "MockObjectStore")
+    }
+}

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -26,7 +26,7 @@ use lance_file::reader::{read_batch, FileReader};
 use lance_file::v2;
 use lance_file::v2::reader::ReaderProjection;
 use lance_io::object_store::ObjectStore;
-use lance_io::scheduler::StoreScheduler;
+use lance_io::scheduler::ScanScheduler;
 use lance_io::ReadBatchParams;
 use lance_table::format::{DataFile, DeletionFile, Fragment};
 use lance_table::io::deletion::{deletion_file_path, read_deletion_file, write_deletion_file};
@@ -457,7 +457,7 @@ impl FileFragment {
             Ok(None)
         } else {
             let path = self.dataset.data_dir().child(data_file.path.as_str());
-            let store_scheduler = StoreScheduler::new(self.dataset.object_store.clone(), 16);
+            let store_scheduler = ScanScheduler::new(self.dataset.object_store.clone(), 16);
             let file_scheduler = store_scheduler.open_file(&path).await?;
             let reader = Arc::new(v2::reader::FileReader::try_open(file_scheduler, None).await?);
             let field_id_to_column_idx = Arc::new(BTreeMap::from_iter(


### PR DESCRIPTION
This also renames store scheduler to scan scheduler.  I'm thinking I don't want to get into the thorny issue of how to prioritize I/O requests across different scans.  So, with this approach, if multiple scans are running at the same time, then they will overschedule (and let the OS deal with it).  This can be revisited in the future.

Closes #1958 