### PR TITLE
perf: use the file metadata cache in scalar indices

### DIFF
--- a/rust/lance-core/src/cache.rs
+++ b/rust/lance-core/src/cache.rs
@@ -20,7 +20,7 @@ type ArcAny = Arc<dyn Any + Send + Sync>;
 /// Cache for various metadata about files.
 ///
 /// The cache is keyed by the file path and the type of metadata.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FileMetadataCache {
     cache: Arc<Cache<(Path, TypeId), ArcAny>>,
 }

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -57,7 +57,7 @@ impl BenchmarkFixture {
         let test_path = tempdir.path();
         let (object_store, test_path) =
             ObjectStore::from_path(test_path.as_os_str().to_str().unwrap()).unwrap();
-        Arc::new(LanceIndexStore::new(object_store, test_path))
+        Arc::new(LanceIndexStore::new(object_store, test_path, None))
     }
 
     async fn write_baseline_data(tempdir: &TempDir) -> Arc<Dataset> {

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use lance_core::Result;
+use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::DatasetIndexExt;
 use lance_table::format::Index;
 use serde::{Deserialize, Serialize};
@@ -66,5 +67,20 @@ impl IndexRemapper for DatasetIndexRemapper {
             }
         }
         Ok(remapped)
+    }
+}
+
+pub trait LanceIndexStoreExt {
+    fn from_dataset(dataset: &Dataset, uuid: &str) -> Self;
+}
+
+impl LanceIndexStoreExt for LanceIndexStore {
+    fn from_dataset(dataset: &Dataset, uuid: &str) -> Self {
+        let index_dir = dataset.indices_dir().child(uuid);
+        LanceIndexStore::new(
+            dataset.object_store.as_ref().clone(),
+            index_dir,
+            Some(dataset.session.file_metadata_cache.clone()),
+        )
     }
 }

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -3542,7 +3542,7 @@ mod test {
             .await
             .unwrap();
         let second_index_scan_bytes = get_bytes() - start_bytes;
-        assert!(second_index_scan_bytes < index_scan_bytes);
+        assert!(second_index_scan_bytes < filtered_scan_bytes);
     }
 
     #[tokio::test]

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -38,6 +38,7 @@ pub(crate) mod prefilter;
 pub mod scalar;
 pub mod vector;
 
+use crate::dataset::index::LanceIndexStoreExt;
 pub use crate::index::prefilter::{FilterLoader, PreFilter};
 
 use crate::dataset::transaction::{Operation, Transaction};
@@ -93,8 +94,7 @@ pub(crate) async fn remap_index(
 
     match generic.index_type() {
         IndexType::Scalar => {
-            let index_dir = dataset.indices_dir().child(new_id.to_string());
-            let new_store = LanceIndexStore::new((*dataset.object_store).clone(), index_dir);
+            let new_store = LanceIndexStore::from_dataset(dataset, &new_id.to_string());
 
             let scalar_index = dataset
                 .open_scalar_index(&field.name, &index_id.to_string())

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 
 use super::vector::ivf::optimize_vector_indices;
 use super::DatasetIndexInternalExt;
+use crate::dataset::index::LanceIndexStoreExt;
 use crate::dataset::scanner::ColumnOrdering;
 use crate::dataset::Dataset;
 
@@ -95,8 +96,7 @@ pub async fn merge_indices<'a>(
 
             let new_uuid = Uuid::new_v4();
 
-            let index_dir = dataset.indices_dir().child(new_uuid.to_string());
-            let new_store = LanceIndexStore::new((*dataset.object_store).clone(), index_dir);
+            let new_store = LanceIndexStore::from_dataset(&dataset, &new_uuid.to_string());
 
             index.update(new_data_stream.into(), &new_store).await?;
 


### PR DESCRIPTION
We were not using the cache before which meant every scalar index query had to load a bunch of metadata from the index files (some of which was quite expensive)

Closes #2313 