### PR TITLE
fix: rework list encoder to handle list-struct

### DIFF
--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -547,11 +547,8 @@ impl DecodeBatchScheduler {
         trace!("Scheduling range {:?} ({} rows)", range, rows_to_read);
 
         let mut context = SchedulerContext::new(sink, scheduler);
-        self.root_scheduler.schedule_ranges_u64(
-            &[range.clone()],
-            &mut context,
-            range.start as u64,
-        )?;
+        self.root_scheduler
+            .schedule_ranges_u64(&[range.clone()], &mut context, range.start)?;
 
         trace!("Finished scheduling of range {:?}", range);
         Ok(())
@@ -589,7 +586,7 @@ impl DecodeBatchScheduler {
         let mut context = SchedulerContext::new(sink, scheduler);
 
         self.root_scheduler
-            .schedule_take_u64(&indices, &mut context, indices[0] as u64)?;
+            .schedule_take_u64(indices, &mut context, indices[0])?;
         trace!("Finished scheduling take of {} rows", indices.len());
         Ok(())
     }
@@ -1086,6 +1083,7 @@ pub async fn decode_batch(batch: &EncodedBatch) -> Result<RecordBatch> {
     decode_scheduler
         .schedule_range(0..batch.num_rows, tx, io_scheduler)
         .await?;
+    #[allow(clippy::single_range_in_vec_init)]
     let root_decoder = decode_scheduler
         .root_scheduler
         .new_root_decoder_ranges(&[0..batch.num_rows]);

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -218,7 +218,7 @@ use crate::encodings::logical::binary::BinaryPageScheduler;
 use crate::encodings::logical::fixed_size_list::FslPageScheduler;
 use crate::encodings::logical::list::ListPageScheduler;
 use crate::encodings::logical::primitive::PrimitivePageScheduler;
-use crate::encodings::logical::r#struct::SimpleStructScheduler;
+use crate::encodings::logical::r#struct::{SimpleStructDecoder, SimpleStructScheduler};
 use crate::encodings::physical::{ColumnBuffers, FileBuffers};
 use crate::format::pb;
 use crate::{BufferScheduler, EncodingsIo};
@@ -282,7 +282,7 @@ impl ColumnInfo {
 ///
 /// TODO: Implement backpressure
 pub struct DecodeBatchScheduler {
-    root_scheduler: SimpleStructScheduler,
+    pub root_scheduler: SimpleStructScheduler,
 }
 
 impl DecodeBatchScheduler {
@@ -303,7 +303,7 @@ impl DecodeBatchScheduler {
         data_type: &DataType,
         column: &ColumnInfo,
         buffers: FileBuffers,
-    ) -> Vec<Box<dyn LogicalPageScheduler>> {
+    ) -> Vec<Arc<dyn LogicalPageScheduler>> {
         // Primitive fields map to a single column
         let column_buffers = ColumnBuffers {
             file_buffers: buffers,
@@ -314,11 +314,11 @@ impl DecodeBatchScheduler {
             .iter()
             .cloned()
             .map(|page_info| {
-                Box::new(PrimitivePageScheduler::new(
+                Arc::new(PrimitivePageScheduler::new(
                     data_type.clone(),
                     page_info,
                     column_buffers,
-                )) as Box<dyn LogicalPageScheduler>
+                )) as Arc<dyn LogicalPageScheduler>
             })
             .collect::<Vec<_>>()
     }
@@ -386,7 +386,7 @@ impl DecodeBatchScheduler {
         data_type: &DataType,
         column_infos: &mut impl Iterator<Item = &'a ColumnInfo>,
         buffers: FileBuffers,
-    ) -> Vec<Box<dyn LogicalPageScheduler>> {
+    ) -> Vec<Arc<dyn LogicalPageScheduler>> {
         if Self::is_primitive(data_type) {
             let primitive_col = column_infos.next().unwrap();
             return Self::create_primitive_scheduler(data_type, primitive_col, buffers);
@@ -404,8 +404,8 @@ impl DecodeBatchScheduler {
                     inner_schedulers
                         .into_iter()
                         .map(|inner| {
-                            Box::new(FslPageScheduler::new(inner, *dimension as u32))
-                                as Box<dyn LogicalPageScheduler>
+                            Arc::new(FslPageScheduler::new(inner, *dimension as u32))
+                                as Arc<dyn LogicalPageScheduler>
                         })
                         .collect::<Vec<_>>()
                 }
@@ -418,7 +418,8 @@ impl DecodeBatchScheduler {
                 };
                 let items =
                     Self::create_field_scheduler(items_field.data_type(), column_infos, buffers);
-                let mut items = items.into_iter();
+                let mut items = items.into_iter().peekable();
+                let mut cur_items_page_offset = 0;
                 offsets_column
                     .page_infos
                     .iter()
@@ -426,17 +427,25 @@ impl DecodeBatchScheduler {
                         if let Some(pb::array_encoding::ArrayEncoding::List(list_encoding)) =
                             &offsets_page.encoding.array_encoding
                         {
-                            let inner = Box::new(PrimitivePageScheduler::new(
+                            let inner = Arc::new(PrimitivePageScheduler::new(
                                 DataType::UInt64,
                                 offsets_page.clone(),
                                 offsets_column_buffers,
                             ))
-                                as Box<dyn LogicalPageScheduler>;
+                                as Arc<dyn LogicalPageScheduler>;
                             let mut items_schedulers = Vec::new();
                             let mut num_items = list_encoding.num_items;
+                            let first_items_page_offset = cur_items_page_offset;
                             while num_items > 0 {
-                                let next_items_page = items.next().unwrap();
-                                num_items -= next_items_page.num_rows() as u64;
+                                let next_items_page = items.peek().unwrap().clone();
+                                if next_items_page.num_rows() as u64 <= num_items {
+                                    num_items -= next_items_page.num_rows() as u64;
+                                    cur_items_page_offset = 0;
+                                    items.next().unwrap();
+                                } else {
+                                    cur_items_page_offset += num_items as u32;
+                                    num_items = 0;
+                                }
                                 items_schedulers.push(next_items_page);
                             }
                             let offset_type = if matches!(data_type, DataType::List(_)) {
@@ -444,13 +453,14 @@ impl DecodeBatchScheduler {
                             } else {
                                 DataType::Int64
                             };
-                            Box::new(ListPageScheduler::new(
+                            Arc::new(ListPageScheduler::new(
                                 inner,
                                 items_schedulers,
                                 items_field.data_type().clone(),
                                 offset_type,
                                 list_encoding.null_offset_adjustment,
-                            )) as Box<dyn LogicalPageScheduler>
+                                first_items_page_offset,
+                            )) as Arc<dyn LogicalPageScheduler>
                         } else {
                             // TODO: Should probably return Err here
                             panic!("Expected a list column");
@@ -468,8 +478,8 @@ impl DecodeBatchScheduler {
                 list_decoders
                     .into_iter()
                     .map(|list_decoder| {
-                        Box::new(BinaryPageScheduler::new(list_decoder, data_type.clone()))
-                            as Box<dyn LogicalPageScheduler>
+                        Arc::new(BinaryPageScheduler::new(list_decoder, data_type.clone()))
+                            as Arc<dyn LogicalPageScheduler>
                     })
                     .collect::<Vec<_>>()
             }
@@ -486,7 +496,7 @@ impl DecodeBatchScheduler {
                 // only one "page" of struct data.  In the future, this will change.  A null-aware
                 // struct scheduler will need to first calculate how many rows are in the struct page
                 // and then find the child pages that overlap.  This should be doable.
-                vec![Box::new(SimpleStructScheduler::new(
+                vec![Arc::new(SimpleStructScheduler::new(
                     child_schedulers,
                     fields.clone(),
                 ))]
@@ -536,11 +546,12 @@ impl DecodeBatchScheduler {
         let rows_to_read = range.end - range.start;
         trace!("Scheduling range {:?} ({} rows)", range, rows_to_read);
 
-        let range = range.start as u32..range.end as u32;
-
         let mut context = SchedulerContext::new(sink, scheduler);
-        self.root_scheduler
-            .schedule_ranges(&[range.clone()], &mut context, range.start as u64)?;
+        self.root_scheduler.schedule_ranges_u64(
+            &[range.clone()],
+            &mut context,
+            range.start as u64,
+        )?;
 
         trace!("Finished scheduling of range {:?}", range);
         Ok(())
@@ -575,12 +586,10 @@ impl DecodeBatchScheduler {
         if indices.is_empty() {
             return Ok(());
         }
-        // TODO: Figure out how to handle u64 indices
-        let indices = indices.iter().map(|i| *i as u32).collect::<Vec<_>>();
         let mut context = SchedulerContext::new(sink, scheduler);
 
         self.root_scheduler
-            .schedule_take(&indices, &mut context, indices[0] as u64)?;
+            .schedule_take_u64(&indices, &mut context, indices[0] as u64)?;
         trace!("Finished scheduling take of {} rows", indices.len());
         Ok(())
     }
@@ -594,7 +603,7 @@ pub struct ReadBatchTask {
 /// A stream that takes scheduled jobs and generates decode tasks from them.
 pub struct BatchDecodeStream {
     context: DecoderContext,
-    root_decoders: VecDeque<Box<dyn LogicalPageDecoder>>,
+    root_decoder: SimpleStructDecoder,
     rows_remaining: u64,
     rows_per_batch: u32,
     rows_scheduled: u64,
@@ -616,10 +625,11 @@ impl BatchDecodeStream {
         scheduled: mpsc::UnboundedReceiver<DecoderMessage>,
         rows_per_batch: u32,
         num_rows: u64,
+        root_decoder: SimpleStructDecoder,
     ) -> Self {
         Self {
             context: DecoderContext::new(scheduled),
-            root_decoders: VecDeque::new(),
+            root_decoder,
             rows_remaining: num_rows,
             rows_per_batch,
             rows_scheduled: 0,
@@ -628,22 +638,8 @@ impl BatchDecodeStream {
     }
 
     fn accept_decoder(&mut self, decoder: DecoderReady) -> Result<()> {
-        if decoder.path.is_empty() {
-            self.root_decoders.push_back(decoder.decoder);
-        } else {
-            let root = self
-                .root_decoders
-                .front_mut()
-                .ok_or_else(|| Error::Internal {
-                    message: format!(
-                        "A child decoder with path {:?} arrived before any root decoder",
-                        decoder.path
-                    ),
-                    location: location!(),
-                })?;
-            root.accept_child(decoder)?;
-        }
-        Ok(())
+        debug_assert!(!decoder.path.is_empty());
+        self.root_decoder.accept_child(decoder)
     }
 
     async fn wait_for_scheduled(&mut self, scheduled_need: u64) -> Result<()> {
@@ -695,22 +691,16 @@ impl BatchDecodeStream {
             self.wait_for_scheduled(desired_scheduled).await?;
         }
 
-        let current = self
-            .root_decoders
-            .front_mut()
-            .ok_or_else(|| Error::Internal {
-                message: "the scheduler never emitted a top-level decoder".into(),
-                location: location!(),
-            })?;
-        let avail = current.avail();
+        let avail = self.root_decoder.avail_u64();
         trace!("Top level page has {} rows already available", avail);
-        if avail < to_take {
-            current.wait(to_take).await?;
+        if avail < to_take as u64 {
+            trace!(
+                "Top level page waiting for an additional {} rows",
+                to_take as u64 - avail
+            );
+            self.root_decoder.wait(to_take).await?;
         }
-        let next_task = current.drain(to_take)?;
-        if !next_task.has_more {
-            self.root_decoders.pop_front();
-        }
+        let next_task = self.root_decoder.drain(to_take)?;
         self.rows_drained += to_take as u64;
         Ok(Some(next_task))
     }
@@ -1096,6 +1086,9 @@ pub async fn decode_batch(batch: &EncodedBatch) -> Result<RecordBatch> {
     decode_scheduler
         .schedule_range(0..batch.num_rows, tx, io_scheduler)
         .await?;
-    let stream = BatchDecodeStream::new(rx, batch.num_rows as u32, batch.num_rows);
+    let root_decoder = decode_scheduler
+        .root_scheduler
+        .new_root_decoder_ranges(&[0..batch.num_rows]);
+    let stream = BatchDecodeStream::new(rx, batch.num_rows as u32, batch.num_rows, root_decoder);
     stream.into_stream().next().await.unwrap().task.await
 }

--- a/rust/lance-encoding/src/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/encodings/logical/binary.rs
@@ -29,13 +29,13 @@ use super::{list::ListFieldEncoder, primitive::PrimitiveFieldEncoder};
 /// A logical scheduler for utf8/binary pages which assumes the data are encoded as List<u8>
 #[derive(Debug)]
 pub struct BinaryPageScheduler {
-    varbin_scheduler: Box<dyn LogicalPageScheduler>,
+    varbin_scheduler: Arc<dyn LogicalPageScheduler>,
     data_type: DataType,
 }
 
 impl BinaryPageScheduler {
     // Create a new ListPageScheduler
-    pub fn new(varbin_scheduler: Box<dyn LogicalPageScheduler>, data_type: DataType) -> Self {
+    pub fn new(varbin_scheduler: Arc<dyn LogicalPageScheduler>, data_type: DataType) -> Self {
         Self {
             varbin_scheduler,
             data_type,

--- a/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
@@ -31,12 +31,12 @@ use lance_core::Result;
 
 #[derive(Debug)]
 pub struct FslPageScheduler {
-    items_scheduler: Box<dyn LogicalPageScheduler>,
+    items_scheduler: Arc<dyn LogicalPageScheduler>,
     dimension: u32,
 }
 
 impl FslPageScheduler {
-    pub fn new(items_scheduler: Box<dyn LogicalPageScheduler>, dimension: u32) -> Self {
+    pub fn new(items_scheduler: Arc<dyn LogicalPageScheduler>, dimension: u32) -> Self {
         debug_assert_eq!(items_scheduler.num_rows() % dimension, 0);
         Self {
             items_scheduler,

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -10,7 +10,7 @@ use arrow_array::{
     Array, ArrayRef, BooleanArray, Int32Array, Int64Array, LargeListArray, ListArray, UInt64Array,
 };
 use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, Buffer, NullBuffer, OffsetBuffer};
-use arrow_schema::{DataType, Field};
+use arrow_schema::{DataType, Field, Fields};
 use futures::{future::BoxFuture, FutureExt};
 use log::trace;
 use snafu::{location, Location};
@@ -20,13 +20,18 @@ use lance_core::{Error, Result};
 
 use crate::{
     decoder::{
-        DecodeArrayTask, LogicalPageDecoder, LogicalPageScheduler, NextDecodeTask, SchedulerContext,
+        DecodeArrayTask, DecoderMessage, LogicalPageDecoder, LogicalPageScheduler, NextDecodeTask,
+        SchedulerContext,
     },
     encoder::{ArrayEncoder, EncodeTask, EncodedArray, EncodedPage, FieldEncoder},
+    encodings::logical::r#struct::SimpleStructScheduler,
     format::pb,
 };
 
-use super::primitive::{AccumulationQueue, PrimitiveFieldEncoder};
+use super::{
+    primitive::{AccumulationQueue, PrimitiveFieldEncoder},
+    r#struct::SimpleStructDecoder,
+};
 
 /// A page scheduler for list fields that encodes offsets in one field and items in another
 ///
@@ -42,34 +47,30 @@ use super::primitive::{AccumulationQueue, PrimitiveFieldEncoder};
 /// Whenever we schedule follow-up I/O like this the priority is based on the top-level row
 /// index.  This helps ensure that earlier rows get finished completely (including follow up
 /// tasks) before we perform I/O for later rows.
-///
-/// TODO: Actually implement the priority system described above
-///
-// TODO: Right now we are assuming that list offsets and list items are written at the same time.
-// As a result, we know which item pages correspond to which offsets page and there are no item
-// pages which overlap two different offsets pages.
-//
-// We could relax this constraint.  Either each offsets page could store the u64 offset into
-// the total range of item pages or each offsets page could store a u64 num_items and a u32
-// first_item_page_offset.
 #[derive(Debug)]
 pub struct ListPageScheduler {
-    offsets_scheduler: Box<dyn LogicalPageScheduler>,
-    items_schedulers: Arc<Vec<Box<dyn LogicalPageScheduler>>>,
+    offsets_scheduler: Arc<dyn LogicalPageScheduler>,
+    items_schedulers: Arc<Vec<Arc<dyn LogicalPageScheduler>>>,
     items_type: DataType,
     offset_type: DataType,
     null_offset_adjustment: u64,
+    // Two list pages might share an items page.  For example, when given a List<Struct<...>>
+    // the struct items page is often very large (if there are no nulls in the struct it will
+    // be 1 giant page) since it is just a header page.  This means the second list page starts
+    // at some offset into the items page which we record here.
+    first_items_page_offset: u32,
 }
 
 impl ListPageScheduler {
     // Create a new ListPageScheduler
     pub fn new(
-        offsets_scheduler: Box<dyn LogicalPageScheduler>,
-        items_schedulers: Vec<Box<dyn LogicalPageScheduler>>,
+        offsets_scheduler: Arc<dyn LogicalPageScheduler>,
+        items_schedulers: Vec<Arc<dyn LogicalPageScheduler>>,
         items_type: DataType,
         // Should be int32 or int64
         offset_type: DataType,
         null_offset_adjustment: u64,
+        first_items_page_offset: u32,
     ) -> Self {
         match &offset_type {
             DataType::Int32 | DataType::Int64 => {}
@@ -81,6 +82,7 @@ impl ListPageScheduler {
             items_type,
             offset_type,
             null_offset_adjustment,
+            first_items_page_offset,
         }
     }
 
@@ -270,9 +272,11 @@ impl LogicalPageScheduler for ListPageScheduler {
                     message: format!("scheduling offsets yielded {} pages", num_offset_decoders),
                     location: location!(),
                 })?;
+
         let items_schedulers = self.items_schedulers.clone();
         let ranges = ranges.to_vec();
-
+        let items_type = self.items_type.clone();
+        let first_items_page_offset = self.first_items_page_offset;
         let mut indirect_context = context.temporary();
 
         // First we schedule, as normal, the I/O for the offsets.  Then we immediately spawn
@@ -287,7 +291,7 @@ impl LogicalPageScheduler for ListPageScheduler {
             let decode_task = scheduled_offsets.drain(num_offsets)?;
             let offsets = decode_task.task.decode()?;
 
-            let (mut item_ranges, offsets, validity) =
+            let (item_ranges, offsets, validity) =
                 Self::decode_offsets(offsets.as_ref(), &ranges, null_offset_adjustment);
 
             trace!(
@@ -300,91 +304,49 @@ impl LogicalPageScheduler for ListPageScheduler {
             if items_schedulers.is_empty() || item_ranges.is_empty() {
                 debug_assert!(item_ranges.iter().all(|r| r.start == r.end));
                 return Ok(IndirectlyLoaded {
-                    item_decoders: Vec::new(),
+                    root_decoder: None,
                     offsets,
                     validity,
                 });
             }
 
-            let mut item_schedulers = VecDeque::from_iter(items_schedulers.iter());
-            let mut row_offset = 0_u64;
-            let mut next_scheduler = item_schedulers.pop_front().unwrap();
-            let mut next_range = item_ranges.pop_front().unwrap();
-            let mut next_item_ranges = Vec::new();
+            // Create a new root scheduler, which has one column, which is our items data
+            let indirect_root_scheduler = SimpleStructScheduler::new_root(
+                vec![items_schedulers.as_ref().clone()],
+                Fields::from(vec![Field::new("item", items_type, true)]),
+            );
 
-            // This is a bit complicated.  We have a list of ranges and we have a list of
-            // item schedulers.  We walk through both lists, scheduling the overlap.  For
-            // example, if we need items [500...1000], [2200..2300] [2500...4000] and we have 5 item
-            // pages with 1000 rows each then we need to schedule:
-            //
-            // page 0: 500..1000
-            // page 1: nothing
-            // page 2: 200..300, 500..1000
-            // page 3: 0..1000
-            // page 4: nothing
-            loop {
-                let current_scheduler_end = row_offset + next_scheduler.num_rows() as u64;
-                if next_range.start > current_scheduler_end {
-                    // All requested items are past this page, continue
-                    row_offset += next_scheduler.num_rows() as u64;
-                    if !next_item_ranges.is_empty() {
-                        // Note: we are providing the same top_level_row to ALL items pages referenced by
-                        // this offsets page.  This gives them higher priority.
-                        // TODO: Ideally we would ALSO have a guarantee from the scheduler that items with
-                        // the same top_level_row are scheduled in FCFS order but I don't think it works
-                        // that way.  Still, this is probably good enough for a while
-                        next_scheduler.schedule_ranges(
-                            &next_item_ranges,
-                            &mut indirect_context,
-                            top_level_row,
-                        )?;
-                        next_item_ranges.clear();
-                    }
-                    next_scheduler = item_schedulers.pop_front().unwrap();
-                } else if next_range.end <= current_scheduler_end {
-                    // Range entirely contained in current scheduler
-                    let page_range = (next_range.start - row_offset) as u32
-                        ..(next_range.end - row_offset) as u32;
-                    next_item_ranges.push(page_range);
-                    if let Some(item_range) = item_ranges.pop_front() {
-                        next_range = item_range;
-                    } else {
-                        // We have processed all pages
-                        break;
-                    }
-                } else {
-                    // Range partially contained in current scheduler
-                    let page_range =
-                        (next_range.start - row_offset) as u32..next_scheduler.num_rows();
-                    next_range = current_scheduler_end..next_range.end;
-                    next_item_ranges.push(page_range);
-                    row_offset += next_scheduler.num_rows() as u64;
-                    if !next_item_ranges.is_empty() {
-                        next_scheduler.schedule_ranges(
-                            &next_item_ranges,
-                            &mut indirect_context,
-                            top_level_row,
-                        )?;
-                        next_item_ranges.clear();
-                    }
-                    next_scheduler = item_schedulers.pop_front().unwrap();
+            let patched_item_ranges = item_ranges
+                .clone()
+                .into_iter()
+                .map(|range| {
+                    (range.start + first_items_page_offset as u64)
+                        ..(range.end + first_items_page_offset as u64)
+                })
+                .collect::<Vec<_>>();
+
+            // Immediately run the scheduling and process the decode messages (we could start
+            // a new thread here for decode to run in parallel but, at the moment, that seems
+            // like overkill)
+            indirect_root_scheduler.schedule_ranges_u64(
+                &patched_item_ranges,
+                &mut indirect_context,
+                top_level_row,
+            )?;
+            let mut root_decoder =
+                indirect_root_scheduler.new_root_decoder_ranges(&patched_item_ranges);
+
+            for message in indirect_context.into_messages() {
+                if let DecoderMessage::Decoder(decoder) = message {
+                    debug_assert!(!decoder.path.is_empty());
+                    root_decoder.accept_child(decoder)?;
                 }
             }
-            if !next_item_ranges.is_empty() {
-                next_scheduler.schedule_ranges(
-                    &next_item_ranges,
-                    &mut indirect_context,
-                    top_level_row,
-                )?;
-            }
-            // TODO: Should probably use into_messages here.  Can figure out once we add
-            // tests for List<Struct<...>>
-            let item_decoders = indirect_context.into_decoders();
 
             Ok(IndirectlyLoaded {
                 offsets,
                 validity,
-                item_decoders,
+                root_decoder: Some(root_decoder),
             })
         });
         let data_type = match &self.offset_type {
@@ -399,8 +361,7 @@ impl LogicalPageScheduler for ListPageScheduler {
         context.emit(Box::new(ListPageDecoder {
             offsets: Vec::new(),
             validity: BooleanBuffer::new(Buffer::from_vec(Vec::<u8>::default()), 0, 0),
-            unawaited_item_decoders: VecDeque::new(),
-            awaited_item_decoders: VecDeque::new(),
+            item_decoder: None,
             rows_drained: 0,
             lists_available: 0,
             num_rows,
@@ -450,9 +411,7 @@ struct ListPageDecoder {
     // offsets and validity will have already been decoded as part of the indirect I/O
     offsets: Vec<u64>,
     validity: BooleanBuffer,
-    // Items will not yet be decoded, that happens in the decode thread
-    unawaited_item_decoders: VecDeque<Box<dyn LogicalPageDecoder>>,
-    awaited_item_decoders: VecDeque<Box<dyn LogicalPageDecoder>>,
+    item_decoder: Option<SimpleStructDecoder>,
     lists_available: u32,
     num_rows: u32,
     rows_drained: u32,
@@ -464,7 +423,8 @@ struct ListPageDecoder {
 struct ListDecodeTask {
     offsets: Vec<u64>,
     validity: BooleanBuffer,
-    items: Vec<Box<dyn DecodeArrayTask>>,
+    // Will be None if there are no items (all empty / null lists)
+    items: Option<Box<dyn DecodeArrayTask>>,
     items_type: DataType,
     offset_type: DataType,
 }
@@ -473,18 +433,14 @@ impl DecodeArrayTask for ListDecodeTask {
     fn decode(self: Box<Self>) -> Result<ArrayRef> {
         let items = self
             .items
-            .into_iter()
-            .map(|task| task.decode())
-            .collect::<Result<Vec<_>>>()?;
-        let item_refs = items.iter().map(|item| item.as_ref()).collect::<Vec<_>>();
-        // TODO: could maybe try and "page bridge" these at some point
-        // (assuming item type is primitive) to avoid the concat
-        let items = if item_refs.is_empty() {
-            // This can happen if we have are building an array made only of empty lists
-            new_empty_array(&self.items_type)
-        } else {
-            arrow_select::concat::concat(&item_refs)?
-        };
+            .map(|items| {
+                // When we run the indirect I/O we wrap things in a struct array with a single field
+                // named "item".  We can unwrap that now.
+                let wrapped_items = items.decode()?;
+                Result::Ok(wrapped_items.as_struct().column(0).clone())
+            })
+            .unwrap_or_else(|| Ok(new_empty_array(&self.items_type)))?;
+
         // TODO: we default to nullable true here, should probably use the nullability given to
         // us from the input schema
         let item_field = Arc::new(Field::new("item", self.items_type.clone(), true));
@@ -530,7 +486,8 @@ impl DecodeArrayTask for ListDecodeTask {
 impl LogicalPageDecoder for ListPageDecoder {
     fn wait(&mut self, num_rows: u32) -> BoxFuture<Result<()>> {
         async move {
-            // wait for the indirect I/O to finish, then wait for enough items to arrive
+            // wait for the indirect I/O to finish, run the scheduler for the indirect
+            // I/O and then wait for enough items to arrive
             if self.unloaded.is_some() {
                 trace!("List scheduler needs to wait for indirect I/O to complete");
                 let indirectly_loaded = self.unloaded.take().unwrap().await;
@@ -541,15 +498,16 @@ impl LogicalPageDecoder for ListPageDecoder {
                     };
                 }
                 let indirectly_loaded = indirectly_loaded.unwrap()?;
+
                 self.offsets = indirectly_loaded.offsets;
                 self.validity = indirectly_loaded.validity;
-                self.unawaited_item_decoders
-                    .extend(indirectly_loaded.item_decoders);
+                self.item_decoder = indirectly_loaded.root_decoder;
             }
             trace!(
-                "List decoder is waiting for {} rows and {} are already available",
+                "List decoder is waiting for {} rows and {} are already available and {} are unawaited",
                 num_rows,
-                self.lists_available
+                self.lists_available,
+                self.num_rows - self.rows_drained
             );
             if self.lists_available >= num_rows {
                 self.lists_available -= num_rows;
@@ -561,44 +519,18 @@ impl LogicalPageDecoder for ListPageDecoder {
             let item_start = self.offsets[offset_wait_start as usize];
             let mut items_needed =
                 self.offsets[offset_wait_start as usize + num_rows as usize] - item_start;
-            // First discount any already available items
-            let items_already_available = self
-                .awaited_item_decoders
-                .iter()
-                .map(|d| d.avail() as u64)
-                .sum::<u64>();
-            trace!(
-                "List's items decoder already has {} items available in {} awaited pages",
-                items_already_available,
-                self.awaited_item_decoders.len(),
-            );
-            items_needed = items_needed.saturating_sub(items_already_available);
-            // The last decoder in the awaited list may not be fully awaited
-            if let Some(last_decoder) = self.awaited_item_decoders.back_mut() {
-                let to_await = items_needed.min(last_decoder.unawaited() as u64) as u32;
+            if items_needed > 0 {
+                // First discount any already available items
+                let items_already_available = self.item_decoder.as_mut().unwrap().avail_u64();
                 trace!(
-                    "List decoder waiting for {} items from the last awaited page",
-                    to_await
+                    "List's items decoder needs {} items and already has {} items available",
+                    items_needed,
+                    items_already_available,
                 );
-                if to_await > 0 {
-                    last_decoder.wait(to_await).await?;
-                    items_needed = items_needed.saturating_sub(last_decoder.avail() as u64);
+                items_needed = items_needed.saturating_sub(items_already_available);
+                if items_needed > 0 {
+                    self.item_decoder.as_mut().unwrap().wait_u64(items_needed).await?;
                 }
-            }
-            // Finally wait for more I/O
-            while items_needed > 0 {
-                let mut next_item_decoder = self.unawaited_item_decoders.pop_front().unwrap();
-                let unawaited = next_item_decoder.unawaited() as u64;
-                trace!(
-                    "List decoder waiting on a new page that has {} items unawaited",
-                    unawaited
-                );
-                let to_await = items_needed.min(unawaited) as u32;
-                // TODO: Seems like this will fail in List<Struct> case
-                next_item_decoder.wait(to_await).await?;
-                // Might end up loading more items than needed so use saturating_sub
-                items_needed = items_needed.saturating_sub(next_item_decoder.avail() as u64);
-                self.awaited_item_decoders.push_back(next_item_decoder);
             }
             // This is technically undercounting a little.  It's possible that we loaded a big items
             // page with many items and then only needed a few of them for the requested lists.  However,
@@ -648,21 +580,13 @@ impl LogicalPageDecoder for ListPageDecoder {
             .slice(self.rows_drained as usize, actual_num_rows as usize);
         let start = offsets[0];
         let end = offsets[offsets.len() - 1];
-        let mut num_items_to_drain = end - start;
+        let num_items_to_drain = end - start;
 
-        let mut item_decodes = Vec::new();
-        while num_items_to_drain > 0 {
-            let next_item_page = self.awaited_item_decoders.front_mut().unwrap();
-            let avail = next_item_page.avail();
-            let to_take = num_items_to_drain.min(avail as u64) as u32;
-            num_items_to_drain -= to_take as u64;
-            let next_task = next_item_page.drain(to_take)?;
-
-            if !next_task.has_more {
-                self.awaited_item_decoders.pop_front();
-            }
-            item_decodes.push(next_task.task);
-        }
+        let item_decode = self
+            .item_decoder
+            .as_mut()
+            .map(|item_decoder| Result::Ok(item_decoder.drain_u64(num_items_to_drain)?.task))
+            .transpose()?;
 
         self.rows_drained += num_rows;
         Ok(NextDecodeTask {
@@ -671,7 +595,7 @@ impl LogicalPageDecoder for ListPageDecoder {
             task: Box::new(ListDecodeTask {
                 offsets,
                 validity,
-                items: item_decodes,
+                items: item_decode,
                 items_type: self.items_type.clone(),
                 offset_type: self.offset_type.clone(),
             }) as Box<dyn DecodeArrayTask>,
@@ -690,7 +614,7 @@ impl LogicalPageDecoder for ListPageDecoder {
 struct IndirectlyLoaded {
     offsets: Vec<u64>,
     validity: BooleanBuffer,
-    item_decoders: Vec<Box<dyn LogicalPageDecoder>>,
+    root_decoder: Option<SimpleStructDecoder>,
 }
 
 impl std::fmt::Debug for IndirectlyLoaded {
@@ -1094,7 +1018,7 @@ mod tests {
         ArrayRef, BooleanArray, ListArray,
     };
     use arrow_buffer::{OffsetBuffer, ScalarBuffer};
-    use arrow_schema::{DataType, Field};
+    use arrow_schema::{DataType, Field, Fields};
 
     use crate::testing::{
         check_round_trip_encoding_of_data, check_round_trip_encoding_random, TestCases,
@@ -1113,6 +1037,18 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn test_nested_list() {
         let field = Field::new("", make_list_type(DataType::Utf8), true);
+        check_round_trip_encoding_random(field).await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_list_struct_list() {
+        let struct_type = DataType::Struct(Fields::from(vec![Field::new(
+            "inner_str",
+            DataType::Utf8,
+            false,
+        )]));
+
+        let field = Field::new("", make_list_type(struct_type), true);
         check_round_trip_encoding_random(field).await;
     }
 

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -485,7 +485,7 @@ impl ChildState {
             num_rows,
             self.rows_available
         );
-        let mut remaining = num_rows.saturating_sub(self.rows_available as u64);
+        let mut remaining = num_rows.saturating_sub(self.rows_available);
         for next_decoder in &mut self.scheduled {
             if next_decoder.unawaited() > 0 {
                 let rows_to_wait = remaining.min(next_decoder.unawaited() as u64) as u32;
@@ -590,7 +590,7 @@ impl SimpleStructDecoder {
             .unwrap()
     }
 
-    pub fn wait_u64<'a>(&'a mut self, num_rows: u64) -> BoxFuture<'a, Result<()>> {
+    pub fn wait_u64(&mut self, num_rows: u64) -> BoxFuture<Result<()>> {
         async move {
             for child in self.children.iter_mut() {
                 child.wait(num_rows).await?;

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -29,23 +29,28 @@ use lance_core::{Error, Result};
 ///
 /// Note: this scheduler is the starting point for all decoding.  This is because we treat the top-level
 /// record batch as a non-nullable struct.
+///
+/// This means this scheduler has to deal with u64 indices / ranges because the top-level
+/// scheduler spans up to u64 rows.
 #[derive(Debug)]
 pub struct SimpleStructScheduler {
-    children: Vec<Vec<Box<dyn LogicalPageScheduler>>>,
+    children: Vec<Vec<Arc<dyn LogicalPageScheduler>>>,
     child_fields: Fields,
-    num_rows: u32,
+    // A single page cannot contain more than u32 rows.  However, we also use SimpleStructScheduler
+    // at the top level and a single file *can* contain more than u32 rows.
+    num_rows: u64,
     // True if this is the top-level decoder (and we should send scan line messages)
     is_root: bool,
 }
 
 impl SimpleStructScheduler {
     fn new_with_params(
-        children: Vec<Vec<Box<dyn LogicalPageScheduler>>>,
+        children: Vec<Vec<Arc<dyn LogicalPageScheduler>>>,
         child_fields: Fields,
         is_root: bool,
     ) -> Self {
         debug_assert!(!children.is_empty());
-        let num_rows = children[0].iter().map(|page| page.num_rows()).sum();
+        let num_rows = children[0].iter().map(|page| page.num_rows() as u64).sum();
         // Ensure that all the children have the same number of rows
         Self {
             children,
@@ -55,79 +60,32 @@ impl SimpleStructScheduler {
         }
     }
 
-    pub fn new(children: Vec<Vec<Box<dyn LogicalPageScheduler>>>, child_fields: Fields) -> Self {
+    pub fn new(children: Vec<Vec<Arc<dyn LogicalPageScheduler>>>, child_fields: Fields) -> Self {
         Self::new_with_params(children, child_fields, false)
     }
 
     pub fn new_root(
-        children: Vec<Vec<Box<dyn LogicalPageScheduler>>>,
+        children: Vec<Vec<Arc<dyn LogicalPageScheduler>>>,
         child_fields: Fields,
     ) -> Self {
         Self::new_with_params(children, child_fields, true)
     }
-}
 
-// As we schedule a range we keep one of these per column so that we know
-// how far into the column we have already scheduled.
-#[derive(Debug, Clone, Copy)]
-struct RangeFieldWalkStatus {
-    rows_to_skip: u32,
-    rows_to_take: u32,
-    page_offset: u32,
-    rows_queued: u32,
-}
-
-impl RangeFieldWalkStatus {
-    fn new_from_range(range: Range<u32>) -> Self {
-        Self {
-            rows_to_skip: range.start,
-            rows_to_take: range.end - range.start,
-            page_offset: 0,
-            rows_queued: 0,
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct TakeFieldWalkStatus<'a> {
-    indices: &'a [u32],
-    indices_index: usize,
-    page_offset: u32,
-    rows_queued: u32,
-    rows_passed: u32,
-}
-
-impl<'a> TakeFieldWalkStatus<'a> {
-    fn new_from_indices(indices: &'a [u32]) -> Self {
-        Self {
-            indices,
-            indices_index: 0,
-            page_offset: 0,
-            rows_queued: 0,
-            rows_passed: 0,
-        }
+    pub fn new_root_decoder_ranges(&self, ranges: &[Range<u64>]) -> SimpleStructDecoder {
+        let rows_to_read = ranges
+            .iter()
+            .map(|range| range.end - range.start)
+            .sum::<u64>();
+        SimpleStructDecoder::new(self.child_fields.clone(), rows_to_read)
     }
 
-    // If the next page has `rows_in_page` rows then return the indices that would be included
-    // in that page (the returned indices are relative to the start of the page)
-    fn advance_page(&mut self, rows_in_page: u32) -> Vec<u32> {
-        let mut indices = Vec::new();
-        while self.indices_index < self.indices.len()
-            && (self.indices[self.indices_index] - self.rows_passed) < rows_in_page
-        {
-            indices.push(self.indices[self.indices_index] - self.rows_passed);
-            self.indices_index += 1;
-        }
-        self.rows_passed += rows_in_page;
-        self.page_offset += 1;
-        indices
+    pub fn new_root_decoder_indices(&self, indices: &[u64]) -> SimpleStructDecoder {
+        SimpleStructDecoder::new(self.child_fields.clone(), indices.len() as u64)
     }
-}
 
-impl LogicalPageScheduler for SimpleStructScheduler {
-    fn schedule_ranges(
+    pub fn schedule_ranges_u64(
         &self,
-        ranges: &[Range<u32>],
+        ranges: &[Range<u64>],
         mut context: &mut SchedulerContext,
         top_level_row: u64,
     ) -> Result<()> {
@@ -138,16 +96,6 @@ impl LogicalPageScheduler for SimpleStructScheduler {
                 range,
                 rows_to_read
             );
-
-            // Before we do anything, send a struct decoder to the decode thread so it can start decoding the pages
-            // we are about to send.
-            //
-            // This will need to get a tiny bit more complicated once structs have their own nullability and that nullability
-            // information starts to span multiple pages.
-            context.emit(Box::new(SimpleStructDecoder::new(
-                self.child_fields.clone(),
-                rows_to_read,
-            )));
 
             let mut field_status =
                 vec![RangeFieldWalkStatus::new_from_range(range); self.children.len()];
@@ -185,16 +133,19 @@ impl LogicalPageScheduler for SimpleStructScheduler {
                         trace!("Need additional rows for column {}", col_idx);
                         let mut next_page = &field_scheduler[status.page_offset as usize];
 
-                        while status.rows_to_skip >= next_page.num_rows() {
-                            status.rows_to_skip -= next_page.num_rows();
+                        while status.rows_to_skip >= next_page.num_rows() as u64 {
+                            status.rows_to_skip -= next_page.num_rows() as u64;
                             status.page_offset += 1;
                             trace!("Skipping entire page of {} rows", next_page.num_rows());
                             next_page = &field_scheduler[status.page_offset as usize];
                         }
 
-                        let page_range_start = status.rows_to_skip;
+                        debug_assert!(status.rows_to_skip < u32::MAX as u64);
+
+                        let page_range_start = status.rows_to_skip as u32;
                         let page_rows_remaining = next_page.num_rows() - page_range_start;
-                        let rows_to_take = status.rows_to_take.min(page_rows_remaining);
+                        let rows_to_take =
+                            status.rows_to_take.min(page_rows_remaining as u64) as u32;
                         let page_range = page_range_start..(page_range_start + rows_to_take);
 
                         trace!(
@@ -212,7 +163,7 @@ impl LogicalPageScheduler for SimpleStructScheduler {
                         context = scope.pop();
 
                         status.rows_queued += rows_to_take;
-                        status.rows_to_take -= rows_to_take;
+                        status.rows_to_take -= rows_to_take as u64;
                         status.page_offset += 1;
                         status.rows_to_skip = 0;
 
@@ -229,7 +180,7 @@ impl LogicalPageScheduler for SimpleStructScheduler {
                 if min_rows_added == 0 {
                     panic!("Error in scheduling logic, panic to avoid infinite loop");
                 }
-                rows_to_read -= min_rows_added;
+                rows_to_read -= min_rows_added as u64;
                 current_top_level_row += min_rows_added as u64;
                 if self.is_root {
                     trace!(
@@ -251,13 +202,9 @@ impl LogicalPageScheduler for SimpleStructScheduler {
         Ok(())
     }
 
-    fn num_rows(&self) -> u32 {
-        self.num_rows
-    }
-
-    fn schedule_take(
+    pub fn schedule_take_u64(
         &self,
-        indices: &[u32],
+        indices: &[u64],
         mut context: &mut SchedulerContext,
         top_level_row: u64,
     ) -> Result<()> {
@@ -266,16 +213,6 @@ impl LogicalPageScheduler for SimpleStructScheduler {
             indices.len(),
             top_level_row
         );
-
-        // Before we do anything, send a struct decoder to the decode thread so it can start decoding the pages
-        // we are about to send.
-        //
-        // This will need to get a tiny bit more complicated once structs have their own nullability and that nullability
-        // information starts to span multiple pages.
-        context.emit(Box::new(SimpleStructDecoder::new(
-            self.child_fields.clone(),
-            indices.len() as u32,
-        )));
 
         // Create a cursor into indices for each column
         let mut field_status =
@@ -371,6 +308,117 @@ impl LogicalPageScheduler for SimpleStructScheduler {
     }
 }
 
+// As we schedule a range we keep one of these per column so that we know
+// how far into the column we have already scheduled.
+#[derive(Debug, Clone, Copy)]
+struct RangeFieldWalkStatus {
+    rows_to_skip: u64,
+    rows_to_take: u64,
+    page_offset: u32,
+    rows_queued: u32,
+}
+
+impl RangeFieldWalkStatus {
+    fn new_from_range(range: Range<u64>) -> Self {
+        Self {
+            rows_to_skip: range.start,
+            rows_to_take: range.end - range.start,
+            page_offset: 0,
+            rows_queued: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TakeFieldWalkStatus<'a> {
+    indices: &'a [u64],
+    indices_index: usize,
+    page_offset: u32,
+    rows_queued: u32,
+    rows_passed: u64,
+}
+
+impl<'a> TakeFieldWalkStatus<'a> {
+    fn new_from_indices(indices: &'a [u64]) -> Self {
+        Self {
+            indices,
+            indices_index: 0,
+            page_offset: 0,
+            rows_queued: 0,
+            rows_passed: 0,
+        }
+    }
+
+    // If the next page has `rows_in_page` rows then return the indices that would be included
+    // in that page (the returned indices are relative to the start of the page)
+    fn advance_page(&mut self, rows_in_page: u32) -> Vec<u32> {
+        let mut indices = Vec::new();
+        while self.indices_index < self.indices.len()
+            && (self.indices[self.indices_index] - self.rows_passed) < rows_in_page as u64
+        {
+            indices.push((self.indices[self.indices_index] - self.rows_passed) as u32);
+            self.indices_index += 1;
+        }
+        self.rows_passed += rows_in_page as u64;
+        self.page_offset += 1;
+        indices
+    }
+}
+
+impl LogicalPageScheduler for SimpleStructScheduler {
+    fn schedule_ranges(
+        &self,
+        ranges: &[Range<u32>],
+        context: &mut SchedulerContext,
+        top_level_row: u64,
+    ) -> Result<()> {
+        // Send info to the decoder thread so it knows a struct is here.  In the future we will also
+        // send validity info here.
+        //
+        // Note: the root decoder is treated differently which is why this is here and not in schedule_ranges_u64
+        context.emit(Box::new(SimpleStructDecoder::new(
+            self.child_fields.clone(),
+            ranges
+                .iter()
+                .map(|range| range.end as u64 - range.start as u64)
+                .sum(),
+        )));
+
+        let ranges = ranges
+            .iter()
+            .map(|range| range.start as u64..range.end as u64)
+            .collect::<Vec<_>>();
+        self.schedule_ranges_u64(&ranges, context, top_level_row)
+    }
+
+    fn num_rows(&self) -> u32 {
+        if self.num_rows > u32::MAX as u64 {
+            // Not great, but works since we never call num_rows on the top-level scheduler
+            unreachable!("Call to num_rows on a top-level SimpleStructScheduler with more than u32::MAX rows")
+        }
+        self.num_rows as u32
+    }
+
+    fn schedule_take(
+        &self,
+        indices: &[u32],
+        context: &mut SchedulerContext,
+        top_level_row: u64,
+    ) -> Result<()> {
+        // Send info to the decoder thread so it knows a struct is here.  In the future we will also
+        // send validity info here.
+        //
+        // Note: the root decoder is treated differently which is why this is here and not in schedule_ranges_u64
+        context.emit(Box::new(SimpleStructDecoder::new(
+            self.child_fields.clone(),
+            indices.len() as u64,
+        )));
+
+        let indices = indices.iter().map(|idx| *idx as u64).collect::<Vec<_>>();
+        self.schedule_take_u64(&indices, context, top_level_row)
+    }
+}
+
 #[derive(Debug)]
 struct ChildState {
     // As child decoders are scheduled they are added to this queue
@@ -386,10 +434,10 @@ struct ChildState {
     scheduled: VecDeque<Box<dyn LogicalPageDecoder>>,
     // Rows that should still be coming over the channel source but haven't yet been
     // put into the awaited queue
-    rows_unawaited: u32,
+    rows_unawaited: u64,
     // Rows that have been pulled out of the channel source, awaited, and are ready to
     // be drained
-    rows_available: u32,
+    rows_available: u64,
     // The field index in the struct (used for debugging / logging)
     field_index: u32,
 }
@@ -420,7 +468,7 @@ impl CompositeDecodeTask {
 }
 
 impl ChildState {
-    fn new(num_rows: u32, field_index: u32) -> Self {
+    fn new(num_rows: u64, field_index: u32) -> Self {
         Self {
             scheduled: VecDeque::new(),
             rows_unawaited: num_rows,
@@ -430,17 +478,17 @@ impl ChildState {
     }
 
     // Wait for the next set of rows to arrive.
-    async fn wait(&mut self, num_rows: u32) -> Result<()> {
+    async fn wait(&mut self, num_rows: u64) -> Result<()> {
         trace!(
             "Struct child {} waiting for {} rows and {} are available already",
             self.field_index,
             num_rows,
             self.rows_available
         );
-        let mut remaining = num_rows.saturating_sub(self.rows_available);
+        let mut remaining = num_rows.saturating_sub(self.rows_available as u64);
         for next_decoder in &mut self.scheduled {
             if next_decoder.unawaited() > 0 {
-                let rows_to_wait = remaining.min(next_decoder.unawaited());
+                let rows_to_wait = remaining.min(next_decoder.unawaited() as u64) as u32;
                 trace!(
                     "Struct await an additional {} rows from the current page",
                     rows_to_wait
@@ -456,14 +504,14 @@ impl ChildState {
                 next_decoder.wait(rows_to_wait).await?;
                 let newly_avail = next_decoder.avail() - previously_avail;
                 trace!("The await loaded {} rows", newly_avail);
-                self.rows_available += newly_avail;
+                self.rows_available += newly_avail as u64;
                 // Need to use saturating_sub here because we might have asked for range
                 // 0-1000 and this page we just loaded might cover 900-1100 and so newly_avail
                 // is 200 but rows_unawaited is only 100
                 //
                 // TODO: Unit tests may not be covering this branch right now
-                self.rows_unawaited = self.rows_unawaited.saturating_sub(newly_avail);
-                remaining -= rows_to_wait;
+                self.rows_unawaited = self.rows_unawaited.saturating_sub(newly_avail as u64);
+                remaining -= rows_to_wait as u64;
                 if remaining == 0 {
                     break;
                 }
@@ -476,7 +524,7 @@ impl ChildState {
         }
     }
 
-    fn drain(&mut self, num_rows: u32) -> Result<CompositeDecodeTask> {
+    fn drain(&mut self, num_rows: u64) -> Result<CompositeDecodeTask> {
         trace!("Struct draining {} rows", num_rows);
         debug_assert!(self.rows_available >= num_rows);
         debug_assert!(num_rows > 0);
@@ -489,13 +537,13 @@ impl ChildState {
         };
         while remaining > 0 {
             let next = self.scheduled.front_mut().unwrap();
-            let rows_to_take = remaining.min(next.avail());
+            let rows_to_take = remaining.min(next.avail() as u64) as u32;
             let next_task = next.drain(rows_to_take)?;
             if next.avail() == 0 && next.unawaited() == 0 {
                 trace!("Completely drained page");
                 self.scheduled.pop_front();
             }
-            remaining -= rows_to_take;
+            remaining -= rows_to_take as u64;
             composite.tasks.push(next_task.task);
             composite.num_rows += next_task.num_rows;
         }
@@ -505,14 +553,14 @@ impl ChildState {
 }
 
 #[derive(Debug)]
-struct SimpleStructDecoder {
+pub struct SimpleStructDecoder {
     children: Vec<ChildState>,
     child_fields: Fields,
     data_type: DataType,
 }
 
 impl SimpleStructDecoder {
-    fn new(child_fields: Fields, num_rows: u32) -> Self {
+    fn new(child_fields: Fields, num_rows: u64) -> Self {
         let data_type = DataType::Struct(child_fields.clone());
         Self {
             children: child_fields
@@ -523,6 +571,53 @@ impl SimpleStructDecoder {
             child_fields,
             data_type,
         }
+    }
+
+    pub fn avail_u64(&self) -> u64 {
+        self.children
+            .iter()
+            .map(|c| c.rows_available)
+            .min()
+            .unwrap()
+    }
+
+    // Rows are unawaited if they are unawaited in any child column
+    pub fn unawaited_u64(&self) -> u64 {
+        self.children
+            .iter()
+            .map(|c| c.rows_unawaited)
+            .max()
+            .unwrap()
+    }
+
+    pub fn wait_u64<'a>(&'a mut self, num_rows: u64) -> BoxFuture<'a, Result<()>> {
+        async move {
+            for child in self.children.iter_mut() {
+                child.wait(num_rows).await?;
+            }
+            Ok(())
+        }
+        .boxed()
+    }
+
+    pub fn drain_u64(&mut self, num_rows: u64) -> Result<NextDecodeTask> {
+        let child_tasks = self
+            .children
+            .iter_mut()
+            .map(|child| child.drain(num_rows))
+            .collect::<Result<Vec<_>>>()?;
+        let num_rows = child_tasks[0].num_rows;
+        let has_more = child_tasks[0].has_more;
+        debug_assert!(child_tasks.iter().all(|task| task.num_rows == num_rows));
+        debug_assert!(child_tasks.iter().all(|task| task.has_more == has_more));
+        Ok(NextDecodeTask {
+            task: Box::new(SimpleStructDecodeTask {
+                children: child_tasks,
+                child_fields: self.child_fields.clone(),
+            }),
+            num_rows,
+            has_more,
+        })
     }
 }
 
@@ -546,7 +641,7 @@ impl LogicalPageDecoder for SimpleStructDecoder {
     fn wait(&mut self, num_rows: u32) -> BoxFuture<Result<()>> {
         async move {
             for child in self.children.iter_mut() {
-                child.wait(num_rows).await?;
+                child.wait(num_rows as u64).await?;
             }
             Ok(())
         }
@@ -557,7 +652,7 @@ impl LogicalPageDecoder for SimpleStructDecoder {
         let child_tasks = self
             .children
             .iter_mut()
-            .map(|child| child.drain(num_rows))
+            .map(|child| child.drain(num_rows as u64))
             .collect::<Result<Vec<_>>>()?;
         let num_rows = child_tasks[0].num_rows;
         let has_more = child_tasks[0].has_more;
@@ -575,20 +670,16 @@ impl LogicalPageDecoder for SimpleStructDecoder {
 
     // Rows are available only if they are available in every child column
     fn avail(&self) -> u32 {
-        self.children
-            .iter()
-            .map(|c| c.rows_available)
-            .min()
-            .unwrap()
+        let avail = self.avail_u64();
+        debug_assert!(avail <= u32::MAX as u64);
+        avail as u32
     }
 
     // Rows are unawaited if they are unawaited in any child column
     fn unawaited(&self) -> u32 {
-        self.children
-            .iter()
-            .map(|c| c.rows_unawaited)
-            .max()
-            .unwrap()
+        let unawaited = self.unawaited_u64();
+        debug_assert!(unawaited <= u32::MAX as u64);
+        unawaited as u32
     }
 
     fn data_type(&self) -> &DataType {

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -17,6 +17,7 @@ use lance_datagen::{array, gen, RowCount, Seed};
 use crate::{
     decoder::{BatchDecodeStream, ColumnInfo, DecodeBatchScheduler, DecoderMessage, PageInfo},
     encoder::{BatchEncoder, EncodedPage, FieldEncoder},
+    encodings::logical::r#struct::SimpleStructDecoder,
     EncodingsIo,
 };
 
@@ -66,16 +67,18 @@ async fn test_decode(
     schedule_fn: impl FnOnce(
         DecodeBatchScheduler,
         UnboundedSender<DecoderMessage>,
-    ) -> BoxFuture<'static, Result<()>>,
+    ) -> (SimpleStructDecoder, BoxFuture<'static, Result<()>>),
 ) {
     let decode_scheduler = DecodeBatchScheduler::new(schema, column_infos, &Vec::new());
 
     let (tx, rx) = mpsc::unbounded_channel();
 
-    schedule_fn(decode_scheduler, tx).await.unwrap();
+    let (decoder, scheduler_fut) = schedule_fn(decode_scheduler, tx);
+
+    scheduler_fut.await.unwrap();
 
     const BATCH_SIZE: u32 = 100;
-    let mut decode_stream = BatchDecodeStream::new(rx, BATCH_SIZE, num_rows).into_stream();
+    let mut decode_stream = BatchDecodeStream::new(rx, BATCH_SIZE, num_rows, decoder).into_stream();
 
     let mut offset = 0;
     while let Some(batch) = decode_stream.next().await {
@@ -241,12 +244,18 @@ async fn check_round_trip_encoding_inner(
         &column_infos,
         concat_data.clone(),
         |mut decode_scheduler, tx| {
-            async move {
-                decode_scheduler
-                    .schedule_range(0..num_rows, tx, scheduler_copy)
-                    .await
-            }
-            .boxed()
+            let root_decoder = decode_scheduler
+                .root_scheduler
+                .new_root_decoder_ranges(&[0..num_rows]);
+            (
+                root_decoder,
+                async move {
+                    decode_scheduler
+                        .schedule_range(0..num_rows, tx, scheduler_copy)
+                        .await
+                }
+                .boxed(),
+            )
         },
     )
     .await;
@@ -266,7 +275,14 @@ async fn check_round_trip_encoding_inner(
             &column_infos,
             expected,
             |mut decode_scheduler, tx| {
-                async move { decode_scheduler.schedule_range(range, tx, scheduler).await }.boxed()
+                let root_decoder = decode_scheduler
+                    .root_scheduler
+                    .new_root_decoder_ranges(&[0..num_rows]);
+                (
+                    root_decoder,
+                    async move { decode_scheduler.schedule_range(range, tx, scheduler).await }
+                        .boxed(),
+                )
             },
         )
         .await;
@@ -297,12 +313,18 @@ async fn check_round_trip_encoding_inner(
             &column_infos,
             expected,
             |mut decode_scheduler, tx| {
-                async move {
-                    decode_scheduler
-                        .schedule_take(&indices, tx, scheduler)
-                        .await
-                }
-                .boxed()
+                let root_decoder = decode_scheduler
+                    .root_scheduler
+                    .new_root_decoder_indices(&indices);
+                (
+                    root_decoder,
+                    async move {
+                        decode_scheduler
+                            .schedule_take(&indices, tx, scheduler)
+                            .await
+                    }
+                    .boxed(),
+                )
             },
         )
         .await;

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -244,6 +244,7 @@ async fn check_round_trip_encoding_inner(
         &column_infos,
         concat_data.clone(),
         |mut decode_scheduler, tx| {
+            #[allow(clippy::single_range_in_vec_init)]
             let root_decoder = decode_scheduler
                 .root_scheduler
                 .new_root_decoder_ranges(&[0..num_rows]);
@@ -275,6 +276,7 @@ async fn check_round_trip_encoding_inner(
             &column_infos,
             expected,
             |mut decode_scheduler, tx| {
+                #[allow(clippy::single_range_in_vec_init)]
                 let root_decoder = decode_scheduler
                     .root_scheduler
                     .new_root_decoder_ranges(&[0..num_rows]);

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -596,6 +596,10 @@ impl FileReader {
             &vec![],
         );
 
+        let root_decoder = decode_scheduler
+            .root_scheduler
+            .new_root_decoder_ranges(&[range.clone()]);
+
         let (tx, rx) = mpsc::unbounded_channel();
 
         let num_rows_to_read = range.end - range.start;
@@ -605,7 +609,7 @@ impl FileReader {
             async move { decode_scheduler.schedule_range(range, tx, scheduler).await },
         );
 
-        Ok(BatchDecodeStream::new(rx, batch_size, num_rows_to_read).into_stream())
+        Ok(BatchDecodeStream::new(rx, batch_size, num_rows_to_read, root_decoder).into_stream())
     }
 
     fn take_rows(
@@ -629,6 +633,10 @@ impl FileReader {
             &vec![],
         );
 
+        let root_decoder = decode_scheduler
+            .root_scheduler
+            .new_root_decoder_indices(&indices);
+
         let (tx, rx) = mpsc::unbounded_channel();
 
         let num_rows_to_read = indices.len() as u64;
@@ -640,7 +648,7 @@ impl FileReader {
                 .await
         });
 
-        Ok(BatchDecodeStream::new(rx, batch_size, num_rows_to_read).into_stream())
+        Ok(BatchDecodeStream::new(rx, batch_size, num_rows_to_read, root_decoder).into_stream())
     }
 
     /// Creates a stream of "read tasks" to read the data from the file


### PR DESCRIPTION
We had previously scanned through the items pages triggering decoding in a manner that was very similar to the struct decoder but incomplete.

Now, we reuse the struct decoder in the list decoder.  So the "indirect schedule & decode" is nearly identical to a direct schedule & decode.  This removed some near-duplicate code and makes it so that we can handle list-struct (or list-anything)

This also forced us to fix another issue that was preventing us from decoding files with more than 2^32 rows.

