### PR TITLE
ci: fix pytorch CI failure in arm64 jobs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -110,7 +110,8 @@ jobs:
       run: sudo rm -rf target/wheels
   linux-arm:
     timeout-minutes: 45
-    runs-on: warp-ubuntu-latest-arm64-4x
+    #runs-on: warp-ubuntu-latest-arm64-4x
+    runs-on: buildjet-4vcpu-ubuntu-2204-arm
     name: Python Linux 3.${{ matrix.python-minor-version }} ARM
     strategy:
       matrix:


### PR DESCRIPTION
Fix pytorch CI failure on arm64 by changing to buildjet service