### PR TITLE
feat: add standalone partition assignment operation

### DIFF
--- a/python/python/benchmarks/test_index.py
+++ b/python/python/benchmarks/test_index.py
@@ -101,11 +101,29 @@ def test_optimize_index(
 @pytest.mark.benchmark(group="optimize_index")
 @pytest.mark.parametrize("num_partitions", [100, 300])
 def test_train_ivf(test_large_dataset, benchmark, num_partitions):
-    builder = IndicesBuilder(test_large_dataset)
+    builder = IndicesBuilder(test_large_dataset, "vector")
     benchmark.pedantic(
         builder.train_ivf,
-        args=["vector"],
         kwargs={"num_partitions": num_partitions},
         iterations=1,
         rounds=1,
+    )
+
+
+# Pre-computing partition assigment only makes sense on CUDA and so this benchmark runs
+# only on CUDA.
+@pytest.mark.benchmark(group="assign_partitions")
+@pytest.mark.parametrize("num_partitions", [100, 300])
+def test_partition_assignment(test_large_dataset, benchmark, num_partitions):
+    from lance.dependencies import torch
+
+    try:
+        if not torch.cuda.is_available():
+            return
+    except:  # noqa: E722
+        return
+    builder = IndicesBuilder(test_large_dataset, "vector")
+    ivf = builder.train_ivf(num_partitions=num_partitions)
+    benchmark.pedantic(
+        builder.assign_ivf_partitions, args=[ivf, None, "cuda"], iterations=1, rounds=1
     )

--- a/python/python/lance/indices.py
+++ b/python/python/lance/indices.py
@@ -319,13 +319,14 @@ class IndicesBuilder:
     def assign_ivf_partitions(
         self,
         ivf_model: IvfModel,
-        dst_dataset_uri: Optional[str],
         accelerator: Union[str, "torch.Device"],
+        *,
+        output_uri: Optional[str] = None,
     ) -> str:
         """
         Calculates which IVF partition each vector belongs to.  This searches the
         IVF centroids and assigns the closest centroid to the vector.  The result is
-        stored in a Lance dataset located at dst_dataset_uri.  The schema of the
+        stored in a Lance dataset located at output_uri.  The schema of the
         partition assignment dataset is:
 
         row_id: uint64
@@ -340,18 +341,18 @@ class IndicesBuilder:
         ivf_model: IvfModel
             An IvfModel, previously created by ``train_ivf`` which the data will be
             assigned to.
-        dst_dataset_uri: Optional[str]
-            Destination Lance dataset where the partition assignments will be written
-            Can be None in which case a random directory will be used.
-        accelerator: Optional[Union[str, torch.Device]] = None
+        accelerator: Union[str, torch.Device]
             An optional accelerator to use to offload computation to specialized
             hardware.  Currently supported values are the same as those in ``train_ivf``
+        output_uri: Optional[str], default None
+            Destination Lance dataset where the partition assignments will be written
+            Can be None in which case a random directory will be used.
 
         Returns
         -------
         str
             The path of the partition assignment dataset (will be equal to
-            dst_dataset_uri unless the input is None)
+            output_uri unless the value is None)
         """
         from .dependencies import torch
         from .torch.kmeans import KMeans
@@ -367,7 +368,7 @@ class IndicesBuilder:
             centroids=centroids,
         )
         return compute_partitions(
-            self.dataset, self.column[0], kmeans, dst_dataset_uri=dst_dataset_uri
+            self.dataset, self.column[0], kmeans, dst_dataset_uri=output_uri
         )
 
     def _determine_num_partitions(self, num_partitions: Optional[int], num_rows: int):

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -267,8 +267,17 @@ def compute_partitions(
 
     if dst_dataset_uri is None:
         dst_dataset_uri = tempfile.mkdtemp()
+    ds = write_dataset(
+        rbr,
+        dst_dataset_uri,
+        schema=output_schema,
+        max_rows_per_file=dataset.count_rows(),
+        use_legacy_format=True,
+    )
+    assert len(ds.get_fragments()) == 1
+    files = ds.get_fragments()[0].data_files()
+    assert len(files) == 1
 
-    write_dataset(rbr, dst_dataset_uri, output_schema, use_legacy_format=False)
     progress.close()
 
     logging.info("Saved precomputed partitions to %s", dst_dataset_uri)

--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 import re
 import tempfile
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Literal, Optional, Union
 
 import pyarrow as pa
@@ -19,6 +18,8 @@ from .dependencies import _check_for_numpy, torch
 from .dependencies import numpy as np
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from . import LanceDataset
 
 
@@ -191,7 +192,7 @@ def compute_partitions(
     column: str,
     kmeans: Any,  # KMeans
     batch_size: int = 10240,
-    spill_dir: Union[str, Path] = None,
+    dst_dataset_uri: Union[str, Path] = None,
 ) -> str:
     """Compute partitions for each row using GPU kmeans and spill to disk.
 
@@ -205,8 +206,9 @@ def compute_partitions(
         KMeans model to use to compute partitions.
     batch_size: int, default 10240
         The batch size used to read the dataset.
-    spill_dir: Path
-        The path to store the partitions.
+    dst_dataset_uri: Union[str, Path], optional
+        The path to store the partitions.  If not specified a random
+        directory is used instead
 
     Returns
     -------
@@ -214,6 +216,8 @@ def compute_partitions(
         The absolute path of the partition dataset.
     """
     from lance.torch.data import LanceDataset as PytorchLanceDataset
+
+    num_rows = dataset.count_rows()
 
     torch_ds = PytorchLanceDataset(
         dataset,
@@ -227,6 +231,8 @@ def compute_partitions(
             pa.field("partition", pa.uint32()),
         ]
     )
+
+    progress = tqdm(total=num_rows)
 
     def _partition_assignment() -> Iterable[pa.RecordBatch]:
         with torch.no_grad():
@@ -254,27 +260,16 @@ def compute_partitions(
                         len(part_batch) - len(ids),
                     )
 
+                progress.update(part_batch.num_rows)
                 yield part_batch
 
-    rbr = pa.RecordBatchReader.from_batches(
-        output_schema, tqdm(_partition_assignment())
-    )
+    rbr = pa.RecordBatchReader.from_batches(output_schema, _partition_assignment())
 
-    if spill_dir is None:
-        spill_dir = tempfile.mkdtemp()
+    if dst_dataset_uri is None:
+        dst_dataset_uri = tempfile.mkdtemp()
 
-    spill_uri = Path(spill_dir) / "precomputed_partitions.lance"
+    write_dataset(rbr, dst_dataset_uri, output_schema, use_legacy_format=False)
+    progress.close()
 
-    ds = write_dataset(
-        rbr,
-        spill_uri,
-        schema=output_schema,
-        max_rows_per_file=dataset.count_rows(),
-    )
-    assert len(ds.get_fragments()) == 1
-    files = ds.get_fragments()[0].data_files()
-    assert len(files) == 1
-
-    logging.info("Saved recomputed partitions to %s", spill_uri.absolute())
-
-    return str(spill_uri)
+    logging.info("Saved precomputed partitions to %s", dst_dataset_uri)
+    return str(dst_dataset_uri)

--- a/python/python/tests/test_indices.py
+++ b/python/python/tests/test_indices.py
@@ -104,9 +104,9 @@ def test_assign_partitions(tmpdir):
     builder = IndicesBuilder(ds, "vectors")
 
     ivf = builder.train_ivf(sample_rate=16, num_partitions=20)
-    builder.assign_ivf_partitions(ivf, str(tmpdir / "partitions"), accelerator="cuda")
+    partitions_uri = builder.assign_ivf_partitions(ivf, accelerator="cuda")
 
-    partitions = lance.dataset(str(tmpdir / "partitions"))
+    partitions = lance.dataset(partitions_uri)
     found_row_ids = set()
     for batch in partitions.to_batches():
         row_ids = batch["row_id"]

--- a/python/python/tests/test_indices.py
+++ b/python/python/tests/test_indices.py
@@ -20,7 +20,7 @@ def gen_dataset(tmpdir, datatype=np.float32):
 def test_ivf_centroids(tmpdir):
     ds = gen_dataset(tmpdir)
 
-    ivf = IndicesBuilder(ds).train_ivf("vectors", sample_rate=16)
+    ivf = IndicesBuilder(ds, "vectors").train_ivf(sample_rate=16)
 
     assert ivf.distance_type == "l2"
     assert len(ivf.centroids) == 100
@@ -34,7 +34,7 @@ def test_ivf_centroids(tmpdir):
 @pytest.mark.cuda
 def test_ivf_centroids_cuda(tmpdir):
     ds = gen_dataset(tmpdir)
-    ivf = IndicesBuilder(ds).train_ivf("vectors", sample_rate=16, accelerator="cuda")
+    ivf = IndicesBuilder(ds, "vectors").train_ivf(sample_rate=16, accelerator="cuda")
 
     assert ivf.distance_type == "l2"
     assert len(ivf.centroids) == 100
@@ -43,7 +43,7 @@ def test_ivf_centroids_cuda(tmpdir):
 def test_ivf_centroids_column_type(tmpdir):
     def check(column_type, typename):
         ds = gen_dataset(tmpdir / typename, column_type)
-        ivf = IndicesBuilder(ds).train_ivf("vectors", sample_rate=16)
+        ivf = IndicesBuilder(ds, "vectors").train_ivf(sample_rate=16)
         assert len(ivf.centroids) == 100
         ivf.save(str(tmpdir / f"ivf_{typename}"))
         reloaded = IvfModel.load(str(tmpdir / f"ivf_{typename}"))
@@ -58,8 +58,8 @@ def test_ivf_centroids_distance_type(tmpdir):
     ds = gen_dataset(tmpdir)
 
     def check(distance_type):
-        ivf = IndicesBuilder(ds).train_ivf(
-            "vectors", sample_rate=16, distance_type=distance_type
+        ivf = IndicesBuilder(ds, "vectors").train_ivf(
+            sample_rate=16, distance_type=distance_type
         )
         assert ivf.distance_type == distance_type
         ivf.save(str(tmpdir / "ivf"))
@@ -74,21 +74,21 @@ def test_ivf_centroids_distance_type(tmpdir):
 def test_num_partitions(tmpdir):
     ds = gen_dataset(tmpdir)
 
-    ivf = IndicesBuilder(ds).train_ivf("vectors", sample_rate=16, num_partitions=10)
+    ivf = IndicesBuilder(ds, "vectors").train_ivf(sample_rate=16, num_partitions=10)
     assert ivf.num_partitions == 10
 
 
 @pytest.fixture
 def ds_with_ivf(tmpdir):
     ds = gen_dataset(tmpdir)
-    ivf = IndicesBuilder(ds).train_ivf("vectors", sample_rate=16)
+    ivf = IndicesBuilder(ds, "vectors").train_ivf(sample_rate=16)
     return ds, ivf
 
 
 def test_gen_pq(tmpdir, ds_with_ivf):
     ds, ivf = ds_with_ivf
 
-    pq = IndicesBuilder(ds).train_pq("vectors", ivf, sample_rate=16)
+    pq = IndicesBuilder(ds, "vectors").train_pq(ivf, sample_rate=16)
     assert pq.dimension == 128
     assert pq.num_subvectors == 8
 
@@ -96,3 +96,22 @@ def test_gen_pq(tmpdir, ds_with_ivf):
     reloaded = PqModel.load(str(tmpdir / "pq"))
     assert pq.dimension == reloaded.dimension
     assert pq.codebook == reloaded.codebook
+
+
+def test_assign_partitions(tmpdir):
+    ds = gen_dataset(tmpdir)
+    builder = IndicesBuilder(ds, "vectors")
+
+    ivf = builder.train_ivf(sample_rate=16, num_partitions=20)
+    builder.assign_ivf_partitions(ivf, str(tmpdir / "partitions"), accelerator="cuda")
+
+    partitions = lance.dataset(str(tmpdir / "partitions"))
+    found_row_ids = set()
+    for batch in partitions.to_batches():
+        row_ids = batch["row_id"]
+        for row_id in row_ids:
+            found_row_ids.add(row_id)
+        part_ids = batch["partition"]
+        for part_id in part_ids:
+            assert part_id.as_py() < 20
+    assert len(found_row_ids) == ds.count_rows()

--- a/python/python/tests/test_indices.py
+++ b/python/python/tests/test_indices.py
@@ -98,6 +98,7 @@ def test_gen_pq(tmpdir, ds_with_ivf):
     assert pq.codebook == reloaded.codebook
 
 
+@pytest.mark.cuda
 def test_assign_partitions(tmpdir):
     ds = gen_dataset(tmpdir)
     builder = IndicesBuilder(ds, "vectors")


### PR DESCRIPTION
This also fixes up the tqdm progress bar for partition assignment so that it has a definite end.  This also makes one small tweak to the indices builder, moving the column argument into the builder constructor, since this argument will be shared by all methods in the class.