### PR TITLE
chore(java): enable lance-jni rust release

### DIFF
--- a/java/core/lance-jni/Cargo.toml
+++ b/java/core/lance-jni/Cargo.toml
@@ -8,7 +8,6 @@ license.workspace = true
 description = "JNI bindings for Lance Columnar format"
 keywords.workspace = true
 categories.workspace = true
-publish = false
 
 [lib]
 crate-type = ["cdylib"]

--- a/java/core/lance-jni/src/ffi.rs
+++ b/java/core/lance-jni/src/ffi.rs
@@ -27,10 +27,18 @@ pub trait JNIEnvExt {
     /// Get strings from Java List<String> object.
     fn get_strings(&mut self, obj: &JObject) -> Result<Vec<String>>;
 
-    /// Get strings from Java String[] object.
-    /// Note that get Option<Vec<String>> from Java Optional<String[]> just doesn't work.
+    /// Converts a Java `String[]` array to a Rust `Vec<String>`.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because it dereferences a raw pointer `jobjectArray`.
+    /// The caller must ensure that the `jobjectArray` is a valid Java string array
+    /// and that the JNI environment `self` is correctly initialized and valid.
+    /// The function assumes that the `jobjectArray` is not null and that its elements
+    /// are valid Java strings. If these conditions are not met, the function may
+    /// exhibit undefined behavior.
     #[allow(dead_code)]
-    fn get_strings_array(&mut self, obj: jobjectArray) -> Result<Vec<String>>;
+    unsafe fn get_strings_array(&mut self, obj: jobjectArray) -> Result<Vec<String>>;
 
     /// Get Option<String> from Java Optional<String>.
     fn get_string_opt(&mut self, obj: &JObject) -> Result<Option<String>>;
@@ -84,7 +92,7 @@ impl JNIEnvExt for JNIEnv<'_> {
         Ok(results)
     }
 
-    fn get_strings_array(&mut self, obj: jobjectArray) -> Result<Vec<String>> {
+    unsafe fn get_strings_array(&mut self, obj: jobjectArray) -> Result<Vec<String>> {
         let jobject_array = unsafe { JObjectArray::from_raw(obj) };
         let array_len = self.get_array_length(&jobject_array)?;
         let mut res: Vec<String> = Vec::new();

--- a/java/core/lance-jni/src/lib.rs
+++ b/java/core/lance-jni/src/lib.rs
@@ -53,16 +53,18 @@ macro_rules! ok_or_throw_with_return {
 mod blocking_dataset;
 mod blocking_scanner;
 pub mod error;
-mod ffi;
+pub mod ffi;
 mod fragment;
-mod traits;
-mod utils;
+pub mod traits;
+pub mod utils;
+pub use error::Error;
 pub use error::Result;
+pub use ffi::JNIEnvExt;
 
 use lazy_static::lazy_static;
 
 lazy_static! {
-    static ref RT: tokio::runtime::Runtime = tokio::runtime::Builder::new_multi_thread()
+    pub static ref RT: tokio::runtime::Runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .expect("Failed to create tokio runtime");


### PR DESCRIPTION
Enable the release of lance-jni so that it's utils can be reused by lancedb-jni rust module