### PR TITLE
fix: incorrect chunking was making lance datasets use too much RAM

### DIFF
--- a/rust/lance-datafusion/Cargo.toml
+++ b/rust/lance-datafusion/Cargo.toml
@@ -30,6 +30,7 @@ tokio.workspace = true
 
 [dev-dependencies]
 substrait-expr = { version = "0.2.1" }
+lance-datagen.workspace = true
 
 [features]
 substrait = ["dep:datafusion-substrait"]

--- a/rust/lance-datafusion/src/chunker.rs
+++ b/rust/lance-datafusion/src/chunker.rs
@@ -104,6 +104,63 @@ impl BatchReaderChunker {
     }
 }
 
+struct BreakStreamState {
+    max_rows: usize,
+    rows_seen: usize,
+    rows_remaining: usize,
+    batch: Option<RecordBatch>,
+}
+
+impl BreakStreamState {
+    fn next(mut self) -> Option<(Result<RecordBatch>, Self)> {
+        if self.rows_remaining == 0 {
+            return None;
+        }
+        if self.rows_remaining + self.rows_seen <= self.max_rows {
+            self.rows_seen = (self.rows_seen + self.rows_remaining) % self.max_rows;
+            self.rows_remaining = 0;
+            let next = self.batch.take().unwrap();
+            Some((Ok(next), self))
+        } else {
+            let rows_to_emit = self.max_rows - self.rows_seen;
+            self.rows_seen = 0;
+            self.rows_remaining -= rows_to_emit;
+            let batch = self.batch.as_mut().unwrap();
+            let next = batch.slice(0, rows_to_emit);
+            *batch = batch.slice(rows_to_emit, batch.num_rows() - rows_to_emit);
+            Some((Ok(next), self))
+        }
+    }
+}
+
+// Given a stream of record batches, and a desired break point, this will
+// make sure that a new record batch is emitted every time `break_point` rows
+// have passed.
+//
+// This method will not combine record batches in any way.  For example, if
+// the input lengths are [3, 5, 8, 3, 5], and the break point is 10 then the
+// output batches will be [3, 5, 2 (break inserted) 6, 3, 1 (break inserted) 4]
+pub fn break_stream(
+    stream: SendableRecordBatchStream,
+    max_chunk_size: usize,
+) -> Pin<Box<dyn Stream<Item = Result<RecordBatch>> + Send>> {
+    let mut rows_already_seen = 0;
+    stream
+        .map_ok(move |batch| {
+            let state = BreakStreamState {
+                rows_remaining: batch.num_rows(),
+                max_rows: max_chunk_size,
+                rows_seen: rows_already_seen,
+                batch: Some(batch),
+            };
+            rows_already_seen = (state.rows_seen + state.rows_remaining) % state.max_rows;
+
+            futures::stream::unfold(state, move |state| std::future::ready(state.next())).boxed()
+        })
+        .try_flatten()
+        .boxed()
+}
+
 pub fn chunk_stream(
     stream: SendableRecordBatchStream,
     chunk_size: usize,
@@ -137,4 +194,76 @@ pub fn chunk_concat_stream(
         .map_err(DataFusionError::from)
         .boxed();
     Box::pin(RecordBatchStreamAdapter::new(schema_copy, chunk_concat))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::datatypes::Int32Type;
+    use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+    use futures::{StreamExt, TryStreamExt};
+    use lance_datagen::RowCount;
+
+    #[tokio::test]
+    async fn test_chunkers() {
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("", arrow::datatypes::DataType::Int32, false),
+        ]));
+
+        let make_batch = |num_rows: u32| {
+            lance_datagen::gen()
+                .anon_col(lance_datagen::array::step::<Int32Type>())
+                .into_batch_rows(RowCount::from(num_rows as u64))
+                .unwrap()
+        };
+
+        let batches = vec![make_batch(10), make_batch(5), make_batch(13), make_batch(0)];
+
+        let make_stream = || {
+            let stream = futures::stream::iter(
+                batches
+                    .clone()
+                    .into_iter()
+                    .map(datafusion_common::Result::Ok),
+            )
+            .boxed();
+            Box::pin(RecordBatchStreamAdapter::new(schema.clone(), stream))
+        };
+
+        let chunked = super::chunk_stream(make_stream(), 10)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(chunked.len(), 3);
+        assert_eq!(chunked[0].len(), 1);
+        assert_eq!(chunked[0][0].num_rows(), 10);
+        assert_eq!(chunked[1].len(), 2);
+        assert_eq!(chunked[1][0].num_rows(), 5);
+        assert_eq!(chunked[1][1].num_rows(), 5);
+        assert_eq!(chunked[2].len(), 1);
+        assert_eq!(chunked[2][0].num_rows(), 8);
+
+        let chunked = super::chunk_concat_stream(make_stream(), 10)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(chunked.len(), 3);
+        assert_eq!(chunked[0].num_rows(), 10);
+        assert_eq!(chunked[1].num_rows(), 10);
+        assert_eq!(chunked[2].num_rows(), 8);
+
+        let chunked = super::break_stream(make_stream(), 10)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(chunked.len(), 4);
+        assert_eq!(chunked[0].num_rows(), 10);
+        assert_eq!(chunked[1].num_rows(), 5);
+        assert_eq!(chunked[2].num_rows(), 5);
+        assert_eq!(chunked[3].num_rows(), 8);
+    }
 }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 
 use arrow_array::{RecordBatch, RecordBatchReader};
 use datafusion::physical_plan::SendableRecordBatchStream;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use lance_core::{datatypes::Schema, Error, Result};
-use lance_datafusion::chunker::chunk_stream;
+use lance_datafusion::chunker::{break_stream, chunk_stream};
 use lance_datafusion::utils::{peek_reader_schema, reader_to_stream};
 use lance_file::format::{MAJOR_VERSION, MINOR_VERSION_NEXT};
 use lance_file::v2;
@@ -218,9 +218,11 @@ pub async fn write_fragments_internal(
     let mut buffered_reader = if params.use_legacy_format {
         chunk_stream(data, params.max_rows_per_group)
     } else {
-        // In v2 we don't care about group size but we do want to chunk
-        // by max_rows_per_file
-        chunk_stream(data, params.max_rows_per_file)
+        // In v2 we don't care about group size but we do want to break
+        // the stream on file boundaries
+        break_stream(data, params.max_rows_per_file)
+            .map_ok(|batch| vec![batch])
+            .boxed()
     };
 
     let writer_generator =


### PR DESCRIPTION
In the v2 write path it was chunking to make sure that we don't put more than `max_rows_per_file` rows into any file.  However, this also became a point of accumulation.  This PR removes that accumulation but still inserts the breaks for `max_rows_per_file`.