### PR TITLE
feat: support to query with vectors of another types

### DIFF
--- a/rust/lance-arrow/src/floats.rs
+++ b/rust/lance-arrow/src/floats.rs
@@ -5,6 +5,7 @@
 
 use std::fmt::{Debug, Display};
 use std::iter::Sum;
+use std::sync::Arc;
 use std::{
     fmt::Formatter,
     ops::{AddAssign, DivAssign},
@@ -202,16 +203,16 @@ impl FloatArray<Float64Type> for Float64Array {
 }
 
 /// Convert a float32 array to another float array.
-pub fn coerce_float_vector(input: &Float32Array, float_type: FloatType) -> Result<Box<dyn Array>> {
+pub fn coerce_float_vector(input: &Float32Array, float_type: FloatType) -> Result<Arc<dyn Array>> {
     match float_type {
-        FloatType::BFloat16 => Ok(Box::new(BFloat16Array::from_iter_values(
+        FloatType::BFloat16 => Ok(Arc::new(BFloat16Array::from_iter_values(
             input.values().iter().map(|v| bf16::from_f32(*v)),
         ))),
-        FloatType::Float16 => Ok(Box::new(Float16Array::from_iter_values(
+        FloatType::Float16 => Ok(Arc::new(Float16Array::from_iter_values(
             input.values().iter().map(|v| f16::from_f32(*v)),
         ))),
-        FloatType::Float32 => Ok(Box::new(input.clone())),
-        FloatType::Float64 => Ok(Box::new(Float64Array::from_iter_values(
+        FloatType::Float32 => Ok(Arc::new(input.clone())),
+        FloatType::Float64 => Ok(Arc::new(Float64Array::from_iter_values(
             input.values().iter().map(|v| *v as f64),
         ))),
     }

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -206,7 +206,7 @@ mod tests {
 
         let q = array.value(5);
         let mut scanner = dataset.scan();
-        scanner.nearest("vector", q.as_primitive(), 10).unwrap();
+        scanner.nearest("vector", q.as_ref(), 10).unwrap();
         let results = scanner
             .try_into_stream()
             .await
@@ -238,7 +238,7 @@ mod tests {
         assert_eq!(index_dirs.len(), 2);
 
         let mut scanner = dataset.scan();
-        scanner.nearest("vector", q.as_primitive(), 10).unwrap();
+        scanner.nearest("vector", q.as_ref(), 10).unwrap();
         let results = scanner
             .try_into_stream()
             .await
@@ -367,7 +367,7 @@ mod tests {
             .scan()
             .project(&["id"])
             .unwrap()
-            .nearest("vector", array.value(0).as_primitive(), 2)
+            .nearest("vector", array.value(0).as_ref(), 2)
             .unwrap()
             .try_into_batch()
             .await

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -785,7 +785,7 @@ mod tests {
     use super::*;
 
     use arrow_array::RecordBatchIterator;
-    use arrow_array::{cast::as_primitive_array, FixedSizeListArray, Int32Array, StringArray};
+    use arrow_array::{FixedSizeListArray, Int32Array, StringArray};
     use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
     use lance_linalg::distance::MetricType;
     use lance_testing::datagen::generate_random_array;
@@ -851,7 +851,7 @@ mod tests {
         let dataset = Dataset::open(test_uri).await.unwrap();
         let stream = dataset
             .scan()
-            .nearest("vector", as_primitive_array(&q), 10)
+            .nearest("vector", q.as_ref(), 10)
             .unwrap()
             .try_into_stream()
             .await


### PR DESCRIPTION
BREAKING CHANGE: this would make the type infer failed cause now the query vector won't be always `Float32Array`