### PR TITLE
feat: make it possible to create v2 fragments using the fragment API

### DIFF
--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -58,6 +58,16 @@ def test_write_fragment_two_phases(tmp_path: Path):
     )
 
 
+def test_write_v2_fragment(tmp_path: Path):
+    tab = pa.table({"a": range(1024)})
+    frag = LanceFragment.create(tmp_path, tab, use_legacy_format=True)
+    assert "file_minor_version: 3" not in str(frag)
+
+    tab = pa.table({"a": range(1024)})
+    frag = LanceFragment.create(tmp_path, tab, use_legacy_format=False)
+    assert "file_minor_version: 3" in str(frag)
+
+
 def test_scan_fragment(tmp_path: Path):
     tab = pa.table({"a": range(100), "b": range(100, 200)})
     ds = write_dataset(tab, tmp_path)

--- a/rust/lance/src/dataset/fragment/write.rs
+++ b/rust/lance/src/dataset/fragment/write.rs
@@ -6,14 +6,16 @@ use std::borrow::Cow;
 use arrow_array::RecordBatchReader;
 use arrow_schema::Schema as ArrowSchema;
 use datafusion::execution::SendableRecordBatchStream;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use lance_core::datatypes::Schema;
 use lance_core::Error;
-use lance_datafusion::chunker::chunk_stream;
+use lance_datafusion::chunker::{break_stream, chunk_stream};
 use lance_datafusion::utils::{peek_reader_schema, reader_to_stream};
+use lance_file::format::{MAJOR_VERSION, MINOR_VERSION_NEXT};
+use lance_file::v2::writer::FileWriterOptions;
 use lance_file::writer::FileWriter;
 use lance_io::object_store::ObjectStore;
-use lance_table::format::Fragment;
+use lance_table::format::{DataFile, Fragment};
 use lance_table::io::manifest::ManifestDescribing;
 use snafu::{location, Location};
 use uuid::Uuid;
@@ -67,6 +69,68 @@ impl<'a> FragmentCreateBuilder<'a> {
         self.write_impl(stream, schema, id).await
     }
 
+    async fn write_v2_impl(
+        &self,
+        stream: SendableRecordBatchStream,
+        schema: Schema,
+        id: u64,
+    ) -> Result<Fragment> {
+        let params = self.write_params.map(Cow::Borrowed).unwrap_or_default();
+        let progress = params.progress.as_ref();
+
+        Self::validate_schema(&schema, stream.schema().as_ref())?;
+
+        let (object_store, base_path) = ObjectStore::from_uri(self.dataset_uri).await?;
+        let filename = format!("{}.lance", Uuid::new_v4());
+        let mut fragment = Fragment::new(id);
+        let full_path = base_path.child(DATA_DIR).child(filename.clone());
+        let obj_writer = object_store.create(&full_path).await?;
+        let mut writer = lance_file::v2::writer::FileWriter::try_new(
+            obj_writer,
+            full_path.to_string(),
+            schema,
+            FileWriterOptions::default(),
+        )?;
+
+        progress.begin(&fragment, writer.multipart_id()).await?;
+
+        let break_limit = (128 * 1024).min(params.max_rows_per_file);
+
+        let mut broken_stream = break_stream(stream, break_limit)
+            .map_ok(|batch| vec![batch])
+            .boxed();
+        while let Some(batched_chunk) = broken_stream.next().await {
+            let batch_chunk = batched_chunk?;
+            writer.write_batches(batch_chunk.iter()).await?;
+        }
+
+        fragment.physical_rows = Some(writer.finish().await? as usize);
+
+        let field_ids = writer
+            .field_id_to_column_indices()
+            .iter()
+            .map(|(field_id, _)| *field_id)
+            .collect::<Vec<_>>();
+        let column_indices = writer
+            .field_id_to_column_indices()
+            .iter()
+            .map(|(_, column_index)| *column_index)
+            .collect::<Vec<_>>();
+        let data_file = DataFile::new(
+            filename,
+            field_ids,
+            column_indices,
+            MAJOR_VERSION as u32,
+            MINOR_VERSION_NEXT as u32,
+        );
+
+        fragment.files.push(data_file);
+
+        progress.complete(&fragment).await?;
+
+        Ok(fragment)
+    }
+
     async fn write_impl(
         &self,
         stream: SendableRecordBatchStream,
@@ -76,6 +140,9 @@ impl<'a> FragmentCreateBuilder<'a> {
         let id = id.unwrap_or_default();
 
         let params = self.write_params.map(Cow::Borrowed).unwrap_or_default();
+        if !params.use_legacy_format {
+            return self.write_v2_impl(stream, schema, id).await;
+        }
         let progress = params.progress.as_ref();
 
         Self::validate_schema(&schema, stream.schema().as_ref())?;


### PR DESCRIPTION
Previously it was ignoring the `use_legacy_format` option