### PR TITLE
fix: recognize a simple expression like 'is_foo' as a scalar index query

### DIFF
--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -474,7 +474,6 @@ fn visit_binary_expr(
 }
 
 fn visit_node(expr: &Expr, index_info: &dyn IndexInformationProvider) -> Option<IndexedExpression> {
-    dbg!(expr);
     match expr {
         Expr::Between(between) => visit_between(between, index_info),
         Expr::Column(_) => visit_column(expr, index_info),


### PR DESCRIPTION
Closes #2312 