### PR TITLE
feat: add pushdown to the read path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ datafusion-functions = { version = "37.1", features = ["regex_expressions"] }
 datafusion-sql = "37.1"
 datafusion-expr = "37.1"
 datafusion-execution = "37.1"
+datafusion-optimizer = "37.1"
 datafusion-physical-expr = { version = "37.1", features = [
     "regex_expressions",
 ] }

--- a/protos/encodings.proto
+++ b/protos/encodings.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package lance.encodings;
  
+import "google/protobuf/empty.proto";
+
 // This file contains a specification for encodings that can be used
 // to store and load Arrow data into a Lance file.
 //
@@ -186,4 +188,21 @@ message ArrayEncoding {
         List list = 4;
         SimpleStruct struct = 5;
     }
+}
+
+// Wraps a column with a zone map index that can be used
+// to apply pushdown filters
+message ZoneIndex {
+  uint32 rows_per_zone = 1;
+  Buffer zone_map_buffer = 2;
+  ColumnEncoding inner = 3;
+}
+
+// Encodings that describe a column of values
+message ColumnEncoding {
+  oneof column_encoding {
+    // No special encoding, just column values
+    google.protobuf.Empty values = 1;
+    ZoneIndex zone_index = 2;
+  }
 }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -33,6 +33,7 @@ lance = { path = "../rust/lance", features = [
 lance-arrow = { path = "../rust/lance-arrow" }
 lance-core = { path = "../rust/lance-core" }
 lance-datagen = { path = "../rust/lance-datagen", optional = true }
+lance-encoding = { path = "../rust/lance-encoding" }
 lance-file = { path = "../rust/lance-file" }
 lance-index = { path = "../rust/lance-index" }
 lance-io = { path = "../rust/lance-io" }

--- a/rust/lance-encoding-datafusion/Cargo.toml
+++ b/rust/lance-encoding-datafusion/Cargo.toml
@@ -13,20 +13,27 @@ rust-version.workspace = true
 
 [dependencies]
 lance-core = { workspace = true, features = ["datafusion"] }
+lance-datafusion = { workspace = true, features = ["substrait"] }
 lance-encoding.workspace = true
 lance-file.workspace = true
+lance-io.workspace = true
 arrow-array.workspace = true
 arrow-buffer.workspace = true
 arrow-schema.workspace = true
+bytes.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
+datafusion-optimizer.workspace = true
 datafusion-physical-expr.workspace = true
 futures.workspace = true
+log.workspace = true
 prost.workspace = true
 prost-types.workspace = true
+snafu.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
+test-log.workspace = true
 tokio.workspace = true
 lance-datagen.workspace = true
 

--- a/rust/lance-encoding-datafusion/src/lib.rs
+++ b/rust/lance-encoding-datafusion/src/lib.rs
@@ -1,14 +1,159 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use arrow_schema::DataType;
-use lance_encoding::encoder::{
-    ColumnIndexSequence, CoreFieldEncodingStrategy, FieldEncodingStrategy,
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
 };
-use zone::ZoneMapsFieldEncoder;
+
+use arrow_schema::DataType;
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use lance_core::{
+    datatypes::{Field, Schema},
+    Result,
+};
+use lance_encoding::{
+    decoder::{ColumnInfo, DecoderMiddlewareChainCursor, FieldDecoderStrategy, FieldScheduler},
+    encoder::{ColumnIndexSequence, CoreFieldEncodingStrategy, FieldEncodingStrategy},
+    encodings::physical::FileBuffers,
+};
+use zone::{extract_zone_info, UnloadedPushdown, ZoneMapsFieldEncoder, ZoneMapsFieldScheduler};
 
 pub mod format;
+pub mod substrait;
 pub mod zone;
+
+#[derive(Debug)]
+struct LanceDfFieldDecoderState {
+    /// We assume that all columns have the same number of rows per map
+    rows_per_map: Option<u32>,
+    /// As we visit the decoding tree we populate this with the pushdown
+    /// information that is available.
+    zone_map_buffers: Vec<UnloadedPushdown>,
+}
+
+/// This strategy is responsible for creating the field scheduler
+/// that handles the pushdown filtering.  It is a top-level scheduler
+/// that uses column info from various leaf schedulers.
+///
+/// The current implementation is a bit of a hack.  It assumes that
+/// the decoder strategy will only be used once.  The very first time
+/// that create_field_scheduler is called, we assume we are at the root.
+///
+/// Field decoding strategies are supposed to be stateless but this one
+/// is not.  As a result, we use a mutex to gather the state even though
+/// we aren't technically doing any concurrency.
+#[derive(Debug)]
+pub struct LanceDfFieldDecoderStrategy {
+    state: Arc<Mutex<Option<LanceDfFieldDecoderState>>>,
+    schema: Arc<Schema>,
+}
+
+impl LanceDfFieldDecoderStrategy {
+    pub fn new(schema: Arc<Schema>) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(None)),
+            schema,
+        }
+    }
+
+    fn initialize(&self) -> bool {
+        let mut state = self.state.lock().unwrap();
+        if state.is_none() {
+            *state = Some(LanceDfFieldDecoderState {
+                rows_per_map: None,
+                zone_map_buffers: Vec::new(),
+            });
+            true
+        } else {
+            false
+        }
+    }
+
+    fn add_pushdown_field(&self, rows_per_map: u32, unloaded_pushdown: UnloadedPushdown) {
+        let mut state = self.state.lock().unwrap();
+        let state = state.as_mut().unwrap();
+        match state.rows_per_map {
+            Some(existing) if existing != rows_per_map => {
+                panic!("Inconsistent rows per map");
+            }
+            _ => {
+                state.rows_per_map = Some(rows_per_map);
+            }
+        }
+        state.zone_map_buffers.push(unloaded_pushdown);
+    }
+}
+
+impl FieldDecoderStrategy for LanceDfFieldDecoderStrategy {
+    fn create_field_scheduler<'a>(
+        &self,
+        field: &Field,
+        column_infos: &mut VecDeque<ColumnInfo>,
+        buffers: FileBuffers,
+        chain: DecoderMiddlewareChainCursor<'a>,
+    ) -> Result<(
+        DecoderMiddlewareChainCursor<'a>,
+        BoxFuture<'static, Result<Arc<dyn FieldScheduler>>>,
+    )> {
+        let is_root = self.initialize();
+
+        if let Some((rows_per_map, unloaded_pushdown)) = extract_zone_info(
+            column_infos.front_mut().unwrap(),
+            &field.data_type(),
+            chain.current_path(),
+        ) {
+            // If there is pushdown info then record it and unwrap the
+            // pushdown encoding layer.
+            self.add_pushdown_field(rows_per_map, unloaded_pushdown);
+        }
+        // Delegate to the rest of the chain to create the decoder
+        let (chain, next) = chain.next(field, column_infos, buffers)?;
+
+        // If this is the top level decoder then wrap it with our
+        // pushdown filtering scheduler.
+        let state = if is_root {
+            self.state.lock().unwrap().take()
+        } else {
+            None
+        };
+        let schema = self.schema.clone();
+        let io = chain.io().clone();
+
+        let scheduler_fut = async move {
+            let next = next.await?;
+            if is_root {
+                let state = state.unwrap();
+                let rows_per_map = state.rows_per_map;
+                let zone_map_buffers = state.zone_map_buffers;
+                let num_rows = next.num_rows();
+                if rows_per_map.is_none() {
+                    // No columns had any pushdown info
+                    Ok(next)
+                } else {
+                    let mut scheduler = ZoneMapsFieldScheduler::new(
+                        next,
+                        schema,
+                        zone_map_buffers,
+                        rows_per_map.unwrap(),
+                        num_rows,
+                    );
+                    // Load all the zone maps from disk
+                    // TODO: it would be slightly more efficient to do this
+                    // later when we know what columns are actually used
+                    // for filtering.
+                    scheduler.initialize(io.as_ref()).await?;
+                    Ok(Arc::new(scheduler) as Arc<dyn FieldScheduler>)
+                }
+            } else {
+                Ok(next)
+            }
+        }
+        .boxed();
+        Ok((chain, scheduler_fut))
+    }
+}
 
 /// Wraps the core encoding strategy and adds the encoders from this
 /// crate
@@ -16,6 +161,15 @@ pub mod zone;
 pub struct LanceDfFieldEncodingStrategy {
     core: CoreFieldEncodingStrategy,
     rows_per_map: u32,
+}
+
+impl Default for LanceDfFieldEncodingStrategy {
+    fn default() -> Self {
+        Self {
+            core: CoreFieldEncodingStrategy::default(),
+            rows_per_map: 10000,
+        }
+    }
 }
 
 impl FieldEncodingStrategy for LanceDfFieldEncodingStrategy {

--- a/rust/lance-encoding-datafusion/src/substrait.rs
+++ b/rust/lance-encoding-datafusion/src/substrait.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use arrow_schema::Schema as ArrowSchema;
+use bytes::Bytes;
+use datafusion_common::DFSchema;
+use datafusion_common::ScalarValue;
+use datafusion_expr::Expr;
+use futures::FutureExt;
+use lance_core::datatypes::Schema;
+use lance_core::Result;
+use lance_datafusion::expr::encode_substrait;
+use lance_datafusion::expr::parse_substrait;
+use lance_encoding::decoder::FilterExpression;
+
+/// Helper trait to bridge lance-encoding and substrait
+pub trait FilterExpressionExt {
+    /// Convert a lance-encoding filter expression (which we assume is
+    /// substrait encoded) into a datafusion expr
+    fn substrait_to_df(&self, schema: &Schema) -> Result<(Expr, DFSchema)>;
+    /// Convert a datafusion filter expression into a lance-encoding
+    /// filter expression (using substrait)
+    fn df_to_substrait(expr: Expr, schema: &Schema) -> Result<Self>
+    where
+        Self: Sized;
+}
+
+impl FilterExpressionExt for FilterExpression {
+    fn substrait_to_df(&self, schema: &Schema) -> Result<(Expr, DFSchema)> {
+        if self.0.is_empty() {
+            return Ok((
+                Expr::Literal(ScalarValue::Boolean(Some(true))),
+                DFSchema::empty(),
+            ));
+        }
+        let input_schema = Arc::new(ArrowSchema::from(schema));
+        let expr = parse_substrait(&self.0, input_schema.clone())
+            .now_or_never()
+            .unwrap()?;
+        let df_schema = DFSchema::try_from(input_schema.as_ref().clone())?;
+        Ok((expr, df_schema))
+    }
+
+    fn df_to_substrait(expr: Expr, schema: &Schema) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let schema = Arc::new(ArrowSchema::from(schema));
+        let bytes = Bytes::from(encode_substrait(expr, schema)?);
+        Ok(Self(bytes))
+    }
+}

--- a/rust/lance-encoding-datafusion/src/zone.rs
+++ b/rust/lance-encoding-datafusion/src/zone.rs
@@ -111,7 +111,7 @@ impl<F: Fn(u64) -> bool> ZoneMapsFilter<F> {
 ///
 /// This method converts that into a datafusion expression
 fn path_to_expr(path: &VecDeque<u32>) -> Expr {
-    let mut parts_iter = path.into_iter().map(|path_num| path_num.to_string());
+    let mut parts_iter = path.iter().map(|path_num| path_num.to_string());
     let mut expr = col(parts_iter.next().unwrap());
     for part in parts_iter {
         expr = expr.field(part);
@@ -193,7 +193,7 @@ impl ZoneMapsFieldScheduler {
             schema,
             pushdown_buffers,
             zone_guarantees: Arc::default(),
-            rows_per_zone: rows_per_zone,
+            rows_per_zone,
             num_rows,
         }
     }
@@ -598,7 +598,7 @@ mod tests {
 
         let decoder_middleware = DecoderMiddlewareChain::new()
             .add_strategy(Arc::new(LanceDfFieldDecoderStrategy::new(schema.clone())))
-            .add_strategy(Arc::new(CoreFieldDecoderStrategy::default()));
+            .add_strategy(Arc::new(CoreFieldDecoderStrategy));
 
         let num_rows = data.iter().map(|rb| rb.num_rows()).sum::<usize>();
 
@@ -612,7 +612,7 @@ mod tests {
 
         let decoder_middleware = DecoderMiddlewareChain::new()
             .add_strategy(Arc::new(LanceDfFieldDecoderStrategy::new(schema.clone())))
-            .add_strategy(Arc::new(CoreFieldDecoderStrategy::default()));
+            .add_strategy(Arc::new(CoreFieldDecoderStrategy));
 
         let result = count_lance_file(
             &fs,
@@ -632,7 +632,7 @@ mod tests {
 
         let decoder_middleware = DecoderMiddlewareChain::new()
             .add_strategy(Arc::new(LanceDfFieldDecoderStrategy::new(schema.clone())))
-            .add_strategy(Arc::new(CoreFieldDecoderStrategy::default()));
+            .add_strategy(Arc::new(CoreFieldDecoderStrategy));
 
         let result = count_lance_file(
             &fs,

--- a/rust/lance-encoding-datafusion/src/zone.rs
+++ b/rust/lance-encoding-datafusion/src/zone.rs
@@ -597,8 +597,8 @@ mod tests {
         let (schema, data) = write_lance_file(data, &fs, options).await;
 
         let decoder_middleware = DecoderMiddlewareChain::new()
-            .add(Arc::new(LanceDfFieldDecoderStrategy::new(schema.clone())))
-            .add(Arc::new(CoreFieldDecoderStrategy::default()));
+            .add_strategy(Arc::new(LanceDfFieldDecoderStrategy::new(schema.clone())))
+            .add_strategy(Arc::new(CoreFieldDecoderStrategy::default()));
 
         let num_rows = data.iter().map(|rb| rb.num_rows()).sum::<usize>();
 
@@ -611,8 +611,8 @@ mod tests {
         assert_eq!(num_rows, result);
 
         let decoder_middleware = DecoderMiddlewareChain::new()
-            .add(Arc::new(LanceDfFieldDecoderStrategy::new(schema.clone())))
-            .add(Arc::new(CoreFieldDecoderStrategy::default()));
+            .add_strategy(Arc::new(LanceDfFieldDecoderStrategy::new(schema.clone())))
+            .add_strategy(Arc::new(CoreFieldDecoderStrategy::default()));
 
         let result = count_lance_file(
             &fs,
@@ -631,8 +631,8 @@ mod tests {
         assert_eq!(0, result);
 
         let decoder_middleware = DecoderMiddlewareChain::new()
-            .add(Arc::new(LanceDfFieldDecoderStrategy::new(schema.clone())))
-            .add(Arc::new(CoreFieldDecoderStrategy::default()));
+            .add_strategy(Arc::new(LanceDfFieldDecoderStrategy::new(schema.clone())))
+            .add_strategy(Arc::new(CoreFieldDecoderStrategy::default()));
 
         let result = count_lance_file(
             &fs,

--- a/rust/lance-encoding-datafusion/src/zone.rs
+++ b/rust/lance-encoding-datafusion/src/zone.rs
@@ -1,26 +1,391 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::sync::Arc;
+use std::{collections::VecDeque, ops::Range, sync::Arc};
 
-use arrow_array::{ArrayRef, RecordBatch, UInt32Array};
+use arrow_array::{cast::AsArray, types::UInt32Type, ArrayRef, RecordBatch, UInt32Array};
 use arrow_buffer::Buffer;
-use arrow_schema::{Field, Schema};
-use datafusion_common::{arrow::datatypes::DataType, ScalarValue};
-use datafusion_expr::Accumulator;
+use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
+use bytes::Bytes;
+use datafusion_common::{arrow::datatypes::DataType, DFSchemaRef, ScalarValue};
+use datafusion_expr::{
+    col,
+    execution_props::ExecutionProps,
+    interval_arithmetic::{Interval, NullableInterval},
+    simplify::SimplifyContext,
+    Accumulator, Expr,
+};
+use datafusion_optimizer::simplify_expressions::ExprSimplifier;
 use datafusion_physical_expr::expressions::{MaxAccumulator, MinAccumulator};
 use futures::{future::BoxFuture, FutureExt};
-use lance_encoding::encoder::{
-    encode_batch, CoreFieldEncodingStrategy, EncodedBuffer, FieldEncoder,
+use lance_encoding::{
+    decoder::{
+        decode_batch, ColumnInfo, DecoderMiddlewareChain, FieldScheduler, FilterExpression,
+        ScheduledScanLine, SchedulerContext, SchedulingJob,
+    },
+    encoder::{
+        encode_batch, CoreFieldEncodingStrategy, EncodedBatch, EncodedBuffer, EncodedColumn,
+        FieldEncoder,
+    },
+    format::pb,
+    EncodingsIo,
 };
 
-use lance_core::Result;
-use lance_file::v2::writer::EncodedBatchWriteExt;
+use lance_core::{datatypes::Schema, Error, Result};
+use lance_file::v2::{reader::EncodedBatchReaderExt, writer::EncodedBatchWriteExt};
+use snafu::{location, Location};
 
+use crate::substrait::FilterExpressionExt;
+
+#[derive(Debug)]
 struct CreatedZoneMap {
     min: ScalarValue,
     max: ScalarValue,
     null_count: u32,
+}
+
+/// Builds up a vector of ranges from a series of sorted ranges that
+/// may be adjacent (in which case we merge them) or disjoint (in
+/// which case we create separate ranges).
+#[derive(Default)]
+struct RangesBuilder {
+    ranges: Vec<Range<u64>>,
+}
+
+impl RangesBuilder {
+    fn add_range(&mut self, range: Range<u64>) {
+        if let Some(cur) = self.ranges.last_mut() {
+            if cur.end == range.start {
+                cur.end = range.end;
+            } else {
+                self.ranges.push(range);
+            }
+        } else {
+            self.ranges.push(range);
+        }
+    }
+}
+
+struct ZoneMapsFilter<F: Fn(u64) -> bool> {
+    filter: F,
+    rows_per_zone: u64,
+}
+
+impl<F: Fn(u64) -> bool> ZoneMapsFilter<F> {
+    fn new(filter: F, rows_per_zone: u64) -> Self {
+        Self {
+            filter,
+            rows_per_zone,
+        }
+    }
+
+    /// Given a requested range, and a filter telling us which zones
+    /// could possibly include matching data, generate a smaller range
+    /// (or ranges) that only include matching zones.
+    fn refine_range(&self, mut range: std::ops::Range<u64>) -> Vec<std::ops::Range<u64>> {
+        let mut ranges_builder = RangesBuilder::default();
+        let mut zone_idx = range.start / self.rows_per_zone;
+        while !range.is_empty() {
+            let end = range.end.min((zone_idx + 1) * self.rows_per_zone);
+
+            if (self.filter)(zone_idx) {
+                let zone_range = range.start..end;
+                ranges_builder.add_range(zone_range);
+            }
+
+            range.start = end;
+            zone_idx += 1;
+        }
+        ranges_builder.ranges
+    }
+
+    fn refine_ranges(&self, ranges: &[Range<u64>]) -> Vec<Range<u64>> {
+        ranges
+            .iter()
+            .flat_map(|r| self.refine_range(r.clone()))
+            .collect()
+    }
+}
+
+/// Substrait represents paths as a series of field indices
+///
+/// This method converts that into a datafusion expression
+fn path_to_expr(path: &VecDeque<u32>) -> Expr {
+    let mut parts_iter = path.into_iter().map(|path_num| path_num.to_string());
+    let mut expr = col(parts_iter.next().unwrap());
+    for part in parts_iter {
+        expr = expr.field(part);
+    }
+    expr
+}
+
+/// If a column has zone info in the encoding description then extract it
+pub(crate) fn extract_zone_info(
+    column_info: &mut ColumnInfo,
+    data_type: &DataType,
+    cur_path: &VecDeque<u32>,
+) -> Option<(u32, UnloadedPushdown)> {
+    let encoding = column_info.encoding.column_encoding.take().unwrap();
+    match encoding {
+        pb::column_encoding::ColumnEncoding::ZoneIndex(mut zone_index) => {
+            let inner = zone_index.inner.take().unwrap();
+            let rows_per_zone = zone_index.rows_per_zone;
+            let zone_map_buffer = zone_index.zone_map_buffer.as_ref().unwrap().clone();
+            assert_eq!(
+                zone_map_buffer.buffer_type,
+                i32::from(pb::buffer::BufferType::Column)
+            );
+            let (position, size) =
+                column_info.buffer_offsets_and_sizes[zone_map_buffer.buffer_index as usize];
+            column_info.encoding = *inner;
+            let column = path_to_expr(cur_path);
+            let unloaded_pushdown = UnloadedPushdown {
+                data_type: data_type.clone(),
+                column,
+                position,
+                size,
+            };
+            Some((rows_per_zone, unloaded_pushdown))
+        }
+        _ => {
+            column_info.encoding.column_encoding = Some(encoding);
+            None
+        }
+    }
+}
+
+/// Extracted pushdown information obtained from the column encoding
+/// description.
+///
+/// This is "unloaded" because we haven't yet loaded the actual zone
+/// maps from the file (though position and size tell us where they
+/// are)
+#[derive(Debug)]
+pub struct UnloadedPushdown {
+    data_type: DataType,
+    column: Expr,
+    position: u64,
+    size: u64,
+}
+
+/// A top level scheduler that refines the requested range based on
+/// pushdown filtering with zone maps
+#[derive(Debug)]
+pub struct ZoneMapsFieldScheduler {
+    inner: Arc<dyn FieldScheduler>,
+    schema: Arc<Schema>,
+    pushdown_buffers: Vec<UnloadedPushdown>,
+    zone_guarantees: Arc<Vec<Vec<(Expr, NullableInterval)>>>,
+    rows_per_zone: u32,
+    num_rows: u64,
+}
+
+impl ZoneMapsFieldScheduler {
+    pub fn new(
+        inner: Arc<dyn FieldScheduler>,
+        schema: Arc<Schema>,
+        pushdown_buffers: Vec<UnloadedPushdown>,
+        rows_per_zone: u32,
+        num_rows: u64,
+    ) -> Self {
+        Self {
+            inner,
+            schema,
+            pushdown_buffers,
+            zone_guarantees: Arc::default(),
+            rows_per_zone: rows_per_zone,
+            num_rows,
+        }
+    }
+
+    /// Load the zone maps from the file
+    ///
+    /// TODO: only load zone maps for columns used in the filter
+    pub fn initialize<'a>(&'a mut self, io: &dyn EncodingsIo) -> BoxFuture<'a, Result<()>> {
+        let ranges = self
+            .pushdown_buffers
+            .iter()
+            .map(|unloaded_pushdown| {
+                unloaded_pushdown.position..(unloaded_pushdown.position + unloaded_pushdown.size)
+            })
+            .collect::<Vec<_>>();
+        let zone_maps_fut = io.submit_request(ranges, 0);
+        async move {
+            let zone_map_buffers = zone_maps_fut.await?;
+            let mut all_fields = Vec::with_capacity(zone_map_buffers.len());
+            for (bytes, unloaded_pushdown) in
+                zone_map_buffers.iter().zip(self.pushdown_buffers.iter())
+            {
+                let guarantees = self
+                    .map_from_buffer(
+                        bytes.clone(),
+                        &unloaded_pushdown.data_type,
+                        &unloaded_pushdown.column,
+                    )
+                    .await?;
+                all_fields.push(guarantees);
+            }
+            self.zone_guarantees = Arc::new(transpose2(all_fields));
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn process_filter(
+        &self,
+        filter: Expr,
+        projection_schema: DFSchemaRef,
+    ) -> Result<impl Fn(u64) -> bool> {
+        let zone_guarantees = self.zone_guarantees.clone();
+        Ok(move |zone_idx| {
+            let guarantees = &zone_guarantees[zone_idx as usize];
+            let props = ExecutionProps::new();
+            let context = SimplifyContext::new(&props).with_schema(projection_schema.clone());
+            let mut simplifier = ExprSimplifier::new(context);
+            simplifier = simplifier.with_guarantees(guarantees.clone());
+            match simplifier.simplify(filter.clone()) {
+                Ok(expr) => match expr {
+                    // Predicate, given guarantees, is always false, we can skip the zone
+                    Expr::Literal(ScalarValue::Boolean(Some(false))) => false,
+                    // Predicate may be true, need to load the zone
+                    _ => true,
+                },
+                Err(err) => {
+                    // TODO: this logs on each iteration, but maybe should should
+                    // only log once per call of this func?
+                    log::debug!("Failed to simplify predicate: {}", err);
+                    true
+                }
+            }
+        })
+    }
+
+    /// Parse the statistics into a set of guarantees for each batch.
+    fn extract_guarantees(
+        stats: &RecordBatch,
+        rows_per_zone: u32,
+        num_rows: u64,
+        data_type: &DataType,
+        col: Expr,
+    ) -> Vec<(Expr, NullableInterval)> {
+        let min_values = stats.column(0);
+        let max_values = stats.column(1);
+        let null_counts = stats.column(2).as_primitive::<UInt32Type>();
+
+        let mut guarantees = Vec::new();
+        for zone_idx in 0..stats.num_rows() {
+            let num_rows_in_zone = if zone_idx == stats.num_rows() - 1 {
+                (num_rows % rows_per_zone as u64) as u32
+            } else {
+                rows_per_zone
+            };
+            let min_value = ScalarValue::try_from_array(&min_values, zone_idx).unwrap();
+            let max_value = ScalarValue::try_from_array(&max_values, zone_idx).unwrap();
+            let null_count = null_counts.values()[zone_idx];
+
+            let values = Interval::try_new(min_value, max_value).unwrap();
+            let interval = match (null_count, num_rows_in_zone) {
+                (0, _) => NullableInterval::NotNull { values },
+                (null_count, num_rows_in_zone) if null_count == num_rows_in_zone => {
+                    NullableInterval::Null {
+                        datatype: data_type.clone(),
+                    }
+                }
+                _ => NullableInterval::MaybeNull { values },
+            };
+            guarantees.push((col.clone(), interval));
+        }
+        guarantees
+    }
+
+    async fn map_from_buffer(
+        &self,
+        buffer: Bytes,
+        data_type: &DataType,
+        col: &Expr,
+    ) -> Result<Vec<(Expr, NullableInterval)>> {
+        let zone_map_schema = Schema::try_from(&ArrowSchema::new(vec![
+            ArrowField::new("min", data_type.clone(), true),
+            ArrowField::new("max", data_type.clone(), true),
+            ArrowField::new("null_count", DataType::UInt32, false),
+        ]))
+        .unwrap();
+        let zone_maps_batch = EncodedBatch::try_from_mini_lance(buffer, &zone_map_schema)?;
+        let zone_maps_batch = decode_batch(
+            &zone_maps_batch,
+            &FilterExpression::no_filter(),
+            &DecoderMiddlewareChain::default(),
+        )
+        .await?;
+
+        Ok(Self::extract_guarantees(
+            &zone_maps_batch,
+            self.rows_per_zone,
+            self.num_rows,
+            data_type,
+            col.clone(),
+        ))
+    }
+}
+
+// Utility function to transpose Vec<Vec<...>> from Stack Overflow
+// https://stackoverflow.com/questions/64498617/how-to-transpose-a-vector-of-vectors-in-rust
+// Author: https://stackoverflow.com/users/1695172/netwave
+fn transpose2<T>(v: Vec<Vec<T>>) -> Vec<Vec<T>> {
+    assert!(!v.is_empty());
+    let len = v[0].len();
+    let mut iters: Vec<_> = v.into_iter().map(|n| n.into_iter()).collect();
+    (0..len)
+        .map(|_| {
+            iters
+                .iter_mut()
+                .map(|n| n.next().unwrap())
+                .collect::<Vec<T>>()
+        })
+        .collect()
+}
+
+// Schedulers don't always handle empty ranges well, so we need to provide a dummy job
+#[derive(Debug)]
+struct EmptySchedulingJob {}
+
+impl SchedulingJob for EmptySchedulingJob {
+    fn schedule_next(
+        &mut self,
+        _context: &mut SchedulerContext,
+        _top_level_row: u64,
+    ) -> Result<ScheduledScanLine> {
+        Ok(ScheduledScanLine {
+            rows_scheduled: 0,
+            decoders: vec![],
+        })
+    }
+
+    fn num_rows(&self) -> u64 {
+        0
+    }
+}
+
+impl FieldScheduler for ZoneMapsFieldScheduler {
+    fn schedule_ranges<'a>(
+        &'a self,
+        ranges: &[std::ops::Range<u64>],
+        filter: &FilterExpression,
+    ) -> Result<Box<dyn SchedulingJob + 'a>> {
+        let (df_filter, projection_schema) = filter.substrait_to_df(self.schema.as_ref())?;
+        let zone_filter_fn = self.process_filter(df_filter, Arc::new(projection_schema))?;
+        let zone_filter = ZoneMapsFilter::new(zone_filter_fn, self.rows_per_zone as u64);
+        let ranges = zone_filter.refine_ranges(ranges);
+        if ranges.is_empty() {
+            Ok(Box::new(EmptySchedulingJob {}))
+        } else {
+            self.inner.schedule_ranges(&ranges, filter)
+        }
+    }
+
+    fn num_rows(&self) -> u64 {
+        self.inner.num_rows()
+    }
 }
 
 /// A field encoder that creates zone maps for the data it encodes
@@ -110,7 +475,7 @@ impl ZoneMapsFieldEncoder {
         Ok(())
     }
 
-    async fn maps_to_metadata(&mut self) -> Result<Vec<EncodedBuffer>> {
+    async fn maps_to_metadata(&mut self) -> Result<EncodedBuffer> {
         let maps = std::mem::take(&mut self.maps);
         let (mins, (maxes, null_counts)): (Vec<_>, (Vec<_>, Vec<_>)) = maps
             .into_iter()
@@ -119,18 +484,21 @@ impl ZoneMapsFieldEncoder {
         let mins = ScalarValue::iter_to_array(mins.into_iter())?;
         let maxes = ScalarValue::iter_to_array(maxes.into_iter())?;
         let null_counts = Arc::new(UInt32Array::from_iter_values(null_counts.into_iter()));
-        let zone_map_schema = Arc::new(Schema::new(vec![
-            Field::new("min", mins.data_type().clone(), true),
-            Field::new("max", maxes.data_type().clone(), true),
-            Field::new("null_count", DataType::UInt32, false),
-        ]));
-        let zone_maps = RecordBatch::try_new(zone_map_schema, vec![mins, maxes, null_counts])?;
+        let zone_map_schema = ArrowSchema::new(vec![
+            ArrowField::new("min", mins.data_type().clone(), true),
+            ArrowField::new("max", maxes.data_type().clone(), true),
+            ArrowField::new("null_count", DataType::UInt32, false),
+        ]);
+        let schema = Schema::try_from(&zone_map_schema)?;
+        let zone_maps =
+            RecordBatch::try_new(Arc::new(zone_map_schema), vec![mins, maxes, null_counts])?;
         let encoding_strategy = CoreFieldEncodingStrategy::default();
-        let encoded_zone_maps = encode_batch(&zone_maps, &encoding_strategy, u64::MAX).await?;
+        let encoded_zone_maps =
+            encode_batch(&zone_maps, Arc::new(schema), &encoding_strategy, u64::MAX).await?;
         let zone_maps_buffer = encoded_zone_maps.try_to_mini_lance()?;
-        Ok(vec![EncodedBuffer {
+        Ok(EncodedBuffer {
             parts: vec![Buffer::from(zone_maps_buffer)],
-        }])
+        })
     }
 }
 
@@ -156,8 +524,36 @@ impl FieldEncoder for ZoneMapsFieldEncoder {
         self.items_encoder.flush()
     }
 
-    fn finish(&mut self) -> BoxFuture<'_, Result<Vec<EncodedBuffer>>> {
-        async move { self.maps_to_metadata().await }.boxed()
+    fn finish(&mut self) -> BoxFuture<'_, Result<Vec<EncodedColumn>>> {
+        async move {
+            let items_columns = self.items_encoder.finish().await?;
+            if items_columns.is_empty() {
+                return Err(Error::invalid_input("attempt to apply zone maps to a field encoder that generated zero columns of data".to_string(), location!()))
+            }
+            let items_column = items_columns.into_iter().next().unwrap();
+            let final_pages = items_column.final_pages;
+            let mut column_buffers = items_column.column_buffers;
+            let zone_buffer_index = column_buffers.len();
+            column_buffers.push(self.maps_to_metadata().await?);
+            let column_encoding = pb::ColumnEncoding {
+                column_encoding: Some(pb::column_encoding::ColumnEncoding::ZoneIndex(Box::new(
+                    pb::ZoneIndex {
+                        inner: Some(Box::new(items_column.encoding)),
+                        rows_per_zone: self.rows_per_map,
+                        zone_map_buffer: Some(pb::Buffer {
+                            buffer_index: zone_buffer_index as u32,
+                            buffer_type: i32::from(pb::buffer::BufferType::Column),
+                        }),
+                    },
+                ))),
+            };
+            Ok(vec![EncodedColumn {
+                encoding: column_encoding,
+                final_pages,
+                column_buffers,
+            }])
+        }
+        .boxed()
     }
 
     fn num_columns(&self) -> u32 {
@@ -167,55 +563,91 @@ impl FieldEncoder for ZoneMapsFieldEncoder {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::sync::Arc;
 
     use arrow_array::types::Int32Type;
-    use arrow_schema::DataType;
+    use datafusion_common::ScalarValue;
+    use datafusion_expr::{col, BinaryExpr, Expr, Operator};
     use lance_datagen::{BatchCount, RowCount};
-    use lance_encoding::encoder::{
-        ColumnIndexSequence, CoreFieldEncodingStrategy, FieldEncoder, FieldEncodingStrategy,
+    use lance_encoding::decoder::{
+        CoreFieldDecoderStrategy, DecoderMiddlewareChain, FilterExpression,
+    };
+    use lance_file::v2::{
+        testing::{count_lance_file, write_lance_file, FsFixture},
+        writer::FileWriterOptions,
     };
 
-    #[tokio::test]
+    use crate::{
+        substrait::FilterExpressionExt, LanceDfFieldDecoderStrategy, LanceDfFieldEncodingStrategy,
+    };
+
+    #[test_log::test(tokio::test)]
     async fn test_basic_stats() {
-        let encoding_strategy = CoreFieldEncodingStrategy::default();
-        let mut col_idx_seq = ColumnIndexSequence::default();
-        let mock_field = lance_core::datatypes::Field::try_from(arrow_schema::Field::new(
-            "foo",
-            DataType::Int32,
-            false,
-        ))
-        .unwrap();
-        let inner = encoding_strategy
-            .create_field_encoder(
-                &encoding_strategy,
-                &mock_field,
-                &mut col_idx_seq,
-                4096,
-                true,
-                &HashMap::new(),
+        let data = lance_datagen::gen()
+            .col("0", lance_datagen::array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(1024), BatchCount::from(30));
+
+        let fs = FsFixture::default();
+
+        let options = FileWriterOptions {
+            encoding_strategy: Some(Arc::new(LanceDfFieldEncodingStrategy::default())),
+            ..Default::default()
+        };
+
+        let (schema, data) = write_lance_file(data, &fs, options).await;
+
+        let decoder_middleware = DecoderMiddlewareChain::new()
+            .add(Arc::new(LanceDfFieldDecoderStrategy::new(schema.clone())))
+            .add(Arc::new(CoreFieldDecoderStrategy::default()));
+
+        let num_rows = data.iter().map(|rb| rb.num_rows()).sum::<usize>();
+
+        let result = count_lance_file(
+            &fs,
+            decoder_middleware.clone(),
+            FilterExpression::no_filter(),
+        )
+        .await;
+        assert_eq!(num_rows, result);
+
+        let decoder_middleware = DecoderMiddlewareChain::new()
+            .add(Arc::new(LanceDfFieldDecoderStrategy::new(schema.clone())))
+            .add(Arc::new(CoreFieldDecoderStrategy::default()));
+
+        let result = count_lance_file(
+            &fs,
+            decoder_middleware,
+            FilterExpression::df_to_substrait(
+                Expr::BinaryExpr(BinaryExpr {
+                    left: Box::new(col("0")),
+                    op: Operator::Gt,
+                    right: Box::new(Expr::Literal(ScalarValue::Int32(Some(50000)))),
+                }),
+                schema.as_ref(),
             )
-            .unwrap();
-        let mut encoder =
-            super::ZoneMapsFieldEncoder::try_new(inner, DataType::Int32, 100).unwrap();
+            .unwrap(),
+        )
+        .await;
+        assert_eq!(0, result);
 
-        let gen = lance_datagen::gen()
-            .anon_col(lance_datagen::array::step::<Int32Type>())
-            .into_reader_rows(RowCount::from(1024), BatchCount::from(7));
+        let decoder_middleware = DecoderMiddlewareChain::new()
+            .add(Arc::new(LanceDfFieldDecoderStrategy::new(schema.clone())))
+            .add(Arc::new(CoreFieldDecoderStrategy::default()));
 
-        for batch in gen {
-            let batch = batch.unwrap();
-            let array = batch.column(0);
-            encoder.maybe_encode(array.clone()).unwrap();
-        }
-
-        let zone_maps_buffer = encoder.finish().await.unwrap();
-        assert_eq!(zone_maps_buffer.len(), 1);
-        let zone_maps_buffer = zone_maps_buffer.into_iter().next().unwrap();
-        assert_eq!(zone_maps_buffer.parts.len(), 1);
-        let zone_maps_buffer = zone_maps_buffer.parts.into_iter().next().unwrap();
-        // TODO: Once reading is available we can check the contents of the zone maps buffer
-        // TODO: Test out the different types
-        assert!(!zone_maps_buffer.is_empty());
+        let result = count_lance_file(
+            &fs,
+            decoder_middleware,
+            FilterExpression::df_to_substrait(
+                Expr::BinaryExpr(BinaryExpr {
+                    left: Box::new(col("0")),
+                    op: Operator::Gt,
+                    right: Box::new(Expr::Literal(ScalarValue::Int32(Some(20000)))),
+                }),
+                schema.as_ref(),
+            )
+            .unwrap(),
+        )
+        .await;
+        assert_eq!(30 * 1024 - 20000, result);
     }
 }

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -7,7 +7,6 @@ use arrow_buffer::Buffer;
 use arrow_schema::DataType;
 use bytes::{Bytes, BytesMut};
 use futures::future::BoxFuture;
-use futures::FutureExt;
 use lance_core::datatypes::{Field, Schema};
 use lance_core::Result;
 
@@ -77,6 +76,19 @@ pub struct EncodedArray {
     pub encoding: pb::ArrayEncoding,
 }
 
+impl EncodedArray {
+    pub fn into_parts(mut self) -> (Vec<EncodedBuffer>, pb::ArrayEncoding) {
+        self.buffers.sort_by_key(|b| b.index);
+        (
+            self.buffers
+                .into_iter()
+                .map(|b| EncodedBuffer { parts: b.parts })
+                .collect(),
+            self.encoding,
+        )
+    }
+}
+
 /// An encoded page of data
 ///
 /// Maps to a top-level array
@@ -129,6 +141,30 @@ pub trait ArrayEncoder: std::fmt::Debug + Send + Sync {
     fn encode(&self, arrays: &[ArrayRef], buffer_index: &mut u32) -> Result<EncodedArray>;
 }
 
+pub fn values_column_encoding() -> pb::ColumnEncoding {
+    pb::ColumnEncoding {
+        column_encoding: Some(pb::column_encoding::ColumnEncoding::Values(())),
+    }
+}
+
+pub struct EncodedColumn {
+    pub column_buffers: Vec<EncodedBuffer>,
+    pub encoding: pb::ColumnEncoding,
+    pub final_pages: Vec<EncodedPage>,
+}
+
+impl Default for EncodedColumn {
+    fn default() -> Self {
+        Self {
+            column_buffers: Default::default(),
+            encoding: pb::ColumnEncoding {
+                column_encoding: Some(pb::column_encoding::ColumnEncoding::Values(())),
+            },
+            final_pages: Default::default(),
+        }
+    }
+}
+
 /// A task to create a page of data
 pub type EncodeTask = BoxFuture<'static, Result<EncodedPage>>;
 
@@ -160,14 +196,12 @@ pub trait FieldEncoder: Send {
     /// This may be called intermittently throughout encoding but will always be called
     /// once at the end of encoding just before calling finish
     fn flush(&mut self) -> Result<Vec<EncodeTask>>;
-    /// Finish encoding and return column metadata buffers
+    /// Finish encoding and return column metadata
     ///
     /// This is called only once, after all encode tasks have completed
     ///
-    /// By default, returns an empty Vec (no column metadata buffers)
-    fn finish(&mut self) -> BoxFuture<'_, Result<Vec<EncodedBuffer>>> {
-        std::future::ready(Ok(vec![])).boxed()
-    }
+    /// This returns a Vec because a single field may have created multiple columns
+    fn finish(&mut self) -> BoxFuture<'_, Result<Vec<EncodedColumn>>>;
     /// The number of output columns this encoding will create
     fn num_columns(&self) -> u32;
 }
@@ -421,9 +455,28 @@ impl BatchEncoder {
 /// This is returned by [`crate::encoder::encode_batch`]
 pub struct EncodedBatch {
     pub data: Bytes,
-    pub page_table: Vec<ColumnInfo>,
-    pub schema: Arc<arrow_schema::Schema>,
+    pub page_table: Vec<Arc<ColumnInfo>>,
+    pub schema: Arc<Schema>,
     pub num_rows: u64,
+}
+
+fn write_page_to_data_buffer(page: EncodedPage, data_buffer: &mut BytesMut) -> PageInfo {
+    let mut buffers = page.array.buffers;
+    buffers.sort_by_key(|b| b.index);
+    let mut buffer_offsets_and_sizes = Vec::new();
+    for buffer in buffers {
+        let buffer_offset = data_buffer.len() as u64;
+        for part in buffer.parts {
+            data_buffer.extend_from_slice(&part);
+        }
+        let size = data_buffer.len() as u64 - buffer_offset;
+        buffer_offsets_and_sizes.push((buffer_offset, size));
+    }
+    PageInfo {
+        buffer_offsets_and_sizes: Arc::from(buffer_offsets_and_sizes),
+        encoding: page.array.encoding,
+        num_rows: page.num_rows,
+    }
 }
 
 /// Helper method to encode a batch of data into memory
@@ -432,6 +485,7 @@ pub struct EncodedBatch {
 /// niche situations like IPC.
 pub async fn encode_batch(
     batch: &RecordBatch,
+    schema: Arc<Schema>,
     encoding_strategy: &dyn FieldEncodingStrategy,
     cache_bytes_per_column: u64,
 ) -> Result<EncodedBatch> {
@@ -444,39 +498,53 @@ pub async fn encode_batch(
         true,
     )?;
     let mut page_table = Vec::new();
+    let mut col_idx_offset = 0;
     for (arr, mut encoder) in batch.columns().iter().zip(batch_encoder.field_encoders) {
         let mut tasks = encoder.maybe_encode(arr.clone())?;
         tasks.extend(encoder.flush()?);
-        let mut pages = Vec::new();
+        let mut pages = HashMap::<u32, Vec<PageInfo>>::new();
         for task in tasks {
             let encoded_page = task.await?;
-            let mut buffers = encoded_page.array.buffers;
-            buffers.sort_by_key(|b| b.index);
-            let mut buffer_offsets_and_sizes = Vec::new();
-            for buffer in buffers {
+            pages
+                .entry(encoded_page.column_idx)
+                .or_default()
+                .push(write_page_to_data_buffer(encoded_page, &mut data_buffer));
+        }
+        let encoded_columns = encoder.finish().await?;
+        let num_columns = encoded_columns.len();
+        for (col_idx, encoded_column) in encoded_columns.into_iter().enumerate() {
+            let col_idx = col_idx + col_idx_offset;
+            let mut col_buffer_offsets_and_sizes = Vec::new();
+            for buffer in encoded_column.column_buffers {
                 let buffer_offset = data_buffer.len() as u64;
                 for part in buffer.parts {
                     data_buffer.extend_from_slice(&part);
                 }
                 let size = data_buffer.len() as u64 - buffer_offset;
-                buffer_offsets_and_sizes.push((buffer_offset, size));
+                col_buffer_offsets_and_sizes.push((buffer_offset, size));
             }
-            pages.push(PageInfo {
-                buffer_offsets_and_sizes: Arc::from(buffer_offsets_and_sizes.into_boxed_slice()),
-                encoding: encoded_page.array.encoding,
-                num_rows: encoded_page.num_rows,
-            })
+            for page in encoded_column.final_pages {
+                pages
+                    .entry(page.column_idx)
+                    .or_default()
+                    .push(write_page_to_data_buffer(page, &mut data_buffer));
+            }
+            let col_pages = std::mem::take(pages.entry(col_idx as u32).or_default());
+            page_table.push(Arc::new(ColumnInfo {
+                index: col_idx as u32,
+                buffer_offsets_and_sizes: Arc::from(
+                    col_buffer_offsets_and_sizes.into_boxed_slice(),
+                ),
+                page_infos: Arc::from(col_pages.into_boxed_slice()),
+                encoding: encoded_column.encoding,
+            }))
         }
-        page_table.push(ColumnInfo {
-            index: 0,
-            buffer_offsets_and_sizes: Arc::new([]),
-            page_infos: Arc::from(pages.into_boxed_slice()),
-        })
+        col_idx_offset += num_columns;
     }
     Ok(EncodedBatch {
         data: data_buffer.freeze(),
         page_table,
-        schema: batch.schema(),
+        schema: schema,
         num_rows: batch.num_rows() as u64,
     })
 }

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -544,7 +544,7 @@ pub async fn encode_batch(
     Ok(EncodedBatch {
         data: data_buffer.freeze(),
         page_table,
-        schema: schema,
+        schema,
         num_rows: batch.num_rows() as u64,
     })
 }

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -28,10 +28,11 @@ use lance_core::{Error, Result};
 
 use crate::{
     decoder::{
-        DecodeArrayTask, FieldScheduler, LogicalPageDecoder, NextDecodeTask, PageInfo,
-        PageScheduler, PhysicalPageDecoder, ScheduledScanLine, SchedulerContext, SchedulingJob,
+        DecodeArrayTask, FieldScheduler, FilterExpression, LogicalPageDecoder, NextDecodeTask,
+        PageInfo, PageScheduler, PhysicalPageDecoder, ScheduledScanLine, SchedulerContext,
+        SchedulingJob,
     },
-    encoder::{ArrayEncodingStrategy, EncodeTask, EncodedPage, FieldEncoder},
+    encoder::{ArrayEncodingStrategy, EncodeTask, EncodedColumn, EncodedPage, FieldEncoder},
     encodings::physical::{decoder_from_array_encoding, ColumnBuffers, PageBuffers},
 };
 
@@ -184,6 +185,10 @@ impl<'a> SchedulingJob for PrimitiveFieldSchedulingJob<'a> {
             rows_scheduled: num_rows_in_next,
         })
     }
+
+    fn num_rows(&self) -> u64 {
+        self.ranges.iter().map(|r| r.end - r.start).sum()
+    }
 }
 
 impl FieldScheduler for PrimitiveFieldScheduler {
@@ -194,6 +199,8 @@ impl FieldScheduler for PrimitiveFieldScheduler {
     fn schedule_ranges<'a>(
         &'a self,
         ranges: &[std::ops::Range<u64>],
+        // TODO: Could potentially use filter to simplify decode, something of a micro-optimization probably
+        _filter: &FilterExpression,
     ) -> Result<Box<dyn SchedulingJob + 'a>> {
         Ok(Box::new(PrimitiveFieldSchedulingJob::new(
             self,
@@ -667,5 +674,9 @@ impl FieldEncoder for PrimitiveFieldEncoder {
 
     fn num_columns(&self) -> u32 {
         1
+    }
+
+    fn finish(&mut self) -> BoxFuture<'_, Result<Vec<crate::encoder::EncodedColumn>>> {
+        std::future::ready(Ok(vec![EncodedColumn::default()])).boxed()
     }
 }

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -15,9 +15,12 @@ use lance_core::Result;
 use lance_datagen::{array, gen, RowCount, Seed};
 
 use crate::{
-    decoder::{BatchDecodeStream, ColumnInfo, DecodeBatchScheduler, DecoderMessage, PageInfo},
+    decoder::{
+        BatchDecodeStream, ColumnInfo, DecodeBatchScheduler, DecoderMessage,
+        DecoderMiddlewareChain, FilterExpression, PageInfo,
+    },
     encoder::{
-        ColumnIndexSequence, CoreFieldEncodingStrategy, EncodedPage, FieldEncoder,
+        ColumnIndexSequence, CoreFieldEncodingStrategy, EncodedBuffer, EncodedPage, FieldEncoder,
         FieldEncodingStrategy,
     },
     encodings::logical::r#struct::SimpleStructDecoder,
@@ -29,18 +32,8 @@ pub(crate) struct SimulatedScheduler {
 }
 
 impl SimulatedScheduler {
-    pub fn new(data: Vec<EncodedPage>) -> Self {
-        let mut bytes = BytesMut::new();
-        for page in data.into_iter() {
-            for buf in page.array.buffers {
-                for part in buf.parts.into_iter() {
-                    bytes.extend_from_slice(&part)
-                }
-            }
-        }
-        Self {
-            data: bytes.freeze(),
-        }
+    pub fn new(data: Bytes) -> Self {
+        Self { data }
     }
 
     fn satisfy_request(&self, req: Range<u64>) -> Bytes {
@@ -66,20 +59,31 @@ async fn test_decode(
     num_rows: u64,
     batch_size: u32,
     schema: &Schema,
-    column_infos: &[ColumnInfo],
+    column_infos: &[Arc<ColumnInfo>],
     expected: Option<Arc<dyn Array>>,
+    io: &Arc<dyn EncodingsIo>,
     schedule_fn: impl FnOnce(
         DecodeBatchScheduler,
-        UnboundedSender<DecoderMessage>,
-    ) -> (SimpleStructDecoder, BoxFuture<'static, Result<()>>),
+        UnboundedSender<Result<DecoderMessage>>,
+    ) -> (SimpleStructDecoder, BoxFuture<'static, ()>),
 ) {
-    let decode_scheduler = DecodeBatchScheduler::new(schema, column_infos, &Vec::new());
+    let lance_schema = lance_core::datatypes::Schema::try_from(schema).unwrap();
+    let decode_scheduler = DecodeBatchScheduler::try_new(
+        &lance_schema,
+        &column_infos,
+        &Vec::new(),
+        num_rows,
+        &DecoderMiddlewareChain::default(),
+        io,
+    )
+    .await
+    .unwrap();
 
     let (tx, rx) = mpsc::unbounded_channel();
 
     let (decoder, scheduler_fut) = schedule_fn(decode_scheduler, tx);
 
-    scheduler_fut.await.unwrap();
+    scheduler_fut.await;
 
     let mut decode_stream = BatchDecodeStream::new(rx, batch_size, num_rows, decoder).into_stream();
 
@@ -197,6 +201,49 @@ pub async fn check_round_trip_encoding_of_data(data: Vec<Arc<dyn Array>>, test_c
     }
 }
 
+struct SimulatedWriter {
+    page_infos: Vec<Vec<PageInfo>>,
+    encoded_data: BytesMut,
+}
+
+impl SimulatedWriter {
+    fn new(num_columns: u32) -> Self {
+        let mut page_infos = Vec::with_capacity(num_columns as usize);
+        page_infos.resize_with(num_columns as usize, Default::default);
+        Self {
+            page_infos,
+            encoded_data: BytesMut::new(),
+        }
+    }
+
+    fn write_buffer(&mut self, buffer: EncodedBuffer) -> (u64, u64) {
+        let offset = self.encoded_data.len() as u64;
+        for part in buffer.parts.iter() {
+            self.encoded_data.extend_from_slice(&part);
+        }
+        let size = self.encoded_data.len() as u64 - offset;
+        (offset, size)
+    }
+
+    fn write_page(&mut self, encoded_page: EncodedPage) {
+        trace!("Encoded page {:?}", encoded_page);
+        let (page_buffers, page_encoding) = encoded_page.array.into_parts();
+        let buffer_offsets_and_sizes = page_buffers
+            .into_iter()
+            .map(|b| self.write_buffer(b))
+            .collect::<Vec<_>>();
+
+        let page_info = PageInfo {
+            num_rows: encoded_page.num_rows,
+            encoding: page_encoding,
+            buffer_offsets_and_sizes: Arc::from(buffer_offsets_and_sizes.clone()),
+        };
+
+        let col_idx = encoded_page.column_idx as usize;
+        self.page_infos[col_idx].push(page_info);
+    }
+}
+
 /// This is the inner-most check function that actually runs the round trip and tests it
 async fn check_round_trip_encoding_inner(
     mut encoder: Box<dyn FieldEncoder>,
@@ -204,64 +251,46 @@ async fn check_round_trip_encoding_inner(
     data: Vec<Arc<dyn Array>>,
     test_cases: &TestCases,
 ) {
-    let mut all_encoded_pages = Vec::new();
-    let mut page_infos: Vec<Vec<PageInfo>> = Vec::with_capacity(encoder.num_columns() as usize);
-    page_infos.resize_with(encoder.num_columns() as usize, Default::default);
-    let mut buffer_offset = 0;
-
-    let mut simulate_write = |mut encoded_page: EncodedPage| {
-        trace!("Encoded page {:?}", encoded_page);
-        encoded_page.array.buffers.sort_by_key(|b| b.index);
-        let buffer_offsets_and_sizes = encoded_page
-            .array
-            .buffers
-            .iter()
-            .map(|buf| {
-                let offset = buffer_offset;
-                let size = buf.parts.iter().map(|part| part.len() as u64).sum::<u64>();
-                buffer_offset += size;
-                (offset, size)
-            })
-            .collect::<Vec<_>>();
-
-        let page_info = PageInfo {
-            num_rows: encoded_page.num_rows,
-            encoding: encoded_page.array.encoding.clone(),
-            buffer_offsets_and_sizes: Arc::from(
-                buffer_offsets_and_sizes.clone().into_boxed_slice(),
-            ),
-        };
-
-        let col_idx = encoded_page.column_idx as usize;
-        all_encoded_pages.push(encoded_page);
-        page_infos[col_idx].push(page_info);
-    };
+    let mut writer = SimulatedWriter::new(encoder.num_columns());
 
     for arr in &data {
         for encode_task in encoder.maybe_encode(arr.clone()).unwrap() {
             let encoded_page = encode_task.await.unwrap();
-            simulate_write(encoded_page);
+            writer.write_page(encoded_page);
         }
     }
 
     for encode_task in encoder.flush().unwrap() {
         let encoded_page = encode_task.await.unwrap();
-        simulate_write(encoded_page);
+        writer.write_page(encoded_page);
     }
 
-    let scheduler = Arc::new(SimulatedScheduler::new(all_encoded_pages)) as Arc<dyn EncodingsIo>;
+    let encoded_columns = encoder.finish().await.unwrap();
+    let mut column_infos = Vec::new();
+    for (col_idx, encoded_column) in encoded_columns.into_iter().enumerate() {
+        for page in encoded_column.final_pages {
+            writer.write_page(page);
+        }
 
-    let column_infos = page_infos
-        .into_iter()
-        .enumerate()
-        .map(|(col_idx, page_infos)| {
-            ColumnInfo::new(
-                col_idx as u32,
-                Arc::from(page_infos.into_boxed_slice()),
-                Vec::new(),
-            )
-        })
-        .collect::<Vec<_>>();
+        let col_buffer_off_and_size = encoded_column
+            .column_buffers
+            .into_iter()
+            .map(|b| writer.write_buffer(b))
+            .collect::<Vec<_>>();
+
+        let column_info = ColumnInfo::new(
+            col_idx as u32,
+            Arc::from(std::mem::take(&mut writer.page_infos[col_idx])),
+            col_buffer_off_and_size,
+            encoded_column.encoding,
+        );
+
+        column_infos.push(Arc::new(column_info));
+    }
+
+    let scheduler =
+        Arc::new(SimulatedScheduler::new(writer.encoded_data.freeze())) as Arc<dyn EncodingsIo>;
+
     let schema = Schema::new(vec![field.clone()]);
 
     let num_rows = data.iter().map(|arr| arr.len() as u64).sum::<u64>();
@@ -280,15 +309,21 @@ async fn check_round_trip_encoding_inner(
         &schema,
         &column_infos,
         concat_data.clone(),
+        &scheduler_copy.clone(),
         |mut decode_scheduler, tx| {
             #[allow(clippy::single_range_in_vec_init)]
-            let root_decoder = decode_scheduler
-                .root_scheduler
-                .new_root_decoder_ranges(&[0..num_rows]);
+            let root_decoder = decode_scheduler.new_root_decoder_ranges(&[0..num_rows]);
             (
                 root_decoder,
-                async move { decode_scheduler.schedule_range(0..num_rows, tx, scheduler_copy) }
-                    .boxed(),
+                async move {
+                    decode_scheduler.schedule_range(
+                        0..num_rows,
+                        &FilterExpression::no_filter(),
+                        tx,
+                        scheduler_copy,
+                    )
+                }
+                .boxed(),
             )
         },
     )
@@ -309,14 +344,21 @@ async fn check_round_trip_encoding_inner(
             &schema,
             &column_infos,
             expected,
+            &scheduler.clone(),
             |mut decode_scheduler, tx| {
                 #[allow(clippy::single_range_in_vec_init)]
-                let root_decoder = decode_scheduler
-                    .root_scheduler
-                    .new_root_decoder_ranges(&[0..num_rows]);
+                let root_decoder = decode_scheduler.new_root_decoder_ranges(&[0..num_rows]);
                 (
                     root_decoder,
-                    async move { decode_scheduler.schedule_range(range, tx, scheduler) }.boxed(),
+                    async move {
+                        decode_scheduler.schedule_range(
+                            range,
+                            &FilterExpression::no_filter(),
+                            tx,
+                            scheduler,
+                        )
+                    }
+                    .boxed(),
                 )
             },
         )
@@ -348,13 +390,20 @@ async fn check_round_trip_encoding_inner(
             &schema,
             &column_infos,
             expected,
+            &scheduler.clone(),
             |mut decode_scheduler, tx| {
-                let root_decoder = decode_scheduler
-                    .root_scheduler
-                    .new_root_decoder_indices(&indices);
+                let root_decoder = decode_scheduler.new_root_decoder_indices(&indices);
                 (
                     root_decoder,
-                    async move { decode_scheduler.schedule_take(&indices, tx, scheduler) }.boxed(),
+                    async move {
+                        decode_scheduler.schedule_take(
+                            &indices,
+                            &FilterExpression::no_filter(),
+                            tx,
+                            scheduler,
+                        )
+                    }
+                    .boxed(),
                 )
             },
         )

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -70,7 +70,7 @@ async fn test_decode(
     let lance_schema = lance_core::datatypes::Schema::try_from(schema).unwrap();
     let decode_scheduler = DecodeBatchScheduler::try_new(
         &lance_schema,
-        &column_infos,
+        column_infos,
         &Vec::new(),
         num_rows,
         &DecoderMiddlewareChain::default(),
@@ -219,7 +219,7 @@ impl SimulatedWriter {
     fn write_buffer(&mut self, buffer: EncodedBuffer) -> (u64, u64) {
         let offset = self.encoded_data.len() as u64;
         for part in buffer.parts.iter() {
-            self.encoded_data.extend_from_slice(&part);
+            self.encoded_data.extend_from_slice(part);
         }
         let size = self.encoded_data.len() as u64 - offset;
         (offset, size)

--- a/rust/lance-file/Cargo.toml
+++ b/rust/lance-file/Cargo.toml
@@ -38,13 +38,13 @@ prost.workspace = true
 prost-types.workspace = true
 roaring.workspace = true
 snafu.workspace = true
+tempfile.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
 rand.workspace = true
-tempfile.workspace = true
 proptest.workspace = true
 pretty_assertions.workspace = true
 test-log.workspace = true

--- a/rust/lance-file/src/v2.rs
+++ b/rust/lance-file/src/v2.rs
@@ -3,4 +3,5 @@
 
 pub(crate) mod io;
 pub mod reader;
+pub mod testing;
 pub mod writer;

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -6,14 +6,18 @@ use std::{collections::BTreeSet, io::Cursor, ops::Range, pin::Pin, sync::Arc};
 use arrow_schema::Schema as ArrowSchema;
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
 use bytes::{Bytes, BytesMut};
-use futures::{stream::BoxStream, Stream, StreamExt};
+use futures::{stream::BoxStream, FutureExt, Stream, StreamExt};
 use lance_arrow::DataTypeExt;
 use lance_encoding::{
-    decoder::{BatchDecodeStream, ColumnInfo, DecodeBatchScheduler, PageInfo, ReadBatchTask},
+    decoder::{
+        BatchDecodeStream, ColumnInfo, DecodeBatchScheduler, DecoderMiddlewareChain,
+        FilterExpression, PageInfo, ReadBatchTask,
+    },
+    encoder::EncodedBatch,
     EncodingsIo,
 };
 use log::debug;
-use prost::Message;
+use prost::{Message, Name};
 use snafu::{location, Location};
 
 use lance_core::{
@@ -87,7 +91,7 @@ pub struct CachedFileMetadata {
 pub struct ReaderProjection {
     /// The data types (schema) of the selected columns.  The names
     /// of the schema are arbitrary and ignored.
-    pub schema: Arc<ArrowSchema>,
+    pub schema: Arc<Schema>,
     /// The indices of the columns to load.  Note, these are the
     /// indices of the top level fields only
     pub column_indices: Vec<u32>,
@@ -100,8 +104,10 @@ pub struct FileReader {
     base_projection: ReaderProjection,
     num_rows: u64,
     metadata: Arc<CachedFileMetadata>,
+    decoder_strategy: DecoderMiddlewareChain,
 }
 
+#[derive(Debug)]
 struct Footer {
     #[allow(dead_code)]
     column_meta_start: u64,
@@ -199,7 +205,7 @@ impl FileReader {
     }
 
     // TODO: Once we have coalesced I/O we should only read the column metadatas that we need
-    async fn read_all_column_metadata(
+    fn read_all_column_metadata(
         column_metadata_bytes: Bytes,
         footer: &Footer,
     ) -> Result<Vec<pbfile::ColumnMetadata>> {
@@ -244,6 +250,22 @@ impl FileReader {
         }
     }
 
+    fn do_decode_gbo_table(gbo_bytes: &Bytes, footer: &Footer) -> Result<Vec<BufferDescriptor>> {
+        let mut global_bufs_cursor = Cursor::new(gbo_bytes);
+
+        let mut global_buffers = Vec::with_capacity(footer.num_global_buffers as usize);
+        for _ in 0..footer.num_global_buffers {
+            let buf_pos = global_bufs_cursor.read_u64::<LittleEndian>()?;
+            let buf_size = global_bufs_cursor.read_u64::<LittleEndian>()?;
+            global_buffers.push(BufferDescriptor {
+                position: buf_pos,
+                size: buf_size,
+            });
+        }
+
+        Ok(global_buffers)
+    }
+
     async fn decode_gbo_table(
         tail_bytes: &Bytes,
         file_len: u64,
@@ -259,19 +281,7 @@ impl FileReader {
             file_len,
         )
         .await?;
-        let mut global_bufs_cursor = Cursor::new(&gbo_bytes);
-
-        let mut global_buffers = Vec::with_capacity(footer.num_global_buffers as usize);
-        for _ in 0..footer.num_global_buffers {
-            let buf_pos = global_bufs_cursor.read_u64::<LittleEndian>()?;
-            let buf_size = global_bufs_cursor.read_u64::<LittleEndian>()?;
-            global_buffers.push(BufferDescriptor {
-                position: buf_pos,
-                size: buf_size,
-            });
-        }
-
-        Ok(global_buffers)
+        Self::do_decode_gbo_table(&gbo_bytes, footer)
     }
 
     fn decode_schema(schema_bytes: Bytes) -> Result<(u64, lance_core::datatypes::Schema)> {
@@ -330,8 +340,7 @@ impl FileReader {
         let column_metadata_end = (footer.global_buff_offsets_start - schema_start) as usize;
         let column_metadata_bytes =
             all_metadata_bytes.slice(column_metadata_start..column_metadata_end);
-        let column_metadatas =
-            Self::read_all_column_metadata(column_metadata_bytes, &footer).await?;
+        let column_metadatas = Self::read_all_column_metadata(column_metadata_bytes, &footer)?;
 
         let footer_start = file_len - FOOTER_LEN as u64;
         let num_data_bytes = footer.column_meta_start;
@@ -339,7 +348,7 @@ impl FileReader {
             + (footer_start - footer.global_buff_offsets_start);
         let num_column_metadata_bytes = footer.global_buff_offsets_start - footer.column_meta_start;
 
-        let column_infos = Self::meta_to_col_infos(&column_metadatas);
+        let column_infos = Self::meta_to_col_infos(column_metadatas.as_slice());
 
         Ok(CachedFileMetadata {
             file_schema: Arc::new(schema),
@@ -356,75 +365,13 @@ impl FileReader {
         })
     }
 
-    pub async fn print_all_metadata(metadata: &CachedFileMetadata) -> Result<()> {
-        // 1. read and print the footer
-        println!("# Footer");
-        println!();
-        println!(
-            "File version           : {}.{}",
-            MAJOR_VERSION, MINOR_VERSION_NEXT
-        );
-        println!("Data bytes             : {}", metadata.num_data_bytes);
-        println!("Col. meta bytes: {}", metadata.num_column_metadata_bytes);
-        println!("Glo. data bytes: {}", metadata.num_global_buffer_bytes);
-
-        // 2. print the global buffers
-        println!("Global buffers:");
-        for file_buffer in &metadata.file_buffers {
-            println!(
-                " * {}..{}",
-                file_buffer.position,
-                file_buffer.position + file_buffer.size
-            );
-        }
-
-        println!("Columns:");
-        for (idx, col) in metadata.column_metadatas.iter().enumerate() {
-            println!(" * Column {}", idx);
-            println!();
-            println!("   Buffers:");
-            for idx in 0..col.buffer_offsets.len() {
-                println!(
-                    "    * {}..{}",
-                    col.buffer_offsets[idx],
-                    col.buffer_offsets[idx] + col.buffer_sizes[idx]
-                );
-            }
-            println!("   Pages:");
-            println!();
-            for (page_idx, page) in col.pages.iter().enumerate() {
-                println!("   * Page {}", page_idx);
-                println!();
-                println!("     Buffers:");
-                for buf_idx in 0..page.buffer_offsets.len() {
-                    println!(
-                        "      * {}..{}",
-                        page.buffer_offsets[buf_idx],
-                        page.buffer_offsets[buf_idx] + page.buffer_sizes[buf_idx]
-                    );
-                }
-                let encoding = page.encoding.as_ref().unwrap();
-                let encoding = Self::fetch_encoding(encoding);
-                println!("     Encoding:");
-                println!();
-                let encoding_dbg = format!("{:#?}", encoding);
-                for line in encoding_dbg.lines() {
-                    println!("       {}", line);
-                }
-                println!();
-            }
-        }
-
-        Ok(())
-    }
-
-    fn fetch_encoding(encoding: &pbfile::Encoding) -> pbenc::ArrayEncoding {
+    fn fetch_encoding<M: Default + Name + Sized>(encoding: &pbfile::Encoding) -> M {
         match &encoding.location {
             Some(pbfile::encoding::Location::Indirect(_)) => todo!(),
             Some(pbfile::encoding::Location::Direct(encoding)) => {
                 let encoding_buf = Bytes::from(encoding.encoding.clone());
                 let encoding_any = prost_types::Any::decode(encoding_buf).unwrap();
-                encoding_any.to_msg::<pbenc::ArrayEncoding>().unwrap()
+                encoding_any.to_msg::<M>().unwrap()
             }
             Some(pbfile::encoding::Location::None(_)) => panic!(),
             None => panic!(),
@@ -456,10 +403,19 @@ impl FileReader {
                         }
                     })
                     .collect::<Vec<_>>();
+                let buffer_offsets_and_sizes = Arc::from(
+                    col_meta
+                        .buffer_offsets
+                        .iter()
+                        .zip(col_meta.buffer_sizes.iter())
+                        .map(|(offset, size)| (*offset, *size))
+                        .collect::<Vec<_>>(),
+                );
                 Arc::new(ColumnInfo {
                     index: col_idx as u32,
                     page_infos: Arc::from(page_infos),
-                    buffer_offsets_and_sizes: Arc::new([]),
+                    buffer_offsets_and_sizes,
+                    encoding: Self::fetch_encoding(col_meta.encoding.as_ref().unwrap()),
                 })
             })
             .collect::<Vec<_>>()
@@ -522,7 +478,7 @@ impl FileReader {
     /// Loads a default projection for all columns in the file, using the data type that
     /// was provided when the file was written.
     fn default_projection(lance_schema: &Schema) -> ReaderProjection {
-        let schema = Arc::new(ArrowSchema::from(lance_schema));
+        let schema = Arc::new(lance_schema.clone());
         let mut column_indices = Vec::with_capacity(lance_schema.fields.len());
         let mut column_index = 0;
         for field in &lance_schema.fields {
@@ -544,6 +500,7 @@ impl FileReader {
     pub async fn try_open(
         scheduler: FileScheduler,
         base_projection: Option<ReaderProjection>,
+        decoder_strategy: DecoderMiddlewareChain,
     ) -> Result<Self> {
         let file_metadata = Arc::new(Self::read_all_metadata(&scheduler).await?);
         if let Some(base_projection) = base_projection.as_ref() {
@@ -556,6 +513,7 @@ impl FileReader {
                 .unwrap_or(Self::default_projection(file_metadata.file_schema.as_ref())),
             num_rows,
             metadata: file_metadata,
+            decoder_strategy,
         })
     }
 
@@ -603,41 +561,128 @@ impl FileReader {
             .zip(projection.column_indices.iter())
         {
             let mut starting_column = *starting_column as usize;
-            let lance_field = Field::try_from(field.as_ref())?;
-            self.collect_columns(&lance_field, &mut starting_column, &mut column_infos)?;
+            self.collect_columns(&field, &mut starting_column, &mut column_infos)?;
         }
         Ok(column_infos)
     }
 
-    fn read_range(
-        &self,
+    async fn do_read_range(
+        column_infos: Vec<Arc<ColumnInfo>>,
+        scheduler: Arc<dyn EncodingsIo>,
+        num_rows: u64,
+        decoder_strategy: DecoderMiddlewareChain,
         range: Range<u64>,
         batch_size: u32,
         projection: &ReaderProjection,
+        filter: FilterExpression,
     ) -> Result<BoxStream<'static, ReadBatchTask>> {
-        let column_infos = self.collect_columns_from_projection(projection)?;
         debug!(
             "Reading range {:?} with batch_size {} from columns {:?}",
             range,
             batch_size,
             column_infos.iter().map(|ci| ci.index).collect::<Vec<_>>()
         );
-        let mut decode_scheduler = DecodeBatchScheduler::new(
-            &projection.schema,
-            column_infos.iter().map(|ci| ci.as_ref()),
-            &vec![],
-        );
 
-        let root_decoder = decode_scheduler
-            .root_scheduler
-            .new_root_decoder_ranges(&[range.clone()]);
+        let mut decode_scheduler = DecodeBatchScheduler::try_new(
+            &projection.schema,
+            &column_infos,
+            &vec![],
+            num_rows,
+            &decoder_strategy,
+            &scheduler,
+        )
+        .await?;
+
+        let root_decoder = decode_scheduler.new_root_decoder_ranges(&[range.clone()]);
 
         let (tx, rx) = mpsc::unbounded_channel();
 
         let num_rows_to_read = range.end - range.start;
 
-        let scheduler = self.scheduler.clone() as Arc<dyn EncodingsIo>;
-        tokio::task::spawn(async move { decode_scheduler.schedule_range(range, tx, scheduler) });
+        tokio::task::spawn(async move {
+            decode_scheduler.schedule_range(range, &filter, tx, scheduler)
+        });
+
+        Ok(BatchDecodeStream::new(rx, batch_size, num_rows_to_read, root_decoder).into_stream())
+    }
+
+    fn read_range<'a>(
+        &self,
+        range: Range<u64>,
+        batch_size: u32,
+        projection: &ReaderProjection,
+        filter: FilterExpression,
+    ) -> Result<BoxStream<'static, ReadBatchTask>> {
+        // Grab what we need to initialize the stream
+        let range = range.clone();
+        let projection = projection.clone();
+        let column_infos = self.collect_columns_from_projection(&projection)?;
+        let scheduler = self.scheduler.clone();
+        let num_rows = self.num_rows;
+        let decoder_strategy = self.decoder_strategy.clone();
+        // Create and initialize the stream
+        let stream_fut = async move {
+            let maybe_stream = Self::do_read_range(
+                column_infos,
+                scheduler,
+                num_rows,
+                decoder_strategy,
+                range,
+                batch_size,
+                &projection,
+                filter,
+            )
+            .await;
+            // If something goes wrong then turn that error into a stream with one failing task
+            match maybe_stream {
+                Ok(stream) => stream,
+                Err(err) => futures::stream::once(std::future::ready(ReadBatchTask {
+                    num_rows: 0,
+                    task: std::future::ready(Err(err)).boxed(),
+                }))
+                .boxed(),
+            }
+        };
+        Ok(futures::stream::once(stream_fut).flatten().boxed())
+    }
+
+    async fn do_take_rows(
+        column_infos: Vec<Arc<ColumnInfo>>,
+        scheduler: Arc<dyn EncodingsIo>,
+        num_rows: u64,
+        decoder_strategy: DecoderMiddlewareChain,
+        indices: Vec<u64>,
+        batch_size: u32,
+        projection: &ReaderProjection,
+    ) -> Result<BoxStream<'static, ReadBatchTask>> {
+        debug!(
+            "Taking {} rows spread across range {}..{} with batch_size {} from columns {:?}",
+            indices.len(),
+            indices[0],
+            indices[indices.len() - 1],
+            batch_size,
+            column_infos.iter().map(|ci| ci.index).collect::<Vec<_>>()
+        );
+
+        let mut decode_scheduler = DecodeBatchScheduler::try_new(
+            &projection.schema,
+            &column_infos,
+            &vec![],
+            num_rows,
+            &decoder_strategy,
+            &scheduler,
+        )
+        .await?;
+
+        let root_decoder = decode_scheduler.new_root_decoder_indices(&indices);
+
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        let num_rows_to_read = indices.len() as u64;
+
+        tokio::task::spawn(async move {
+            decode_scheduler.schedule_take(&indices, &FilterExpression::no_filter(), tx, scheduler)
+        });
 
         Ok(BatchDecodeStream::new(rx, batch_size, num_rows_to_read, root_decoder).into_stream())
     }
@@ -648,33 +693,35 @@ impl FileReader {
         batch_size: u32,
         projection: &ReaderProjection,
     ) -> Result<BoxStream<'static, ReadBatchTask>> {
-        let column_infos = self.collect_columns_from_projection(projection)?;
-        debug!(
-            "Taking {} rows spread across range {}..{} with batch_size {} from columns {:?}",
-            indices.len(),
-            indices[0],
-            indices[indices.len() - 1],
-            batch_size,
-            column_infos.iter().map(|ci| ci.index).collect::<Vec<_>>()
-        );
-        let mut decode_scheduler = DecodeBatchScheduler::new(
-            &projection.schema,
-            column_infos.iter().map(|ci| ci.as_ref()),
-            &vec![],
-        );
-
-        let root_decoder = decode_scheduler
-            .root_scheduler
-            .new_root_decoder_indices(&indices);
-
-        let (tx, rx) = mpsc::unbounded_channel();
-
-        let num_rows_to_read = indices.len() as u64;
-
-        let scheduler = self.scheduler.clone() as Arc<dyn EncodingsIo>;
-        tokio::task::spawn(async move { decode_scheduler.schedule_take(&indices, tx, scheduler) });
-
-        Ok(BatchDecodeStream::new(rx, batch_size, num_rows_to_read, root_decoder).into_stream())
+        // Grab what we need to initialize the stream
+        let projection = projection.clone();
+        let column_infos = self.collect_columns_from_projection(&projection)?;
+        let scheduler = self.scheduler.clone();
+        let num_rows = self.num_rows;
+        let decoder_strategy = self.decoder_strategy.clone();
+        // Create and initialize the stream
+        let stream_fut = async move {
+            let maybe_stream = Self::do_take_rows(
+                column_infos,
+                scheduler,
+                num_rows,
+                decoder_strategy,
+                indices,
+                batch_size,
+                &projection,
+            )
+            .await;
+            // If something goes wrong then turn that error into a stream with one failing task
+            match maybe_stream {
+                Ok(stream) => stream,
+                Err(err) => futures::stream::once(std::future::ready(ReadBatchTask {
+                    num_rows: 0,
+                    task: std::future::ready(Err(err)).boxed(),
+                }))
+                .boxed(),
+            }
+        };
+        Ok(futures::stream::once(stream_fut).flatten().boxed())
     }
 
     /// Creates a stream of "read tasks" to read the data from the file
@@ -692,6 +739,7 @@ impl FileReader {
         params: ReadBatchParams,
         batch_size: u32,
         projection: &ReaderProjection,
+        filter: FilterExpression,
     ) -> Result<Pin<Box<dyn Stream<Item = ReadBatchTask> + Send>>> {
         Self::validate_projection(projection, &self.metadata)?;
         let verify_bound = |params: &ReadBatchParams, bound: u64, inclusive: bool| {
@@ -727,17 +775,29 @@ impl FileReader {
             }
             ReadBatchParams::Range(range) => {
                 verify_bound(&params, range.end as u64, false)?;
-                self.read_range(range.start as u64..range.end as u64, batch_size, projection)
+                self.read_range(
+                    range.start as u64..range.end as u64,
+                    batch_size,
+                    projection,
+                    filter,
+                )
             }
             ReadBatchParams::RangeFrom(range) => {
                 verify_bound(&params, range.start as u64, true)?;
-                self.read_range(range.start as u64..self.num_rows, batch_size, projection)
+                self.read_range(
+                    range.start as u64..self.num_rows,
+                    batch_size,
+                    projection,
+                    filter,
+                )
             }
             ReadBatchParams::RangeTo(range) => {
                 verify_bound(&params, range.end as u64, false)?;
-                self.read_range(0..range.end as u64, batch_size, projection)
+                self.read_range(0..range.end as u64, batch_size, projection, filter)
             }
-            ReadBatchParams::RangeFull => self.read_range(0..self.num_rows, batch_size, projection),
+            ReadBatchParams::RangeFull => {
+                self.read_range(0..self.num_rows, batch_size, projection, filter)
+            }
         }
     }
 
@@ -768,14 +828,16 @@ impl FileReader {
         batch_size: u32,
         batch_readahead: u32,
         projection: &ReaderProjection,
+        filter: FilterExpression,
     ) -> Result<Pin<Box<dyn RecordBatchStream>>> {
-        let tasks_stream = self.read_tasks(params, batch_size, projection)?;
+        let tasks_stream = self.read_tasks(params, batch_size, projection, filter)?;
         let batch_stream = tasks_stream
             .map(|task| task.task)
             .buffered(batch_readahead as usize)
             .boxed();
+        let arrow_schema = Arc::new(ArrowSchema::from(projection.schema.as_ref()));
         Ok(Box::pin(RecordBatchStreamAdapter::new(
-            projection.schema.clone(),
+            arrow_schema,
             batch_stream,
         )))
     }
@@ -790,8 +852,15 @@ impl FileReader {
         params: ReadBatchParams,
         batch_size: u32,
         batch_readahead: u32,
+        filter: FilterExpression,
     ) -> Result<Pin<Box<dyn RecordBatchStream>>> {
-        self.read_stream_projected(params, batch_size, batch_readahead, &self.base_projection)
+        self.read_stream_projected(
+            params,
+            batch_size,
+            batch_readahead,
+            &self.base_projection,
+            filter,
+        )
     }
 
     pub fn schema(&self) -> &Arc<Schema> {
@@ -838,57 +907,125 @@ pub fn describe_encoding(page: &pbfile::column_metadata::Page) -> String {
     }
 }
 
+pub trait EncodedBatchReaderExt {
+    fn try_from_mini_lance(bytes: Bytes, schema: &Schema) -> Result<Self>
+    where
+        Self: Sized;
+    fn try_from_self_described_lance(bytes: Bytes) -> Result<Self>
+    where
+        Self: Sized;
+}
+
+impl EncodedBatchReaderExt for EncodedBatch {
+    fn try_from_mini_lance(bytes: Bytes, schema: &Schema) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let footer = FileReader::decode_footer(&bytes)?;
+
+        // Next, read the metadata for the columns
+        // This is both the column metadata and the CMO table
+        let column_metadata_start = footer.column_meta_start as usize;
+        let column_metadata_end = footer.global_buff_offsets_start as usize;
+        let column_metadata_bytes = bytes.slice(column_metadata_start..column_metadata_end);
+        let column_metadatas =
+            FileReader::read_all_column_metadata(column_metadata_bytes, &footer)?;
+
+        let page_table = FileReader::meta_to_col_infos(&column_metadatas);
+
+        Ok(EncodedBatch {
+            data: bytes,
+            num_rows: page_table
+                .first()
+                .map(|col| {
+                    col.page_infos
+                        .iter()
+                        .map(|page| page.num_rows as u64)
+                        .sum::<u64>()
+                })
+                .unwrap_or(0),
+            page_table,
+            schema: Arc::new(schema.clone()),
+        })
+    }
+
+    fn try_from_self_described_lance(bytes: Bytes) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        let footer = FileReader::decode_footer(&bytes)?;
+
+        let gbo_table = FileReader::do_decode_gbo_table(
+            &bytes.slice(footer.global_buff_offsets_start as usize..),
+            &footer,
+        )?;
+        if gbo_table.is_empty() {
+            return Err(Error::Internal {
+                message: "File did not contain any global buffers, schema expected".to_string(),
+                location: location!(),
+            });
+        }
+        let schema_start = gbo_table[0].position as usize;
+        let schema_size = gbo_table[0].size as usize;
+
+        let schema_bytes = bytes.slice(schema_start..(schema_start + schema_size) as usize);
+        let (_, schema) = FileReader::decode_schema(schema_bytes)?;
+
+        // Next, read the metadata for the columns
+        // This is both the column metadata and the CMO table
+        let column_metadata_start = footer.column_meta_start as usize;
+        let column_metadata_end = footer.global_buff_offsets_start as usize;
+        let column_metadata_bytes = bytes.slice(column_metadata_start..column_metadata_end);
+        let column_metadatas =
+            FileReader::read_all_column_metadata(column_metadata_bytes, &footer)?;
+
+        let page_table = FileReader::meta_to_col_infos(&column_metadatas);
+
+        Ok(EncodedBatch {
+            data: bytes,
+            num_rows: page_table
+                .first()
+                .map(|col| {
+                    col.page_infos
+                        .iter()
+                        .map(|page| page.num_rows as u64)
+                        .sum::<u64>()
+                })
+                .unwrap_or(0),
+            page_table,
+            schema: Arc::new(schema.clone()),
+        })
+    }
+}
+
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use std::{pin::Pin, sync::Arc};
 
-    use arrow_array::{types::Float64Type, RecordBatch, RecordBatchReader};
-    use arrow_schema::{ArrowError, DataType, Field, Fields, Schema as ArrowSchema};
+    use arrow_array::{
+        types::{Float64Type, Int32Type},
+        RecordBatch,
+    };
+    use arrow_schema::{DataType, Field, Fields, Schema as ArrowSchema};
     use bytes::Bytes;
     use futures::{prelude::stream::TryStreamExt, StreamExt};
     use lance_arrow::RecordBatchExt;
     use lance_core::datatypes::Schema;
-    use lance_datagen::{array, gen, BatchCount, RowCount};
-    use lance_io::{
-        object_store::ObjectStore, scheduler::ScanScheduler, stream::RecordBatchStream,
+    use lance_datagen::{array, gen, BatchCount, ByteCount, RowCount};
+    use lance_encoding::{
+        decoder::{decode_batch, DecoderMiddlewareChain, FilterExpression},
+        encoder::{encode_batch, CoreFieldEncodingStrategy, EncodedBatch},
     };
+    use lance_io::stream::RecordBatchStream;
     use log::debug;
-    use object_store::path::Path;
-    use tempfile::TempDir;
 
     use crate::v2::{
-        reader::{FileReader, ReaderProjection},
-        writer::{FileWriter, FileWriterOptions},
+        reader::{EncodedBatchReaderExt, FileReader, ReaderProjection},
+        testing::{write_lance_file, FsFixture},
+        writer::{EncodedBatchWriteExt, FileWriter, FileWriterOptions},
     };
 
-    struct FsFixture {
-        _tmp_dir: TempDir,
-        tmp_path: Path,
-        object_store: Arc<ObjectStore>,
-        scheduler: Arc<ScanScheduler>,
-    }
-
-    impl Default for FsFixture {
-        fn default() -> Self {
-            let tmp_dir = tempfile::tempdir().unwrap();
-            let tmp_path: String = tmp_dir.path().to_str().unwrap().to_owned();
-            let tmp_path = Path::parse(tmp_path).unwrap();
-            let tmp_path = tmp_path.child("some_file.lance");
-            let object_store = Arc::new(ObjectStore::local());
-            let scheduler = ScanScheduler::new(object_store.clone(), 8);
-            Self {
-                _tmp_dir: tmp_dir,
-                object_store,
-                tmp_path,
-                scheduler,
-            }
-        }
-    }
-
-    async fn create_some_file(
-        object_store: &ObjectStore,
-        path: &Path,
-    ) -> (Arc<Schema>, Vec<RecordBatch>) {
+    async fn create_some_file(fs: &FsFixture) -> (Arc<Schema>, Vec<RecordBatch>) {
         let location_type = DataType::Struct(Fields::from(vec![
             Field::new("x", DataType::Float64, true),
             Field::new("y", DataType::Float64, true),
@@ -901,29 +1038,7 @@ mod tests {
             .col("categories", array::rand_type(&categories_type))
             .into_reader_rows(RowCount::from(1000), BatchCount::from(100));
 
-        let writer = object_store.create(path).await.unwrap();
-
-        let lance_schema =
-            lance_core::datatypes::Schema::try_from(reader.schema().as_ref()).unwrap();
-
-        let mut file_writer = FileWriter::try_new(
-            writer,
-            path.to_string(),
-            lance_schema.clone(),
-            FileWriterOptions::default(),
-        )
-        .unwrap();
-
-        let data = reader
-            .collect::<std::result::Result<Vec<_>, ArrowError>>()
-            .unwrap();
-
-        for batch in &data {
-            file_writer.write_batch(batch).await.unwrap();
-        }
-        file_writer.add_schema_metadata("foo", "bar");
-        file_writer.finish().await.unwrap();
-        (Arc::new(lance_schema), data)
+        write_lance_file(reader, fs, FileWriterOptions::default()).await
     }
 
     type Transformer = Box<dyn Fn(&RecordBatch) -> RecordBatch>;
@@ -982,17 +1097,25 @@ mod tests {
     async fn test_round_trip() {
         let fs = FsFixture::default();
 
-        let (_, data) = create_some_file(&fs.object_store, &fs.tmp_path).await;
+        let (_, data) = create_some_file(&fs).await;
 
         for read_size in [32, 1024, 1024 * 1024] {
             let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
-            let file_reader = FileReader::try_open(file_scheduler, None).await.unwrap();
+            let file_reader =
+                FileReader::try_open(file_scheduler, None, DecoderMiddlewareChain::default())
+                    .await
+                    .unwrap();
 
             let schema = file_reader.schema();
             assert_eq!(schema.metadata.get("foo").unwrap(), "bar");
 
             let batch_stream = file_reader
-                .read_stream(lance_io::ReadBatchParams::RangeFull, read_size, 16)
+                .read_stream(
+                    lance_io::ReadBatchParams::RangeFull,
+                    read_size,
+                    16,
+                    FilterExpression::no_filter(),
+                )
                 .unwrap();
 
             verify_expected(&data, batch_stream, read_size, None).await;
@@ -1000,10 +1123,59 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
+    async fn test_encoded_batch_round_trip() {
+        let data = gen()
+            .col("x", array::rand::<Int32Type>())
+            .col("y", array::rand_utf8(ByteCount::from(16), false))
+            .into_batch_rows(RowCount::from(10000))
+            .unwrap();
+
+        let lance_schema = Arc::new(Schema::try_from(data.schema().as_ref()).unwrap());
+
+        let encoded_batch = encode_batch(
+            &data,
+            lance_schema.clone(),
+            &CoreFieldEncodingStrategy::default(),
+            4096,
+        )
+        .await
+        .unwrap();
+
+        // Test self described
+        let bytes = encoded_batch.try_to_self_described_lance().unwrap();
+
+        let decoded_batch = EncodedBatch::try_from_self_described_lance(bytes).unwrap();
+
+        let decoded = decode_batch(
+            &decoded_batch,
+            &FilterExpression::no_filter(),
+            &DecoderMiddlewareChain::default(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(data, decoded);
+
+        // Test mini
+        let bytes = encoded_batch.try_to_mini_lance().unwrap();
+        let decoded_batch =
+            EncodedBatch::try_from_mini_lance(bytes, lance_schema.as_ref()).unwrap();
+        let decoded = decode_batch(
+            &decoded_batch,
+            &FilterExpression::no_filter(),
+            &DecoderMiddlewareChain::default(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(data, decoded);
+    }
+
+    #[test_log::test(tokio::test)]
     async fn test_projection() {
         let fs = FsFixture::default();
 
-        let (schema, data) = create_some_file(&fs.object_store, &fs.tmp_path).await;
+        let (schema, data) = create_some_file(&fs).await;
         let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
 
         for columns in [
@@ -1018,49 +1190,66 @@ mod tests {
         ] {
             debug!("Testing round trip with projection {:?}", columns);
             // We can specify the projection as part of the read operation via read_stream_projected
-            let file_reader = FileReader::try_open(file_scheduler.clone(), None)
-                .await
-                .unwrap();
+            let file_reader = FileReader::try_open(
+                file_scheduler.clone(),
+                None,
+                DecoderMiddlewareChain::default(),
+            )
+            .await
+            .unwrap();
 
-            let projection = schema.project(&columns).unwrap();
-            let projection_arrow = Arc::new(ArrowSchema::from(&projection));
+            let projection = Arc::new(schema.project(&columns).unwrap());
             let projection = ReaderProjection {
-                schema: projection_arrow,
                 column_indices: projection.fields.iter().map(|f| f.id as u32).collect(),
+                schema: projection,
             };
 
             let batch_stream = file_reader
-                .read_stream_projected(lance_io::ReadBatchParams::RangeFull, 1024, 16, &projection)
+                .read_stream_projected(
+                    lance_io::ReadBatchParams::RangeFull,
+                    1024,
+                    16,
+                    &projection,
+                    FilterExpression::no_filter(),
+                )
                 .unwrap();
 
-            let projection_copy = projection.clone();
+            let projection_arrow = ArrowSchema::try_from(projection.schema.as_ref()).unwrap();
             verify_expected(
                 &data,
                 batch_stream,
                 1024,
                 Some(Box::new(move |batch: &RecordBatch| {
-                    batch.project_by_schema(&projection_copy.schema).unwrap()
+                    batch.project_by_schema(&projection_arrow).unwrap()
                 })),
             )
             .await;
 
             // We can also specify the projection as a base projection when we open the file
-            let file_reader =
-                FileReader::try_open(file_scheduler.clone(), Some(projection.clone()))
-                    .await
-                    .unwrap();
+            let file_reader = FileReader::try_open(
+                file_scheduler.clone(),
+                Some(projection.clone()),
+                DecoderMiddlewareChain::default(),
+            )
+            .await
+            .unwrap();
 
             let batch_stream = file_reader
-                .read_stream(lance_io::ReadBatchParams::RangeFull, 1024, 16)
+                .read_stream(
+                    lance_io::ReadBatchParams::RangeFull,
+                    1024,
+                    16,
+                    FilterExpression::no_filter(),
+                )
                 .unwrap();
 
-            let projection_copy = projection.clone();
+            let projection_arrow = ArrowSchema::try_from(projection.schema.as_ref()).unwrap();
             verify_expected(
                 &data,
                 batch_stream,
                 1024,
                 Some(Box::new(move |batch: &RecordBatch| {
-                    batch.project_by_schema(&projection_copy.schema).unwrap()
+                    batch.project_by_schema(&projection_arrow).unwrap()
                 })),
             )
             .await;
@@ -1068,28 +1257,35 @@ mod tests {
 
         let empty_projection = ReaderProjection {
             column_indices: Vec::default(),
-            schema: Arc::new(ArrowSchema::new(Vec::<Field>::default())),
+            schema: Arc::new(Schema::default()),
         };
 
-        assert!(
-            FileReader::try_open(file_scheduler.clone(), Some(empty_projection))
-                .await
-                .is_err()
-        );
+        assert!(FileReader::try_open(
+            file_scheduler.clone(),
+            Some(empty_projection),
+            DecoderMiddlewareChain::default()
+        )
+        .await
+        .is_err());
+
+        let arrow_schema = ArrowSchema::new(vec![
+            Field::new("x", DataType::Int32, true),
+            Field::new("y", DataType::Int32, true),
+        ]);
+        let schema = Schema::try_from(&arrow_schema).unwrap();
 
         let projection_with_dupes = ReaderProjection {
             column_indices: vec![0, 0],
-            schema: Arc::new(ArrowSchema::new(vec![
-                Field::new("x", DataType::Int32, true),
-                Field::new("y", DataType::Int32, true),
-            ])),
+            schema: Arc::new(schema),
         };
 
-        assert!(
-            FileReader::try_open(file_scheduler.clone(), Some(projection_with_dupes))
-                .await
-                .is_err()
-        );
+        assert!(FileReader::try_open(
+            file_scheduler.clone(),
+            Some(projection_with_dupes),
+            DecoderMiddlewareChain::default()
+        )
+        .await
+        .is_err());
     }
 
     struct EnvVarGuard {
@@ -1124,32 +1320,41 @@ mod tests {
         // set env var temporarily to test compressed page
         let _env_guard = EnvVarGuard::new("LANCE_PAGE_COMPRESSION", "zstd");
 
-        let (schema, data) = create_some_file(&fs.object_store, &fs.tmp_path).await;
+        let (schema, data) = create_some_file(&fs).await;
         let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
 
         // We can specify the projection as part of the read operation via read_stream_projected
-        let file_reader = FileReader::try_open(file_scheduler.clone(), None)
-            .await
-            .unwrap();
+        let file_reader = FileReader::try_open(
+            file_scheduler.clone(),
+            None,
+            DecoderMiddlewareChain::default(),
+        )
+        .await
+        .unwrap();
 
         let projection = schema.project(&["score"]).unwrap();
-        let projection_arrow = Arc::new(ArrowSchema::from(&projection));
         let projection = ReaderProjection {
-            schema: projection_arrow,
             column_indices: projection.fields.iter().map(|f| f.id as u32).collect(),
+            schema: Arc::new(projection),
         };
 
         let batch_stream = file_reader
-            .read_stream_projected(lance_io::ReadBatchParams::RangeFull, 1024, 16, &projection)
+            .read_stream_projected(
+                lance_io::ReadBatchParams::RangeFull,
+                1024,
+                16,
+                &projection,
+                FilterExpression::no_filter(),
+            )
             .unwrap();
 
-        let projection_copy = projection.clone();
+        let projection_arrow = Arc::new(ArrowSchema::from(projection.schema.as_ref()));
         verify_expected(
             &data,
             batch_stream,
             1024,
             Some(Box::new(move |batch: &RecordBatch| {
-                batch.project_by_schema(&projection_copy.schema).unwrap()
+                batch.project_by_schema(&projection_arrow).unwrap()
             })),
         )
         .await;
@@ -1158,16 +1363,25 @@ mod tests {
     #[tokio::test]
     async fn test_read_all() {
         let fs = FsFixture::default();
-        let (_, data) = create_some_file(&fs.object_store, &fs.tmp_path).await;
+        let (_, data) = create_some_file(&fs).await;
         let total_rows = data.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
         let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
-        let file_reader = FileReader::try_open(file_scheduler.clone(), None)
-            .await
-            .unwrap();
+        let file_reader = FileReader::try_open(
+            file_scheduler.clone(),
+            None,
+            DecoderMiddlewareChain::default(),
+        )
+        .await
+        .unwrap();
 
         let batches = file_reader
-            .read_stream(lance_io::ReadBatchParams::RangeFull, total_rows as u32, 16)
+            .read_stream(
+                lance_io::ReadBatchParams::RangeFull,
+                total_rows as u32,
+                16,
+                FilterExpression::no_filter(),
+            )
             .unwrap()
             .try_collect::<Vec<_>>()
             .await
@@ -1208,9 +1422,13 @@ mod tests {
         file_writer.finish().await.unwrap();
 
         let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
-        let file_reader = FileReader::try_open(file_scheduler.clone(), None)
-            .await
-            .unwrap();
+        let file_reader = FileReader::try_open(
+            file_scheduler.clone(),
+            None,
+            DecoderMiddlewareChain::default(),
+        )
+        .await
+        .unwrap();
 
         let buf = file_reader.read_global_buffer(1).await.unwrap();
         assert_eq!(buf, test_bytes);

--- a/rust/lance-file/src/v2/testing.rs
+++ b/rust/lance-file/src/v2/testing.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use arrow_array::{RecordBatch, RecordBatchReader};
+use arrow_schema::ArrowError;
+use futures::TryStreamExt;
+use lance_core::datatypes::Schema;
+use lance_encoding::decoder::{DecoderMiddlewareChain, FilterExpression};
+use lance_io::{object_store::ObjectStore, scheduler::ScanScheduler, ReadBatchParams};
+use object_store::path::Path;
+use tempfile::TempDir;
+
+use crate::v2::reader::FileReader;
+
+use super::writer::{FileWriter, FileWriterOptions};
+
+pub struct FsFixture {
+    _tmp_dir: TempDir,
+    pub tmp_path: Path,
+    pub object_store: Arc<ObjectStore>,
+    pub scheduler: Arc<ScanScheduler>,
+}
+
+impl Default for FsFixture {
+    fn default() -> Self {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let tmp_path: String = tmp_dir.path().to_str().unwrap().to_owned();
+        let tmp_path = Path::parse(tmp_path).unwrap();
+        let tmp_path = tmp_path.child("some_file.lance");
+        let object_store = Arc::new(ObjectStore::local());
+        let scheduler = ScanScheduler::new(object_store.clone(), 8);
+        Self {
+            _tmp_dir: tmp_dir,
+            object_store,
+            tmp_path,
+            scheduler,
+        }
+    }
+}
+
+pub async fn write_lance_file(
+    data: impl RecordBatchReader,
+    fs: &FsFixture,
+    options: FileWriterOptions,
+) -> (Arc<Schema>, Vec<RecordBatch>) {
+    let writer = fs.object_store.create(&fs.tmp_path).await.unwrap();
+
+    let lance_schema = lance_core::datatypes::Schema::try_from(data.schema().as_ref()).unwrap();
+
+    let mut file_writer = FileWriter::try_new(
+        writer,
+        fs.tmp_path.to_string(),
+        lance_schema.clone(),
+        options,
+    )
+    .unwrap();
+
+    let data = data
+        .collect::<std::result::Result<Vec<_>, ArrowError>>()
+        .unwrap();
+
+    for batch in &data {
+        file_writer.write_batch(batch).await.unwrap();
+    }
+    file_writer.add_schema_metadata("foo", "bar");
+    file_writer.finish().await.unwrap();
+    (Arc::new(lance_schema), data)
+}
+
+pub async fn read_lance_file(
+    fs: &FsFixture,
+    decoder_middleware: DecoderMiddlewareChain,
+    filter: FilterExpression,
+) -> Vec<RecordBatch> {
+    let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+    let file_reader = FileReader::try_open(file_scheduler, None, decoder_middleware)
+        .await
+        .unwrap();
+
+    let schema = file_reader.schema();
+    assert_eq!(schema.metadata.get("foo").unwrap(), "bar");
+
+    let batch_stream = file_reader
+        .read_stream(ReadBatchParams::RangeFull, 1024, 16, filter)
+        .unwrap();
+
+    batch_stream.try_collect().await.unwrap()
+}
+
+pub async fn count_lance_file(
+    fs: &FsFixture,
+    decoder_middleware: DecoderMiddlewareChain,
+    filter: FilterExpression,
+) -> usize {
+    read_lance_file(fs, decoder_middleware, filter)
+        .await
+        .iter()
+        .map(|b| b.num_rows())
+        .sum()
+}

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -370,7 +370,7 @@ impl FileWriter {
                 col_idx += 1;
             }
         }
-        if col_idx as usize != self.column_metadata.len() {
+        if col_idx != self.column_metadata.len() {
             panic!(
                 "Column writers finished with {} columns but we expected {}",
                 col_idx,

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -85,9 +85,7 @@ fn initial_column_metadata() -> pbfile::ColumnMetadata {
         pages: Vec::new(),
         buffer_offsets: Vec::new(),
         buffer_sizes: Vec::new(),
-        encoding: Some(pbfile::Encoding {
-            location: Some(pbfile::encoding::Location::None(())),
-        }),
+        encoding: None,
     }
 }
 
@@ -335,6 +333,53 @@ impl FileWriter {
         Ok(self.global_buffers.len() as u32)
     }
 
+    async fn finish_writers(&mut self) -> Result<()> {
+        let mut col_idx = 0;
+        for mut writer in std::mem::take(&mut self.column_writers) {
+            let columns = writer.finish().await?;
+            debug_assert_eq!(
+                columns.len(),
+                writer.num_columns() as usize,
+                "Expected {} columns from column at index {} and got {}",
+                writer.num_columns(),
+                col_idx,
+                columns.len()
+            );
+            for column in columns {
+                for page in column.final_pages {
+                    self.write_page(page).await?;
+                }
+                let column_metadata = &mut self.column_metadata[col_idx];
+                let mut buffer_pos = self.writer.tell().await? as u64;
+                for buffer in column.column_buffers {
+                    column_metadata.buffer_offsets.push(buffer_pos);
+                    let mut size = 0;
+                    for part in buffer.parts {
+                        self.writer.write_all(&part).await?;
+                        size += part.len() as u64;
+                    }
+                    buffer_pos += size;
+                    column_metadata.buffer_sizes.push(size);
+                }
+                let encoded_encoding = Any::from_msg(&column.encoding)?.encode_to_vec();
+                column_metadata.encoding = Some(pbfile::Encoding {
+                    location: Some(pbfile::encoding::Location::Direct(pbfile::DirectEncoding {
+                        encoding: encoded_encoding,
+                    })),
+                });
+                col_idx += 1;
+            }
+        }
+        if col_idx as usize != self.column_metadata.len() {
+            panic!(
+                "Column writers finished with {} columns but we expected {}",
+                col_idx,
+                self.column_metadata.len()
+            );
+        }
+        Ok(())
+    }
+
     /// Finishes writing the file
     ///
     /// This method will wait until all data has been flushed to the file.  Then it
@@ -355,7 +400,8 @@ impl FileWriter {
             .collect::<FuturesUnordered<_>>();
         self.write_pages(encoding_tasks).await?;
 
-        // 2. write the column metadata buffers (coming soon)
+        self.finish_writers().await?;
+
         // 3. write global buffers (we write the schema here)
         let global_buffer_offsets = self.write_global_buffers().await?;
         let num_global_buffers = global_buffer_offsets.len() as u32;
@@ -429,18 +475,16 @@ fn concat_lance_footer(batch: &EncodedBatch, write_schema: bool) -> Result<Bytes
     // Estimating 1MiB for file footer
     let mut data = BytesMut::with_capacity(batch.data.len() + 1024 * 1024);
     data.put(batch.data.clone());
-    // Write column metadata buffers
-    let column_metadata_buffers_start = data.len() as u64;
     // write global buffers (we write the schema here)
-    let global_buffers_start = data.len() as u64;
     let global_buffers = if write_schema {
+        let schema_start = data.len() as u64;
         let lance_schema = lance_core::datatypes::Schema::try_from(batch.schema.as_ref())?;
         let descriptor = FileWriter::make_file_descriptor(&lance_schema, batch.num_rows)?;
         let descriptor_bytes = descriptor.encode_to_vec();
         let descriptor_len = descriptor_bytes.len() as u64;
         data.put(descriptor_bytes.as_slice());
 
-        vec![(global_buffers_start, descriptor_len)]
+        vec![(schema_start, descriptor_len)]
     } else {
         vec![]
     };
@@ -475,16 +519,19 @@ fn concat_lance_footer(batch: &EncodedBatch, write_schema: bool) -> Result<Bytes
             .collect::<Result<Vec<_>>>()?;
         let (buffer_offsets, buffer_sizes): (Vec<_>, Vec<_>) =
             col.buffer_offsets_and_sizes.iter().cloned().unzip();
+        let encoded_col_encoding = Any::from_msg(&col.encoding)?.encode_to_vec();
         let column = pbfile::ColumnMetadata {
             pages,
             buffer_offsets,
             buffer_sizes,
             encoding: Some(pbfile::Encoding {
-                location: Some(pbfile::encoding::Location::None(())),
+                location: Some(pbfile::encoding::Location::Direct(pbfile::DirectEncoding {
+                    encoding: encoded_col_encoding,
+                })),
             }),
         };
         let column_bytes = column.encode_to_vec();
-        col_metadata_positions.push((position, data.len() as u64));
+        col_metadata_positions.push((position, column_bytes.len() as u64));
         data.put(column_bytes.as_slice());
     }
     // Write column metadata offsets table
@@ -502,8 +549,6 @@ fn concat_lance_footer(batch: &EncodedBatch, write_schema: bool) -> Result<Bytes
     }
 
     // write the footer
-    data.put_u64_le(column_metadata_buffers_start);
-    data.put_u64_le(global_buffers_start);
     data.put_u64_le(col_metadata_start);
     data.put_u64_le(cmo_table_start);
     data.put_u64_le(gbo_table_start);

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -33,6 +33,7 @@ itertools.workspace = true
 lance-arrow.workspace = true
 lance-core.workspace = true
 lance-datafusion.workspace = true
+lance-encoding.workspace = true
 lance-file.workspace = true
 lance-io.workspace = true
 lance-linalg.workspace = true

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -12,6 +12,7 @@ use deepsize::DeepSizeOf;
 use futures::prelude::stream::TryStreamExt;
 use lance_arrow::RecordBatchExt;
 use lance_core::{Error, Result};
+use lance_encoding::decoder::FilterExpression;
 use lance_file::v2::reader::FileReader;
 use lance_io::ReadBatchParams;
 use lance_linalg::distance::DistanceType;
@@ -219,7 +220,12 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
         let range = self.ivf.row_range(part_id);
         let batches = self
             .reader
-            .read_stream(ReadBatchParams::Range(range), 4096, 16)?
+            .read_stream(
+                ReadBatchParams::Range(range),
+                4096,
+                16,
+                FilterExpression::no_filter(),
+            )?
             .try_collect::<Vec<_>>()
             .await?;
         let schema = Arc::new(self.reader.schema().as_ref().into());

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -20,6 +20,7 @@ lance-arrow = { workspace = true }
 lance-core = { workspace = true }
 lance-datafusion = { workspace = true }
 lance-datagen = { workspace = true }
+lance-encoding = { workspace = true }
 lance-file = { workspace = true }
 lance-io = { workspace = true }
 lance-linalg = { workspace = true }


### PR DESCRIPTION
This PR adds quite a few pre-requisites as well:

 * We add the concept of a "filter" to the read path
 * We make the selection of decoder extensible with the `FieldDecoderStrategy` and `DecoderMiddlewareChain`
 * Various changes to the decode path so that we can handle the case where the number of rows scheduled is less than the number of rows originally asked for
 * We add Lance deserialization to `EncodedBatch` (serialization was added in an earlier PR)
 * We fix some bugs in the serialization and deserialization of `EncodedBatch`

The basic flow is this:
 * On write, we store statistics for each leaf column.  These are a record batch of min/max/null_count with a row for every X rows (X is configurable and we should experiment with it).
 * This batch is encoded into a single buffer (as a mini lance file) and written at the end of the data section of the file.  Each leaf column's encoding is wrapped with a header that points to this buffer
 * When creating decoders, every time we create a leaf column, we unwrap the stats location and collect these.
 * When creating the root decoder, after the decoder is created, we wrap the root decoder with a filtering decoder that is aware of all of these zone maps.  At this time we go out and collect all the zone maps from the file and decode them back into record batches.  We now have a map from field to zone map
 * At schedule time, this outer decoder uses the user provided filter and the zone maps to refine the range that the user asked for.

This is not the final PR for pushdown, there are still a few things that need to be done:

 * We need to use `LanceDfFieldDecoderStrategy` in fragment and the python bindings
 * The way we are mapping fields to DF columns is not quite right
 * Ideally we can move the zone map "initialization" to the beginning of the scheduling process (instead of opening the file) so that we can only inflate statistics for columns involved in the filter
 * We need to cache the inflated statistics in the cached metadata
 * Ideally we can add a "context" to the decoder middleware chain so that `LanceDfFieldDecoderStrategy` doesn't have to use a mutex

Right now pushdown is implemented as a "best effort" filter so a `FilterExec` is still needed in any plan doing pushdown.  In the future we might want to move the `FilterExec` into the decoder.  This would close https://github.com/lancedb/lance/issues/2398