### PR TITLE
refactor: simplify kmeans and clustering API, prepare for kmode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ prost = "0.12.2"
 prost-build = "0.12.2"
 prost-types = "0.12.2"
 rand = { version = "0.8.3", features = ["small_rng"] }
+rayon = "1.10"
 roaring = "0.10.1"
 rustc_version = "0.4"
 serde = { version = "^1" }

--- a/python/src/utils.rs
+++ b/python/src/utils.rs
@@ -31,8 +31,9 @@ use lance_arrow::FixedSizeListArrayExt;
 use lance_file::writer::FileWriter;
 use lance_index::vector::hnsw::builder::HnswBuildParams;
 use lance_linalg::{
-    distance::MetricType,
+    distance::DistanceType,
     kmeans::{KMeans as LanceKMeans, KMeansParams},
+    Clustering,
 };
 use lance_table::io::manifest::ManifestDescribing;
 use object_store::path::Path;
@@ -50,7 +51,7 @@ pub struct KMeans {
     k: usize,
 
     /// Metric type
-    metric_type: MetricType,
+    metric_type: DistanceType,
 
     max_iters: u32,
 
@@ -113,12 +114,7 @@ impl KMeans {
             return Err(PyValueError::new_err("Must be a FixedSizeList of Float32"));
         };
         let values: Arc<Float32Array> = fixed_size_arr.values().as_primitive().clone().into();
-        let membership = RT.block_on(Some(py), kmeans.compute_membership(values))?;
-        let cluster_ids: UInt32Array = membership
-            .cluster_id_and_distances
-            .iter()
-            .map(|cd| cd.map(|(c, _)| c))
-            .collect();
+        let cluster_ids = UInt32Array::from(kmeans.compute_membership(values.values(), None));
         cluster_ids.into_data().to_pyarrow(py)
     }
 
@@ -243,7 +239,7 @@ pub fn build_sq_storage(
     let upper_bound = bounds.get_item(1)?.extract::<f64>()?;
     let quantizer =
         lance_index::vector::sq::ScalarQuantizer::with_bounds(8, dim, lower_bound..upper_bound);
-    let storage = sq::build_sq_storage(MetricType::L2, row_ids, vectors, quantizer)
+    let storage = sq::build_sq_storage(DistanceType::L2, row_ids, vectors, quantizer)
         .map_err(|e| PyIOError::new_err(e.to_string()))?;
     storage.batch().clone().to_pyarrow(py)
 }

--- a/python/src/utils.rs
+++ b/python/src/utils.rs
@@ -73,7 +73,7 @@ impl KMeans {
     }
 
     /// Train the model
-    fn fit(&mut self, py: Python, arr: &PyAny) -> PyResult<()> {
+    fn fit(&mut self, _py: Python, arr: &PyAny) -> PyResult<()> {
         let data = ArrayData::from_pyarrow(arr)?;
         if !matches!(data.data_type(), DataType::FixedSizeList(_, _)) {
             return Err(PyValueError::new_err("Must be a FixedSizeList"));
@@ -84,11 +84,7 @@ impl KMeans {
             max_iters: self.max_iters,
             ..Default::default()
         };
-        let kmeans = RT
-            .block_on(
-                Some(py),
-                LanceKMeans::new_with_params(&fixed_size_arr, self.k, &params),
-            )?
+        let kmeans = LanceKMeans::new_with_params(&fixed_size_arr, self.k, &params)
             .map_err(|e| PyRuntimeError::new_err(format!("Error training KMeans: {}", e)))?;
         self.trained_kmeans = Some(kmeans);
         Ok(())

--- a/rust/lance-index/src/vector/ivf.rs
+++ b/rust/lance-index/src/vector/ivf.rs
@@ -18,10 +18,10 @@ use snafu::{location, Location};
 pub use builder::IvfBuildParams;
 use lance_arrow::*;
 use lance_core::{Error, Result};
-use lance_linalg::kmeans::KMeans;
 use lance_linalg::{
     distance::{Dot, MetricType, L2},
-    MatrixView,
+    kmeans::KMeans,
+    Clustering, MatrixView,
 };
 
 use crate::vector::ivf::transform::IvfTransformer;

--- a/rust/lance-index/src/vector/kmeans.rs
+++ b/rust/lance-index/src/vector/kmeans.rs
@@ -63,6 +63,6 @@ where
         ..Default::default()
     };
     let data = FixedSizeListArray::try_new_from_values(data, dimension as i32)?;
-    let model = KMeans::<T>::new_with_params(&data, k, &params).await?;
+    let model = KMeans::<T>::new_with_params(&data, k, &params)?;
     Ok(model.centroids.as_ref().clone())
 }

--- a/rust/lance-linalg/Cargo.toml
+++ b/rust/lance-linalg/Cargo.toml
@@ -22,6 +22,7 @@ log = { workspace = true }
 num_cpus = { workspace = true }
 num-traits = { workspace = true }
 rand = { workspace = true }
+rayon = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/rust/lance-linalg/benches/kmeans.rs
+++ b/rust/lance-linalg/benches/kmeans.rs
@@ -21,22 +21,7 @@ fn bench_train(c: &mut Criterion) {
 
     c.bench_function("train_128d_4k", |b| {
         b.to_async(&rt).iter(|| async {
-            KMeans::<Float32Type>::new(&array, 25, 50)
-                .await
-                .ok()
-                .unwrap();
-        })
-    });
-
-    #[cfg(feature = "faiss")]
-    c.bench_function("train_128d_4k_faiss", |b| {
-        use arrow_array::{cast::as_primitive_array, Float32Array};
-        use faiss::cluster::kmeans_clustering;
-
-        let array = data.as_ref().values();
-        let f32array: &Float32Array = as_primitive_array(&array);
-        b.iter(|| {
-            kmeans_clustering(dimension as u32, 256, f32array.values()).unwrap();
+            KMeans::<Float32Type>::new(&array, 25, 50).ok().unwrap();
         })
     });
 
@@ -44,22 +29,7 @@ fn bench_train(c: &mut Criterion) {
     let array = FixedSizeListArray::try_new_from_values(values, dimension).unwrap();
     c.bench_function("train_128d_65535", |b| {
         b.to_async(&rt).iter(|| async {
-            KMeans::<Float32Type>::new(&array, 25, 50)
-                .await
-                .ok()
-                .unwrap();
-        })
-    });
-
-    #[cfg(feature = "faiss")]
-    c.bench_function("train_128d_65535_faiss", |b| {
-        use arrow_array::{cast::as_primitive_array, Float32Array};
-        use faiss::cluster::kmeans_clustering;
-
-        let array = data.as_ref().values();
-        let f32array: &Float32Array = as_primitive_array(&array);
-        b.iter(|| {
-            kmeans_clustering(dimension as u32, 256, f32array.values()).unwrap();
+            KMeans::<Float32Type>::new(&array, 25, 50).ok().unwrap();
         })
     });
 
@@ -68,10 +38,7 @@ fn bench_train(c: &mut Criterion) {
     let array = FixedSizeListArray::try_new_from_values(values, dimension).unwrap();
     c.bench_function("train_8d_65535", |b| {
         b.to_async(&rt).iter(|| async {
-            KMeans::<Float32Type>::new(&array, 25, 50)
-                .await
-                .ok()
-                .unwrap();
+            KMeans::<Float32Type>::new(&array, 25, 50).ok().unwrap();
         })
     });
 }
@@ -82,6 +49,7 @@ criterion_group!(
     config = Criterion::default().significance_level(0.1).sample_size(10)
     .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = bench_train);
+
 // Non-linux version does not support pprof.
 #[cfg(not(target_os = "linux"))]
 criterion_group!(

--- a/rust/lance-linalg/src/clustering.rs
+++ b/rust/lance-linalg/src/clustering.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Clustering algorithms.
+//!
+
+use arrow_array::UInt32Array;
+use num_traits::Num;
+
+use crate::Result;
+
+/// Clustering Trait.
+pub trait Clustering<T: Num> {
+    /// The dimension of the vectors.
+    fn deminsion(&self) -> u32;
+
+    /// The number of clusters.
+    fn num_clusters(&self) -> u32;
+
+    /// Find n-nearest partitions for the given query.
+    ///
+    /// ## Parameters
+    /// * `query`: a `D`-dimensional query vector.
+    /// * `nprobes`: The number of probes to return.
+    ///
+    /// ## Returns
+    ///
+    /// `n` of nearest partitions.
+    fn find_partitions(&self, query: &[T], nprobes: usize) -> Result<UInt32Array>;
+
+    /// Get the n nearest partitions for an array of vectors.
+    ///
+    /// ## Parameters:
+    /// * `data`: an `N * D` of D-dimensional vectors.
+    /// * `nprobes`: If provided, the number of partitions per vector to return.
+    ///    If not provided, return 1 partition per vector.
+    ///
+    /// ## Returns:
+    /// * An `N * nprobes` matrix of partition IDs.
+    fn compute_membership(&self, data: &[T], nprobes: Option<usize>) -> Vec<Option<u32>>;
+}

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -535,17 +535,18 @@ where
         assert!(_nprobes.is_none());
         let centroids = self.centroids.as_ref().as_slice();
         data.par_chunks(self.dimension)
-            .map(|vec| match self.distance_type {
-                MetricType::L2 => argmin_value(l2_distance_batch(vec, centroids, self.dimension))
-                    .map(|(idx, _)| idx),
-                MetricType::Dot => argmin_value(dot_distance_batch(vec, centroids, self.dimension))
-                    .map(|(idx, _)| idx),
-                _ => {
-                    panic!(
-                        "KMeans::find_partitions: {} is not supported",
-                        self.distance_type
-                    );
-                }
+            .map(|vec| {
+                argmin_value(match self.distance_type {
+                    MetricType::L2 => l2_distance_batch(vec, centroids, self.dimension),
+                    MetricType::Dot => dot_distance_batch(vec, centroids, self.dimension),
+                    _ => {
+                        panic!(
+                            "KMeans::find_partitions: {} is not supported",
+                            self.distance_type
+                        );
+                    }
+                })
+                .map(|(idx, _)| idx)
             })
             .collect::<Vec<_>>()
     }

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -299,6 +299,7 @@ where
                     params.distance_type,
                 )
                 .unwrap();
+                last_membership = Some(membership);
                 if (loss - last_loss).abs() / last_loss < params.tolerance {
                     info!(
                         "KMeans training: converged at iteration {} / {}, redo={}",
@@ -307,7 +308,6 @@ where
                     break;
                 }
                 loss = last_loss;
-                last_membership = Some(membership);
             }
             let stddev = hist_stddev(
                 k,

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -244,7 +244,7 @@ where
         // TODO: use seed for Rng.
         let rng = SmallRng::from_entropy();
         for redo in 1..=params.redos {
-            let kmeans = match params.init {
+            let mut kmeans: Self = match params.init {
                 KMeanInit::Random => Self::init_random(
                     data.as_slice(),
                     dimension,
@@ -267,7 +267,7 @@ where
                 };
                 let (last_membership, last_loss) =
                     kmeans.compute_membership_and_loss(data.as_slice());
-                let kmeans = Self::to_kmeans(
+                kmeans = Self::to_kmeans(
                     data.as_slice(),
                     dimension,
                     k,
@@ -283,8 +283,8 @@ where
                     break;
                 }
                 loss = last_loss;
-                best_kmeans = kmeans;
             }
+            best_kmeans = kmeans;
         }
 
         Ok(best_kmeans)

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -468,6 +468,7 @@ mod tests {
     use lance_testing::datagen::generate_random_array;
 
     use super::*;
+    use crate::distance::l2;
     use crate::kernels::argmin;
 
     #[test]
@@ -531,9 +532,11 @@ mod tests {
         let centroids = generate_random_array(DIM * NUM_CENTROIDS);
         let values = Float32Array::from_iter_values(repeat(f32::NAN).take(DIM * K));
 
-        compute_partitions_l2(centroids.values(), values.values(), DIM).for_each(|cd| {
-            assert!(cd.is_none());
-        });
+        compute_partitions::<Float32Type>(centroids.into(), values.into(), DIM, DistanceType::L2)
+            .iter()
+            .for_each(|cd| {
+                assert!(cd.is_none());
+            });
     }
 
     #[tokio::test]

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -300,7 +300,6 @@ where
     /// - *data*: a `N * dimension` floating array. Not necessarily normalized.
     ///
     fn compute_membership_and_loss(&self, data: &[T::Native]) -> (Vec<Option<u32>>, f64) {
-        // TODO: consolidate with `compute_membership`.
         let centroids = self.centroids.as_ref().as_slice();
         let cluster_and_dists = data
             .par_chunks(self.dimension)

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -9,7 +9,6 @@
 //! and run ``l2`` distance on the unit vectors.
 //!
 
-use std::cmp::min;
 use std::ops::DivAssign;
 use std::sync::Arc;
 use std::vec;
@@ -19,17 +18,17 @@ use arrow_ord::sort::sort_to_indices;
 use arrow_schema::ArrowError;
 use lance_arrow::{ArrowFloatType, FloatArray};
 use log::{info, warn};
-use num_traits::{AsPrimitive, Float, FromPrimitive, Num, Zero};
+use num_traits::{AsPrimitive, Float, FromPrimitive, Zero};
 use rand::prelude::*;
 use rayon::prelude::*;
 
 use crate::distance::norm_l2::Normalize;
 use crate::distance::{dot_distance_batch, DistanceType};
-use crate::kernels::{argmax, argmin_value_float};
+use crate::kernels::argmax;
 use crate::{
     clustering::Clustering,
     distance::{
-        l2::{l2, l2_distance_batch, L2},
+        l2::{l2_distance_batch, L2},
         Dot,
     },
     kernels::argmin_value,

--- a/rust/lance-linalg/src/lib.rs
+++ b/rust/lance-linalg/src/lib.rs
@@ -5,6 +5,7 @@
 
 #![deny(clippy::unused_async)]
 
+mod clustering;
 pub mod distance;
 pub mod kernels;
 pub mod kmeans;
@@ -14,6 +15,7 @@ pub mod simd;
 #[cfg(test)]
 pub(crate) mod test_utils;
 
+pub use clustering::Clustering;
 pub use matrix::MatrixView;
 
 use arrow_schema::ArrowError;


### PR DESCRIPTION
* Use `rayon` to replace homemade tokio multi-threading and tiling
* Simplify KMeans interface to `Clustering`, preparing for KMode implementation
* Found surprising speed up by using rayon.