### PR TITLE
perf: don't write precomputed partitions to trace file

### DIFF
--- a/rust/lance/src/index/vector/ivf/builder.rs
+++ b/rust/lance/src/index/vector/ivf/builder.rs
@@ -29,7 +29,7 @@ use super::io::write_hnsw_quantization_index_partitions;
 ///
 ///
 #[allow(clippy::too_many_arguments)]
-#[instrument(level = "debug", skip(writer, data, ivf, pq))]
+#[instrument(level = "debug", skip_all)]
 pub(super) async fn build_partitions(
     writer: &mut dyn Writer,
     data: impl RecordBatchStream + Unpin + 'static,


### PR DESCRIPTION
At 50M rows this writes 1GB to the trace file :laughing:  