### PR TITLE
chore: replace `self.uri.to_string()` with `self.uri.clone()`

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -287,7 +287,7 @@ impl Dataset {
         Self::checkout_manifest(
             self.object_store.clone(),
             base_path,
-            self.uri.to_string(),
+            self.uri.clone(),
             &manifest_location,
             self.session.clone(),
             self.commit_handler.clone(),


### PR DESCRIPTION
the `uri` is `String` already