### PR TITLE
[chore] Insert api for HNSW

### DIFF
--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -208,6 +208,32 @@ impl HNSW {
         Ok(hnsw)
     }
 
+    pub fn build_empty(
+        distance_type: DistanceType,
+        params: HnswBuildParams,
+        storage: Arc<dyn VectorStorage>,
+    ) -> Self {
+        let inner = HNSWBuilderInner::with_params(distance_type, params, storage.as_ref());
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    pub fn insert(
+        &self,
+        node: u32,
+        visited_generator: &mut VisitedGenerator,
+        storage: &dyn VectorStorage,
+    ) -> Result<()> {
+        if node as usize >= self.inner.nodes().len() {
+            return Err(Error::Index {
+                message: "node index is too large for initialized HNSW instance".to_string(),
+                location: location!(),
+            });
+        }
+        self.inner.insert(node, visited_generator, storage)
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn search(
         &self,
@@ -586,7 +612,7 @@ impl HNSWBuilderInner {
     }
 
     /// Insert one node.
-    fn insert(
+    pub fn insert(
         &self,
         node: u32,
         visited_generator: &mut VisitedGenerator,

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -165,7 +165,7 @@ impl HNSW {
         params: HnswBuildParams,
         storage: Arc<dyn VectorStorage>,
     ) -> Result<Self> {
-        let inner = HNSWBuilderInner::with_params(distance_type, params, storage.as_ref());
+        let inner = HNSWBuilderInner::with_params(distance_type, params, storage.len());
         let hnsw = Self {
             inner: Arc::new(inner),
         };
@@ -210,12 +210,8 @@ impl HNSW {
         Ok(hnsw)
     }
 
-    pub fn build_empty(
-        distance_type: DistanceType,
-        params: HnswBuildParams,
-        storage: Arc<dyn VectorStorage>,
-    ) -> Self {
-        let inner = HNSWBuilderInner::with_params(distance_type, params, storage.as_ref());
+    pub fn build_empty(distance_type: DistanceType, params: HnswBuildParams) -> Self {
+        let inner = HNSWBuilderInner::with_params(distance_type, params, 0);
         Self {
             inner: Arc::new(inner),
         }
@@ -580,9 +576,9 @@ impl HNSWBuilderInner {
     pub fn with_params(
         distance_type: DistanceType,
         params: HnswBuildParams,
-        storage: &dyn VectorStorage,
+        initial_capacity: usize,
     ) -> Self {
-        let len = storage.len();
+        let len = initial_capacity;
         let max_level = params.max_level;
 
         let mut level_count = Vec::with_capacity(max_level as usize);
@@ -606,7 +602,7 @@ impl HNSWBuilderInner {
             visited_generator_queue,
         };
 
-        if storage.is_empty() {
+        if initial_capacity == 0 {
             return builder;
         }
 


### PR DESCRIPTION
We didn't previously have a way of inserting into HNSW post-build.
This adds that functionality.
There's an important aspect to how this works without affecting performance:
- We always keep the nodes stored in a flat structure
- To do that, we need the number of nodes to be "fixed".
- We add a RwLock to the nodes vec itself, and double its size whenever we overflow with a global lock. This took a long time to figure out, but in retrospect this is probably the simplest & fastest approach.
Note that this will result in a brief slow-down whenever the size overflows, so latency of inserts (and also queries) will very occasionally spike briefly (but with smaller and smaller probability as the graph size grows).