### PR TITLE
chore: upgrade aws-config for aarch64-pc-windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ async-recursion = "1.0"
 async-trait = "0.1"
 aws-config = "0.57"
 aws-credential-types = "0.57"
-aws-sdk-dynamodb = "0.34"
+aws-sdk-dynamodb = "0.35"
 half = { "version" = "2.4.1", default-features = false, features = [
     "num-traits",
     "std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ arrow-schema = "51.0"
 arrow-select = "51.0"
 async-recursion = "1.0"
 async-trait = "0.1"
-aws-config = "0.56"
+aws-config = "0.57"
 aws-credential-types = "0.56"
 aws-sdk-dynamodb = "0.34"
 half = { "version" = "2.4.1", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ arrow-select = "51.0"
 async-recursion = "1.0"
 async-trait = "0.1"
 aws-config = "0.57"
-aws-credential-types = "0.56"
+aws-credential-types = "0.57"
 aws-sdk-dynamodb = "0.34"
 half = { "version" = "2.4.1", default-features = false, features = [
     "num-traits",

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -361,7 +361,10 @@ async fn build_dynamodb_external_store(
     app_name: &str,
 ) -> Result<Arc<dyn ExternalManifestStore>> {
     use super::commit::dynamodb::DynamoDBExternalManifestStore;
-    use aws_sdk_dynamodb::{config::{IdentityCache, Region}, Client};
+    use aws_sdk_dynamodb::{
+        config::{IdentityCache, Region},
+        Client,
+    };
 
     let mut dynamodb_config = aws_sdk_dynamodb::config::Builder::new()
         .region(Some(Region::new(region.to_string())))

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -46,7 +46,6 @@ use lance_io::object_store::{ObjectStore, ObjectStoreExt, ObjectStoreParams};
 #[cfg(feature = "dynamodb")]
 use {
     self::external_manifest::{ExternalManifestCommitHandler, ExternalManifestStore},
-    aws_credential_types::cache::CredentialsCache,
     aws_credential_types::provider::error::CredentialsError,
     aws_credential_types::provider::ProvideCredentials,
     lance_io::object_store::{build_aws_credential, StorageOptions},
@@ -362,13 +361,13 @@ async fn build_dynamodb_external_store(
     app_name: &str,
 ) -> Result<Arc<dyn ExternalManifestStore>> {
     use super::commit::dynamodb::DynamoDBExternalManifestStore;
-    use aws_sdk_dynamodb::{config::Region, Client};
+    use aws_sdk_dynamodb::{config::{IdentityCache, Region}, Client};
 
     let mut dynamodb_config = aws_sdk_dynamodb::config::Builder::new()
         .region(Some(Region::new(region.to_string())))
         .credentials_provider(OSObjectStoreToAwsCredAdaptor(creds))
         // caching should be handled by passed AwsCredentialProvider
-        .credentials_cache(CredentialsCache::no_caching());
+        .identity_cache(IdentityCache::no_cache());
 
     if let Some(endpoint) = endpoint {
         dynamodb_config = dynamodb_config.endpoint_url(endpoint);

--- a/rust/lance-table/src/io/commit/dynamodb.rs
+++ b/rust/lance-table/src/io/commit/dynamodb.rs
@@ -184,8 +184,7 @@ impl DynamoDBExternalManifestStore {
                     return Err(Error::io(
                         format!(
                             "dynamodb table: {} unknown key type encountered name:{}",
-                            table_name,
-                            key.attribute_name
+                            table_name, key.attribute_name
                         ),
                         location!(),
                     ));

--- a/rust/lance-table/src/io/commit/dynamodb.rs
+++ b/rust/lance-table/src/io/commit/dynamodb.rs
@@ -173,19 +173,7 @@ impl DynamoDBExternalManifestStore {
                     location!(),
                 )
             })?;
-            let key_type = key.key_type.ok_or_else(|| {
-                Error::io(
-                    format!("dynamodb table: {table_name} key types must be defined"),
-                    location!(),
-                )
-            })?;
-            let name = key.attribute_name.ok_or_else(|| {
-                Error::io(
-                    format!("dynamodb table: {table_name} key must have an attribute name"),
-                    location!(),
-                )
-            })?;
-            match (key_type, name.as_str()) {
+            match (key.key_type, key.attribute_name.as_str()) {
                 (KeyType::Hash, base_uri!()) => {
                     has_hask_key = true;
                 }
@@ -195,7 +183,9 @@ impl DynamoDBExternalManifestStore {
                 _ => {
                     return Err(Error::io(
                         format!(
-                            "dynamodb table: {table_name} unknown key type encountered name:{name}",
+                            "dynamodb table: {} unknown key type encountered name:{}",
+                            table_name,
+                            key.attribute_name
                         ),
                         location!(),
                     ));


### PR DESCRIPTION
Upgrades `aws-config` because `aws-config@0.56` has a dependency on `ring@0.16` [^1] which does not support `aarch64-pc-windows` [^2].

> error: failed to run custom build command for `ring v0.16.20`.

Support for `aarch64-pc-windows` was added in `ring@0.17` [^3] which `aws-config@0.57` uses [^4].

Unfortunately, there's a hideous amount of changes between these two version, although no breaking changes are mentioned in the changelog [^5]. Does a maintainer here have a suggestion of what kind of testing we might need to do?

[^1]: https://github.com/awslabs/aws-sdk-rust/blob/d212f8dd428e140b8ff414261f6921b2901a7dbc/sdk/aws-config/Cargo.toml#L98-L100
[^2]: https://github.com/briansmith/ring/issues/1514
[^3]: https://github.com/briansmith/ring/issues/1167#issuecomment-1745560468
[^4]: https://github.com/awslabs/aws-sdk-rust/blob/511abe92a476c27d1e49758fe54eac0886ecf731/sdk/aws-config/Cargo.toml#L98-L100
[^5]: https://github.com/awslabs/aws-sdk-rust/compare/d212f8d..511abe9