### PR TITLE
feat: use hyperloglog for cardinality estimation for dictionary encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ deepsize = "0.2.0"
 either = "1.0"
 futures = "0.3"
 http = "0.2.9"
+hyperloglogplus = { version = "0.4.1", features = ["const-loop"] }
 itertools = "0.12"
 lazy_static = "1"
 log = "0.4"

--- a/rust/lance-encoding/Cargo.toml
+++ b/rust/lance-encoding/Cargo.toml
@@ -31,6 +31,7 @@ snafu.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 zstd.workspace = true
+hyperloglogplus.workspace = true
 
 [dev-dependencies]
 rand.workspace = true


### PR DESCRIPTION
Currently, to determine whether dictionary encoding should be applied, we use a `HashSet` for accurate cardinality calculation. However, I believe that perfect accuracy in cardinality isn't necessary in this context. Therefore, we could use HyperLogLog for a rough cardinality estimation, which might save memory and potentially speed up the cardinality check.

* `HyperLogLog` uses a fixed size of memory, determined by the precision in the code. And the `HashSet` uses the `threshold * each_item_string_size` of memory, if certain items are large, `HashSet` may use non trivial amount of memory
* `HyperLogLog` has an error rate (1.56%, translated from precision 12), while `HashSet` is accurate