### PR TITLE
refactor: minor refactor to allow I/O scheduler to be cloned in page schedulers

### DIFF
--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -866,7 +866,7 @@ pub trait PageScheduler: Send + Sync + std::fmt::Debug {
     fn schedule_ranges(
         &self,
         ranges: &[Range<u32>],
-        scheduler: &dyn EncodingsIo,
+        scheduler: &Arc<dyn EncodingsIo>,
         top_level_row: u64,
     ) -> BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>>;
 }

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -164,11 +164,10 @@ impl<'a> SchedulingJob for PrimitiveFieldSchedulingJob<'a> {
         self.global_row_offset += cur_page.num_rows as u64;
         self.page_idx += 1;
 
-        let physical_decoder = cur_page.scheduler.schedule_ranges(
-            &ranges_in_page,
-            context.io().as_ref(),
-            top_level_row,
-        );
+        let physical_decoder =
+            cur_page
+                .scheduler
+                .schedule_ranges(&ranges_in_page, context.io(), top_level_row);
 
         let logical_decoder = PrimitiveFieldDecoder {
             data_type: self.scheduler.data_type.clone(),

--- a/rust/lance-encoding/src/encodings/physical/basic.rs
+++ b/rust/lance-encoding/src/encodings/physical/basic.rs
@@ -122,7 +122,7 @@ impl PageScheduler for BasicPageScheduler {
     fn schedule_ranges(
         &self,
         ranges: &[std::ops::Range<u32>],
-        scheduler: &dyn EncodingsIo,
+        scheduler: &Arc<dyn EncodingsIo>,
         top_level_row: u64,
     ) -> BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>> {
         let validity_future = match &self.mode {

--- a/rust/lance-encoding/src/encodings/physical/bitmap.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitmap.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::ops::Range;
+use std::{ops::Range, sync::Arc};
 
 use arrow_buffer::BooleanBufferBuilder;
 use bytes::{Bytes, BytesMut};
@@ -34,7 +34,7 @@ impl PageScheduler for DenseBitmapScheduler {
     fn schedule_ranges(
         &self,
         ranges: &[Range<u32>],
-        scheduler: &dyn EncodingsIo,
+        scheduler: &Arc<dyn EncodingsIo>,
         top_level_row: u64,
     ) -> BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>> {
         let mut min = u64::MAX;

--- a/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::sync::Arc;
+
 use arrow_array::{cast::AsArray, ArrayRef};
 use futures::{future::BoxFuture, FutureExt};
 use lance_core::Result;
@@ -35,7 +37,7 @@ impl PageScheduler for FixedListScheduler {
     fn schedule_ranges(
         &self,
         ranges: &[std::ops::Range<u32>],
-        scheduler: &dyn EncodingsIo,
+        scheduler: &Arc<dyn EncodingsIo>,
         top_level_row: u64,
     ) -> BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>> {
         let expanded_ranges = ranges

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -83,7 +83,7 @@ impl PageScheduler for ValuePageScheduler {
     fn schedule_ranges(
         &self,
         ranges: &[std::ops::Range<u32>],
-        scheduler: &dyn EncodingsIo,
+        scheduler: &Arc<dyn EncodingsIo>,
         top_level_row: u64,
     ) -> BoxFuture<'static, Result<Box<dyn PhysicalPageDecoder>>> {
         let (mut min, mut max) = (u64::MAX, 0);


### PR DESCRIPTION
This should allow for page schedulers to schedule indirect I/O if they need to and will unblock conversion of the binary field scheduler into a page scheduler