### PR TITLE
fix: fix file writer which was not writing page buffers in the correct order

### DIFF
--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -135,9 +135,11 @@ impl FileWriter {
     }
 
     async fn write_page(&mut self, encoded_page: EncodedPage) -> Result<()> {
-        let mut buffer_offsets = Vec::with_capacity(encoded_page.array.buffers.len());
-        let mut buffer_sizes = Vec::with_capacity(encoded_page.array.buffers.len());
-        for buffer in encoded_page.array.buffers {
+        let mut buffers = encoded_page.array.buffers;
+        buffers.sort_by_key(|b| b.index);
+        let mut buffer_offsets = Vec::with_capacity(buffers.len());
+        let mut buffer_sizes = Vec::with_capacity(buffers.len());
+        for buffer in buffers {
             buffer_offsets.push(self.writer.tell().await? as u64);
             buffer_sizes.push(
                 buffer


### PR DESCRIPTION
Pages with multiple buffers (today just primitive pages where some of the values are null) were being mangled as a result.  This was not caught during testing since we only had null testing in encoding unit tests which don't go through lance files.  I've added a basic test for nulls to the python tests to catch this in the future.