### PR TITLE
feat: expose DatasetPreFilter, PreFilter, and FilterLoader to the public API

### DIFF
--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -36,7 +36,7 @@ use vector::ivf::v2::IVFIndex;
 
 pub(crate) mod append;
 pub(crate) mod cache;
-pub(crate) mod prefilter;
+pub mod prefilter;
 pub mod scalar;
 pub mod vector;
 


### PR DESCRIPTION
A [recent change](https://github.com/lancedb/lance/commit/36c08d586d51a77b0ef5b67adac86f709ff9241b) moved these types out of the public API of `lance_index` and into the private API of `lance`.  This broke a customer (full disclosure, us) that was relying on these types.

These types are well documented and straightforward.  I think they were intended to be part of a public API.  However, I could be wrong.  Exposing them allows users to supply their own prefilter implementations when using `lance_index` utilities directly.  I think it would be fair to call the API experimental if we want to but the prefilter has been stable for a bit.