### PR TITLE
feat: pickle the manifest when pickling a dataset

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -277,6 +277,7 @@ pub struct Dataset {
 
 #[pymethods]
 impl Dataset {
+    #[allow(clippy::too_many_arguments)]
     #[new]
     fn new(
         uri: String,

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -54,7 +54,7 @@ use lance_table::io::commit::CommitHandler;
 use object_store::path::Path;
 use pyo3::exceptions::{PyStopIteration, PyTypeError};
 use pyo3::prelude::*;
-use pyo3::types::{PyList, PySet, PyString};
+use pyo3::types::{PyBytes, PyList, PySet, PyString};
 use pyo3::{
     exceptions::{PyIOError, PyKeyError, PyValueError},
     pyclass,
@@ -63,6 +63,7 @@ use pyo3::{
 };
 use snafu::{location, Location};
 
+use crate::error::PythonErrorExt;
 use crate::fragment::{FileFragment, FragmentMetadata};
 use crate::schema::LanceSchema;
 use crate::session::Session;
@@ -285,6 +286,7 @@ impl Dataset {
         metadata_cache_size: Option<usize>,
         commit_handler: Option<PyObject>,
         storage_options: Option<HashMap<String, String>>,
+        manifest: Option<&[u8]>,
     ) -> PyResult<Self> {
         let mut params = ReadParams {
             index_cache_size: index_cache_size.unwrap_or(DEFAULT_INDEX_CACHE_SIZE),
@@ -307,6 +309,9 @@ impl Dataset {
         }
         if let Some(storage_options) = storage_options {
             builder = builder.with_storage_options(storage_options);
+        }
+        if let Some(manifest) = manifest {
+            builder = builder.with_serialized_manifest(manifest).infer_error()?;
         }
 
         let dataset = RT.runtime.block_on(builder.load());
@@ -349,6 +354,11 @@ impl Dataset {
                     index_name, err
                 )),
             })
+    }
+
+    fn serialized_manifest(&self, py: Python) -> PyObject {
+        let manifest_bytes = self.ds.manifest().serialized();
+        PyBytes::new(py, &manifest_bytes).into()
     }
 
     /// Load index metadata

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -81,6 +81,11 @@ impl Field {
         }
     }
 
+    pub fn has_dictionary_types(&self) -> bool {
+        matches!(self.data_type(), DataType::Dictionary(_, _))
+            || self.children.iter().any(Field::has_dictionary_types)
+    }
+
     fn explain_differences(
         &self,
         expected: &Self,

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -142,6 +142,10 @@ impl Schema {
         }
     }
 
+    pub fn has_dictionary_types(&self) -> bool {
+        self.fields.iter().any(|f| f.has_dictionary_types())
+    }
+
     pub fn check_compatible(&self, expected: &Self, options: &SchemaCompareOptions) -> Result<()> {
         if !self.compare_with_options(expected, options) {
             let difference = self.explain_difference(expected, options);

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -10,6 +10,7 @@ use lance_file::datatypes::{populate_schema_dictionary, Fields, FieldsWithMeta};
 use lance_file::reader::FileReader;
 use lance_io::traits::{ProtoStruct, Reader};
 use object_store::path::Path;
+use prost::Message;
 use prost_types::Timestamp;
 
 use super::Fragment;
@@ -256,6 +257,13 @@ impl Manifest {
     /// Whether the dataset uses move-stable row ids.
     pub fn uses_move_stable_row_ids(&self) -> bool {
         self.reader_feature_flags & FLAG_MOVE_STABLE_ROW_IDS != 0
+    }
+
+    /// Creates a serialized copy of the manifest, suitable for IPC or temp storage
+    /// and can be used to create a dataset
+    pub fn serialized(&self) -> Vec<u8> {
+        let pb_manifest: pb::Manifest = self.into();
+        pb_manifest.encode_to_vec()
     }
 }
 


### PR DESCRIPTION
This allows us to send the pickled dataset across IPC and not require a reload of the manifest on the remote.  It should be safe since manifests are read only.  It uses the existing protobuf serialization for manifests.

If the manifest contains a dictionary field then we still need to load the dictionary information on the remote.  Perhaps we can pickle the dictionary at some point (or, with lv2, maybe dictionary won't need to be in manifest)