### PR TITLE
chore: bump version to 0.11 to reflect breaking changes

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,7 @@
 name: PR Checks
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened]
 
 concurrency:
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.19"
+version = "0.11.0"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 license = "Apache-2.0"
@@ -42,19 +42,19 @@ categories = [
 rust-version = "1.75"
 
 [workspace.dependencies]
-lance = { version = "=0.10.19", path = "./rust/lance" }
-lance-arrow = { version = "=0.10.19", path = "./rust/lance-arrow" }
-lance-core = { version = "=0.10.19", path = "./rust/lance-core" }
-lance-datafusion = { version = "=0.10.19", path = "./rust/lance-datafusion" }
-lance-datagen = { version = "=0.10.19", path = "./rust/lance-datagen" }
-lance-encoding = { version = "=0.10.19", path = "./rust/lance-encoding" }
-lance-file = { version = "=0.10.19", path = "./rust/lance-file" }
-lance-index = { version = "=0.10.19", path = "./rust/lance-index" }
-lance-io = { version = "=0.10.19", path = "./rust/lance-io" }
-lance-linalg = { version = "=0.10.19", path = "./rust/lance-linalg" }
-lance-table = { version = "=0.10.19", path = "./rust/lance-table" }
-lance-test-macros = { version = "=0.10.19", path = "./rust/lance-test-macros" }
-lance-testing = { version = "=0.10.19", path = "./rust/lance-testing" }
+lance = { version = "=0.11.0", path = "./rust/lance" }
+lance-arrow = { version = "=0.11.0", path = "./rust/lance-arrow" }
+lance-core = { version = "=0.11.0", path = "./rust/lance-core" }
+lance-datafusion = { version = "=0.11.0", path = "./rust/lance-datafusion" }
+lance-datagen = { version = "=0.11.0", path = "./rust/lance-datagen" }
+lance-encoding = { version = "=0.11.0", path = "./rust/lance-encoding" }
+lance-file = { version = "=0.11.0", path = "./rust/lance-file" }
+lance-index = { version = "=0.11.0", path = "./rust/lance-index" }
+lance-io = { version = "=0.11.0", path = "./rust/lance-io" }
+lance-linalg = { version = "=0.11.0", path = "./rust/lance-linalg" }
+lance-table = { version = "=0.11.0", path = "./rust/lance-table" }
+lance-test-macros = { version = "=0.11.0", path = "./rust/lance-test-macros" }
+lance-testing = { version = "=0.11.0", path = "./rust/lance-testing" }
 approx = "0.5.1"
 # Note that this one does not include pyarrow
 arrow = { version = "51.0.0", optional = false, features = ["prettyprint"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pylance"
-version = "0.10.19"
+version = "0.11.0"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 rust-version = "1.65"


### PR DESCRIPTION
https://github.com/lancedb/lance/commit/33d576f9d6d5783b7678d0950dfb2d3abd2cb837 introduced a breaking change but did not bump the minor version.  This PR only bumps the minor version.