### PR TITLE
test: benchmark the index merge performance

### DIFF
--- a/python/python/benchmarks/test_index.py
+++ b/python/python/benchmarks/test_index.py
@@ -69,31 +69,23 @@ def test_create_ivf_pq_cuda(test_dataset, benchmark):
 
 
 @pytest.mark.benchmark(group="optimize_index")
-@pytest.mark.parametrize("num_partitions", [512])
-@pytest.mark.parametrize("ef_construction", [150, 300])
-@pytest.mark.parametrize("m", [16])
-@pytest.mark.parametrize("num_small_indexes", [1, 5])
-@pytest.mark.parametrize("num_new_rows", [500])
+@pytest.mark.parametrize("num_partitions", [256, 512])
+@pytest.mark.parametrize("num_small_indexes", [5])
+@pytest.mark.parametrize("num_new_rows", [12_000])
 def test_optimize_index(
     test_large_dataset,
     benchmark,
     num_partitions,
-    ef_construction,
-    m,
     num_small_indexes,
     num_new_rows,
 ):
     # insert smaller batch(es) into the large dataset,
     # then benchmark the optimize_index method
-    m_max = m * 2
     test_large_dataset = test_large_dataset.create_index(
         column="vector",
-        index_type="IVF_HNSW_SQ",
+        index_type="IVF_PQ",
         metric_type="L2",
         num_partitions=num_partitions,
-        ef_construction=ef_construction,
-        m=m,
-        m_max=m_max,
         num_bits=8,
         replace=True,
     )

--- a/python/python/benchmarks/test_index.py
+++ b/python/python/benchmarks/test_index.py
@@ -74,7 +74,15 @@ def test_create_ivf_pq_cuda(test_dataset, benchmark):
 @pytest.mark.parametrize("m", [16])
 @pytest.mark.parametrize("num_small_indexes", [1, 5])
 @pytest.mark.parametrize("num_new_rows", [500])
-def test_optimize_index(test_large_dataset, benchmark, num_partitions, ef_construction, m, num_small_indexes, num_new_rows):
+def test_optimize_index(
+    test_large_dataset,
+    benchmark,
+    num_partitions,
+    ef_construction,
+    m,
+    num_small_indexes,
+    num_new_rows,
+):
     # insert smaller batch(es) into the large dataset,
     # then benchmark the optimize_index method
     m_max = m * 2

--- a/python/python/benchmarks/test_index.py
+++ b/python/python/benchmarks/test_index.py
@@ -69,9 +69,24 @@ def test_create_ivf_pq_cuda(test_dataset, benchmark):
 
 
 @pytest.mark.benchmark(group="optimize_index")
-def test_optimize_index(test_large_dataset, benchmark):
+@pytest.mark.parametrize("num_partitions", [32, 256, 512, 1024])
+@pytest.mark.parametrize("ef_construction", [150, 300, 500])
+@pytest.mark.parametrize("m", [16, 24])
+def test_optimize_index(test_large_dataset, benchmark, num_partitions, ef_construction, m):
     # insert a smaller batch into the large dataset,
     # then benchmark the optimize_index method
+    m_max = m * 2
+    test_large_dataset = test_large_dataset.create_index(
+        column="vector",
+        index_type="IVF_HNSW_SQ",
+        metric_type="L2",
+        num_partitions=num_partitions,
+        ef_construction=ef_construction,
+        m=m,
+        m_max=m_max,
+        num_bits=8,
+        replace=True,
+    )
     small_table = gen_table(test_large_dataset.count_rows() * 30 // 100)
     lance.write_dataset(small_table, test_large_dataset.uri, mode="append")
 

--- a/python/python/benchmarks/test_index.py
+++ b/python/python/benchmarks/test_index.py
@@ -7,22 +7,35 @@ import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
 
-N_DIMS = 768
+N_DIMS = 512
+
+
+def gen_table(num_rows):
+    values = pc.random(num_rows * N_DIMS).cast(pa.float32())
+    vectors = pa.FixedSizeListArray.from_arrays(values, N_DIMS)
+    table = pa.table({"vector": vectors})
+
+    return table
+
+
+def gen_dataset(tmpdir_factory, num_rows):
+    tmp_path = Path(tmpdir_factory.mktemp("index_dataset"))
+    table = gen_table(num_rows)
+    dataset = lance.write_dataset(table, tmp_path)
+
+    return dataset
 
 
 @pytest.fixture(scope="module")
 def test_dataset(tmpdir_factory):
     # We are writing to this, so it's not beneficial to cache it in the data_dir.
-    tmp_path = Path(tmpdir_factory.mktemp("index_dataset"))
-    num_rows = 1_000
+    return gen_dataset(tmpdir_factory, 1_000)
 
-    values = pc.random(num_rows * N_DIMS).cast(pa.float32())
-    vectors = pa.FixedSizeListArray.from_arrays(values, N_DIMS)
-    table = pa.table({"vector": vectors})
 
-    dataset = lance.write_dataset(table, tmp_path)
-
-    return dataset
+@pytest.fixture(scope="module")
+def test_large_dataset(tmpdir_factory):
+    # We are writing to this, so it's not beneficial to cache it in the data_dir.
+    return gen_dataset(tmpdir_factory, 1_000_000)
 
 
 @pytest.mark.benchmark(group="create_index")
@@ -53,3 +66,13 @@ def test_create_ivf_pq_cuda(test_dataset, benchmark):
         accelerator="cuda",
         replace=True,
     )
+
+
+@pytest.mark.benchmark(group="optimize_index")
+def test_optimize_index(test_large_dataset, benchmark):
+    # insert a smaller batch into the large dataset,
+    # then benchmark the optimize_index method
+    small_table = gen_table(test_large_dataset.count_rows() * 30 // 100)
+    lance.write_dataset(small_table, test_large_dataset.uri, mode="append")
+
+    benchmark(test_large_dataset.optimize.optimize_indices)

--- a/python/python/benchmarks/test_index.py
+++ b/python/python/benchmarks/test_index.py
@@ -69,11 +69,13 @@ def test_create_ivf_pq_cuda(test_dataset, benchmark):
 
 
 @pytest.mark.benchmark(group="optimize_index")
-@pytest.mark.parametrize("num_partitions", [32, 256, 512, 1024])
-@pytest.mark.parametrize("ef_construction", [150, 300, 500])
-@pytest.mark.parametrize("m", [16, 24])
-def test_optimize_index(test_large_dataset, benchmark, num_partitions, ef_construction, m):
-    # insert a smaller batch into the large dataset,
+@pytest.mark.parametrize("num_partitions", [512])
+@pytest.mark.parametrize("ef_construction", [150, 300])
+@pytest.mark.parametrize("m", [16])
+@pytest.mark.parametrize("num_small_indexes", [1, 5])
+@pytest.mark.parametrize("num_new_rows", [500])
+def test_optimize_index(test_large_dataset, benchmark, num_partitions, ef_construction, m, num_small_indexes, num_new_rows):
+    # insert smaller batch(es) into the large dataset,
     # then benchmark the optimize_index method
     m_max = m * 2
     test_large_dataset = test_large_dataset.create_index(
@@ -87,7 +89,9 @@ def test_optimize_index(test_large_dataset, benchmark, num_partitions, ef_constr
         num_bits=8,
         replace=True,
     )
-    small_table = gen_table(test_large_dataset.count_rows() * 30 // 100)
-    lance.write_dataset(small_table, test_large_dataset.uri, mode="append")
+
+    for _ in range(num_small_indexes):
+        small_table = gen_table(num_new_rows // num_small_indexes)
+        lance.write_dataset(small_table, test_large_dataset.uri, mode="append")
 
     benchmark(test_large_dataset.optimize.optimize_indices)


### PR DESCRIPTION
this is slow cause we now reconstruct the entire index after merging data.
for 512d 1M rows IVF_HNSW_SQ dataset:
merge 500 rows: 41.4195s
merge 5 batches (100 rows per batch): 42.3950s

for 512d 100K rows IVF_HNSW_SQ dataset:
merge 500 rows: 2.2307s
merge 5 batches (100 rows per batch): 2.2654s

for 512d 1M rows IVF_PQ dataset:
merge 500 rows: 174.4656ms
merge 5 batches (100 rows per batch): 178.6720ms