### PR TITLE
fix: fix incorrect validation logic in updater

### DIFF
--- a/rust/lance/src/dataset/updater.rs
+++ b/rust/lance/src/dataset/updater.rs
@@ -319,9 +319,11 @@ impl DeletionRestorer {
         let deleted_batch_offsets = self.deleted_batch_offsets_in_range(batch.num_rows() as u32);
         let batch = add_blanks(batch, &deleted_batch_offsets)?;
 
-        // validation just in case
         if let Some(batch_size) = self.batch_size {
-            if batch.num_rows() != batch_size as usize {
+            // validation just in case, when the input has a fixed batch size then the
+            // output should have the same fixed batch size (except the last batch)
+            let is_last = self.is_exhausted();
+            if batch.num_rows() != batch_size as usize && !is_last {
                 return Err(Error::Internal {
                     message: format!(
                         "Fragment Updater: batch size mismatch: {} != {}",


### PR DESCRIPTION
The updater has a check in the deletion restorer to make sure each batch has the same size as the batch size (if using v1 files).  This is not true for the final batch because it might be smaller than the batch size.  This PR adds a unit test to regress this case and fixes the validation logic.