### PR TITLE
ci: bump nodejs version in github actions

### DIFF
--- a/.github/workflows/build_mac_wheel/action.yml
+++ b/.github/workflows/build_mac_wheel/action.yml
@@ -22,4 +22,3 @@ runs:
         command: build
         args: ${{ inputs.args }}
         working-directory: python
-        interpreter: 3.${{ inputs.python-minor-version }}

--- a/.github/workflows/build_windows_wheel/action.yml
+++ b/.github/workflows/build_windows_wheel/action.yml
@@ -27,7 +27,7 @@ runs:
         command: build
         args: ${{ inputs.args }}
         working-directory: python
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: windows-wheels
         path: python\target\wheels

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -177,7 +177,7 @@ jobs:
         shell: powershell
         working-directory: python
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -46,7 +46,7 @@ jobs:
         fetch-depth: 0
         lfs: true
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.11  # Ray does not support 3.12 yet.
     - uses: Swatinem/rust-cache@v2
@@ -96,7 +96,7 @@ jobs:
         fetch-depth: 0
         lfs: true
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.${{ matrix.python-minor-version }}
     - uses: Swatinem/rust-cache@v2
@@ -125,13 +125,9 @@ jobs:
         fetch-depth: 0
         lfs: true
     - name: Set up Python
-      run: |
-        sudo apt update
-        sudo apt install -y -qq wget software-properties-common
-        sudo add-apt-repository ppa:deadsnakes/ppa
-        sudo apt install -y python3.${{ matrix.python-minor-version }}
-        sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.${{ matrix.python-minor-version }} 1
-        sudo apt install -y python3-pip python3.${{ matrix.python-minor-version }}-distutils
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.${{ matrix.python-minor-version }}
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: python
@@ -158,7 +154,7 @@ jobs:
         fetch-depth: 0
         lfs: true
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - uses: Swatinem/rust-cache@v2
@@ -177,7 +173,7 @@ jobs:
         shell: powershell
         working-directory: python
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           lfs: true
@@ -215,7 +211,7 @@ jobs:
         fetch-depth: 0
         lfs: true
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -110,8 +110,11 @@ jobs:
       run: sudo rm -rf target/wheels
   linux-arm:
     timeout-minutes: 45
-    name: Python Linux 3.12 ARM
     runs-on: warp-ubuntu-latest-arm64-4x
+    name: Python Linux 3.${{ matrix.python-minor-version }} ARM
+    strategy:
+      matrix:
+        python-minor-version: [ "12" ]
     defaults:
       run:
         shell: bash
@@ -122,9 +125,13 @@ jobs:
         fetch-depth: 0
         lfs: true
     - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.11
+      run: |
+        sudo apt update
+        sudo apt install -y -qq wget software-properties-common
+        sudo add-apt-repository ppa:deadsnakes/ppa
+        sudo apt install -y python3.${{ matrix.python-minor-version }}
+        sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.${{ matrix.python-minor-version }} 1
+        sudo apt install -y python3-pip python3.${{ matrix.python-minor-version }}-distutils
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -213,7 +213,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.12.3"
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -110,10 +110,7 @@ jobs:
       run: sudo rm -rf target/wheels
   linux-arm:
     timeout-minutes: 45
-    name: Python Linux 3.${{ matrix.python-minor-version }} ARM
-    strategy:
-      matrix:
-        python-minor-version: [ "12" ]
+    name: Python Linux 3.12 ARM
     runs-on: warp-ubuntu-latest-arm64-4x
     defaults:
       run:
@@ -127,7 +124,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.${{ matrix.python-minor-version }}
+        python-version: 3.12.3
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: python
@@ -213,7 +210,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12.3"
+        python-version: "3.12"
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -124,7 +124,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12.3
+        python-version: 3.11
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: python


### PR DESCRIPTION
Github deprecated node16 based steps. It requires to upgrade to the node-20 steps.