### PR TITLE
feat: support binary & float vectors for IVF_FLAT index

### DIFF
--- a/rust/lance-index/benches/hnsw.rs
+++ b/rust/lance-index/benches/hnsw.rs
@@ -14,7 +14,7 @@ use lance_arrow::FixedSizeListArrayExt;
 use pprof::criterion::{Output, PProfProfiler};
 
 use lance_index::vector::{
-    flat::storage::FlatStorage,
+    flat::storage::FloatFlatStorage,
     hnsw::builder::{HnswBuildParams, HNSW},
 };
 use lance_linalg::distance::DistanceType;
@@ -30,7 +30,7 @@ fn bench_hnsw(c: &mut Criterion) {
 
     let data = generate_random_array_with_seed::<Float32Type>(TOTAL * DIMENSION, SEED);
     let fsl = FixedSizeListArray::try_new_from_values(data, DIMENSION as i32).unwrap();
-    let vectors = Arc::new(FlatStorage::new(fsl.clone(), DistanceType::L2));
+    let vectors = Arc::new(FloatFlatStorage::new(fsl.clone(), DistanceType::L2));
 
     let query = fsl.value(0);
     c.bench_function(

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -27,7 +27,7 @@ pub const FLAT_COLUMN: &str = "flat";
 
 /// All data are stored in memory
 #[derive(Clone)]
-pub struct FlatStorage {
+pub struct FloatFlatStorage {
     batch: RecordBatch,
     distance_type: DistanceType,
 
@@ -36,14 +36,14 @@ pub struct FlatStorage {
     vectors: Arc<FixedSizeListArray>,
 }
 
-impl DeepSizeOf for FlatStorage {
+impl DeepSizeOf for FloatFlatStorage {
     fn deep_size_of_children(&self, _: &mut deepsize::Context) -> usize {
         self.batch.get_array_memory_size()
     }
 }
 
 #[async_trait::async_trait]
-impl QuantizerStorage for FlatStorage {
+impl QuantizerStorage for FloatFlatStorage {
     type Metadata = FlatMetadata;
     async fn load_partition(
         _: &FileReader,
@@ -55,7 +55,7 @@ impl QuantizerStorage for FlatStorage {
     }
 }
 
-impl FlatStorage {
+impl FloatFlatStorage {
     // deprecated, use `try_from_batch` instead
     pub fn new(vectors: FixedSizeListArray, distance_type: DistanceType) -> Self {
         let row_ids = Arc::new(UInt64Array::from_iter_values(0..vectors.len() as u64));
@@ -80,8 +80,8 @@ impl FlatStorage {
     }
 }
 
-impl VectorStore for FlatStorage {
-    type DistanceCalculator<'a> = FlatDistanceCal<'a>;
+impl VectorStore for FloatFlatStorage {
+    type DistanceCalculator<'a> = FloatFlatDistanceCal<'a>;
 
     fn try_from_batch(batch: RecordBatch, distance_type: DistanceType) -> Result<Self> {
         let row_ids = Arc::new(
@@ -149,11 +149,11 @@ impl VectorStore for FlatStorage {
     }
 
     fn dist_calculator(&self, query: ArrayRef) -> Self::DistanceCalculator<'_> {
-        FlatDistanceCal::new(self.vectors.as_ref(), query, self.distance_type)
+        FloatFlatDistanceCal::new(self.vectors.as_ref(), query, self.distance_type)
     }
 
     fn dist_calculator_from_id(&self, id: u32) -> Self::DistanceCalculator<'_> {
-        FlatDistanceCal::new(
+        FloatFlatDistanceCal::new(
             self.vectors.as_ref(),
             self.vectors.value(id as usize),
             self.distance_type,
@@ -176,14 +176,165 @@ impl VectorStore for FlatStorage {
     }
 }
 
-pub struct FlatDistanceCal<'a> {
+/// All data are stored in memory
+#[derive(Clone)]
+pub struct IntFlatStorage {
+    batch: RecordBatch,
+    distance_type: DistanceType,
+
+    // helper fields
+    pub(super) row_ids: Arc<UInt64Array>,
+    vectors: Arc<FixedSizeListArray>,
+}
+
+impl DeepSizeOf for IntFlatStorage {
+    fn deep_size_of_children(&self, _: &mut deepsize::Context) -> usize {
+        self.batch.get_array_memory_size()
+    }
+}
+
+#[async_trait::async_trait]
+impl QuantizerStorage for IntFlatStorage {
+    type Metadata = FlatMetadata;
+    async fn load_partition(
+        _: &FileReader,
+        _: std::ops::Range<usize>,
+        _: DistanceType,
+        _: &Self::Metadata,
+    ) -> Result<Self> {
+        unimplemented!("Flat will be used in new index builder which doesn't require this")
+    }
+}
+
+impl IntFlatStorage {
+    // deprecated, use `try_from_batch` instead
+    pub fn new(vectors: FixedSizeListArray, distance_type: DistanceType) -> Self {
+        let row_ids = Arc::new(UInt64Array::from_iter_values(0..vectors.len() as u64));
+        let vectors = Arc::new(vectors);
+
+        let batch = RecordBatch::try_from_iter_with_nullable(vec![
+            (ROW_ID, row_ids.clone() as ArrayRef, true),
+            (FLAT_COLUMN, vectors.clone() as ArrayRef, true),
+        ])
+        .unwrap();
+
+        Self {
+            batch,
+            distance_type,
+            row_ids,
+            vectors,
+        }
+    }
+
+    pub fn vector(&self, id: u32) -> ArrayRef {
+        self.vectors.value(id as usize)
+    }
+}
+
+impl VectorStore for IntFlatStorage {
+    type DistanceCalculator<'a> = FloatFlatDistanceCal<'a>;
+
+    fn try_from_batch(batch: RecordBatch, distance_type: DistanceType) -> Result<Self> {
+        let row_ids = Arc::new(
+            batch
+                .column_by_name(ROW_ID)
+                .ok_or(Error::Schema {
+                    message: format!("column {} not found", ROW_ID),
+                    location: location!(),
+                })?
+                .as_primitive::<UInt64Type>()
+                .clone(),
+        );
+        let vectors = Arc::new(
+            batch
+                .column_by_name(FLAT_COLUMN)
+                .ok_or(Error::Schema {
+                    message: "column flat not found".to_string(),
+                    location: location!(),
+                })?
+                .as_fixed_size_list()
+                .clone(),
+        );
+        Ok(Self {
+            batch,
+            distance_type,
+            row_ids,
+            vectors,
+        })
+    }
+
+    fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch>> {
+        Ok([self.batch.clone()].into_iter())
+    }
+
+    fn append_batch(&self, batch: RecordBatch, _vector_column: &str) -> Result<Self> {
+        // TODO: use chunked storage
+        let new_batch = concat_batches(&batch.schema(), vec![&self.batch, &batch].into_iter())?;
+        let mut storage = self.clone();
+        storage.batch = new_batch;
+        Ok(storage)
+    }
+
+    fn schema(&self) -> &SchemaRef {
+        self.batch.schema_ref()
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn len(&self) -> usize {
+        self.vectors.len()
+    }
+
+    fn distance_type(&self) -> DistanceType {
+        self.distance_type
+    }
+
+    fn row_id(&self, id: u32) -> u64 {
+        self.row_ids.values()[id as usize]
+    }
+
+    fn row_ids(&self) -> impl Iterator<Item = &u64> {
+        self.row_ids.values().iter()
+    }
+
+    fn dist_calculator(&self, query: ArrayRef) -> Self::DistanceCalculator<'_> {
+        FloatFlatDistanceCal::new(self.vectors.as_ref(), query, self.distance_type)
+    }
+
+    fn dist_calculator_from_id(&self, id: u32) -> Self::DistanceCalculator<'_> {
+        FloatFlatDistanceCal::new(
+            self.vectors.as_ref(),
+            self.vectors.value(id as usize),
+            self.distance_type,
+        )
+    }
+
+    /// Distance between two vectors.
+    fn distance_between(&self, a: u32, b: u32) -> f32 {
+        match self.vectors.value_type() {
+            DataType::Float32 => {
+                let vector1 = self.vectors.value(a as usize);
+                let vector2 = self.vectors.value(b as usize);
+                self.distance_type.func()(
+                    vector1.as_primitive::<Float32Type>().values(),
+                    vector2.as_primitive::<Float32Type>().values(),
+                )
+            }
+            _ => unimplemented!(),
+        }
+    }
+}
+
+pub struct FloatFlatDistanceCal<'a> {
     vectors: &'a [f32],
     query: Vec<f32>,
     dimension: usize,
     distance_fn: fn(&[f32], &[f32]) -> f32,
 }
 
-impl<'a> FlatDistanceCal<'a> {
+impl<'a> FloatFlatDistanceCal<'a> {
     fn new(vectors: &'a FixedSizeListArray, query: ArrayRef, distance_type: DistanceType) -> Self {
         // Gained sigificant performance improvement by using strong typed primtive slice.
         // TODO: to support other data types other than `f32`, make FlatDistanceCal a generic struct.
@@ -203,7 +354,48 @@ impl<'a> FlatDistanceCal<'a> {
     }
 }
 
-impl DistCalculator for FlatDistanceCal<'_> {
+impl DistCalculator for FloatFlatDistanceCal<'_> {
+    #[inline]
+    fn distance(&self, id: u32) -> f32 {
+        let vector = self.get_vector(id);
+        (self.distance_fn)(&self.query, vector)
+    }
+
+    #[inline]
+    fn prefetch(&self, id: u32) {
+        let vector = self.get_vector(id);
+        do_prefetch(vector.as_ptr_range())
+    }
+}
+
+pub struct IntFlatDistanceCal<'a> {
+    vectors: &'a [f32],
+    query: Vec<f32>,
+    dimension: usize,
+    distance_fn: fn(&[f32], &[f32]) -> f32,
+}
+
+impl<'a> IntFlatDistanceCal<'a> {
+    fn new(vectors: &'a FixedSizeListArray, query: ArrayRef, distance_type: DistanceType) -> Self {
+        // Gained sigificant performance improvement by using strong typed primtive slice.
+        // TODO: to support other data types other than `f32`, make FlatDistanceCal a generic struct.
+        let flat_array = vectors.values().as_primitive::<Float32Type>();
+        let dimension = vectors.value_length() as usize;
+        Self {
+            vectors: flat_array.values(),
+            query: query.as_primitive::<Float32Type>().values().to_vec(),
+            dimension,
+            distance_fn: distance_type.func(),
+        }
+    }
+
+    #[inline]
+    fn get_vector(&self, id: u32) -> &[f32] {
+        &self.vectors[self.dimension * id as usize..self.dimension * (id + 1) as usize]
+    }
+}
+
+impl DistCalculator for IntFlatDistanceCal<'_> {
     #[inline]
     fn distance(&self, id: u32) -> f32 {
         let vector = self.get_vector(id);

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -232,7 +232,7 @@ impl IntFlatStorage {
 }
 
 impl VectorStore for IntFlatStorage {
-    type DistanceCalculator<'a> = FloatFlatDistanceCal<'a>;
+    type DistanceCalculator<'a> = IntFlatDistanceCal<'a>;
 
     fn try_from_batch(batch: RecordBatch, distance_type: DistanceType) -> Result<Self> {
         let row_ids = Arc::new(
@@ -300,11 +300,11 @@ impl VectorStore for IntFlatStorage {
     }
 
     fn dist_calculator(&self, query: ArrayRef) -> Self::DistanceCalculator<'_> {
-        FloatFlatDistanceCal::new(self.vectors.as_ref(), query, self.distance_type)
+        IntFlatDistanceCal::new(self.vectors.as_ref(), query, self.distance_type)
     }
 
     fn dist_calculator_from_id(&self, id: u32) -> Self::DistanceCalculator<'_> {
-        FloatFlatDistanceCal::new(
+        IntFlatDistanceCal::new(
             self.vectors.as_ref(),
             self.vectors.value(id as usize),
             self.distance_type,

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use super::super::graph::beam_search;
 use super::{select_neighbors_heuristic, HnswMetadata, HNSW_TYPE, VECTOR_ID_COL, VECTOR_ID_FIELD};
 use crate::scalar::IndexWriter;
-use crate::vector::flat::storage::FlatStorage;
+use crate::vector::flat::storage::FloatFlatStorage;
 use crate::vector::graph::builder::GraphBuilderNode;
 use crate::vector::graph::greedy_search;
 use crate::vector::graph::{
@@ -107,7 +107,7 @@ impl HnswBuildParams {
 
     pub async fn build(self, data: ArrayRef) -> Result<HNSW> {
         // We have normalized the vectors if the metric type is cosine, so we can use the L2 distance
-        let vec_store = Arc::new(FlatStorage::new(
+        let vec_store = Arc::new(FloatFlatStorage::new(
             data.as_fixed_size_list().clone(),
             DistanceType::L2,
         ));
@@ -779,7 +779,7 @@ mod tests {
     use object_store::path::Path;
 
     use crate::vector::{
-        flat::storage::FlatStorage,
+        flat::storage::FloatFlatStorage,
         graph::{DISTS_FIELD, NEIGHBORS_FIELD},
         hnsw::{builder::HnswBuildParams, HNSW, VECTOR_ID_FIELD},
     };
@@ -791,7 +791,7 @@ mod tests {
         const NUM_EDGES: usize = 20;
         let data = generate_random_array(TOTAL * DIM);
         let fsl = FixedSizeListArray::try_new_from_values(data, DIM as i32).unwrap();
-        let store = Arc::new(FlatStorage::new(fsl.clone(), DistanceType::L2));
+        let store = Arc::new(FloatFlatStorage::new(fsl.clone(), DistanceType::L2));
         let builder = HNSW::build_with_storage(
             DistanceType::L2,
             HnswBuildParams::default()

--- a/rust/lance-index/src/vector/ivf.rs
+++ b/rust/lance-index/src/vector/ivf.rs
@@ -57,6 +57,7 @@ pub fn new_ivf_with_quantizer(
 ) -> Result<Ivf> {
     match quantizer {
         Quantizer::Flat(_) => Ok(Ivf::new_flat(centroids, metric_type, vector_column, range)),
+        Quantizer::BinFlat(_) => Ok(Ivf::new_flat(centroids, metric_type, vector_column, range)),
         Quantizer::Product(pq) => Ok(Ivf::with_pq(
             centroids,
             metric_type,

--- a/rust/lance-index/src/vector/quantizer.rs
+++ b/rust/lance-index/src/vector/quantizer.rs
@@ -19,7 +19,7 @@ use snafu::{location, Location};
 
 use crate::{IndexMetadata, INDEX_METADATA_SCHEMA_KEY};
 
-use super::flat::index::FlatQuantizer;
+use super::flat::index::{BinFlatQuantizer, FlatQuantizer};
 use super::pq::storage::PQ_METADTA_KEY;
 use super::pq::ProductQuantizer;
 use super::sq::storage::SQ_METADATA_KEY;
@@ -74,6 +74,7 @@ impl std::fmt::Display for QuantizationType {
 #[derive(Debug, Clone, DeepSizeOf)]
 pub enum Quantizer {
     Flat(FlatQuantizer),
+    BinFlat(BinFlatQuantizer),
     Product(Arc<dyn ProductQuantizer>),
     Scalar(ScalarQuantizer),
 }
@@ -82,6 +83,7 @@ impl Quantizer {
     pub fn code_dim(&self) -> usize {
         match self {
             Self::Flat(fq) => fq.code_dim(),
+            Self::BinFlat(bfq) => bfq.code_dim(),
             Self::Product(pq) => pq.num_sub_vectors(),
             Self::Scalar(sq) => sq.dim,
         }
@@ -90,6 +92,7 @@ impl Quantizer {
     pub fn column(&self) -> &'static str {
         match self {
             Self::Flat(fq) => fq.column(),
+            Self::BinFlat(bfq) => bfq.column(),
             Self::Product(pq) => pq.column(),
             Self::Scalar(sq) => sq.column(),
         }
@@ -98,6 +101,7 @@ impl Quantizer {
     pub fn metadata_key(&self) -> &'static str {
         match self {
             Self::Flat(_) => FlatQuantizer::metadata_key(),
+            Self::BinFlat(_) => FlatQuantizer::metadata_key(),
             Self::Product(_) => ProductQuantizerImpl::<Float32Type>::metadata_key(),
             Self::Scalar(_) => ScalarQuantizer::metadata_key(),
         }
@@ -106,6 +110,7 @@ impl Quantizer {
     pub fn quantization_type(&self) -> QuantizationType {
         match self {
             Self::Flat(fq) => fq.quantization_type(),
+            Self::BinFlat(bfq) => bfq.quantization_type(),
             Self::Product(pq) => pq.quantization_type(),
             Self::Scalar(sq) => sq.quantization_type(),
         }
@@ -114,6 +119,7 @@ impl Quantizer {
     pub fn metadata(&self, args: Option<QuantizationMetadata>) -> Result<serde_json::Value> {
         match self {
             Self::Flat(fq) => fq.metadata(args),
+            Self::BinFlat(bfq) => bfq.metadata(args),
             Self::Product(pq) => pq.metadata(args),
             Self::Scalar(sq) => sq.metadata(args),
         }

--- a/rust/lance/examples/hnsw.rs
+++ b/rust/lance/examples/hnsw.rs
@@ -15,7 +15,7 @@ use clap::Parser;
 use futures::StreamExt;
 use lance::Dataset;
 use lance_index::vector::{
-    flat::storage::FlatStorage,
+    flat::storage::FloatFlatStorage,
     hnsw::{builder::HnswBuildParams, HNSW},
 };
 use lance_linalg::distance::DistanceType;
@@ -78,7 +78,7 @@ async fn main() {
     let fsl = concat(&arrs).unwrap().as_fixed_size_list().clone();
     println!("Loaded {:?} batches", fsl.len());
 
-    let vector_store = Arc::new(FlatStorage::new(fsl.clone(), DistanceType::L2));
+    let vector_store = Arc::new(FloatFlatStorage::new(fsl.clone(), DistanceType::L2));
 
     let q = fsl.value(0);
     let k = 10;

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -12,14 +12,17 @@ use async_trait::async_trait;
 use futures::{stream, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use lance_file::reader::FileReader;
+use lance_file::v2;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::pb::index::Implementation;
 use lance_index::scalar::expression::IndexInformationProvider;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::ScalarIndex;
-use lance_index::vector::flat::index::{FlatIndex, FlatQuantizer};
+use lance_index::vector::flat::index::{BinFlatQuantizer, FlatIndex, FlatQuantizer};
 pub use lance_index::IndexParams;
+use lance_index::INDEX_METADATA_SCHEMA_KEY;
 use lance_index::{pb, vector::VectorIndex, DatasetIndexExt, Index, IndexType, INDEX_FILE_NAME};
+use lance_io::scheduler::ScanScheduler;
 use lance_io::traits::Reader;
 use lance_io::utils::{
     read_last_block, read_message, read_message_from_buf, read_metadata_offset, read_version,
@@ -557,14 +560,70 @@ impl DatasetIndexInternalExt for Dataset {
             }
 
             (0, 3) => {
-                let ivf = IVFIndex::<FlatIndex, FlatQuantizer>::try_new(
-                    self.object_store.clone(),
-                    self.indices_dir(),
-                    uuid.to_owned(),
-                    Arc::downgrade(&self.session),
-                )
-                .await?;
-                Ok(Arc::new(ivf))
+                let scheduler = ScanScheduler::new(self.object_store.clone(), 16);
+                let file = scheduler.open_file(&index_file).await?;
+                let reader =
+                    v2::reader::FileReader::try_open(file, None, Default::default()).await?;
+                let index_metadata = reader
+                    .schema()
+                    .metadata
+                    .get(INDEX_METADATA_SCHEMA_KEY)
+                    .ok_or(Error::Index {
+                        message: "Index Metadata not found".to_owned(),
+                        location: location!(),
+                    })?;
+                let index_metadata: lance_index::IndexMetadata =
+                    serde_json::from_str(index_metadata)?;
+                let field = self.schema().field(column).ok_or_else(|| Error::Index {
+                    message: format!("Column {} does not exist in the schema", column),
+                    location: location!(),
+                })?;
+
+                match index_metadata.index_type.as_str() {
+                    "FLAT" => match field.data_type() {
+                        DataType::FixedSizeList(df, _) => match df.data_type() {
+                            DataType::Float16 | DataType::Float32 | DataType::Float64 => {
+                                let ivf = IVFIndex::<FlatIndex, FlatQuantizer>::try_new(
+                                    self.object_store.clone(),
+                                    self.indices_dir(),
+                                    uuid.to_owned(),
+                                    Arc::downgrade(&self.session),
+                                )
+                                .await?;
+                                Ok(Arc::new(ivf))
+                            }
+                            DataType::UInt8 => {
+                                let ivf = IVFIndex::<FlatIndex, BinFlatQuantizer>::try_new(
+                                    self.object_store.clone(),
+                                    self.indices_dir(),
+                                    uuid.to_owned(),
+                                    Arc::downgrade(&self.session),
+                                )
+                                .await?;
+                                Ok(Arc::new(ivf))
+                            }
+                            _ => Err(Error::Index {
+                                message: format!(
+                                    "the field type {} is not supported for FLAT index",
+                                    field.data_type()
+                                ),
+                                location: location!(),
+                            }),
+                        },
+                        _ => Err(Error::Index {
+                            message: format!(
+                                "the field type {} is not supported for FLAT index",
+                                field.data_type()
+                            ),
+                            location: location!(),
+                        }),
+                    },
+
+                    _ => Err(Error::Index {
+                        message: format!("Unsupported index type: {}", index_metadata.index_type),
+                        location: location!(),
+                    }),
+                }
             }
 
             _ => Err(Error::Index {

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -27,6 +27,7 @@ use lance_index::{
     },
     INDEX_AUXILIARY_FILE_NAME, INDEX_FILE_NAME,
 };
+use lance_index::{IndexMetadata, INDEX_METADATA_SCHEMA_KEY};
 use lance_io::{
     object_store::ObjectStore, scheduler::ScanScheduler, stream::RecordBatchStreamAdapter,
     ReadBatchParams,
@@ -313,6 +314,14 @@ impl<S: IvfSubIndex, Q: Quantization + Clone> IvfIndexBuilder<S, Q> {
         );
 
         let index_ivf_pb = pb::Ivf::try_from(&index_ivf)?;
+        let index_metadata = IndexMetadata {
+            index_type: self.sub_index.name().to_string(),
+            distance_type: self.distance_type.to_string(),
+        };
+        index_writer.add_schema_metadata(
+            INDEX_METADATA_SCHEMA_KEY,
+            serde_json::to_string(&index_metadata)?,
+        );
         index_writer.add_schema_metadata(DISTANCE_TYPE_KEY, self.distance_type.to_string());
         index_writer
             .add_schema_metadata(IVF_METADATA_KEY, hex::encode(index_ivf_pb.encode_to_vec()));

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -505,6 +505,7 @@ async fn optimize_ivf_hnsw_indices<Q: Quantization>(
     // Write the metadata of quantizer
     let quantization_metadata = match &quantizer {
         Quantizer::Flat(_) => None,
+        Quantizer::BinFlat(_) => None,
         Quantizer::Product(pq) => {
             let mat = MatrixView::<Float32Type>::new(
                 Arc::new(
@@ -1538,6 +1539,7 @@ async fn write_ivf_hnsw_file(
     // For PQ, we need to store the codebook
     let quantization_metadata = match &quantizer {
         Quantizer::Flat(_) => None,
+        Quantizer::BinFlat(_) => None,
         Quantizer::Product(pq) => {
             let mat = MatrixView::<Float32Type>::new(
                 Arc::new(

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -318,6 +318,7 @@ pub(super) async fn write_hnsw_quantization_index_partitions(
 
         let code_column = match &quantizer {
             Quantizer::Flat(_) => None,
+            Quantizer::BinFlat(_) => None,
             Quantizer::Product(pq) => Some(pq.column()),
             Quantizer::Scalar(_) => None,
         };
@@ -483,7 +484,7 @@ async fn build_hnsw_quantization_partition(
     let build_hnsw = build_and_write_hnsw((*hnsw_params).clone(), vectors.clone(), writer);
 
     let build_store = match quantizer {
-        Quantizer::Flat(_) => {
+        Quantizer::Flat(_) | Quantizer::BinFlat(_) => {
             return Err(Error::Index {
                 message: "Flat quantizer is not supported for IVF_HNSW".to_string(),
                 location: location!(),


### PR DESCRIPTION
this splits the flat storage & distance calculator to float/int ones to support binary vectors.
merge them back after we figure out a generic way to handle both of binary & float vectors