### PR TITLE
feat: add take_rows operation to the v2 file reader's python bindings

### DIFF
--- a/python/python/lance/file.py
+++ b/python/python/lance/file.py
@@ -106,6 +106,27 @@ class LanceFileReader:
             self._reader.read_range(start, num_rows, batch_size, batch_readahead)
         )
 
+    def take_rows(
+        self, indices, *, batch_size: int = 1024, batch_readahead=16
+    ) -> ReaderResults:
+        """
+        Read a specific set of rows from the file
+
+        Parameters
+        ----------
+        indices: List[int]
+            The indices of the rows to read from the file
+        batch_size: int, default 1024
+            The file will be read in batches.  This parameter controls
+            how many rows will be in each batch (except the final batch)
+
+            Smaller batches will use less memory but might be slightly
+            slower because there is more per-batch overhead
+        """
+        return ReaderResults(
+            self._reader.take_rows(indices, batch_size, batch_readahead)
+        )
+
     def metadata(self) -> LanceFileMetadata:
         """
         Return metadata describing the file contents

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -52,6 +52,9 @@ class LanceFileReader:
     def read_range(
         self, start: int, num_rows: int, batch_size: int, batch_readahead: int
     ) -> pa.RecordBatchReader: ...
+    def take_rows(
+        self, indices: List[int], batch_size: int, batch_readahead: int
+    ) -> pa.RecordBatchReader: ...
 
 class LanceBufferDescriptor:
     position: int

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -248,6 +248,7 @@ impl LogicalPageScheduler for SimpleStructScheduler {
         // NOTE: See schedule_range for a description of the scheduling algorithm
         let mut current_top_level_row = top_level_row;
         while rows_to_read > 0 {
+            trace!("Beginning scheduler scan of columns");
             let mut min_rows_added = u32::MAX;
             for (col_idx, field_scheduler) in self.children.iter().enumerate() {
                 let status = &mut field_status[col_idx];
@@ -263,12 +264,15 @@ impl LogicalPageScheduler for SimpleStructScheduler {
                             "{}",
                             if indices_in_page.is_empty() {
                                 format!(
-                                    "Skipping entire page of {} rows",
-                                    next_candidate_page.num_rows()
+                                    "Skipping entire page of {} rows for column {}",
+                                    next_candidate_page.num_rows(),
+                                    col_idx,
                                 )
                             } else {
                                 format!(
-                                    "Found page with {} overlapping indices",
+                                    "Found page for column {} with {} rows that had {} overlapping indices",
+                                    col_idx,
+                                    next_candidate_page.num_rows(),
                                     indices_in_page.len()
                                 )
                             }
@@ -290,11 +294,18 @@ impl LogicalPageScheduler for SimpleStructScheduler {
                     status.rows_queued += rows_scheduled;
 
                     min_rows_added = min_rows_added.min(rows_scheduled);
+                } else {
+                    // TODO: Unit tests are not covering this path right now
+                    min_rows_added = min_rows_added.min(status.rows_queued);
                 }
             }
             if min_rows_added == 0 {
                 panic!("Error in scheduling logic, panic to avoid infinite loop");
             }
+            trace!(
+                "One scheduling pass complete, {} rows added",
+                min_rows_added
+            );
             rows_to_read -= min_rows_added;
             current_top_level_row += min_rows_added as u64;
             for field_status in &mut field_status {
@@ -380,6 +391,11 @@ impl ChildState {
         );
         let mut remaining = num_rows.saturating_sub(self.rows_available);
         if remaining > 0 {
+            trace!(
+                "Struct must await {} rows from {} unawaited rows",
+                remaining,
+                self.rows_unawaited
+            );
             if let Some(back) = self.awaited.back_mut() {
                 if back.unawaited() > 0 {
                     let rows_to_wait = remaining.min(back.unawaited());
@@ -394,7 +410,12 @@ impl ChildState {
                     let newly_avail = back.avail() - previously_avail;
                     trace!("The await loaded {} rows", newly_avail);
                     self.rows_available += newly_avail;
-                    self.rows_unawaited -= newly_avail;
+                    // Need to use saturating_sub here because we might have asked for range
+                    // 0-1000 and this page we just loaded might cover 900-1100 and so newly_avail
+                    // is 200 but rows_unawaited is only 100
+                    //
+                    // TODO: Unit tests are not covering this branch right now
+                    self.rows_unawaited = self.rows_unawaited.saturating_sub(newly_avail);
                     remaining -= rows_to_wait;
                     if remaining == 0 {
                         return Ok(true);
@@ -425,9 +446,9 @@ impl ChildState {
             // newly_avail this way (we do this above too)
             let newly_avail = decoder.avail() - previously_avail;
             self.awaited.push_back(decoder);
-            self.rows_available += newly_avail;
-            self.rows_unawaited -= newly_avail;
             trace!("The new await loaded {} rows", newly_avail);
+            self.rows_available += newly_avail;
+            self.rows_unawaited = self.rows_unawaited.saturating_sub(newly_avail);
             Ok(remaining == rows_to_wait)
         } else {
             Ok(true)

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -3,7 +3,7 @@
 
 use std::{ops::Range, sync::Arc};
 
-use arrow_array::{Array, UInt32Array};
+use arrow_array::{Array, UInt64Array};
 use arrow_schema::{DataType, Field, Schema};
 use arrow_select::concat::concat;
 use bytes::{Bytes, BytesMut};
@@ -122,7 +122,7 @@ fn supports_nulls(data_type: &DataType) -> bool {
 #[derive(Clone, Default)]
 pub struct TestCases {
     ranges: Vec<Range<u64>>,
-    indices: Vec<Vec<u32>>,
+    indices: Vec<Vec<u64>>,
     skip_validation: bool,
 }
 
@@ -132,7 +132,7 @@ impl TestCases {
         self
     }
 
-    pub fn with_indices(mut self, indices: Vec<u32>) -> Self {
+    pub fn with_indices(mut self, indices: Vec<u64>) -> Self {
         self.indices.push(indices);
         self
     }
@@ -285,7 +285,7 @@ async fn check_round_trip_encoding_inner(
             );
         }
         let num_rows = indices.len() as u64;
-        let indices_arr = UInt32Array::from(indices.clone());
+        let indices_arr = UInt64Array::from(indices.clone());
         let expected = concat_data
             .as_ref()
             .map(|concat_data| arrow_select::take::take(&concat_data, &indices_arr, None).unwrap());


### PR DESCRIPTION
This also plumbs out basic support for take_rows and is a prerequisite for adding a fragment-level take