### PR TITLE
refactor: pull row_id and deletion vector out of v1 file reader

### DIFF
--- a/rust/lance-file/src/writer.rs
+++ b/rust/lance-file/src/writer.rs
@@ -922,10 +922,7 @@ mod tests {
         file_writer.finish().await.unwrap();
 
         let reader = FileReader::try_new(&store, &path, schema).await.unwrap();
-        let actual = reader
-            .read_batch(0, .., reader.schema(), None)
-            .await
-            .unwrap();
+        let actual = reader.read_batch(0, .., reader.schema()).await.unwrap();
         assert_eq!(actual, batch);
     }
 
@@ -959,10 +956,7 @@ mod tests {
         file_writer.finish().await.unwrap();
 
         let reader = FileReader::try_new(&store, &path, schema).await.unwrap();
-        let actual = reader
-            .read_batch(0, .., reader.schema(), None)
-            .await
-            .unwrap();
+        let actual = reader.read_batch(0, .., reader.schema()).await.unwrap();
         assert_eq!(actual, batch);
     }
 
@@ -1004,10 +998,7 @@ mod tests {
         file_writer.finish().await.unwrap();
 
         let reader = FileReader::try_new(&store, &path, schema).await.unwrap();
-        let actual = reader
-            .read_batch(0, .., reader.schema(), None)
-            .await
-            .unwrap();
+        let actual = reader.read_batch(0, .., reader.schema()).await.unwrap();
         assert_eq!(actual, batch);
     }
 
@@ -1215,7 +1206,7 @@ mod tests {
         for i in 0..reader.num_batches() {
             batches.push(
                 reader
-                    .read_batch(i as i32, .., reader.schema(), None)
+                    .read_batch(i as i32, .., reader.schema())
                     .await
                     .unwrap(),
             );

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -73,13 +73,8 @@ impl<M: ManifestProvider + Send + Sync> IndexWriter for FileWriter<M> {
 #[async_trait]
 impl IndexReader for FileReader {
     async fn read_record_batch(&self, offset: u32) -> Result<RecordBatch> {
-        self.read_batch(
-            offset as i32,
-            ReadBatchParams::RangeFull,
-            self.schema(),
-            None,
-        )
-        .await
+        self.read_batch(offset as i32, ReadBatchParams::RangeFull, self.schema())
+            .await
     }
 
     async fn num_batches(&self) -> u32 {

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -426,7 +426,7 @@ impl HNSW {
             .map(|i| {
                 let start = range.start + level_offsets[i];
                 let end = range.start + level_offsets[i + 1];
-                reader.read_range(start..end, reader.schema(), None)
+                reader.read_range(start..end, reader.schema())
             })
             .buffered(num_cpus::get())
             .try_collect()

--- a/rust/lance-index/src/vector/ivf/shuffler.rs
+++ b/rust/lance-index/src/vector/ivf/shuffler.rs
@@ -295,7 +295,7 @@ impl IvfShuffler {
                 .expect("part id should exist");
 
             let mut stream = stream::iter(start..end)
-                .map(|i| reader.read_batch(i as i32, .., &lance_schema, None))
+                .map(|i| reader.read_batch(i as i32, .., &lance_schema))
                 .buffer_unordered(16);
 
             while let Some(batch) = stream.next().await {
@@ -335,9 +335,7 @@ impl IvfShuffler {
             let total_batch = reader.num_batches();
 
             let mut stream = stream::iter(start..end)
-                .map(|i| {
-                    reader.read_batch(i as i32, ReadBatchParams::RangeFull, reader.schema(), None)
-                })
+                .map(|i| reader.read_batch(i as i32, ReadBatchParams::RangeFull, reader.schema()))
                 .buffered(16)
                 .enumerate();
 
@@ -481,7 +479,7 @@ impl IvfShuffler {
                 .zip(stream::repeat(reader))
                 .map(|(i, reader)| async move {
                     reader
-                        .read_batch(i as i32, ReadBatchParams::RangeFull, reader.schema(), None)
+                        .read_batch(i as i32, ReadBatchParams::RangeFull, reader.schema())
                         .await
                 })
                 .buffered(4);

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -406,7 +406,7 @@ impl QuantizerStorage for ProductQuantizationStorage {
         );
 
         let schema = reader.schema();
-        let batch = reader.read_range(range, schema, None).await?;
+        let batch = reader.read_range(range, schema).await?;
 
         Self::new(
             codebook,

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -192,7 +192,7 @@ impl QuantizerStorage for ScalarQuantizationStorage {
         metadata: &Self::Metadata,
     ) -> Result<Self> {
         let schema = reader.schema();
-        let batch = reader.read_range(range, schema, None).await?;
+        let batch = reader.read_range(range, schema).await?;
 
         Self::new(
             metadata.num_bits,

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -172,7 +172,7 @@ pub struct RowIdAndDeletesConfig {
     pub total_num_rows: u32,
 }
 
-fn apply_row_id_and_deletes(
+pub fn apply_row_id_and_deletes(
     batch: RecordBatch,
     batch_offset: u32,
     fragment_id: u32,

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -12,10 +12,8 @@ use std::sync::Arc;
 
 use arrow::compute::concat_batches;
 use arrow_array::cast::as_primitive_array;
-use arrow_array::{
-    NullArray, RecordBatch, RecordBatchReader, StructArray, UInt32Array, UInt64Array,
-};
-use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+use arrow_array::{RecordBatch, RecordBatchReader, StructArray, UInt32Array, UInt64Array};
+use arrow_schema::Schema as ArrowSchema;
 use datafusion::logical_expr::Expr;
 use datafusion::scalar::ScalarValue;
 use futures::future::try_join_all;

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -126,8 +126,6 @@ fn ranges_to_tasks(
                     &ReadBatchParams::Range(range.clone()),
                     &projection,
                     batch_idx,
-                    false,
-                    None,
                 )
                 .await
             })
@@ -200,11 +198,9 @@ impl GenericFileReader for FileReader {
         projection: Arc<Schema>,
     ) -> Result<ReadBatchTaskStream> {
         let indices_vec = indices.to_vec();
-        let mut reader = self.clone();
+        let reader = self.clone();
         // In the new path the row id is added by the fragment and not the file
-        reader.with_row_id(false);
-        let task_fut =
-            async move { reader.take(&indices_vec, projection.as_ref(), None).await }.boxed();
+        let task_fut = async move { reader.take(&indices_vec, projection.as_ref()).await }.boxed();
         let task = std::future::ready(ReadBatchTask {
             task: task_fut,
             num_rows: indices.len() as u32,
@@ -480,7 +476,7 @@ impl FileFragment {
             if with_row_id || !schema_per_file.fields.is_empty() {
                 let path = self.dataset.data_dir().child(data_file.path.as_str());
                 let field_id_offset = Self::get_field_id_offset(data_file);
-                let mut reader = FileReader::try_new_with_fragment_id(
+                let reader = FileReader::try_new_with_fragment_id(
                     &self.dataset.object_store,
                     &path,
                     self.schema().clone(),
@@ -490,7 +486,6 @@ impl FileFragment {
                     Some(&self.dataset.session.file_metadata_cache),
                 )
                 .await?;
-                reader.with_row_id(with_row_id);
                 let initialized_schema = reader
                     .schema()
                     .project_by_schema(schema_per_file.as_ref())?;
@@ -1250,9 +1245,6 @@ impl FragmentReader {
 
     pub(crate) fn with_row_id(&mut self) -> &mut Self {
         self.with_row_id = true;
-        if let Some(legacy_reader) = self.readers[0].0.as_legacy_opt_mut() {
-            legacy_reader.with_row_id(true);
-        }
         self.output_schema = self
             .output_schema
             .try_with_column(ROW_ID_FIELD.clone())
@@ -1262,11 +1254,6 @@ impl FragmentReader {
 
     pub(crate) fn with_make_deletions_null(&mut self) -> &mut Self {
         self.make_deletions_null = true;
-        for (reader, _) in self.readers.iter_mut() {
-            if let Some(legacy_reader) = reader.as_legacy_opt_mut() {
-                legacy_reader.with_make_deletions_null(true);
-            }
-        }
         self
     }
 
@@ -1332,40 +1319,6 @@ impl FragmentReader {
         }
     }
 
-    #[cfg(test)]
-    async fn read_impl<'a, Fut>(
-        &'a self,
-        read_fn: impl Fn(&'a dyn GenericFileReader, &'a Schema) -> Fut,
-    ) -> Result<RecordBatch>
-    where
-        Fut: std::future::Future<Output = Result<RecordBatch>> + 'a,
-    {
-        let futures = self
-            .readers
-            .iter()
-            .map(|(reader, schema)| read_fn(reader.as_ref(), schema))
-            .collect::<Vec<_>>();
-        let batches = try_join_all(futures).await?;
-        Ok(merge_batches(&batches)?.project_by_schema(&self.output_schema)?)
-    }
-
-    #[cfg(test)]
-    pub(crate) async fn legacy_read_batch(
-        &self,
-        batch_id: usize,
-        params: impl Into<ReadBatchParams> + Clone,
-    ) -> Result<RecordBatch> {
-        self.read_impl(move |reader, schema| {
-            reader.as_legacy().read_batch(
-                batch_id as i32,
-                params.clone(),
-                schema,
-                self.deletion_vec.as_ref().map(|dv| dv.as_ref()),
-            )
-        })
-        .await
-    }
-
     /// Read a batch of rows from the fragment, with a subset of columns.
     ///
     /// Note: the projection must be a subset of the schema the reader was created with.
@@ -1380,11 +1333,11 @@ impl FragmentReader {
         params: impl Into<ReadBatchParams> + Clone,
         projection: &Schema,
     ) -> Result<RecordBatch> {
-        let read_tasks = self
-            .readers
-            .iter()
-            .enumerate()
-            .map(|(reader_idx, (reader, schema))| {
+        // These will be concatenated horizontally.
+        let mut batches = vec![];
+
+        if !projection.fields.is_empty() {
+            let read_tasks = self.readers.iter().map(|(reader, schema)| {
                 let projection = schema.intersection(projection);
                 let params = params.clone();
 
@@ -1394,29 +1347,51 @@ impl FragmentReader {
                     // Apply ? inside the task to keep read_tasks a simple iter of futures
                     // for try_join_all
                     let projection = projection?;
-                    // We always get the row_id from the first reader and so we need that even
-                    // if the projection is empty
-                    let need_for_row_id = self.with_row_id && reader_idx == 0;
-                    if projection.fields.is_empty() && !need_for_row_id {
+                    if projection.fields.is_empty() {
                         // The projection caused one of the data files to become
                         // irrelevant and so we can skip it
                         Result::Ok(None)
                     } else {
                         Ok(Some(
                             reader
-                                .read_batch(
-                                    batch_id as i32,
-                                    params,
-                                    &projection,
-                                    self.deletion_vec.as_ref().map(|dv| dv.as_ref()),
-                                )
+                                .read_batch(batch_id as i32, params, &projection)
                                 .await?,
                         ))
                     }
                 }
             });
-        let batches = try_join_all(read_tasks).await?;
-        let batches = batches.into_iter().flatten().collect::<Vec<_>>();
+            let results = try_join_all(read_tasks).await?;
+            batches.extend(results.into_iter().flatten());
+        }
+
+        // If desired, add row id column
+        let params = params.into();
+        let first_reader = self.readers[0].0.as_legacy();
+        let batch_offset = (0..batch_id)
+            .map(|i| first_reader.num_rows_in_batch(i as i32))
+            .sum();
+        let rows_in_batch = first_reader.num_rows_in_batch(batch_id as i32);
+        if self.with_row_id {
+            let ids_in_batch = params
+                .slice(batch_offset, rows_in_batch)
+                .unwrap()
+                .to_offsets()
+                .unwrap();
+            let row_ids: UInt64Array = ids_in_batch
+                .values()
+                .iter()
+                .map(|row_id| {
+                    u64::from(RowAddress::new_from_parts(self.fragment_id as u32, *row_id))
+                })
+                .collect();
+            let batch = RecordBatch::try_new(
+                Arc::new(ArrowSchema::new(vec![ROW_ID_FIELD.clone()])),
+                vec![Arc::new(row_ids)],
+            )?;
+            batches.push(batch);
+        }
+
+        // TODO: we also have to apply the deletion vector
 
         let output_schema = {
             let mut output_schema = ArrowSchema::from(projection);
@@ -1428,7 +1403,42 @@ impl FragmentReader {
 
         let result = merge_batches(&batches)?.project_by_schema(&output_schema)?;
 
-        Ok(result)
+        // Need to apply deletions as well
+        // In order to apply deletions we need to change the parameters to be
+        // relative to the file, not the batch.
+        let file_params = match params {
+            ReadBatchParams::Indices(indices) => ReadBatchParams::Indices(
+                indices
+                    .values()
+                    .iter()
+                    .map(|i| *i + batch_offset as u32)
+                    .collect(),
+            ),
+            ReadBatchParams::RangeFull => {
+                ReadBatchParams::Range(batch_offset..(batch_offset + rows_in_batch))
+            }
+            ReadBatchParams::RangeFrom(start) => {
+                ReadBatchParams::Range((start.start + batch_offset)..(batch_offset + rows_in_batch))
+            }
+            ReadBatchParams::RangeTo(end) => {
+                ReadBatchParams::Range(batch_offset..(end.end + batch_offset))
+            }
+            ReadBatchParams::Range(range) => {
+                ReadBatchParams::Range((range.start + batch_offset)..(range.end + batch_offset))
+            }
+        };
+        lance_table::utils::stream::apply_row_id_and_deletes(
+            result,
+            0,
+            self.fragment_id as u32,
+            &RowIdAndDeletesConfig {
+                params: file_params,
+                deletion_vector: self.deletion_vec.clone(),
+                with_row_id: false, // We already added the row id column
+                make_deletions_null: self.make_deletions_null,
+                total_num_rows: first_reader.len() as u32,
+            },
+        )
     }
 
     fn new_read_impl(
@@ -1804,19 +1814,28 @@ mod tests {
         reader.with_make_deletions_null();
 
         // Since the first batch is all deleted, it will return an empty batch.
-        let batch1 = reader.legacy_read_batch(0, ..).await.unwrap();
+        let batch1 = reader
+            .legacy_read_batch_projected(0, .., dataset.schema())
+            .await
+            .unwrap();
         assert_eq!(batch1.num_rows(), 0);
 
         // The second batch is partially deleted, so the deleted rows will be
         // marked null with null row ids.
-        let batch2 = reader.legacy_read_batch(1, ..).await.unwrap();
+        let batch2 = reader
+            .legacy_read_batch_projected(1, .., dataset.schema())
+            .await
+            .unwrap();
         assert_eq!(
             batch2.column_by_name(ROW_ID).unwrap().as_ref(),
             &UInt64Array::from_iter((10..20).map(|v| if v < 15 { None } else { Some(v) }))
         );
 
         // The final batch is not deleted, so it will be returned as-is.
-        let batch3 = reader.legacy_read_batch(2, ..).await.unwrap();
+        let batch3 = reader
+            .legacy_read_batch_projected(2, .., dataset.schema())
+            .await
+            .unwrap();
         assert_eq!(
             batch3.column_by_name(ROW_ID).unwrap().as_ref(),
             &UInt64Array::from_iter_values(20..30)

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -682,7 +682,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(reader.num_batches(), 1);
-        let batch = reader.read_batch(0, .., &schema, None).await.unwrap();
+        let batch = reader.read_batch(0, .., &schema).await.unwrap();
         assert_eq!(batch, data);
     }
 }

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -406,7 +406,6 @@ pub(super) async fn write_hnsw_quantization_index_partitions(
                     batch_id as i32,
                     ReadBatchParams::RangeFull,
                     part_reader.schema(),
-                    None,
                 )
             })
             .buffered(num_cpus::get())
@@ -431,7 +430,6 @@ pub(super) async fn write_hnsw_quantization_index_partitions(
                         batch_id as i32,
                         ReadBatchParams::RangeFull,
                         aux_part_reader.schema(),
-                        None,
                     )
                 })
                 .buffered(num_cpus::get())

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -668,6 +668,7 @@ mod test {
     use arrow_select::concat::concat_batches;
     use datafusion::prelude::{lit, Column, SessionContext};
     use lance_arrow::{FixedSizeListArrayExt, SchemaExt};
+    use pretty_assertions::assert_eq;
     use tempfile::tempdir;
 
     use crate::{datafusion::logical_expr::tests::ExprExt, dataset::WriteParams};
@@ -1448,7 +1449,7 @@ mod test {
             let ints = result["int"].as_primitive::<Int32Type>();
             let expected =
                 Int32Array::from_iter_values(expected_int.into_iter().filter(|x| x < &max_value));
-            assert_eq!(ints, &expected);
+            assert_eq!(ints, &expected, "Failed with max_value = {}", max_value);
 
             let floats = result["float"].as_primitive::<Float32Type>();
             let expected = Float32Array::from_iter_values(


### PR DESCRIPTION
Consolidates row_id logic. This is to make the stable row id logic much easier to work with.