### PR TITLE
feat: add outer retry loop to more object_store operations

### DIFF
--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -1011,7 +1011,7 @@ pub mod tests {
     use bytes::Bytes;
     use futures::{prelude::stream::TryStreamExt, StreamExt};
     use lance_arrow::RecordBatchExt;
-    use lance_core::datatypes::Schema;
+    use lance_core::{datatypes::Schema, utils::testing::EnvVarGuard};
     use lance_datagen::{array, gen, BatchCount, ByteCount, RowCount};
     use lance_encoding::{
         decoder::{decode_batch, DecoderMiddlewareChain, FilterExpression},
@@ -1287,32 +1287,6 @@ pub mod tests {
         )
         .await
         .is_err());
-    }
-
-    struct EnvVarGuard {
-        key: String,
-        original_value: Option<String>,
-    }
-
-    impl EnvVarGuard {
-        fn new(key: &str, new_value: &str) -> Self {
-            let original_value = std::env::var(key).ok();
-            std::env::set_var(key, new_value);
-            Self {
-                key: key.to_string(),
-                original_value,
-            }
-        }
-    }
-
-    impl Drop for EnvVarGuard {
-        fn drop(&mut self) {
-            if let Some(ref value) = self.original_value {
-                std::env::set_var(&self.key, value);
-            } else {
-                std::env::remove_var(&self.key);
-            }
-        }
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-io/src/object_reader.rs
+++ b/rust/lance-io/src/object_reader.rs
@@ -7,13 +7,12 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::Bytes;
 use deepsize::DeepSizeOf;
-use futures::future::BoxFuture;
 use lance_core::Result;
 use object_store::{path::Path, ObjectStore};
 use tokio::sync::OnceCell;
 use tracing::instrument;
 
-use crate::traits::Reader;
+use crate::{traits::Reader, utils::do_with_retry};
 
 /// Object Reader
 ///
@@ -52,27 +51,6 @@ impl CloudObjectReader {
             block_size,
         })
     }
-
-    // Retries for the initial request are handled by object store, but
-    // there are no retries for failures that occur during the streaming
-    // of the response body. Thus we add an outer retry loop here.
-    async fn do_with_retry<'a, O>(
-        &self,
-        f: impl Fn() -> BoxFuture<'a, std::result::Result<O, object_store::Error>>,
-    ) -> object_store::Result<O> {
-        let mut retries = 3;
-        loop {
-            match f().await {
-                Ok(val) => return Ok(val),
-                Err(err) => {
-                    if retries == 0 {
-                        return Err(err);
-                    }
-                    retries -= 1;
-                }
-            }
-        }
-    }
 }
 
 #[async_trait]
@@ -89,9 +67,7 @@ impl Reader for CloudObjectReader {
     async fn size(&self) -> object_store::Result<usize> {
         self.size
             .get_or_try_init(|| async move {
-                let meta = self
-                    .do_with_retry(|| self.object_store.head(&self.path))
-                    .await?;
+                let meta = do_with_retry(|| self.object_store.head(&self.path)).await?;
                 Ok(meta.size)
             })
             .await
@@ -100,7 +76,6 @@ impl Reader for CloudObjectReader {
 
     #[instrument(level = "debug", skip(self))]
     async fn get_range(&self, range: Range<usize>) -> object_store::Result<Bytes> {
-        self.do_with_retry(|| self.object_store.get_range(&self.path, range.clone()))
-            .await
+        do_with_retry(|| self.object_store.get_range(&self.path, range.clone())).await
     }
 }

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -489,7 +489,7 @@ mod tests {
             let times_map = self.last_modified_times.clone();
             policy.set_before_policy(
                 "record_file_time",
-                Arc::new(move |_, path| {
+                Box::new(move |_, path| {
                     let mut times_map = times_map.lock().unwrap();
                     times_map.insert(path.clone(), utc_now());
                     Ok(())
@@ -625,7 +625,7 @@ mod tests {
             let mut policy = self.mock_store.policy.lock().unwrap();
             policy.set_before_policy(
                 "block_commit",
-                Arc::new(|op, _| -> Result<()> {
+                Box::new(|op, _| -> Result<()> {
                     if op.contains("copy") {
                         return Err(Error::Internal {
                             message: "Copy blocked".to_string(),
@@ -641,7 +641,7 @@ mod tests {
             let mut policy = self.mock_store.policy.lock().unwrap();
             policy.set_before_policy(
                 "block_delete_manifest",
-                Arc::new(|op, path| -> Result<()> {
+                Box::new(|op, path| -> Result<()> {
                     if op.contains("delete") && path.extension() == Some("manifest") {
                         Err(Error::Internal {
                             message: "Delete manifest blocked".to_string(),


### PR DESCRIPTION
I was investigating a GCS error that a user was seeing and discovered there were several places that we do not have an outer retry loop around object_store.  However, I later realized that `object_store` was actually performing retries in the original error I was investigating.  So I'm not certain these changes would be needed in a real world scenario.  Curious to get a second opinion.