### PR TITLE
chore: provide a trait to decouple take rows from Dataset

### DIFF
--- a/rust/lance-core/src/lib.rs
+++ b/rust/lance-core/src/lib.rs
@@ -4,6 +4,7 @@
 use arrow_schema::{DataType, Field as ArrowField};
 
 pub mod cache;
+pub mod traits;
 pub mod datatypes;
 pub mod error;
 pub mod utils;

--- a/rust/lance-core/src/lib.rs
+++ b/rust/lance-core/src/lib.rs
@@ -4,9 +4,9 @@
 use arrow_schema::{DataType, Field as ArrowField};
 
 pub mod cache;
-pub mod traits;
 pub mod datatypes;
 pub mod error;
+pub mod traits;
 pub mod utils;
 
 pub use error::{Error, Result};

--- a/rust/lance-core/src/traits.rs
+++ b/rust/lance-core/src/traits.rs
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Dataset Traits
+
+use std::fmt::Debug;
+
+use arrow_array::RecordBatch;
+
+use crate::{datatypes::Schema, Result};
+
+/// `TakeRow` trait.
+///
+/// It offers a lightweight trait to use `take_rows()` over a dataset, without
+/// depending on the `lance` trait.
+///
+/// <section class="warning">
+/// Internal API
+/// </section>
+#[async_trait::async_trait]
+pub trait DatasetTakeRows: Debug + Send + Sync {
+    /// The schema of the dataset.
+    fn schema(&self) -> &Schema;
+
+    /// Take rows by the internal ROW ids.
+    async fn take_rows(&self, row_ids: &[u64], projection: &Schema) -> Result<RecordBatch>;
+}

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -11,7 +11,7 @@ use deepsize::DeepSizeOf;
 use futures::future::BoxFuture;
 use futures::stream::{self, StreamExt, TryStreamExt};
 use futures::{FutureExt, Stream};
-use lance_core::datatypes::SchemaCompareOptions;
+use lance_core::{datatypes::SchemaCompareOptions, traits::DatasetTakeRows};
 use lance_datafusion::utils::{peek_reader_schema, reader_to_stream};
 use lance_file::datatypes::populate_schema_dictionary;
 use lance_io::object_store::{ObjectStore, ObjectStoreParams};
@@ -1233,6 +1233,17 @@ impl Dataset {
     /// then call `cleanup_files` to remove the old files.
     pub async fn drop_columns(&mut self, columns: &[&str]) -> Result<()> {
         schema_evolution::drop_columns(self, columns).await
+    }
+}
+
+#[async_trait::async_trait]
+impl DatasetTakeRows for Dataset {
+    fn schema(&self) -> &Schema {
+        Self::schema(self)
+    }
+
+    async fn take_rows(&self, row_ids: &[u64], projection: &Schema) -> Result<RecordBatch> {
+        Self::take_rows(self, row_ids, projection).await
     }
 }
 

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -114,8 +114,14 @@ pub async fn merge_indices<'a>(
                 Some(scanner.try_into_stream().await?)
             };
 
-            optimize_vector_indices(&dataset, new_data_stream, &column.name, &indices, options)
-                .await
+            optimize_vector_indices(
+                dataset.as_ref().clone(),
+                new_data_stream,
+                &column.name,
+                &indices,
+                options,
+            )
+            .await
         }
     }?;
 

--- a/rust/lance/src/index/vector/ivf/builder.rs
+++ b/rust/lance/src/index/vector/ivf/builder.rs
@@ -12,7 +12,7 @@ use object_store::path::Path;
 use snafu::{location, Location};
 use tracing::instrument;
 
-use lance_core::{Error, Result, ROW_ID};
+use lance_core::{traits::DatasetTakeRows, Error, Result, ROW_ID};
 use lance_index::vector::{
     hnsw::{builder::HnswBuildParams, HnswMetadata},
     ivf::{shuffler::shuffle_dataset, storage::IvfData},
@@ -21,10 +21,7 @@ use lance_index::vector::{
 use lance_io::{stream::RecordBatchStream, traits::Writer};
 use lance_linalg::distance::MetricType;
 
-use crate::{
-    index::vector::ivf::{io::write_pq_partitions, Ivf},
-    Dataset,
-};
+use crate::index::vector::ivf::{io::write_pq_partitions, Ivf};
 
 use super::io::write_hnsw_quantization_index_partitions;
 
@@ -91,7 +88,7 @@ pub(super) async fn build_partitions(
 #[allow(clippy::too_many_arguments)]
 #[instrument(level = "debug", skip(writer, auxiliary_writer, data, ivf, quantizer))]
 pub(super) async fn build_hnsw_partitions(
-    dataset: &Dataset,
+    dataset: Arc<dyn DatasetTakeRows>,
     writer: &mut FileWriter<ManifestDescribing>,
     auxiliary_writer: Option<&mut FileWriter<ManifestDescribing>>,
     data: impl RecordBatchStream + Unpin + 'static,

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -564,6 +564,7 @@ mod tests {
     use super::*;
 
     use crate::index::{vector::VectorIndexParams, DatasetIndexExt, DatasetIndexInternalExt};
+    use crate::Dataset;
     use arrow_array::RecordBatchIterator;
     use arrow_schema::{Field, Schema};
     use lance_index::IndexType;

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -15,6 +15,7 @@ use futures::stream::Peekable;
 use futures::{Stream, StreamExt, TryStreamExt};
 use lance_arrow::*;
 use lance_core::datatypes::Schema;
+use lance_core::traits::DatasetTakeRows;
 use lance_core::utils::tokio::spawn_cpu;
 use lance_core::Error;
 use lance_file::reader::FileReader;
@@ -45,10 +46,10 @@ use tempfile::TempDir;
 use tokio::sync::Semaphore;
 
 use super::{IVFIndex, Ivf};
+use crate::dataset::ROW_ID;
 use crate::index::vector::pq::{build_pq_storage, PQIndex};
 use crate::index::vector::sq::build_sq_storage;
 use crate::Result;
-use crate::{dataset::ROW_ID, Dataset};
 
 // TODO: make it configurable, limit by the number of CPU cores & memory
 lazy_static::lazy_static! {
@@ -246,9 +247,9 @@ pub(super) async fn write_pq_partitions(
 
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn write_hnsw_quantization_index_partitions(
-    dataset: &Dataset,
+    dataset: Arc<dyn DatasetTakeRows>,
     column: &str,
-    metric_type: MetricType,
+    distance_type: DistanceType,
     hnsw_params: &HnswBuildParams,
     writer: &mut FileWriter<ManifestDescribing>,
     mut auxiliary_writer: Option<&mut FileWriter<ManifestDescribing>>,
@@ -257,8 +258,6 @@ pub(super) async fn write_hnsw_quantization_index_partitions(
     streams: Option<Vec<impl Stream<Item = Result<RecordBatch>>>>,
     existing_indices: Option<&[&IVFIndex]>,
 ) -> Result<(Vec<HnswMetadata>, IvfData)> {
-    let dataset = Arc::new(dataset.clone());
-    let column = Arc::new(column.to_owned());
     let hnsw_params = Arc::new(hnsw_params.clone());
 
     let mut streams_heap = BinaryHeap::new();
@@ -360,7 +359,7 @@ pub(super) async fn write_hnsw_quantization_index_partitions(
         };
 
         let dataset = dataset.clone();
-        let column = column.clone();
+        let column = column.to_owned();
         let hnsw_params = hnsw_params.clone();
         let quantizer = quantizer.clone();
         let sem = sem.clone();
@@ -370,8 +369,8 @@ pub(super) async fn write_hnsw_quantization_index_partitions(
             log::debug!("Building HNSW partition {}", part_id);
             let result = build_hnsw_quantization_partition(
                 dataset,
-                column,
-                metric_type,
+                &column,
+                distance_type,
                 hnsw_params,
                 part_writer,
                 aux_part_writer,
@@ -450,8 +449,8 @@ pub(super) async fn write_hnsw_quantization_index_partitions(
 
 #[allow(clippy::too_many_arguments)]
 async fn build_hnsw_quantization_partition(
-    dataset: Arc<Dataset>,
-    column: Arc<String>,
+    dataset: Arc<dyn DatasetTakeRows>,
+    column: &str,
     metric_type: MetricType,
     hnsw_params: Arc<HnswBuildParams>,
     writer: FileWriter<ManifestDescribing>,
@@ -465,7 +464,7 @@ async fn build_hnsw_quantization_partition(
     std::mem::drop(row_ids_array);
     let num_rows = row_ids.len();
 
-    let projection = Arc::new(dataset.schema().project(&[column.as_ref()])?);
+    let projection = Arc::new(dataset.schema().project(&[column])?);
     let mut vectors = dataset
         .take_rows(row_ids.as_primitive::<UInt64Type>().values(), &projection)
         .await?


### PR DESCRIPTION
In the effort of moving all indexing code from `lance` crate to `lance-index` crate, this traits allow the indexing job not depending on the full `Dataset` struct.