### PR TITLE
chore: chunked SQ storage

### DIFF
--- a/rust/lance-core/src/utils/mask.rs
+++ b/rust/lance-core/src/utils/mask.rs
@@ -73,8 +73,8 @@ impl RowIdMask {
     }
 
     /// Return the indices of the input row ids that were valid
-    pub fn selected_indices(&self, row_ids: &[u64]) -> Vec<u64> {
-        let enumerated_ids = row_ids.iter().enumerate();
+    pub fn selected_indices<'a>(&self, row_ids: impl Iterator<Item = &'a u64> + 'a) -> Vec<u64> {
+        let enumerated_ids = row_ids.enumerate();
         match (&self.block_list, &self.allow_list) {
             (Some(block_list), Some(allow_list)) => {
                 // Only take rows that are both in the allow list and not in the block list

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -78,3 +78,7 @@ harness = false
 [[bench]]
 name = "hnsw"
 harness = false
+
+[[bench]]
+name = "sq"
+harness = false

--- a/rust/lance-index/benches/find_partitions.rs
+++ b/rust/lance-index/benches/find_partitions.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-mod sq;
-
 use arrow_array::Float32Array;
 use arrow_array::{types::Float32Type, FixedSizeListArray};
 use lance_arrow::FixedSizeListArrayExt;

--- a/rust/lance-index/benches/find_partitions.rs
+++ b/rust/lance-index/benches/find_partitions.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+mod sq;
+
 use arrow_array::Float32Array;
 use arrow_array::{types::Float32Type, FixedSizeListArray};
 use lance_arrow::FixedSizeListArrayExt;

--- a/rust/lance-index/benches/sq.rs
+++ b/rust/lance-index/benches/sq.rs
@@ -21,7 +21,7 @@ use rand::prelude::*;
 
 fn create_full_batch(range: Range<u64>, dim: usize) -> RecordBatch {
     let mut rng = rand::thread_rng();
-    let row_ids = UInt64Array::from_iter_values(range.clone().into_iter());
+    let row_ids = UInt64Array::from_iter_values(range);
     let sq_code =
         UInt8Array::from_iter_values(repeat_with(|| rng.gen::<u8>()).take(row_ids.len() * dim));
     let sq_code_fsl = FixedSizeListArray::try_new_from_values(sq_code, dim as i32).unwrap();

--- a/rust/lance-index/benches/sq.rs
+++ b/rust/lance-index/benches/sq.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Scalar Quantization Benchmarks
+
+use std::{iter::repeat_with, ops::Range, sync::Arc, time::Duration};
+
+use arrow_array::{FixedSizeListArray, RecordBatch, UInt64Array, UInt8Array};
+use arrow_schema::{DataType, Field, Schema};
+use criterion::{criterion_group, criterion_main, Criterion};
+use lance_arrow::{FixedSizeListArrayExt, RecordBatchExt};
+use lance_core::ROW_ID;
+use lance_index::vector::{
+    sq::storage::ScalarQuantizationStorage, v3::storage::VectorStore, SQ_CODE_COLUMN,
+};
+use lance_linalg::distance::DistanceType;
+use lance_testing::datagen::generate_random_array;
+use rand::prelude::*;
+
+fn create_full_batch(range: Range<u64>, dim: usize) -> RecordBatch {
+    let mut rng = rand::thread_rng();
+    let row_ids = UInt64Array::from_iter_values(range.clone().into_iter());
+    let sq_code =
+        UInt8Array::from_iter_values(repeat_with(|| rng.gen::<u8>()).take(row_ids.len() * dim));
+    let sq_code_fsl = FixedSizeListArray::try_new_from_values(sq_code, dim as i32).unwrap();
+
+    let vector_data = generate_random_array(row_ids.len() * dim);
+    let vector_fsl = FixedSizeListArray::try_new_from_values(vector_data, dim as i32).unwrap();
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(ROW_ID, DataType::UInt64, false),
+        Field::new(
+            SQ_CODE_COLUMN,
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::UInt8, true)),
+                dim as i32,
+            ),
+            false,
+        ),
+        Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                dim as i32,
+            ),
+            false,
+        ),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(row_ids),
+            Arc::new(sq_code_fsl),
+            Arc::new(vector_fsl),
+        ],
+    )
+    .unwrap()
+}
+
+fn create_sq_batch(row_id_range: Range<u64>, dim: usize) -> RecordBatch {
+    let batch = create_full_batch(row_id_range, dim);
+    batch.drop_column("vector").unwrap()
+}
+
+fn bench_storge(c: &mut Criterion) {
+    let mut rng = rand::thread_rng();
+
+    c.bench_function("ScalarQuantizationStorage,chunks=1x1M", |b| {
+        let batch = create_sq_batch(0..10240, 128);
+        let storage =
+            ScalarQuantizationStorage::try_new(8, DistanceType::L2, -1.0..1.0, batch).unwrap();
+        let total = storage.len();
+        b.iter(|| {
+            let a = rng.gen_range(0..total as u32);
+            let b = rng.gen_range(0..total as u32);
+            storage.distance_between(a, b)
+        });
+    });
+}
+
+#[cfg(target_os = "linux")]
+criterion_group!(
+    name=benches;
+    config = Criterion::default()
+        .measurement_time(Duration::from_secs(10))
+        .sample_size(10)
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench_storge);
+
+// Non-linux version does not support pprof.
+#[cfg(not(target_os = "linux"))]
+criterion_group!(
+    name=benches;
+    config = Criterion::default()
+        .measurement_time(Duration::from_secs(10))
+        .sample_size(10);
+    targets = bench_storge);
+
+criterion_main!(benches);

--- a/rust/lance-index/benches/sq.rs
+++ b/rust/lance-index/benches/sq.rs
@@ -64,7 +64,8 @@ fn create_sq_batch(row_id_range: Range<u64>, dim: usize) -> RecordBatch {
     batch.drop_column("vector").unwrap()
 }
 
-fn bench_storge(c: &mut Criterion) {
+#[allow(dead_code)]
+pub fn bench_storage(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
 
     const TOTAL: usize = 8 * 1024 * 1024; // 8M rows
@@ -98,7 +99,7 @@ criterion_group!(
         .measurement_time(Duration::from_secs(10))
         .sample_size(10)
         .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bench_storge);
+    targets = bench_storage);
 
 // Non-linux version does not support pprof.
 #[cfg(not(target_os = "linux"))]
@@ -107,6 +108,6 @@ criterion_group!(
     config = Criterion::default()
         .measurement_time(Duration::from_secs(10))
         .sample_size(10);
-    targets = bench_storge);
+    targets = bench_storage);
 
 criterion_main!(benches);

--- a/rust/lance-index/benches/sq.rs
+++ b/rust/lance-index/benches/sq.rs
@@ -68,7 +68,23 @@ fn bench_storge(c: &mut Criterion) {
     c.bench_function("ScalarQuantizationStorage,chunks=1x1M", |b| {
         let batch = create_sq_batch(0..10240, 128);
         let storage =
-            ScalarQuantizationStorage::try_new(8, DistanceType::L2, -1.0..1.0, batch).unwrap();
+            ScalarQuantizationStorage::try_new(8, DistanceType::L2, -1.0..1.0, [batch]).unwrap();
+        let total = storage.len();
+        b.iter(|| {
+            let a = rng.gen_range(0..total as u32);
+            let b = rng.gen_range(0..total as u32);
+            storage.distance_between(a, b)
+        });
+    });
+
+    c.bench_function("ScalarQuantizationStorage,chunks=1024x1M", |b| {
+        let storage = ScalarQuantizationStorage::try_new(
+            8,
+            DistanceType::L2,
+            -1.0..1.0,
+            repeat_with(|| create_sq_batch(0..10240, 128)).take(1024),
+        )
+        .unwrap();
         let total = storage.len();
         b.iter(|| {
             let a = rng.gen_range(0..total as u32);

--- a/rust/lance-index/benches/sq.rs
+++ b/rust/lance-index/benches/sq.rs
@@ -65,7 +65,7 @@ fn create_sq_batch(row_id_range: Range<u64>, dim: usize) -> RecordBatch {
 fn bench_storge(c: &mut Criterion) {
     let mut rng = rand::thread_rng();
 
-    c.bench_function("ScalarQuantizationStorage,chunks=1x1M", |b| {
+    c.bench_function("ScalarQuantizationStorage,chunks=1x10K", |b| {
         let batch = create_sq_batch(0..10240, 128);
         let storage =
             ScalarQuantizationStorage::try_new(8, DistanceType::L2, -1.0..1.0, [batch]).unwrap();
@@ -77,7 +77,7 @@ fn bench_storge(c: &mut Criterion) {
         });
     });
 
-    c.bench_function("ScalarQuantizationStorage,chunks=1024x1M", |b| {
+    c.bench_function("ScalarQuantizationStorage,chunks=1024x10K", |b| {
         let storage = ScalarQuantizationStorage::try_new(
             8,
             DistanceType::L2,

--- a/rust/lance-index/src/prefilter.rs
+++ b/rust/lance-index/src/prefilter.rs
@@ -40,5 +40,5 @@ pub trait PreFilter: Send + Sync {
     /// also known as a selection vector.
     ///
     /// This method must be called after `wait_for_ready`
-    fn filter_row_ids<'a>(&self, row_ids: impl Iterator<Item = &'a u64> + 'a) -> Vec<u64>;
+    fn filter_row_ids<'a>(&self, row_ids: Box<dyn Iterator<Item = &'a u64> + 'a>) -> Vec<u64>;
 }

--- a/rust/lance-index/src/prefilter.rs
+++ b/rust/lance-index/src/prefilter.rs
@@ -40,5 +40,5 @@ pub trait PreFilter: Send + Sync {
     /// also known as a selection vector.
     ///
     /// This method must be called after `wait_for_ready`
-    fn filter_row_ids(&self, row_ids: &[u64]) -> Vec<u64>;
+    fn filter_row_ids<'a>(&self, row_ids: impl Iterator<Item = &'a u64> + 'a) -> Vec<u64>;
 }

--- a/rust/lance-index/src/vector.rs
+++ b/rust/lance-index/src/vector.rs
@@ -144,7 +144,7 @@ pub trait VectorIndex: Send + Sync + std::fmt::Debug + Index {
     }
 
     /// Return the IDs of rows in the index.
-    fn row_ids(&self) -> &[u64];
+    fn row_ids(&self) -> Box<dyn Iterator<Item = &'_ u64> + '_>;
 
     /// Remap the index according to mapping
     ///

--- a/rust/lance-index/src/vector/flat/index.rs
+++ b/rust/lance-index/src/vector/flat/index.rs
@@ -58,7 +58,7 @@ impl IvfSubIndex for FlatIndex {
     ) -> Result<RecordBatch> {
         let dist_calc = storage.dist_calculator_from_native(query);
         let (row_ids, dists): (Vec<u64>, Vec<f32>) = (0..storage.len())
-            .filter(|&id| !prefilter.should_drop(storage.row_ids()[id]))
+            .filter(|&id| !prefilter.should_drop(storage.row_id(id as u32)))
             .map(|id| OrderedNode {
                 id: id as u32,
                 dist: OrderedFloat(dist_calc.distance(id as u32)),
@@ -69,7 +69,7 @@ impl IvfSubIndex for FlatIndex {
                 |OrderedNode {
                      id,
                      dist: OrderedFloat(dist),
-                 }| (storage.row_ids()[id as usize], dist),
+                 }| (storage.row_id(id), dist),
             )
             .unzip();
 

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -137,6 +137,10 @@ impl VectorStore for FlatStorage {
         self.row_ids.values()[id as usize]
     }
 
+    fn row_ids(&self) -> impl Iterator<Item = &u64> {
+        self.row_ids.values().iter()
+    }
+
     fn dist_calculator(&self, query: ArrayRef) -> Self::DistanceCalculator<'_> {
         FlatDistanceCal {
             vectors: self.vectors.clone(),

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -9,7 +9,7 @@ use crate::vector::quantizer::QuantizerStorage;
 use crate::vector::utils::prefetch_arrow_array;
 use crate::vector::v3::storage::{DistCalculator, VectorStore};
 use arrow::array::AsArray;
-use arrow::compute::{concat, concat_batches};
+use arrow::compute::concat_batches;
 use arrow::datatypes::UInt64Type;
 use arrow_array::{types::Float32Type, RecordBatch};
 use arrow_array::{Array, ArrayRef, FixedSizeListArray, UInt64Array};
@@ -115,7 +115,7 @@ impl VectorStore for FlatStorage {
         Ok([self.batch.clone()].into_iter())
     }
 
-    fn append_record_batch(&self, batch: RecordBatch, _vector_column: &str) -> Result<Self> {
+    fn append_batch(&self, batch: RecordBatch, _vector_column: &str) -> Result<Self> {
         // TODO: use chunked storage
         let new_batch = concat_batches(&batch.schema(), vec![&self.batch, &batch].into_iter())?;
         let mut storage = self.clone();

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -30,7 +30,7 @@ pub struct FlatStorage {
     distance_type: DistanceType,
 
     // helper fields
-    row_ids: Arc<UInt64Array>,
+    pub(super) row_ids: Arc<UInt64Array>,
     vectors: Arc<FixedSizeListArray>,
 }
 
@@ -125,12 +125,12 @@ impl VectorStore for FlatStorage {
         self.vectors.len()
     }
 
-    fn row_ids(&self) -> &[u64] {
-        self.row_ids.values()
-    }
-
     fn distance_type(&self) -> DistanceType {
         self.distance_type
+    }
+
+    fn row_id(&self, id: u32) -> u64 {
+        self.row_ids.values()[id as usize]
     }
 
     fn dist_calculator(&self, query: ArrayRef) -> Self::DistanceCalculator<'_> {

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -12,7 +12,7 @@ use arrow::array::AsArray;
 use arrow::datatypes::UInt64Type;
 use arrow_array::{types::Float32Type, RecordBatch};
 use arrow_array::{Array, ArrayRef, FixedSizeListArray, UInt64Array};
-use arrow_schema::DataType;
+use arrow_schema::{DataType, SchemaRef};
 use deepsize::DeepSizeOf;
 use lance_core::{Error, Result, ROW_ID};
 use lance_file::reader::FileReader;
@@ -115,6 +115,10 @@ impl VectorStore for FlatStorage {
 
     fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch>> {
         Ok([self.batch.clone()].into_iter())
+    }
+
+    fn schema(&self) -> &SchemaRef {
+        self.batch.schema_ref()
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -113,8 +113,8 @@ impl VectorStore for FlatStorage {
         })
     }
 
-    fn to_batch(&self) -> Result<RecordBatch> {
-        Ok(self.batch.clone())
+    fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch>> {
+        Ok([self.batch.clone()].into_iter())
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -129,7 +129,7 @@ impl VectorStore for FlatStorage {
         self.row_ids.values()
     }
 
-    fn metric_type(&self) -> DistanceType {
+    fn distance_type(&self) -> DistanceType {
         self.distance_type
     }
 

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -500,6 +500,10 @@ impl VectorStore for ProductQuantizationStorage {
         Ok([self.batch.clone().with_schema(schema.into())?].into_iter())
     }
 
+    fn schema(&self) -> &SchemaRef {
+        self.batch.schema_ref()
+    }
+
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -520,6 +520,10 @@ impl VectorStore for ProductQuantizationStorage {
         self.row_ids.values()[id as usize]
     }
 
+    fn row_ids(&self) -> impl Iterator<Item = &u64> {
+        self.row_ids.values().iter()
+    }
+
     fn dist_calculator(&self, query: ArrayRef) -> Self::DistanceCalculator<'_> {
         PQDistCalculator::new(
             self.codebook.values(),

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -508,12 +508,12 @@ impl VectorStore for ProductQuantizationStorage {
         self.batch.num_rows()
     }
 
-    fn row_ids(&self) -> &[u64] {
-        self.row_ids.values()
-    }
-
     fn distance_type(&self) -> DistanceType {
         self.distance_type
+    }
+
+    fn row_id(&self, id: u32) -> u64 {
+        self.row_ids.values()[id as usize]
     }
 
     fn dist_calculator(&self, query: ArrayRef) -> Self::DistanceCalculator<'_> {

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -7,7 +7,6 @@
 
 use std::{cmp::min, collections::HashMap, sync::Arc};
 
-use arrow::compute::concat_batches;
 use arrow_array::{
     cast::AsArray,
     types::{Float32Type, UInt64Type, UInt8Type},
@@ -501,11 +500,8 @@ impl VectorStore for ProductQuantizationStorage {
         Ok([self.batch.clone().with_schema(schema.into())?].into_iter())
     }
 
-    fn append_batch(&self, batch: RecordBatch, _vector_column: &str) -> Result<Self> {
-        let new_batch = concat_batches(&batch.schema(), vec![&self.batch, &batch].into_iter())?;
-        let mut storage = self.clone();
-        storage.batch = new_batch;
-        Ok(storage)
+    fn append_batch(&self, _batch: RecordBatch, _vector_column: &str) -> Result<Self> {
+        unimplemented!()
     }
 
     fn schema(&self) -> &SchemaRef {

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -501,8 +501,7 @@ impl VectorStore for ProductQuantizationStorage {
         Ok([self.batch.clone().with_schema(schema.into())?].into_iter())
     }
 
-    fn append_record_batch(&self, batch: RecordBatch, _vector_column: &str) -> Result<Self> {
-        // TODO: use chunked storage
+    fn append_batch(&self, batch: RecordBatch, _vector_column: &str) -> Result<Self> {
         let new_batch = concat_batches(&batch.schema(), vec![&self.batch, &batch].into_iter())?;
         let mut storage = self.clone();
         storage.batch = new_batch;

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -473,7 +473,7 @@ impl VectorStore for ProductQuantizationStorage {
         })
     }
 
-    fn to_batch(&self) -> Result<RecordBatch> {
+    fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch>> {
         let codebook_fsl = FixedSizeListArray::try_new_from_values(
             self.codebook.as_ref().clone(),
             self.dimension as i32,
@@ -497,7 +497,7 @@ impl VectorStore for ProductQuantizationStorage {
             .as_ref()
             .clone()
             .with_metadata(metadata);
-        Ok(self.batch.clone().with_schema(schema.into())?)
+        Ok([self.batch.clone().with_schema(schema.into())?].into_iter())
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/rust/lance-index/src/vector/quantizer.rs
+++ b/rust/lance-index/src/vector/quantizer.rs
@@ -147,7 +147,7 @@ pub trait QuantizerMetadata: Clone + Sized + DeepSizeOf {
 }
 
 #[async_trait::async_trait]
-pub trait QuantizerStorage: Clone + Sized + DeepSizeOf {
+pub trait QuantizerStorage: Clone + Sized + DeepSizeOf + VectorStore {
     type Metadata: QuantizerMetadata;
 
     async fn load_partition(

--- a/rust/lance-index/src/vector/sq.rs
+++ b/rust/lance-index/src/vector/sq.rs
@@ -15,6 +15,7 @@ use snafu::{location, Location};
 
 pub mod builder;
 pub mod storage;
+pub mod transform;
 
 /// Scalar Quantization, optimized for [Apache Arrow] buffer memory layout.
 ///

--- a/rust/lance-index/src/vector/sq/builder.rs
+++ b/rust/lance-index/src/vector/sq/builder.rs
@@ -9,7 +9,7 @@ use arrow_array::Array;
 
 use arrow_schema::DataType;
 use lance_core::{Error, Result};
-use lance_linalg::distance::MetricType;
+use lance_linalg::distance::DistanceType;
 use snafu::{location, Location};
 
 use super::ScalarQuantizer;
@@ -33,7 +33,7 @@ impl Default for SQBuildParams {
 }
 
 impl SQBuildParams {
-    pub fn build(&self, data: &dyn Array, _: MetricType) -> Result<ScalarQuantizer> {
+    pub fn build(&self, data: &dyn Array, _: DistanceType) -> Result<ScalarQuantizer> {
         let fsl = data.as_fixed_size_list_opt().ok_or(Error::Index {
             message: format!(
                 "SQ builder: input is not a FixedSizeList: {}",

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -305,6 +305,14 @@ impl VectorStore for ScalarQuantizationStorage {
         }))
     }
 
+    fn append_record_batch(&self, batch: RecordBatch, _vector_column: &str) -> Result<Self> {
+        // TODO: use chunked storage
+        let new_batch = concat_batches(&batch.schema(), vec![&self.batch, &batch].into_iter())?;
+        let mut storage = self.clone();
+        storage.batch = new_batch;
+        Ok(self)
+    }
+
     fn schema(&self) -> &SchemaRef {
         self.chunks
             .first_key_value()
@@ -323,7 +331,7 @@ impl VectorStore for ScalarQuantizationStorage {
             .unwrap_or_default()
     }
 
-    /// Return the metric type of the vectors.
+    /// Return the [DistanceType] of the vectors.
     fn distance_type(&self) -> DistanceType {
         self.distance_type
     }

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -276,7 +276,7 @@ impl QuantizerStorage for ScalarQuantizationStorage {
             metadata.num_bits,
             distance_type,
             metadata.bounds.clone(),
-            [batch].into_iter(),
+            [batch],
         )
     }
 }

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -13,7 +13,7 @@ use deepsize::DeepSizeOf;
 use lance_core::{Error, Result, ROW_ID};
 use lance_file::reader::FileReader;
 use lance_io::object_store::ObjectStore;
-use lance_linalg::distance::{l2_distance_uint_scalar, MetricType};
+use lance_linalg::distance::{l2_distance_uint_scalar, DistanceType, MetricType};
 use lance_table::format::SelfDescribingFileReader;
 use object_store::path::Path;
 use serde::{Deserialize, Serialize};
@@ -68,7 +68,7 @@ impl QuantizerMetadata for ScalarQuantizationMetadata {
 
 #[derive(Clone)]
 pub struct ScalarQuantizationStorage {
-    metric_type: MetricType,
+    distance_type: DistanceType,
 
     // Metadata
     num_bits: u16,
@@ -116,7 +116,7 @@ impl ScalarQuantizationStorage {
 
         Ok(Self {
             num_bits,
-            metric_type,
+            distance_type: metric_type,
             bounds,
             batch,
             row_ids,
@@ -129,7 +129,7 @@ impl ScalarQuantizationStorage {
     }
 
     pub fn metric_type(&self) -> MetricType {
-        self.metric_type
+        self.distance_type
     }
 
     pub fn bounds(&self) -> Range<f64> {
@@ -241,7 +241,7 @@ impl VectorStore for ScalarQuantizationStorage {
             .clone();
 
         Ok(Self {
-            metric_type: distance_type,
+            distance_type,
             num_bits: metadata.num_bits,
             bounds: metadata.bounds.clone(),
             batch,
@@ -281,8 +281,8 @@ impl VectorStore for ScalarQuantizationStorage {
     }
 
     /// Return the metric type of the vectors.
-    fn metric_type(&self) -> MetricType {
-        self.metric_type
+    fn distance_type(&self) -> DistanceType {
+        self.distance_type
     }
 
     /// Create a [DistCalculator] to compute the distance between the query.

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -172,7 +172,7 @@ impl DeepSizeOf for ScalarQuantizationStorage {
 }
 
 impl ScalarQuantizationStorage {
-    pub fn new(
+    pub fn try_new(
         num_bits: u16,
         distance_type: DistanceType,
         bounds: Range<f64>,
@@ -249,7 +249,7 @@ impl QuantizerStorage for ScalarQuantizationStorage {
         let schema = reader.schema();
         let batch = reader.read_range(range, schema).await?;
 
-        Self::new(
+        Self::try_new(
             metadata.num_bits,
             distance_type,
             metadata.bounds.clone(),
@@ -278,7 +278,7 @@ impl VectorStore for ScalarQuantizationStorage {
             })?;
         let metadata: ScalarQuantizationMetadata = serde_json::from_str(metadata_json)?;
 
-        Self::new(metadata.num_bits, distance_type, metadata.bounds, batch)
+        Self::try_new(metadata.num_bits, distance_type, metadata.bounds, batch)
     }
 
     fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch>> {
@@ -472,7 +472,7 @@ mod tests {
         let first_batch = create_record_batch(0..100);
 
         let storage =
-            ScalarQuantizationStorage::new(8, DistanceType::L2, -0.7..0.7, first_batch).unwrap();
+            ScalarQuantizationStorage::try_new(8, DistanceType::L2, -0.7..0.7, first_batch).unwrap();
 
         assert_eq!(storage.len(), 100);
 

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -129,8 +129,8 @@ impl SQStorageChunk {
         self.row_ids.len()
     }
 
-    fn schema(&self) -> SchemaRef {
-        self.batch.schema()
+    fn schema(&self) -> &SchemaRef {
+        self.batch.schema_ref()
     }
 
     fn row_id(&self, id: u32) -> u64 {
@@ -308,6 +308,13 @@ impl VectorStore for ScalarQuantizationStorage {
                 .with_schema(schema.clone())
                 .expect("attach schema")
         }))
+    }
+
+    fn schema(&self) -> &SchemaRef {
+        self.chunks
+            .first_key_value()
+            .map(|(_, c)| c.schema())
+            .unwrap()
     }
 
     fn as_any(&self) -> &dyn std::any::Any {

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -495,6 +495,9 @@ mod tests {
         .unwrap();
 
         assert_eq!(storage.len(), 400);
+        let storage =
+            ScalarQuantizationStorage::try_new(8, DistanceType::L2, -0.7..0.7, first_batch)
+                .unwrap();
 
         let (offset, chunk) = storage.chunk(0);
         assert_eq!(offset, 0);

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -414,3 +414,13 @@ impl<'a> DistCalculator for SQDistCalculator<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_chunks() {
+        
+    }
+}

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -338,6 +338,10 @@ impl VectorStore for ScalarQuantizationStorage {
         chunk.row_id(id - offset)
     }
 
+    fn row_ids(&self) -> impl Iterator<Item = &u64> {
+        self.chunks.values().flat_map(|c| c.row_ids.values())
+    }
+
     /// Create a [DistCalculator] to compute the distance between the query.
     ///
     /// Using dist calcualtor can be more efficient as it can pre-compute some

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -463,7 +463,7 @@ mod tests {
         const DIM: usize = 64;
 
         let mut rng = rand::thread_rng();
-        let row_ids = UInt64Array::from_iter_values(row_ids.clone().into_iter());
+        let row_ids = UInt64Array::from_iter_values(row_ids.clone());
         let sq_code =
             UInt8Array::from_iter_values(repeat_with(|| rng.gen::<u8>()).take(row_ids.len() * DIM));
         let code_arr = FixedSizeListArray::try_new_from_values(sq_code, DIM as i32).unwrap();

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -139,7 +139,7 @@ impl SQStorageChunk {
     /// Get a slice of SQ code for id
     #[inline]
     fn sq_code_slice(&self, id: u32) -> &[u8] {
-        assert!(id < self.len() as u32);
+        // assert!(id < self.len() as u32);
         &self.sq_codes.values()[id as usize * self.dim..(id + 1) as usize * self.dim]
     }
 }
@@ -204,7 +204,6 @@ impl ScalarQuantizationStorage {
     ///
     /// We did not check out of range in this call. But the out of range will
     /// panic once you access the data in the last [SQStorageChunk].
-    #[inline]
     fn chunk(&self, id: u32) -> (u32, &SQStorageChunk) {
         match self.offsets.binary_search(&id) {
             Ok(o) => (self.offsets[o], &self.chunks[o]),
@@ -437,7 +436,7 @@ impl<'a> DistCalculator for SQDistCalculator<'a> {
 
             unsafe {
                 // Loop over the sq_code to prefetch each cache line
-                for offset in (0..self.dim).step_by(CACHE_LINE_SIZE) {
+                for offset in (0..dim).step_by(CACHE_LINE_SIZE) {
                     {
                         use core::arch::x86_64::{_mm_prefetch, _MM_HINT_T0};
                         _mm_prefetch(base_ptr.add(offset) as *const i8, _MM_HINT_T0);

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -495,9 +495,6 @@ mod tests {
         .unwrap();
 
         assert_eq!(storage.len(), 400);
-        let storage =
-            ScalarQuantizationStorage::try_new(8, DistanceType::L2, -0.7..0.7, first_batch)
-                .unwrap();
 
         let (offset, chunk) = storage.chunk(0);
         assert_eq!(offset, 0);

--- a/rust/lance-index/src/vector/v3/storage.rs
+++ b/rust/lance-index/src/vector/v3/storage.rs
@@ -66,7 +66,7 @@ pub trait VectorStore: Send + Sync + Sized {
 
     /// Append Raw [RecordBatch] into the Storage.
     /// The storage implement will perform quantization if necessary.
-    fn append_record_batch(&self, batch: RecordBatch, vector_column: &str) -> Result<Self>;
+    fn append_batch(&self, batch: RecordBatch, vector_column: &str) -> Result<Self>;
 
     /// Create a [DistCalculator] to compute the distance between the query.
     ///

--- a/rust/lance-index/src/vector/v3/storage.rs
+++ b/rust/lance-index/src/vector/v3/storage.rs
@@ -13,7 +13,11 @@ use snafu::{location, Location};
 
 use crate::vector::quantizer::Quantization;
 
-/// WARNING: Internal API,  API stability is not guaranteed
+/// <section class="warning">
+///  Internal API
+///
+///  API stability is not guaranteed
+/// </section>
 pub trait DistCalculator {
     fn distance(&self, id: u32) -> f32;
     fn prefetch(&self, _id: u32) {}

--- a/rust/lance-index/src/vector/v3/storage.rs
+++ b/rust/lance-index/src/vector/v3/storage.rs
@@ -4,7 +4,7 @@
 use std::any::Any;
 
 use arrow_array::{ArrayRef, RecordBatch};
-use arrow_schema::Field;
+use arrow_schema::{Field, SchemaRef};
 use lance_arrow::RecordBatchExt;
 use lance_core::{Error, Result};
 use lance_linalg::distance::DistanceType;
@@ -40,6 +40,8 @@ pub trait VectorStore: Send + Sync {
     fn try_from_batch(batch: RecordBatch, distance_type: DistanceType) -> Result<Self>
     where
         Self: Sized;
+
+    fn schema(&self) -> &SchemaRef;
 
     fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch>>;
 

--- a/rust/lance-index/src/vector/v3/storage.rs
+++ b/rust/lance-index/src/vector/v3/storage.rs
@@ -7,7 +7,7 @@ use arrow_array::{ArrayRef, RecordBatch};
 use arrow_schema::Field;
 use lance_arrow::RecordBatchExt;
 use lance_core::{Error, Result};
-use lance_linalg::distance::{DistanceType, MetricType};
+use lance_linalg::distance::DistanceType;
 use num_traits::Num;
 use snafu::{location, Location};
 
@@ -50,8 +50,8 @@ pub trait VectorStore: Send + Sync {
 
     fn row_ids(&self) -> &[u64];
 
-    /// Return the metric type of the vectors.
-    fn metric_type(&self) -> MetricType;
+    /// Return [DistanceType].
+    fn distance_type(&self) -> DistanceType;
 
     /// Create a [DistCalculator] to compute the distance between the query.
     ///

--- a/rust/lance-index/src/vector/v3/storage.rs
+++ b/rust/lance-index/src/vector/v3/storage.rs
@@ -37,7 +37,7 @@ pub trait VectorStore: Send + Sync {
     where
         Self: Sized;
 
-    fn to_batch(&self) -> Result<RecordBatch>;
+    fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch>>;
 
     fn as_any(&self) -> &dyn Any;
 

--- a/rust/lance-index/src/vector/v3/storage.rs
+++ b/rust/lance-index/src/vector/v3/storage.rs
@@ -45,11 +45,11 @@ pub trait VectorStore: Send + Sync {
     where
         Self: Sized;
 
+    fn as_any(&self) -> &dyn Any;
+
     fn schema(&self) -> &SchemaRef;
 
     fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch>>;
-
-    fn as_any(&self) -> &dyn Any;
 
     fn len(&self) -> usize;
 

--- a/rust/lance-index/src/vector/v3/storage.rs
+++ b/rust/lance-index/src/vector/v3/storage.rs
@@ -60,6 +60,8 @@ pub trait VectorStore: Send + Sync {
     /// Get the lance ROW ID from one vector.
     fn row_id(&self, id: u32) -> u64;
 
+    fn row_ids(&self) -> impl Iterator<Item = &u64>;
+
     /// Create a [DistCalculator] to compute the distance between the query.
     ///
     /// Using dist calcualtor can be more efficient as it can pre-compute some

--- a/rust/lance-index/src/vector/v3/storage.rs
+++ b/rust/lance-index/src/vector/v3/storage.rs
@@ -27,7 +27,11 @@ pub trait DistCalculator {
 ///
 /// TODO: should we rename this to "VectorDistance"?;
 ///
-/// WARNING: Internal API,  API stability is not guaranteed
+/// <section class="warning">
+///  Internal API
+///
+///  API stability is not guaranteed
+/// </section>
 pub trait VectorStore: Send + Sync {
     type DistanceCalculator<'a>: DistCalculator
     where
@@ -48,10 +52,11 @@ pub trait VectorStore: Send + Sync {
         self.len() == 0
     }
 
-    fn row_ids(&self) -> &[u64];
-
     /// Return [DistanceType].
     fn distance_type(&self) -> DistanceType;
+
+    /// Get the lance ROW ID from one vector.
+    fn row_id(&self, id: u32) -> u64;
 
     /// Create a [DistCalculator] to compute the distance between the query.
     ///

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -190,7 +190,7 @@ impl PreFilter for DatasetPreFilter {
     ///
     /// This method must be called after `wait_for_ready`
     #[instrument(level = "debug", skip_all)]
-    fn filter_row_ids(&self, row_ids: &[u64]) -> Vec<u64> {
+    fn filter_row_ids<'a>(&self, row_ids: impl Iterator<Item = &'a u64> + 'a) -> Vec<u64> {
         let final_mask = self.final_mask.lock().unwrap();
         final_mask
             .get()

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -190,7 +190,7 @@ impl PreFilter for DatasetPreFilter {
     ///
     /// This method must be called after `wait_for_ready`
     #[instrument(level = "debug", skip_all)]
-    fn filter_row_ids<'a>(&self, row_ids: impl Iterator<Item = &'a u64> + 'a) -> Vec<u64> {
+    fn filter_row_ids<'a>(&self, row_ids: Box<dyn Iterator<Item = &'a u64> + 'a>) -> Vec<u64> {
         let final_mask = self.final_mask.lock().unwrap();
         final_mask
             .get()

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -190,7 +190,7 @@ impl PreFilter for DatasetPreFilter {
     ///
     /// This method must be called after `wait_for_ready`
     #[instrument(level = "debug", skip_all)]
-    pub fn filter_row_ids<'a>(&self, row_ids: impl Iterator<Item = &'a u64> + 'a) -> Vec<u64> {
+    fn filter_row_ids(&self, row_ids: &[u64]) -> Vec<u64> {
         let final_mask = self.final_mask.lock().unwrap();
         final_mask
             .get()

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -190,7 +190,7 @@ impl PreFilter for DatasetPreFilter {
     ///
     /// This method must be called after `wait_for_ready`
     #[instrument(level = "debug", skip_all)]
-    fn filter_row_ids(&self, row_ids: &[u64]) -> Vec<u64> {
+    pub fn filter_row_ids<'a>(&self, row_ids: impl Iterator<Item = &'a u64> + 'a) -> Vec<u64> {
         let final_mask = self.final_mask.lock().unwrap();
         final_mask
             .get()

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -193,14 +193,15 @@ impl<S: IvfSubIndex, Q: Quantization + Clone> IvfIndexBuilder<S, Q> {
         .build(batch)?;
         let path = self.temp_dir.child(format!("storage_part{}", part_id));
         let writer = object_store.create(&path).await?;
-        let storage_batch = storage.to_batch()?;
         let mut writer = FileWriter::try_new(
             writer,
             path.to_string(),
-            storage_batch.schema_ref().as_ref().try_into()?,
+            storage.schema().as_ref().try_into()?,
             Default::default(),
         )?;
-        writer.write_batch(&storage_batch).await?;
+        for batch in storage.to_batches()? {
+            writer.write_batch(&batch).await?;
+        }
         let storage_len = writer.finish().await? as usize;
 
         // build the sub index, with in-memory storage

--- a/rust/lance/src/index/vector/fixture_test.rs
+++ b/rust/lance/src/index/vector/fixture_test.rs
@@ -114,7 +114,7 @@ mod test {
             Ok(Box::new(self.clone()))
         }
 
-        fn row_ids(&self) -> &[u64] {
+        fn row_ids(&self) -> Box<dyn Iterator<Item = &u64>> {
             todo!("this method is for only IVF_HNSW_* index");
         }
 

--- a/rust/lance/src/index/vector/hnsw.rs
+++ b/rust/lance/src/index/vector/hnsw.rs
@@ -171,7 +171,7 @@ impl<Q: Quantization + Send + Sync + 'static> VectorIndex for HNSWIndex<Q> {
         } else {
             pre_filter.wait_for_ready().await?;
 
-            let indices = pre_filter.filter_row_ids(storage.row_ids());
+            let indices = pre_filter.filter_row_ids(Box::new(storage.row_ids()));
             Some(
                 RoaringBitmap::from_sorted_iter(indices.into_iter().map(|i| i as u32)).map_err(
                     |e| Error::Index {

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -738,7 +738,7 @@ impl VectorIndex for IVFIndex {
         })
     }
 
-    fn row_ids(&self) -> &[u64] {
+    fn row_ids(&self) -> Box<dyn Iterator<Item = &u64>> {
         todo!("this method is for only IVF_HNSW_* index");
     }
 

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -24,8 +24,11 @@ use lance_index::vector::hnsw::builder::HNSW_METADATA_KEY;
 use lance_index::vector::hnsw::{builder::HnswBuildParams, HnswMetadata};
 use lance_index::vector::ivf::storage::IvfData;
 use lance_index::vector::pq::ProductQuantizer;
-use lance_index::vector::quantizer::{Quantization as _, Quantizer};
-use lance_index::vector::sq::ScalarQuantizer;
+use lance_index::vector::{
+    quantizer::{Quantization, Quantizer},
+    sq::ScalarQuantizer,
+    v3::storage::VectorStore,
+};
 use lance_index::vector::{PART_ID_COLUMN, PQ_CODE_COLUMN};
 use lance_io::encodings::plain::PlainEncoder;
 use lance_io::object_store::ObjectStore;
@@ -550,7 +553,9 @@ async fn build_and_write_sq_storage(
     })
     .await?;
 
-    writer.write_record_batch(storage.batch().clone()).await?;
+    for batch in storage.to_batches()? {
+        writer.write_record_batch(batch.clone()).await?;
+    }
     writer.finish().await?;
     Ok(())
 }

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -31,7 +31,7 @@ use lance_io::encodings::plain::PlainEncoder;
 use lance_io::object_store::ObjectStore;
 use lance_io::traits::Writer;
 use lance_io::ReadBatchParams;
-use lance_linalg::distance::MetricType;
+use lance_linalg::distance::{DistanceType, MetricType};
 use lance_linalg::kernels::normalize_fsl;
 use lance_table::format::SelfDescribingFileReader;
 use lance_table::io::manifest::ManifestDescribing;
@@ -538,14 +538,14 @@ async fn build_and_write_pq_storage(
 }
 
 async fn build_and_write_sq_storage(
-    metric_type: MetricType,
+    distance_type: DistanceType,
     row_ids: Arc<dyn Array>,
     vectors: Arc<dyn Array>,
     sq: ScalarQuantizer,
     mut writer: FileWriter<ManifestDescribing>,
 ) -> Result<()> {
     let storage = spawn_cpu(move || {
-        let storage = build_sq_storage(metric_type, row_ids, vectors, sq)?;
+        let storage = build_sq_storage(distance_type, row_ids, vectors, sq)?;
         Ok(storage)
     })
     .await?;

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -311,9 +311,7 @@ pub(super) async fn write_hnsw_quantization_index_partitions(
         if let Some(&previous_indices) = existing_indices.as_ref() {
             for &idx in previous_indices.iter() {
                 let sub_index = idx.load_partition(part_id, true).await?;
-                let row_ids = Arc::new(UInt64Array::from_iter_values(
-                    sub_index.row_ids().iter().cloned(),
-                ));
+                let row_ids = Arc::new(UInt64Array::from_iter_values(sub_index.row_ids().cloned()));
                 row_id_array.push(row_ids);
             }
         }

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -106,7 +106,7 @@ impl PQIndex {
         row_ids: Arc<UInt64Array>,
         num_sub_vectors: i32,
     ) -> Result<(Arc<UInt8Array>, Arc<UInt64Array>)> {
-        let indices_to_keep = pre_filter.filter_row_ids(row_ids.values());
+        let indices_to_keep = pre_filter.filter_row_ids(row_ids.values().iter());
         let indices_to_keep = UInt64Array::from(indices_to_keep);
 
         let row_ids = take(row_ids.as_ref(), &indices_to_keep, None)?;
@@ -254,7 +254,7 @@ impl VectorIndex for PQIndex {
         }))
     }
 
-    fn row_ids(&self) -> &[u64] {
+    fn row_ids(&self) -> Box<dyn Iterator<Item = &u64>> {
         todo!("this method is for only IVF_HNSW_* index");
     }
 

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -106,7 +106,7 @@ impl PQIndex {
         row_ids: Arc<UInt64Array>,
         num_sub_vectors: i32,
     ) -> Result<(Arc<UInt8Array>, Arc<UInt64Array>)> {
-        let indices_to_keep = pre_filter.filter_row_ids(row_ids.values().iter());
+        let indices_to_keep = pre_filter.filter_row_ids(Box::new(row_ids.values().iter()));
         let indices_to_keep = UInt64Array::from(indices_to_keep);
 
         let row_ids = take(row_ids.as_ref(), &indices_to_keep, None)?;

--- a/rust/lance/src/index/vector/sq.rs
+++ b/rust/lance/src/index/vector/sq.rs
@@ -64,11 +64,12 @@ pub fn build_sq_storage(
     let code_column = sq.transform::<Float32Type>(vectors.as_ref())?;
     std::mem::drop(vectors);
 
-    let pq_batch = RecordBatch::try_from_iter_with_nullable(vec![
+    let batch = RecordBatch::try_from_iter_with_nullable(vec![
         (ROW_ID, row_ids, true),
         (sq.column(), code_column, false),
     ])?;
-    let store = ScalarQuantizationStorage::new(sq.num_bits(), metric_type, sq.bounds(), pq_batch)?;
+    let store =
+        ScalarQuantizationStorage::try_new(sq.num_bits(), metric_type, sq.bounds(), [batch])?;
 
     Ok(store)
 }

--- a/rust/lance/src/session/index_extension.rs
+++ b/rust/lance/src/session/index_extension.rs
@@ -140,7 +140,7 @@ mod test {
             todo!("panic")
         }
 
-        fn row_ids(&self) -> &[u64] {
+        fn row_ids(&self) -> Box<dyn Iterator<Item = &u64>> {
             todo!("panic")
         }
 


### PR DESCRIPTION
* Use chunked storage for `ScalarQuantizationStorage`, so that we can append new values cheaply. 
* It does auto-compaction after a hard-code threshold is met.