### PR TITLE
feat: more flexible and sophisticated handling of non-null constraints

### DIFF
--- a/python/python/tests/test_ingestion.py
+++ b/python/python/tests/test_ingestion.py
@@ -5,8 +5,8 @@ import pyarrow as pa
 import pytest
 
 
-@pytest.mark.parametrize("use_legacy_format", [True, False])
-def test_nullability(tmp_path, use_legacy_format):
+@pytest.mark.parametrize("data_storage_version", ["legacy", "2.0"])
+def test_nullability(tmp_path, data_storage_version):
     nullable_schema = pa.schema([pa.field("a", pa.string(), nullable=True)])
     non_nullable_schema = pa.schema([pa.field("a", pa.string(), nullable=False)])
 
@@ -21,13 +21,13 @@ def test_nullability(tmp_path, use_legacy_format):
         [],
         str(tmp_path / "nullable.lance"),
         schema=nullable_schema,
-        use_legacy_format=use_legacy_format,
+        data_storage_version=data_storage_version,
     )
     non_nullable_dataset = lance.write_dataset(
         [],
         str(tmp_path / "non_nullable.lance"),
         schema=non_nullable_schema,
-        use_legacy_format=use_legacy_format,
+        data_storage_version=data_storage_version,
     )
 
     # Can write nullable data into nullable table
@@ -58,7 +58,7 @@ def test_nullability(tmp_path, use_legacy_format):
         [],
         str(tmp_path / "outer_struct_nullable.lance"),
         schema=outer_nullable,
-        use_legacy_format=use_legacy_format,
+        data_storage_version=data_storage_version,
     )
     can_write({"point": [None]}, dataset, outer_nullable)
     cannot_write({"point": [{"x": None}]}, dataset, outer_nullable)
@@ -76,7 +76,7 @@ def test_nullability(tmp_path, use_legacy_format):
         [],
         str(tmp_path / "inner_struct_nullable.lance"),
         schema=inner_nullable,
-        use_legacy_format=use_legacy_format,
+        data_storage_version=data_storage_version,
     )
     cannot_write({"point": [None]}, dataset, inner_nullable)
     can_write({"point": [{"x": None}]}, dataset, inner_nullable)
@@ -94,7 +94,7 @@ def test_nullability(tmp_path, use_legacy_format):
         [],
         str(tmp_path / "outer_list_nullable.lance"),
         schema=outer_nullable,
-        use_legacy_format=use_legacy_format,
+        data_storage_version=data_storage_version,
     )
     can_write({"list": [None]}, dataset, outer_nullable)
     cannot_write({"list": [[None]]}, dataset, outer_nullable)
@@ -112,7 +112,7 @@ def test_nullability(tmp_path, use_legacy_format):
         [],
         str(tmp_path / "inner_list_nullable.lance"),
         schema=inner_nullable,
-        use_legacy_format=use_legacy_format,
+        data_storage_version=data_storage_version,
     )
     cannot_write({"list": [None]}, dataset, inner_nullable)
     can_write({"list": [[None]]}, dataset, inner_nullable)

--- a/python/python/tests/test_ingestion.py
+++ b/python/python/tests/test_ingestion.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+import lance
+import pyarrow as pa
+import pytest
+
+
+@pytest.mark.parametrize("use_legacy_format", [True, False])
+def test_nullability(tmp_path, use_legacy_format):
+    nullable_schema = pa.schema([pa.field("a", pa.string(), nullable=True)])
+    non_nullable_schema = pa.schema([pa.field("a", pa.string(), nullable=False)])
+
+    def can_write(data, dataset, schema=None):
+        lance.write_dataset(pa.table(data, schema=schema), dataset.uri, mode="append")
+
+    def cannot_write(data, dataset, schema=None):
+        with pytest.raises(Exception, match="contained null values"):
+            can_write(data, dataset, schema)
+
+    nullable_dataset = lance.write_dataset(
+        [],
+        str(tmp_path / "nullable.lance"),
+        schema=nullable_schema,
+        use_legacy_format=use_legacy_format,
+    )
+    non_nullable_dataset = lance.write_dataset(
+        [],
+        str(tmp_path / "non_nullable.lance"),
+        schema=non_nullable_schema,
+        use_legacy_format=use_legacy_format,
+    )
+
+    # Can write nullable data into nullable table
+    can_write({"a": ["7", None]}, nullable_dataset, nullable_schema)
+    # Can write non-nullable data into nullable table
+    can_write({"a": ["7"]}, nullable_dataset, non_nullable_schema)
+    # Can write non-nullable data into non-nullable table
+    can_write({"a": ["7"]}, non_nullable_dataset, non_nullable_schema)
+    # Can write nullable data into non-nullable table if
+    # the data does not contain nulls
+    can_write({"a": ["7"]}, non_nullable_dataset, nullable_schema)
+    # If the data contains nulls, it will raise an error
+    cannot_write({"a": [None]}, non_nullable_dataset, nullable_schema)
+    # This is true even if the data lies and claims it is non-nullable
+    cannot_write({"a": [None]}, non_nullable_dataset, non_nullable_schema)
+
+    # Verify nested nullabilities too
+    outer_nullable = pa.schema(
+        [
+            pa.field(
+                "point",
+                pa.struct([pa.field("x", pa.string(), nullable=False)]),
+                nullable=True,
+            )
+        ]
+    )
+    dataset = lance.write_dataset(
+        [],
+        str(tmp_path / "outer_struct_nullable.lance"),
+        schema=outer_nullable,
+        use_legacy_format=use_legacy_format,
+    )
+    can_write({"point": [None]}, dataset, outer_nullable)
+    cannot_write({"point": [{"x": None}]}, dataset, outer_nullable)
+
+    inner_nullable = pa.schema(
+        [
+            pa.field(
+                "point",
+                pa.struct([pa.field("x", pa.string(), nullable=True)]),
+                nullable=False,
+            )
+        ]
+    )
+    dataset = lance.write_dataset(
+        [],
+        str(tmp_path / "inner_struct_nullable.lance"),
+        schema=inner_nullable,
+        use_legacy_format=use_legacy_format,
+    )
+    cannot_write({"point": [None]}, dataset, inner_nullable)
+    can_write({"point": [{"x": None}]}, dataset, inner_nullable)
+
+    outer_nullable = pa.schema(
+        [
+            pa.field(
+                "list",
+                pa.list_(pa.field("item", pa.string(), nullable=False)),
+                nullable=True,
+            )
+        ]
+    )
+    dataset = lance.write_dataset(
+        [],
+        str(tmp_path / "outer_list_nullable.lance"),
+        schema=outer_nullable,
+        use_legacy_format=use_legacy_format,
+    )
+    can_write({"list": [None]}, dataset, outer_nullable)
+    cannot_write({"list": [[None]]}, dataset, outer_nullable)
+
+    inner_nullable = pa.schema(
+        [
+            pa.field(
+                "list",
+                pa.list_(pa.field("item", pa.string(), nullable=True)),
+                nullable=False,
+            )
+        ]
+    )
+    dataset = lance.write_dataset(
+        [],
+        str(tmp_path / "inner_list_nullable.lance"),
+        schema=inner_nullable,
+        use_legacy_format=use_legacy_format,
+    )
+    cannot_write({"list": [None]}, dataset, inner_nullable)
+    can_write({"list": [[None]]}, dataset, inner_nullable)

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -20,6 +20,7 @@ mod schema;
 use crate::{Error, Result};
 pub use field::Encoding;
 pub use field::Field;
+pub use field::NullabilityComparison;
 pub use field::SchemaCompareOptions;
 pub use schema::Schema;
 

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -44,8 +44,7 @@ pub struct SchemaCompareOptions {
     pub compare_dictionary: bool,
     /// Should the field ids be compared (default false)
     pub compare_field_ids: bool,
-    /// If the expected schema is nullable then is a non-nullable
-    /// version of the field allowed (default False)
+    /// Should nullability be compared (default Strict)
     pub compare_nullability: NullabilityComparison,
 }
 /// Encoding enum.

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -7,10 +7,11 @@ use std::sync::Arc;
 
 use arrow_array::RecordBatch;
 
+use arrow_data::ArrayData;
 use bytes::{BufMut, Bytes, BytesMut};
 use futures::stream::FuturesOrdered;
 use futures::StreamExt;
-use lance_core::datatypes::Schema as LanceSchema;
+use lance_core::datatypes::{Field, Schema as LanceSchema};
 use lance_core::{Error, Result};
 use lance_encoding::decoder::PageEncoding;
 use lance_encoding::encoder::{
@@ -205,6 +206,29 @@ impl FileWriter {
         Ok(())
     }
 
+    fn verify_field_nullability(&self, arr: &ArrayData, field: &Field) -> Result<()> {
+        if !field.nullable && arr.null_count() > 0 {
+            return Err(Error::invalid_input(format!("The field `{}` contained null values even though the field is marked non-null in the schema", field.name), location!()));
+        }
+
+        for (child_field, child_arr) in field.children.iter().zip(arr.child_data()) {
+            self.verify_field_nullability(child_arr, child_field)?;
+        }
+
+        Ok(())
+    }
+
+    fn verify_nullability_constraints(&self, batch: &RecordBatch) -> Result<()> {
+        for (col, field) in batch
+            .columns()
+            .iter()
+            .zip(self.schema.as_ref().unwrap().fields.iter())
+        {
+            self.verify_field_nullability(&col.to_data(), field)?;
+        }
+        Ok(())
+    }
+
     fn initialize(&mut self, mut schema: LanceSchema) -> Result<()> {
         let cache_bytes_per_column = if let Some(data_cache_bytes) = self.options.data_cache_bytes {
             data_cache_bytes / schema.fields.len() as u64
@@ -292,6 +316,7 @@ impl FileWriter {
             batch.get_array_memory_size()
         );
         self.ensure_initialized(batch)?;
+        self.verify_nullability_constraints(batch)?;
         let num_rows = batch.num_rows() as u64;
         if num_rows == 0 {
             return Ok(());

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -206,13 +206,13 @@ impl FileWriter {
         Ok(())
     }
 
-    fn verify_field_nullability(&self, arr: &ArrayData, field: &Field) -> Result<()> {
+    fn verify_field_nullability(arr: &ArrayData, field: &Field) -> Result<()> {
         if !field.nullable && arr.null_count() > 0 {
             return Err(Error::invalid_input(format!("The field `{}` contained null values even though the field is marked non-null in the schema", field.name), location!()));
         }
 
         for (child_field, child_arr) in field.children.iter().zip(arr.child_data()) {
-            self.verify_field_nullability(child_arr, child_field)?;
+            Self::verify_field_nullability(child_arr, child_field)?;
         }
 
         Ok(())
@@ -224,7 +224,7 @@ impl FileWriter {
             .iter()
             .zip(self.schema.as_ref().unwrap().fields.iter())
         {
-            self.verify_field_nullability(&col.to_data(), field)?;
+            Self::verify_field_nullability(&col.to_data(), field)?;
         }
         Ok(())
     }

--- a/rust/lance-file/src/writer.rs
+++ b/rust/lance-file/src/writer.rs
@@ -11,11 +11,12 @@ use arrow_array::cast::{as_large_list_array, as_list_array, as_struct_array};
 use arrow_array::types::{Int32Type, Int64Type};
 use arrow_array::{Array, ArrayRef, RecordBatch, StructArray};
 use arrow_buffer::ArrowNativeType;
+use arrow_data::ArrayData;
 use arrow_schema::DataType;
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 use lance_arrow::*;
-use lance_core::datatypes::{Encoding, Field, Schema, SchemaCompareOptions};
+use lance_core::datatypes::{Encoding, Field, NullabilityComparison, Schema, SchemaCompareOptions};
 use lance_core::{Error, Result};
 use lance_io::encodings::{
     binary::BinaryEncoder, dictionary::DictionaryEncoder, plain::PlainEncoder, Encoder,
@@ -142,6 +143,25 @@ impl<M: ManifestProvider + Send + Sync> FileWriter<M> {
         &self.schema
     }
 
+    fn verify_field_nullability(&self, arr: &ArrayData, field: &Field) -> Result<()> {
+        if !field.nullable && arr.null_count() > 0 {
+            return Err(Error::invalid_input(format!("The field `{}` contained null values even though the field is marked non-null in the schema", field.name), location!()));
+        }
+
+        for (child_field, child_arr) in field.children.iter().zip(arr.child_data()) {
+            self.verify_field_nullability(child_arr, child_field)?;
+        }
+
+        Ok(())
+    }
+
+    fn verify_nullability_constraints(&self, batch: &RecordBatch) -> Result<()> {
+        for (col, field) in batch.columns().iter().zip(self.schema.fields.iter()) {
+            self.verify_field_nullability(&col.to_data(), field)?;
+        }
+        Ok(())
+    }
+
     /// Write a [RecordBatch] to the open file.
     /// All RecordBatch will be treated as one RecordBatch on disk
     ///
@@ -155,7 +175,14 @@ impl<M: ManifestProvider + Send + Sync> FileWriter<M> {
             // Compare, ignore metadata and dictionary
             //   dictionary should have been checked earlier and could be an expensive check
             let schema = Schema::try_from(batch.schema().as_ref())?;
-            schema.check_compatible(&self.schema, &SchemaCompareOptions::default())?;
+            schema.check_compatible(
+                &self.schema,
+                &SchemaCompareOptions {
+                    compare_nullability: NullabilityComparison::Ignore,
+                    ..Default::default()
+                },
+            )?;
+            self.verify_nullability_constraints(batch)?;
         }
 
         // If we are collecting stats for this column, collect them.

--- a/rust/lance-file/src/writer.rs
+++ b/rust/lance-file/src/writer.rs
@@ -143,13 +143,13 @@ impl<M: ManifestProvider + Send + Sync> FileWriter<M> {
         &self.schema
     }
 
-    fn verify_field_nullability(&self, arr: &ArrayData, field: &Field) -> Result<()> {
+    fn verify_field_nullability(arr: &ArrayData, field: &Field) -> Result<()> {
         if !field.nullable && arr.null_count() > 0 {
             return Err(Error::invalid_input(format!("The field `{}` contained null values even though the field is marked non-null in the schema", field.name), location!()));
         }
 
         for (child_field, child_arr) in field.children.iter().zip(arr.child_data()) {
-            self.verify_field_nullability(child_arr, child_field)?;
+            Self::verify_field_nullability(child_arr, child_field)?;
         }
 
         Ok(())
@@ -157,7 +157,7 @@ impl<M: ManifestProvider + Send + Sync> FileWriter<M> {
 
     fn verify_nullability_constraints(&self, batch: &RecordBatch) -> Result<()> {
         for (col, field) in batch.columns().iter().zip(self.schema.fields.iter()) {
-            self.verify_field_nullability(&col.to_data(), field)?;
+            Self::verify_field_nullability(&col.to_data(), field)?;
         }
         Ok(())
     }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -11,6 +11,7 @@ use deepsize::DeepSizeOf;
 use futures::future::BoxFuture;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use futures::{FutureExt, Stream};
+use lance_core::datatypes::NullabilityComparison;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use lance_core::{datatypes::SchemaCompareOptions, traits::DatasetTakeRows};
 use lance_datafusion::projection::ProjectionPlan;
@@ -554,6 +555,9 @@ impl Dataset {
                     &m.schema,
                     &SchemaCompareOptions {
                         compare_dictionary: true,
+                        // array nullability is checked later, using actual data instead
+                        // of the schema
+                        compare_nullability: NullabilityComparison::Ignore,
                         ..Default::default()
                     },
                 )?;


### PR DESCRIPTION
Previously, we used batch schema to check if incoming data was compatible with the dataset.  This has a few problems:

 * You couldn't add a non-nullable batch to a nullable dataset even though this should be perfectly valid
 * You couldn't add a nullable batch to a non-nullable dataset even when the batch didn't contain nulls
 * It's possible (and with pyarrow, easy) to create a batch that has nulls but the fields are marked non-null, this led to confusing errors.

This PR resolves those issues by checking the null count of the actual arrays instead of relying on the schema assigned to the data.

Closes #1936