### PR TITLE
feat: stable row id deletions and scalar indices

### DIFF
--- a/rust/lance-table/src/rowids/bitmap.rs
+++ b/rust/lance-table/src/rowids/bitmap.rs
@@ -3,7 +3,7 @@
 
 use deepsize::DeepSizeOf;
 
-#[derive(PartialEq, Eq, Clone, DeepSizeOf)]
+#[derive(PartialEq, Eq, Clone, DeepSizeOf, Hash)]
 pub struct Bitmap {
     pub data: Vec<u8>,
     pub len: usize,

--- a/rust/lance-table/src/rowids/encoded_array.rs
+++ b/rust/lance-table/src/rowids/encoded_array.rs
@@ -8,7 +8,7 @@ use deepsize::DeepSizeOf;
 /// Encoded array of u64 values.
 ///
 /// This is a internal data type used as part of row id indices.
-#[derive(Debug, Clone, PartialEq, Eq, DeepSizeOf)]
+#[derive(Debug, Clone, PartialEq, Eq, DeepSizeOf, Hash)]
 pub enum EncodedU64Array {
     /// u64 values represented as u16 offset from a base value.
     ///

--- a/rust/lance-table/src/rowids/index.rs
+++ b/rust/lance-table/src/rowids/index.rs
@@ -24,7 +24,7 @@ use super::{RowIdSequence, U64Segment};
 // Disjoint ranges of row ids are stored as the keys of the map. The values are
 // a pair of segments. The first segment is the row ids, and the second segment
 // is the addresses.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Hash)]
 pub struct RowIdIndex(RangeInclusiveMap<u64, (U64Segment, U64Segment)>);
 
 impl RowIdIndex {

--- a/rust/lance-table/src/rowids/segment.rs
+++ b/rust/lance-table/src/rowids/segment.rs
@@ -31,7 +31,7 @@ use super::{bitmap::Bitmap, encoded_array::EncodedU64Array};
 /// Size of SortedArray for N values (assuming u16 packed):
 ///     8 bytes + 8 bytes + 8 bytes + 2 bytes * N
 ///
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub enum U64Segment {
     /// A contiguous sorted range of row ids.
     ///

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1020,11 +1020,7 @@ impl Scanner {
         // Stage 6: physical projection -- reorder physical columns needed before final projection
         let output_arrow_schema = physical_schema.as_ref().into();
         if plan.schema().as_ref() != &output_arrow_schema {
-            plan = Arc::new(project(
-                plan,
-                &None, // TODO,
-                &physical_schema,
-            )?);
+            plan = Arc::new(project(plan, &physical_schema)?);
         }
 
         // Stage 7: final projection
@@ -1188,7 +1184,7 @@ impl Scanner {
             // knn_node: _distance, _rowid, vector
             // topk_appended: vector, <filter columns?>, _rowid, _distance
             let new_schema = Schema::try_from(knn_node.schema().as_ref())?;
-            let topk_appended = project(topk_appended, &None, &new_schema)?;
+            let topk_appended = project(topk_appended, &new_schema)?;
             assert_eq!(topk_appended.schema(), knn_node.schema());
             // union
             let unioned = UnionExec::new(vec![Arc::new(topk_appended), knn_node]);
@@ -1305,11 +1301,7 @@ impl Scanner {
             );
             let filtered = Arc::new(FilterExec::try_new(physical_refine_expr, new_data_scan)?);
             let projection = Schema::try_from(plan.schema().as_ref())?;
-            Some(Arc::new(project(
-                filtered,
-                &None, // TODO
-                &projection,
-            )?))
+            Some(Arc::new(project(filtered, &projection)?))
         } else {
             None
         };

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -371,9 +371,11 @@ impl MergeInsertJob {
         // First, we need to project to the key column
         let schema = shared_input.schema();
         let field = schema.field_with_name(&self.params.on[0])?;
-        let key_only_schema =
-            lance_core::datatypes::Schema::try_from(&Schema::new(vec![field.clone()]))?; // schema for only the key join column
-        let index_mapper_input = Arc::new(project(shared_input.clone(), &key_only_schema)?);
+        let index_mapper_input = Arc::new(project(
+            shared_input.clone(),
+            // schema for only the key join column
+            &Schema::new(vec![field.clone()]),
+        )?);
 
         // Then we pass the key column into the index mapper
         let index_column = self.params.on[0].clone();
@@ -399,8 +401,7 @@ impl MergeInsertJob {
         let fields = schema.fields();
         let mut columns = fields[1..].to_vec();
         columns.push(fields[0].clone());
-        let projected_schema = lance_core::datatypes::Schema::try_from(&Schema::new(columns))?;
-        target = Arc::new(project(target, &projected_schema)?);
+        target = Arc::new(project(target, &Schema::new(columns))?);
 
         // 5a - We also need to scan any new unindexed data and union it in
         let unindexed_fragments = self.dataset.unindexed_fragments(&index.name).await?;

--- a/rust/lance/src/io/exec.rs
+++ b/rust/lance/src/io/exec.rs
@@ -22,6 +22,6 @@ pub use knn::{ANNIvfPartitionExec, ANNIvfSubIndexExec, KNNVectorDistanceExec, Pr
 pub use planner::{FilterPlan, Planner};
 pub use projection::project;
 pub use pushdown_scan::{LancePushdownScanExec, ScanConfig};
-pub use rowids::RowAddrExpr;
+pub use rowids::AddRowAddrExec;
 pub use scan::LanceScanExec;
 pub use take::TakeExec;

--- a/rust/lance/src/io/exec.rs
+++ b/rust/lance/src/io/exec.rs
@@ -10,6 +10,7 @@ mod optimizer;
 mod planner;
 mod projection;
 mod pushdown_scan;
+mod rowids;
 pub mod scalar_index;
 mod scan;
 mod take;
@@ -19,7 +20,8 @@ pub mod utils;
 
 pub use knn::{ANNIvfPartitionExec, ANNIvfSubIndexExec, KNNVectorDistanceExec, PreFilterSource};
 pub use planner::{FilterPlan, Planner};
-pub use projection::ProjectionExec;
+pub use projection::project;
 pub use pushdown_scan::{LancePushdownScanExec, ScanConfig};
+pub use rowids::RowAddrExpr;
 pub use scan::LanceScanExec;
 pub use take::TakeExec;

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -113,12 +113,11 @@ impl KNNVectorDistanceExec {
         if output_schema.column_with_name(DIST_COL).is_some() {
             output_schema = output_schema.without_column(DIST_COL);
         }
-        let output_schema = Arc::new(Schema::new(
-            output_schema
-                .try_with_column(Field::new(DIST_COL, DataType::Float32, true))
-                .unwrap()
-                .fields,
-        ));
+        let output_schema = Arc::new(output_schema.try_with_column(Field::new(
+            DIST_COL,
+            DataType::Float32,
+            true,
+        ))?);
 
         // This node has the same partitioning & boundedness as the input node
         // but it destroys any ordering.

--- a/rust/lance/src/io/exec/projection.rs
+++ b/rust/lance/src/io/exec/projection.rs
@@ -1,207 +1,108 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-//! Projection
-//!
-
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
 
-use arrow_array::RecordBatch;
-use arrow_schema::{Schema as ArrowSchema, SchemaRef};
-use datafusion::common::Statistics;
-use datafusion::error::{DataFusionError, Result as DataFusionResult};
-use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, RecordBatchStream,
-    SendableRecordBatchStream,
-};
-use datafusion_physical_expr::EquivalenceProperties;
-use futures::{stream, FutureExt, Stream, StreamExt, TryStreamExt};
-use tokio::sync::mpsc::Receiver;
-use tokio::task::JoinHandle;
-
-use crate::arrow::*;
 use crate::datatypes::Schema;
-use crate::Result;
+use arrow_schema::DataType;
+use datafusion::error::DataFusionError;
+use datafusion::error::Result;
+use datafusion::physical_plan::expressions;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_physical_expr::PhysicalExpr;
+use lance_core::datatypes::Field;
+use lance_core::{ROW_ADDR, ROW_ID};
+use lance_table::rowids::RowIdIndex;
 
-/// Executing Projection on a stream of record batches.
-pub struct ProjectionStream {
-    rx: Receiver<DataFusionResult<RecordBatch>>,
+use super::RowAddrExpr;
 
-    bg_thread: Option<JoinHandle<()>>,
-
-    projection: Arc<ArrowSchema>,
-}
-
-impl ProjectionStream {
-    fn new(input: SendableRecordBatchStream, projection: &Schema) -> Self {
-        let (tx, rx) = tokio::sync::mpsc::channel(2);
-
-        let schema = Arc::new(ArrowSchema::from(projection));
-        let schema_clone = schema.clone();
-        let bg_thread = tokio::spawn(async move {
-            if let Err(e) = input
-                .zip(stream::repeat_with(|| schema_clone.clone()))
-                .then(|(batch, schema)| async move {
-                    let batch = batch?;
-                    batch.project_by_schema(schema.as_ref())
-                })
-                .map(|r| r.map_err(|e| DataFusionError::Execution(e.to_string())))
-                .try_for_each(|b| async {
-                    if tx.send(Ok(b)).await.is_err() {
-                        // If channel is closed, make sure we return an error to end the stream.
-                        return Err(DataFusionError::Internal(
-                            "ExecNode(Projection): channel closed".to_string(),
-                        ));
-                    }
-                    Ok(())
-                })
-                .await
-            {
-                if let Err(e) = tx.send(Err(e)).await {
-                    if let Err(e) = e.0 {
-                        // if channel was closed, it was cancelled by the receiver.
-                        // But if there was a different error we should send it
-                        // or log it.
-                        if !e.to_string().contains("channel closed") {
-                            log::error!("channel was closed by receiver, but error occurred in background thread: {:?}", e);
-                        }
-                    }
-                }
-            }
-        });
-
-        Self {
-            rx,
-            bg_thread: Some(bg_thread),
-            projection: schema,
-        }
-    }
-}
-
-impl Stream for ProjectionStream {
-    type Item = DataFusionResult<RecordBatch>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = Pin::into_inner(self);
-        // We need to check the JoinHandle to make sure the thread hasn't panicked.
-        let bg_thread_completed = if let Some(bg_thread) = &mut this.bg_thread {
-            match bg_thread.poll_unpin(cx) {
-                Poll::Ready(Ok(())) => true,
-                Poll::Ready(Err(join_error)) => {
-                    return Poll::Ready(Some(Err(DataFusionError::Execution(format!(
-                        "ExecNode(Projection): thread panicked: {}",
-                        join_error
-                    )))));
-                }
-                Poll::Pending => false,
-            }
-        } else {
-            false
-        };
-        if bg_thread_completed {
-            // Need to take it, since we aren't allowed to poll if again after.
-            this.bg_thread.take();
-        }
-        // this.rx.
-        this.rx.poll_recv(cx)
-    }
-}
-
-impl RecordBatchStream for ProjectionStream {
-    fn schema(&self) -> arrow_schema::SchemaRef {
-        self.projection.clone()
-    }
-}
-
-#[derive(Debug)]
-pub struct ProjectionExec {
+/// Make a DataFusion projection node from a Lance Schema.
+pub fn project(
     input: Arc<dyn ExecutionPlan>,
-    project: Arc<Schema>,
-    properties: PlanProperties,
-}
+    row_id_index: &Option<Arc<RowIdIndex>>,
+    projection: &Schema,
+) -> Result<ProjectionExec> {
+    // Use input schema and projection schema to create a list of physical expressions.
+    let mut exprs: Vec<(Arc<dyn PhysicalExpr>, String)> =
+        Vec::with_capacity(projection.fields.len());
 
-impl DisplayAs for ProjectionExec {
-    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match t {
-            DisplayFormatType::Default | DisplayFormatType::Verbose => {
-                let columns = self
-                    .project
-                    .fields
-                    .iter()
-                    .map(|f| f.name.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ");
-                write!(f, "Projection: fields=[{}]", columns)
+    let input_schema = input.schema();
+
+    for field in &projection.fields {
+        // TODO: is there something we need to do special here to make sure _rowid
+        // is not optimized out of earlier nodes?
+        if field.name == "_rowaddr" {
+            let rowid_pos = input
+                .schema()
+                .fields
+                .iter()
+                .position(|f| f.name() == ROW_ID)
+                .ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "Projection: _rowaddr requested but _rowid missing in input schema"
+                    ))
+                })?;
+
+            exprs.push((
+                Arc::new(RowAddrExpr::new(row_id_index.clone(), rowid_pos)),
+                ROW_ADDR.to_string(),
+            ));
+        } else {
+            match field.data_type() {
+                DataType::Struct(_) => {
+                    let (expr, name) = struct_project_expr(field)?;
+                    exprs.push((expr, name));
+                }
+                DataType::List(_) => {
+                    todo!()
+                }
+                _ => {
+                    // This is a simple field, so we can just use the field name.
+                    let expr =
+                        expressions::Column::new_with_schema(&field.name, input_schema.as_ref())?;
+                    exprs.push((Arc::new(expr), field.name.clone()));
+                }
             }
         }
     }
+
+    ProjectionExec::try_new(exprs, input)
 }
 
-impl ProjectionExec {
-    pub fn try_new(input: Arc<dyn ExecutionPlan>, project: Arc<Schema>) -> Result<Self> {
-        let arrow_schema = ArrowSchema::from(project.as_ref());
-        // TODO: we reset the EquivalenceProperties here but we could probably just project
-        // them, that way ordering is maintained (or just use DF project?)
-        let properties = input
-            .properties()
-            .clone()
-            .with_eq_properties(EquivalenceProperties::new(Arc::new(arrow_schema)));
-        Ok(Self {
-            input,
-            project,
-            properties,
-        })
-    }
+fn struct_project_expr(field: &Field) -> Result<(Arc<dyn PhysicalExpr>, String)> {
+    todo!()
 }
 
-impl ExecutionPlan for ProjectionExec {
-    fn name(&self) -> &str {
-        "ProjectionExec"
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // TODO: what if we already projected rowaddr?
+
+    #[tokio::test]
+    async fn test_project_node() {
+
+        // Create a nested schema
+
+        // Project that schema with nested fields selected
+
+        // Make execution plan for it
+
+        // Execute the plan on a batch
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
+    #[test]
+    fn test_validates_input_schema() {
+        // Errors if top-level field missing
+
+        // Errors if _rowaddr requested but _rowid missing
+
+        // Errors if nested field missing
     }
 
-    fn schema(&self) -> SchemaRef {
-        let arrow_schema = ArrowSchema::from(self.project.as_ref());
-        arrow_schema.into()
-    }
-
-    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        vec![&self.input]
-    }
-
-    fn with_new_children(
-        self: Arc<Self>,
-        children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> datafusion::error::Result<Arc<dyn ExecutionPlan>> {
-        Ok(Arc::new(Self::try_new(
-            children[0].clone(),
-            self.project.clone(),
-        )?))
-    }
-
-    fn execute(
-        &self,
-        partition: usize,
-        context: Arc<datafusion::execution::context::TaskContext>,
-    ) -> datafusion::error::Result<datafusion::physical_plan::SendableRecordBatchStream> {
-        let input_stream = self.input.execute(partition, context)?;
-        Ok(Box::pin(ProjectionStream::new(input_stream, &self.project)))
-    }
-
-    fn statistics(&self) -> datafusion::error::Result<datafusion::physical_plan::Statistics> {
-        let num_rows = self.input.statistics()?.num_rows;
-        Ok(Statistics {
-            num_rows,
-            ..datafusion::physical_plan::Statistics::new_unknown(self.schema().as_ref())
-        })
-    }
-
-    fn properties(&self) -> &PlanProperties {
-        &self.properties
+    #[tokio::test]
+    async fn test_project_node_with_rowaddr() {
+        // Create a batch with row id
     }
 }

--- a/rust/lance/src/io/exec/projection.rs
+++ b/rust/lance/src/io/exec/projection.rs
@@ -5,24 +5,25 @@ use std::sync::{Arc, OnceLock};
 
 use arrow_schema::{DataType, Field, Fields, Schema as ArrowSchema};
 use datafusion::error::{DataFusionError, Result};
-use datafusion::logical_expr::ScalarUDFImpl;
+use datafusion::logical_expr::ScalarUDF;
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::scalar::ScalarValue;
 use datafusion_functions::core::getfield::GetFieldFunc;
+use datafusion_functions::core::named_struct::NamedStructFunc;
 use datafusion_physical_expr::expressions::{Column, Literal};
 use datafusion_physical_expr::{PhysicalExpr, ScalarFunctionExpr};
 
-fn get_field_func() -> Arc<dyn ScalarUDFImpl> {
-    static GET_FIELD_FUNC: OnceLock<Arc<dyn ScalarUDFImpl>> = OnceLock::new();
+fn get_field_func() -> Arc<ScalarUDF> {
+    static GET_FIELD_FUNC: OnceLock<Arc<ScalarUDF>> = OnceLock::new();
     GET_FIELD_FUNC
-        .get_or_init(|| Arc::new(GetFieldFunc::new()))
+        .get_or_init(|| Arc::new(ScalarUDF::new_from_impl(GetFieldFunc::new())))
         .clone()
 }
-fn get_make_struct_func() -> Arc<dyn ScalarUDFImpl> {
-    static MAKE_STRUCT_FUNC: OnceLock<Arc<dyn ScalarUDFImpl>> = OnceLock::new();
+fn get_make_struct_func() -> Arc<ScalarUDF> {
+    static MAKE_STRUCT_FUNC: OnceLock<Arc<ScalarUDF>> = OnceLock::new();
     MAKE_STRUCT_FUNC
-        .get_or_init(|| Arc::new(NamedStructFunc::new()))
+        .get_or_init(|| Arc::new(ScalarUDF::new_from_impl(NamedStructFunc::new())))
         .clone()
 }
 
@@ -36,9 +37,11 @@ pub fn project(input: Arc<dyn ExecutionPlan>, projection: &ArrowSchema) -> Resul
 
     let selections = compute_projection(input_schema.fields(), &projection.fields)?;
 
-    for selection in selections {
+    let field_names = projection.fields().iter().map(|f| f.name()).cloned();
+
+    for (name, selection) in field_names.zip(selections.into_iter()) {
         let expr = selection_as_expr(&selection, input_schema.fields(), None);
-        exprs.push((expr, todo!()));
+        exprs.push((expr, name));
     }
 
     ProjectionExec::try_new(exprs, input)
@@ -54,44 +57,81 @@ fn selection_as_expr(
             let (field_index, field) = &parent_fields.find(field_name).unwrap();
             if let Some(expr) = parent_expr {
                 // We are extracting a child field.
-                sub_field(expr, field.as_ref(), field_name)
+                sub_field(expr, field)
             } else {
                 // This is a top-level field
                 Arc::new(Column::new(field.name(), *field_index))
             }
         }
-        Selection::StructProjection(i, sub_selections) => {
-            todo!()
+        Selection::StructProjection(field_name, sub_selections) => {
+            let (field_index, field) = &parent_fields.find(field_name).unwrap();
+            let parent = if let Some(grandparent) = parent_expr {
+                sub_field(grandparent, field)
+            } else {
+                Arc::new(Column::new(field_name, *field_index))
+            };
+            let DataType::Struct(fields) = field.data_type() else {
+                panic!("Expected struct");
+            };
+            let mut sub_exprs = Vec::with_capacity(2 * sub_selections.len());
+            for sub_selection in sub_selections {
+                sub_exprs.push(Arc::new(Literal::new(ScalarValue::Utf8(Some(
+                    sub_selection.name().to_string(),
+                )))) as Arc<dyn PhysicalExpr>);
+                sub_exprs.push(selection_as_expr(
+                    sub_selection,
+                    fields,
+                    Some(parent.clone()),
+                ));
+            }
+
+            let make_struct = get_make_struct_func();
+            Arc::new(ScalarFunctionExpr::new(
+                make_struct.name(),
+                make_struct.clone(),
+                sub_exprs,
+                project_field(field.data_type(), selection),
+            ))
         }
     }
 }
 
-fn sub_field(
-    parent_expr: Arc<dyn PhysicalExpr>,
-    field: &Field,
-    field_name: &str,
-) -> Arc<dyn PhysicalExpr> {
-    match field.data_type() {
-        DataType::Struct(_) => {
-            // TODO: global reference to this?
-            let function = Arc::new(GetFieldFunc::new());
-            Arc::new(ScalarFunctionExpr::new(
-                function.name(),
-                function.clone(),
-                vec![
-                    parent_expr,
-                    Arc::new(Literal::new(ScalarValue::Int64(field_index as i64))),
-                ],
-                field.data_type().clone(),
-                function.monotonicity(),
-                function.signature().type_signature.supports_zero_argument(),
-            ))
+fn sub_field(parent_expr: Arc<dyn PhysicalExpr>, field: &Field) -> Arc<dyn PhysicalExpr> {
+    let func = get_field_func();
+    Arc::new(ScalarFunctionExpr::new(
+        func.name(),
+        func.clone(),
+        vec![
+            parent_expr,
+            Arc::new(Literal::new(ScalarValue::Utf8(Some(field.name().clone())))),
+        ],
+        field.data_type().clone(),
+    ))
+}
+
+fn project_field(field_type: &DataType, selection: &Selection) -> DataType {
+    match selection {
+        Selection::FullField(_) => field_type.clone(),
+        Selection::StructProjection(_, sub_selections) => {
+            if let DataType::Struct(fields) = field_type {
+                let mut projected_fields = Vec::with_capacity(sub_selections.len());
+                for sub_selection in sub_selections {
+                    let field_name = sub_selection.name();
+                    let field = fields.iter().find(|f| f.name() == field_name).unwrap();
+                    let projected_field_type = project_field(field.data_type(), sub_selection);
+                    // If we project, it's always null (for some reason).
+                    projected_fields.push(Field::new(field_name, projected_field_type, true));
+                }
+                DataType::Struct(projected_fields.into())
+            } else {
+                panic!("Expected struct")
+            }
         }
-        _ => Arc::new(Column::new(field.name(), field_index)),
     }
 }
 
 /// Represents selection of fields from a struct / schema.
+#[derive(Debug)]
 pub enum Selection<'a> {
     /// Selects this fields and all subfields
     FullField(&'a str),
@@ -99,9 +139,19 @@ pub enum Selection<'a> {
     StructProjection(&'a str, Vec<Selection<'a>>),
 }
 
+impl Selection<'_> {
+    /// Returns the name of the field being selected.
+    pub fn name(&self) -> &str {
+        match self {
+            Selection::FullField(name) => name,
+            Selection::StructProjection(name, _) => name,
+        }
+    }
+}
+
 /// Resolves the projection into a list of selections.
-pub fn compute_projection<'a, 'b>(
-    schema: &'b Fields,
+pub fn compute_projection<'a>(
+    schema: &'_ Fields,
     projection: &'a Fields,
 ) -> Result<Vec<Selection<'a>>> {
     let mut selections = Vec::with_capacity(projection.len());
@@ -110,7 +160,7 @@ pub fn compute_projection<'a, 'b>(
             DataType::Struct(fields) => {
                 let original_field = schema
                     .iter()
-                    .find(|f| &f.name() == &projected_field.name())
+                    .find(|f| f.name() == projected_field.name())
                     .ok_or_else(|| {
                         DataFusionError::Internal(format!(
                             "compute_projection: projected field {} not found in schema {:?}",
@@ -118,16 +168,13 @@ pub fn compute_projection<'a, 'b>(
                             schema
                         ))
                     })?;
-                let input_fields = if let DataType::Struct(fields) = original_field.data_type() {
-                    fields
-                } else {
+                let DataType::Struct(input_fields) = original_field.data_type() else {
                     return Err(DataFusionError::Internal(
                         "compute_projection: expected struct".to_string(),
-                    )
-                    .into());
+                    ));
                 };
 
-                let sub_selections = compute_projection(&input_fields, fields)?;
+                let sub_selections = compute_projection(input_fields, fields)?;
                 if fields.len() == input_fields.len()
                     && sub_selections
                         .iter()
@@ -149,54 +196,120 @@ pub fn compute_projection<'a, 'b>(
     Ok(selections)
 }
 
-/// Basically has two paths:
-///  * if we are selecting all of it, then `Column(name)`
-///  * if we are selecting subset of it, then
-/// ```
-/// MakeStruct(
-///     GetFieldAccess(Column(name), field1),
-///     GetFieldAccess(Column(name), field2),
-///     ...
-/// )
-/// ```
-fn struct_project_expr(
-    field: &Field,
-    access_expr: Arc<dyn PhysicalExpr>,
-) -> Result<(Arc<dyn PhysicalExpr>, String)> {
-    debug_assert!(matches!(field.data_type(), DataType::Struct(_)));
-    // For each sub field, get the field access
-    // Then use create struct
-}
-
 #[cfg(test)]
 mod tests {
+    use arrow_array::{ArrayRef, Int32Array, RecordBatch, StructArray};
+    use datafusion::{physical_plan::memory::MemoryExec, prelude::SessionContext};
+    use futures::TryStreamExt;
+    use lance_core::datatypes::Schema;
+
     use super::*;
 
-    // TODO: what if we already projected rowaddr?
+    fn sample_nested_data() -> RecordBatch {
+        let schema = Arc::new(
+            ArrowSchema::new(vec![
+                Field::new("a", DataType::Int32, true),
+                Field::new(
+                    "b",
+                    DataType::Struct(
+                        vec![
+                            Field::new("c", DataType::Int32, true),
+                            Field::new(
+                                "d",
+                                DataType::Struct(
+                                    vec![
+                                        Field::new("e", DataType::Int32, true),
+                                        Field::new("f", DataType::Int32, true),
+                                    ]
+                                    .into(),
+                                ),
+                                true,
+                            ),
+                        ]
+                        .into(),
+                    ),
+                    true,
+                ),
+            ])
+            .with_metadata([("key".into(), "value".into())].into()),
+        );
+
+        // Only needs to be one row
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from(vec![1])) as ArrayRef,
+                Arc::new(StructArray::from(vec![
+                    (
+                        Arc::new(Field::new("c", DataType::Int32, true)),
+                        Arc::new(Int32Array::from(vec![2])) as ArrayRef,
+                    ),
+                    (
+                        Arc::new(Field::new(
+                            "d",
+                            DataType::Struct(
+                                vec![
+                                    Field::new("e", DataType::Int32, true),
+                                    Field::new("f", DataType::Int32, true),
+                                ]
+                                .into(),
+                            ),
+                            true,
+                        )),
+                        Arc::new(StructArray::from(vec![
+                            (
+                                Arc::new(Field::new("e", DataType::Int32, true)),
+                                Arc::new(Int32Array::from(vec![3])) as ArrayRef,
+                            ),
+                            (
+                                Arc::new(Field::new("f", DataType::Int32, true)),
+                                Arc::new(Int32Array::from(vec![4])),
+                            ),
+                        ])),
+                    ),
+                ])),
+            ],
+        )
+        .unwrap()
+    }
+
+    async fn apply_to_batch(batch: RecordBatch, projection: &ArrowSchema) -> Result<RecordBatch> {
+        let schema = batch.schema();
+        let memory_exec = MemoryExec::try_new(&[vec![batch]], schema, None).unwrap();
+        let exec = project(Arc::new(memory_exec), projection)?;
+        let claimed_schema = exec.schema();
+        let session = SessionContext::new();
+        let task_ctx = session.task_ctx();
+        let stream = exec.execute(0, task_ctx)?;
+        assert_eq!(stream.schema().as_ref(), claimed_schema.as_ref());
+        let batches = stream.try_collect::<Vec<_>>().await?;
+        assert_eq!(batches.len(), 1);
+        Ok(batches.into_iter().next().unwrap())
+    }
 
     #[tokio::test]
     async fn test_project_node() {
-
-        // Create a nested schema
-
+        let sample_data = sample_nested_data();
+        let schema = sample_data.schema();
         // Project that schema with nested fields selected
+        let lance_schema = Schema::try_from(schema.as_ref()).unwrap();
 
-        // Make execution plan for it
+        let projections: [&[i32]; 4] = [
+            &[0, 2, 4, 5], // All leaves
+            &[0, 1],       // Top-level fields
+            &[2],          // Partial first level struct
+            &[4],          // Partial second level struct
+        ];
 
-        // Execute the plan on a batch
-    }
+        for projection in projections {
+            let projected_schema = lance_schema.project_by_ids(projection);
+            let projected_arrow_schema = (&projected_schema).into();
 
-    #[test]
-    fn test_validates_input_schema() {
-        // Errors if top-level field missing
+            let result = apply_to_batch(sample_data.clone(), &projected_arrow_schema)
+                .await
+                .unwrap();
 
-        // Errors if _rowaddr requested but _rowid missing
-
-        // Errors if nested field missing
-    }
-
-    #[tokio::test]
-    async fn test_project_node_with_rowaddr() {
-        // Create a batch with row id
+            assert_eq!(result.schema().as_ref(), &projected_arrow_schema);
+        }
     }
 }

--- a/rust/lance/src/io/exec/projection.rs
+++ b/rust/lance/src/io/exec/projection.rs
@@ -1,77 +1,171 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
-use crate::datatypes::Schema;
-use arrow_schema::DataType;
-use datafusion::error::DataFusionError;
-use datafusion::error::Result;
-use datafusion::physical_plan::expressions;
+use arrow_schema::{DataType, Field, Fields, Schema as ArrowSchema};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::ScalarUDFImpl;
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion_physical_expr::PhysicalExpr;
-use lance_core::datatypes::Field;
-use lance_core::{ROW_ADDR, ROW_ID};
-use lance_table::rowids::RowIdIndex;
+use datafusion::scalar::ScalarValue;
+use datafusion_functions::core::getfield::GetFieldFunc;
+use datafusion_physical_expr::expressions::{Column, Literal};
+use datafusion_physical_expr::{PhysicalExpr, ScalarFunctionExpr};
 
-use super::RowAddrExpr;
+fn get_field_func() -> Arc<dyn ScalarUDFImpl> {
+    static GET_FIELD_FUNC: OnceLock<Arc<dyn ScalarUDFImpl>> = OnceLock::new();
+    GET_FIELD_FUNC
+        .get_or_init(|| Arc::new(GetFieldFunc::new()))
+        .clone()
+}
+fn get_make_struct_func() -> Arc<dyn ScalarUDFImpl> {
+    static MAKE_STRUCT_FUNC: OnceLock<Arc<dyn ScalarUDFImpl>> = OnceLock::new();
+    MAKE_STRUCT_FUNC
+        .get_or_init(|| Arc::new(NamedStructFunc::new()))
+        .clone()
+}
 
 /// Make a DataFusion projection node from a Lance Schema.
-pub fn project(
-    input: Arc<dyn ExecutionPlan>,
-    row_id_index: &Option<Arc<RowIdIndex>>,
-    projection: &Schema,
-) -> Result<ProjectionExec> {
+pub fn project(input: Arc<dyn ExecutionPlan>, projection: &ArrowSchema) -> Result<ProjectionExec> {
     // Use input schema and projection schema to create a list of physical expressions.
     let mut exprs: Vec<(Arc<dyn PhysicalExpr>, String)> =
         Vec::with_capacity(projection.fields.len());
 
     let input_schema = input.schema();
 
-    for field in &projection.fields {
-        // TODO: is there something we need to do special here to make sure _rowid
-        // is not optimized out of earlier nodes?
-        if field.name == "_rowaddr" {
-            let rowid_pos = input
-                .schema()
-                .fields
-                .iter()
-                .position(|f| f.name() == ROW_ID)
-                .ok_or_else(|| {
-                    DataFusionError::Execution(format!(
-                        "Projection: _rowaddr requested but _rowid missing in input schema"
-                    ))
-                })?;
+    let selections = compute_projection(input_schema.fields(), &projection.fields)?;
 
-            exprs.push((
-                Arc::new(RowAddrExpr::new(row_id_index.clone(), rowid_pos)),
-                ROW_ADDR.to_string(),
-            ));
-        } else {
-            match field.data_type() {
-                DataType::Struct(_) => {
-                    let (expr, name) = struct_project_expr(field)?;
-                    exprs.push((expr, name));
-                }
-                DataType::List(_) => {
-                    todo!()
-                }
-                _ => {
-                    // This is a simple field, so we can just use the field name.
-                    let expr =
-                        expressions::Column::new_with_schema(&field.name, input_schema.as_ref())?;
-                    exprs.push((Arc::new(expr), field.name.clone()));
-                }
-            }
-        }
+    for selection in selections {
+        let expr = selection_as_expr(&selection, input_schema.fields(), None);
+        exprs.push((expr, todo!()));
     }
 
     ProjectionExec::try_new(exprs, input)
 }
 
-fn struct_project_expr(field: &Field) -> Result<(Arc<dyn PhysicalExpr>, String)> {
-    todo!()
+fn selection_as_expr(
+    selection: &Selection,
+    parent_fields: &Fields,
+    parent_expr: Option<Arc<dyn PhysicalExpr>>,
+) -> Arc<dyn PhysicalExpr> {
+    match selection {
+        Selection::FullField(field_name) => {
+            let (field_index, field) = &parent_fields.find(field_name).unwrap();
+            if let Some(expr) = parent_expr {
+                // We are extracting a child field.
+                sub_field(expr, field.as_ref(), field_name)
+            } else {
+                // This is a top-level field
+                Arc::new(Column::new(field.name(), *field_index))
+            }
+        }
+        Selection::StructProjection(i, sub_selections) => {
+            todo!()
+        }
+    }
+}
+
+fn sub_field(
+    parent_expr: Arc<dyn PhysicalExpr>,
+    field: &Field,
+    field_name: &str,
+) -> Arc<dyn PhysicalExpr> {
+    match field.data_type() {
+        DataType::Struct(_) => {
+            // TODO: global reference to this?
+            let function = Arc::new(GetFieldFunc::new());
+            Arc::new(ScalarFunctionExpr::new(
+                function.name(),
+                function.clone(),
+                vec![
+                    parent_expr,
+                    Arc::new(Literal::new(ScalarValue::Int64(field_index as i64))),
+                ],
+                field.data_type().clone(),
+                function.monotonicity(),
+                function.signature().type_signature.supports_zero_argument(),
+            ))
+        }
+        _ => Arc::new(Column::new(field.name(), field_index)),
+    }
+}
+
+/// Represents selection of fields from a struct / schema.
+pub enum Selection<'a> {
+    /// Selects this fields and all subfields
+    FullField(&'a str),
+    /// For a struct, selections of subfields
+    StructProjection(&'a str, Vec<Selection<'a>>),
+}
+
+/// Resolves the projection into a list of selections.
+pub fn compute_projection<'a, 'b>(
+    schema: &'b Fields,
+    projection: &'a Fields,
+) -> Result<Vec<Selection<'a>>> {
+    let mut selections = Vec::with_capacity(projection.len());
+    for projected_field in projection {
+        match projected_field.data_type() {
+            DataType::Struct(fields) => {
+                let original_field = schema
+                    .iter()
+                    .find(|f| &f.name() == &projected_field.name())
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(format!(
+                            "compute_projection: projected field {} not found in schema {:?}",
+                            projected_field.name(),
+                            schema
+                        ))
+                    })?;
+                let input_fields = if let DataType::Struct(fields) = original_field.data_type() {
+                    fields
+                } else {
+                    return Err(DataFusionError::Internal(
+                        "compute_projection: expected struct".to_string(),
+                    )
+                    .into());
+                };
+
+                let sub_selections = compute_projection(&input_fields, fields)?;
+                if fields.len() == input_fields.len()
+                    && sub_selections
+                        .iter()
+                        .all(|s| matches!(s, Selection::FullField(_)))
+                {
+                    selections.push(Selection::FullField(projected_field.name()));
+                } else {
+                    selections.push(Selection::StructProjection(
+                        projected_field.name(),
+                        sub_selections,
+                    ));
+                }
+            }
+            _ => {
+                selections.push(Selection::FullField(projected_field.name()));
+            }
+        }
+    }
+    Ok(selections)
+}
+
+/// Basically has two paths:
+///  * if we are selecting all of it, then `Column(name)`
+///  * if we are selecting subset of it, then
+/// ```
+/// MakeStruct(
+///     GetFieldAccess(Column(name), field1),
+///     GetFieldAccess(Column(name), field2),
+///     ...
+/// )
+/// ```
+fn struct_project_expr(
+    field: &Field,
+    access_expr: Arc<dyn PhysicalExpr>,
+) -> Result<(Arc<dyn PhysicalExpr>, String)> {
+    debug_assert!(matches!(field.data_type(), DataType::Struct(_)));
+    // For each sub field, get the field access
+    // Then use create struct
 }
 
 #[cfg(test)]

--- a/rust/lance/src/io/exec/rowids.rs
+++ b/rust/lance/src/io/exec/rowids.rs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::hash::Hash;
+use std::sync::Arc;
+
+use arrow::array::AsArray;
+use arrow::datatypes::UInt64Type;
+use arrow_array::{Array, RecordBatch, UInt64Array};
+use arrow_schema::{DataType, Schema};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::ColumnarValue;
+use datafusion_physical_expr::PhysicalExpr;
+use lance_table::rowids::RowIdIndex;
+
+/// A physical expression that returns the row address for a given row id.
+#[derive(Debug, PartialEq, Hash)]
+pub struct RowAddrExpr {
+    row_id_index: Option<Arc<RowIdIndex>>,
+    rowid_pos: usize,
+}
+
+impl RowAddrExpr {
+    pub fn new(row_id_index: Option<Arc<RowIdIndex>>, rowid_pos: usize) -> Self {
+        Self {
+            row_id_index,
+            rowid_pos,
+        }
+    }
+}
+
+impl PartialEq<dyn std::any::Any + 'static> for RowAddrExpr {
+    fn eq(&self, other: &(dyn std::any::Any + 'static)) -> bool {
+        other.downcast_ref::<Self>().map_or(false, |o| self == o)
+    }
+}
+
+impl std::fmt::Display for RowAddrExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "RowAddrExpr")
+    }
+}
+
+impl PhysicalExpr for RowAddrExpr {
+    fn as_any(&self) -> &(dyn std::any::Any + 'static) {
+        self
+    }
+
+    fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
+        Ok(DataType::UInt64)
+    }
+
+    fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
+        Ok(true)
+    }
+
+    fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
+        let rowids = batch
+            .column(self.rowid_pos)
+            .as_primitive_opt::<UInt64Type>()
+            .ok_or_else(|| {
+                DataFusionError::Internal("RowAddrExpr: rowid column is not a UInt64Type".into())
+            })?;
+
+        if let Some(row_id_index) = &self.row_id_index {
+            if rowids.null_count() > 0 {
+                let mut builder = arrow::array::UInt64Builder::with_capacity(rowids.len());
+                for rowid in rowids.iter() {
+                    if let Some(rowid) = rowid {
+                        if let Some(row_addr) = row_id_index.get(rowid) {
+                            builder.append_value(row_addr.into());
+                        } else {
+                            return Err(DataFusionError::Internal(
+                                "RowAddrExpr: rowid not found in index".into(),
+                            ));
+                        }
+                    } else {
+                        builder.append_null();
+                    }
+                }
+                Ok(ColumnarValue::Array(Arc::new(builder.finish())))
+            } else {
+                // Fast path - no branching for null values
+                let mut rowaddrs: Vec<u64> = Vec::with_capacity(rowids.len());
+                for rowid in rowids.values() {
+                    if let Some(row_addr) = row_id_index.get(*rowid) {
+                        rowaddrs.push(row_addr.into());
+                    } else {
+                        return Err(DataFusionError::Internal(
+                            "RowAddrExpr: rowid not found in index".into(),
+                        ));
+                    }
+                }
+                Ok(ColumnarValue::Array(Arc::new(UInt64Array::from(rowaddrs))))
+            }
+        } else {
+            // No index, then we should just copy the rowids
+            Ok(ColumnarValue::Array(batch.column(self.rowid_pos).clone()))
+        }
+    }
+
+    fn children(&self) -> Vec<Arc<dyn PhysicalExpr>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        _children: Vec<Arc<dyn PhysicalExpr>>,
+    ) -> Result<Arc<dyn PhysicalExpr>> {
+        Ok(self)
+    }
+
+    fn dyn_hash(&self, state: &mut dyn std::hash::Hasher) {
+        let mut s = state;
+        self.hash(&mut s);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use arrow_array::Int32Array;
+    use arrow_schema::Field;
+    use lance_table::rowids::RowIdSequence;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_address_style_ids() {
+        // Passing no index means rowids are same as rowaddrs
+        let row_id_index: Option<Arc<RowIdIndex>> = None;
+        let rowid_pos: usize = 0;
+
+        // Create a record batch with rowids
+        let rowids = Arc::new(UInt64Array::from(vec![1, 2, 3]));
+        let schema = Schema::new(vec![Field::new("rowid", DataType::UInt64, true)]);
+        let record_batch = RecordBatch::try_new(Arc::new(schema), vec![rowids.clone()]).unwrap();
+
+        // Create the RowAddrExpr instance
+        let row_addr_expr = RowAddrExpr::new(row_id_index, rowid_pos);
+
+        // Evaluate the RowAddrExpr
+        let result = row_addr_expr.evaluate(&record_batch).unwrap();
+        let result = result.into_array(rowids.len()).unwrap();
+
+        // Verify the result
+        assert_eq!(result.as_ref(), rowids.as_ref() as &dyn Array);
+        assert_eq!(Arc::as_ptr(&result), Arc::as_ptr(&rowids));
+    }
+
+    fn sample_row_id_index() -> Arc<RowIdIndex> {
+        // Create a row id index
+        // 0 -> 10
+        // 1 -> 20
+        // 2 -> 30
+        let mut row_id_seq = RowIdSequence::from(100..110); // 10 rows
+        row_id_seq.extend((0..1).into()); // rowid=0
+        row_id_seq.extend((111..120).into()); // 9 rows
+        row_id_seq.extend((1..2).into()); // rowid=1
+        row_id_seq.extend((131..140).into()); // 9 rows
+        row_id_seq.extend((2..3).into()); // rowid=2
+        Arc::new(RowIdIndex::new(&[(0, Arc::new(row_id_seq))]).unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_row_ids_no_nulls() {
+        let row_id_index = sample_row_id_index();
+
+        // Set the rowid_pos
+        let rowid_pos: usize = 0;
+
+        // Create a record batch with rowids
+        let rowids = Arc::new(UInt64Array::from(vec![0, 1, 2]));
+        let schema = Schema::new(vec![Field::new("rowid", DataType::UInt64, true)]);
+        let record_batch = RecordBatch::try_new(Arc::new(schema), vec![rowids.clone()]).unwrap();
+
+        // Create the RowAddrExpr instance
+        let row_addr_expr = RowAddrExpr::new(Some(row_id_index.clone()), rowid_pos);
+
+        // Evaluate the RowAddrExpr
+        let result = row_addr_expr.evaluate(&record_batch).unwrap();
+        let result = result.into_array(rowids.len()).unwrap();
+
+        // Verify the result
+        assert_eq!(
+            result.as_ref(),
+            Arc::new(UInt64Array::from(vec![10, 20, 30])).as_ref() as &dyn Array
+        );
+    }
+
+    #[tokio::test]
+    async fn test_row_ids_with_nulls() {
+        let row_id_index = sample_row_id_index();
+
+        // Set the rowid_pos
+        let rowid_pos: usize = 0;
+
+        // Create a record batch with rowids and null values
+        let rowids = Arc::new(UInt64Array::from(vec![Some(0), None, Some(2)]));
+        let schema = Schema::new(vec![Field::new("rowid", DataType::UInt64, true)]);
+        let record_batch = RecordBatch::try_new(Arc::new(schema), vec![rowids.clone()]).unwrap();
+
+        // Create the RowAddrExpr instance
+        let row_addr_expr = RowAddrExpr::new(Some(row_id_index.clone()), rowid_pos);
+
+        // Evaluate the RowAddrExpr
+        let result = row_addr_expr.evaluate(&record_batch).unwrap();
+        let result = result.into_array(rowids.len()).unwrap();
+
+        // Verify the result
+        assert_eq!(
+            result.as_ref(),
+            Arc::new(UInt64Array::from(vec![Some(10), None, Some(30)])).as_ref() as &dyn Array
+        );
+    }
+
+    #[tokio::test]
+    async fn test_invalid_schema() {
+        let row_id_index = sample_row_id_index();
+
+        // Set the rowid_pos
+        let rowid_pos: usize = 0;
+
+        // Create a record batch with rowids
+        let rowids = Arc::new(Int32Array::from(vec![0, 1, 2]));
+        let schema = Schema::new(vec![Field::new("invalid", DataType::Int32, true)]);
+        let record_batch = RecordBatch::try_new(Arc::new(schema), vec![rowids.clone()]).unwrap();
+
+        // Create the RowAddrExpr instance
+        let row_addr_expr = RowAddrExpr::new(Some(row_id_index.clone()), rowid_pos);
+
+        // Evaluate the RowAddrExpr
+        let result = row_addr_expr.evaluate(&record_batch);
+
+        // Verify the result
+        assert!(result.is_err());
+    }
+}

--- a/rust/lance/src/io/exec/rowids.rs
+++ b/rust/lance/src/io/exec/rowids.rs
@@ -179,8 +179,8 @@ impl ExecutionPlan for AddRowAddrExec {
         self.output_schema.clone()
     }
 
-    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
-        vec![self.input.clone()]
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
     }
 
     fn with_new_children(

--- a/rust/lance/src/io/exec/rowids.rs
+++ b/rust/lance/src/io/exec/rowids.rs
@@ -1,237 +1,436 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::hash::Hash;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
-use arrow::array::AsArray;
-use arrow::datatypes::UInt64Type;
-use arrow_array::{Array, RecordBatch, UInt64Array};
-use arrow_schema::{DataType, Schema};
+use arrow_array::{Array, ArrayRef, RecordBatch, UInt64Array};
+use arrow_schema::{Schema, SchemaRef};
+use datafusion::common::stats::Precision;
+use datafusion::common::ColumnStatistics;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::logical_expr::ColumnarValue;
-use datafusion_physical_expr::PhysicalExpr;
+use datafusion::execution::SendableRecordBatchStream;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use futures::StreamExt;
+use lance_core::{ROW_ADDR_FIELD, ROW_ID};
 use lance_table::rowids::RowIdIndex;
 
-/// A physical expression that returns the row address for a given row id.
-#[derive(Debug, PartialEq, Hash)]
-pub struct RowAddrExpr {
-    row_id_index: Option<Arc<RowIdIndex>>,
+use crate::dataset::rowids::get_row_id_index;
+use crate::utils::future::SharedPrerequisite;
+use crate::Dataset;
+
+/// Add a `_rowaddr` column to a stream of record batches that have a `_rowid`.
+///
+/// It's generally more efficient to scan the `_rowaddr` column, but this can be
+/// useful when reading secondary indices, which only have the `_rowid` column.
+pub struct AddRowAddrExec {
+    input: Arc<dyn ExecutionPlan>,
+    dataset: Arc<Dataset>,
+    /// Task to get the rowid index. Is not initialized until the first call to
+    /// `execute`.
+    row_id_index: OnceLock<Arc<SharedPrerequisite<Option<Arc<RowIdIndex>>>>>,
+    /// Position in the input schema where the rowids are located
     rowid_pos: usize,
+    /// Position in the output schema where to insert the row address
+    rowaddr_pos: usize,
+    output_schema: SchemaRef,
+    properties: PlanProperties,
 }
 
-impl RowAddrExpr {
-    pub fn new(row_id_index: Option<Arc<RowIdIndex>>, rowid_pos: usize) -> Self {
-        Self {
-            row_id_index,
-            rowid_pos,
-        }
-    }
-}
-
-impl PartialEq<dyn std::any::Any + 'static> for RowAddrExpr {
-    fn eq(&self, other: &(dyn std::any::Any + 'static)) -> bool {
-        other.downcast_ref::<Self>().map_or(false, |o| self == o)
-    }
-}
-
-impl std::fmt::Display for RowAddrExpr {
+impl std::fmt::Debug for AddRowAddrExec {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "RowAddrExpr")
+        f.debug_struct("AddRowAddrExec")
+            .field("input", &self.input)
+            .field("dataset", &self.dataset)
+            .field("rowid_pos", &self.rowid_pos)
+            .field("rowaddr_pos", &self.rowaddr_pos)
+            .field("output_schema", &self.output_schema)
+            .field("properties", &self.properties)
+            .finish()
     }
 }
 
-impl PhysicalExpr for RowAddrExpr {
-    fn as_any(&self) -> &(dyn std::any::Any + 'static) {
-        self
-    }
-
-    fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
-        Ok(DataType::UInt64)
-    }
-
-    fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
-        Ok(true)
-    }
-
-    fn evaluate(&self, batch: &RecordBatch) -> Result<ColumnarValue> {
-        let rowids = batch
-            .column(self.rowid_pos)
-            .as_primitive_opt::<UInt64Type>()
+impl AddRowAddrExec {
+    /// Create a new AddRowAddrExec node.
+    ///
+    /// This adds a `_rowaddr` column to streams where there is a `_rowid`
+    /// column.
+    ///
+    /// # Errors
+    ///
+    /// If the `_rowid` field is not found in the input schema.
+    ///
+    /// # Arguments
+    /// * `input` - The input plan to add row addresses to.
+    /// * `dataset` - The dataset to get the row id index from.
+    /// * `rowaddr_pos` - The position in the output schema where to insert the row address.
+    pub fn try_new(
+        input: Arc<dyn ExecutionPlan>,
+        dataset: Arc<Dataset>,
+        rowaddr_pos: usize,
+    ) -> Result<Self> {
+        // Need to know the physical position of the row id field, so we don't
+        // have to do a schema lookup for every batch.
+        let input_schema = input.schema();
+        let rowid_pos = input_schema
+            .fields()
+            .iter()
+            .position(|f| f.name() == ROW_ID)
             .ok_or_else(|| {
-                DataFusionError::Internal("RowAddrExpr: rowid column is not a UInt64Type".into())
+                DataFusionError::Internal("rowid field not found in input schema".into())
             })?;
 
-        if let Some(row_id_index) = &self.row_id_index {
-            if rowids.null_count() > 0 {
-                let mut builder = arrow::array::UInt64Builder::with_capacity(rowids.len());
-                for rowid in rowids.iter() {
+        let mut fields = input_schema.fields().iter().cloned().collect::<Vec<_>>();
+        fields.insert(rowaddr_pos, Arc::new(ROW_ADDR_FIELD.clone()));
+        let output_schema = Arc::new(Schema::new_with_metadata(
+            fields,
+            input_schema.metadata().clone(),
+        ));
+
+        let row_id_index = OnceLock::new();
+
+        // Is just a simple projections, so it inherits the partitioning and
+        // execution mode from parent.
+        let properties = input.properties().clone();
+
+        Ok(Self {
+            input,
+            dataset,
+            row_id_index,
+            rowid_pos,
+            rowaddr_pos,
+            output_schema,
+            properties,
+        })
+    }
+
+    fn compute_row_addrs(
+        row_ids: &ArrayRef,
+        row_id_index: Option<&RowIdIndex>,
+    ) -> Result<ArrayRef> {
+        let row_id_values = row_ids
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| {
+                DataFusionError::Internal(
+                    "AddRowAddrExec: rowid column is not a UInt64Array".into(),
+                )
+            })?;
+        if let Some(row_id_index) = row_id_index {
+            if row_id_values.null_count() > 0 {
+                let mut builder = arrow::array::UInt64Builder::with_capacity(row_id_values.len());
+                for rowid in row_id_values.iter() {
                     if let Some(rowid) = rowid {
                         if let Some(row_addr) = row_id_index.get(rowid) {
                             builder.append_value(row_addr.into());
                         } else {
-                            return Err(DataFusionError::Internal(
-                                "RowAddrExpr: rowid not found in index".into(),
-                            ));
+                            return Err(DataFusionError::Internal(format!(
+                                "AddRowAddrExec: rowid not found in index: {}",
+                                rowid
+                            )));
                         }
                     } else {
                         builder.append_null();
                     }
                 }
-                Ok(ColumnarValue::Array(Arc::new(builder.finish())))
+                Ok(Arc::new(builder.finish()))
             } else {
                 // Fast path - no branching for null values
-                let mut rowaddrs: Vec<u64> = Vec::with_capacity(rowids.len());
-                for rowid in rowids.values() {
+                let mut rowaddrs: Vec<u64> = Vec::with_capacity(row_id_values.len());
+                for rowid in row_id_values.values() {
                     if let Some(row_addr) = row_id_index.get(*rowid) {
                         rowaddrs.push(row_addr.into());
                     } else {
-                        return Err(DataFusionError::Internal(
-                            "RowAddrExpr: rowid not found in index".into(),
-                        ));
+                        return Err(DataFusionError::Internal(format!(
+                            "AddRowAddrExec: rowid not found in index: {}",
+                            rowid
+                        )));
                     }
                 }
-                Ok(ColumnarValue::Array(Arc::new(UInt64Array::from(rowaddrs))))
+                Ok(Arc::new(UInt64Array::from(rowaddrs)))
             }
         } else {
             // No index, then we should just copy the rowids
-            Ok(ColumnarValue::Array(batch.column(self.rowid_pos).clone()))
+            Ok(row_ids.clone())
         }
     }
+}
 
-    fn children(&self) -> Vec<Arc<dyn PhysicalExpr>> {
-        vec![]
+impl DisplayAs for AddRowAddrExec {
+    fn fmt_as(
+        &self,
+        _format_type: DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        write!(f, "AddRowAddrExec")
+    }
+}
+
+impl ExecutionPlan for AddRowAddrExec {
+    fn name(&self) -> &str {
+        "AddRowAddrExec"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> Arc<Schema> {
+        self.output_schema.clone()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
     }
 
     fn with_new_children(
         self: Arc<Self>,
-        _children: Vec<Arc<dyn PhysicalExpr>>,
-    ) -> Result<Arc<dyn PhysicalExpr>> {
-        Ok(self)
+        _children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        todo!()
     }
 
-    fn dyn_hash(&self, state: &mut dyn std::hash::Hasher) {
-        let mut s = state;
-        self.hash(&mut s);
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion::execution::context::TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let index_prereq = self
+            .row_id_index
+            .get_or_init(|| {
+                let dataset = self.dataset.clone();
+                let fut = async move { get_row_id_index(dataset.as_ref()).await };
+                SharedPrerequisite::spawn(fut)
+            })
+            .clone();
+
+        let input_stream = self.input.execute(partition, context.clone())?;
+
+        let rowid_pos = self.rowid_pos;
+        let rowaddr_pos = self.rowaddr_pos;
+        let output_schema = self.output_schema.clone();
+        let stream = input_stream.then(move |batch| {
+            let output_schema = output_schema.clone();
+            let index_prereq = index_prereq.clone();
+            async move {
+                let batch = batch?;
+                index_prereq.wait_ready().await?;
+                let row_id_index = index_prereq.get_ready();
+                let index_ref = row_id_index.as_deref();
+
+                let row_addr = Self::compute_row_addrs(batch.column(rowid_pos), index_ref)?;
+
+                let mut columns = Vec::with_capacity(batch.num_columns() + 1);
+                let existing_columns = batch.columns();
+                columns.extend_from_slice(&existing_columns[..rowaddr_pos]);
+                columns.push(row_addr);
+                columns.extend_from_slice(&existing_columns[rowaddr_pos..]);
+
+                Ok(RecordBatch::try_new(output_schema.clone(), columns)?)
+            }
+        });
+
+        let stream = RecordBatchStreamAdapter::new(self.output_schema.clone(), stream.boxed());
+        Ok(Box::pin(stream))
+    }
+
+    fn statistics(&self) -> Result<datafusion::physical_plan::Statistics> {
+        let mut stats = self.input.statistics()?;
+
+        let row_id_col_stats = stats.column_statistics.get(self.rowid_pos).ok_or_else(|| {
+            DataFusionError::Internal("RowAddrExec: rowid column stats not found".into())
+        })?;
+        let row_addr_col_stats = ColumnStatistics {
+            null_count: row_id_col_stats.null_count.clone(),
+            distinct_count: row_id_col_stats.distinct_count.clone(),
+            max_value: Precision::Absent,
+            min_value: Precision::Absent,
+        };
+
+        let base_size = std::mem::size_of::<UInt64Array>();
+        // Buffer size is the number of rows times 8 bytes per row, but there
+        // is a minimum size of 64 bytes.
+        let mut added_byte_size = stats
+            .num_rows
+            .clone()
+            .map(|n| (n * 8).max(64))
+            .add(&Precision::Exact(base_size));
+        if row_id_col_stats
+            .null_count
+            .get_value()
+            .map(|v| *v > 0)
+            .unwrap_or_default()
+        {
+            // Account for null buffer.
+            added_byte_size =
+                added_byte_size.add(&stats.num_rows.clone().map(|n| n.div_ceil(8).max(64)));
+        }
+        stats.total_byte_size = stats.total_byte_size.add(&added_byte_size);
+        stats
+            .column_statistics
+            .insert(self.rowaddr_pos, row_addr_col_stats);
+
+        Ok(stats)
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
     }
 }
 
 #[cfg(test)]
 mod test {
-    use arrow_array::Int32Array;
-    use arrow_schema::Field;
-    use lance_table::rowids::RowIdSequence;
+    use arrow_array::{Int32Array, RecordBatchIterator};
+    use arrow_schema::{DataType, Field};
+    use datafusion::{physical_plan::memory::MemoryExec, prelude::SessionContext};
+    use futures::TryStreamExt;
+    use lance_core::{ROW_ADDR, ROW_ID_FIELD};
+
+    use crate::dataset::WriteParams;
 
     use super::*;
 
+    async fn apply_to_batch(batch: RecordBatch, dataset: Arc<Dataset>) -> Result<RecordBatch> {
+        let schema = batch.schema();
+        let memory_exec = MemoryExec::try_new(&[vec![batch]], schema, None).unwrap();
+        let exec = AddRowAddrExec::try_new(Arc::new(memory_exec), dataset, 0)?;
+        let session = SessionContext::new();
+        let task_ctx = session.task_ctx();
+        let stream = exec.execute(0, task_ctx)?;
+        let batches = stream.try_collect::<Vec<_>>().await?;
+        assert_eq!(batches.len(), 1);
+        Ok(batches.into_iter().next().unwrap())
+    }
+
     #[tokio::test]
     async fn test_address_style_ids() {
-        // Passing no index means rowids are same as rowaddrs
-        let row_id_index: Option<Arc<RowIdIndex>> = None;
-        let rowid_pos: usize = 0;
+        // Creating a dataset with no stable row ids means that the row address
+        // will be the same as the row id.
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let reader = RecordBatchIterator::new(vec![], schema.clone());
+        let dataset = Dataset::write(
+            reader,
+            "memory://",
+            Some(WriteParams {
+                enable_move_stable_row_ids: false,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        let dataset = Arc::new(dataset);
 
-        // Create a record batch with rowids
         let rowids = Arc::new(UInt64Array::from(vec![1, 2, 3]));
-        let schema = Schema::new(vec![Field::new("rowid", DataType::UInt64, true)]);
-        let record_batch = RecordBatch::try_new(Arc::new(schema), vec![rowids.clone()]).unwrap();
+        let schema = Schema::new(vec![ROW_ID_FIELD.clone()]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![rowids.clone()]).unwrap();
 
-        // Create the RowAddrExpr instance
-        let row_addr_expr = RowAddrExpr::new(row_id_index, rowid_pos);
+        let result = apply_to_batch(batch, dataset).await.unwrap();
+        let result = result[ROW_ADDR].clone();
 
-        // Evaluate the RowAddrExpr
-        let result = row_addr_expr.evaluate(&record_batch).unwrap();
-        let result = result.into_array(rowids.len()).unwrap();
-
-        // Verify the result
         assert_eq!(result.as_ref(), rowids.as_ref() as &dyn Array);
+        // The array should be just a copy of the _rowid array pointer.
         assert_eq!(Arc::as_ptr(&result), Arc::as_ptr(&rowids));
     }
 
-    fn sample_row_id_index() -> Arc<RowIdIndex> {
+    async fn sample_dataset_with_rowid_index() -> Arc<Dataset> {
         // Create a row id index
-        // 0 -> 10
-        // 1 -> 20
-        // 2 -> 30
-        let mut row_id_seq = RowIdSequence::from(100..110); // 10 rows
-        row_id_seq.extend((0..1).into()); // rowid=0
-        row_id_seq.extend((111..120).into()); // 9 rows
-        row_id_seq.extend((1..2).into()); // rowid=1
-        row_id_seq.extend((131..140).into()); // 9 rows
-        row_id_seq.extend((2..3).into()); // rowid=2
-        Arc::new(RowIdIndex::new(&[(0, Arc::new(row_id_seq))]).unwrap())
+        // 0 -> 0
+        // 1 -> 1 << 32
+        // 2 -> 2 << 32
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+        let dataset = Dataset::write(
+            reader,
+            "memory://",
+            Some(WriteParams {
+                enable_move_stable_row_ids: true,
+                max_rows_per_file: 1,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(dataset.get_fragments().len(), 3);
+        Arc::new(dataset)
     }
 
     #[tokio::test]
     async fn test_row_ids_no_nulls() {
-        let row_id_index = sample_row_id_index();
+        let dataset = sample_dataset_with_rowid_index().await;
 
-        // Set the rowid_pos
-        let rowid_pos: usize = 0;
-
-        // Create a record batch with rowids
         let rowids = Arc::new(UInt64Array::from(vec![0, 1, 2]));
-        let schema = Schema::new(vec![Field::new("rowid", DataType::UInt64, true)]);
-        let record_batch = RecordBatch::try_new(Arc::new(schema), vec![rowids.clone()]).unwrap();
+        let schema = Schema::new(vec![ROW_ID_FIELD.clone()]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![rowids.clone()]).unwrap();
 
-        // Create the RowAddrExpr instance
-        let row_addr_expr = RowAddrExpr::new(Some(row_id_index.clone()), rowid_pos);
+        let result = apply_to_batch(batch, dataset).await.unwrap();
+        let result = result[ROW_ADDR].clone();
 
-        // Evaluate the RowAddrExpr
-        let result = row_addr_expr.evaluate(&record_batch).unwrap();
-        let result = result.into_array(rowids.len()).unwrap();
-
-        // Verify the result
         assert_eq!(
             result.as_ref(),
-            Arc::new(UInt64Array::from(vec![10, 20, 30])).as_ref() as &dyn Array
+            Arc::new(UInt64Array::from(vec![0, 1 << 32, 2 << 32])).as_ref() as &dyn Array
         );
     }
 
     #[tokio::test]
     async fn test_row_ids_with_nulls() {
-        let row_id_index = sample_row_id_index();
+        let dataset = sample_dataset_with_rowid_index().await;
 
-        // Set the rowid_pos
-        let rowid_pos: usize = 0;
-
-        // Create a record batch with rowids and null values
         let rowids = Arc::new(UInt64Array::from(vec![Some(0), None, Some(2)]));
-        let schema = Schema::new(vec![Field::new("rowid", DataType::UInt64, true)]);
-        let record_batch = RecordBatch::try_new(Arc::new(schema), vec![rowids.clone()]).unwrap();
+        let schema = Schema::new(vec![ROW_ID_FIELD.clone()]);
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![rowids.clone()]).unwrap();
 
-        // Create the RowAddrExpr instance
-        let row_addr_expr = RowAddrExpr::new(Some(row_id_index.clone()), rowid_pos);
+        let result = apply_to_batch(batch, dataset).await.unwrap();
+        let result = result[ROW_ADDR].clone();
 
-        // Evaluate the RowAddrExpr
-        let result = row_addr_expr.evaluate(&record_batch).unwrap();
-        let result = result.into_array(rowids.len()).unwrap();
-
-        // Verify the result
         assert_eq!(
             result.as_ref(),
-            Arc::new(UInt64Array::from(vec![Some(10), None, Some(30)])).as_ref() as &dyn Array
+            Arc::new(UInt64Array::from(vec![Some(0), None, Some(2 << 32)])).as_ref() as &dyn Array
         );
     }
 
     #[tokio::test]
     async fn test_invalid_schema() {
-        let row_id_index = sample_row_id_index();
+        let dataset = sample_dataset_with_rowid_index().await;
 
-        // Set the rowid_pos
-        let rowid_pos: usize = 0;
-
-        // Create a record batch with rowids
         let rowids = Arc::new(Int32Array::from(vec![0, 1, 2]));
         let schema = Schema::new(vec![Field::new("invalid", DataType::Int32, true)]);
-        let record_batch = RecordBatch::try_new(Arc::new(schema), vec![rowids.clone()]).unwrap();
+        let batch = RecordBatch::try_new(Arc::new(schema), vec![rowids.clone()]).unwrap();
 
-        // Create the RowAddrExpr instance
-        let row_addr_expr = RowAddrExpr::new(Some(row_id_index.clone()), rowid_pos);
-
-        // Evaluate the RowAddrExpr
-        let result = row_addr_expr.evaluate(&record_batch);
-
-        // Verify the result
+        let result = apply_to_batch(batch, dataset).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_stats() {
+        let dataset = sample_dataset_with_rowid_index().await;
+
+        let rowids = Arc::new(UInt64Array::from(vec![Some(0), None, Some(2)]));
+        let schema = Arc::new(Schema::new(vec![ROW_ID_FIELD.clone()]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![rowids.clone()]).unwrap();
+
+        let exec = AddRowAddrExec::try_new(
+            Arc::new(MemoryExec::try_new(&[vec![batch.clone()]], schema.clone(), None).unwrap()),
+            dataset.clone(),
+            0,
+        )
+        .unwrap();
+        let stats = exec.statistics().unwrap();
+        let result = apply_to_batch(batch, dataset).await.unwrap();
+
+        assert_eq!(stats.num_rows, Precision::Exact(3));
+        assert_eq!(stats.column_statistics.len(), 2);
+        assert_eq!(stats.column_statistics[0].null_count, Precision::Exact(1));
+        assert_eq!(stats.column_statistics[1].null_count, Precision::Exact(1));
+
+        let actual_byte_size = result
+            .columns()
+            .iter()
+            .fold(0, |acc, col| acc + col.get_array_memory_size());
+        assert_eq!(stats.total_byte_size, Precision::Exact(actual_byte_size));
     }
 }


### PR DESCRIPTION
* Replace our custom `ProjectionExec` with a function that maps the old API into DataFusion's `ProjectionExec`.
* Create a new `PhysicalExpr` for mapping `_rowid` to `_rowaddr`.
