### PR TITLE
chore: remove type restriction from ArrowFloatType over distance traits

### DIFF
--- a/rust/lance-index/src/vector/ivf.rs
+++ b/rust/lance-index/src/vector/ivf.rs
@@ -111,7 +111,7 @@ fn new_ivf_with_pq_impl<T: ArrowFloatType + ArrowPrimitiveType>(
     range: Option<Range<u32>>,
 ) -> Arc<dyn Ivf>
 where
-    <T as ArrowFloatType>::Native: Dot + L2,
+    <T as ArrowFloatType>::Native: Dot + L2 + Normalize,
 {
     let mat = MatrixView::<T>::new(Arc::new(centroids.clone()), dimension);
     Arc::new(IvfImpl::<T>::new_with_pq(

--- a/rust/lance-index/src/vector/ivf/transform.rs
+++ b/rust/lance-index/src/vector/ivf/transform.rs
@@ -6,8 +6,9 @@
 use std::ops::Range;
 use std::sync::Arc;
 
+use arrow::datatypes::ArrowPrimitiveType;
 use arrow_array::types::UInt32Type;
-use arrow_array::{cast::AsArray, Array, ArrowPrimitiveType, RecordBatch, UInt32Array};
+use arrow_array::{cast::AsArray, Array, RecordBatch, UInt32Array};
 use arrow_schema::Field;
 use futures::{stream, StreamExt};
 use log::info;
@@ -115,9 +116,9 @@ where
 }
 
 #[async_trait::async_trait]
-impl<T: ArrowFloatType> Transformer for IvfTransformer<T>
+impl<T: ArrowFloatType + ArrowPrimitiveType> Transformer for IvfTransformer<T>
 where
-    T::Native: Dot + L2 + Normalize,
+    <T as ArrowFloatType>::Native: Dot + L2 + Normalize,
 {
     async fn transform(&self, batch: &RecordBatch) -> Result<RecordBatch> {
         if batch.column_by_name(&self.output_column).is_some() {

--- a/rust/lance-index/src/vector/ivf/transformer.rs
+++ b/rust/lance-index/src/vector/ivf/transformer.rs
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: Copyright The Lance Authors
-
-//! IVF Transformer
-//!
-//! It transforms a column of vectors into a column of IVF

--- a/rust/lance-index/src/vector/kmeans.rs
+++ b/rust/lance-index/src/vector/kmeans.rs
@@ -10,13 +10,13 @@ use std::sync::Arc;
 
 use lance_core::{Error, Result};
 use lance_linalg::{
-    distance::{Dot, MetricType, L2},
+    distance::{Dot, MetricType, Normalize, L2},
     kmeans::{KMeans, KMeansParams},
 };
 
 /// Train KMeans model and returns the centroids of each cluster.
 #[allow(clippy::too_many_arguments)]
-pub async fn train_kmeans<T: ArrowFloatType + Dot + L2>(
+pub async fn train_kmeans<T: ArrowFloatType>(
     array: &T::ArrayType,
     centroids: Option<Arc<T::ArrayType>>,
     dimension: usize,
@@ -26,7 +26,10 @@ pub async fn train_kmeans<T: ArrowFloatType + Dot + L2>(
     mut rng: impl Rng,
     metric_type: MetricType,
     sample_rate: usize,
-) -> Result<T::ArrayType> {
+) -> Result<T::ArrayType>
+where
+    T::Native: Dot + L2 + Normalize,
+{
     let num_rows = array.len() / dimension;
     if num_rows < k {
         return Err(Error::Index{message: format!(

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -58,7 +58,10 @@ pub trait ProductQuantizer: Send + Sync + std::fmt::Debug {
 //
 // TODO: move this to be pub(crate) once we have a better way to test it.
 #[derive(Debug, Clone)]
-pub struct ProductQuantizerImpl<T: ArrowFloatType + Dot + L2> {
+pub struct ProductQuantizerImpl<T: ArrowFloatType>
+where
+    T::Native: Dot + L2,
+{
     /// Number of bits for the centroids.
     ///
     /// Only support 8, as one of `u8` byte now.
@@ -93,7 +96,10 @@ pub struct ProductQuantizerImpl<T: ArrowFloatType + Dot + L2> {
     pub codebook: Arc<T::ArrayType>,
 }
 
-impl<T: ArrowFloatType + Dot + L2> ProductQuantizerImpl<T> {
+impl<T: ArrowFloatType> ProductQuantizerImpl<T>
+where
+    T::Native: Dot + L2,
+{
     /// Create a [`ProductQuantizer`] with pre-trained codebook.
     pub fn new(
         m: usize,
@@ -305,7 +311,10 @@ impl<T: ArrowFloatType + Dot + L2> ProductQuantizerImpl<T> {
 }
 
 #[async_trait]
-impl<T: ArrowFloatType + Dot + L2 + 'static> ProductQuantizer for ProductQuantizerImpl<T> {
+impl<T: ArrowFloatType + 'static> ProductQuantizer for ProductQuantizerImpl<T>
+where
+    T::Native: Dot + L2,
+{
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -3,7 +3,6 @@
 
 use std::cmp::min;
 
-use lance_arrow::FloatToArrayType;
 use lance_linalg::distance::{l2_distance_batch, L2};
 
 use super::{num_centroids, utils::get_sub_vector_centroids};

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -10,15 +10,12 @@ use super::{num_centroids, utils::get_sub_vector_centroids};
 
 /// Build a Distance Table from the query to each PQ centroid
 /// using L2 distance.
-pub(super) fn build_distance_table_l2<T: FloatToArrayType>(
+pub(super) fn build_distance_table_l2<T: L2>(
     codebook: &[T],
     num_bits: u32,
     num_sub_vectors: usize,
     query: &[T],
-) -> Vec<f32>
-where
-    T::ArrowType: L2,
-{
+) -> Vec<f32> {
     let dimension = query.len();
 
     let sub_vector_length = dimension / num_sub_vectors;

--- a/rust/lance-index/src/vector/pq/utils.rs
+++ b/rust/lance-index/src/vector/pq/utils.rs
@@ -54,7 +54,7 @@ pub fn num_centroids(num_bits: impl Into<u32>) -> usize {
     2_usize.pow(num_bits.into())
 }
 
-pub fn get_sub_vector_centroids<T: FloatToArrayType>(
+pub fn get_sub_vector_centroids<T>(
     codebook: &[T],
     dimension: usize,
     num_bits: impl Into<u32>,

--- a/rust/lance-index/src/vector/pq/utils.rs
+++ b/rust/lance-index/src/vector/pq/utils.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use lance_arrow::{ArrowFloatType, FloatToArrayType};
+use lance_arrow::ArrowFloatType;
 use lance_core::{Error, Result};
 use lance_linalg::MatrixView;
 use snafu::{location, Location};

--- a/rust/lance-index/src/vector/quantizer.rs
+++ b/rust/lance-index/src/vector/quantizer.rs
@@ -234,7 +234,10 @@ impl Quantization for dyn ProductQuantizer {
     }
 }
 
-impl<T: ArrowFloatType + Dot + L2 + 'static> Quantization for ProductQuantizerImpl<T> {
+impl<T: ArrowFloatType + 'static> Quantization for ProductQuantizerImpl<T>
+where
+    T::Native: Dot + L2,
+{
     type Metadata = ProductQuantizationMetadata;
     type Storage = ProductQuantizationStorage;
 

--- a/rust/lance-linalg/benches/cosine.rs
+++ b/rust/lance-linalg/benches/cosine.rs
@@ -32,7 +32,10 @@ fn cosine_scalar<T: Float>(x: &[T], y: &[T], dim: usize) -> Vec<T> {
         .collect()
 }
 
-fn run_bench<T: Cosine>(c: &mut Criterion) {
+fn run_bench<T: ArrowFloatType>(c: &mut Criterion)
+where
+    T::Native: Cosine,
+{
     const DIMENSION: usize = 1024;
     const TOTAL: usize = 1024 * 1024; // 1M vectors
 
@@ -51,7 +54,7 @@ fn run_bench<T: Cosine>(c: &mut Criterion) {
         |b| {
             b.iter(|| {
                 black_box(
-                    cosine_distance_batch::<T>(key.as_slice(), target.as_slice(), DIMENSION)
+                    cosine_distance_batch(key.as_slice(), target.as_slice(), DIMENSION)
                         .collect::<Vec<_>>(),
                 );
             })

--- a/rust/lance-linalg/benches/cosine.rs
+++ b/rust/lance-linalg/benches/cosine.rs
@@ -32,7 +32,7 @@ fn cosine_scalar<T: Float>(x: &[T], y: &[T], dim: usize) -> Vec<T> {
         .collect()
 }
 
-fn run_bench<T: ArrowFloatType + Cosine>(c: &mut Criterion) {
+fn run_bench<T: Cosine>(c: &mut Criterion) {
     const DIMENSION: usize = 1024;
     const TOTAL: usize = 1024 * 1024; // 1M vectors
 
@@ -51,12 +51,8 @@ fn run_bench<T: ArrowFloatType + Cosine>(c: &mut Criterion) {
         |b| {
             b.iter(|| {
                 black_box(
-                    cosine_distance_batch::<T::Native>(
-                        key.as_slice(),
-                        target.as_slice(),
-                        DIMENSION,
-                    )
-                    .collect::<Vec<_>>(),
+                    cosine_distance_batch::<T>(key.as_slice(), target.as_slice(), DIMENSION)
+                        .collect::<Vec<_>>(),
                 );
             })
         },

--- a/rust/lance-linalg/benches/dot.rs
+++ b/rust/lance-linalg/benches/dot.rs
@@ -25,7 +25,10 @@ fn dot_scalar<T: Float + Sum>(x: &[T], y: &[T]) -> T {
     x.iter().zip(y.iter()).map(|(&xi, &yi)| xi * yi).sum::<T>()
 }
 
-fn run_bench<T: ArrowFloatType + Dot>(c: &mut Criterion) {
+fn run_bench<T: ArrowFloatType>(c: &mut Criterion)
+where
+    T::Native: Dot,
+{
     const DIMENSION: usize = 1024;
     const TOTAL: usize = 1024 * 1024; // 1M vectors
 
@@ -113,7 +116,7 @@ fn bench_distance(c: &mut Criterion) {
             let x = key.values().as_ref();
             Float32Array::from_trusted_len_iter((0..target.len() / DIMENSION).map(|idx| {
                 let y = target.values()[idx * DIMENSION..(idx + 1) * DIMENSION].as_ref();
-                Some(Float32Type::dot(x, y))
+                Some(f32::dot(x, y))
             }))
         });
     });

--- a/rust/lance-linalg/benches/l2.rs
+++ b/rust/lance-linalg/benches/l2.rs
@@ -30,7 +30,10 @@ fn l2_scalar<T: Float + AsPrimitive<f32>>(x: &[T], y: &[T]) -> T {
     sum.sqrt()
 }
 
-fn run_bench<T: ArrowFloatType + L2>(c: &mut Criterion) {
+fn run_bench<T: ArrowFloatType>(c: &mut Criterion)
+where
+    T::Native: L2,
+{
     const DIMENSION: usize = 1024;
     const TOTAL: usize = 1024 * 1024; // 1M vectors
 

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -59,9 +59,9 @@ impl DistanceType {
     }
 
     /// Returns the distance function between two vectors.
-    pub fn func<T: FloatToArrayType>(&self) -> DistanceFunc<T>
+    pub fn func<T: FloatToArrayType + L2>(&self) -> DistanceFunc<T>
     where
-        T::ArrowType: L2 + Cosine + Dot,
+        T::ArrowType: Cosine + Dot,
     {
         match self {
             Self::L2 => l2,

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -22,7 +22,6 @@ pub mod norm_l2;
 pub use cosine::*;
 pub use dot::*;
 pub use l2::*;
-use lance_arrow::FloatToArrayType;
 pub use norm_l2::*;
 
 use crate::Result;
@@ -59,10 +58,7 @@ impl DistanceType {
     }
 
     /// Returns the distance function between two vectors.
-    pub fn func<T: FloatToArrayType + L2>(&self) -> DistanceFunc<T>
-    where
-        T::ArrowType: Cosine + Dot,
-    {
+    pub fn func<T: L2 + Cosine + Dot>(&self) -> DistanceFunc<T> {
         match self {
             Self::L2 => l2,
             Self::Cosine => cosine_distance,

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -84,7 +84,7 @@ mod kernel {
 }
 
 impl Cosine for f16 {
-    fn cosine_fast(x: &[f16], x_norm: f32, y: &[f16]) -> f32 {
+    fn cosine_fast(x: &[Self], x_norm: f32, y: &[Self]) -> f32 {
         match *FP16_SIMD_SUPPORT {
             #[cfg(all(feature = "fp16kernels", target_arch = "aarch64"))]
             SimdSupport::Neon => unsafe {
@@ -128,7 +128,7 @@ mod f32 {
 
 impl Cosine for f32 {
     #[inline]
-    fn cosine_fast(x: &[f32], x_norm: f32, other: &[f32]) -> f32 {
+    fn cosine_fast(x: &[Self], x_norm: Self, other: &[Self]) -> f32 {
         let dim = x.len();
         let unrolled_len = dim / 16 * 16;
         let mut y_norm16 = f32x16::zeros();
@@ -160,7 +160,7 @@ impl Cosine for f32 {
     }
 
     #[inline]
-    fn cosine_with_norms(x: &[f32], x_norm: f32, y_norm: f32, y: &[f32]) -> Self {
+    fn cosine_with_norms(x: &[Self], x_norm: Self, y_norm: Self, y: &[Self]) -> Self {
         let dim = x.len();
         let unrolled_len = dim / 16 * 16;
         let mut xy16 = f32x16::zeros();

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -80,8 +80,8 @@ pub trait Dot: Num {
 
 impl Dot for bf16 {
     #[inline]
-    fn dot(x: &[bf16], y: &[bf16]) -> f32 {
-        dot_scalar::<bf16, f32, 32>(x, y)
+    fn dot(x: &[Self], y: &[Self]) -> f32 {
+        dot_scalar::<Self, f32, 32>(x, y)
     }
 }
 
@@ -103,7 +103,7 @@ mod kernel {
 
 impl Dot for f16 {
     #[inline]
-    fn dot(x: &[f16], y: &[f16]) -> f32 {
+    fn dot(x: &[Self], y: &[Self]) -> f32 {
         match *FP16_SIMD_SUPPORT {
             #[cfg(all(feature = "fp16kernels", target_arch = "aarch64"))]
             SimdSupport::Neon => unsafe {
@@ -121,14 +121,14 @@ impl Dot for f16 {
             SimdSupport::Avx2 => unsafe {
                 kernel::dot_f16_avx2(x.as_ptr(), y.as_ptr(), x.len() as u32)
             },
-            _ => dot_scalar::<f16, f32, 16>(x, y),
+            _ => dot_scalar::<Self, f32, 16>(x, y),
         }
     }
 }
 
 impl Dot for f32 {
     #[inline]
-    fn dot(x: &[f32], y: &[f32]) -> f32 {
+    fn dot(x: &[Self], y: &[Self]) -> f32 {
         // Manually unrolled 8 times to get enough registers.
         // TODO: avx512 can unroll more
         let x_unrolled_chunks = x.chunks_exact(64);
@@ -184,8 +184,8 @@ impl Dot for f32 {
 
 impl Dot for f64 {
     #[inline]
-    fn dot(x: &[f64], y: &[f64]) -> f32 {
-        dot_scalar::<f64, f64, 8>(x, y) as f32
+    fn dot(x: &[Self], y: &[Self]) -> f32 {
+        dot_scalar::<Self, Self, 8>(x, y) as f32
     }
 }
 

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -4,7 +4,7 @@
 //! Dot product.
 
 use std::iter::Sum;
-use std::ops::{AddAssign, Neg};
+use std::ops::AddAssign;
 use std::sync::Arc;
 
 use crate::Error;
@@ -12,13 +12,11 @@ use arrow_array::types::{Float16Type, Float64Type};
 use arrow_array::{cast::AsArray, types::Float32Type, Array, FixedSizeListArray, Float32Array};
 use arrow_schema::DataType;
 use half::{bf16, f16};
-use lance_arrow::bfloat16::BFloat16Type;
-use lance_arrow::{ArrowFloatType, FloatArray, FloatToArrayType};
+use lance_arrow::{ArrowFloatType, FloatArray};
 #[cfg(feature = "fp16kernels")]
 use lance_core::utils::cpu::SimdSupport;
 use lance_core::utils::cpu::FP16_SIMD_SUPPORT;
-use num_traits::real::Real;
-use num_traits::AsPrimitive;
+use num_traits::{real::Real, AsPrimitive, Num};
 
 use crate::simd::{
     f32::{f32x16, f32x8},
@@ -64,29 +62,23 @@ fn dot_scalar<
 
 /// Dot product.
 #[inline]
-pub fn dot<T: FloatToArrayType + Neg<Output = T>>(from: &[T], to: &[T]) -> f32
-where
-    T::ArrowType: Dot,
-{
-    T::ArrowType::dot(from, to)
+pub fn dot<T: Dot>(from: &[T], to: &[T]) -> f32 {
+    T::dot(from, to)
 }
 
 /// Negative dot distance.
 #[inline]
-pub fn dot_distance<T: FloatToArrayType + Neg<Output = T>>(from: &[T], to: &[T]) -> f32
-where
-    T::ArrowType: Dot,
-{
-    T::ArrowType::dot(from, to).neg()
+pub fn dot_distance<T: Dot>(from: &[T], to: &[T]) -> f32 {
+    -T::dot(from, to)
 }
 
 /// Dot product
-pub trait Dot: ArrowFloatType {
+pub trait Dot: Num {
     /// Dot product.
-    fn dot(x: &[Self::Native], y: &[Self::Native]) -> f32;
+    fn dot(x: &[Self], y: &[Self]) -> f32;
 }
 
-impl Dot for BFloat16Type {
+impl Dot for bf16 {
     #[inline]
     fn dot(x: &[bf16], y: &[bf16]) -> f32 {
         dot_scalar::<bf16, f32, 32>(x, y)
@@ -109,7 +101,7 @@ mod kernel {
     }
 }
 
-impl Dot for Float16Type {
+impl Dot for f16 {
     #[inline]
     fn dot(x: &[f16], y: &[f16]) -> f32 {
         match *FP16_SIMD_SUPPORT {
@@ -134,7 +126,7 @@ impl Dot for Float16Type {
     }
 }
 
-impl Dot for Float32Type {
+impl Dot for f32 {
     #[inline]
     fn dot(x: &[f32], y: &[f32]) -> f32 {
         // Manually unrolled 8 times to get enough registers.
@@ -190,7 +182,7 @@ impl Dot for Float32Type {
     }
 }
 
-impl Dot for Float64Type {
+impl Dot for f64 {
     #[inline]
     fn dot(x: &[f64], y: &[f64]) -> f32 {
         dot_scalar::<f64, f64, 8>(x, y) as f32
@@ -198,23 +190,23 @@ impl Dot for Float64Type {
 }
 
 /// Negative dot product, to present the relative order of dot distance.
-pub fn dot_distance_batch<'a, T: FloatToArrayType>(
+pub fn dot_distance_batch<'a, T: Dot>(
     from: &'a [T],
     to: &'a [T],
     dimension: usize,
-) -> Box<dyn Iterator<Item = f32> + 'a>
-where
-    T::ArrowType: Dot,
-{
+) -> Box<dyn Iterator<Item = f32> + 'a> {
     debug_assert_eq!(from.len(), dimension);
     debug_assert_eq!(to.len() % dimension, 0);
     Box::new(to.chunks_exact(dimension).map(|v| dot_distance(from, v)))
 }
 
-fn do_dot_distance_arrow_batch<T: ArrowFloatType + Dot>(
+fn do_dot_distance_arrow_batch<T: ArrowFloatType>(
     from: &T::ArrayType,
     to: &FixedSizeListArray,
-) -> Result<Arc<Float32Array>> {
+) -> Result<Arc<Float32Array>>
+where
+    T::Native: Dot,
+{
     let dimension = to.value_length() as usize;
     debug_assert_eq!(from.len(), dimension);
 
@@ -285,20 +277,20 @@ mod tests {
         let x: Vec<f32> = (0..20).map(|v| v as f32).collect();
         let y: Vec<f32> = (100..120).map(|v| v as f32).collect();
 
-        assert_eq!(Float32Type::dot(&x, &y), dot(&x, &y));
+        assert_eq!(f32::dot(&x, &y), dot(&x, &y));
 
         let x: Vec<f32> = (0..512).map(|v| v as f32).collect();
         let y: Vec<f32> = (100..612).map(|v| v as f32).collect();
 
-        assert_eq!(Float32Type::dot(&x, &y), dot(&x, &y));
+        assert_eq!(f32::dot(&x, &y), dot(&x, &y));
 
         let x: Vec<f16> = (0..20).map(|v| f16::from_i32(v).unwrap()).collect();
         let y: Vec<f16> = (100..120).map(|v| f16::from_i32(v).unwrap()).collect();
-        assert_eq!(Float16Type::dot(&x, &y), dot(&x, &y));
+        assert_eq!(f16::dot(&x, &y), dot(&x, &y));
 
         let x: Vec<f64> = (20..40).map(|v| f64::from_i32(v).unwrap()).collect();
         let y: Vec<f64> = (120..140).map(|v| f64::from_i32(v).unwrap()).collect();
-        assert_eq!(Float64Type::dot(&x, &y), dot(&x, &y));
+        assert_eq!(f64::dot(&x, &y), dot(&x, &y));
     }
 
     /// Reference implementation of dot product.
@@ -325,10 +317,10 @@ mod tests {
         (2.0 * T::epsilon().as_() * dot) as f32
     }
 
-    fn do_dot_test<T: FloatToArrayType>(x: &[T], y: &[T]) -> std::result::Result<(), TestCaseError>
-    where
-        T::ArrowType: Dot,
-    {
+    fn do_dot_test<T: Dot + AsPrimitive<f64> + Float>(
+        x: &[T],
+        y: &[T],
+    ) -> std::result::Result<(), TestCaseError> {
         let f64_x = x.iter().map(|&v| v.as_()).collect::<Vec<f64>>();
         let f64_y = y.iter().map(|&v| v.as_()).collect::<Vec<f64>>();
 

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -100,9 +100,9 @@ pub fn l2_scalar<
 
 impl L2 for bf16 {
     #[inline]
-    fn l2(x: &[bf16], y: &[bf16]) -> f32 {
+    fn l2(x: &[Self], y: &[Self]) -> f32 {
         // TODO: add SIMD support
-        l2_scalar::<bf16, f32, 16>(x, y)
+        l2_scalar::<Self, f32, 16>(x, y)
     }
 }
 
@@ -124,7 +124,7 @@ mod kernel {
 
 impl L2 for f16 {
     #[inline]
-    fn l2(x: &[f16], y: &[f16]) -> f32 {
+    fn l2(x: &[Self], y: &[Self]) -> f32 {
         match *FP16_SIMD_SUPPORT {
             #[cfg(all(feature = "fp16kernels", target_arch = "aarch64"))]
             SimdSupport::Neon => unsafe {
@@ -142,20 +142,20 @@ impl L2 for f16 {
             SimdSupport::Avx2 => unsafe {
                 kernel::l2_f16_avx2(x.as_ptr(), y.as_ptr(), x.len() as u32)
             },
-            _ => l2_scalar::<f16, f32, 16>(x, y),
+            _ => l2_scalar::<Self, f32, 16>(x, y),
         }
     }
 }
 
 impl L2 for f32 {
     #[inline]
-    fn l2(x: &[f32], y: &[f32]) -> f32 {
-        l2_scalar::<f32, f32, 32>(x, y)
+    fn l2(x: &[Self], y: &[Self]) -> f32 {
+        l2_scalar::<Self, Self, 32>(x, y)
     }
 
     fn l2_batch<'a>(
-        x: &'a [f32],
-        y: &'a [f32],
+        x: &'a [Self],
+        y: &'a [Self],
         dimension: usize,
     ) -> Box<dyn Iterator<Item = f32> + 'a> {
         use self::f32::l2_once;
@@ -176,10 +176,8 @@ impl L2 for f32 {
 
 impl L2 for f64 {
     #[inline]
-    fn l2(x: &[f64], y: &[f64]) -> f32 {
-        // TODO: add SIMD support
-        // TODO: should we let this return f64 to avoid overflow?
-        l2_scalar::<f64, f64, 8>(x, y) as f32
+    fn l2(x: &[Self], y: &[Self]) -> f32 {
+        l2_scalar::<Self, Self, 8>(x, y) as f32
     }
 }
 

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -15,11 +15,11 @@ use arrow_array::{
 };
 use arrow_schema::DataType;
 use half::{bf16, f16};
-use lance_arrow::{bfloat16::BFloat16Type, ArrowFloatType, FloatArray, FloatToArrayType};
+use lance_arrow::{ArrowFloatType, FloatArray};
 #[cfg(feature = "fp16kernels")]
 use lance_core::utils::cpu::SimdSupport;
 use lance_core::utils::cpu::FP16_SIMD_SUPPORT;
-use num_traits::{AsPrimitive, Float};
+use num_traits::{AsPrimitive, Float, Num};
 
 use crate::simd::{
     f32::{f32x16, f32x8},
@@ -27,17 +27,15 @@ use crate::simd::{
 };
 use crate::{Error, Result};
 
-use super::Normalize;
-
 /// Calculate the L2 distance between two vectors.
 ///
-pub trait L2: ArrowFloatType + Normalize {
+pub trait L2: Num {
     /// Calculate the L2 distance between two vectors.
-    fn l2(x: &[Self::Native], y: &[Self::Native]) -> f32;
+    fn l2(x: &[Self], y: &[Self]) -> f32;
 
     fn l2_batch<'a>(
-        x: &'a [Self::Native],
-        y: &'a [Self::Native],
+        x: &'a [Self],
+        y: &'a [Self],
         dimension: usize,
     ) -> Box<dyn Iterator<Item = f32> + 'a> {
         Box::new(y.chunks_exact(dimension).map(|v| Self::l2(x, v)))
@@ -45,11 +43,8 @@ pub trait L2: ArrowFloatType + Normalize {
 }
 
 #[inline]
-pub fn l2<T: FloatToArrayType>(from: &[T], to: &[T]) -> f32
-where
-    T::ArrowType: L2,
-{
-    T::ArrowType::l2(from, to)
+pub fn l2<T: L2>(from: &[T], to: &[T]) -> f32 {
+    T::l2(from, to)
 }
 
 /// Calculate L2 distance between two uint8 slices.
@@ -103,7 +98,7 @@ pub fn l2_scalar<
     s + sums.iter().copied().sum()
 }
 
-impl L2 for BFloat16Type {
+impl L2 for bf16 {
     #[inline]
     fn l2(x: &[bf16], y: &[bf16]) -> f32 {
         // TODO: add SIMD support
@@ -127,7 +122,7 @@ mod kernel {
     }
 }
 
-impl L2 for Float16Type {
+impl L2 for f16 {
     #[inline]
     fn l2(x: &[f16], y: &[f16]) -> f32 {
         match *FP16_SIMD_SUPPORT {
@@ -152,17 +147,17 @@ impl L2 for Float16Type {
     }
 }
 
-impl L2 for Float32Type {
+impl L2 for f32 {
     #[inline]
     fn l2(x: &[f32], y: &[f32]) -> f32 {
         l2_scalar::<f32, f32, 32>(x, y)
     }
 
     fn l2_batch<'a>(
-        x: &'a [Self::Native],
-        y: &'a [Self::Native],
+        x: &'a [f32],
+        y: &'a [f32],
         dimension: usize,
-    ) -> Box<dyn Iterator<Item = Self::Native> + 'a> {
+    ) -> Box<dyn Iterator<Item = f32> + 'a> {
         use self::f32::l2_once;
         // Dispatch based on the dimension.
         match dimension {
@@ -179,7 +174,7 @@ impl L2 for Float32Type {
     }
 }
 
-impl L2 for Float64Type {
+impl L2 for f64 {
     #[inline]
     fn l2(x: &[f64], y: &[f64]) -> f32 {
         // TODO: add SIMD support
@@ -191,7 +186,7 @@ impl L2 for Float64Type {
 /// Compute L2 distance between two vectors.
 #[inline]
 pub fn l2_distance(from: &[f32], to: &[f32]) -> f32 {
-    Float32Type::l2(from, to)
+    l2(from, to)
 }
 
 // f32 kernels for L2
@@ -220,24 +215,24 @@ mod f32 {
 /// Returns
 ///
 /// An iterator of pair-wise distance between `from` vector to each vector in the batch.
-pub fn l2_distance_batch<'a, T: FloatToArrayType>(
+pub fn l2_distance_batch<'a, T: L2>(
     from: &'a [T],
     to: &'a [T],
     dimension: usize,
-) -> Box<dyn Iterator<Item = f32> + 'a>
-where
-    T::ArrowType: L2,
-{
+) -> Box<dyn Iterator<Item = f32> + 'a> {
     debug_assert_eq!(from.len(), dimension);
     debug_assert_eq!(to.len() % dimension, 0);
 
-    Box::new(T::ArrowType::l2_batch(from, to, dimension))
+    Box::new(T::l2_batch(from, to, dimension))
 }
 
-fn do_l2_distance_arrow_batch<T: ArrowFloatType + L2>(
+fn do_l2_distance_arrow_batch<T: ArrowFloatType>(
     from: &T::ArrayType,
     to: &FixedSizeListArray,
-) -> Result<Arc<Float32Array>> {
+) -> Result<Arc<Float32Array>>
+where
+    T::Native: L2,
+{
     let dimension = to.value_length() as usize;
     debug_assert_eq!(from.len(), dimension);
 
@@ -291,6 +286,7 @@ mod tests {
     use super::*;
 
     use approx::assert_relative_eq;
+    use num_traits::ToPrimitive;
     use proptest::prelude::*;
 
     use crate::test_utils::{
@@ -404,10 +400,7 @@ mod tests {
             .sum::<f64>()
     }
 
-    fn do_l2_test<T: FloatToArrayType>(x: &[T], y: &[T]) -> std::result::Result<(), TestCaseError>
-    where
-        T::ArrowType: L2,
-    {
+    fn do_l2_test<T: L2 + ToPrimitive>(x: &[T], y: &[T]) -> std::result::Result<(), TestCaseError> {
         let x_f64 = x.iter().map(|v| v.to_f64().unwrap()).collect::<Vec<f64>>();
         let y_f64 = y.iter().map(|v| v.to_f64().unwrap()).collect::<Vec<f64>>();
 

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -39,7 +39,7 @@ mod kernel {
 
 impl Normalize for f16 {
     #[inline]
-    fn norm_l2(vector: &[f16]) -> f32 {
+    fn norm_l2(vector: &[Self]) -> f32 {
         match *FP16_SIMD_SUPPORT {
             #[cfg(all(feature = "fp16kernels", target_arch = "aarch64"))]
             SimdSupport::Neon => unsafe {
@@ -57,21 +57,21 @@ impl Normalize for f16 {
             SimdSupport::Avx2 => unsafe {
                 kernel::norm_l2_f16_avx2(vector.as_ptr(), vector.len() as u32)
             },
-            _ => norm_l2_impl::<f16, f32, 32>(vector),
+            _ => norm_l2_impl::<Self, f32, 32>(vector),
         }
     }
 }
 
 impl Normalize for bf16 {
     #[inline]
-    fn norm_l2(vector: &[bf16]) -> f32 {
-        norm_l2_impl::<bf16, f32, 32>(vector)
+    fn norm_l2(vector: &[Self]) -> f32 {
+        norm_l2_impl::<Self, f32, 32>(vector)
     }
 }
 
 impl Normalize for f32 {
     #[inline]
-    fn norm_l2(vector: &[f32]) -> f32 {
+    fn norm_l2(vector: &[Self]) -> f32 {
         let dim = vector.len();
         if dim % 16 == 0 {
             let mut sum = f32x16::zeros();
@@ -89,15 +89,15 @@ impl Normalize for f32 {
             sum.reduce_sum().sqrt()
         } else {
             // Fallback to scalar
-            norm_l2_impl::<f32, f32, 16>(vector)
+            norm_l2_impl::<Self, Self, 16>(vector)
         }
     }
 }
 
 impl Normalize for f64 {
     #[inline]
-    fn norm_l2(vector: &[f64]) -> f32 {
-        norm_l2_impl::<f64, f64, 8>(vector) as f32
+    fn norm_l2(vector: &[Self]) -> f32 {
+        norm_l2_impl::<Self, Self, 8>(vector) as f32
     }
 }
 

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -3,14 +3,12 @@
 
 use std::{iter::Sum, ops::AddAssign};
 
-use arrow_array::types::{Float16Type, Float32Type, Float64Type};
 use half::{bf16, f16};
-use lance_arrow::{bfloat16::BFloat16Type, ArrowFloatType, FloatToArrayType};
 #[cfg(feature = "fp16kernels")]
 use lance_core::utils::cpu::SimdSupport;
 #[allow(unused_imports)]
 use lance_core::utils::cpu::FP16_SIMD_SUPPORT;
-use num_traits::{AsPrimitive, Float};
+use num_traits::{AsPrimitive, Float, Num};
 
 use crate::simd::{
     f32::{f32x16, f32x8},
@@ -18,9 +16,9 @@ use crate::simd::{
 };
 
 /// L2 normalization
-pub trait Normalize: ArrowFloatType {
+pub trait Normalize: Num {
     /// L2 Normalization over a Vector.
-    fn norm_l2(vector: &[Self::Native]) -> f32;
+    fn norm_l2(vector: &[Self]) -> f32;
 }
 
 #[cfg(feature = "fp16kernels")]
@@ -39,9 +37,9 @@ mod kernel {
     }
 }
 
-impl Normalize for Float16Type {
+impl Normalize for f16 {
     #[inline]
-    fn norm_l2(vector: &[Self::Native]) -> f32 {
+    fn norm_l2(vector: &[f16]) -> f32 {
         match *FP16_SIMD_SUPPORT {
             #[cfg(all(feature = "fp16kernels", target_arch = "aarch64"))]
             SimdSupport::Neon => unsafe {
@@ -64,16 +62,16 @@ impl Normalize for Float16Type {
     }
 }
 
-impl Normalize for BFloat16Type {
+impl Normalize for bf16 {
     #[inline]
-    fn norm_l2(vector: &[Self::Native]) -> f32 {
+    fn norm_l2(vector: &[bf16]) -> f32 {
         norm_l2_impl::<bf16, f32, 32>(vector)
     }
 }
 
-impl Normalize for Float32Type {
+impl Normalize for f32 {
     #[inline]
-    fn norm_l2(vector: &[Self::Native]) -> f32 {
+    fn norm_l2(vector: &[f32]) -> f32 {
         let dim = vector.len();
         if dim % 16 == 0 {
             let mut sum = f32x16::zeros();
@@ -96,9 +94,9 @@ impl Normalize for Float32Type {
     }
 }
 
-impl Normalize for Float64Type {
+impl Normalize for f64 {
     #[inline]
-    fn norm_l2(vector: &[Self::Native]) -> f32 {
+    fn norm_l2(vector: &[f64]) -> f32 {
         norm_l2_impl::<f64, f64, 8>(vector) as f32
     }
 }
@@ -136,17 +134,15 @@ pub fn norm_l2_impl<
 /// The parameters must be cache line aligned. For example, from
 /// Arrow Arrays, i.e., Float32Array
 #[inline]
-pub fn norm_l2<T: FloatToArrayType>(vector: &[T]) -> f32
-where
-    T::ArrowType: Normalize,
-{
-    T::ArrowType::norm_l2(vector)
+pub fn norm_l2<T: Normalize>(vector: &[T]) -> f32 {
+    T::norm_l2(vector)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_utils::{arbitrary_bf16, arbitrary_f16, arbitrary_f32, arbitrary_f64};
+    use num_traits::ToPrimitive;
     use proptest::prelude::*;
 
     /// Reference implementation of L2 norm.
@@ -154,10 +150,9 @@ mod tests {
         data.iter().map(|v| (*v * *v)).sum::<f64>().sqrt() as f32
     }
 
-    fn do_norm_l2_test<T: FloatToArrayType>(data: &[T]) -> std::result::Result<(), TestCaseError>
-    where
-        T::ArrowType: Normalize,
-    {
+    fn do_norm_l2_test<T: Normalize + ToPrimitive>(
+        data: &[T],
+    ) -> std::result::Result<(), TestCaseError> {
         let f64_data = data
             .iter()
             .map(|v| v.to_f64().unwrap())

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -519,7 +519,6 @@ where
             MetricType::L2 => {
                 l2_distance_batch(query, self.centroids.as_slice(), self.dimension).collect()
             }
-
             MetricType::Dot => {
                 dot_distance_batch(query, self.centroids.as_slice(), self.dimension).collect()
             }


### PR DESCRIPTION
No logic change in this PR. It only changes the types used for L2 / Dot / Cosine.
This is part of the cleanup to make the code simpler to support Hamming / KMode.