### PR TITLE
fix: dot distance so kmeans can converge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ categories = [
     "development-tools",
     "science",
 ]
-rust-version = "1.79"
+rust-version = "1.78"
 
 [workspace.dependencies]
 lance = { version = "=0.13.0", path = "./rust/lance" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = ["python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.12.4"
+version = "0.13.0"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ categories = [
     "development-tools",
     "science",
 ]
-rust-version = "1.75"
+rust-version = "1.79"
 
 [workspace.dependencies]
 lance = { version = "=0.13.0", path = "./rust/lance" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,20 +43,20 @@ categories = [
 rust-version = "1.75"
 
 [workspace.dependencies]
-lance = { version = "=0.12.4", path = "./rust/lance" }
-lance-arrow = { version = "=0.12.4", path = "./rust/lance-arrow" }
-lance-core = { version = "=0.12.4", path = "./rust/lance-core" }
-lance-datafusion = { version = "=0.12.4", path = "./rust/lance-datafusion" }
-lance-datagen = { version = "=0.12.4", path = "./rust/lance-datagen" }
-lance-encoding = { version = "=0.12.4", path = "./rust/lance-encoding" }
-lance-encoding-datafusion = { version = "=0.12.4", path = "./rust/lance-encoding-datafusion" }
-lance-file = { version = "=0.12.4", path = "./rust/lance-file" }
-lance-index = { version = "=0.12.4", path = "./rust/lance-index" }
-lance-io = { version = "=0.12.4", path = "./rust/lance-io" }
-lance-linalg = { version = "=0.12.4", path = "./rust/lance-linalg" }
-lance-table = { version = "=0.12.4", path = "./rust/lance-table" }
-lance-test-macros = { version = "=0.12.4", path = "./rust/lance-test-macros" }
-lance-testing = { version = "=0.12.4", path = "./rust/lance-testing" }
+lance = { version = "=0.13.0", path = "./rust/lance" }
+lance-arrow = { version = "=0.13.0", path = "./rust/lance-arrow" }
+lance-core = { version = "=0.13.0", path = "./rust/lance-core" }
+lance-datafusion = { version = "=0.13.0", path = "./rust/lance-datafusion" }
+lance-datagen = { version = "=0.13.0", path = "./rust/lance-datagen" }
+lance-encoding = { version = "=0.13.0", path = "./rust/lance-encoding" }
+lance-encoding-datafusion = { version = "=0.13.0", path = "./rust/lance-encoding-datafusion" }
+lance-file = { version = "=0.13.0", path = "./rust/lance-file" }
+lance-index = { version = "=0.13.0", path = "./rust/lance-index" }
+lance-io = { version = "=0.13.0", path = "./rust/lance-io" }
+lance-linalg = { version = "=0.13.0", path = "./rust/lance-linalg" }
+lance-table = { version = "=0.13.0", path = "./rust/lance-table" }
+lance-test-macros = { version = "=0.13.0", path = "./rust/lance-test-macros" }
+lance-testing = { version = "=0.13.0", path = "./rust/lance-testing" }
 approx = "0.5.1"
 # Note that this one does not include pyarrow
 arrow = { version = "51.0.0", optional = false, features = ["prettyprint"] }

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pylance"
-version = "0.12.4"
+version = "0.13.0"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 rust-version = "1.65"

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -66,10 +66,10 @@ pub fn dot<T: Dot>(from: &[T], to: &[T]) -> f32 {
     T::dot(from, to)
 }
 
-/// Negative dot distance.
+/// Negative [Dot] distance.
 #[inline]
 pub fn dot_distance<T: Dot>(from: &[T], to: &[T]) -> f32 {
-    -T::dot(from, to)
+    1.0 - T::dot(from, to)
 }
 
 /// Dot product

--- a/rust/lance-linalg/src/kernels.rs
+++ b/rust/lance-linalg/src/kernels.rs
@@ -75,6 +75,7 @@ pub fn argmin_value<T: Num + Bounded + PartialOrd + Copy>(
 /// Returns the minimal value (float) and the index (argmin) from an Iterator.
 ///
 /// Return `None` if the iterator is empty or all are `Nan/Inf`.
+#[inline]
 pub fn argmin_value_float<T: Float>(iter: impl Iterator<Item = T>) -> Option<(u32, T)> {
     let mut min_idx = None;
     let mut min_value = T::infinity();

--- a/rust/lance-linalg/src/kmeans.rs
+++ b/rust/lance-linalg/src/kmeans.rs
@@ -30,7 +30,7 @@ use rayon::prelude::*;
 
 use crate::distance::hamming::hamming;
 use crate::distance::{dot_distance_batch, DistanceType};
-use crate::kernels::argmax;
+use crate::kernels::{argmax, argmin_value_float};
 use crate::{
     distance::{
         l2::{l2_distance_batch, L2},
@@ -214,11 +214,11 @@ where
         let cluster_and_dists = match distance_type {
             DistanceType::L2 => data
                 .par_chunks(dimension)
-                .map(|vec| argmin_value(l2_distance_batch(vec, centroids, dimension)))
+                .map(|vec| argmin_value_float(l2_distance_batch(vec, centroids, dimension)))
                 .collect::<Vec<_>>(),
             DistanceType::Dot => data
                 .par_chunks(dimension)
-                .map(|vec| argmin_value(dot_distance_batch(vec, centroids, dimension)))
+                .map(|vec| argmin_value_float(dot_distance_batch(vec, centroids, dimension)))
                 .collect::<Vec<_>>(),
             _ => {
                 panic!(
@@ -500,8 +500,8 @@ impl KMeans {
                 last_membership = Some(membership);
                 if (loss - last_loss).abs() / last_loss < params.tolerance {
                     info!(
-                        "KMeans training: converged at iteration {} / {}, redo={}",
-                        i, params.max_iters, redo
+                        "KMeans training: converged at iteration {} / {}, redo={}, loss={}, last_loss={}, loss_diff={}",
+                        i, params.max_iters, redo, loss, last_loss, (loss - last_loss).abs() / last_loss
                     );
                     break;
                 }


### PR DESCRIPTION
BREAKING CHANGE: Fix dot distance calculation from `-|xy|` to `1 - |xy|`. 
* Add `log::info` to show loss after kmeans converge earlier. 