### PR TITLE
feat: once a table has been created with v1 or v2 format then it should always use that format

### DIFF
--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -14,6 +14,11 @@ pub const FLAG_DELETION_FILES: u64 = 1;
 /// Row ids are table after moves, but not updates. Fragments contain an index
 /// mapping row ids to row addresses.
 pub const FLAG_MOVE_STABLE_ROW_IDS: u64 = 2;
+/// Files are written with the new v2 format (temporary flag, will be removed
+/// once v2 is the default format)
+pub const FLAG_USE_V2_FORMAT: u64 = 4;
+/// The first bit that is invalid as a feature flag
+pub const FLAG_INVALID: u64 = 8;
 
 /// Set the reader and writer feature flags in the manifest based on the contents of the manifest.
 pub fn apply_feature_flags(manifest: &mut Manifest) -> Result<()> {
@@ -55,11 +60,15 @@ pub fn apply_feature_flags(manifest: &mut Manifest) -> Result<()> {
 }
 
 pub fn can_read_dataset(reader_flags: u64) -> bool {
-    reader_flags <= 3
+    reader_flags <= 7
 }
 
 pub fn can_write_dataset(writer_flags: u64) -> bool {
-    writer_flags <= 3
+    writer_flags <= 7
+}
+
+pub fn should_use_legacy_format(writer_flags: u64) -> bool {
+    writer_flags & FLAG_USE_V2_FORMAT == 0
 }
 
 #[cfg(test)]
@@ -71,10 +80,11 @@ mod tests {
         assert!(can_read_dataset(0));
         assert!(can_read_dataset(super::FLAG_DELETION_FILES));
         assert!(can_read_dataset(super::FLAG_MOVE_STABLE_ROW_IDS));
+        assert!(can_read_dataset(super::FLAG_USE_V2_FORMAT));
         assert!(can_read_dataset(
             super::FLAG_DELETION_FILES | super::FLAG_MOVE_STABLE_ROW_IDS
         ));
-        assert!(!can_read_dataset(super::FLAG_MOVE_STABLE_ROW_IDS << 1));
+        assert!(!can_read_dataset(super::FLAG_INVALID));
     }
 
     #[test]
@@ -82,9 +92,12 @@ mod tests {
         assert!(can_write_dataset(0));
         assert!(can_write_dataset(super::FLAG_DELETION_FILES));
         assert!(can_write_dataset(super::FLAG_MOVE_STABLE_ROW_IDS));
+        assert!(can_read_dataset(super::FLAG_USE_V2_FORMAT));
         assert!(can_write_dataset(
-            super::FLAG_DELETION_FILES | super::FLAG_MOVE_STABLE_ROW_IDS
+            super::FLAG_DELETION_FILES
+                | super::FLAG_MOVE_STABLE_ROW_IDS
+                | super::FLAG_USE_V2_FORMAT
         ));
-        assert!(!can_write_dataset(super::FLAG_MOVE_STABLE_ROW_IDS << 1));
+        assert!(!can_write_dataset(super::FLAG_INVALID));
     }
 }

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -17,8 +17,8 @@ pub const FLAG_MOVE_STABLE_ROW_IDS: u64 = 2;
 /// Files are written with the new v2 format (temporary flag, will be removed
 /// once v2 is the default format)
 pub const FLAG_USE_V2_FORMAT: u64 = 4;
-/// The first bit that is invalid as a feature flag
-pub const FLAG_INVALID: u64 = 8;
+/// The first bit that is unknown as a feature flag
+pub const FLAG_UNKNOWN: u64 = 8;
 
 /// Set the reader and writer feature flags in the manifest based on the contents of the manifest.
 pub fn apply_feature_flags(manifest: &mut Manifest) -> Result<()> {
@@ -60,11 +60,11 @@ pub fn apply_feature_flags(manifest: &mut Manifest) -> Result<()> {
 }
 
 pub fn can_read_dataset(reader_flags: u64) -> bool {
-    reader_flags <= 7
+    reader_flags < FLAG_UNKNOWN
 }
 
 pub fn can_write_dataset(writer_flags: u64) -> bool {
-    writer_flags <= 7
+    writer_flags < FLAG_UNKNOWN
 }
 
 pub fn should_use_legacy_format(writer_flags: u64) -> bool {
@@ -84,7 +84,7 @@ mod tests {
         assert!(can_read_dataset(
             super::FLAG_DELETION_FILES | super::FLAG_MOVE_STABLE_ROW_IDS
         ));
-        assert!(!can_read_dataset(super::FLAG_INVALID));
+        assert!(!can_read_dataset(super::FLAG_UNKNOWN));
     }
 
     #[test]
@@ -98,6 +98,6 @@ mod tests {
                 | super::FLAG_MOVE_STABLE_ROW_IDS
                 | super::FLAG_USE_V2_FORMAT
         ));
-        assert!(!can_write_dataset(super::FLAG_INVALID));
+        assert!(!can_write_dataset(super::FLAG_UNKNOWN));
     }
 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -448,12 +448,10 @@ impl Dataset {
                 );
                 params.use_legacy_format = !use_v2;
             }
-        } else {
-            if !params.use_legacy_format {
-                schema
-                    .metadata
-                    .insert("lance:use_lance_v2".to_string(), "true".to_string());
-            }
+        } else if !params.use_legacy_format {
+            schema
+                .metadata
+                .insert("lance:use_lance_v2".to_string(), "true".to_string());
         }
 
         let params = params; // discard mut

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1653,7 +1653,7 @@ mod tests {
     #[rstest]
     #[tokio::test]
     async fn test_write_manifest(#[values(false, true)] use_legacy_format: bool) {
-        use lance_table::feature_flags::FLAG_INVALID;
+        use lance_table::feature_flags::FLAG_UNKNOWN;
 
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
@@ -1692,7 +1692,9 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(manifest.writer_feature_flags, 0);
+        if !use_legacy_format {
+            assert_eq!(manifest.writer_feature_flags, FLAG_USE_V2_FORMAT);
+        }
         assert_eq!(manifest.reader_feature_flags, 0);
 
         // Create one with deletions
@@ -1720,8 +1722,8 @@ mod tests {
         );
 
         // Write with custom manifest
-        manifest.writer_feature_flags |= FLAG_INVALID; // Set another flag
-        manifest.reader_feature_flags |= FLAG_INVALID;
+        manifest.writer_feature_flags |= FLAG_UNKNOWN; // Set another flag
+        manifest.reader_feature_flags |= FLAG_UNKNOWN;
         manifest.version += 1;
         write_manifest_file(
             dataset.object_store(),

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -25,7 +25,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use lance_table::feature_flags::FLAG_USE_V2_FORMAT;
 use lance_table::format::{pb, DeletionFile, Fragment, Index, Manifest, WriterVersion};
 use lance_table::io::commit::{CommitConfig, CommitError, CommitHandler};
 use lance_table::io::deletion::read_deletion_file;
@@ -118,16 +117,11 @@ pub(crate) async fn commit_new_dataset(
     base_path: &Path,
     transaction: &Transaction,
     write_config: &ManifestWriteConfig,
-    use_legacy_format: bool,
 ) -> Result<Manifest> {
     let transaction_file = write_transaction_file(object_store, base_path, transaction).await?;
 
     let (mut manifest, indices) =
         transaction.build_manifest(None, vec![], &transaction_file, write_config)?;
-
-    if !use_legacy_format {
-        manifest.writer_feature_flags |= FLAG_USE_V2_FORMAT;
-    }
 
     write_manifest_file(
         object_store,


### PR DESCRIPTION
We want to avoid mixed-format datasets.  In theory, they should work.  However, it just expands our list of potential test scenarios without any real benefit.  Also, its easier to expose the use_legacy_format flag in lancedb if we only have to modify the create table operation.