### PR TITLE
fix: show underlying cause of DynamoDB service error

### DIFF
--- a/rust/lance-table/src/io/commit/dynamodb.rs
+++ b/rust/lance-table/src/io/commit/dynamodb.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use aws_sdk_dynamodb::error::SdkError;
+use aws_sdk_dynamodb::operation::RequestId;
 use aws_sdk_dynamodb::operation::{
     get_item::builders::GetItemFluentBuilder, put_item::builders::PutItemFluentBuilder,
     query::builders::QueryFluentBuilder,
@@ -44,7 +45,14 @@ where
     E: std::error::Error + Send + Sync + 'static,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "WrappedSdkError: {}", self.0)
+        let request_id = self.0.request_id().unwrap_or("unknown");
+        let service_err = &self.0.raw_response();
+        write!(f, "WrappedSdkError: request_id: {}", request_id)?;
+        if let Some(err) = service_err {
+            write!(f, ", service_error: {:?}", err)
+        } else {
+            write!(f, ", no service error")
+        }
     }
 }
 


### PR DESCRIPTION
Found this issue while trying to debug LanceDB, but I think a user had reported they were having trouble debugging this feature too.

Previous unhelpful error message:

`LanceError(IO): WrappedSdkError: service error, /Users/willjones/.cargo/git/checkouts/lance-b31243ab5673a03e/fb84707/rust/lance-table/src/io/commit/dynamodb.rs:37:23`

New error message:

`LanceError(IO): WrappedSdkError: request_id: db9807d8-8d17-45d1-973e-babfaf177998, service_error: Response { status: 400, version: HTTP/1.1, headers: {"content-type": "application/json", "x-amzn-errortype": "ResourceNotFoundException", "content-length": "98", "x-amzn-requestid": "db9807d8-8d17-45d1-973e-babfaf177998", "x-amz-crc32": "137764666", "connection": "close", "date": "Thu, 27 Jun 2024 16:05:49 GMT", "server": "hypercorn-h11"}, body: SdkBody { inner: Once(Some(b"{\"__type\": \"ResourceNotFoundException\", \"message\": \"Cannot do operations on a non-existent table\"}")), retryable: true } }, /Users/willjones/Documents/lance/rust/lance-table/src/io/commit/dynamodb.rs:38:23`

