### PR TITLE
refactor: make proto conversion fallible and not copy

### DIFF
--- a/rust/lance-file/src/format/metadata.rs
+++ b/rust/lance-file/src/format/metadata.rs
@@ -52,9 +52,10 @@ impl From<&Metadata> for pb::Metadata {
     }
 }
 
-impl From<pb::Metadata> for Metadata {
-    fn from(m: pb::Metadata) -> Self {
-        Self {
+impl TryFrom<pb::Metadata> for Metadata {
+    type Error = Error;
+    fn try_from(m: pb::Metadata) -> Result<Self> {
+        Ok(Self {
             batch_offsets: m.batch_offsets.clone(),
             page_table_position: m.page_table_position as usize,
             manifest_position: Some(m.manifest_position as usize),
@@ -70,7 +71,7 @@ impl From<pb::Metadata> for Metadata {
             } else {
                 None
             },
-        }
+        })
     }
 }
 

--- a/rust/lance-table/src/format/index.rs
+++ b/rust/lance-table/src/format/index.rs
@@ -31,10 +31,10 @@ pub struct Index {
     pub fragment_bitmap: Option<RoaringBitmap>,
 }
 
-impl TryFrom<&pb::IndexMetadata> for Index {
+impl TryFrom<pb::IndexMetadata> for Index {
     type Error = Error;
 
-    fn try_from(proto: &pb::IndexMetadata) -> Result<Self> {
+    fn try_from(proto: pb::IndexMetadata) -> Result<Self> {
         let fragment_bitmap = if proto.fragment_bitmap.is_empty() {
             None
         } else {
@@ -50,8 +50,8 @@ impl TryFrom<&pb::IndexMetadata> for Index {
                     location!(),
                 )
             })??,
-            name: proto.name.clone(),
-            fields: proto.fields.clone(),
+            name: proto.name,
+            fields: proto.fields,
             dataset_version: proto.dataset_version,
             fragment_bitmap,
         })

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -328,8 +328,9 @@ impl ProtoStruct for Manifest {
     type Proto = pb::Manifest;
 }
 
-impl From<pb::Manifest> for Manifest {
-    fn from(p: pb::Manifest) -> Self {
+impl TryFrom<pb::Manifest> for Manifest {
+    type Error = Error;
+    fn try_from(p: pb::Manifest) -> Result<Self> {
         let timestamp_nanos = p.timestamp.map(|ts| {
             let sec = ts.seconds as u128 * 1e9 as u128;
             let nanos = ts.nanos as u128;
@@ -342,13 +343,18 @@ impl From<pb::Manifest> for Manifest {
             }
             _ => None,
         };
-        let fragments = Arc::new(p.fragments.iter().map(Fragment::from).collect::<Vec<_>>());
+        let fragments = Arc::new(
+            p.fragments
+                .into_iter()
+                .map(Fragment::try_from)
+                .collect::<Result<Vec<_>>>()?,
+        );
         let fragment_offsets = compute_fragment_offsets(fragments.as_slice());
         let fields_with_meta = FieldsWithMeta {
             fields: Fields(p.fields),
             metadata: p.metadata,
         };
-        Self {
+        Ok(Self {
             schema: Schema::from(fields_with_meta),
             version: p.version,
             writer_version,
@@ -366,7 +372,7 @@ impl From<pb::Manifest> for Manifest {
                 Some(p.transaction_file)
             },
             fragment_offsets,
-        }
+        })
     }
 }
 

--- a/rust/lance-table/src/io/manifest.rs
+++ b/rust/lance-table/src/io/manifest.rs
@@ -90,7 +90,7 @@ pub async fn read_manifest(object_store: &ObjectStore, path: &Path) -> Result<Ma
     }
 
     let proto = pb::Manifest::decode(buf)?;
-    Ok(Manifest::from(proto))
+    Manifest::try_from(proto)
 }
 
 #[instrument(level = "debug", skip(object_store, manifest))]
@@ -105,7 +105,7 @@ pub async fn read_manifest_indexes(
 
         Ok(section
             .indices
-            .iter()
+            .into_iter()
             .map(Index::try_from)
             .collect::<Result<Vec<_>>>()?)
     } else {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -646,7 +646,7 @@ impl Dataset {
         };
         let data = self.object_store.inner.get(&path).await?.bytes().await?;
         let transaction = lance_table::format::pb::Transaction::decode(data)?;
-        Transaction::try_from(&transaction).map(Some)
+        Transaction::try_from(transaction).map(Some)
     }
 
     /// Restore the currently checked out version of the dataset as the latest version.

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -59,7 +59,7 @@ async fn read_transaction_file(
     let result = object_store.inner.get(&path).await?;
     let data = result.bytes().await?;
     let transaction = pb::Transaction::decode(data)?;
-    (&transaction).try_into()
+    transaction.try_into()
 }
 
 /// Write a transaction to a file and return the relative path.


### PR DESCRIPTION
Minor refactor to allow conversions *from* proto structs to be fallible and also consume the struct. This reduces some data copies, though it's probably not all that impactful.