### PR TITLE
chore: enable aarch64-pc-windows builds

### DIFF
--- a/rust/lance-core/src/utils/cpu.rs
+++ b/rust/lance-core/src/utils/cpu.rs
@@ -92,6 +92,14 @@ mod aarch64 {
     }
 }
 
+#[cfg(all(target_arch = "aarch64", target_os = "windows"))]
+mod aarch64 {
+    pub fn has_neon_f16_support() -> bool {
+        // https://github.com/lancedb/lance/issues/2411
+        false
+    }
+}
+
 #[cfg(target_arch = "loongarch64")]
 mod loongarch64 {
     pub fn has_lsx_support() -> bool {


### PR DESCRIPTION
Minimally enables `aarch64-pc-windows` by always returning false for NEON FP16 support checks.