### PR TITLE
ci: cargo check on various platforms

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -166,6 +166,8 @@ jobs:
         run: |
           rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
           rustup component add rustfmt
+      - name: Check all
+        run: cargo check --tests --benches --all-features --workspace
       - name: Run tests
         run: |
           cargo build --all-features
@@ -189,6 +191,8 @@ jobs:
           7z x protoc.zip
           Add-Content $env:GITHUB_PATH "C:\protoc\bin"
         shell: powershell
+      - name: Check all
+        run: cargo check --tests --benches --all-features --workspace
       - name: Run tests
         run: |
           cargo build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -166,11 +166,10 @@ jobs:
         run: |
           rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
           rustup component add rustfmt
-      - name: Check all
-        run: cargo check --tests --benches --all-features --workspace
       - name: Run tests
-        run: |
-          cargo build --all-features
+        # Check all benches, even though we aren't going to run them.
+        run: |  
+          cargo build --tests --benches --all-features --workspace
           cargo test --all-features
   windows-build:
     runs-on: windows-latest
@@ -191,9 +190,8 @@ jobs:
           7z x protoc.zip
           Add-Content $env:GITHUB_PATH "C:\protoc\bin"
         shell: powershell
-      - name: Check all
-        run: cargo check --tests --benches --all-features --workspace
       - name: Run tests
+        # Check all benches, even though we aren't going to run them.
         run: |
-          cargo build
+          cargo build --tests --benches --all-features --workspace
           cargo test

--- a/rust/lance-linalg/build.rs
+++ b/rust/lance-linalg/build.rs
@@ -25,9 +25,10 @@ fn main() -> Result<(), String> {
     }
 
     if cfg!(target_os = "windows") {
-        return Err(
-            "cargo:warning=fp16 kernels are not supported on Windows.  Please remove fp16kernels feature".to_string()
+        println!(
+            "cargo:warning=fp16 kernels are not supported on Windows. Skipping compilation of kernels."
         );
+        return Ok(());
     }
 
     if cfg!(all(target_arch = "aarch64", target_os = "macos")) {


### PR DESCRIPTION
Issues have come up where the benchmarks couldn't be built on all platforms. This PR makes sure we check in CI that benchmarks and tests are all buildable on each platform.

https://github.com/lancedb/lance/pull/2523#pullrequestreview-2138893921