### PR TITLE
feat: scan with stable row id

### DIFF
--- a/docs/read_and_write.rst
+++ b/docs/read_and_write.rst
@@ -469,10 +469,11 @@ During compaction, Lance can also remove deleted rows. Rewritten fragments will
 not have deletion files. This can improve scan performance since the soft deleted
 rows don't have to be skipped during the scan.
 
-When files are rewritten, the original row ids are invalidated. This means the
+When files are rewritten, the original row addresses are invalidated. This means the
 affected files are no longer part of any ANN index if they were before. Because
 of this, it's recommended to rewrite files before re-building indices.
 
+.. TODO: remove this last comment once move-stable row ids are default.
 
 Object Store Configuration
 --------------------------

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -272,14 +272,14 @@ message DataFile {
 // where {extension} is `.arrow` or `.bin` depending on the type of deletion.
 message DeletionFile {
   // Type of deletion file, which varies depending on what is the most efficient
-  // way to store the deleted row ids. If none, then will be unspecified. If there are
+  // way to store the deleted row offsets. If none, then will be unspecified. If there are
   // sparsely deleted rows, then ARROW_ARRAY is the most efficient. If there are
   // densely deleted rows, then BIT_MAP is the most efficient.
   enum DeletionFileType {
-    // Deletion file is a single Int32Array of deleted row ids. This is stored as
+    // Deletion file is a single Int32Array of deleted row offsets. This is stored as
     // an Arrow IPC file with one batch and one column. Has a .arrow extension.
     ARROW_ARRAY = 0;
-    // Deletion file is a Roaring Bitmap of deleted row ids. Has a .bin extension.
+    // Deletion file is a Roaring Bitmap of deleted row offsets. Has a .bin extension.
     BITMAP = 1;
   }
 

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -399,7 +399,7 @@ class LanceDataset(pa.dataset.Dataset):
         prefilter: bool, default False
             Run filter before the vector search.
         with_row_id: bool, default False
-            Return physical row ID.
+            Return row ID.
         use_stats: bool, default True
             Use stats pushdown during filters.
 
@@ -2046,7 +2046,7 @@ class ScannerBuilder:
         return self
 
     def with_row_id(self, with_row_id: bool = True) -> ScannerBuilder:
-        """Enable returns with physical row IDs."""
+        """Enable returns with row IDs."""
         self._with_row_id = with_row_id
         return self
 

--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -456,7 +456,6 @@ impl RecordBatchExt for RecordBatch {
     }
 
     fn project_by_schema(&self, schema: &Schema) -> Result<Self> {
-        // TODO: test can project by empty schema
         let struct_array: StructArray = self.clone().into();
         self.try_new_from_struct_array(project(&struct_array, schema.fields())?)
     }

--- a/rust/lance-core/src/lib.rs
+++ b/rust/lance-core/src/lib.rs
@@ -12,9 +12,14 @@ pub use error::{Error, Result};
 
 /// Column name for the meta row ID.
 pub const ROW_ID: &str = "_rowid";
+/// Column name for the meta row address.
+pub const ROW_ADDR: &str = "_rowaddr";
 
 lazy_static::lazy_static! {
     /// Row ID field. This is nullable because its validity bitmap is sometimes used
     /// as a selection vector.
     pub static ref ROW_ID_FIELD: ArrowField = ArrowField::new(ROW_ID, DataType::UInt64, true);
+    /// Row address field. This is nullable because its validity bitmap is sometimes used
+    /// as a selection vector.
+    pub static ref ROW_ADDR_FIELD: ArrowField = ArrowField::new(ROW_ADDR, DataType::UInt64, true);
 }

--- a/rust/lance-core/src/utils/deletion.rs
+++ b/rust/lance-core/src/utils/deletion.rs
@@ -11,7 +11,7 @@ use roaring::RoaringBitmap;
 const BITMAP_THRESDHOLD: usize = 5_000;
 // TODO: Benchmark to find a better value.
 
-/// Represents a set of deleted row ids in a single fragment.
+/// Represents a set of deleted row offsets in a single fragment.
 #[derive(Debug, Clone)]
 pub enum DeletionVector {
     NoDeletions,

--- a/rust/lance-table/benches/row_id_index.rs
+++ b/rust/lance-table/benches/row_id_index.rs
@@ -16,7 +16,7 @@
 // How can I write out the file? Where should I put it?
 // How can I take a argument to set the size of the index?
 
-use std::{collections::HashMap, io::Write, ops::Range};
+use std::{collections::HashMap, io::Write, ops::Range, sync::Arc};
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
@@ -41,7 +41,7 @@ fn make_frag_sequences(
     num_rows: u64,
     num_frags: u64,
     percent_deletion: f32,
-) -> Vec<(u32, RowIdSequence)> {
+) -> Vec<(u32, Arc<RowIdSequence>)> {
     let rows_per_frag = num_rows / num_frags;
     let mut start = 0;
     (0..num_frags)
@@ -51,7 +51,7 @@ fn make_frag_sequences(
                 (rows_per_frag as f32 * percent_deletion) as usize,
             );
             start += rows_per_frag;
-            (i as u32, sequence)
+            (i as u32, Arc::new(sequence))
         })
         .collect()
 }

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -214,7 +214,7 @@ pub struct Fragment {
     /// Files within the fragment.
     pub files: Vec<DataFile>,
 
-    /// Optional file with deleted row ids.
+    /// Optional file with deleted local row offsets.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deletion_file: Option<DeletionFile>,
 

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -252,6 +252,11 @@ impl Manifest {
 
         fragments
     }
+
+    /// Whether the dataset uses move-stable row ids.
+    pub fn uses_move_stable_row_ids(&self) -> bool {
+        self.reader_feature_flags & FLAG_MOVE_STABLE_ROW_IDS != 0
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -25,9 +25,15 @@ mod serde;
 use deepsize::DeepSizeOf;
 // These are the public API.
 pub use index::RowIdIndex;
+use lance_core::{Error, Result};
+use lance_io::ReadBatchParams;
 pub use serde::{read_row_ids, write_row_ids};
 
+use snafu::{location, Location};
+
 use segment::U64Segment;
+
+use crate::utils::LanceIteratorExtension;
 
 /// A sequence of row ids.
 ///
@@ -41,7 +47,7 @@ use segment::U64Segment;
 /// contiguous or sorted.
 ///
 /// We can make optimizations that assume uniqueness.
-#[derive(Debug, Clone, DeepSizeOf)]
+#[derive(Debug, Clone, DeepSizeOf, PartialEq, Eq)]
 pub struct RowIdSequence(Vec<U64Segment>);
 
 impl std::fmt::Display for RowIdSequence {
@@ -148,7 +154,7 @@ impl RowIdSequence {
 
     /// Find the row ids in the sequence.
     ///
-    /// Returns the row ids sorted by their appearane in the sequence.
+    /// Returns the row ids sorted by their appearance in the sequence.
     /// Also returns the segment index and the range where that segment's
     /// row id matches are found in the returned row id vector.
     fn find_ids(
@@ -205,6 +211,210 @@ impl RowIdSequence {
             .collect();
 
         (row_ids, segment_ranges)
+    }
+
+    pub fn slice(&self, offset: usize, len: usize) -> RowIdSeqSlice<'_> {
+        // Find the starting position
+        let mut offset_start = offset;
+        let mut segment_offset = 0;
+        for segment in &self.0 {
+            let segment_len = segment.len();
+            if offset_start < segment_len {
+                break;
+            }
+            offset_start -= segment_len;
+            segment_offset += 1;
+        }
+
+        // Find the ending position
+        let mut offset_last = offset_start + len;
+        let segment_offset_last = segment_offset;
+        for segment in &self.0[segment_offset..] {
+            let segment_len = segment.len();
+            if offset_last <= segment_len {
+                break;
+            }
+            offset_last -= segment_len;
+        }
+
+        RowIdSeqSlice {
+            segments: &self.0[segment_offset..=segment_offset_last],
+            offset_start,
+            offset_last,
+        }
+    }
+
+    pub fn get(&self, index: usize) -> Option<u64> {
+        let mut offset = 0;
+        for segment in &self.0 {
+            let segment_len = segment.len();
+            if index < offset + segment_len {
+                return segment.get(index - offset);
+            }
+            offset += segment_len;
+        }
+        None
+    }
+}
+
+pub struct RowIdSeqSlice<'a> {
+    /// Current slice of the segments we cover
+    segments: &'a [U64Segment],
+    /// Offset into the first segment to start iterating from
+    offset_start: usize,
+    /// Offset into the last segment to stop iterating at
+    offset_last: usize,
+}
+
+impl<'a> RowIdSeqSlice<'a> {
+    pub fn iter(&self) -> impl Iterator<Item = u64> + '_ {
+        let mut known_size = self.segments.iter().map(|segment| segment.len()).sum();
+        known_size -= self.offset_start;
+        known_size -= self.segments.last().unwrap().len() - self.offset_last;
+
+        self.segments
+            .iter()
+            .enumerate()
+            .flat_map(move |(i, segment)| {
+                match i {
+                    0 if self.segments.len() == 1 => {
+                        let len = self.offset_last - self.offset_start;
+                        // TODO: Optimize this so we don't have to use skip
+                        // (take is probably fine though.)
+                        Box::new(segment.iter().skip(self.offset_start).take(len))
+                            as Box<dyn Iterator<Item = u64>>
+                    }
+                    0 => Box::new(segment.iter().skip(self.offset_start)),
+                    1 => Box::new(segment.iter().take(self.offset_last)),
+                    _ => Box::new(segment.iter()),
+                }
+            })
+            // TODO: unit test iteration and size hint
+            .exact_size(known_size)
+    }
+}
+
+
+/// Re-chunk a sequences of row ids into chunks of a given size.
+///
+/// # Errors
+///
+/// Will return an error if the sum of the chunk sizes is not equal to the total
+/// number of row ids in the sequences.
+pub fn rechunk_sequences(
+    sequences: impl IntoIterator<Item = RowIdSequence>,
+    chunk_sizes: impl IntoIterator<Item = u64>,
+) -> Result<Vec<RowIdSequence>> {
+    // TODO: return an iterator. (with a good size hint?)
+    let chunk_size_iter = chunk_sizes.into_iter();
+    let mut chunked_sequences = Vec::with_capacity(chunk_size_iter.size_hint().0);
+    let mut segment_iter = sequences
+        .into_iter()
+        .flat_map(|sequence| sequence.0.into_iter())
+        .peekable();
+
+    let mut segment_offset = 0_u64;
+    for chunk_size in chunk_size_iter {
+        let mut sequence = RowIdSequence(Vec::new());
+        let mut remaining = chunk_size;
+
+        let too_many_segments_error = || {
+            Error::invalid_input(
+                "Got too many segments for the provided chunk lengths",
+                location!(),
+            )
+        };
+
+        while remaining > 0 {
+            let remaining_in_segment = segment_iter
+                .peek()
+                .map_or(0, |segment| segment.len() as u64 - segment_offset);
+            use std::cmp::Ordering::*;
+            match (remaining_in_segment.cmp(&remaining), remaining_in_segment) {
+                (Greater, _) => {
+                    // Can only push part of the segment, we are done with this chunk.
+                    let segment = segment_iter
+                        .peek()
+                        .ok_or_else(too_many_segments_error)?
+                        .slice(segment_offset as usize, remaining as usize);
+                    sequence.extend(RowIdSequence(vec![segment]));
+                    segment_offset += remaining;
+                    remaining = 0;
+                }
+                (_, 0) => {
+                    // Can push the entire segment.
+                    let segment = segment_iter.next().ok_or_else(too_many_segments_error)?;
+                    sequence.extend(RowIdSequence(vec![segment]));
+                    remaining = 0;
+                }
+                (_, _) => {
+                    // Push remaining segment
+                    let segment = segment_iter
+                        .next()
+                        .ok_or_else(too_many_segments_error)?
+                        .slice(segment_offset as usize, remaining_in_segment as usize);
+                    sequence.extend(RowIdSequence(vec![segment]));
+                    segment_offset = 0;
+                    remaining -= remaining_in_segment;
+                }
+            }
+        }
+
+        chunked_sequences.push(sequence);
+    }
+
+    if segment_iter.peek().is_some() {
+        return Err(Error::invalid_input(
+            "Got too few segments for the provided chunk lengths",
+            location!(),
+        ));
+    }
+
+    Ok(chunked_sequences)
+}
+
+/// Selects the row ids from a sequence based on the provided offsets.
+pub fn select_row_ids<'a>(
+    sequence: &'a RowIdSequence,
+    offsets: &'a ReadBatchParams,
+) -> Result<Vec<u64>> {
+    match offsets {
+        ReadBatchParams::Indices(indices) => indices
+            .values()
+            .iter()
+            .map(|index| {
+                sequence.get(*index as usize).ok_or_else(|| {
+                    Error::invalid_input(
+                        format!(
+                            "Index out of bounds: {} for sequence of length {}",
+                            index,
+                            sequence.len()
+                        ),
+                        location!(),
+                    )
+                })
+            })
+            .collect(),
+        ReadBatchParams::Range(range) => {
+            let sequence = sequence.slice(
+                range.start,
+                range.end - range.start,
+            );
+            Ok(sequence.iter().collect())
+        }
+        ReadBatchParams::RangeFull => Ok(sequence.iter().collect()),
+        ReadBatchParams::RangeTo(to) => {
+            let len = to.end;
+            let sequence = sequence.slice(0, len);
+            Ok(sequence.iter().collect())
+        }
+        ReadBatchParams::RangeFrom(from) => {
+            let sequence = sequence.slice(
+                from.start,
+                sequence.len() as usize - from.start,
+            );
+            Ok(sequence.iter().collect())
+        }
     }
 }
 
@@ -266,5 +476,56 @@ mod test {
         let mut sequence = RowIdSequence::from(0..10);
         sequence.delete(vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
         assert_eq!(sequence.0, vec![U64Segment::Range(0..0)]);
+    }
+
+    #[test]
+    fn test_row_id_sequence_rechunk() {
+        fn assert_rechunked(
+            input: Vec<RowIdSequence>,
+            chunk_sizes: Vec<u64>,
+            expected: Vec<RowIdSequence>,
+        ) {
+            let chunked = rechunk_sequences(input, chunk_sizes).unwrap();
+            assert_eq!(chunked, expected);
+        }
+
+        // Small pieces to larger ones
+        let many_segments = vec![
+            RowIdSequence(vec![U64Segment::Range(0..5), U64Segment::Range(35..40)]),
+            RowIdSequence::from(10..18),
+            RowIdSequence::from(18..28),
+            RowIdSequence::from(28..30),
+        ];
+        let fewer_segments = vec![
+            RowIdSequence(vec![U64Segment::Range(0..5), U64Segment::Range(35..40)]),
+            RowIdSequence::from(10..30),
+        ];
+        assert_rechunked(
+            many_segments.clone(),
+            fewer_segments.iter().map(|seq| seq.len()).collect(),
+            fewer_segments.clone(),
+        );
+
+        // Large pieces to smaller ones
+        assert_rechunked(
+            fewer_segments.clone(),
+            many_segments.iter().map(|seq| seq.len()).collect(),
+            many_segments.clone(),
+        );
+
+        // Equal pieces
+        assert_rechunked(
+            many_segments.clone(),
+            many_segments.iter().map(|seq| seq.len()).collect(),
+            many_segments.clone(),
+        );
+
+        // Too few segments -> error
+        let result = rechunk_sequences(many_segments.clone(), vec![100]);
+        assert!(result.is_err());
+
+        // Too many segments -> error
+        let result = rechunk_sequences(many_segments.clone(), vec![5]);
+        assert!(result.is_err());
     }
 }

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -294,7 +294,6 @@ impl<'a> RowIdSeqSlice<'a> {
     }
 }
 
-
 /// Re-chunk a sequences of row ids into chunks of a given size.
 ///
 /// # Errors
@@ -396,10 +395,7 @@ pub fn select_row_ids<'a>(
             })
             .collect(),
         ReadBatchParams::Range(range) => {
-            let sequence = sequence.slice(
-                range.start,
-                range.end - range.start,
-            );
+            let sequence = sequence.slice(range.start, range.end - range.start);
             Ok(sequence.iter().collect())
         }
         ReadBatchParams::RangeFull => Ok(sequence.iter().collect()),
@@ -409,10 +405,7 @@ pub fn select_row_ids<'a>(
             Ok(sequence.iter().collect())
         }
         ReadBatchParams::RangeFrom(from) => {
-            let sequence = sequence.slice(
-                from.start,
-                sequence.len() as usize - from.start,
-            );
+            let sequence = sequence.slice(from.start, sequence.len() as usize - from.start);
             Ok(sequence.iter().collect())
         }
     }

--- a/rust/lance-table/src/rowids/index.rs
+++ b/rust/lance-table/src/rowids/index.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::ops::RangeInclusive;
+use std::sync::Arc;
 
 use deepsize::DeepSizeOf;
 use lance_core::utils::address::RowAddress;
@@ -27,7 +28,7 @@ pub struct RowIdIndex(RangeInclusiveMap<u64, (U64Segment, U64Segment)>);
 
 impl RowIdIndex {
     /// Create a new index from a list of fragment ids and their corresponding row id sequences.
-    pub fn new(fragment_indices: &[(u32, RowIdSequence)]) -> Result<Self> {
+    pub fn new(fragment_indices: &[(u32, Arc<RowIdSequence>)]) -> Result<Self> {
         let mut pieces = fragment_indices
             .iter()
             .flat_map(|(fragment_id, sequence)| decompose_sequence(*fragment_id, sequence))
@@ -101,24 +102,24 @@ mod tests {
         let fragment_indices = vec![
             (
                 10,
-                RowIdSequence(vec![
+                Arc::new(RowIdSequence(vec![
                     U64Segment::Range(0..10),
                     U64Segment::RangeWithHoles {
                         range: 10..17,
                         holes: vec![12, 15].into(),
                     },
                     U64Segment::SortedArray(vec![20, 25, 30].into()),
-                ]),
+                ])),
             ),
             (
                 20,
-                RowIdSequence(vec![
+                Arc::new(RowIdSequence(vec![
                     U64Segment::RangeWithBitmap {
                         range: 17..20,
                         bitmap: [true, false, true].as_slice().into(),
                     },
                     U64Segment::Array(vec![40, 50, 60].into()),
-                ]),
+                ])),
             ),
         ];
 

--- a/rust/lance-table/src/utils.rs
+++ b/rust/lance-table/src/utils.rs
@@ -45,4 +45,3 @@ impl<I: Iterator> Iterator for ExactSize<I> {
         (self.size, Some(self.size))
     }
 }
-

--- a/rust/lance-table/src/utils.rs
+++ b/rust/lance-table/src/utils.rs
@@ -2,3 +2,47 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 pub mod stream;
+
+pub trait LanceIteratorExtension {
+    fn exact_size(self, size: usize) -> ExactSize<Self>
+    where
+        Self: Sized;
+}
+
+impl<I: Iterator> LanceIteratorExtension for I {
+    fn exact_size(self, size: usize) -> ExactSize<Self>
+    where
+        Self: Sized,
+    {
+        ExactSize { inner: self, size }
+    }
+}
+
+/// A iterator that is tagged with a known size. This is useful when we are
+/// able to pre-compute the size of the iterator but the iterator implementation
+/// isn't able to itself. A common example is when using `flatten()`.
+///
+/// This is inspired by discussion in https://github.com/rust-lang/rust/issues/68995
+pub struct ExactSize<I> {
+    inner: I,
+    size: usize,
+}
+
+impl<I: Iterator> Iterator for ExactSize<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.inner.next() {
+            None => None,
+            Some(x) => {
+                self.size -= 1;
+                Some(x)
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.size, Some(self.size))
+    }
+}
+

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -244,8 +244,8 @@ pub fn apply_row_id_and_deletes(
     let span = tracing::span!(tracing::Level::DEBUG, "apply_deletions");
     let _enter = span.enter();
     let deletion_mask = deletion_vector.and_then(|v| {
-        let row_ids: &[u64] = row_ids.as_ref().unwrap().values();
-        v.build_predicate(row_ids.iter())
+        let row_addrs: &[u64] = row_addrs.as_ref().unwrap().values();
+        v.build_predicate(row_addrs.iter())
     });
 
     let batch = if config.with_row_id {

--- a/rust/lance/src/datafusion/logical_plan.rs
+++ b/rust/lance/src/datafusion/logical_plan.rs
@@ -63,7 +63,7 @@ impl TableProvider for Dataset {
         if let Some(limit) = limit {
             scanner.limit(Some(limit as i64), None)?;
         }
-        let plan: Arc<dyn ExecutionPlan> = scanner.scan(false, false, projections.into());
+        let plan: Arc<dyn ExecutionPlan> = scanner.scan(false, false, false, projections.into());
 
         Ok(plan)
     }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1639,7 +1639,7 @@ mod tests {
         assert_eq!(dataset.count_fragments(), 10);
         for fragment in &fragments {
             assert_eq!(fragment.count_rows().await.unwrap(), 100);
-            let reader = fragment.open(dataset.schema(), false).await.unwrap();
+            let reader = fragment.open(dataset.schema(), false, false).await.unwrap();
             // No group / batch concept in v2
             if use_legacy_format {
                 assert_eq!(reader.legacy_num_batches(), 10);

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1014,7 +1014,7 @@ impl FileFragment {
         if let Some(columns) = columns {
             schema = schema.project(columns)?;
         }
-        // If there is no projection, we are least need to read the row addresses
+        // If there is no projection, we at least need to read the row addresses
         let with_row_addr = schema.fields.is_empty();
         let reader = self.open(&schema, false, with_row_addr);
         let deletion_vector = read_deletion_file(

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -474,7 +474,7 @@ impl FileFragment {
         let mut reader = FragmentReader::try_new(
             self.id(),
             deletion_vec,
-            dbg!(row_id_sequence),
+            row_id_sequence,
             opened_files,
             ArrowSchema::from(projection),
             self.count_rows().await?,

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -18,10 +18,9 @@ use datafusion::logical_expr::Expr;
 use datafusion::scalar::ScalarValue;
 use futures::future::try_join_all;
 use futures::{join, stream, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
-use lance_core::utils::address::RowAddress;
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::{datatypes::Schema, Error, Result};
-use lance_core::{ROW_ADDR, ROW_ADDR_FIELD, ROW_ID, ROW_ID_FIELD};
+use lance_core::{ROW_ADDR, ROW_ADDR_FIELD, ROW_ID_FIELD};
 use lance_encoding::decoder::DecoderMiddlewareChain;
 use lance_file::reader::{read_batch, FileReader};
 use lance_file::v2;
@@ -433,16 +432,33 @@ impl FileFragment {
     /// Parameters
     /// - `projection`: The projection schema.
     /// - `with_row_id`: If true, the row id will be included in the output.
+    /// - `with_row_address`: If true, the row address will be included in the output.
     ///
     /// `projection` may be an empty schema only if `with_row_id` is true. In that
     /// case, the reader will only be generating row ids.
-    pub async fn open(&self, projection: &Schema, with_row_id: bool) -> Result<FragmentReader> {
-        let open_files = self.open_readers(projection, with_row_id);
+    pub async fn open(
+        &self,
+        projection: &Schema,
+        with_row_id: bool,
+        with_row_address: bool,
+    ) -> Result<FragmentReader> {
+        let open_files = self.open_readers(projection, with_row_id, with_row_address);
         let deletion_vec_load =
             self.load_deletion_vector(&self.dataset.object_store, &self.metadata);
-        let (opened_files, deletion_vec) = join!(open_files, deletion_vec_load);
+
+        let row_id_load = if self.dataset.manifest.uses_move_stable_row_ids() {
+            futures::future::Either::Left(
+                load_row_id_sequence(&self.dataset, &self.metadata).map_ok(Some),
+            )
+        } else {
+            futures::future::Either::Right(futures::future::ready(Ok(None)))
+        };
+
+        let (opened_files, deletion_vec, row_id_sequence) =
+            join!(open_files, deletion_vec_load, row_id_load);
         let opened_files = opened_files?;
         let deletion_vec = deletion_vec?;
+        let row_id_sequence = row_id_sequence?;
 
         if opened_files.is_empty() {
             return Err(Error::io(
@@ -458,6 +474,7 @@ impl FileFragment {
         let mut reader = FragmentReader::try_new(
             self.id(),
             deletion_vec,
+            dbg!(row_id_sequence),
             opened_files,
             ArrowSchema::from(projection),
             self.count_rows().await?,
@@ -466,6 +483,10 @@ impl FileFragment {
         if with_row_id {
             reader.with_row_id();
         }
+        if with_row_address {
+            reader.with_row_address();
+        }
+
         Ok(reader)
     }
 
@@ -478,6 +499,7 @@ impl FileFragment {
         data_file: &DataFile,
         projection: Option<&Schema>,
         with_row_id: bool,
+        with_row_address: bool,
     ) -> Result<Option<(Box<dyn GenericFileReader>, Arc<Schema>)>> {
         let full_schema = self.dataset.schema();
         // The data file may contain fields that are not part of the dataset any longer, remove those
@@ -488,7 +510,7 @@ impl FileFragment {
 
         if data_file.is_legacy_file() {
             let max_field_id = data_file.fields.iter().max().unwrap();
-            if with_row_id || !schema_per_file.fields.is_empty() {
+            if with_row_id || with_row_address || !schema_per_file.fields.is_empty() {
                 let path = self.dataset.data_dir().child(data_file.path.as_str());
                 let field_id_offset = Self::get_field_id_offset(data_file);
                 let reader = FileReader::try_new_with_fragment_id(
@@ -545,12 +567,14 @@ impl FileFragment {
         &self,
         projection: &Schema,
         with_row_id: bool,
+        with_row_address: bool,
     ) -> Result<Vec<(Box<dyn GenericFileReader>, Arc<Schema>)>> {
         let mut opened_files = vec![];
         for (i, data_file) in self.metadata.files.iter().enumerate() {
-            let with_row_id = with_row_id && i == 0;
+            // TODO: do we still need to do this?
+            let with_row_id = (with_row_id || with_row_address) && i == 0;
             if let Some((reader, schema)) = self
-                .open_reader(data_file, Some(projection), with_row_id)
+                .open_reader(data_file, Some(projection), with_row_id, with_row_address)
                 .await?
             {
                 opened_files.push((reader, schema));
@@ -645,7 +669,7 @@ impl FileFragment {
         // Just open any file. All of them should have same size.
         let some_file = &self.metadata.files[0];
         let (reader, _) = self
-            .open_reader(some_file, None, false)
+            .open_reader(some_file, None, false, false)
             .await?
             .ok_or_else(|| Error::Internal {
                 message: format!(
@@ -739,7 +763,7 @@ impl FileFragment {
 
         let get_lengths = self.metadata.files.iter().map(|data_file| async move {
             let (reader, _) = self
-                .open_reader(data_file, None, false)
+                .open_reader(data_file, None, false, false)
                 .await?
                 .ok_or_else(|| {
                     Error::corrupt_file(
@@ -814,8 +838,8 @@ impl FileFragment {
                 }
             }
 
-            for row_id in deletion_vector {
-                if row_id >= *expected_length as u32 {
+            for offset in deletion_vector {
+                if offset >= *expected_length as u32 {
                     let deletion_file_meta = self.metadata.deletion_file.as_ref().unwrap();
                     return Err(Error::corrupt_file(
                         deletion_file_path(
@@ -823,7 +847,7 @@ impl FileFragment {
                             self.metadata.id,
                             deletion_file_meta,
                         ),
-                        format!("deletion vector contains row id that is out of range. Row id: {} Fragment length: {}", row_id, expected_length),
+                        format!("deletion vector contains an offset that is out of range. Offset: {} Fragment length: {}", offset, expected_length),
                         location!(),
                     ));
                 }
@@ -935,7 +959,8 @@ impl FileFragment {
         projection: &Schema,
         with_row_id: bool,
     ) -> Result<RecordBatch> {
-        let reader = self.open(projection, with_row_id).await?;
+        // TODO: support taking row addresses
+        let reader = self.open(projection, with_row_id, false).await?;
 
         if row_ids.len() > 1 && Self::row_ids_contiguous(row_ids) {
             let range = (row_ids[0] as usize)..(row_ids[row_ids.len() - 1] as usize + 1);
@@ -989,9 +1014,9 @@ impl FileFragment {
         if let Some(columns) = columns {
             schema = schema.project(columns)?;
         }
-        // If there is no projection, we are least need to read the row id
-        let with_row_id = schema.fields.is_empty();
-        let reader = self.open(&schema, with_row_id);
+        // If there is no projection, we are least need to read the row addresses
+        let with_row_addr = schema.fields.is_empty();
+        let reader = self.open(&schema, false, with_row_addr);
         let deletion_vector = read_deletion_file(
             &self.dataset.base,
             &self.metadata,
@@ -1034,7 +1059,7 @@ impl FileFragment {
 
         let starting_length = deletion_vector.len();
 
-        // scan with predicate and row ids
+        // scan with predicate and row addresses
         let mut scanner = self.scan();
 
         let predicate_lower = predicate.trim().to_lowercase();
@@ -1045,7 +1070,7 @@ impl FileFragment {
         }
 
         scanner
-            .with_row_id()
+            .with_row_address()
             .filter(predicate)?
             .project::<&str>(&[])?;
 
@@ -1062,18 +1087,18 @@ impl FileFragment {
             }
         }
 
-        // As we get row ids, add them into our deletion vector
+        // As we get row addrs, add them into our deletion vector
         scanner
             .try_into_stream()
             .await?
             .try_for_each(|batch| {
-                let array = batch[ROW_ID].clone();
+                let array = batch[ROW_ADDR].clone();
                 let int_array: &UInt64Array = as_primitive_array(array.as_ref());
 
-                // _row_id is global, not within fragment level. The high bits
+                // _rowaddr is global, not within fragment level. The high bits
                 // are the fragment_id, the low bits are the row_id within the
                 // fragment.
-                let local_row_ids = int_array.iter().map(|v| v.unwrap() as u32);
+                let local_row_ids = int_array.values().iter().map(|v| *v as u32);
 
                 deletion_vector.extend(local_row_ids);
                 futures::future::ready(Ok(()))
@@ -1163,6 +1188,11 @@ pub struct FragmentReader {
     /// The deleted row IDs
     deletion_vec: Option<Arc<DeletionVector>>,
 
+    /// The row id sequence
+    ///
+    /// Only populated if the move-stable row id feature is enabled.
+    row_id_sequence: Option<Arc<RowIdSequence>>,
+
     /// ID of the fragment
     fragment_id: usize,
 
@@ -1194,8 +1224,10 @@ impl Clone for FragmentReader {
                 .collect::<Vec<_>>(),
             output_schema: self.output_schema.clone(),
             deletion_vec: self.deletion_vec.clone(),
+            row_id_sequence: self.row_id_sequence.clone(),
             fragment_id: self.fragment_id,
             with_row_id: self.with_row_id,
+            with_row_addr: self.with_row_addr,
             make_deletions_null: self.make_deletions_null,
             num_rows: self.num_rows,
         }
@@ -1227,6 +1259,7 @@ impl FragmentReader {
     fn try_new(
         fragment_id: usize,
         deletion_vec: Option<Arc<DeletionVector>>,
+        row_id_sequence: Option<Arc<RowIdSequence>>,
         readers: Vec<(Box<dyn GenericFileReader>, Arc<Schema>)>,
         output_schema: ArrowSchema,
         num_rows: usize,
@@ -1261,8 +1294,10 @@ impl FragmentReader {
             readers,
             output_schema,
             deletion_vec,
+            row_id_sequence,
             fragment_id,
             with_row_id: false,
+            with_row_addr: false,
             make_deletions_null: false,
             num_rows,
         })
@@ -1274,6 +1309,15 @@ impl FragmentReader {
             .output_schema
             .try_with_column(ROW_ID_FIELD.clone())
             .expect("Table already has a column named _rowid");
+        self
+    }
+
+    pub(crate) fn with_row_address(&mut self) -> &mut Self {
+        self.with_row_addr = true;
+        self.output_schema = self
+            .output_schema
+            .try_with_column(ROW_ADDR_FIELD.clone())
+            .expect("Table already has a column named _rowaddr");
         self
     }
 
@@ -1440,6 +1484,7 @@ impl FragmentReader {
             &RowIdAndDeletesConfig {
                 params: file_params,
                 deletion_vector: self.deletion_vec.clone(),
+                row_id_sequence: self.row_id_sequence.clone(),
                 with_row_id: self.with_row_id,
                 with_row_addr: self.with_row_addr,
                 make_deletions_null: self.make_deletions_null,
@@ -1451,6 +1496,9 @@ impl FragmentReader {
             let mut output_schema = ArrowSchema::from(projection);
             if self.with_row_id {
                 output_schema = output_schema.try_with_column(ROW_ID_FIELD.clone())?;
+            }
+            if self.with_row_addr {
+                output_schema = output_schema.try_with_column(ROW_ADDR_FIELD.clone())?;
             }
             output_schema
         };
@@ -1477,78 +1525,67 @@ impl FragmentReader {
                 location!(),
             ));
         }
-        // If just the row id there is no need to actually read any data
+        // If just the row id or address there is no need to actually read any data
         // and we don't need to involve the readers at all.
         //
-        // TODO: This is somewhat redundant at the moment.  The `wrap_with_row_id_and_delete`
-        // function can handle empty (zero column) batches.  However, the v1 reader will
-        // not emit such batches and so we need this path.
+        // The v1 reader does not support reading batches with zero columns, so
+        // we need this as a separate code path.
+        // In these cases, we can just emit batches with zero columns and rely
+        // on `wrap_with_row_id_and_delete` to add the row id or address column.
         //
         // We could potentially delete the support for no-columns in the wrap function or
         // we can delete this path once we migrate away from any support of v1.
-        if self.with_row_id && self.output_schema.fields.len() == 1 {
-            let mut offsets = params
+        let merged = if self.with_row_addr as usize + self.with_row_id as usize
+            == self.output_schema.fields.len()
+        {
+            let selected_rows = params
                 .slice(0, total_num_rows as usize)
                 .unwrap()
                 .to_offsets()
-                .unwrap();
-            if let Some(deletion_vector) = self.deletion_vec.as_ref() {
-                // TODO: More efficient set subtraction
-                offsets = UInt32Array::from_iter_values(
-                    offsets
-                        .values()
-                        .iter()
-                        .copied()
-                        .filter(|row_offset| !deletion_vector.contains(*row_offset)),
-                );
-            }
-            let row_ids: Vec<u64> = offsets
-                .values()
-                .iter()
-                .map(|row_id| {
-                    u64::from(RowAddress::new_from_parts(self.fragment_id as u32, *row_id))
-                })
-                .collect();
-            let num_intact_rows = row_ids.len() as u32;
-            let row_ids_array = UInt64Array::from(row_ids);
-            let row_id_schema = Arc::new(self.output_schema.clone());
-            let tasks = (0..num_intact_rows)
+                .unwrap()
+                .len();
+            let tasks = (0..selected_rows)
                 .step_by(batch_size as usize)
                 .map(move |offset| {
-                    let length = batch_size.min(num_intact_rows - offset);
-                    let array = Arc::new(row_ids_array.slice(offset as usize, length as usize));
-                    let batch = RecordBatch::try_new(row_id_schema.clone(), vec![array]);
-                    std::future::ready(batch.map_err(Error::from)).boxed()
+                    let num_rows = (batch_size as usize).min(selected_rows - offset);
+                    let batch = RecordBatch::from(StructArray::new_empty_fields(num_rows, None));
+                    ReadBatchTask {
+                        task: std::future::ready(Ok(batch)).boxed(),
+                        num_rows: num_rows as u32,
+                    }
                 });
-            return Ok(stream::iter(tasks).boxed());
-        }
-        // Read each data file, these reads should produce streams of equal sized
-        // tasks.  In other words, if we get 3 tasks of 20 rows and then a task
-        // of 10 rows from one data file we should get the same from the other.
-        let read_streams = self
-            .readers
-            .iter()
-            .filter_map(|(reader, schema)| {
-                // Normally we filter out empty readers in the open_readers method
-                // However, we will keep the first empty reader to use for row id
-                // purposes on some legacy paths and so we need to filter that out
-                // here.
-                if schema.fields.is_empty() {
-                    None
-                } else {
-                    Some(read_fn(reader.as_ref(), schema))
-                }
-            })
-            .collect::<Result<Vec<_>>>()?;
-        // Merge the streams, this merges the generated batches
-        let merged = lance_table::utils::stream::merge_streams(read_streams);
+            stream::iter(tasks).boxed()
+        } else {
+            // Read each data file, these reads should produce streams of equal sized
+            // tasks.  In other words, if we get 3 tasks of 20 rows and then a task
+            // of 10 rows from one data file we should get the same from the other.
+            let read_streams = self
+                .readers
+                .iter()
+                .filter_map(|(reader, schema)| {
+                    // Normally we filter out empty readers in the open_readers method
+                    // However, we will keep the first empty reader to use for row id
+                    // purposes on some legacy paths and so we need to filter that out
+                    // here.
+                    if schema.fields.is_empty() {
+                        None
+                    } else {
+                        Some(read_fn(reader.as_ref(), schema))
+                    }
+                })
+                .collect::<Result<Vec<_>>>()?;
+            // Merge the streams, this merges the generated batches
+            lance_table::utils::stream::merge_streams(read_streams)
+        };
 
         // Add the row id column (if needed) and delete rows (if a deletion
         // vector is present).
         let config = RowIdAndDeletesConfig {
             deletion_vector: self.deletion_vec.clone(),
+            row_id_sequence: self.row_id_sequence.clone(),
             make_deletions_null: self.make_deletions_null,
             with_row_id: self.with_row_id,
+            with_row_addr: self.with_row_addr,
             params,
             total_num_rows,
         };
@@ -1637,6 +1674,7 @@ mod tests {
     use arrow_arith::numeric::mul;
     use arrow_array::{ArrayRef, Int32Array, RecordBatchIterator, StringArray};
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+    use lance_core::ROW_ID;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use tempfile::tempdir;
@@ -1803,7 +1841,10 @@ mod tests {
         assert_eq!(fragment.metadata.num_rows().unwrap(), 20);
 
         for with_row_id in [false, true] {
-            let reader = fragment.open(fragment.schema(), with_row_id).await.unwrap();
+            let reader = fragment
+                .open(fragment.schema(), with_row_id, false)
+                .await
+                .unwrap();
             for valid_range in [0..40, 20..40] {
                 reader
                     .read_range(valid_range, 100)
@@ -1827,7 +1868,7 @@ mod tests {
         dataset.delete("i >= 0 and i < 15").await.unwrap();
 
         let fragment = &dataset.get_fragments()[0];
-        let mut reader = fragment.open(dataset.schema(), true).await.unwrap();
+        let mut reader = fragment.open(dataset.schema(), true, false).await.unwrap();
         reader.with_make_deletions_null();
 
         // Since the first batch is all deleted, it will return an empty batch.
@@ -2326,7 +2367,7 @@ mod tests {
             .get_fragments()
             .first()
             .unwrap()
-            .open(dataset.schema(), false)
+            .open(dataset.schema(), false, false)
             .await?;
         let actual_data = reader.take_as_batch(&[0, 1, 2]).await?;
         assert_eq!(expected_data.slice(0, 3), actual_data);
@@ -2375,7 +2416,7 @@ mod tests {
         let fragment = dataset.get_fragments().pop().unwrap();
 
         let reader = fragment
-            .open(&dataset.schema().project::<&str>(&[])?, true)
+            .open(&dataset.schema().project::<&str>(&[])?, true, false)
             .await?;
         let batch = reader.legacy_read_range_as_batch(0..20).await?;
 
@@ -2387,7 +2428,7 @@ mod tests {
 
         // We should get error if we pass empty schema and with_row_id false
         let res = fragment
-            .open(&dataset.schema().project::<&str>(&[])?, false)
+            .open(&dataset.schema().project::<&str>(&[])?, false, false)
             .await;
         assert!(matches!(res, Err(Error::IO { .. })));
 

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -96,9 +96,7 @@ async fn load_row_id_index(dataset: &Dataset) -> Result<lance_table::rowids::Row
 mod test {
     use std::ops::Range;
 
-    use crate::dataset::{
-        builder::DatasetBuilder, optimize::compact_files, UpdateBuilder, WriteMode, WriteParams,
-    };
+    use crate::dataset::{builder::DatasetBuilder, UpdateBuilder, WriteMode, WriteParams};
 
     use super::*;
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -31,7 +31,7 @@ use datafusion_physical_expr::PhysicalExpr;
 use futures::stream::{Stream, StreamExt};
 use futures::TryStreamExt;
 use lance_arrow::floats::{coerce_float_vector, FloatType};
-use lance_core::{ROW_ID, ROW_ID_FIELD};
+use lance_core::{ROW_ADDR, ROW_ADDR_FIELD, ROW_ID, ROW_ID_FIELD};
 use lance_datafusion::exec::{execute_plan, LanceExecutionOptions};
 use lance_index::vector::{Query, DIST_COL};
 use lance_index::{scalar::expression::ScalarIndexExpr, DatasetIndexExt};
@@ -164,6 +164,9 @@ pub struct Scanner {
     /// Scan the dataset with a meta column: "_rowid"
     with_row_id: bool,
 
+    /// Scan the dataset with a meta column: "_rowaddr"
+    with_row_address: bool,
+
     /// Whether to use statistics to optimize the scan (default: true)
     ///
     /// This is used for debugging or benchmarking purposes.
@@ -204,6 +207,7 @@ impl Scanner {
             nearest: None,
             use_stats: true,
             with_row_id: false,
+            with_row_address: false,
             ordered: true,
             fragments: None,
         }
@@ -557,6 +561,12 @@ impl Scanner {
         self
     }
 
+    /// Instruct the scanner to return the `_rowaddr` meta column from the dataset.
+    pub fn with_row_address(&mut self) -> &mut Self {
+        self.with_row_address = true;
+        self
+    }
+
     /// Set whether to use statistics to optimize the scan (default: true)
     ///
     /// This is used for debugging or benchmarking purposes.
@@ -587,6 +597,10 @@ impl Scanner {
 
         if self.with_row_id {
             extra_columns.push(ROW_ID_FIELD.clone());
+        }
+
+        if self.with_row_address {
+            extra_columns.push(ROW_ADDR_FIELD.clone());
         }
 
         let schema = if !extra_columns.is_empty() {
@@ -663,6 +677,11 @@ impl Scanner {
         if self.with_row_id {
             let row_id_expr = expressions::col(ROW_ID, &physical_schema)?;
             output_expr.push((row_id_expr, ROW_ID.to_string()));
+        }
+
+        if self.with_row_address {
+            let row_addr_expr = expressions::col(ROW_ADDR, &physical_schema)?;
+            output_expr.push((row_addr_expr, ROW_ADDR.to_string()));
         }
 
         Ok(output_expr)
@@ -797,7 +816,7 @@ impl Scanner {
     /// 4. Limit / Offset
     /// 5. Take remaining columns / Projection
     pub async fn create_plan(&self) -> Result<Arc<dyn ExecutionPlan>> {
-        if self.phyical_columns.fields.is_empty() && !self.with_row_id {
+        if self.phyical_columns.fields.is_empty() && !self.with_row_id && !self.with_row_address {
             return Err(Error::InvalidInput {
                 source:
                     "no columns were selected and with_row_id is false, there is nothing to scan"
@@ -896,7 +915,7 @@ impl Scanner {
                     } else {
                         Arc::new(self.phyical_columns.clone())
                     };
-                    self.scan(with_row_id, false, schema)
+                    self.scan(with_row_id, self.with_row_address, false, schema)
                 }
             }
         };
@@ -1074,7 +1093,7 @@ impl Scanner {
                 self.scalar_indexed_scan(&vector_scan_projection, index_query)
                     .await?
             } else {
-                self.scan(true, true, vector_scan_projection)
+                self.scan(true, false, true, vector_scan_projection)
             };
             if let Some(refine_expr) = &filter_plan.refine_expr {
                 let planner = Planner::new(plan.schema());
@@ -1110,6 +1129,7 @@ impl Scanner {
             // than the scalar indices anyways
             let mut scan_node = self.scan_fragments(
                 true,
+                false,
                 true,
                 vector_scan_projection,
                 Arc::new(unindexed_fragments),
@@ -1242,6 +1262,7 @@ impl Scanner {
             let new_data_scan = self.scan_fragments(
                 true,
                 false,
+                false,
                 Arc::new(schema.clone()),
                 missing_frags.into(),
                 false,
@@ -1276,6 +1297,7 @@ impl Scanner {
     pub(crate) fn scan(
         &self,
         with_row_id: bool,
+        with_row_address: bool,
         with_make_deletions_null: bool,
         projection: Arc<Schema>,
     ) -> Arc<dyn ExecutionPlan> {
@@ -1292,6 +1314,7 @@ impl Scanner {
         };
         self.scan_fragments(
             with_row_id,
+            with_row_address,
             with_make_deletions_null,
             projection,
             fragments,
@@ -1302,6 +1325,7 @@ impl Scanner {
     fn scan_fragments(
         &self,
         with_row_id: bool,
+        with_row_address: bool,
         with_make_deletions_null: bool,
         projection: Arc<Schema>,
         fragments: Arc<Vec<Fragment>>,
@@ -1315,6 +1339,7 @@ impl Scanner {
             self.batch_readahead,
             self.fragment_readahead,
             with_row_id,
+            with_row_address,
             with_make_deletions_null,
             ordered,
         ))
@@ -1329,6 +1354,7 @@ impl Scanner {
             batch_readahead: self.batch_readahead,
             fragment_readahead: self.fragment_readahead,
             with_row_id: self.with_row_id,
+            with_row_address: self.with_row_address,
             make_deletions_null,
             ordered_output: self.ordered,
         };
@@ -1395,7 +1421,7 @@ impl Scanner {
                 // of the filter columns to determine the valid row ids.
                 let columns_in_filter = Planner::column_names_in_expr(refine_expr);
                 let filter_schema = Arc::new(self.dataset.schema().project(&columns_in_filter)?);
-                let filter_input = self.scan(true, true, filter_schema);
+                let filter_input = self.scan(true, false, true, filter_schema);
                 let planner = Planner::new(filter_input.schema());
                 let physical_refine_expr = planner.create_physical_expr(refine_expr)?;
                 let filtered_row_ids =
@@ -3736,7 +3762,7 @@ mod test {
             assert_plan_equals(
                 &dataset.dataset,
                 |scan| scan.project(&["s"])?.filter("i > 10 and i < 20"),
-                "LancePushdownScan: uri=..., projection=[s], predicate=i > Int32(10) AND i < Int32(20), row_id=false, ordered=true"
+                "LancePushdownScan: uri=..., projection=[s], predicate=i > Int32(10) AND i < Int32(20), row_id=false, row_addr=false, ordered=true"
             ).await?;
         }
 
@@ -3750,15 +3776,14 @@ mod test {
             "Projection: fields=[s]
   Take: columns=\"i, _rowid, s\"
     FilterExec: i@0 > 10 AND i@0 < 20
-      LanceScan: uri..., projection=[i], row_id=true, ordered=true",
+      LanceScan: uri..., projection=[i], row_id=true, row_addr=false, ordered=true",
         )
         .await?;
 
         assert_plan_equals(
             &dataset.dataset,
             |scan| Ok(scan.project(&["s"])?.with_row_id().scan_in_order(false)),
-            "Projection: fields=[s, _rowid]
-  LanceScan: uri=..., projection=[s], row_id=true, ordered=false",
+            "LanceScan: uri=..., projection=[s], row_id=true, row_addr=false, ordered=false",
         )
         .await?;
 
@@ -3771,7 +3796,7 @@ mod test {
             "Projection: fields=[i, s, vec, _distance]
   Take: columns=\"vec, _rowid, _distance, i, s\"
     KNNFlat: k=5 metric=l2
-      LanceScan: uri=..., projection=[vec], row_id=true, ordered=false",
+      LanceScan: uri=..., projection=[vec], row_id=true, row_addr=false, ordered=false",
         )
         .await?;
 
@@ -3809,7 +3834,7 @@ mod test {
             "Projection: fields=[i, s, vec, _distance]
   Take: columns=\"vec, _rowid, _distance, i, s\"
     KNNFlat: k=13 metric=l2
-      LanceScan: uri=..., projection=[vec], row_id=true, ordered=false",
+      LanceScan: uri=..., projection=[vec], row_id=true, row_addr=false, ordered=false",
         )
         .await?;
 
@@ -3848,7 +3873,7 @@ mod test {
       ANNSubIndex: name=..., k=17, deltas=1
         ANNIvfPartition: uuid=..., nprobes=1, deltas=1
         FilterExec: i@0 > 10
-          LanceScan: uri=..., projection=[i], row_id=true, ordered=false",
+          LanceScan: uri=..., projection=[i], row_id=true, row_addr=false, ordered=false",
         )
         .await?;
 
@@ -3865,7 +3890,7 @@ mod test {
         UnionExec
           Projection: fields=[_distance, _rowid, vec]
             KNNFlat: k=5 metric=l2
-              LanceScan: uri=..., projection=[vec], row_id=true, ordered=false
+              LanceScan: uri=..., projection=[vec], row_id=true, row_addr=false, ordered=false
           Take: columns=\"_distance, _rowid, vec\"
             SortExec: TopK(fetch=5), expr=...
               ANNSubIndex: name=..., k=5, deltas=1
@@ -3886,7 +3911,7 @@ mod test {
             UnionExec
               Projection: fields=[_distance, _rowid, vec]
                 KNNFlat: k=5 metric=l2
-                  LanceScan: uri=..., projection=[vec], row_id=true, ordered=false
+                  LanceScan: uri=..., projection=[vec], row_id=true, row_addr=false, ordered=false
               Take: columns=\"_distance, _rowid, vec\"
                 SortExec: TopK(fetch=5), expr=...
                   ANNSubIndex: name=..., k=5, deltas=1
@@ -3913,13 +3938,13 @@ mod test {
           Projection: fields=[_distance, _rowid, vec]
             KNNFlat: k=5 metric=l2
               FilterExec: i@1 > 10
-                LanceScan: uri=..., projection=[vec, i], row_id=true, ordered=false
+                LanceScan: uri=..., projection=[vec, i], row_id=true, row_addr=false, ordered=false
           Take: columns=\"_distance, _rowid, vec\"
             SortExec: TopK(fetch=5), expr=...
               ANNSubIndex: name=..., k=5, deltas=1
                 ANNIvfPartition: uuid=..., nprobes=1, deltas=1
                 FilterExec: i@0 > 10
-                  LanceScan: uri=..., projection=[i], row_id=true, ordered=false",
+                  LanceScan: uri=..., projection=[i], row_id=true, row_addr=false, ordered=false",
         )
         .await?;
 
@@ -3964,7 +3989,7 @@ mod test {
           Projection: fields=[_distance, _rowid, vec]
             KNNFlat: k=5 metric=l2
               FilterExec: i@1 > 10
-                LanceScan: uri=..., projection=[vec, i], row_id=true, ordered=false
+                LanceScan: uri=..., projection=[vec, i], row_id=true, row_addr=false, ordered=false
           Take: columns=\"_distance, _rowid, vec\"
             SortExec: TopK(fetch=5), expr=...
               ANNSubIndex: name=..., k=5, deltas=1
@@ -3991,7 +4016,7 @@ mod test {
           Projection: fields=[_distance, _rowid, vec]
             KNNFlat: k=5 metric=l2
               FilterExec: i@1 > 10
-                LanceScan: uri=..., projection=[vec, i], row_id=true, ordered=false
+                LanceScan: uri=..., projection=[vec, i], row_id=true, row_addr=false, ordered=false
           Take: columns=\"_distance, _rowid, vec\"
             SortExec: TopK(fetch=5), expr=...
               ANNSubIndex: name=..., k=5, deltas=1
@@ -4022,7 +4047,7 @@ mod test {
         MaterializeIndex: query=i > 10
       Projection: fields=[_rowid, s]
         FilterExec: i@1 > 10
-          LanceScan: uri=..., projection=[s, i], row_id=true, ordered=false",
+          LanceScan: uri=..., projection=[s, i], row_id=true, row_addr=false, ordered=false",
         )
         .await?;
 
@@ -4042,7 +4067,7 @@ mod test {
           MaterializeIndex: query=i > 10
         Projection: fields=[_rowid, s]
           FilterExec: i@1 > 10
-            LanceScan: uri=..., projection=[s, i], row_id=true, ordered=false",
+            LanceScan: uri=..., projection=[s, i], row_id=true, row_addr=false, ordered=false",
         )
         .await?;
 

--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -172,7 +172,7 @@ pub async fn take_rows(
             )
         })?;
 
-        let reader = fragment.open(projection.as_ref(), false).await?;
+        let reader = fragment.open(projection.as_ref(), false, false).await?;
         reader.legacy_read_range_as_batch(range).await
     } else if row_id_meta.sorted {
         // Don't need to re-arrange data, just concatenate

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -382,6 +382,7 @@ mod tests {
             4,
             true,
             false,
+            false,
             true,
         ));
         let take_exec = TakeExec::try_new(dataset, input, extra_schema, 10).unwrap();
@@ -414,6 +415,7 @@ mod tests {
             10,
             4,
             true,
+            false,
             false,
             true,
         ));
@@ -448,6 +450,7 @@ mod tests {
             4,
             false,
             false,
+            false,
             true,
         ));
         assert!(TakeExec::try_new(dataset, input, extra_schema, 10).is_err());
@@ -465,6 +468,7 @@ mod tests {
             10,
             4,
             true,
+            false,
             false,
             true,
         ));


### PR DESCRIPTION
Modifies the scanner to now support two options: `with_row_id` and `with_row_address`. Row addresses are what we used to call `_rowid`. They are returned as the `_rowaddr` column. For backwards compatibility, the `_rowid` column will be a copy of `_rowaddr` for datasets that aren't using stable row ids. For those that have activated the stable row id feature, they will have the row ids in the `_rowid` column.