### PR TITLE
fix: low recall if many partitions with only 1 row

### DIFF
--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -2734,7 +2734,7 @@ mod tests {
 
         let recall = results_set.intersection(&gt_set).count() as f32 / k as f32;
         assert!(
-            recall >= 0.7,
+            recall >= 0.9,
             "recall: {}\n results: {:?}\n\ngt: {:?}",
             recall,
             results,

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -506,7 +506,13 @@ async fn build_hnsw_quantization_partition(
         )),
     };
 
-    futures::join!(build_hnsw, build_store).0?;
+    let index_rows = futures::join!(build_hnsw, build_store).0?;
+    assert!(
+        index_rows >= num_rows,
+        "index rows {} must be greater than or equal to num rows {}",
+        index_rows,
+        num_rows
+    );
     Ok(num_rows)
 }
 


### PR DESCRIPTION
The HNSW building does nothing if there's only 1 row, this leads to we can't find this single node while searching