### PR TITLE
refactor: separate take and schema evolution impls to own files

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -4,15 +4,12 @@
 //! Lance Dataset
 //!
 
-use arrow::compute::CastOptions;
 use arrow_array::{RecordBatch, RecordBatchReader};
-use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use chrono::{prelude::*, Duration};
 use futures::future::BoxFuture;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use futures::{FutureExt, Stream};
-use lance_arrow::SchemaExt;
-use lance_core::datatypes::{Field, SchemaCompareOptions};
+use lance_core::datatypes::SchemaCompareOptions;
 use lance_datafusion::utils::{peek_reader_schema, reader_to_stream};
 use lance_file::datatypes::populate_schema_dictionary;
 use lance_io::object_store::{ObjectStore, ObjectStoreParams};
@@ -26,7 +23,7 @@ use log::warn;
 use object_store::path::Path;
 use prost::Message;
 use snafu::{location, Location};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -41,6 +38,7 @@ pub mod index;
 pub mod optimize;
 pub mod progress;
 pub mod scanner;
+pub mod schema_evolution;
 mod take;
 pub mod transaction;
 pub mod updater;
@@ -52,12 +50,12 @@ use self::cleanup::RemovalStats;
 use self::feature_flags::{apply_feature_flags, can_read_dataset, can_write_dataset};
 use self::fragment::FileFragment;
 use self::scanner::{DatasetRecordBatchStream, Scanner};
+use self::schema_evolution::{ColumnAlteration, NewColumnTransform};
 use self::transaction::{Operation, Transaction};
 use self::write::write_fragments_internal;
 use crate::datatypes::Schema;
 use crate::error::box_error;
 use crate::io::commit::{commit_new_dataset, commit_transaction};
-use crate::io::exec::Planner;
 use crate::session::Session;
 use crate::utils::temporal::{timestamp_to_nanos, utc_now, SystemTime};
 use crate::{Error, Result};
@@ -1183,106 +1181,7 @@ impl Dataset {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct BatchInfo {
-    pub fragment_id: u32,
-    pub batch_index: usize,
-}
-
-/// A mechanism for saving UDF results.
-///
-/// This is used to determine if a UDF has already been run on a given input,
-/// and to store the results of a UDF for future use.
-pub trait UDFCheckpointStore: Send + Sync {
-    fn get_batch(&self, info: &BatchInfo) -> Result<Option<RecordBatch>>;
-    fn insert_batch(&self, info: BatchInfo, batch: RecordBatch) -> Result<()>;
-    fn get_fragment(&self, fragment_id: u32) -> Result<Option<Fragment>>;
-    fn insert_fragment(&self, fragment: Fragment) -> Result<()>;
-}
-
-pub struct BatchUDF {
-    #[allow(clippy::type_complexity)]
-    pub mapper: Box<dyn Fn(&RecordBatch) -> Result<RecordBatch> + Send + Sync>,
-    /// The schema of the returned RecordBatch
-    pub output_schema: Arc<ArrowSchema>,
-    /// A checkpoint store for the UDF results
-    pub result_checkpoint: Option<Arc<dyn UDFCheckpointStore>>,
-}
-
-/// A way to define one or more new columns in a dataset
-pub enum NewColumnTransform {
-    /// A UDF that takes a RecordBatch of existing data and returns a
-    /// RecordBatch with the new columns for those corresponding rows. The returned
-    /// batch must return the same number of rows as the input batch.
-    BatchUDF(BatchUDF),
-    /// A set of SQL expressions that define new columns.
-    SqlExpressions(Vec<(String, String)>),
-}
-
-/// Definition of a change to a column in a dataset
-pub struct ColumnAlteration {
-    /// Path to the existing column to be altered.
-    pub path: String,
-    /// The new name of the column. If None, the column name will not be changed.
-    pub rename: Option<String>,
-    /// Whether the column is nullable. If None, the nullability will not be changed.
-    pub nullable: Option<bool>,
-    /// The new data type of the column. If None, the data type will not be changed.
-    pub data_type: Option<DataType>,
-}
-
-impl ColumnAlteration {
-    pub fn new(path: String) -> Self {
-        Self {
-            path,
-            rename: None,
-            nullable: None,
-            data_type: None,
-        }
-    }
-
-    pub fn rename(mut self, name: String) -> Self {
-        self.rename = Some(name);
-        self
-    }
-
-    pub fn set_nullable(mut self, nullable: bool) -> Self {
-        self.nullable = Some(nullable);
-        self
-    }
-
-    pub fn cast_to(mut self, data_type: DataType) -> Self {
-        self.data_type = Some(data_type);
-        self
-    }
-}
-
-/// Limit casts to same type. This is mostly to filter out weird casts like
-/// casting a string to a boolean or float to string.
-fn is_upcast_downcast(from_type: &DataType, to_type: &DataType) -> bool {
-    use DataType::*;
-    match from_type {
-        from_type if from_type.is_integer() => to_type.is_integer(),
-        from_type if from_type.is_floating() => to_type.is_floating(),
-        from_type if from_type.is_temporal() => to_type.is_temporal(),
-        Boolean => matches!(to_type, Boolean),
-        Utf8 | LargeUtf8 => matches!(to_type, Utf8 | LargeUtf8),
-        Binary | LargeBinary => matches!(to_type, Binary | LargeBinary),
-        Decimal128(_, _) | Decimal256(_, _) => {
-            matches!(to_type, Decimal128(_, _) | Decimal256(_, _))
-        }
-        List(from_field) | LargeList(from_field) | FixedSizeList(from_field, _) => match to_type {
-            List(to_field) | LargeList(to_field) | FixedSizeList(to_field, _) => {
-                is_upcast_downcast(from_field.data_type(), to_field.data_type())
-            }
-            _ => false,
-        },
-        _ => false,
-    }
-}
-
-// TODO: move all schema evolution methods to this impl and provide a dedicated
-// docs section to describe the schema evolution methods.
+/// # Schema Evolution
 impl Dataset {
     /// Append new columns to the dataset.
     pub async fn add_columns(
@@ -1290,357 +1189,14 @@ impl Dataset {
         transforms: NewColumnTransform,
         read_columns: Option<Vec<String>>,
     ) -> Result<()> {
-        // We just transform the SQL expression into a UDF backed by DataFusion
-        // physical expressions.
-        let (
-            BatchUDF {
-                mapper,
-                output_schema,
-                result_checkpoint,
-            },
-            read_columns,
-        ) = match transforms {
-            NewColumnTransform::BatchUDF(udf) => (udf, read_columns),
-            NewColumnTransform::SqlExpressions(expressions) => {
-                let arrow_schema = Arc::new(ArrowSchema::from(self.schema()));
-                let planner = Planner::new(arrow_schema);
-                let exprs = expressions
-                    .into_iter()
-                    .map(|(name, expr)| {
-                        let expr = planner.parse_expr(&expr)?;
-                        let expr = planner.optimize_expr(expr)?;
-                        Ok((name, expr))
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-
-                let needed_columns = exprs
-                    .iter()
-                    .flat_map(|(_, expr)| Planner::column_names_in_expr(expr))
-                    .collect::<HashSet<_>>()
-                    .into_iter()
-                    .collect::<Vec<_>>();
-                let read_schema = self.schema().project(&needed_columns)?;
-                let read_schema = Arc::new(ArrowSchema::from(&read_schema));
-                // Need to re-create the planner with the read schema because physical
-                // expressions use positional column references.
-                let planner = Planner::new(read_schema.clone());
-                let exprs = exprs
-                    .into_iter()
-                    .map(|(name, expr)| {
-                        let expr = planner.create_physical_expr(&expr)?;
-                        Ok((name, expr))
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-
-                let output_schema = Arc::new(ArrowSchema::new(
-                    exprs
-                        .iter()
-                        .map(|(name, expr)| {
-                            Ok(ArrowField::new(
-                                name,
-                                expr.data_type(read_schema.as_ref())?,
-                                expr.nullable(read_schema.as_ref())?,
-                            ))
-                        })
-                        .collect::<Result<Vec<_>>>()?,
-                ));
-
-                let schema_ref = output_schema.clone();
-                let mapper = move |batch: &RecordBatch| {
-                    let num_rows = batch.num_rows();
-                    let columns = exprs
-                        .iter()
-                        .map(|(_, expr)| Ok(expr.evaluate(batch)?.into_array(num_rows)?))
-                        .collect::<Result<Vec<_>>>()?;
-
-                    let batch = RecordBatch::try_new(schema_ref.clone(), columns)?;
-                    Ok(batch)
-                };
-                let mapper = Box::new(mapper);
-
-                let read_columns = Some(read_schema.field_names().into_iter().cloned().collect());
-                (
-                    BatchUDF {
-                        mapper,
-                        output_schema,
-                        result_checkpoint: None,
-                    },
-                    read_columns,
-                )
-            }
-        };
-
-        {
-            let new_names = output_schema.field_names();
-            for field in &self.schema().fields {
-                if new_names.contains(&&field.name) {
-                    return Err(Error::invalid_input(
-                        format!("Column {} already exists in the dataset", field.name),
-                        location!(),
-                    ));
-                }
-            }
-        }
-
-        let mut schema = self.schema().merge(output_schema.as_ref())?;
-        schema.set_field_id(Some(self.manifest.max_field_id()));
-
-        let fragments = self
-            .add_columns_impl(read_columns, mapper, result_checkpoint, None)
-            .await?;
-        let operation = Operation::Merge { fragments, schema };
-        let transaction = Transaction::new(self.manifest.version, operation, None);
-        let new_manifest = commit_transaction(
-            self,
-            &self.object_store,
-            self.commit_handler.as_ref(),
-            &transaction,
-            &Default::default(),
-            &Default::default(),
-        )
-        .await?;
-
-        self.manifest = Arc::new(new_manifest);
-
-        Ok(())
-    }
-
-    #[allow(clippy::type_complexity)]
-    async fn add_columns_impl(
-        &self,
-        read_columns: Option<Vec<String>>,
-        mapper: Box<dyn Fn(&RecordBatch) -> Result<RecordBatch> + Send + Sync>,
-        result_cache: Option<Arc<dyn UDFCheckpointStore>>,
-        schemas: Option<(Schema, Schema)>,
-    ) -> Result<Vec<Fragment>> {
-        let read_columns_ref = read_columns.as_deref();
-        let mapper_ref = mapper.as_ref();
-        let fragments = futures::stream::iter(self.get_fragments())
-            .then(|fragment| {
-                let cache_ref = result_cache.clone();
-                let schemas_ref = &schemas;
-                async move {
-                    if let Some(cache) = &cache_ref {
-                        let fragment_id = fragment.id() as u32;
-                        let fragment = cache.get_fragment(fragment_id)?;
-                        if let Some(fragment) = fragment {
-                            return Ok(fragment);
-                        }
-                    }
-
-                    let mut updater = fragment
-                        .updater(read_columns_ref, schemas_ref.clone())
-                        .await?;
-
-                    let mut batch_index = 0;
-                    // TODO: the structure of the updater prevents batch-level parallelism here,
-                    //       but there is no reason why we couldn't do this in parallel.
-                    while let Some(batch) = updater.next().await? {
-                        let batch_info = BatchInfo {
-                            fragment_id: fragment.id() as u32,
-                            batch_index,
-                        };
-
-                        let new_batch = if let Some(cache) = &cache_ref {
-                            if let Some(batch) = cache.get_batch(&batch_info)? {
-                                batch
-                            } else {
-                                let new_batch = mapper_ref(batch)?;
-                                cache.insert_batch(batch_info, new_batch.clone())?;
-                                new_batch
-                            }
-                        } else {
-                            mapper_ref(batch)?
-                        };
-
-                        updater.update(new_batch).await?;
-                        batch_index += 1;
-                    }
-
-                    let fragment = updater.finish().await?;
-
-                    if let Some(cache) = &cache_ref {
-                        cache.insert_fragment(fragment.clone())?;
-                    }
-
-                    Ok::<_, Error>(fragment)
-                }
-            })
-            .try_collect::<Vec<_>>()
-            .await?;
-        Ok(fragments)
+        schema_evolution::add_columns(self, transforms, read_columns).await
     }
 
     /// Modify columns in the dataset, changing their name, type, or nullability.
     ///
     /// If a column has an index, it's index will be preserved.
     pub async fn alter_columns(&mut self, alterations: &[ColumnAlteration]) -> Result<()> {
-        // Validate we aren't making nullable columns non-nullable and that all
-        // the referenced columns actually exist.
-        let mut new_schema = self.schema().clone();
-
-        // Mapping of old to new fields that need to be casted.
-        let mut cast_fields: Vec<(Field, Field)> = Vec::new();
-
-        let mut next_field_id = self.manifest.max_field_id() + 1;
-
-        for alteration in alterations {
-            let field_src = self.schema().field(&alteration.path).ok_or_else(|| {
-                Error::invalid_input(
-                    format!(
-                        "Column \"{}\" does not exist in the dataset",
-                        alteration.path
-                    ),
-                    location!(),
-                )
-            })?;
-            if let Some(nullable) = alteration.nullable {
-                // TODO: in the future, we could check the values of the column to see if
-                //       they are all non-null and thus the column could be made non-nullable.
-                if field_src.nullable && !nullable {
-                    return Err(Error::invalid_input(
-                        format!(
-                            "Column \"{}\" is already nullable and thus cannot be made non-nullable",
-                            alteration.path
-                        ),
-                        location!(),
-                    ));
-                }
-            }
-
-            let field_dest = new_schema.mut_field_by_id(field_src.id).unwrap();
-            if let Some(rename) = &alteration.rename {
-                field_dest.name.clone_from(rename);
-            }
-            if let Some(nullable) = alteration.nullable {
-                field_dest.nullable = nullable;
-            }
-
-            if let Some(data_type) = &alteration.data_type {
-                if !(lance_arrow::cast::can_cast_types(&field_src.data_type(), data_type)
-                    && is_upcast_downcast(&field_src.data_type(), data_type))
-                {
-                    return Err(Error::invalid_input(
-                        format!(
-                            "Cannot cast column \"{}\" from {:?} to {:?}",
-                            alteration.path,
-                            field_src.data_type(),
-                            data_type
-                        ),
-                        location!(),
-                    ));
-                }
-
-                let arrow_field = ArrowField::new(
-                    field_dest.name.clone(),
-                    data_type.clone(),
-                    field_dest.nullable,
-                );
-                *field_dest = Field::try_from(&arrow_field)?;
-                field_dest.set_id(field_src.parent_id, &mut next_field_id);
-
-                cast_fields.push((field_src.clone(), field_dest.clone()));
-            }
-        }
-
-        new_schema.validate()?;
-
-        // If we aren't casting a column, we don't need to touch the fragments.
-        let transaction = if cast_fields.is_empty() {
-            Transaction::new(
-                self.manifest.version,
-                Operation::Project { schema: new_schema },
-                None,
-            )
-        } else {
-            // Otherwise, we need to re-write the relevant fields.
-            let read_columns = cast_fields
-                .iter()
-                .map(|(old, _new)| {
-                    let parts = self.schema().field_ancestry_by_id(old.id).unwrap();
-                    let part_names = parts.iter().map(|p| p.name.clone()).collect::<Vec<_>>();
-                    part_names.join(".")
-                })
-                .collect::<Vec<_>>();
-
-            let new_ids = cast_fields
-                .iter()
-                .map(|(_old, new)| new.id)
-                .collect::<Vec<_>>();
-            // This schema contains the exact field ids we want to write the new fields with.
-            let new_col_schema = new_schema.project_by_ids(&new_ids);
-
-            let mapper = move |batch: &RecordBatch| {
-                let mut fields = Vec::with_capacity(cast_fields.len());
-                let mut columns = Vec::with_capacity(batch.num_columns());
-                for (old, new) in &cast_fields {
-                    let old_column = batch[&old.name].clone();
-                    let new_column = lance_arrow::cast::cast_with_options(
-                        &old_column,
-                        &new.data_type(),
-                        // Safe: false means it will error if the cast is lossy.
-                        &CastOptions {
-                            safe: false,
-                            ..Default::default()
-                        },
-                    )?;
-                    columns.push(new_column);
-                    fields.push(Arc::new(ArrowField::from(new)));
-                }
-                let schema = Arc::new(ArrowSchema::new(fields));
-                Ok(RecordBatch::try_new(schema, columns)?)
-            };
-            let mapper = Box::new(mapper);
-
-            let fragments = self
-                .add_columns_impl(
-                    Some(read_columns),
-                    mapper,
-                    None,
-                    Some((new_col_schema, new_schema.clone())),
-                )
-                .await?;
-
-            // Some data files may no longer contain any columns in the dataset (e.g. if every
-            // remaining column has been altered into a different data file) and so we remove them
-            let schema_field_ids = new_schema.field_ids().into_iter().collect::<Vec<_>>();
-            let fragments = fragments
-                .into_iter()
-                .map(|mut frag| {
-                    frag.files.retain(|f| {
-                        f.fields
-                            .iter()
-                            .any(|field| schema_field_ids.contains(field))
-                    });
-                    frag
-                })
-                .collect::<Vec<_>>();
-
-            Transaction::new(
-                self.manifest.version,
-                Operation::Merge {
-                    schema: new_schema,
-                    fragments,
-                },
-                None,
-            )
-        };
-
-        // TODO: adjust the indices here for the new schema
-
-        let manifest = commit_transaction(
-            self,
-            &self.object_store,
-            self.commit_handler.as_ref(),
-            &transaction,
-            &Default::default(),
-            &Default::default(),
-        )
-        .await?;
-
-        self.manifest = Arc::new(manifest);
-
-        Ok(())
+        schema_evolution::alter_columns(self, alterations).await
     }
 
     /// Remove columns from the dataset.
@@ -1650,45 +1206,7 @@ impl Dataset {
     /// call `compact_files` to rewrite the data without the removed columns and
     /// then call `cleanup_files` to remove the old files.
     pub async fn drop_columns(&mut self, columns: &[&str]) -> Result<()> {
-        // Check if columns are present in the dataset and construct the new schema.
-        for col in columns {
-            if self.schema().field(col).is_none() {
-                return Err(Error::invalid_input(
-                    format!("Column {} does not exist in the dataset", col),
-                    location!(),
-                ));
-            }
-        }
-
-        let columns_to_remove = self.manifest.schema.project(columns)?;
-        let new_schema = self.manifest.schema.exclude(columns_to_remove)?;
-
-        if new_schema.fields.is_empty() {
-            return Err(Error::invalid_input(
-                "Cannot drop all columns from a dataset",
-                location!(),
-            ));
-        }
-
-        let transaction = Transaction::new(
-            self.manifest.version,
-            Operation::Project { schema: new_schema },
-            None,
-        );
-
-        let manifest = commit_transaction(
-            self,
-            &self.object_store,
-            self.commit_handler.as_ref(),
-            &transaction,
-            &Default::default(),
-            &Default::default(),
-        )
-        .await?;
-
-        self.manifest = Arc::new(manifest);
-
-        Ok(())
+        schema_evolution::drop_columns(self, columns).await
     }
 }
 
@@ -1755,7 +1273,6 @@ fn write_manifest_file_to_path<'a>(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
     use std::vec;
 
     use super::*;
@@ -1769,16 +1286,15 @@ mod tests {
     use arrow::array::as_struct_array;
     use arrow::compute::concat_batches;
     use arrow_array::{
-        builder::StringDictionaryBuilder,
-        cast::as_string_array,
-        types::{Int32Type, Int64Type},
-        ArrayRef, DictionaryArray, Float32Array, Int32Array, Int64Array, Int8Array,
-        Int8DictionaryArray, RecordBatchIterator, StringArray, UInt16Array, UInt32Array,
+        builder::StringDictionaryBuilder, cast::as_string_array, types::Int32Type, ArrayRef,
+        DictionaryArray, Float32Array, Int32Array, Int64Array, Int8Array, Int8DictionaryArray,
+        RecordBatchIterator, StringArray, UInt16Array, UInt32Array,
     };
-    use arrow_array::{FixedSizeListArray, Float16Array, Float64Array, ListArray, StructArray};
+    use arrow_array::{FixedSizeListArray, StructArray};
     use arrow_ord::sort::sort_to_indices;
-    use arrow_schema::{Field, Fields as ArrowFields, Schema as ArrowSchema};
-    use half::f16;
+    use arrow_schema::{
+        DataType, Field as ArrowField, Fields as ArrowFields, Schema as ArrowSchema,
+    };
     use lance_arrow::bfloat16::{self, ARROW_EXT_META_KEY, ARROW_EXT_NAME_KEY, BFLOAT16_EXT_NAME};
     use lance_datagen::{array, gen, BatchCount, RowCount};
     use lance_index::{vector::DIST_COL, DatasetIndexExt, IndexType};
@@ -1796,10 +1312,10 @@ mod tests {
     }
 
     async fn create_file(path: &std::path::Path, mode: WriteMode, use_experimental_writer: bool) {
-        let mut fields = vec![Field::new("i", DataType::Int32, false)];
+        let mut fields = vec![ArrowField::new("i", DataType::Int32, false)];
         // TODO (GH-2347): currently the v2 writer does not support dictionary columns.
         if !use_experimental_writer {
-            fields.push(Field::new(
+            fields.push(ArrowField::new(
                 "dict",
                 DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
                 false,
@@ -1903,7 +1419,7 @@ mod tests {
     ) {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "i",
             DataType::Int32,
             false,
@@ -1984,7 +1500,7 @@ mod tests {
     async fn test_create_with_empty_iter(#[values(false, true)] use_experimental_writer: bool) {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "i",
             DataType::Int32,
             false,
@@ -2012,7 +1528,7 @@ mod tests {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
 
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "i",
             DataType::Int32,
             false,
@@ -2060,7 +1576,7 @@ mod tests {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
 
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "i",
             DataType::Int32,
             false,
@@ -2169,7 +1685,7 @@ mod tests {
     async fn append_dataset(#[values(false, true)] use_experimental_writer: bool) {
         let test_dir = tempdir().unwrap();
 
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "i",
             DataType::Int32,
             false,
@@ -2248,7 +1764,7 @@ mod tests {
     async fn test_self_dataset_append(#[values(false, true)] use_experimental_writer: bool) {
         let test_dir = tempdir().unwrap();
 
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "i",
             DataType::Int32,
             false,
@@ -2333,7 +1849,7 @@ mod tests {
     ) {
         let test_dir = tempdir().unwrap();
 
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "i",
             DataType::Int32,
             false,
@@ -2344,7 +1860,7 @@ mod tests {
         )
         .unwrap()];
 
-        let other_schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let other_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "i",
             DataType::Int64,
             false,
@@ -2381,7 +1897,7 @@ mod tests {
         // We store the dictionary as part of the schema, so we check that the
         // dictionary is consistent between appends.
 
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "x",
             DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
             false,
@@ -2447,7 +1963,7 @@ mod tests {
     async fn overwrite_dataset(#[values(false, true)] use_experimental_writer: bool) {
         let test_dir = tempdir().unwrap();
 
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "i",
             DataType::Int32,
             false,
@@ -2474,7 +1990,7 @@ mod tests {
         assert_eq!(fragments.len(), 1);
         assert_eq!(dataset.manifest.max_fragment_id(), Some(0));
 
-        let new_schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let new_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "s",
             DataType::Utf8,
             false,
@@ -2533,7 +2049,7 @@ mod tests {
     async fn test_fast_count_rows(#[values(false, true)] use_experimental_writer: bool) {
         let test_dir = tempdir().unwrap();
 
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "i",
             DataType::Int32,
             false,
@@ -2580,10 +2096,10 @@ mod tests {
         let test_dir = tempdir().unwrap();
 
         let dimension = 16;
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "embeddings",
             DataType::FixedSizeList(
-                Arc::new(Field::new("item", DataType::Float32, true)),
+                Arc::new(ArrowField::new("item", DataType::Float32, true)),
                 dimension,
             ),
             false,
@@ -2732,7 +2248,7 @@ mod tests {
     async fn create_bad_file(use_experimental_writer: bool) -> Result<Dataset> {
         let test_dir = tempdir().unwrap();
 
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "a.b.c",
             DataType::Int32,
             false,
@@ -2775,206 +2291,10 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn test_drop_columns(#[values(false, true)] use_experimental_writer: bool) -> Result<()> {
-        let metadata: HashMap<String, String> = [("k1".into(), "v1".into())].into();
-
-        let schema = Arc::new(ArrowSchema::new_with_metadata(
-            vec![
-                Field::new("i", DataType::Int32, false),
-                Field::new(
-                    "s",
-                    DataType::Struct(ArrowFields::from(vec![
-                        Field::new("d", DataType::Int32, true),
-                        Field::new("l", DataType::Int32, true),
-                    ])),
-                    true,
-                ),
-                Field::new("x", DataType::Float32, false),
-            ],
-            metadata.clone(),
-        ));
-
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2])),
-                Arc::new(StructArray::from(vec![
-                    (
-                        Arc::new(ArrowField::new("d", DataType::Int32, true)),
-                        Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
-                    ),
-                    (
-                        Arc::new(ArrowField::new("l", DataType::Int32, true)),
-                        Arc::new(Int32Array::from(vec![1, 2])),
-                    ),
-                ])),
-                Arc::new(Float32Array::from(vec![1.0, 2.0])),
-            ],
-        )?;
-
-        let test_dir = tempdir()?;
-        let test_uri = test_dir.path().to_str().unwrap();
-
-        let batches = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
-        let mut dataset = Dataset::write(
-            batches,
-            test_uri,
-            Some(WriteParams {
-                use_experimental_writer,
-                ..Default::default()
-            }),
-        )
-        .await?;
-
-        let lance_schema = dataset.schema().clone();
-        let original_fragments = dataset.fragments().to_vec();
-
-        dataset.drop_columns(&["x"]).await?;
-        dataset.validate().await?;
-
-        let expected_schema = lance_schema.project(&["i", "s"])?;
-        assert_eq!(dataset.schema(), &expected_schema);
-
-        assert_eq!(dataset.version().version, 2);
-        assert_eq!(dataset.fragments().as_ref(), &original_fragments);
-
-        dataset.drop_columns(&["s.d"]).await?;
-        dataset.validate().await?;
-
-        let expected_schema = expected_schema.project(&["i", "s.l"])?;
-        assert_eq!(dataset.schema(), &expected_schema);
-
-        let expected_data = RecordBatch::try_new(
-            Arc::new(ArrowSchema::from(&expected_schema)),
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2])),
-                Arc::new(StructArray::from(vec![(
-                    Arc::new(ArrowField::new("l", DataType::Int32, true)),
-                    Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
-                )])),
-            ],
-        )?;
-        let actual_data = dataset.scan().try_into_batch().await?;
-        assert_eq!(actual_data, expected_data);
-
-        assert_eq!(dataset.version().version, 3);
-        assert_eq!(dataset.fragments().as_ref(), &original_fragments);
-
-        Ok(())
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_drop_add_columns(
-        #[values(false, true)] use_experimental_writer: bool,
-    ) -> Result<()> {
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
-            "i",
-            DataType::Int32,
-            false,
-        )]));
-        let batch =
-            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1, 2]))])?;
-
-        let test_dir = tempdir()?;
-        let test_uri = test_dir.path().to_str().unwrap();
-
-        let batches = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
-        let mut dataset = Dataset::write(
-            batches,
-            test_uri,
-            Some(WriteParams {
-                use_experimental_writer,
-                ..Default::default()
-            }),
-        )
-        .await?;
-        assert_eq!(dataset.manifest.max_field_id(), 0);
-
-        // Test we can add 1 column, drop it, then add another column. Validate
-        // the field ids are as expected.
-        dataset
-            .add_columns(
-                NewColumnTransform::SqlExpressions(vec![("x".into(), "i + 1".into())]),
-                Some(vec!["i".into()]),
-            )
-            .await?;
-        assert_eq!(dataset.manifest.max_field_id(), 1);
-
-        dataset.drop_columns(&["x"]).await?;
-        assert_eq!(dataset.manifest.max_field_id(), 0);
-
-        dataset
-            .add_columns(
-                NewColumnTransform::SqlExpressions(vec![("y".into(), "2 * i".into())]),
-                Some(vec!["i".into()]),
-            )
-            .await?;
-        assert_eq!(dataset.manifest.max_field_id(), 1);
-
-        let data = dataset.scan().try_into_batch().await?;
-        let expected_data = RecordBatch::try_new(
-            Arc::new(schema.try_with_column(Field::new("y", DataType::Int32, false))?),
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2])),
-                Arc::new(Int32Array::from(vec![2, 4])),
-            ],
-        )?;
-        assert_eq!(data, expected_data);
-        dataset.drop_columns(&["y"]).await?;
-        assert_eq!(dataset.manifest.max_field_id(), 0);
-
-        // Test we can add 2 columns, drop 1, then add another column. Validate
-        // the field ids are as expected.
-        dataset
-            .add_columns(
-                NewColumnTransform::SqlExpressions(vec![
-                    ("a".into(), "i + 3".into()),
-                    ("b".into(), "i + 7".into()),
-                ]),
-                Some(vec!["i".into()]),
-            )
-            .await?;
-        assert_eq!(dataset.manifest.max_field_id(), 2);
-
-        dataset.drop_columns(&["b"]).await?;
-        // Even though we dropped a column, we still have the fragment with a and
-        // b. So it should still act as if that field id is still in play.
-        assert_eq!(dataset.manifest.max_field_id(), 2);
-
-        dataset
-            .add_columns(
-                NewColumnTransform::SqlExpressions(vec![("c".into(), "i + 11".into())]),
-                Some(vec!["i".into()]),
-            )
-            .await?;
-        assert_eq!(dataset.manifest.max_field_id(), 3);
-
-        let data = dataset.scan().try_into_batch().await?;
-        let expected_schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("i", DataType::Int32, false),
-            Field::new("a", DataType::Int32, false),
-            Field::new("c", DataType::Int32, false),
-        ]));
-        let expected_data = RecordBatch::try_new(
-            expected_schema,
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2])),
-                Arc::new(Int32Array::from(vec![4, 5])),
-                Arc::new(Int32Array::from(vec![12, 13])),
-            ],
-        )?;
-        assert_eq!(data, expected_data);
-
-        Ok(())
-    }
-
-    #[rstest]
-    #[tokio::test]
     async fn test_merge(#[values(false, true)] use_experimental_writer: bool) {
         let schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("i", DataType::Int32, false),
-            Field::new("x", DataType::Float32, false),
+            ArrowField::new("i", DataType::Int32, false),
+            ArrowField::new("x", DataType::Float32, false),
         ]));
         let batch1 = RecordBatch::try_new(
             schema.clone(),
@@ -3017,8 +2337,8 @@ mod tests {
         assert_eq!(dataset.manifest.max_fragment_id(), Some(1));
 
         let right_schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("i2", DataType::Int32, false),
-            Field::new("y", DataType::Utf8, true),
+            ArrowField::new("i2", DataType::Int32, false),
+            ArrowField::new("y", DataType::Utf8, true),
         ]));
         let right_batch1 = RecordBatch::try_new(
             right_schema.clone(),
@@ -3052,9 +2372,9 @@ mod tests {
         let actual = concat_batches(&actual_batches[0].schema(), &actual_batches).unwrap();
         let expected = RecordBatch::try_new(
             Arc::new(ArrowSchema::new(vec![
-                Field::new("i", DataType::Int32, false),
-                Field::new("x", DataType::Float32, false),
-                Field::new("y", DataType::Utf8, true),
+                ArrowField::new("i", DataType::Int32, false),
+                ArrowField::new("x", DataType::Float32, false),
+                ArrowField::new("y", DataType::Utf8, true),
             ])),
             vec![
                 Arc::new(Int32Array::from(vec![1, 2, 3, 2])),
@@ -3089,10 +2409,12 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_delete(#[values(false, true)] use_experimental_writer: bool) {
+        use std::collections::HashSet;
+
         fn sequence_data(range: Range<u32>) -> RecordBatch {
             let schema = Arc::new(ArrowSchema::new(vec![
-                Field::new("i", DataType::UInt32, false),
-                Field::new("x", DataType::UInt32, false),
+                ArrowField::new("i", DataType::UInt32, false),
+                ArrowField::new("x", DataType::UInt32, false),
             ]));
             RecordBatch::try_new(
                 schema,
@@ -3108,8 +2430,8 @@ mod tests {
         let test_uri = test_dir.path().to_str().unwrap();
 
         let schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("i", DataType::UInt32, false),
-            Field::new("x", DataType::UInt32, false),
+            ArrowField::new("i", DataType::UInt32, false),
+            ArrowField::new("x", DataType::UInt32, false),
         ]));
         let data = sequence_data(0..100);
         // Split over two files.
@@ -3252,7 +2574,7 @@ mod tests {
     #[tokio::test]
     async fn test_restore(#[values(false, true)] use_experimental_writer: bool) {
         // Create a table
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "i",
             DataType::UInt32,
             false,
@@ -3311,9 +2633,12 @@ mod tests {
     #[tokio::test]
     async fn test_search_empty(#[values(false, true)] use_experimental_writer: bool) {
         // Create a table
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "vec",
-            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 128),
+            DataType::FixedSizeList(
+                Arc::new(ArrowField::new("item", DataType::Float32, true)),
+                128,
+            ),
             false,
         )]));
 
@@ -3358,10 +2683,10 @@ mod tests {
             assert_eq!(schema.fields.len(), 2);
             assert_eq!(
                 schema.field_with_name("vec").unwrap(),
-                &Field::new(
+                &ArrowField::new(
                     "vec",
                     DataType::FixedSizeList(
-                        Arc::new(Field::new("item", DataType::Float32, true)),
+                        Arc::new(ArrowField::new("item", DataType::Float32, true)),
                         128
                     ),
                     false,
@@ -3369,7 +2694,7 @@ mod tests {
             );
             assert_eq!(
                 schema.field_with_name(DIST_COL).unwrap(),
-                &Field::new(DIST_COL, DataType::Float32, true)
+                &ArrowField::new(DIST_COL, DataType::Float32, true)
             );
         }
     }
@@ -3378,9 +2703,12 @@ mod tests {
     #[tokio::test]
     async fn test_search_empty_after_delete(#[values(false, true)] use_experimental_writer: bool) {
         // Create a table
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "vec",
-            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 128),
+            DataType::FixedSizeList(
+                Arc::new(ArrowField::new("item", DataType::Float32, true)),
+                128,
+            ),
             false,
         )]));
 
@@ -3426,10 +2754,10 @@ mod tests {
             assert_eq!(schema.fields.len(), 2);
             assert_eq!(
                 schema.field_with_name("vec").unwrap(),
-                &Field::new(
+                &ArrowField::new(
                     "vec",
                     DataType::FixedSizeList(
-                        Arc::new(Field::new("item", DataType::Float32, true)),
+                        Arc::new(ArrowField::new("item", DataType::Float32, true)),
                         128
                     ),
                     false,
@@ -3437,7 +2765,7 @@ mod tests {
             );
             assert_eq!(
                 schema.field_with_name(DIST_COL).unwrap(),
-                &Field::new(DIST_COL, DataType::Float32, true)
+                &ArrowField::new(DIST_COL, DataType::Float32, true)
             );
         }
 
@@ -3461,10 +2789,10 @@ mod tests {
             assert_eq!(schema.fields.len(), 2);
             assert_eq!(
                 schema.field_with_name("vec").unwrap(),
-                &Field::new(
+                &ArrowField::new(
                     "vec",
                     DataType::FixedSizeList(
-                        Arc::new(Field::new("item", DataType::Float32, true)),
+                        Arc::new(ArrowField::new("item", DataType::Float32, true)),
                         128
                     ),
                     false,
@@ -3472,7 +2800,7 @@ mod tests {
             );
             assert_eq!(
                 schema.field_with_name(DIST_COL).unwrap(),
-                &Field::new(DIST_COL, DataType::Float32, true)
+                &ArrowField::new(DIST_COL, DataType::Float32, true)
             );
         }
     }
@@ -3483,10 +2811,10 @@ mod tests {
         let test_dir = tempdir().unwrap();
         let dimensions = 16;
         let column_name = "vec";
-        let field = Field::new(
+        let field = ArrowField::new(
             column_name,
             DataType::FixedSizeList(
-                Arc::new(Field::new("item", DataType::Float32, true)),
+                Arc::new(ArrowField::new("item", DataType::Float32, true)),
                 dimensions,
             ),
             false,
@@ -3908,7 +3236,7 @@ mod tests {
         #[values(false, true)] use_experimental_writer: bool,
     ) -> Result<()> {
         let inner_field = Arc::new(
-            Field::new("item", DataType::FixedSizeBinary(2), true).with_metadata(
+            ArrowField::new("item", DataType::FixedSizeBinary(2), true).with_metadata(
                 [
                     (ARROW_EXT_NAME_KEY.into(), BFLOAT16_EXT_NAME.into()),
                     (ARROW_EXT_META_KEY.into(), "".into()),
@@ -3916,7 +3244,7 @@ mod tests {
                 .into(),
             ),
         );
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "fsl",
             DataType::FixedSizeList(inner_field.clone(), 2),
             false,
@@ -3944,650 +3272,6 @@ mod tests {
 
         let data = dataset.scan().try_into_batch().await?;
         assert_eq!(batch, data);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_append_columns_exprs() -> Result<()> {
-        let num_rows = 5;
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
-            "id",
-            DataType::Int32,
-            false,
-        )]));
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![Arc::new(Int32Array::from_iter_values(0..num_rows as i32))],
-        )?;
-        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
-
-        let test_dir = tempdir()?;
-        let test_uri = test_dir.path().to_str().unwrap();
-        let mut dataset = Dataset::write(
-            reader,
-            test_uri,
-            Some(WriteParams {
-                use_experimental_writer: false,
-                ..Default::default()
-            }),
-        )
-        .await?;
-        dataset.validate().await?;
-
-        // Adding a duplicate column name will break
-        let fut = dataset.add_columns(
-            NewColumnTransform::SqlExpressions(vec![("id".into(), "id + 1".into())]),
-            None,
-        );
-        // (Quick validation that the future is Send)
-        let res = require_send(fut).await;
-        assert!(matches!(res, Err(Error::InvalidInput { .. })));
-
-        // Can add a column that is independent of any existing ones
-        dataset
-            .add_columns(
-                NewColumnTransform::SqlExpressions(vec![("value".into(), "2 * random()".into())]),
-                None,
-            )
-            .await?;
-
-        // Can add a column derived from an existing one.
-        dataset
-            .add_columns(
-                NewColumnTransform::SqlExpressions(vec![("double_id".into(), "2 * id".into())]),
-                None,
-            )
-            .await?;
-
-        // Can derive a column from existing ones across multiple data files.
-        dataset
-            .add_columns(
-                NewColumnTransform::SqlExpressions(vec![(
-                    "triple_id".into(),
-                    "id + double_id".into(),
-                )]),
-                None,
-            )
-            .await?;
-
-        // These can be read back, the dataset is valid
-        dataset.validate().await?;
-
-        let data = dataset.scan().try_into_batch().await?;
-        let expected_schema = ArrowSchema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("value", DataType::Float64, true),
-            Field::new("double_id", DataType::Int32, false),
-            Field::new("triple_id", DataType::Int32, false),
-        ]);
-        assert_eq!(data.schema().as_ref(), &expected_schema);
-        assert_eq!(data.num_rows(), num_rows);
-
-        Ok(())
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_append_columns_udf(
-        #[values(false, true)] use_experimental_writer: bool,
-    ) -> Result<()> {
-        let num_rows = 5;
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
-            "id",
-            DataType::Int32,
-            false,
-        )]));
-
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![Arc::new(Int32Array::from_iter_values(0..num_rows as i32))],
-        )?;
-        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
-
-        let test_dir = tempdir()?;
-        let test_uri = test_dir.path().to_str().unwrap();
-        let mut dataset = Dataset::write(
-            reader,
-            test_uri,
-            Some(WriteParams {
-                use_experimental_writer,
-                ..Default::default()
-            }),
-        )
-        .await?;
-        dataset.validate().await?;
-
-        // Adding a duplicate column name will break
-        let transforms = NewColumnTransform::BatchUDF(BatchUDF {
-            mapper: Box::new(|_| unimplemented!()),
-            output_schema: Arc::new(ArrowSchema::new(vec![Field::new(
-                "id",
-                DataType::Int32,
-                false,
-            )])),
-            result_checkpoint: None,
-        });
-        let res = dataset.add_columns(transforms, None).await;
-        assert!(matches!(res, Err(Error::InvalidInput { .. })));
-
-        // Can add a column that independent (empty read_schema)
-        let output_schema = Arc::new(ArrowSchema::new(vec![Field::new(
-            "value",
-            DataType::Float64,
-            true,
-        )]));
-        let output_schema_ref = output_schema.clone();
-        let mapper = move |batch: &RecordBatch| {
-            Ok(RecordBatch::try_new(
-                output_schema_ref.clone(),
-                vec![Arc::new(Float64Array::from_iter_values(
-                    (0..batch.num_rows()).map(|i| i as f64),
-                ))],
-            )?)
-        };
-        let transforms = NewColumnTransform::BatchUDF(BatchUDF {
-            mapper: Box::new(mapper),
-            output_schema,
-            result_checkpoint: None,
-        });
-        dataset.add_columns(transforms, None).await?;
-
-        // Can add a column that depends on another column (double id)
-        let output_schema = Arc::new(ArrowSchema::new(vec![Field::new(
-            "double_id",
-            DataType::Int32,
-            false,
-        )]));
-        let output_schema_ref = output_schema.clone();
-        let mapper = move |batch: &RecordBatch| {
-            let id = batch
-                .column(0)
-                .as_any()
-                .downcast_ref::<Int32Array>()
-                .unwrap();
-            Ok(RecordBatch::try_new(
-                output_schema_ref.clone(),
-                vec![Arc::new(Int32Array::from_iter_values(
-                    id.values().iter().map(|i| i * 2),
-                ))],
-            )?)
-        };
-        let transforms = NewColumnTransform::BatchUDF(BatchUDF {
-            mapper: Box::new(mapper),
-            output_schema,
-            result_checkpoint: None,
-        });
-        dataset.add_columns(transforms, None).await?;
-        // These can be read back, the dataset is valid
-        dataset.validate().await?;
-
-        let data = dataset.scan().try_into_batch().await?;
-        let expected_schema = ArrowSchema::new(vec![
-            Field::new("id", DataType::Int32, false),
-            Field::new("value", DataType::Float64, true),
-            Field::new("double_id", DataType::Int32, false),
-        ]);
-        assert_eq!(data.schema().as_ref(), &expected_schema);
-        assert_eq!(data.num_rows(), num_rows);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_append_columns_udf_cache() -> Result<()> {
-        let num_rows = 100;
-        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
-            "id",
-            DataType::Int32,
-            false,
-        )]));
-
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![Arc::new(Int32Array::from_iter_values(0..num_rows))],
-        )?;
-        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
-
-        let test_dir = tempdir()?;
-        let test_uri = test_dir.path().to_str().unwrap();
-        let mut dataset = Dataset::write(
-            reader,
-            test_uri,
-            Some(WriteParams {
-                max_rows_per_file: 50,
-                max_rows_per_group: 25,
-                use_experimental_writer: false,
-                ..Default::default()
-            }),
-        )
-        .await?;
-        dataset.validate().await?;
-
-        #[derive(Default)]
-        struct RequestCounter {
-            pub get_batch_requests: Mutex<Vec<BatchInfo>>,
-            pub insert_batch_requests: Mutex<Vec<BatchInfo>>,
-            pub get_fragment_requests: Mutex<Vec<u32>>,
-            pub insert_fragment_requests: Mutex<Vec<u32>>,
-        }
-
-        impl UDFCheckpointStore for RequestCounter {
-            fn get_batch(&self, info: &BatchInfo) -> Result<Option<RecordBatch>> {
-                self.get_batch_requests.lock().unwrap().push(info.clone());
-
-                if info.fragment_id == 1 && info.batch_index == 0 {
-                    Ok(Some(RecordBatch::try_new(
-                        Arc::new(ArrowSchema::new(vec![Field::new(
-                            "double_id",
-                            DataType::Int32,
-                            false,
-                        )])),
-                        vec![Arc::new(Int32Array::from_iter_values(50..75))],
-                    )?))
-                } else {
-                    Ok(None)
-                }
-            }
-
-            fn insert_batch(&self, info: BatchInfo, _value: RecordBatch) -> Result<()> {
-                self.insert_batch_requests.lock().unwrap().push(info);
-                Ok(())
-            }
-
-            fn get_fragment(&self, fragment_id: u32) -> Result<Option<Fragment>> {
-                self.get_fragment_requests.lock().unwrap().push(fragment_id);
-                if fragment_id == 0 {
-                    Ok(Some(Fragment {
-                        files: vec![],
-                        id: 0,
-                        deletion_file: None,
-                        physical_rows: Some(50),
-                    }))
-                } else {
-                    Ok(None)
-                }
-            }
-
-            fn insert_fragment(&self, fragment: Fragment) -> Result<()> {
-                self.insert_fragment_requests
-                    .lock()
-                    .unwrap()
-                    .push(fragment.id as u32);
-                Ok(())
-            }
-        }
-
-        let request_counter = Arc::new(RequestCounter::default());
-
-        let output_schema = Arc::new(ArrowSchema::new(vec![Field::new(
-            "double_id",
-            DataType::Int32,
-            false,
-        )]));
-        let output_schema_ref = output_schema.clone();
-        let mapper = move |batch: &RecordBatch| {
-            let id = batch
-                .column(0)
-                .as_any()
-                .downcast_ref::<Int32Array>()
-                .unwrap();
-            Ok(RecordBatch::try_new(
-                output_schema_ref.clone(),
-                vec![Arc::new(Int32Array::from_iter_values(
-                    id.values().iter().map(|i| i * 2),
-                ))],
-            )?)
-        };
-        let transforms = NewColumnTransform::BatchUDF(BatchUDF {
-            mapper: Box::new(mapper),
-            output_schema,
-            result_checkpoint: Some(request_counter.clone()),
-        });
-        dataset.add_columns(transforms, None).await?;
-
-        // Should have requested both fragments
-        assert_eq!(
-            request_counter
-                .get_fragment_requests
-                .lock()
-                .unwrap()
-                .as_slice(),
-            &[0, 1]
-        );
-        // Should have only inserted the second fragment, since the first one was already cached
-        assert_eq!(
-            request_counter
-                .insert_fragment_requests
-                .lock()
-                .unwrap()
-                .as_slice(),
-            &[1]
-        );
-
-        // Should have only requested the second two batches, since the first fragment was already cached
-        assert_eq!(
-            request_counter
-                .get_batch_requests
-                .lock()
-                .unwrap()
-                .as_slice(),
-            &[
-                BatchInfo {
-                    fragment_id: 1,
-                    batch_index: 0,
-                },
-                BatchInfo {
-                    fragment_id: 1,
-                    batch_index: 1,
-                },
-            ]
-        );
-        // Should have only saved the last batch, since the first batch of second fragment was already cached
-        assert_eq!(
-            request_counter
-                .insert_batch_requests
-                .lock()
-                .unwrap()
-                .as_slice(),
-            &[BatchInfo {
-                fragment_id: 1,
-                batch_index: 1,
-            },]
-        );
-
-        Ok(())
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_rename_columns(
-        #[values(false, true)] use_experimental_writer: bool,
-    ) -> Result<()> {
-        let metadata: HashMap<String, String> = [("k1".into(), "v1".into())].into();
-
-        let schema = Arc::new(ArrowSchema::new_with_metadata(
-            vec![
-                Field::new("a", DataType::Int32, false),
-                Field::new(
-                    "b",
-                    DataType::Struct(ArrowFields::from(vec![Field::new(
-                        "c",
-                        DataType::Int32,
-                        true,
-                    )])),
-                    true,
-                ),
-            ],
-            metadata.clone(),
-        ));
-
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2])),
-                Arc::new(StructArray::from(vec![(
-                    Arc::new(ArrowField::new("c", DataType::Int32, true)),
-                    Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
-                )])),
-            ],
-        )?;
-
-        let test_dir = tempdir()?;
-        let test_uri = test_dir.path().to_str().unwrap();
-
-        let batches = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
-        let mut dataset = Dataset::write(
-            batches,
-            test_uri,
-            Some(WriteParams {
-                use_experimental_writer,
-                ..Default::default()
-            }),
-        )
-        .await?;
-
-        let original_fragments = dataset.fragments().to_vec();
-
-        // Rename a top-level column
-        dataset
-            .alter_columns(&[ColumnAlteration::new("a".into())
-                .rename("x".into())
-                .set_nullable(true)])
-            .await?;
-        dataset.validate().await?;
-        assert_eq!(dataset.manifest.version, 2);
-        assert_eq!(dataset.fragments().as_ref(), &original_fragments);
-
-        let expected_schema = ArrowSchema::new_with_metadata(
-            vec![
-                Field::new("x", DataType::Int32, true),
-                Field::new(
-                    "b",
-                    DataType::Struct(ArrowFields::from(vec![Field::new(
-                        "c",
-                        DataType::Int32,
-                        true,
-                    )])),
-                    true,
-                ),
-            ],
-            metadata.clone(),
-        );
-        assert_eq!(&ArrowSchema::from(dataset.schema()), &expected_schema);
-
-        // Rename to duplicate name fails
-        let err = dataset
-            .alter_columns(&[ColumnAlteration::new("b".into()).rename("x".into())])
-            .await
-            .unwrap_err();
-        assert!(err.to_string().contains("Duplicate field name \"x\""));
-
-        // Rename a nested column.
-        dataset
-            .alter_columns(&[ColumnAlteration::new("b.c".into()).rename("d".into())])
-            .await?;
-        dataset.validate().await?;
-        assert_eq!(dataset.manifest.version, 3);
-        assert_eq!(dataset.fragments().as_ref(), &original_fragments);
-
-        let expected_schema = ArrowSchema::new_with_metadata(
-            vec![
-                Field::new("x", DataType::Int32, true),
-                Field::new(
-                    "b",
-                    DataType::Struct(ArrowFields::from(vec![Field::new(
-                        "d",
-                        DataType::Int32,
-                        true,
-                    )])),
-                    true,
-                ),
-            ],
-            metadata.clone(),
-        );
-        assert_eq!(&ArrowSchema::from(dataset.schema()), &expected_schema);
-
-        Ok(())
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_cast_column(#[values(false, true)] use_experimental_writer: bool) -> Result<()> {
-        // Create a table with 2 scalar columns, 1 vector column
-        let schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("i", DataType::Int32, false),
-            Field::new("f", DataType::Float32, false),
-            Field::new(
-                "vec",
-                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 128),
-                false,
-            ),
-            Field::new("l", DataType::new_list(DataType::Int32, true), true),
-        ]));
-
-        let nrows = 512;
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(Int32Array::from_iter_values(0..nrows)),
-                Arc::new(Float32Array::from_iter_values((0..nrows).map(|i| i as f32))),
-                Arc::new(
-                    <arrow_array::FixedSizeListArray as FixedSizeListArrayExt>::try_new_from_values(
-                        generate_random_array(128 * nrows as usize),
-                        128,
-                    )
-                    .unwrap(),
-                ),
-                Arc::new(ListArray::from_iter_primitive::<Int32Type, _, _>(
-                    (0..nrows).map(|i| Some(vec![Some(i), Some(i + 1)])),
-                )),
-            ],
-        )?;
-
-        let test_dir = tempdir()?;
-        let test_uri = test_dir.path().to_str().unwrap();
-
-        let mut dataset = Dataset::write(
-            RecordBatchIterator::new(vec![Ok(batch.clone())], schema.clone()),
-            test_uri,
-            Some(WriteParams {
-                use_experimental_writer,
-                ..Default::default()
-            }),
-        )
-        .await?;
-
-        let params = VectorIndexParams::ivf_pq(10, 8, 2, MetricType::L2, 50);
-        dataset
-            .create_index(&["vec"], IndexType::Vector, None, &params, false)
-            .await?;
-        dataset
-            .create_index(
-                &["i"],
-                IndexType::Scalar,
-                None,
-                &ScalarIndexParams::default(),
-                false,
-            )
-            .await?;
-        dataset.validate().await?;
-
-        let indices = dataset.load_indices().await?;
-        assert_eq!(indices.len(), 2);
-
-        // Cast a scalar column to another type, nullability
-        dataset
-            .alter_columns(&[ColumnAlteration::new("f".into())
-                .cast_to(DataType::Float16)
-                .set_nullable(true)])
-            .await?;
-        dataset.validate().await?;
-        let expected_schema = ArrowSchema::new(vec![
-            Field::new("i", DataType::Int32, false),
-            Field::new("f", DataType::Float16, true),
-            Field::new(
-                "vec",
-                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 128),
-                false,
-            ),
-            Field::new("l", DataType::new_list(DataType::Int32, true), true),
-        ]);
-        assert_eq!(&ArrowSchema::from(dataset.schema()), &expected_schema);
-
-        // Each fragment gains a file with the new columns
-        dataset.fragments().iter().for_each(|f| {
-            assert_eq!(f.files.len(), 2);
-        });
-
-        // Cast scalar column with index, should not keep index (TODO: keep it)
-        dataset
-            .alter_columns(&[ColumnAlteration::new("i".into()).cast_to(DataType::Int64)])
-            .await?;
-        dataset.validate().await?;
-
-        let expected_schema = ArrowSchema::new(vec![
-            Field::new("i", DataType::Int64, false),
-            Field::new("f", DataType::Float16, true),
-            Field::new(
-                "vec",
-                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 128),
-                false,
-            ),
-            Field::new("l", DataType::new_list(DataType::Int32, true), true),
-        ]);
-        assert_eq!(&ArrowSchema::from(dataset.schema()), &expected_schema);
-
-        // We currently lose the index when casting a column
-        let indices = dataset.load_indices().await?;
-        assert_eq!(indices.len(), 1);
-
-        // Each fragment gains a file with the new columns
-        dataset.fragments().iter().for_each(|f| {
-            assert_eq!(f.files.len(), 3);
-        });
-
-        // Cast vector column, should not keep index (TODO: keep it)
-        dataset
-            .alter_columns(&[
-                ColumnAlteration::new("vec".into()).cast_to(DataType::FixedSizeList(
-                    Arc::new(Field::new("item", DataType::Float16, true)),
-                    128,
-                )),
-            ])
-            .await?;
-        dataset.validate().await?;
-
-        // Finally, case list column to show we can handle children.
-        dataset
-            .alter_columns(&[ColumnAlteration::new("l".into())
-                .cast_to(DataType::new_list(DataType::Int64, true))])
-            .await?;
-        dataset.validate().await?;
-
-        let expected_schema = ArrowSchema::new(vec![
-            Field::new("i", DataType::Int64, false),
-            Field::new("f", DataType::Float16, true),
-            Field::new(
-                "vec",
-                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float16, true)), 128),
-                false,
-            ),
-            Field::new("l", DataType::new_list(DataType::Int64, true), true),
-        ]);
-        assert_eq!(&ArrowSchema::from(dataset.schema()), &expected_schema);
-
-        // We currently lose the index when casting a column
-        let indices = dataset.load_indices().await?;
-        assert_eq!(indices.len(), 0);
-
-        // Each fragment gains a file with the new columns, but then the original file is dropped
-        dataset.fragments().iter().for_each(|f| {
-            assert_eq!(f.files.len(), 4);
-        });
-
-        let expected_data = RecordBatch::try_new(
-            Arc::new(expected_schema),
-            vec![
-                Arc::new(Int64Array::from_iter_values(0..nrows as i64)),
-                Arc::new(Float16Array::from_iter_values(
-                    (0..nrows).map(|i| f16::from_f32(i as f32)),
-                )),
-                lance_arrow::cast::cast_with_options(
-                    batch["vec"].as_ref(),
-                    &DataType::FixedSizeList(
-                        Arc::new(Field::new("item", DataType::Float16, true)),
-                        128,
-                    ),
-                    &Default::default(),
-                )?,
-                Arc::new(ListArray::from_iter_primitive::<Int64Type, _, _>(
-                    (0..nrows as i64).map(|i| Some(vec![Some(i), Some(i + 1)])),
-                )),
-            ],
-        )?;
-        let actual_data = dataset.scan().try_into_batch().await?;
-        assert_eq!(actual_data, expected_data);
 
         Ok(())
     }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -5,21 +5,12 @@
 //!
 
 use arrow::compute::CastOptions;
-use arrow_array::cast::AsArray;
-use arrow_array::types::UInt64Type;
-use arrow_array::Array;
-use arrow_array::{
-    cast::as_struct_array, RecordBatch, RecordBatchReader, StructArray, UInt64Array,
-};
+use arrow_array::{RecordBatch, RecordBatchReader};
 use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
-use arrow_select::interleave::interleave;
-use arrow_select::{concat::concat_batches, take::take};
 use chrono::{prelude::*, Duration};
-use datafusion::error::DataFusionError;
-use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::future::BoxFuture;
 use futures::stream::{self, StreamExt, TryStreamExt};
-use futures::{Future, FutureExt, Stream};
+use futures::{FutureExt, Stream};
 use lance_arrow::SchemaExt;
 use lance_core::datatypes::{Field, SchemaCompareOptions};
 use lance_datafusion::utils::{peek_reader_schema, reader_to_stream};
@@ -50,6 +41,7 @@ pub mod index;
 pub mod optimize;
 pub mod progress;
 pub mod scanner;
+mod take;
 pub mod transaction;
 pub mod updater;
 mod utils;
@@ -962,275 +954,12 @@ impl Dataset {
 
     #[instrument(skip_all, fields(num_rows=row_indices.len()))]
     pub async fn take(&self, row_indices: &[u64], projection: &Schema) -> Result<RecordBatch> {
-        if row_indices.is_empty() {
-            let schema = Arc::new(projection.into());
-            return Ok(RecordBatch::new_empty(schema));
-        }
-
-        let mut sorted_indices: Vec<usize> = (0..row_indices.len()).collect();
-        sorted_indices.sort_by_key(|&i| row_indices[i]);
-
-        let fragments = self.get_fragments();
-
-        // We will split into sub-requests for each fragment.
-        let mut sub_requests: Vec<(&FileFragment, Range<usize>)> = Vec::new();
-        // We will remap the row indices to the original row indices, using a pair
-        // of (request position, position in request)
-        let mut remap_index: Vec<(usize, usize)> = vec![(0, 0); row_indices.len()];
-        let mut local_ids_buffer: Vec<u32> = Vec::with_capacity(row_indices.len());
-
-        let mut fragments_iter = fragments.iter();
-        let mut current_fragment = fragments_iter.next().ok_or_else(|| Error::InvalidInput {
-            source: "Called take on an empty dataset.".to_string().into(),
-            location: location!(),
-        })?;
-        let mut current_fragment_len = current_fragment.count_rows().await?;
-        let mut curr_fragment_offset: u64 = 0;
-        let mut current_fragment_end = current_fragment_len as u64;
-        let mut start = 0;
-        let mut end = 0;
-        // We want to keep track of the previous row_index to detect duplicates
-        // index takes. To start, we pick a value that is guaranteed to be different
-        // from the first row_index.
-        let mut previous_row_index: u64 = row_indices[sorted_indices[0]] + 1;
-        let mut previous_sorted_index: usize = 0;
-
-        for index in sorted_indices {
-            // Get the index
-            let row_index = row_indices[index];
-
-            if previous_row_index == row_index {
-                // If we have a duplicate index request we add a remap_index
-                // entry that points to the original index request.
-                remap_index[index] = remap_index[previous_sorted_index];
-                continue;
-            } else {
-                previous_sorted_index = index;
-                previous_row_index = row_index;
-            }
-
-            // If the row index is beyond the current fragment, iterate
-            // until we find the fragment that contains it.
-            while row_index >= current_fragment_end {
-                // If we have a non-empty sub-request, add it to the list
-                if end - start > 0 {
-                    // If we have a non-empty sub-request, add it to the list
-                    sub_requests.push((current_fragment, start..end));
-                }
-
-                start = end;
-
-                current_fragment = fragments_iter.next().ok_or_else(|| Error::InvalidInput {
-                    source: format!(
-                        "Row index {} is beyond the range of the dataset.",
-                        row_index
-                    )
-                    .into(),
-                    location: location!(),
-                })?;
-                curr_fragment_offset += current_fragment_len as u64;
-                current_fragment_len = current_fragment.count_rows().await?;
-                current_fragment_end = curr_fragment_offset + current_fragment_len as u64;
-            }
-
-            // Note that we cast to u32 *after* subtracting the offset,
-            // since it is possible for the global index to be larger than
-            // u32::MAX.
-            let local_index = (row_index - curr_fragment_offset) as u32;
-            local_ids_buffer.push(local_index);
-
-            remap_index[index] = (sub_requests.len(), end - start);
-
-            end += 1;
-        }
-
-        // flush last batch
-        if end - start > 0 {
-            sub_requests.push((current_fragment, start..end));
-        }
-
-        let take_tasks = sub_requests
-            .into_iter()
-            .map(|(fragment, indices_range)| {
-                let local_ids = &local_ids_buffer[indices_range];
-                fragment.take(local_ids, projection)
-            })
-            .collect::<Vec<_>>();
-        let batches = stream::iter(take_tasks)
-            .buffered(num_cpus::get() * 4)
-            .try_collect::<Vec<RecordBatch>>()
-            .await?;
-
-        let struct_arrs: Vec<StructArray> = batches.into_iter().map(StructArray::from).collect();
-        let refs: Vec<_> = struct_arrs.iter().map(|x| x as &dyn Array).collect();
-        let reordered = interleave(&refs, &remap_index)?;
-        Ok(as_struct_array(&reordered).into())
+        take::take(self, row_indices, projection).await
     }
 
     /// Take rows by the internal ROW ids.
     pub async fn take_rows(&self, row_ids: &[u64], projection: &Schema) -> Result<RecordBatch> {
-        if row_ids.is_empty() {
-            return Ok(RecordBatch::new_empty(Arc::new(projection.into())));
-        }
-
-        let projection = Arc::new(projection.clone());
-        let row_id_meta = check_row_ids(row_ids);
-
-        // This method is mostly to annotate the send bound to avoid the
-        // higher-order lifetime error.
-        // manually implemented async for Send bound
-        #[allow(clippy::manual_async_fn)]
-        fn do_take(
-            fragment: FileFragment,
-            row_ids: Vec<u32>,
-            projection: Arc<Schema>,
-            with_row_id: bool,
-        ) -> impl Future<Output = Result<RecordBatch>> + Send {
-            async move {
-                fragment
-                    .take_rows(&row_ids, projection.as_ref(), with_row_id)
-                    .await
-            }
-        }
-
-        if row_id_meta.contiguous {
-            // Fastest path: Can use `read_range` directly
-            let start = row_ids.first().expect("empty range passed to take_rows");
-            let fragment_id = (start >> 32) as usize;
-            let range_start = *start as u32 as usize;
-            let range_end =
-                *row_ids.last().expect("empty range passed to take_rows") as u32 as usize;
-            let range = range_start..(range_end + 1);
-
-            let fragment = self.get_fragment(fragment_id).ok_or_else(|| {
-                Error::invalid_input(
-                    format!("row_id belongs to non-existant fragment: {start}"),
-                    location!(),
-                )
-            })?;
-
-            let reader = fragment.open(projection.as_ref(), false).await?;
-            reader.legacy_read_range_as_batch(range).await
-        } else if row_id_meta.sorted {
-            // Don't need to re-arrange data, just concatenate
-
-            let mut batches: Vec<_> = Vec::new();
-            let mut current_fragment = row_ids[0] >> 32;
-            let mut current_start = 0;
-            let mut row_ids_iter = row_ids.iter().enumerate();
-            'outer: loop {
-                let (fragment_id, range) = loop {
-                    if let Some((i, row_id)) = row_ids_iter.next() {
-                        let fragment_id = row_id >> 32;
-                        if fragment_id != current_fragment {
-                            let next = (current_fragment, current_start..i);
-                            current_fragment = fragment_id;
-                            current_start = i;
-                            break next;
-                        }
-                    } else if current_start != row_ids.len() {
-                        let next = (current_fragment, current_start..row_ids.len());
-                        current_start = row_ids.len();
-                        break next;
-                    } else {
-                        break 'outer;
-                    }
-                };
-
-                let fragment = self.get_fragment(fragment_id as usize).ok_or_else(|| {
-                    Error::invalid_input(
-                        format!(
-                            "row_id {} belongs to non-existant fragment: {}",
-                            row_ids[range.start], fragment_id
-                        ),
-                        location!(),
-                    )
-                })?;
-                let row_ids: Vec<u32> = row_ids[range].iter().map(|x| *x as u32).collect();
-
-                let batch_fut = do_take(fragment, row_ids, projection.clone(), false);
-                batches.push(batch_fut);
-            }
-            let batches: Vec<RecordBatch> = futures::stream::iter(batches)
-                .buffered(4 * num_cpus::get())
-                .try_collect()
-                .await?;
-            Ok(concat_batches(&batches[0].schema(), &batches)?)
-        } else {
-            let projection_with_row_id = Schema::merge(
-                projection.as_ref(),
-                &ArrowSchema::new(vec![ArrowField::new(
-                    ROW_ID,
-                    arrow::datatypes::DataType::UInt64,
-                    false,
-                )]),
-            )?;
-            let schema_with_row_id = Arc::new(ArrowSchema::from(&projection_with_row_id));
-
-            // Slow case: need to re-map data into expected order
-            let mut sorted_row_ids = Vec::from(row_ids);
-            sorted_row_ids.sort();
-            // Group ROW Ids by the fragment
-            let mut row_ids_per_fragment: BTreeMap<u64, Vec<u32>> = BTreeMap::new();
-            sorted_row_ids.iter().for_each(|row_id| {
-                let fragment_id = row_id >> 32;
-                let offset = (row_id - (fragment_id << 32)) as u32;
-                row_ids_per_fragment
-                    .entry(fragment_id)
-                    .and_modify(|v| v.push(offset))
-                    .or_insert_with(|| vec![offset]);
-            });
-
-            let fragments = self.get_fragments();
-            let fragment_and_indices = fragments.into_iter().filter_map(|f| {
-                let local_row_ids = row_ids_per_fragment.remove(&(f.id() as u64))?;
-                Some((f, local_row_ids))
-            });
-
-            let mut batches = stream::iter(fragment_and_indices)
-                .map(|(fragment, indices)| do_take(fragment, indices, projection.clone(), true))
-                .buffered(4 * num_cpus::get())
-                .try_collect::<Vec<_>>()
-                .await?;
-
-            let one_batch = if batches.len() > 1 {
-                concat_batches(&schema_with_row_id, &batches)?
-            } else {
-                batches.pop().unwrap()
-            };
-            // Note: one_batch may contains fewer rows than the number of requested
-            // row ids because some rows may have been deleted. Because of this, we
-            // get the results with row ids so that we can re-order the results
-            // to match the requested order.
-
-            let returned_row_ids = one_batch
-                .column_by_name(ROW_ID)
-                .ok_or_else(|| Error::Internal {
-                    message: "ROW_ID column not found".into(),
-                    location: location!(),
-                })?
-                .as_primitive::<UInt64Type>()
-                .values();
-
-            let remapping_index: UInt64Array = row_ids
-                .iter()
-                .filter_map(|o| {
-                    returned_row_ids
-                        .iter()
-                        .position(|id| id == o)
-                        .map(|pos| pos as u64)
-                })
-                .collect();
-
-            debug_assert_eq!(remapping_index.len(), one_batch.num_rows());
-
-            // Remove the row id column.
-            let keep_indices = (0..one_batch.num_columns() - 1).collect::<Vec<_>>();
-            let one_batch = one_batch.project(&keep_indices)?;
-            let struct_arr: StructArray = one_batch.into();
-            let reordered = take(&struct_arr, &remapping_index, None)?;
-            Ok(as_struct_array(&reordered).into())
-        }
+        take::take_rows(self, row_ids, projection).await
     }
 
     /// Get a stream of batches based on iterator of ranges of row numbers.
@@ -1242,28 +971,7 @@ impl Dataset {
         projection: Arc<Schema>,
         batch_readahead: usize,
     ) -> DatasetRecordBatchStream {
-        let arrow_schema = Arc::new(projection.as_ref().into());
-        let dataset = Arc::new(self.clone());
-        let batch_stream = row_ranges
-            .map(move |res| {
-                let dataset = dataset.clone();
-                let projection = projection.clone();
-                let fut = async move {
-                    let range = res.map_err(|err| DataFusionError::External(Box::new(err)))?;
-                    let row_pos: Vec<u64> = (range.start..range.end).collect();
-                    dataset
-                        .take(&row_pos, projection.as_ref())
-                        .await
-                        .map_err(|err| DataFusionError::External(Box::new(err)))
-                };
-                async move { tokio::task::spawn(fut).await.unwrap() }
-            })
-            .buffered(batch_readahead);
-
-        DatasetRecordBatchStream::new(Box::pin(RecordBatchStreamAdapter::new(
-            arrow_schema,
-            batch_stream,
-        )))
+        take::take_scan(self, row_ranges, projection, batch_readahead)
     }
 
     /// Sample `n` rows from the dataset.
@@ -2045,33 +1753,6 @@ fn write_manifest_file_to_path<'a>(
     })
 }
 
-struct RowIdMeta {
-    sorted: bool,
-    contiguous: bool,
-}
-
-fn check_row_ids(row_ids: &[u64]) -> RowIdMeta {
-    let mut sorted = true;
-    let mut contiguous = true;
-
-    if row_ids.is_empty() {
-        return RowIdMeta { sorted, contiguous };
-    }
-
-    let mut last_id = row_ids[0];
-    let first_fragment_id = row_ids[0] >> 32;
-
-    for id in row_ids.iter().skip(1) {
-        sorted &= *id > last_id;
-        contiguous &= *id == last_id + 1;
-        // Contiguous also requires the fragment ids are all the same
-        contiguous &= (*id >> 32) == first_fragment_id;
-        last_id = *id;
-    }
-
-    RowIdMeta { sorted, contiguous }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
@@ -2085,13 +1766,16 @@ mod tests {
     use crate::index::vector::VectorIndexParams;
     use crate::utils::test::TestDatasetGenerator;
 
-    use arrow_array::types::Int64Type;
+    use arrow::array::as_struct_array;
+    use arrow::compute::concat_batches;
     use arrow_array::{
-        builder::StringDictionaryBuilder, cast::as_string_array, types::Int32Type, ArrayRef,
-        DictionaryArray, Float32Array, Int32Array, Int64Array, Int8Array, Int8DictionaryArray,
-        RecordBatchIterator, StringArray, UInt16Array, UInt32Array,
+        builder::StringDictionaryBuilder,
+        cast::as_string_array,
+        types::{Int32Type, Int64Type},
+        ArrayRef, DictionaryArray, Float32Array, Int32Array, Int64Array, Int8Array,
+        Int8DictionaryArray, RecordBatchIterator, StringArray, UInt16Array, UInt32Array,
     };
-    use arrow_array::{FixedSizeListArray, Float16Array, Float64Array, ListArray};
+    use arrow_array::{FixedSizeListArray, Float16Array, Float64Array, ListArray, StructArray};
     use arrow_ord::sort::sort_to_indices;
     use arrow_schema::{Field, Fields as ArrowFields, Schema as ArrowSchema};
     use half::f16;
@@ -2105,7 +1789,6 @@ mod tests {
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use tempfile::{tempdir, TempDir};
-    use tests::scanner::test_dataset::TestVectorDataset;
 
     // Used to validate that futures returned are Send.
     fn require_send<T: Send>(t: T) -> T {
@@ -2186,7 +1869,7 @@ mod tests {
         let idx_arr = actual_batch.column_by_name("i").unwrap();
         let sorted_indices = sort_to_indices(idx_arr, None, None).unwrap();
         let struct_arr: StructArray = actual_batch.into();
-        let sorted_arr = take(&struct_arr, &sorted_indices, None).unwrap();
+        let sorted_arr = arrow_select::take::take(&struct_arr, &sorted_indices, None).unwrap();
 
         let expected_struct_arr: StructArray =
             concat_batches(&schema, &expected_batches).unwrap().into();
@@ -2291,7 +1974,7 @@ mod tests {
         let idx_arr = actual_batch.column_by_name("i").unwrap();
         let sorted_indices = sort_to_indices(idx_arr, None, None).unwrap();
         let struct_arr: StructArray = actual_batch.into();
-        let sorted_arr = take(&struct_arr, &sorted_indices, None).unwrap();
+        let sorted_arr = arrow_select::take::take(&struct_arr, &sorted_indices, None).unwrap();
         let expected_struct_arr: StructArray = expected_batch.into();
         assert_eq!(&expected_struct_arr, as_struct_array(sorted_arr.as_ref()));
     }
@@ -2544,7 +2227,7 @@ mod tests {
         let idx_arr = actual_batch.column_by_name("i").unwrap();
         let sorted_indices = sort_to_indices(idx_arr, None, None).unwrap();
         let struct_arr: StructArray = actual_batch.into();
-        let sorted_arr = take(&struct_arr, &sorted_indices, None).unwrap();
+        let sorted_arr = arrow_select::take::take(&struct_arr, &sorted_indices, None).unwrap();
 
         let expected_struct_arr: StructArray = expected_batch.into();
         assert_eq!(&expected_struct_arr, as_struct_array(sorted_arr.as_ref()));
@@ -2635,7 +2318,7 @@ mod tests {
         let idx_arr = actual_batch.column_by_name("i").unwrap();
         let sorted_indices = sort_to_indices(idx_arr, None, None).unwrap();
         let struct_arr: StructArray = actual_batch.into();
-        let sorted_arr = take(&struct_arr, &sorted_indices, None).unwrap();
+        let sorted_arr = arrow_select::take::take(&struct_arr, &sorted_indices, None).unwrap();
 
         let expected_struct_arr: StructArray = expected_batch.into();
         assert_eq!(&expected_struct_arr, as_struct_array(sorted_arr.as_ref()));
@@ -2843,200 +2526,6 @@ mod tests {
         let first_ver = Dataset::checkout(test_uri, 1).await.unwrap();
         assert_eq!(first_ver.version().version, 1);
         assert_eq!(&ArrowSchema::from(first_ver.schema()), schema.as_ref());
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_take(#[values(false, true)] use_experimental_writer: bool) {
-        let test_dir = tempdir().unwrap();
-
-        let schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("i", DataType::Int32, false),
-            Field::new("s", DataType::Utf8, false),
-        ]));
-        let batches: Vec<RecordBatch> = (0..20)
-            .map(|i| {
-                RecordBatch::try_new(
-                    schema.clone(),
-                    vec![
-                        Arc::new(Int32Array::from_iter_values(i * 20..(i + 1) * 20)),
-                        Arc::new(StringArray::from_iter_values(
-                            (i * 20..(i + 1) * 20).map(|i| format!("str-{i}")),
-                        )),
-                    ],
-                )
-                .unwrap()
-            })
-            .collect();
-        let test_uri = test_dir.path().to_str().unwrap();
-        let write_params = WriteParams {
-            max_rows_per_file: 40,
-            max_rows_per_group: 10,
-            use_experimental_writer,
-            ..Default::default()
-        };
-        let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        Dataset::write(batches, test_uri, Some(write_params))
-            .await
-            .unwrap();
-
-        let dataset = Dataset::open(test_uri).await.unwrap();
-        assert_eq!(dataset.count_rows(None).await.unwrap(), 400);
-        let projection = Schema::try_from(schema.as_ref()).unwrap();
-        let values = dataset
-            .take(
-                &[
-                    200, // 200
-                    199, // 199
-                    39,  // 39
-                    40,  // 40
-                    199, // 40
-                    40,  // 40
-                    125, // 125
-                ],
-                &projection,
-            )
-            .await
-            .unwrap();
-        assert_eq!(
-            RecordBatch::try_new(
-                schema.clone(),
-                vec![
-                    Arc::new(Int32Array::from_iter_values([
-                        200, 199, 39, 40, 199, 40, 125
-                    ])),
-                    Arc::new(StringArray::from_iter_values(
-                        [200, 199, 39, 40, 199, 40, 125]
-                            .iter()
-                            .map(|v| format!("str-{v}"))
-                    )),
-                ],
-            )
-            .unwrap(),
-            values
-        );
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_take_rows_out_of_bound(#[values(false, true)] use_experimental_writer: bool) {
-        // a dataset with 1 fragment and 400 rows
-        let test_ds = TestVectorDataset::new(use_experimental_writer)
-            .await
-            .unwrap();
-        let ds = test_ds.dataset;
-
-        // take the last row of first fragment
-        // this triggeres the contiguous branch
-        let indices = &[(1 << 32) - 1];
-        let err = ds.take_rows(indices, ds.schema()).await.unwrap_err();
-        assert!(
-            err.to_string().contains("Invalid read params"),
-            "{}",
-            err.to_string()
-        );
-
-        // this triggeres the sorted branch, but not continguous
-        let indices = &[(1 << 32) - 3, (1 << 32) - 1];
-        let err = ds.take_rows(indices, ds.schema()).await.unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("Invalid read params Indices(4294967293,4294967295)"),
-            "{}",
-            err.to_string()
-        );
-
-        // this triggeres the catch all branch
-        let indices = &[(1 << 32) - 1, (1 << 32) - 3];
-        let err = ds.take_rows(indices, ds.schema()).await.unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("Invalid read params Indices(4294967293,4294967295)"),
-            "{}",
-            err.to_string()
-        );
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn test_take_rows(#[values(false, true)] use_experimental_writer: bool) {
-        let test_dir = tempdir().unwrap();
-
-        let schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("i", DataType::Int32, false),
-            Field::new("s", DataType::Utf8, false),
-        ]));
-        let batches: Vec<RecordBatch> = (0..20)
-            .map(|i| {
-                RecordBatch::try_new(
-                    schema.clone(),
-                    vec![
-                        Arc::new(Int32Array::from_iter_values(i * 20..(i + 1) * 20)),
-                        Arc::new(StringArray::from_iter_values(
-                            (i * 20..(i + 1) * 20).map(|i| format!("str-{i}")),
-                        )),
-                    ],
-                )
-                .unwrap()
-            })
-            .collect();
-        let test_uri = test_dir.path().to_str().unwrap();
-        let write_params = WriteParams {
-            max_rows_per_file: 40,
-            max_rows_per_group: 10,
-            use_experimental_writer,
-            ..Default::default()
-        };
-        let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
-        let mut dataset = Dataset::write(batches, test_uri, Some(write_params))
-            .await
-            .unwrap();
-
-        assert_eq!(dataset.count_rows(None).await.unwrap(), 400);
-        let projection = Schema::try_from(schema.as_ref()).unwrap();
-        let indices = &[
-            5_u64 << 32,        // 200
-            (4_u64 << 32) + 39, // 199
-            39,                 // 39
-            1_u64 << 32,        // 40
-            (2_u64 << 32) + 20, // 100
-        ];
-        let values = dataset.take_rows(indices, &projection).await.unwrap();
-        assert_eq!(
-            RecordBatch::try_new(
-                schema.clone(),
-                vec![
-                    Arc::new(Int32Array::from_iter_values([200, 199, 39, 40, 100])),
-                    Arc::new(StringArray::from_iter_values(
-                        [200, 199, 39, 40, 100].iter().map(|v| format!("str-{v}"))
-                    )),
-                ],
-            )
-            .unwrap(),
-            values
-        );
-
-        // Delete some rows from a fragment
-        dataset.delete("i in (199, 100)").await.unwrap();
-        dataset.validate().await.unwrap();
-        let values = dataset.take_rows(indices, &projection).await.unwrap();
-        assert_eq!(
-            RecordBatch::try_new(
-                schema.clone(),
-                vec![
-                    Arc::new(Int32Array::from_iter_values([200, 39, 40])),
-                    Arc::new(StringArray::from_iter_values(
-                        [200, 39, 40].iter().map(|v| format!("str-{v}"))
-                    )),
-                ],
-            )
-            .unwrap(),
-            values
-        );
-
-        // Take an empty selection.
-        let values = dataset.take_rows(&[], &projection).await.unwrap();
-        assert_eq!(RecordBatch::new_empty(schema.clone()), values);
     }
 
     #[rstest]
@@ -4089,65 +3578,6 @@ mod tests {
             .try_collect::<Vec<_>>()
             .await?;
         Ok(results)
-    }
-
-    #[rstest]
-    #[tokio::test]
-    async fn take_scan_dataset(#[values(false, true)] use_experimental_writer: bool) {
-        let schema = Arc::new(ArrowSchema::new(vec![
-            Field::new("i", DataType::Int32, false),
-            Field::new("x", DataType::Float32, false),
-        ]));
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![
-                Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
-                Arc::new(Float32Array::from(vec![1.0, 2.0, 3.0, 4.0])),
-            ],
-        )
-        .unwrap();
-
-        let test_dir = tempdir().unwrap();
-        let test_uri = test_dir.path().to_str().unwrap();
-
-        let write_params = WriteParams {
-            max_rows_per_group: 2,
-            use_experimental_writer,
-            ..Default::default()
-        };
-
-        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
-        Dataset::write(batches, test_uri, Some(write_params.clone()))
-            .await
-            .unwrap();
-
-        let dataset = Dataset::open(test_uri).await.unwrap();
-
-        let projection = Arc::new(dataset.schema().project(&["i"]).unwrap());
-        let ranges = [0_u64..3, 1..4, 0..1];
-        let range_stream = futures::stream::iter(ranges).map(Ok).boxed();
-        let results = dataset
-            .take_scan(range_stream, projection.clone(), 10)
-            .try_collect::<Vec<_>>()
-            .await
-            .unwrap();
-        let expected_schema = projection.as_ref().into();
-        for batch in &results {
-            assert_eq!(batch.schema().as_ref(), &expected_schema);
-        }
-        assert_eq!(results.len(), 3);
-        assert_eq!(
-            results[0].column(0).as_primitive::<Int32Type>().values(),
-            &[1, 2, 3],
-        );
-        assert_eq!(
-            results[1].column(0).as_primitive::<Int32Type>().values(),
-            &[2, 3, 4],
-        );
-        assert_eq!(
-            results[2].column(0).as_primitive::<Int32Type>().values(),
-            &[1],
-        );
     }
 
     fn copy_dir_all(

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -38,7 +38,7 @@ pub mod index;
 pub mod optimize;
 pub mod progress;
 pub mod scanner;
-pub mod schema_evolution;
+mod schema_evolution;
 mod take;
 pub mod transaction;
 pub mod updater;
@@ -50,7 +50,6 @@ use self::cleanup::RemovalStats;
 use self::feature_flags::{apply_feature_flags, can_read_dataset, can_write_dataset};
 use self::fragment::FileFragment;
 use self::scanner::{DatasetRecordBatchStream, Scanner};
-use self::schema_evolution::{ColumnAlteration, NewColumnTransform};
 use self::transaction::{Operation, Transaction};
 use self::write::write_fragments_internal;
 use crate::datatypes::Schema;
@@ -61,6 +60,9 @@ use crate::utils::temporal::{timestamp_to_nanos, utc_now, SystemTime};
 use crate::{Error, Result};
 use hash_joiner::HashJoiner;
 pub use lance_core::ROW_ID;
+pub use schema_evolution::{
+    BatchInfo, BatchUDF, ColumnAlteration, NewColumnTransform, UDFCheckpointStore,
+};
 pub use write::merge_insert::{
     MergeInsertBuilder, MergeInsertJob, WhenMatched, WhenNotMatched, WhenNotMatchedBySource,
 };

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -1,0 +1,1415 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{collections::HashSet, sync::Arc};
+
+use crate::io::commit::commit_transaction;
+use crate::{io::exec::Planner, Error, Result};
+use arrow::compute::CastOptions;
+use arrow_array::RecordBatch;
+use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+use futures::stream::{StreamExt, TryStreamExt};
+use lance_arrow::SchemaExt;
+use lance_core::datatypes::{Field, Schema};
+use lance_table::format::Fragment;
+use snafu::{location, Location};
+
+use super::{
+    transaction::{Operation, Transaction},
+    Dataset,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BatchInfo {
+    pub fragment_id: u32,
+    pub batch_index: usize,
+}
+
+/// A mechanism for saving UDF results.
+///
+/// This is used to determine if a UDF has already been run on a given input,
+/// and to store the results of a UDF for future use.
+pub trait UDFCheckpointStore: Send + Sync {
+    fn get_batch(&self, info: &BatchInfo) -> Result<Option<RecordBatch>>;
+    fn insert_batch(&self, info: BatchInfo, batch: RecordBatch) -> Result<()>;
+    fn get_fragment(&self, fragment_id: u32) -> Result<Option<Fragment>>;
+    fn insert_fragment(&self, fragment: Fragment) -> Result<()>;
+}
+
+pub struct BatchUDF {
+    #[allow(clippy::type_complexity)]
+    pub mapper: Box<dyn Fn(&RecordBatch) -> Result<RecordBatch> + Send + Sync>,
+    /// The schema of the returned RecordBatch
+    pub output_schema: Arc<ArrowSchema>,
+    /// A checkpoint store for the UDF results
+    pub result_checkpoint: Option<Arc<dyn UDFCheckpointStore>>,
+}
+
+/// A way to define one or more new columns in a dataset
+pub enum NewColumnTransform {
+    /// A UDF that takes a RecordBatch of existing data and returns a
+    /// RecordBatch with the new columns for those corresponding rows. The returned
+    /// batch must return the same number of rows as the input batch.
+    BatchUDF(BatchUDF),
+    /// A set of SQL expressions that define new columns.
+    SqlExpressions(Vec<(String, String)>),
+}
+
+/// Definition of a change to a column in a dataset
+pub struct ColumnAlteration {
+    /// Path to the existing column to be altered.
+    pub path: String,
+    /// The new name of the column. If None, the column name will not be changed.
+    pub rename: Option<String>,
+    /// Whether the column is nullable. If None, the nullability will not be changed.
+    pub nullable: Option<bool>,
+    /// The new data type of the column. If None, the data type will not be changed.
+    pub data_type: Option<DataType>,
+}
+
+impl ColumnAlteration {
+    pub fn new(path: String) -> Self {
+        Self {
+            path,
+            rename: None,
+            nullable: None,
+            data_type: None,
+        }
+    }
+
+    pub fn rename(mut self, name: String) -> Self {
+        self.rename = Some(name);
+        self
+    }
+
+    pub fn set_nullable(mut self, nullable: bool) -> Self {
+        self.nullable = Some(nullable);
+        self
+    }
+
+    pub fn cast_to(mut self, data_type: DataType) -> Self {
+        self.data_type = Some(data_type);
+        self
+    }
+}
+
+/// Limit casts to same type. This is mostly to filter out weird casts like
+/// casting a string to a boolean or float to string.
+fn is_upcast_downcast(from_type: &DataType, to_type: &DataType) -> bool {
+    use DataType::*;
+    match from_type {
+        from_type if from_type.is_integer() => to_type.is_integer(),
+        from_type if from_type.is_floating() => to_type.is_floating(),
+        from_type if from_type.is_temporal() => to_type.is_temporal(),
+        Boolean => matches!(to_type, Boolean),
+        Utf8 | LargeUtf8 => matches!(to_type, Utf8 | LargeUtf8),
+        Binary | LargeBinary => matches!(to_type, Binary | LargeBinary),
+        Decimal128(_, _) | Decimal256(_, _) => {
+            matches!(to_type, Decimal128(_, _) | Decimal256(_, _))
+        }
+        List(from_field) | LargeList(from_field) | FixedSizeList(from_field, _) => match to_type {
+            List(to_field) | LargeList(to_field) | FixedSizeList(to_field, _) => {
+                is_upcast_downcast(from_field.data_type(), to_field.data_type())
+            }
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+pub(super) async fn add_columns(
+    dataset: &mut Dataset,
+    transforms: NewColumnTransform,
+    read_columns: Option<Vec<String>>,
+) -> Result<()> {
+    // We just transform the SQL expression into a UDF backed by DataFusion
+    // physical expressions.
+    let (
+        BatchUDF {
+            mapper,
+            output_schema,
+            result_checkpoint,
+        },
+        read_columns,
+    ) = match transforms {
+        NewColumnTransform::BatchUDF(udf) => (udf, read_columns),
+        NewColumnTransform::SqlExpressions(expressions) => {
+            let arrow_schema = Arc::new(ArrowSchema::from(dataset.schema()));
+            let planner = Planner::new(arrow_schema);
+            let exprs = expressions
+                .into_iter()
+                .map(|(name, expr)| {
+                    let expr = planner.parse_expr(&expr)?;
+                    let expr = planner.optimize_expr(expr)?;
+                    Ok((name, expr))
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            let needed_columns = exprs
+                .iter()
+                .flat_map(|(_, expr)| Planner::column_names_in_expr(expr))
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            let read_schema = dataset.schema().project(&needed_columns)?;
+            let read_schema = Arc::new(ArrowSchema::from(&read_schema));
+            // Need to re-create the planner with the read schema because physical
+            // expressions use positional column references.
+            let planner = Planner::new(read_schema.clone());
+            let exprs = exprs
+                .into_iter()
+                .map(|(name, expr)| {
+                    let expr = planner.create_physical_expr(&expr)?;
+                    Ok((name, expr))
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            let output_schema = Arc::new(ArrowSchema::new(
+                exprs
+                    .iter()
+                    .map(|(name, expr)| {
+                        Ok(ArrowField::new(
+                            name,
+                            expr.data_type(read_schema.as_ref())?,
+                            expr.nullable(read_schema.as_ref())?,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>>>()?,
+            ));
+
+            let schema_ref = output_schema.clone();
+            let mapper = move |batch: &RecordBatch| {
+                let num_rows = batch.num_rows();
+                let columns = exprs
+                    .iter()
+                    .map(|(_, expr)| Ok(expr.evaluate(batch)?.into_array(num_rows)?))
+                    .collect::<Result<Vec<_>>>()?;
+
+                let batch = RecordBatch::try_new(schema_ref.clone(), columns)?;
+                Ok(batch)
+            };
+            let mapper = Box::new(mapper);
+
+            let read_columns = Some(read_schema.field_names().into_iter().cloned().collect());
+            (
+                BatchUDF {
+                    mapper,
+                    output_schema,
+                    result_checkpoint: None,
+                },
+                read_columns,
+            )
+        }
+    };
+
+    {
+        let new_names = output_schema.field_names();
+        for field in &dataset.schema().fields {
+            if new_names.contains(&&field.name) {
+                return Err(Error::invalid_input(
+                    format!("Column {} already exists in the dataset", field.name),
+                    location!(),
+                ));
+            }
+        }
+    }
+
+    let mut schema = dataset.schema().merge(output_schema.as_ref())?;
+    schema.set_field_id(Some(dataset.manifest.max_field_id()));
+
+    let fragments =
+        add_columns_impl(dataset, read_columns, mapper, result_checkpoint, None).await?;
+    let operation = Operation::Merge { fragments, schema };
+    let transaction = Transaction::new(dataset.manifest.version, operation, None);
+    let new_manifest = commit_transaction(
+        dataset,
+        &dataset.object_store,
+        dataset.commit_handler.as_ref(),
+        &transaction,
+        &Default::default(),
+        &Default::default(),
+    )
+    .await?;
+
+    dataset.manifest = Arc::new(new_manifest);
+
+    Ok(())
+}
+
+#[allow(clippy::type_complexity)]
+async fn add_columns_impl(
+    dataset: &Dataset,
+    read_columns: Option<Vec<String>>,
+    mapper: Box<dyn Fn(&RecordBatch) -> Result<RecordBatch> + Send + Sync>,
+    result_cache: Option<Arc<dyn UDFCheckpointStore>>,
+    schemas: Option<(Schema, Schema)>,
+) -> Result<Vec<Fragment>> {
+    let read_columns_ref = read_columns.as_deref();
+    let mapper_ref = mapper.as_ref();
+    let fragments = futures::stream::iter(dataset.get_fragments())
+        .then(|fragment| {
+            let cache_ref = result_cache.clone();
+            let schemas_ref = &schemas;
+            async move {
+                if let Some(cache) = &cache_ref {
+                    let fragment_id = fragment.id() as u32;
+                    let fragment = cache.get_fragment(fragment_id)?;
+                    if let Some(fragment) = fragment {
+                        return Ok(fragment);
+                    }
+                }
+
+                let mut updater = fragment
+                    .updater(read_columns_ref, schemas_ref.clone())
+                    .await?;
+
+                let mut batch_index = 0;
+                // TODO: the structure of the updater prevents batch-level parallelism here,
+                //       but there is no reason why we couldn't do this in parallel.
+                while let Some(batch) = updater.next().await? {
+                    let batch_info = BatchInfo {
+                        fragment_id: fragment.id() as u32,
+                        batch_index,
+                    };
+
+                    let new_batch = if let Some(cache) = &cache_ref {
+                        if let Some(batch) = cache.get_batch(&batch_info)? {
+                            batch
+                        } else {
+                            let new_batch = mapper_ref(batch)?;
+                            cache.insert_batch(batch_info, new_batch.clone())?;
+                            new_batch
+                        }
+                    } else {
+                        mapper_ref(batch)?
+                    };
+
+                    updater.update(new_batch).await?;
+                    batch_index += 1;
+                }
+
+                let fragment = updater.finish().await?;
+
+                if let Some(cache) = &cache_ref {
+                    cache.insert_fragment(fragment.clone())?;
+                }
+
+                Ok::<_, Error>(fragment)
+            }
+        })
+        .try_collect::<Vec<_>>()
+        .await?;
+    Ok(fragments)
+}
+
+/// Modify columns in the dataset, changing their name, type, or nullability.
+///
+/// If a column has an index, it's index will be preserved.
+pub(super) async fn alter_columns(
+    dataset: &mut Dataset,
+    alterations: &[ColumnAlteration],
+) -> Result<()> {
+    // Validate we aren't making nullable columns non-nullable and that all
+    // the referenced columns actually exist.
+    let mut new_schema = dataset.schema().clone();
+
+    // Mapping of old to new fields that need to be casted.
+    let mut cast_fields: Vec<(Field, Field)> = Vec::new();
+
+    let mut next_field_id = dataset.manifest.max_field_id() + 1;
+
+    for alteration in alterations {
+        let field_src = dataset.schema().field(&alteration.path).ok_or_else(|| {
+            Error::invalid_input(
+                format!(
+                    "Column \"{}\" does not exist in the dataset",
+                    alteration.path
+                ),
+                location!(),
+            )
+        })?;
+        if let Some(nullable) = alteration.nullable {
+            // TODO: in the future, we could check the values of the column to see if
+            //       they are all non-null and thus the column could be made non-nullable.
+            if field_src.nullable && !nullable {
+                return Err(Error::invalid_input(
+                    format!(
+                        "Column \"{}\" is already nullable and thus cannot be made non-nullable",
+                        alteration.path
+                    ),
+                    location!(),
+                ));
+            }
+        }
+
+        let field_dest = new_schema.mut_field_by_id(field_src.id).unwrap();
+        if let Some(rename) = &alteration.rename {
+            field_dest.name.clone_from(rename);
+        }
+        if let Some(nullable) = alteration.nullable {
+            field_dest.nullable = nullable;
+        }
+
+        if let Some(data_type) = &alteration.data_type {
+            if !(lance_arrow::cast::can_cast_types(&field_src.data_type(), data_type)
+                && is_upcast_downcast(&field_src.data_type(), data_type))
+            {
+                return Err(Error::invalid_input(
+                    format!(
+                        "Cannot cast column \"{}\" from {:?} to {:?}",
+                        alteration.path,
+                        field_src.data_type(),
+                        data_type
+                    ),
+                    location!(),
+                ));
+            }
+
+            let arrow_field = ArrowField::new(
+                field_dest.name.clone(),
+                data_type.clone(),
+                field_dest.nullable,
+            );
+            *field_dest = Field::try_from(&arrow_field)?;
+            field_dest.set_id(field_src.parent_id, &mut next_field_id);
+
+            cast_fields.push((field_src.clone(), field_dest.clone()));
+        }
+    }
+
+    new_schema.validate()?;
+
+    // If we aren't casting a column, we don't need to touch the fragments.
+    let transaction = if cast_fields.is_empty() {
+        Transaction::new(
+            dataset.manifest.version,
+            Operation::Project { schema: new_schema },
+            None,
+        )
+    } else {
+        // Otherwise, we need to re-write the relevant fields.
+        let read_columns = cast_fields
+            .iter()
+            .map(|(old, _new)| {
+                let parts = dataset.schema().field_ancestry_by_id(old.id).unwrap();
+                let part_names = parts.iter().map(|p| p.name.clone()).collect::<Vec<_>>();
+                part_names.join(".")
+            })
+            .collect::<Vec<_>>();
+
+        let new_ids = cast_fields
+            .iter()
+            .map(|(_old, new)| new.id)
+            .collect::<Vec<_>>();
+        // This schema contains the exact field ids we want to write the new fields with.
+        let new_col_schema = new_schema.project_by_ids(&new_ids);
+
+        let mapper = move |batch: &RecordBatch| {
+            let mut fields = Vec::with_capacity(cast_fields.len());
+            let mut columns = Vec::with_capacity(batch.num_columns());
+            for (old, new) in &cast_fields {
+                let old_column = batch[&old.name].clone();
+                let new_column = lance_arrow::cast::cast_with_options(
+                    &old_column,
+                    &new.data_type(),
+                    // Safe: false means it will error if the cast is lossy.
+                    &CastOptions {
+                        safe: false,
+                        ..Default::default()
+                    },
+                )?;
+                columns.push(new_column);
+                fields.push(Arc::new(ArrowField::from(new)));
+            }
+            let schema = Arc::new(ArrowSchema::new(fields));
+            Ok(RecordBatch::try_new(schema, columns)?)
+        };
+        let mapper = Box::new(mapper);
+
+        let fragments = add_columns_impl(
+            dataset,
+            Some(read_columns),
+            mapper,
+            None,
+            Some((new_col_schema, new_schema.clone())),
+        )
+        .await?;
+
+        // Some data files may no longer contain any columns in the dataset (e.g. if every
+        // remaining column has been altered into a different data file) and so we remove them
+        let schema_field_ids = new_schema.field_ids().into_iter().collect::<Vec<_>>();
+        let fragments = fragments
+            .into_iter()
+            .map(|mut frag| {
+                frag.files.retain(|f| {
+                    f.fields
+                        .iter()
+                        .any(|field| schema_field_ids.contains(field))
+                });
+                frag
+            })
+            .collect::<Vec<_>>();
+
+        Transaction::new(
+            dataset.manifest.version,
+            Operation::Merge {
+                schema: new_schema,
+                fragments,
+            },
+            None,
+        )
+    };
+
+    // TODO: adjust the indices here for the new schema
+
+    let manifest = commit_transaction(
+        dataset,
+        &dataset.object_store,
+        dataset.commit_handler.as_ref(),
+        &transaction,
+        &Default::default(),
+        &Default::default(),
+    )
+    .await?;
+
+    dataset.manifest = Arc::new(manifest);
+
+    Ok(())
+}
+
+/// Remove columns from the dataset.
+///
+/// This is a metadata-only operation and does not remove the data from the
+/// underlying storage. In order to remove the data, you must subsequently
+/// call `compact_files` to rewrite the data without the removed columns and
+/// then call `cleanup_files` to remove the old files.
+pub(super) async fn drop_columns(dataset: &mut Dataset, columns: &[&str]) -> Result<()> {
+    // Check if columns are present in the dataset and construct the new schema.
+    for col in columns {
+        if dataset.schema().field(col).is_none() {
+            return Err(Error::invalid_input(
+                format!("Column {} does not exist in the dataset", col),
+                location!(),
+            ));
+        }
+    }
+
+    let columns_to_remove = dataset.manifest.schema.project(columns)?;
+    let new_schema = dataset.manifest.schema.exclude(columns_to_remove)?;
+
+    if new_schema.fields.is_empty() {
+        return Err(Error::invalid_input(
+            "Cannot drop all columns from a dataset",
+            location!(),
+        ));
+    }
+
+    let transaction = Transaction::new(
+        dataset.manifest.version,
+        Operation::Project { schema: new_schema },
+        None,
+    );
+
+    let manifest = commit_transaction(
+        dataset,
+        &dataset.object_store,
+        dataset.commit_handler.as_ref(),
+        &transaction,
+        &Default::default(),
+        &Default::default(),
+    )
+    .await?;
+
+    dataset.manifest = Arc::new(manifest);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Mutex;
+
+    use crate::dataset::WriteParams;
+
+    use super::*;
+    use arrow_array::{Int32Array, RecordBatchIterator};
+    use arrow_schema::Fields as ArrowFields;
+    use rstest::rstest;
+
+    // Used to validate that futures returned are Send.
+    fn require_send<T: Send>(t: T) -> T {
+        t
+    }
+
+    #[tokio::test]
+    async fn test_append_columns_exprs() -> Result<()> {
+        let num_rows = 5;
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from_iter_values(0..num_rows as i32))],
+        )?;
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+
+        let test_dir = tempfile::tempdir()?;
+        let test_uri = test_dir.path().to_str().unwrap();
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                use_experimental_writer: false,
+                ..Default::default()
+            }),
+        )
+        .await?;
+        dataset.validate().await?;
+
+        // Adding a duplicate column name will break
+        let fut = dataset.add_columns(
+            NewColumnTransform::SqlExpressions(vec![("id".into(), "id + 1".into())]),
+            None,
+        );
+        // (Quick validation that the future is Send)
+        let res = require_send(fut).await;
+        assert!(matches!(res, Err(Error::InvalidInput { .. })));
+
+        // Can add a column that is independent of any existing ones
+        dataset
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![("value".into(), "2 * random()".into())]),
+                None,
+            )
+            .await?;
+
+        // Can add a column derived from an existing one.
+        dataset
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![("double_id".into(), "2 * id".into())]),
+                None,
+            )
+            .await?;
+
+        // Can derive a column from existing ones across multiple data files.
+        dataset
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![(
+                    "triple_id".into(),
+                    "id + double_id".into(),
+                )]),
+                None,
+            )
+            .await?;
+
+        // These can be read back, the dataset is valid
+        dataset.validate().await?;
+
+        let data = dataset.scan().try_into_batch().await?;
+        let expected_schema = ArrowSchema::new(vec![
+            ArrowField::new("id", DataType::Int32, false),
+            ArrowField::new("value", DataType::Float64, true),
+            ArrowField::new("double_id", DataType::Int32, false),
+            ArrowField::new("triple_id", DataType::Int32, false),
+        ]);
+        assert_eq!(data.schema().as_ref(), &expected_schema);
+        assert_eq!(data.num_rows(), num_rows);
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_append_columns_udf(
+        #[values(false, true)] use_experimental_writer: bool,
+    ) -> Result<()> {
+        use arrow_array::Float64Array;
+
+        let num_rows = 5;
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from_iter_values(0..num_rows as i32))],
+        )?;
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+
+        let test_dir = tempfile::tempdir()?;
+        let test_uri = test_dir.path().to_str().unwrap();
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                use_experimental_writer,
+                ..Default::default()
+            }),
+        )
+        .await?;
+        dataset.validate().await?;
+
+        // Adding a duplicate column name will break
+        let transforms = NewColumnTransform::BatchUDF(BatchUDF {
+            mapper: Box::new(|_| unimplemented!()),
+            output_schema: Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                "id",
+                DataType::Int32,
+                false,
+            )])),
+            result_checkpoint: None,
+        });
+        let res = dataset.add_columns(transforms, None).await;
+        assert!(matches!(res, Err(Error::InvalidInput { .. })));
+
+        // Can add a column that independent (empty read_schema)
+        let output_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "value",
+            DataType::Float64,
+            true,
+        )]));
+        let output_schema_ref = output_schema.clone();
+        let mapper = move |batch: &RecordBatch| {
+            Ok(RecordBatch::try_new(
+                output_schema_ref.clone(),
+                vec![Arc::new(Float64Array::from_iter_values(
+                    (0..batch.num_rows()).map(|i| i as f64),
+                ))],
+            )?)
+        };
+        let transforms = NewColumnTransform::BatchUDF(BatchUDF {
+            mapper: Box::new(mapper),
+            output_schema,
+            result_checkpoint: None,
+        });
+        dataset.add_columns(transforms, None).await?;
+
+        // Can add a column that depends on another column (double id)
+        let output_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "double_id",
+            DataType::Int32,
+            false,
+        )]));
+        let output_schema_ref = output_schema.clone();
+        let mapper = move |batch: &RecordBatch| {
+            let id = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Ok(RecordBatch::try_new(
+                output_schema_ref.clone(),
+                vec![Arc::new(Int32Array::from_iter_values(
+                    id.values().iter().map(|i| i * 2),
+                ))],
+            )?)
+        };
+        let transforms = NewColumnTransform::BatchUDF(BatchUDF {
+            mapper: Box::new(mapper),
+            output_schema,
+            result_checkpoint: None,
+        });
+        dataset.add_columns(transforms, None).await?;
+        // These can be read back, the dataset is valid
+        dataset.validate().await?;
+
+        let data = dataset.scan().try_into_batch().await?;
+        let expected_schema = ArrowSchema::new(vec![
+            ArrowField::new("id", DataType::Int32, false),
+            ArrowField::new("value", DataType::Float64, true),
+            ArrowField::new("double_id", DataType::Int32, false),
+        ]);
+        assert_eq!(data.schema().as_ref(), &expected_schema);
+        assert_eq!(data.num_rows(), num_rows);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_append_columns_udf_cache() -> Result<()> {
+        let num_rows = 100;
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            DataType::Int32,
+            false,
+        )]));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from_iter_values(0..num_rows))],
+        )?;
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+
+        let test_dir = tempfile::tempdir()?;
+        let test_uri = test_dir.path().to_str().unwrap();
+        let mut dataset = Dataset::write(
+            reader,
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: 50,
+                max_rows_per_group: 25,
+                use_experimental_writer: false,
+                ..Default::default()
+            }),
+        )
+        .await?;
+        dataset.validate().await?;
+
+        #[derive(Default)]
+        struct RequestCounter {
+            pub get_batch_requests: Mutex<Vec<BatchInfo>>,
+            pub insert_batch_requests: Mutex<Vec<BatchInfo>>,
+            pub get_fragment_requests: Mutex<Vec<u32>>,
+            pub insert_fragment_requests: Mutex<Vec<u32>>,
+        }
+
+        impl UDFCheckpointStore for RequestCounter {
+            fn get_batch(&self, info: &BatchInfo) -> Result<Option<RecordBatch>> {
+                self.get_batch_requests.lock().unwrap().push(info.clone());
+
+                if info.fragment_id == 1 && info.batch_index == 0 {
+                    Ok(Some(RecordBatch::try_new(
+                        Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                            "double_id",
+                            DataType::Int32,
+                            false,
+                        )])),
+                        vec![Arc::new(Int32Array::from_iter_values(50..75))],
+                    )?))
+                } else {
+                    Ok(None)
+                }
+            }
+
+            fn insert_batch(&self, info: BatchInfo, _value: RecordBatch) -> Result<()> {
+                self.insert_batch_requests.lock().unwrap().push(info);
+                Ok(())
+            }
+
+            fn get_fragment(&self, fragment_id: u32) -> Result<Option<Fragment>> {
+                self.get_fragment_requests.lock().unwrap().push(fragment_id);
+                if fragment_id == 0 {
+                    Ok(Some(Fragment {
+                        files: vec![],
+                        id: 0,
+                        deletion_file: None,
+                        physical_rows: Some(50),
+                    }))
+                } else {
+                    Ok(None)
+                }
+            }
+
+            fn insert_fragment(&self, fragment: Fragment) -> Result<()> {
+                self.insert_fragment_requests
+                    .lock()
+                    .unwrap()
+                    .push(fragment.id as u32);
+                Ok(())
+            }
+        }
+
+        let request_counter = Arc::new(RequestCounter::default());
+
+        let output_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "double_id",
+            DataType::Int32,
+            false,
+        )]));
+        let output_schema_ref = output_schema.clone();
+        let mapper = move |batch: &RecordBatch| {
+            let id = batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap();
+            Ok(RecordBatch::try_new(
+                output_schema_ref.clone(),
+                vec![Arc::new(Int32Array::from_iter_values(
+                    id.values().iter().map(|i| i * 2),
+                ))],
+            )?)
+        };
+        let transforms = NewColumnTransform::BatchUDF(BatchUDF {
+            mapper: Box::new(mapper),
+            output_schema,
+            result_checkpoint: Some(request_counter.clone()),
+        });
+        dataset.add_columns(transforms, None).await?;
+
+        // Should have requested both fragments
+        assert_eq!(
+            request_counter
+                .get_fragment_requests
+                .lock()
+                .unwrap()
+                .as_slice(),
+            &[0, 1]
+        );
+        // Should have only inserted the second fragment, since the first one was already cached
+        assert_eq!(
+            request_counter
+                .insert_fragment_requests
+                .lock()
+                .unwrap()
+                .as_slice(),
+            &[1]
+        );
+
+        // Should have only requested the second two batches, since the first fragment was already cached
+        assert_eq!(
+            request_counter
+                .get_batch_requests
+                .lock()
+                .unwrap()
+                .as_slice(),
+            &[
+                BatchInfo {
+                    fragment_id: 1,
+                    batch_index: 0,
+                },
+                BatchInfo {
+                    fragment_id: 1,
+                    batch_index: 1,
+                },
+            ]
+        );
+        // Should have only saved the last batch, since the first batch of second fragment was already cached
+        assert_eq!(
+            request_counter
+                .insert_batch_requests
+                .lock()
+                .unwrap()
+                .as_slice(),
+            &[BatchInfo {
+                fragment_id: 1,
+                batch_index: 1,
+            },]
+        );
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_rename_columns(
+        #[values(false, true)] use_experimental_writer: bool,
+    ) -> Result<()> {
+        use std::collections::HashMap;
+
+        use arrow_array::{ArrayRef, StructArray};
+
+        let metadata: HashMap<String, String> = [("k1".into(), "v1".into())].into();
+
+        let schema = Arc::new(ArrowSchema::new_with_metadata(
+            vec![
+                ArrowField::new("a", DataType::Int32, false),
+                ArrowField::new(
+                    "b",
+                    DataType::Struct(ArrowFields::from(vec![ArrowField::new(
+                        "c",
+                        DataType::Int32,
+                        true,
+                    )])),
+                    true,
+                ),
+            ],
+            metadata.clone(),
+        ));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StructArray::from(vec![(
+                    Arc::new(ArrowField::new("c", DataType::Int32, true)),
+                    Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
+                )])),
+            ],
+        )?;
+
+        let test_dir = tempfile::tempdir()?;
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let batches = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+        let mut dataset = Dataset::write(
+            batches,
+            test_uri,
+            Some(WriteParams {
+                use_experimental_writer,
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+        let original_fragments = dataset.fragments().to_vec();
+
+        // Rename a top-level column
+        dataset
+            .alter_columns(&[ColumnAlteration::new("a".into())
+                .rename("x".into())
+                .set_nullable(true)])
+            .await?;
+        dataset.validate().await?;
+        assert_eq!(dataset.manifest.version, 2);
+        assert_eq!(dataset.fragments().as_ref(), &original_fragments);
+
+        let expected_schema = ArrowSchema::new_with_metadata(
+            vec![
+                ArrowField::new("x", DataType::Int32, true),
+                ArrowField::new(
+                    "b",
+                    DataType::Struct(ArrowFields::from(vec![ArrowField::new(
+                        "c",
+                        DataType::Int32,
+                        true,
+                    )])),
+                    true,
+                ),
+            ],
+            metadata.clone(),
+        );
+        assert_eq!(&ArrowSchema::from(dataset.schema()), &expected_schema);
+
+        // Rename to duplicate name fails
+        let err = dataset
+            .alter_columns(&[ColumnAlteration::new("b".into()).rename("x".into())])
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("Duplicate field name \"x\""));
+
+        // Rename a nested column.
+        dataset
+            .alter_columns(&[ColumnAlteration::new("b.c".into()).rename("d".into())])
+            .await?;
+        dataset.validate().await?;
+        assert_eq!(dataset.manifest.version, 3);
+        assert_eq!(dataset.fragments().as_ref(), &original_fragments);
+
+        let expected_schema = ArrowSchema::new_with_metadata(
+            vec![
+                ArrowField::new("x", DataType::Int32, true),
+                ArrowField::new(
+                    "b",
+                    DataType::Struct(ArrowFields::from(vec![ArrowField::new(
+                        "d",
+                        DataType::Int32,
+                        true,
+                    )])),
+                    true,
+                ),
+            ],
+            metadata.clone(),
+        );
+        assert_eq!(&ArrowSchema::from(dataset.schema()), &expected_schema);
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_cast_column(#[values(false, true)] use_experimental_writer: bool) -> Result<()> {
+        // Create a table with 2 scalar columns, 1 vector column
+
+        use arrow::datatypes::{Int32Type, Int64Type};
+        use arrow_array::{Float16Array, Float32Array, Int64Array, ListArray};
+        use half::f16;
+        use lance_arrow::FixedSizeListArrayExt;
+        use lance_index::{DatasetIndexExt, IndexType};
+        use lance_linalg::distance::MetricType;
+        use lance_testing::datagen::generate_random_array;
+
+        use crate::index::{scalar::ScalarIndexParams, vector::VectorIndexParams};
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int32, false),
+            ArrowField::new("f", DataType::Float32, false),
+            ArrowField::new(
+                "vec",
+                DataType::FixedSizeList(
+                    Arc::new(ArrowField::new("item", DataType::Float32, true)),
+                    128,
+                ),
+                false,
+            ),
+            ArrowField::new("l", DataType::new_list(DataType::Int32, true), true),
+        ]));
+
+        let nrows = 512;
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..nrows)),
+                Arc::new(Float32Array::from_iter_values((0..nrows).map(|i| i as f32))),
+                Arc::new(
+                    <arrow_array::FixedSizeListArray as FixedSizeListArrayExt>::try_new_from_values(
+                        generate_random_array(128 * nrows as usize),
+                        128,
+                    )
+                    .unwrap(),
+                ),
+                Arc::new(ListArray::from_iter_primitive::<Int32Type, _, _>(
+                    (0..nrows).map(|i| Some(vec![Some(i), Some(i + 1)])),
+                )),
+            ],
+        )?;
+
+        let test_dir = tempfile::tempdir()?;
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch.clone())], schema.clone()),
+            test_uri,
+            Some(WriteParams {
+                use_experimental_writer,
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+        let params = VectorIndexParams::ivf_pq(10, 8, 2, MetricType::L2, 50);
+        dataset
+            .create_index(&["vec"], IndexType::Vector, None, &params, false)
+            .await?;
+        dataset
+            .create_index(
+                &["i"],
+                IndexType::Scalar,
+                None,
+                &ScalarIndexParams::default(),
+                false,
+            )
+            .await?;
+        dataset.validate().await?;
+
+        let indices = dataset.load_indices().await?;
+        assert_eq!(indices.len(), 2);
+
+        // Cast a scalar column to another type, nullability
+        dataset
+            .alter_columns(&[ColumnAlteration::new("f".into())
+                .cast_to(DataType::Float16)
+                .set_nullable(true)])
+            .await?;
+        dataset.validate().await?;
+        let expected_schema = ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int32, false),
+            ArrowField::new("f", DataType::Float16, true),
+            ArrowField::new(
+                "vec",
+                DataType::FixedSizeList(
+                    Arc::new(ArrowField::new("item", DataType::Float32, true)),
+                    128,
+                ),
+                false,
+            ),
+            ArrowField::new("l", DataType::new_list(DataType::Int32, true), true),
+        ]);
+        assert_eq!(&ArrowSchema::from(dataset.schema()), &expected_schema);
+
+        // Each fragment gains a file with the new columns
+        dataset.fragments().iter().for_each(|f| {
+            assert_eq!(f.files.len(), 2);
+        });
+
+        // Cast scalar column with index, should not keep index (TODO: keep it)
+        dataset
+            .alter_columns(&[ColumnAlteration::new("i".into()).cast_to(DataType::Int64)])
+            .await?;
+        dataset.validate().await?;
+
+        let expected_schema = ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int64, false),
+            ArrowField::new("f", DataType::Float16, true),
+            ArrowField::new(
+                "vec",
+                DataType::FixedSizeList(
+                    Arc::new(ArrowField::new("item", DataType::Float32, true)),
+                    128,
+                ),
+                false,
+            ),
+            ArrowField::new("l", DataType::new_list(DataType::Int32, true), true),
+        ]);
+        assert_eq!(&ArrowSchema::from(dataset.schema()), &expected_schema);
+
+        // We currently lose the index when casting a column
+        let indices = dataset.load_indices().await?;
+        assert_eq!(indices.len(), 1);
+
+        // Each fragment gains a file with the new columns
+        dataset.fragments().iter().for_each(|f| {
+            assert_eq!(f.files.len(), 3);
+        });
+
+        // Cast vector column, should not keep index (TODO: keep it)
+        dataset
+            .alter_columns(&[
+                ColumnAlteration::new("vec".into()).cast_to(DataType::FixedSizeList(
+                    Arc::new(ArrowField::new("item", DataType::Float16, true)),
+                    128,
+                )),
+            ])
+            .await?;
+        dataset.validate().await?;
+
+        // Finally, case list column to show we can handle children.
+        dataset
+            .alter_columns(&[ColumnAlteration::new("l".into())
+                .cast_to(DataType::new_list(DataType::Int64, true))])
+            .await?;
+        dataset.validate().await?;
+
+        let expected_schema = ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int64, false),
+            ArrowField::new("f", DataType::Float16, true),
+            ArrowField::new(
+                "vec",
+                DataType::FixedSizeList(
+                    Arc::new(ArrowField::new("item", DataType::Float16, true)),
+                    128,
+                ),
+                false,
+            ),
+            ArrowField::new("l", DataType::new_list(DataType::Int64, true), true),
+        ]);
+        assert_eq!(&ArrowSchema::from(dataset.schema()), &expected_schema);
+
+        // We currently lose the index when casting a column
+        let indices = dataset.load_indices().await?;
+        assert_eq!(indices.len(), 0);
+
+        // Each fragment gains a file with the new columns, but then the original file is dropped
+        dataset.fragments().iter().for_each(|f| {
+            assert_eq!(f.files.len(), 4);
+        });
+
+        let expected_data = RecordBatch::try_new(
+            Arc::new(expected_schema),
+            vec![
+                Arc::new(Int64Array::from_iter_values(0..nrows as i64)),
+                Arc::new(Float16Array::from_iter_values(
+                    (0..nrows).map(|i| f16::from_f32(i as f32)),
+                )),
+                lance_arrow::cast::cast_with_options(
+                    batch["vec"].as_ref(),
+                    &DataType::FixedSizeList(
+                        Arc::new(ArrowField::new("item", DataType::Float16, true)),
+                        128,
+                    ),
+                    &Default::default(),
+                )?,
+                Arc::new(ListArray::from_iter_primitive::<Int64Type, _, _>(
+                    (0..nrows as i64).map(|i| Some(vec![Some(i), Some(i + 1)])),
+                )),
+            ],
+        )?;
+        let actual_data = dataset.scan().try_into_batch().await?;
+        assert_eq!(actual_data, expected_data);
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_drop_columns(#[values(false, true)] use_experimental_writer: bool) -> Result<()> {
+        use std::collections::HashMap;
+
+        use arrow_array::{ArrayRef, Float32Array, StructArray};
+
+        let metadata: HashMap<String, String> = [("k1".into(), "v1".into())].into();
+
+        let schema = Arc::new(ArrowSchema::new_with_metadata(
+            vec![
+                ArrowField::new("i", DataType::Int32, false),
+                ArrowField::new(
+                    "s",
+                    DataType::Struct(ArrowFields::from(vec![
+                        ArrowField::new("d", DataType::Int32, true),
+                        ArrowField::new("l", DataType::Int32, true),
+                    ])),
+                    true,
+                ),
+                ArrowField::new("x", DataType::Float32, false),
+            ],
+            metadata.clone(),
+        ));
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StructArray::from(vec![
+                    (
+                        Arc::new(ArrowField::new("d", DataType::Int32, true)),
+                        Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
+                    ),
+                    (
+                        Arc::new(ArrowField::new("l", DataType::Int32, true)),
+                        Arc::new(Int32Array::from(vec![1, 2])),
+                    ),
+                ])),
+                Arc::new(Float32Array::from(vec![1.0, 2.0])),
+            ],
+        )?;
+
+        let test_dir = tempfile::tempdir()?;
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let batches = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+        let mut dataset = Dataset::write(
+            batches,
+            test_uri,
+            Some(WriteParams {
+                use_experimental_writer,
+                ..Default::default()
+            }),
+        )
+        .await?;
+
+        let lance_schema = dataset.schema().clone();
+        let original_fragments = dataset.fragments().to_vec();
+
+        dataset.drop_columns(&["x"]).await?;
+        dataset.validate().await?;
+
+        let expected_schema = lance_schema.project(&["i", "s"])?;
+        assert_eq!(dataset.schema(), &expected_schema);
+
+        assert_eq!(dataset.version().version, 2);
+        assert_eq!(dataset.fragments().as_ref(), &original_fragments);
+
+        dataset.drop_columns(&["s.d"]).await?;
+        dataset.validate().await?;
+
+        let expected_schema = expected_schema.project(&["i", "s.l"])?;
+        assert_eq!(dataset.schema(), &expected_schema);
+
+        let expected_data = RecordBatch::try_new(
+            Arc::new(ArrowSchema::from(&expected_schema)),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StructArray::from(vec![(
+                    Arc::new(ArrowField::new("l", DataType::Int32, true)),
+                    Arc::new(Int32Array::from(vec![1, 2])) as ArrayRef,
+                )])),
+            ],
+        )?;
+        let actual_data = dataset.scan().try_into_batch().await?;
+        assert_eq!(actual_data, expected_data);
+
+        assert_eq!(dataset.version().version, 3);
+        assert_eq!(dataset.fragments().as_ref(), &original_fragments);
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_drop_add_columns(
+        #[values(false, true)] use_experimental_writer: bool,
+    ) -> Result<()> {
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "i",
+            DataType::Int32,
+            false,
+        )]));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![1, 2]))])?;
+
+        let test_dir = tempfile::tempdir()?;
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let batches = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+        let mut dataset = Dataset::write(
+            batches,
+            test_uri,
+            Some(WriteParams {
+                use_experimental_writer,
+                ..Default::default()
+            }),
+        )
+        .await?;
+        assert_eq!(dataset.manifest.max_field_id(), 0);
+
+        // Test we can add 1 column, drop it, then add another column. Validate
+        // the field ids are as expected.
+        dataset
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![("x".into(), "i + 1".into())]),
+                Some(vec!["i".into()]),
+            )
+            .await?;
+        assert_eq!(dataset.manifest.max_field_id(), 1);
+
+        dataset.drop_columns(&["x"]).await?;
+        assert_eq!(dataset.manifest.max_field_id(), 0);
+
+        dataset
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![("y".into(), "2 * i".into())]),
+                Some(vec!["i".into()]),
+            )
+            .await?;
+        assert_eq!(dataset.manifest.max_field_id(), 1);
+
+        let data = dataset.scan().try_into_batch().await?;
+        let expected_data = RecordBatch::try_new(
+            Arc::new(schema.try_with_column(ArrowField::new("y", DataType::Int32, false))?),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(Int32Array::from(vec![2, 4])),
+            ],
+        )?;
+        assert_eq!(data, expected_data);
+        dataset.drop_columns(&["y"]).await?;
+        assert_eq!(dataset.manifest.max_field_id(), 0);
+
+        // Test we can add 2 columns, drop 1, then add another column. Validate
+        // the field ids are as expected.
+        dataset
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![
+                    ("a".into(), "i + 3".into()),
+                    ("b".into(), "i + 7".into()),
+                ]),
+                Some(vec!["i".into()]),
+            )
+            .await?;
+        assert_eq!(dataset.manifest.max_field_id(), 2);
+
+        dataset.drop_columns(&["b"]).await?;
+        // Even though we dropped a column, we still have the fragment with a and
+        // b. So it should still act as if that field id is still in play.
+        assert_eq!(dataset.manifest.max_field_id(), 2);
+
+        dataset
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![("c".into(), "i + 11".into())]),
+                Some(vec!["i".into()]),
+            )
+            .await?;
+        assert_eq!(dataset.manifest.max_field_id(), 3);
+
+        let data = dataset.scan().try_into_batch().await?;
+        let expected_schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int32, false),
+            ArrowField::new("a", DataType::Int32, false),
+            ArrowField::new("c", DataType::Int32, false),
+        ]));
+        let expected_data = RecordBatch::try_new(
+            expected_schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(Int32Array::from(vec![4, 5])),
+                Arc::new(Int32Array::from(vec![12, 13])),
+            ],
+        )?;
+        assert_eq!(data, expected_data);
+
+        Ok(())
+    }
+}

--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -1,0 +1,630 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{collections::BTreeMap, ops::Range, pin::Pin, sync::Arc};
+
+use crate::{Error, Result};
+use arrow::{array::as_struct_array, compute::concat_batches, datatypes::UInt64Type};
+use arrow_array::cast::AsArray;
+use arrow_array::{Array, RecordBatch, StructArray, UInt64Array};
+use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
+use arrow_select::interleave::interleave;
+use datafusion::error::DataFusionError;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use futures::{Future, Stream, StreamExt, TryStreamExt};
+use lance_core::{datatypes::Schema, ROW_ID};
+use snafu::{location, Location};
+
+use super::{fragment::FileFragment, scanner::DatasetRecordBatchStream, Dataset};
+
+pub async fn take(
+    dataset: &Dataset,
+    row_indices: &[u64],
+    projection: &Schema,
+) -> Result<RecordBatch> {
+    if row_indices.is_empty() {
+        let schema = Arc::new(projection.into());
+        return Ok(RecordBatch::new_empty(schema));
+    }
+
+    let mut sorted_indices: Vec<usize> = (0..row_indices.len()).collect();
+    sorted_indices.sort_by_key(|&i| row_indices[i]);
+
+    let fragments = dataset.get_fragments();
+
+    // We will split into sub-requests for each fragment.
+    let mut sub_requests: Vec<(&FileFragment, Range<usize>)> = Vec::new();
+    // We will remap the row indices to the original row indices, using a pair
+    // of (request position, position in request)
+    let mut remap_index: Vec<(usize, usize)> = vec![(0, 0); row_indices.len()];
+    let mut local_ids_buffer: Vec<u32> = Vec::with_capacity(row_indices.len());
+
+    let mut fragments_iter = fragments.iter();
+    let mut current_fragment = fragments_iter.next().ok_or_else(|| Error::InvalidInput {
+        source: "Called take on an empty dataset.".to_string().into(),
+        location: location!(),
+    })?;
+    let mut current_fragment_len = current_fragment.count_rows().await?;
+    let mut curr_fragment_offset: u64 = 0;
+    let mut current_fragment_end = current_fragment_len as u64;
+    let mut start = 0;
+    let mut end = 0;
+    // We want to keep track of the previous row_index to detect duplicates
+    // index takes. To start, we pick a value that is guaranteed to be different
+    // from the first row_index.
+    let mut previous_row_index: u64 = row_indices[sorted_indices[0]] + 1;
+    let mut previous_sorted_index: usize = 0;
+
+    for index in sorted_indices {
+        // Get the index
+        let row_index = row_indices[index];
+
+        if previous_row_index == row_index {
+            // If we have a duplicate index request we add a remap_index
+            // entry that points to the original index request.
+            remap_index[index] = remap_index[previous_sorted_index];
+            continue;
+        } else {
+            previous_sorted_index = index;
+            previous_row_index = row_index;
+        }
+
+        // If the row index is beyond the current fragment, iterate
+        // until we find the fragment that contains it.
+        while row_index >= current_fragment_end {
+            // If we have a non-empty sub-request, add it to the list
+            if end - start > 0 {
+                // If we have a non-empty sub-request, add it to the list
+                sub_requests.push((current_fragment, start..end));
+            }
+
+            start = end;
+
+            current_fragment = fragments_iter.next().ok_or_else(|| Error::InvalidInput {
+                source: format!(
+                    "Row index {} is beyond the range of the dataset.",
+                    row_index
+                )
+                .into(),
+                location: location!(),
+            })?;
+            curr_fragment_offset += current_fragment_len as u64;
+            current_fragment_len = current_fragment.count_rows().await?;
+            current_fragment_end = curr_fragment_offset + current_fragment_len as u64;
+        }
+
+        // Note that we cast to u32 *after* subtracting the offset,
+        // since it is possible for the global index to be larger than
+        // u32::MAX.
+        let local_index = (row_index - curr_fragment_offset) as u32;
+        local_ids_buffer.push(local_index);
+
+        remap_index[index] = (sub_requests.len(), end - start);
+
+        end += 1;
+    }
+
+    // flush last batch
+    if end - start > 0 {
+        sub_requests.push((current_fragment, start..end));
+    }
+
+    let take_tasks = sub_requests
+        .into_iter()
+        .map(|(fragment, indices_range)| {
+            let local_ids = &local_ids_buffer[indices_range];
+            fragment.take(local_ids, projection)
+        })
+        .collect::<Vec<_>>();
+    let batches = futures::stream::iter(take_tasks)
+        .buffered(num_cpus::get() * 4)
+        .try_collect::<Vec<RecordBatch>>()
+        .await?;
+
+    let struct_arrs: Vec<StructArray> = batches.into_iter().map(StructArray::from).collect();
+    let refs: Vec<_> = struct_arrs.iter().map(|x| x as &dyn Array).collect();
+    let reordered = interleave(&refs, &remap_index)?;
+    Ok(as_struct_array(&reordered).into())
+}
+
+/// Take rows by the internal ROW ids.
+pub async fn take_rows(
+    dataset: &Dataset,
+    row_ids: &[u64],
+    projection: &Schema,
+) -> Result<RecordBatch> {
+    if row_ids.is_empty() {
+        return Ok(RecordBatch::new_empty(Arc::new(projection.into())));
+    }
+
+    let projection = Arc::new(projection.clone());
+    let row_id_meta = check_row_ids(row_ids);
+
+    // This method is mostly to annotate the send bound to avoid the
+    // higher-order lifetime error.
+    // manually implemented async for Send bound
+    #[allow(clippy::manual_async_fn)]
+    fn do_take(
+        fragment: FileFragment,
+        row_ids: Vec<u32>,
+        projection: Arc<Schema>,
+        with_row_id: bool,
+    ) -> impl Future<Output = Result<RecordBatch>> + Send {
+        async move {
+            fragment
+                .take_rows(&row_ids, projection.as_ref(), with_row_id)
+                .await
+        }
+    }
+
+    if row_id_meta.contiguous {
+        // Fastest path: Can use `read_range` directly
+        let start = row_ids.first().expect("empty range passed to take_rows");
+        let fragment_id = (start >> 32) as usize;
+        let range_start = *start as u32 as usize;
+        let range_end = *row_ids.last().expect("empty range passed to take_rows") as u32 as usize;
+        let range = range_start..(range_end + 1);
+
+        let fragment = dataset.get_fragment(fragment_id).ok_or_else(|| {
+            Error::invalid_input(
+                format!("row_id belongs to non-existant fragment: {start}"),
+                location!(),
+            )
+        })?;
+
+        let reader = fragment.open(projection.as_ref(), false).await?;
+        reader.legacy_read_range_as_batch(range).await
+    } else if row_id_meta.sorted {
+        // Don't need to re-arrange data, just concatenate
+
+        let mut batches: Vec<_> = Vec::new();
+        let mut current_fragment = row_ids[0] >> 32;
+        let mut current_start = 0;
+        let mut row_ids_iter = row_ids.iter().enumerate();
+        'outer: loop {
+            let (fragment_id, range) = loop {
+                if let Some((i, row_id)) = row_ids_iter.next() {
+                    let fragment_id = row_id >> 32;
+                    if fragment_id != current_fragment {
+                        let next = (current_fragment, current_start..i);
+                        current_fragment = fragment_id;
+                        current_start = i;
+                        break next;
+                    }
+                } else if current_start != row_ids.len() {
+                    let next = (current_fragment, current_start..row_ids.len());
+                    current_start = row_ids.len();
+                    break next;
+                } else {
+                    break 'outer;
+                }
+            };
+
+            let fragment = dataset.get_fragment(fragment_id as usize).ok_or_else(|| {
+                Error::invalid_input(
+                    format!(
+                        "row_id {} belongs to non-existant fragment: {}",
+                        row_ids[range.start], fragment_id
+                    ),
+                    location!(),
+                )
+            })?;
+            let row_ids: Vec<u32> = row_ids[range].iter().map(|x| *x as u32).collect();
+
+            let batch_fut = do_take(fragment, row_ids, projection.clone(), false);
+            batches.push(batch_fut);
+        }
+        let batches: Vec<RecordBatch> = futures::stream::iter(batches)
+            .buffered(4 * num_cpus::get())
+            .try_collect()
+            .await?;
+        Ok(concat_batches(&batches[0].schema(), &batches)?)
+    } else {
+        let projection_with_row_id = Schema::merge(
+            projection.as_ref(),
+            &ArrowSchema::new(vec![ArrowField::new(
+                ROW_ID,
+                arrow::datatypes::DataType::UInt64,
+                false,
+            )]),
+        )?;
+        let schema_with_row_id = Arc::new(ArrowSchema::from(&projection_with_row_id));
+
+        // Slow case: need to re-map data into expected order
+        let mut sorted_row_ids = Vec::from(row_ids);
+        sorted_row_ids.sort();
+        // Group ROW Ids by the fragment
+        let mut row_ids_per_fragment: BTreeMap<u64, Vec<u32>> = BTreeMap::new();
+        sorted_row_ids.iter().for_each(|row_id| {
+            let fragment_id = row_id >> 32;
+            let offset = (row_id - (fragment_id << 32)) as u32;
+            row_ids_per_fragment
+                .entry(fragment_id)
+                .and_modify(|v| v.push(offset))
+                .or_insert_with(|| vec![offset]);
+        });
+
+        let fragments = dataset.get_fragments();
+        let fragment_and_indices = fragments.into_iter().filter_map(|f| {
+            let local_row_ids = row_ids_per_fragment.remove(&(f.id() as u64))?;
+            Some((f, local_row_ids))
+        });
+
+        let mut batches = futures::stream::iter(fragment_and_indices)
+            .map(|(fragment, indices)| do_take(fragment, indices, projection.clone(), true))
+            .buffered(4 * num_cpus::get())
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        let one_batch = if batches.len() > 1 {
+            concat_batches(&schema_with_row_id, &batches)?
+        } else {
+            batches.pop().unwrap()
+        };
+        // Note: one_batch may contains fewer rows than the number of requested
+        // row ids because some rows may have been deleted. Because of this, we
+        // get the results with row ids so that we can re-order the results
+        // to match the requested order.
+
+        let returned_row_ids = one_batch
+            .column_by_name(ROW_ID)
+            .ok_or_else(|| Error::Internal {
+                message: "ROW_ID column not found".into(),
+                location: location!(),
+            })?
+            .as_primitive::<UInt64Type>()
+            .values();
+
+        let remapping_index: UInt64Array = row_ids
+            .iter()
+            .filter_map(|o| {
+                returned_row_ids
+                    .iter()
+                    .position(|id| id == o)
+                    .map(|pos| pos as u64)
+            })
+            .collect();
+
+        debug_assert_eq!(remapping_index.len(), one_batch.num_rows());
+
+        // Remove the row id column.
+        let keep_indices = (0..one_batch.num_columns() - 1).collect::<Vec<_>>();
+        let one_batch = one_batch.project(&keep_indices)?;
+        let struct_arr: StructArray = one_batch.into();
+        let reordered = arrow_select::take::take(&struct_arr, &remapping_index, None)?;
+        Ok(as_struct_array(&reordered).into())
+    }
+}
+
+/// Get a stream of batches based on iterator of ranges of row numbers.
+///
+/// This is an experimental API. It may change at any time.
+pub fn take_scan(
+    dataset: &Dataset,
+    row_ranges: Pin<Box<dyn Stream<Item = Result<Range<u64>>> + Send>>,
+    projection: Arc<Schema>,
+    batch_readahead: usize,
+) -> DatasetRecordBatchStream {
+    let arrow_schema = Arc::new(projection.as_ref().into());
+    let dataset = Arc::new(dataset.clone());
+    let batch_stream = row_ranges
+        .map(move |res| {
+            let dataset = dataset.clone();
+            let projection = projection.clone();
+            let fut = async move {
+                let range = res.map_err(|err| DataFusionError::External(Box::new(err)))?;
+                let row_pos: Vec<u64> = (range.start..range.end).collect();
+                dataset
+                    .take(&row_pos, projection.as_ref())
+                    .await
+                    .map_err(|err| DataFusionError::External(Box::new(err)))
+            };
+            async move { tokio::task::spawn(fut).await.unwrap() }
+        })
+        .buffered(batch_readahead);
+
+    DatasetRecordBatchStream::new(Box::pin(RecordBatchStreamAdapter::new(
+        arrow_schema,
+        batch_stream,
+    )))
+}
+
+struct RowIdMeta {
+    sorted: bool,
+    contiguous: bool,
+}
+
+fn check_row_ids(row_ids: &[u64]) -> RowIdMeta {
+    let mut sorted = true;
+    let mut contiguous = true;
+
+    if row_ids.is_empty() {
+        return RowIdMeta { sorted, contiguous };
+    }
+
+    let mut last_id = row_ids[0];
+    let first_fragment_id = row_ids[0] >> 32;
+
+    for id in row_ids.iter().skip(1) {
+        sorted &= *id > last_id;
+        contiguous &= *id == last_id + 1;
+        // Contiguous also requires the fragment ids are all the same
+        contiguous &= (*id >> 32) == first_fragment_id;
+        last_id = *id;
+    }
+
+    RowIdMeta { sorted, contiguous }
+}
+
+#[cfg(test)]
+mod test {
+    use arrow_array::{Int32Array, RecordBatchIterator, StringArray};
+    use arrow_schema::DataType;
+    use rstest::rstest;
+
+    use crate::dataset::{scanner::test_dataset::TestVectorDataset, WriteParams};
+
+    use super::*;
+
+    // Used to validate that futures returned are Send.
+    fn require_send<T: Send>(t: T) -> T {
+        t
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_take(#[values(false, true)] use_experimental_writer: bool) {
+        let test_dir = tempfile::tempdir().unwrap();
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int32, false),
+            ArrowField::new("s", DataType::Utf8, false),
+        ]));
+        let batches: Vec<RecordBatch> = (0..20)
+            .map(|i| {
+                RecordBatch::try_new(
+                    schema.clone(),
+                    vec![
+                        Arc::new(Int32Array::from_iter_values(i * 20..(i + 1) * 20)),
+                        Arc::new(StringArray::from_iter_values(
+                            (i * 20..(i + 1) * 20).map(|i| format!("str-{i}")),
+                        )),
+                    ],
+                )
+                .unwrap()
+            })
+            .collect();
+        let test_uri = test_dir.path().to_str().unwrap();
+        let write_params = WriteParams {
+            max_rows_per_file: 40,
+            max_rows_per_group: 10,
+            use_experimental_writer,
+            ..Default::default()
+        };
+        let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+        Dataset::write(batches, test_uri, Some(write_params))
+            .await
+            .unwrap();
+
+        let dataset = Dataset::open(test_uri).await.unwrap();
+        assert_eq!(dataset.count_rows(None).await.unwrap(), 400);
+        let projection = Schema::try_from(schema.as_ref()).unwrap();
+        let values = dataset
+            .take(
+                &[
+                    200, // 200
+                    199, // 199
+                    39,  // 39
+                    40,  // 40
+                    199, // 40
+                    40,  // 40
+                    125, // 125
+                ],
+                &projection,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from_iter_values([
+                        200, 199, 39, 40, 199, 40, 125
+                    ])),
+                    Arc::new(StringArray::from_iter_values(
+                        [200, 199, 39, 40, 199, 40, 125]
+                            .iter()
+                            .map(|v| format!("str-{v}"))
+                    )),
+                ],
+            )
+            .unwrap(),
+            values
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_take_rows_out_of_bound(#[values(false, true)] use_experimental_writer: bool) {
+        // a dataset with 1 fragment and 400 rows
+        let test_ds = TestVectorDataset::new(use_experimental_writer)
+            .await
+            .unwrap();
+        let ds = test_ds.dataset;
+
+        // take the last row of first fragment
+        // this triggeres the contiguous branch
+        let indices = &[(1 << 32) - 1];
+        let fut = require_send(ds.take_rows(indices, ds.schema()));
+        let err = fut.await.unwrap_err();
+        assert!(
+            err.to_string().contains("Invalid read params"),
+            "{}",
+            err.to_string()
+        );
+
+        // this triggeres the sorted branch, but not continguous
+        let indices = &[(1 << 32) - 3, (1 << 32) - 1];
+        let err = ds.take_rows(indices, ds.schema()).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Invalid read params Indices(4294967293,4294967295)"),
+            "{}",
+            err.to_string()
+        );
+
+        // this triggeres the catch all branch
+        let indices = &[(1 << 32) - 1, (1 << 32) - 3];
+        let err = ds.take_rows(indices, ds.schema()).await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Invalid read params Indices(4294967293,4294967295)"),
+            "{}",
+            err.to_string()
+        );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_take_rows(#[values(false, true)] use_experimental_writer: bool) {
+        let test_dir = tempfile::tempdir().unwrap();
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int32, false),
+            ArrowField::new("s", DataType::Utf8, false),
+        ]));
+        let batches: Vec<RecordBatch> = (0..20)
+            .map(|i| {
+                RecordBatch::try_new(
+                    schema.clone(),
+                    vec![
+                        Arc::new(Int32Array::from_iter_values(i * 20..(i + 1) * 20)),
+                        Arc::new(StringArray::from_iter_values(
+                            (i * 20..(i + 1) * 20).map(|i| format!("str-{i}")),
+                        )),
+                    ],
+                )
+                .unwrap()
+            })
+            .collect();
+        let test_uri = test_dir.path().to_str().unwrap();
+        let write_params = WriteParams {
+            max_rows_per_file: 40,
+            max_rows_per_group: 10,
+            use_experimental_writer,
+            ..Default::default()
+        };
+        let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+        let mut dataset = Dataset::write(batches, test_uri, Some(write_params))
+            .await
+            .unwrap();
+
+        assert_eq!(dataset.count_rows(None).await.unwrap(), 400);
+        let projection = Schema::try_from(schema.as_ref()).unwrap();
+        let indices = &[
+            5_u64 << 32,        // 200
+            (4_u64 << 32) + 39, // 199
+            39,                 // 39
+            1_u64 << 32,        // 40
+            (2_u64 << 32) + 20, // 100
+        ];
+        let values = dataset.take_rows(indices, &projection).await.unwrap();
+        assert_eq!(
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from_iter_values([200, 199, 39, 40, 100])),
+                    Arc::new(StringArray::from_iter_values(
+                        [200, 199, 39, 40, 100].iter().map(|v| format!("str-{v}"))
+                    )),
+                ],
+            )
+            .unwrap(),
+            values
+        );
+
+        // Delete some rows from a fragment
+        dataset.delete("i in (199, 100)").await.unwrap();
+        dataset.validate().await.unwrap();
+        let values = dataset.take_rows(indices, &projection).await.unwrap();
+        assert_eq!(
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from_iter_values([200, 39, 40])),
+                    Arc::new(StringArray::from_iter_values(
+                        [200, 39, 40].iter().map(|v| format!("str-{v}"))
+                    )),
+                ],
+            )
+            .unwrap(),
+            values
+        );
+
+        // Take an empty selection.
+        let values = dataset.take_rows(&[], &projection).await.unwrap();
+        assert_eq!(RecordBatch::new_empty(schema.clone()), values);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn take_scan_dataset(#[values(false, true)] use_experimental_writer: bool) {
+        use arrow::datatypes::Int32Type;
+        use arrow_array::Float32Array;
+
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int32, false),
+            ArrowField::new("x", DataType::Float32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2, 3, 4])),
+                Arc::new(Float32Array::from(vec![1.0, 2.0, 3.0, 4.0])),
+            ],
+        )
+        .unwrap();
+
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let write_params = WriteParams {
+            max_rows_per_group: 2,
+            use_experimental_writer,
+            ..Default::default()
+        };
+
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
+        Dataset::write(batches, test_uri, Some(write_params.clone()))
+            .await
+            .unwrap();
+
+        let dataset = Dataset::open(test_uri).await.unwrap();
+
+        let projection = Arc::new(dataset.schema().project(&["i"]).unwrap());
+        let ranges = [0_u64..3, 1..4, 0..1];
+        let range_stream = futures::stream::iter(ranges).map(Ok).boxed();
+        let results = dataset
+            .take_scan(range_stream, projection.clone(), 10)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let expected_schema = projection.as_ref().into();
+        for batch in &results {
+            assert_eq!(batch.schema().as_ref(), &expected_schema);
+        }
+        assert_eq!(results.len(), 3);
+        assert_eq!(
+            results[0].column(0).as_primitive::<Int32Type>().values(),
+            &[1, 2, 3],
+        );
+        assert_eq!(
+            results[1].column(0).as_primitive::<Int32Type>().values(),
+            &[2, 3, 4],
+        );
+        assert_eq!(
+            results[2].column(0).as_primitive::<Int32Type>().values(),
+            &[1],
+        );
+    }
+}


### PR DESCRIPTION
This just moves some function implementations and associated tests into own files.

Partly doing this because `RowIdMeta` struct was going to conflict with some row id stuff later. But also making the file shorter and easier to add more tests to.