### PR TITLE
fix: respect storage options on `create_index`

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1516,7 +1516,12 @@ class LanceDataset(pa.dataset.Dataset):
             kwargs["shuffle_partition_concurrency"] = shuffle_partition_concurrency
 
         self._ds.create_index(column, index_type, name, replace, kwargs)
-        return LanceDataset(self.uri, index_cache_size=index_cache_size)
+
+        storage_options = None
+        if "storage_options" in kwargs:
+            storage_options = kwargs.pop("storage_options")
+
+        return LanceDataset(self.uri, index_cache_size=index_cache_size, storage_options=storage_options)
 
     def session(self) -> Session:
         """

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1516,12 +1516,7 @@ class LanceDataset(pa.dataset.Dataset):
             kwargs["shuffle_partition_concurrency"] = shuffle_partition_concurrency
 
         self._ds.create_index(column, index_type, name, replace, kwargs)
-
-        storage_options = None
-        if "storage_options" in kwargs:
-            storage_options = kwargs.pop("storage_options")
-
-        return LanceDataset(self.uri, index_cache_size=index_cache_size, storage_options=storage_options)
+        return self
 
     def session(self) -> Session:
         """


### PR DESCRIPTION
Currently, if `create_index` is used with non-standard storage backends, or configuration options passed at runtime, `lance` does not respect the storage option specified. This can be resolved by checking and passing `storage_options` from the `create_index` methods to allow for the `LanceDataset` to be recreated.