### PR TITLE
ci: bump GHA node version to 20

### DIFF
--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install license-header-checker
         run: curl -s https://raw.githubusercontent.com/lluissm/license-header-checker/master/install.sh | bash
       - name: Check license headers (rust)

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,7 +1,7 @@
 name: PR Checks
 
 on:
-  # This needs to be a pull_request_target event to allow the workflow to 
+  # This needs to be a pull_request_target event to allow the workflow to
   # modify labels on the PR.
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
@@ -53,9 +53,9 @@ jobs:
     name: Verify PR title / description conforms to semantic-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
       # These rules are disabled because Github will always ensure there
       # is a blank line between the title and the body and Github will
       # word wrap the description field to ensure a reasonable max line
@@ -80,7 +80,6 @@ jobs:
         with:
           script: |
             const message = `**ACTION NEEDED**
-              
               Lance follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) for release automation.
 
               The PR title and description are used as the merge commit message.\

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -76,7 +76,7 @@ jobs:
 
             ${{ github.event.pull_request.body }}
       - if: failure()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const message = `**ACTION NEEDED**


### PR DESCRIPTION
Github deprecates node 16/18.