### PR TITLE
ci: fix stepWithCompactEncoding error on MacOS

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Build benchmarks
         run: cargo build --benches
   mac-build:
-    runs-on: "macos-13"
+    runs-on: "macos-14"
     timeout-minutes: 45
     strategy:
       matrix:
@@ -159,7 +159,7 @@ jobs:
         # Default XCode right now is 15.0.1, which contains a bug that causes
         # backtraces to not show properly. See: 
         # https://github.com/rust-lang/rust/issues/113783
-        run: sudo xcode-select -s /Applications/Xcode_15.3.app
+        run: sudo xcode-select -s /Applications/Xcode_15.4.app
       - name: Install dependencies
         run: brew install protobuf
       - name: Set up Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -159,7 +159,7 @@ jobs:
         # Default XCode right now is 15.0.1, which contains a bug that causes
         # backtraces to not show properly. See: 
         # https://github.com/rust-lang/rust/issues/113783
-        run: sudo xcode-select -s /Applications/Xcode_15.4.app
+        run: sudo xcode-select -s '/Applications/Xcode_15.4.app/Contents/Developer'
       - name: Install dependencies
         run: brew install protobuf
       - name: Set up Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Build benchmarks
         run: cargo build --benches
   mac-build:
-    runs-on: "macos-14"
+    runs-on: "macos-13"
     timeout-minutes: 45
     strategy:
       matrix:
@@ -155,6 +155,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
+      - name: Select new xcode
+        # Default XCode right now is 15.0.1, which contains a bug that causes
+        # backtraces to not show properly. See: 
+        # https://github.com/rust-lang/rust/issues/113783
+        run: sudo xcode-select -s /Applications/Xcode_15.4.app
       - name: Install dependencies
         run: brew install protobuf
       - name: Set up Rust
@@ -162,12 +167,6 @@ jobs:
           rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
           rustup component add rustfmt
       - name: Run tests
-        env: 
-          # Make sure backtraces work on MacOS, so we can understand errors output
-          # in CI. Current Mac linker has a bug:
-          #
-          # <https://github.com/rust-lang/rust/issues/113783> 
-          CARGO_BUILD_RUSTFLAGS: "-Clink-arg=-Wl,-ld_classic"
         run: |
           cargo build --all-features
           cargo test --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -159,7 +159,7 @@ jobs:
         # Default XCode right now is 15.0.1, which contains a bug that causes
         # backtraces to not show properly. See: 
         # https://github.com/rust-lang/rust/issues/113783
-        run: sudo xcode-select -s /Applications/Xcode_15.4.app
+        run: sudo xcode-select -s /Applications/Xcode_15.3.app
       - name: Install dependencies
         run: brew install protobuf
       - name: Set up Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -159,7 +159,7 @@ jobs:
         # Default XCode right now is 15.0.1, which contains a bug that causes
         # backtraces to not show properly. See: 
         # https://github.com/rust-lang/rust/issues/113783
-        run: sudo xcode-select -s '/Applications/Xcode_15.4.app/Contents/Developer'
+        run: sudo xcode-select -s /Applications/Xcode_15.4.app
       - name: Install dependencies
         run: brew install protobuf
       - name: Set up Rust

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -162,6 +162,12 @@ jobs:
           rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
           rustup component add rustfmt
       - name: Run tests
+        env: 
+          # Make sure backtraces work on MacOS, so we can understand errors output
+          # in CI. Current Mac linker has a bug:
+          #
+          # <https://github.com/rust-lang/rust/issues/113783> 
+          CARGO_BUILD_RUSTFLAGS: "-Clink-arg=-Wl,-ld_classic"
         run: |
           cargo build --all-features
           cargo test --all-features


### PR DESCRIPTION
Example: 
https://github.com/lancedb/lance/actions/runs/9662156349/job/26651441132?pr=2527

```
libunwind: stepWithCompactEncoding - invalid compact unwind encoding
```

Closes #2002

Inspired by https://github.com/GreptimeTeam/greptimedb/pull/4143/files