### PR TITLE
feat: make the index cache size (in bytes) available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ datafusion-execution = "37.1"
 datafusion-physical-expr = { version = "37.1", features = [
     "regex_expressions",
 ] }
+deepsize = "0.2.0"
 either = "1.0"
 futures = "0.3"
 http = "0.2.9"

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1517,6 +1517,12 @@ class LanceDataset(pa.dataset.Dataset):
         self._ds.create_index(column, index_type, name, replace, kwargs)
         return LanceDataset(self.uri, index_cache_size=index_cache_size)
 
+    def cache_size_bytes(self) -> int:
+        """
+        Return the total size of the index + file metadata caches in bytes.
+        """
+        return self._ds.cache_size_bytes()
+
     @staticmethod
     def _commit(
         base_uri: Union[str, Path],

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -51,6 +51,7 @@ from .lance import (
 )
 from .lance import CompactionMetrics as CompactionMetrics
 from .lance import __version__ as __version__
+from .lance import _Session as Session
 from .optimize import Compaction
 from .schema import LanceSchema
 from .util import td_to_micros
@@ -1517,11 +1518,11 @@ class LanceDataset(pa.dataset.Dataset):
         self._ds.create_index(column, index_type, name, replace, kwargs)
         return LanceDataset(self.uri, index_cache_size=index_cache_size)
 
-    def cache_size_bytes(self) -> int:
+    def session(self) -> Session:
         """
-        Return the total size of the index + file metadata caches in bytes.
+        Return the dataset session, which holds the dataset's state.
         """
-        return self._ds.cache_size_bytes()
+        return self._ds.session()
 
     @staticmethod
     def _commit(

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -76,3 +76,6 @@ class LanceFileMetadata:
     num_global_buffer_bytes: int
     global_buffers: List[LanceBufferDescriptor]
     columns: List[LanceColumnMetadata]
+
+class _Session:
+    def size_bytes(self) -> int: ...

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1554,22 +1554,6 @@ def test_metadata(tmp_path: Path):
     lance.write_dataset(data, tmp_path)
 
 
-def test_cache_size_bytes(tmp_path: Path):
-    """Test expose physical row ids in the scanner."""
-    data = pa.table({"a": range(1000)})
-    lance.write_dataset(data, tmp_path, max_rows_per_file=250)
-
-    ds = lance.dataset(tmp_path)
-
-    initial_size = ds.cache_size_bytes()
-
-    ds.scanner().to_table()
-
-    after_scan_size = ds.cache_size_bytes()
-
-    assert after_scan_size > initial_size
-
-
 def test_scan_with_row_ids(tmp_path: Path):
     """Test expose physical row ids in the scanner."""
     data = pa.table({"a": range(1000)})

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1554,6 +1554,22 @@ def test_metadata(tmp_path: Path):
     lance.write_dataset(data, tmp_path)
 
 
+def test_cache_size_bytes(tmp_path: Path):
+    """Test expose physical row ids in the scanner."""
+    data = pa.table({"a": range(1000)})
+    lance.write_dataset(data, tmp_path, max_rows_per_file=250)
+
+    ds = lance.dataset(tmp_path)
+
+    initial_size = ds.cache_size_bytes()
+
+    ds.scanner().to_table()
+
+    after_scan_size = ds.cache_size_bytes()
+
+    assert after_scan_size > initial_size
+
+
 def test_scan_with_row_ids(tmp_path: Path):
     """Test expose physical row ids in the scanner."""
     data = pa.table({"a": range(1000)})

--- a/python/python/tests/test_session.py
+++ b/python/python/tests/test_session.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
 from pathlib import Path
 
 import lance

--- a/python/python/tests/test_session.py
+++ b/python/python/tests/test_session.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import lance
+import pyarrow as pa
+
+
+def test_cache_size_bytes(
+    tmp_path: Path,
+):
+    data = pa.table({"a": range(1000)})
+    lance.write_dataset(data, tmp_path, max_rows_per_file=250)
+
+    ds = lance.dataset(tmp_path)
+
+    initial_size = ds.session().size_bytes()
+
+    ds.scanner().to_table()
+
+    after_scan_size = ds.session().size_bytes()
+
+    assert after_scan_size > initial_size

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -972,6 +972,10 @@ impl Dataset {
         Ok(self.ds.index_cache_hit_rate())
     }
 
+    fn cache_size_bytes(&self) -> u64 {
+        self.ds.cache_size_bytes()
+    }
+
     #[staticmethod]
     fn commit(
         dataset_uri: &str,

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -65,6 +65,7 @@ use snafu::{location, Location};
 
 use crate::fragment::{FileFragment, FragmentMetadata};
 use crate::schema::LanceSchema;
+use crate::session::Session;
 use crate::RT;
 use crate::{LanceReader, Scanner};
 
@@ -972,8 +973,8 @@ impl Dataset {
         Ok(self.ds.index_cache_hit_rate())
     }
 
-    fn cache_size_bytes(&self) -> u64 {
-        self.ds.cache_size_bytes()
+    fn session(&self) -> Session {
+        Session::new(self.ds.session())
     }
 
     #[staticmethod]

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -43,6 +43,7 @@ use futures::StreamExt;
 use lance_index::DatasetIndexExt;
 use pyo3::exceptions::{PyIOError, PyValueError};
 use pyo3::prelude::*;
+use session::Session;
 
 #[macro_use]
 extern crate lazy_static;
@@ -59,6 +60,7 @@ pub(crate) mod fragment;
 pub(crate) mod reader;
 pub(crate) mod scanner;
 pub(crate) mod schema;
+pub(crate) mod session;
 pub(crate) mod tracing;
 pub(crate) mod updater;
 pub(crate) mod utils;
@@ -127,6 +129,7 @@ fn lance(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyCompactionPlan>()?;
     m.add_class::<PyRewriteResult>()?;
     m.add_class::<PyCompactionMetrics>()?;
+    m.add_class::<Session>()?;
     m.add_class::<TraceGuard>()?;
     m.add_class::<schema::LanceSchema>()?;
     m.add_wrapped(wrap_pyfunction!(bfloat16_array))?;

--- a/python/src/session.rs
+++ b/python/src/session.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use pyo3::{pyclass, pymethods};
+
+use lance::session::Session as LanceSession;
+
+/// The Session holds stateful information for a dataset.
+///
+/// The session contains caches for opened indices and file metadata.
+#[pyclass(name = "_Session", module = "_lib")]
+#[derive(Clone)]
+pub struct Session {
+    inner: Arc<LanceSession>,
+}
+
+impl Session {
+    pub fn new(inner: Arc<LanceSession>) -> Self {
+        Self { inner }
+    }
+}
+
+#[pymethods]
+impl Session {
+    /// Return the current size of the session in bytes
+    pub fn size_bytes(&self) -> u64 {
+        self.inner.size_bytes()
+    }
+}

--- a/rust/lance-core/Cargo.toml
+++ b/rust/lance-core/Cargo.toml
@@ -22,6 +22,7 @@ bytes.workspace = true
 chrono.workspace = true
 datafusion-common = { workspace = true, optional = true }
 datafusion-sql = { workspace = true, optional = true }
+deepsize.workspace = true
 futures.workspace = true
 lazy_static.workspace = true
 mock_instant.workspace = true

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use arrow_array::ArrayRef;
 use arrow_schema::{DataType, Field as ArrowField, TimeUnit};
+use deepsize::DeepSizeOf;
 use lance_arrow::bfloat16::{
     is_bfloat16_field, ARROW_EXT_META_KEY, ARROW_EXT_NAME_KEY, BFLOAT16_EXT_NAME,
 };
@@ -24,7 +25,7 @@ pub use schema::Schema;
 
 /// LogicalType is a string presentation of arrow type.
 /// to be serialized into protobuf.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, DeepSizeOf)]
 pub struct LogicalType(String);
 
 impl fmt::Display for LogicalType {
@@ -322,6 +323,15 @@ pub struct Dictionary {
     pub length: usize,
 
     pub values: Option<ArrayRef>,
+}
+
+impl DeepSizeOf for Dictionary {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
+        self.values
+            .as_ref()
+            .map(|v| v.get_array_memory_size())
+            .unwrap_or(0)
+    }
 }
 
 impl PartialEq for Dictionary {

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -18,6 +18,7 @@ use arrow_array::{
     ArrayRef,
 };
 use arrow_schema::{DataType, Field as ArrowField};
+use deepsize::DeepSizeOf;
 use lance_arrow::{bfloat16::ARROW_EXT_NAME_KEY, *};
 use snafu::{location, Location};
 
@@ -34,7 +35,7 @@ pub struct SchemaCompareOptions {
     pub compare_field_ids: bool,
 }
 /// Encoding enum.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, DeepSizeOf)]
 pub enum Encoding {
     /// Plain encoding.
     Plain,
@@ -48,7 +49,7 @@ pub enum Encoding {
 
 /// Lance Schema Field
 ///
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, DeepSizeOf)]
 pub struct Field {
     pub name: String,
     pub id: i32,

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -10,6 +10,7 @@ use std::{
 
 use arrow_array::RecordBatch;
 use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
+use deepsize::DeepSizeOf;
 use lance_arrow::*;
 use snafu::{location, Location};
 
@@ -17,7 +18,7 @@ use super::field::{Field, SchemaCompareOptions};
 use crate::{Error, Result};
 
 /// Lance Schema.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, DeepSizeOf)]
 pub struct Schema {
     /// Top-level fields in the dataset.
     pub fields: Vec<Field>,

--- a/rust/lance-core/src/utils/deletion.rs
+++ b/rust/lance-core/src/utils/deletion.rs
@@ -4,6 +4,7 @@
 use std::{collections::HashSet, ops::Range};
 
 use arrow_array::BooleanArray;
+use deepsize::{Context, DeepSizeOf};
 use roaring::RoaringBitmap;
 
 /// Threshold for when a DeletionVector::Set should be promoted to a DeletionVector::Bitmap.
@@ -16,6 +17,17 @@ pub enum DeletionVector {
     NoDeletions,
     Set(HashSet<u32>),
     Bitmap(RoaringBitmap),
+}
+
+impl DeepSizeOf for DeletionVector {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        match self {
+            Self::NoDeletions => 0,
+            Self::Set(set) => set.deep_size_of_children(context),
+            // Inexact but probably close enough
+            Self::Bitmap(bitmap) => bitmap.serialized_size(),
+        }
+    }
 }
 
 impl DeletionVector {

--- a/rust/lance-file/Cargo.toml
+++ b/rust/lance-file/Cargo.toml
@@ -27,6 +27,7 @@ async-trait.workspace = true
 byteorder.workspace = true
 bytes.workspace = true
 datafusion-common.workspace = true
+deepsize.workspace = true
 futures.workspace = true
 lance-datagen.workspace = true
 log.workspace = true

--- a/rust/lance-file/src/format/metadata.rs
+++ b/rust/lance-file/src/format/metadata.rs
@@ -6,12 +6,13 @@ use std::ops::Range;
 
 use crate::datatypes::{Fields, FieldsWithMeta};
 use crate::format::pb;
+use deepsize::DeepSizeOf;
 use lance_core::datatypes::Schema;
 use lance_core::{Error, Result};
 use lance_io::traits::ProtoStruct;
 use snafu::{location, Location};
 /// Data File Metadata
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, DeepSizeOf, PartialEq)]
 pub struct Metadata {
     /// Offset of each record batch.
     pub batch_offsets: Vec<i32>,
@@ -197,7 +198,7 @@ impl Metadata {
 }
 
 /// Metadata about the statistics
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, DeepSizeOf)]
 pub struct StatisticsMetadata {
     /// Schema of the page-level statistics.
     ///

--- a/rust/lance-file/src/page_table.rs
+++ b/rust/lance-file/src/page_table.rs
@@ -4,6 +4,7 @@
 use arrow_array::builder::Int64Builder;
 use arrow_array::{Array, Int64Array};
 use arrow_schema::DataType;
+use deepsize::DeepSizeOf;
 use lance_io::encodings::plain::PlainDecoder;
 use lance_io::encodings::Decoder;
 use snafu::{location, Location};
@@ -13,7 +14,7 @@ use tokio::io::AsyncWriteExt;
 use lance_core::{Error, Result};
 use lance_io::traits::{Reader, Writer};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, DeepSizeOf)]
 pub struct PageInfo {
     pub position: usize,
     pub length: usize,
@@ -27,7 +28,7 @@ impl PageInfo {
 
 /// Page lookup table.
 ///
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, DeepSizeOf)]
 pub struct PageTable {
     /// map[field-id,  map[batch-id, PageInfo]]
     pages: BTreeMap<i32, BTreeMap<i32, PageInfo>>,

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -21,6 +21,7 @@ use arrow_schema::{DataType, FieldRef, Schema as ArrowSchema};
 use arrow_select::concat::{self, concat_batches};
 use arrow_select::filter::filter_record_batch;
 use async_recursion::async_recursion;
+use deepsize::DeepSizeOf;
 use futures::{stream, Future, FutureExt, StreamExt, TryStreamExt};
 use lance_arrow::*;
 use lance_core::cache::FileMetadataCache;
@@ -51,7 +52,7 @@ fn compute_row_id(fragment_id: u64, offset: i32) -> u64 {
 /// Lance File Reader.
 ///
 /// It reads arrow data from one data file.
-#[derive(Clone)]
+#[derive(Clone, DeepSizeOf)]
 pub struct FileReader {
     pub object_reader: Arc<dyn Reader>,
     metadata: Arc<Metadata>,
@@ -229,7 +230,7 @@ impl FileReader {
     }
 
     /// Load some metadata about the fragment from the cache, if there is one.
-    async fn load_from_cache<T: Send + Sync + 'static, F, Fut>(
+    async fn load_from_cache<T: DeepSizeOf + Send + Sync + 'static, F, Fut>(
         cache: Option<&FileMetadataCache>,
         path: &Path,
         loader: F,

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -25,6 +25,7 @@ datafusion-expr.workspace = true
 datafusion-physical-expr.workspace = true
 datafusion-sql.workspace = true
 datafusion.workspace = true
+deepsize.workspace = true
 futures.workspace = true
 half.workspace = true
 itertools.workspace = true

--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -11,6 +11,7 @@
 use std::{any::Any, sync::Arc};
 
 use async_trait::async_trait;
+use deepsize::DeepSizeOf;
 use lance_core::Result;
 use roaring::RoaringBitmap;
 use serde::{Deserialize, Serialize};
@@ -37,7 +38,7 @@ pub mod pb {
 /// Generic methods common across all types of secondary indices
 ///
 #[async_trait]
-pub trait Index: Send + Sync {
+pub trait Index: Send + Sync + DeepSizeOf {
     /// Cast to [Any].
     fn as_any(&self) -> &dyn Any;
 
@@ -58,7 +59,7 @@ pub trait Index: Send + Sync {
 }
 
 /// Index Type
-#[derive(Debug, PartialEq, Eq, Copy, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Hash, Clone, DeepSizeOf)]
 pub enum IndexType {
     // Preserve 0-100 for simple indices.
     Scalar = 0,

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -13,6 +13,7 @@ use datafusion::physical_plan::SendableRecordBatchStream;
 use datafusion_common::{scalar::ScalarValue, Column};
 
 use datafusion_expr::Expr;
+use deepsize::DeepSizeOf;
 use lance_core::Result;
 
 use crate::Index;
@@ -48,7 +49,7 @@ pub trait IndexReader: Send + Sync {
 /// named "files".  The index store is responsible for serializing and deserializing
 /// these batches into file data (e.g. as .lance files or .parquet files, etc.)
 #[async_trait]
-pub trait IndexStore: std::fmt::Debug + Send + Sync {
+pub trait IndexStore: std::fmt::Debug + Send + Sync + DeepSizeOf {
     fn as_any(&self) -> &dyn Any;
 
     /// Create a new file and return a writer to store data in the file
@@ -173,7 +174,7 @@ impl ScalarQuery {
 
 /// A trait for a scalar index, a structure that can determine row ids that satisfy scalar queries
 #[async_trait]
-pub trait ScalarIndex: Send + Sync + std::fmt::Debug + Index {
+pub trait ScalarIndex: Send + Sync + std::fmt::Debug + Index + DeepSizeOf {
     /// Search the scalar index
     ///
     /// Returns all row ids that satisfy the query, these row ids are not neccesarily ordered

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -8,6 +8,7 @@ use std::{any::Any, sync::Arc};
 use arrow_array::RecordBatch;
 use arrow_schema::Schema;
 use async_trait::async_trait;
+use deepsize::DeepSizeOf;
 use lance_file::{
     reader::FileReader,
     writer::{FileWriter, FileWriterOptions, ManifestProvider},
@@ -31,6 +32,14 @@ pub struct LanceIndexStore {
     object_store: ObjectStore,
     index_dir: Path,
     metadata_cache: Option<FileMetadataCache>,
+}
+
+impl DeepSizeOf for LanceIndexStore {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.object_store.deep_size_of_children(context)
+            + self.index_dir.as_ref().deep_size_of_children(context)
+            + self.metadata_cache.deep_size_of_children(context)
+    }
 }
 
 impl LanceIndexStore {

--- a/rust/lance-index/src/vector/graph.rs
+++ b/rust/lance-index/src/vector/graph.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use arrow_schema::{DataType, Field};
 use bitvec::vec::BitVec;
+use deepsize::DeepSizeOf;
 use lance_core::Result;
 
 pub mod builder;
@@ -55,7 +56,7 @@ impl<I> From<I> for GraphNode<I> {
 
 /// A wrapper for f32 to make it ordered, so that we can put it into
 /// a BTree or Heap
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, DeepSizeOf)]
 pub struct OrderedFloat(pub f32);
 
 impl PartialOrd for OrderedFloat {
@@ -84,7 +85,7 @@ impl From<OrderedFloat> for f32 {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone, DeepSizeOf)]
 pub struct OrderedNode {
     pub id: u32,
     pub dist: OrderedFloat,

--- a/rust/lance-index/src/vector/graph/builder.rs
+++ b/rust/lance-index/src/vector/graph/builder.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use deepsize::DeepSizeOf;
+
 use super::OrderedFloat;
 use super::OrderedNode;
 use std::sync::Arc;
@@ -8,7 +10,7 @@ use std::sync::Arc;
 /// GraphNode during build.
 ///
 /// WARNING: Internal API,  API stability is not guaranteed
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, DeepSizeOf)]
 pub struct GraphBuilderNode {
     /// neighbors of each level of the node.
     pub(crate) bottom_neighbors: Arc<Vec<u32>>,

--- a/rust/lance-index/src/vector/hnsw.rs
+++ b/rust/lance-index/src/vector/hnsw.rs
@@ -9,6 +9,7 @@
 pub mod builder;
 use arrow_schema::{DataType, Field};
 pub use builder::HNSW;
+use deepsize::DeepSizeOf;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
@@ -29,7 +30,7 @@ lazy_static::lazy_static! {
     pub static ref VECTOR_ID_FIELD: Field = Field::new(VECTOR_ID_COL, DataType::UInt32, true);
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, DeepSizeOf)]
 pub struct HnswMetadata {
     pub entry_point: u32,
     pub params: HnswBuildParams,

--- a/rust/lance-index/src/vector/ivf/storage.rs
+++ b/rust/lance-index/src/vector/ivf/storage.rs
@@ -4,7 +4,8 @@
 use std::ops::Range;
 use std::sync::Arc;
 
-use arrow_array::FixedSizeListArray;
+use arrow_array::{Array, FixedSizeListArray};
+use deepsize::DeepSizeOf;
 use lance_core::{Error, Result};
 use lance_file::{reader::FileReader, writer::FileWriter};
 use lance_io::{traits::WriteExt, utils::read_message};
@@ -29,6 +30,17 @@ pub struct IvfData {
 
     /// pre-computed row offset for each partition, do not persist.
     partition_row_offsets: Vec<usize>,
+}
+
+impl DeepSizeOf for IvfData {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.centroids
+            .as_ref()
+            .map(|centroids| centroids.get_array_memory_size())
+            .unwrap_or(0)
+            + self.lengths.deep_size_of_children(context)
+            + self.partition_row_offsets.deep_size_of_children(context)
+    }
 }
 
 /// The IVF metadata stored in the Lance Schema

--- a/rust/lance-index/src/vector/sq.rs
+++ b/rust/lance-index/src/vector/sq.rs
@@ -6,6 +6,7 @@ use std::{ops::Range, sync::Arc};
 use arrow::array::AsArray;
 use arrow_array::{Array, ArrayRef, FixedSizeListArray, UInt8Array};
 
+use deepsize::DeepSizeOf;
 use itertools::Itertools;
 use lance_arrow::*;
 use lance_core::{Error, Result};
@@ -30,6 +31,12 @@ pub struct ScalarQuantizer {
     pub dim: usize,
 
     pub bounds: Range<f64>,
+}
+
+impl DeepSizeOf for ScalarQuantizer {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
+        0
+    }
 }
 
 impl ScalarQuantizer {

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -9,6 +9,7 @@ use arrow::{
 };
 use arrow_array::{Array, ArrayRef, FixedSizeListArray, RecordBatch, UInt64Array, UInt8Array};
 use async_trait::async_trait;
+use deepsize::DeepSizeOf;
 use lance_core::{Error, Result, ROW_ID};
 use lance_file::reader::FileReader;
 use lance_io::object_store::ObjectStore;
@@ -36,6 +37,12 @@ pub struct ScalarQuantizationMetadata {
     pub dim: usize,
     pub num_bits: u16,
     pub bounds: Range<f64>,
+}
+
+impl DeepSizeOf for ScalarQuantizationMetadata {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
+        0
+    }
 }
 
 #[async_trait]
@@ -73,6 +80,14 @@ pub struct ScalarQuantizationStorage {
     // Helper fields, references to the batch
     row_ids: Arc<UInt64Array>,
     sq_codes: Arc<FixedSizeListArray>,
+}
+
+impl DeepSizeOf for ScalarQuantizationStorage {
+    fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
+        self.batch.get_array_memory_size()
+            + self.row_ids.get_array_memory_size()
+            + self.sq_codes.get_array_memory_size()
+    }
 }
 
 impl ScalarQuantizationStorage {

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -29,6 +29,7 @@ aws-credential-types.workspace = true
 byteorder.workspace = true
 bytes.workspace = true
 chrono.workspace = true
+deepsize.workspace = true
 futures.workspace = true
 lazy_static.workspace = true
 num_cpus.workspace = true

--- a/rust/lance-io/src/local.rs
+++ b/rust/lance-io/src/local.rs
@@ -16,6 +16,7 @@ use std::os::windows::fs::FileExt;
 
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
+use deepsize::DeepSizeOf;
 use lance_core::{Error, Result};
 use object_store::path::Path;
 use snafu::{location, Location};
@@ -57,6 +58,13 @@ pub struct LocalObjectReader {
 
     /// Block size, in bytes.
     block_size: usize,
+}
+
+impl DeepSizeOf for LocalObjectReader {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        // Skipping `file` as it should just be a file handle
+        self.path.as_ref().deep_size_of_children(context)
+    }
 }
 
 impl LocalObjectReader {

--- a/rust/lance-io/src/object_reader.rs
+++ b/rust/lance-io/src/object_reader.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use deepsize::DeepSizeOf;
 use futures::future::BoxFuture;
 use lance_core::Result;
 use object_store::{path::Path, ObjectStore};
@@ -24,6 +25,13 @@ pub struct CloudObjectReader {
     pub path: Path,
 
     block_size: usize,
+}
+
+impl DeepSizeOf for CloudObjectReader {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        // Skipping object_store because there is no easy way to do that and it shouldn't be too big
+        self.path.as_ref().deep_size_of_children(context)
+    }
 }
 
 impl CloudObjectReader {

--- a/rust/lance-io/src/traits.rs
+++ b/rust/lance-io/src/traits.rs
@@ -5,6 +5,7 @@ use std::ops::Range;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use deepsize::DeepSizeOf;
 use object_store::path::Path;
 use prost::Message;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
@@ -79,7 +80,7 @@ impl<W: Writer + ?Sized> WriteExt for W {
 }
 
 #[async_trait]
-pub trait Reader: std::fmt::Debug + Send + Sync {
+pub trait Reader: std::fmt::Debug + Send + Sync + DeepSizeOf {
     fn path(&self) -> &Path;
 
     /// Suggest optimal I/O size per storage device.

--- a/rust/lance-linalg/Cargo.toml
+++ b/rust/lance-linalg/Cargo.toml
@@ -14,6 +14,7 @@ arrow-array = { workspace = true }
 arrow-ord = { workspace = true }
 arrow-schema = { workspace = true }
 bitvec = { workspace = true }
+deepsize = { workspace = true }
 futures = { workspace = true }
 half = { workspace = true }
 lance-arrow = { workspace = true }

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -20,6 +20,7 @@ pub mod l2;
 pub mod norm_l2;
 
 pub use cosine::*;
+use deepsize::DeepSizeOf;
 pub use dot::*;
 pub use l2::*;
 pub use norm_l2::*;
@@ -27,7 +28,7 @@ pub use norm_l2::*;
 use crate::Result;
 
 /// Distance metrics type.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, DeepSizeOf)]
 pub enum DistanceType {
     L2,
     Cosine,

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -28,6 +28,7 @@ aws-sdk-dynamodb = { workspace = true, optional = true }
 byteorder.workspace = true
 bytes.workspace = true
 chrono.workspace = true
+deepsize.workspace = true
 futures.workspace = true
 lazy_static = { workspace = true, optional = true }
 log.workspace = true

--- a/rust/lance-table/src/format/index.rs
+++ b/rust/lance-table/src/format/index.rs
@@ -3,6 +3,7 @@
 
 //! Metadata for index
 
+use deepsize::DeepSizeOf;
 use roaring::RoaringBitmap;
 use snafu::{location, Location};
 use uuid::Uuid;
@@ -29,6 +30,20 @@ pub struct Index {
     ///
     /// If this is None, then this is unknown.
     pub fragment_bitmap: Option<RoaringBitmap>,
+}
+
+impl DeepSizeOf for Index {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.uuid.as_bytes().deep_size_of_children(context)
+            + self.fields.deep_size_of_children(context)
+            + self.name.deep_size_of_children(context)
+            + self.dataset_version.deep_size_of_children(context)
+            + self
+                .fragment_bitmap
+                .as_ref()
+                .map(|fragment_bitmap| fragment_bitmap.serialized_size())
+                .unwrap_or(0)
+    }
 }
 
 impl TryFrom<pb::IndexMetadata> for Index {

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -40,6 +40,7 @@ chrono.workspace = true
 clap = { version = "4.1.1", features = ["derive"], optional = true }
 # This is already used by datafusion
 dashmap = "5"
+deepsize.workspace = true
 # matches arrow-rs use
 half.workspace = true
 itertools.workspace = true

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1058,6 +1058,10 @@ impl Dataset {
         self.base.child(INDICES_DIR)
     }
 
+    pub fn session(&self) -> Arc<Session> {
+        self.session.clone()
+    }
+
     pub fn version(&self) -> Version {
         Version::from(self.manifest.as_ref())
     }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -6,6 +6,7 @@
 
 use arrow_array::{RecordBatch, RecordBatchReader};
 use chrono::{prelude::*, Duration};
+use deepsize::DeepSizeOf;
 use futures::future::BoxFuture;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use futures::{FutureExt, Stream};
@@ -1069,6 +1070,10 @@ impl Dataset {
     /// Get cache hit ratio.
     pub fn index_cache_hit_rate(&self) -> f32 {
         self.session.index_cache.hit_rate()
+    }
+
+    pub fn cache_size_bytes(&self) -> u64 {
+        self.session.deep_size_of() as u64
     }
 
     /// Get all versions.

--- a/rust/lance/src/index/vector/fixture_test.rs
+++ b/rust/lance/src/index/vector/fixture_test.rs
@@ -17,6 +17,7 @@ mod test {
     use arrow_array::{FixedSizeListArray, Float32Array, RecordBatch};
     use arrow_schema::{DataType, Field, Schema};
     use async_trait::async_trait;
+    use deepsize::{Context, DeepSizeOf};
     use lance_arrow::FixedSizeListArrayExt;
     use lance_index::{vector::Query, Index, IndexType};
     use lance_io::{local::LocalObjectReader, traits::Reader};
@@ -42,6 +43,12 @@ mod test {
         assert_query_value: Vec<f32>,
 
         ret_val: RecordBatch,
+    }
+
+    impl DeepSizeOf for ResidualCheckMockIndex {
+        fn deep_size_of_children(&self, _: &mut Context) -> usize {
+            todo!()
+        }
     }
 
     #[async_trait]

--- a/rust/lance/src/index/vector/hnsw.rs
+++ b/rust/lance/src/index/vector/hnsw.rs
@@ -10,6 +10,7 @@ use std::{
 
 use arrow_array::{Float32Array, RecordBatch, UInt64Array};
 use async_trait::async_trait;
+use deepsize::DeepSizeOf;
 use lance_core::{datatypes::Schema, Error, Result};
 use lance_file::reader::FileReader;
 use lance_index::vector::{hnsw::HNSW, quantizer::Quantizer};
@@ -37,12 +38,12 @@ use crate::RESULT_SCHEMA;
 
 pub mod builder;
 
-#[derive(Clone)]
+#[derive(Clone, DeepSizeOf)]
 pub(crate) struct HNSWIndexOptions {
     pub use_residual: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, DeepSizeOf)]
 pub(crate) struct HNSWIndex<Q: Quantization> {
     distance_type: DistanceType,
 

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -19,6 +19,7 @@ use arrow_ord::sort::sort_to_indices;
 use arrow_schema::{DataType, Schema};
 use arrow_select::{concat::concat_batches, take::take};
 use async_trait::async_trait;
+use deepsize::DeepSizeOf;
 use futures::{
     stream::{self, StreamExt},
     TryStreamExt,
@@ -115,6 +116,15 @@ pub struct IVFIndex {
     // hold a weak pointer to avoid cycles
     /// The session cache, used when fetching pages
     session: Weak<Session>,
+}
+
+impl DeepSizeOf for IVFIndex {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.uuid.deep_size_of_children(context)
+            + self.reader.deep_size_of_children(context)
+            + self.sub_index.deep_size_of_children(context)
+        // Skipping session since it is a weak ref
+    }
 }
 
 impl IVFIndex {

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -14,6 +14,7 @@ use arrow_ord::sort::sort_to_indices;
 use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use arrow_select::take::take;
 use async_trait::async_trait;
+use deepsize::DeepSizeOf;
 use lance_core::utils::tokio::spawn_cpu;
 use lance_core::ROW_ID;
 use lance_core::{utils::address::RowAddress, ROW_ID_FIELD};
@@ -57,6 +58,22 @@ pub struct PQIndex {
 
     /// Metric type.
     metric_type: MetricType,
+}
+
+impl DeepSizeOf for PQIndex {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.pq.deep_size_of_children(context)
+            + self
+                .code
+                .as_ref()
+                .map(|code| code.get_array_memory_size())
+                .unwrap_or(0)
+            + self
+                .row_ids
+                .as_ref()
+                .map(|row_ids| row_ids.get_array_memory_size())
+                .unwrap_or(0)
+    }
 }
 
 impl std::fmt::Debug for PQIndex {

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -4,6 +4,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use deepsize::DeepSizeOf;
 use lance_core::cache::FileMetadataCache;
 use lance_core::{Error, Result};
 use lance_index::IndexType;
@@ -17,7 +18,7 @@ use self::index_extension::IndexExtension;
 pub mod index_extension;
 
 /// A user session tracks the runtime state.
-#[derive(Clone)]
+#[derive(Clone, DeepSizeOf)]
 pub struct Session {
     /// Cache for opened indices.
     pub(crate) index_cache: IndexCache,

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -94,6 +94,13 @@ impl Session {
 
         Ok(())
     }
+
+    /// Return the current size of the session in bytes
+    pub fn size_bytes(&self) -> u64 {
+        // We re-expose deep_size_of here so that users don't
+        // need the deepsize crate themselves (e.g. to use deep_size_of)
+        self.deep_size_of() as u64
+    }
 }
 
 impl Default for Session {

--- a/rust/lance/src/session/index_extension.rs
+++ b/rust/lance/src/session/index_extension.rs
@@ -3,13 +3,14 @@
 
 use std::sync::Arc;
 
+use deepsize::DeepSizeOf;
 use lance_core::Result;
 use lance_file::reader::FileReader;
 use lance_index::{IndexParams, IndexType};
 
 use crate::{index::vector::VectorIndex, Dataset};
 
-pub trait IndexExtension: Send + Sync {
+pub trait IndexExtension: Send + Sync + DeepSizeOf {
     fn index_type(&self) -> IndexType;
 
     // TODO: this shouldn't exist, as upcasting should be well defined
@@ -66,6 +67,7 @@ mod test {
 
     use arrow_array::RecordBatch;
     use arrow_schema::Schema;
+    use deepsize::DeepSizeOf;
     use lance_file::writer::{FileWriter, FileWriterOptions};
     use lance_index::{
         vector::{hnsw::VECTOR_ID_FIELD, Query},
@@ -81,6 +83,12 @@ mod test {
 
     #[derive(Debug)]
     struct MockIndex;
+
+    impl DeepSizeOf for MockIndex {
+        fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
+            todo!()
+        }
+    }
 
     #[async_trait::async_trait]
     impl Index for MockIndex {
@@ -156,6 +164,12 @@ mod test {
                 create_index_called: AtomicBool::new(false),
                 load_index_called: AtomicBool::new(false),
             }
+        }
+    }
+
+    impl DeepSizeOf for MockIndexExtension {
+        fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
+            todo!()
         }
     }
 


### PR DESCRIPTION
This PR makes extensive use of the deepsize crate for tracking the deep size of standard structures (Vec, BTreeMap, etc.).  This crate does appear to be abandoned (no updates in 3 years).  However, I'm unable to find anything similar, the code is fairly small should we need to vendor it in the future, and it is unlikely to be doing anything dangerous.

It turns out we store many many things in the cache (transitively) though most of them are probably small.