### PR TITLE
feat: allow users to create a file writer without a schema

### DIFF
--- a/python/python/lance/file.py
+++ b/python/python/lance/file.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
-from typing import Union
+from typing import Optional, Union
 
 import pyarrow as pa
 
@@ -146,9 +146,9 @@ class LanceFileWriter:
     def __init__(
         self,
         path: str,
-        schema: pa.Schema,
+        schema: Optional[pa.Schema] = None,
         *,
-        data_cache_bytes: int = None,
+        data_cache_bytes: Optional[int] = None,
         **kwargs,
     ):
         """
@@ -160,7 +160,9 @@ class LanceFileWriter:
             The path to write to.  Can be a pathname for local storage
             or a URI for remote storage.
         schema: pa.Schema
-            The schema of data that will be written
+            The schema of data that will be written.  If not specified then
+            the schema will be inferred from the first batch.  If the schema
+            is not specified and no data is written then the write will fail.
         data_cache_bytes: int
             How many bytes (per column) to cache before writing a page.  The
             default is an appropriate value based on the filesystem.

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -37,9 +37,9 @@ class LanceFileWriter:
     def __init__(
         self,
         path: str,
-        schema: pa.Schema,
-        data_cache_bytes: int,
-        keep_original_array: bool,
+        schema: Optional[pa.Schema],
+        data_cache_bytes: Optional[int],
+        keep_original_array: Optional[bool],
     ): ...
     def write_batch(self, batch: pa.RecordBatch) -> None: ...
     def finish(self) -> int: ...

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -172,24 +172,28 @@ pub struct LanceFileWriter {
 impl LanceFileWriter {
     async fn open(
         uri_or_path: String,
-        schema: PyArrowType<ArrowSchema>,
+        schema: Option<PyArrowType<ArrowSchema>>,
         data_cache_bytes: Option<u64>,
         keep_original_array: Option<bool>,
     ) -> PyResult<Self> {
         let (object_store, path) = object_store_from_uri_or_path(uri_or_path).await?;
         let object_writer = object_store.create(&path).await.infer_error()?;
-        let lance_schema = lance_core::datatypes::Schema::try_from(&schema.0).infer_error()?;
-        let inner = FileWriter::try_new(
-            object_writer,
-            path.to_string(),
-            lance_schema,
-            FileWriterOptions {
-                data_cache_bytes,
-                keep_original_array,
-                ..Default::default()
-            },
-        )
-        .infer_error()?;
+        let options = FileWriterOptions {
+            data_cache_bytes,
+            keep_original_array,
+            ..Default::default()
+        };
+        let inner = if let Some(schema) = schema {
+            let lance_schema = lance_core::datatypes::Schema::try_from(&schema.0).infer_error()?;
+            FileWriter::try_new(object_writer, path.to_string(), lance_schema, options)
+                .infer_error()
+        } else {
+            Ok(FileWriter::new_lazy(
+                object_writer,
+                path.to_string(),
+                options,
+            ))
+        }?;
         Ok(Self {
             inner: Box::new(inner),
         })
@@ -201,7 +205,7 @@ impl LanceFileWriter {
     #[new]
     pub fn new(
         path: String,
-        schema: PyArrowType<ArrowSchema>,
+        schema: Option<PyArrowType<ArrowSchema>>,
         data_cache_bytes: Option<u64>,
         keep_original_array: Option<bool>,
     ) -> PyResult<Self> {

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -185,14 +185,9 @@ impl LanceFileWriter {
         };
         let inner = if let Some(schema) = schema {
             let lance_schema = lance_core::datatypes::Schema::try_from(&schema.0).infer_error()?;
-            FileWriter::try_new(object_writer, path.to_string(), lance_schema, options)
-                .infer_error()
+            FileWriter::try_new(object_writer, lance_schema, options).infer_error()
         } else {
-            Ok(FileWriter::new_lazy(
-                object_writer,
-                path.to_string(),
-                options,
-            ))
+            Ok(FileWriter::new_lazy(object_writer, options))
         }?;
         Ok(Self {
             inner: Box::new(inner),

--- a/rust/lance-file/benches/reader.rs
+++ b/rust/lance-file/benches/reader.rs
@@ -29,7 +29,6 @@ fn bench_reader(c: &mut Criterion) {
 
     let mut writer = FileWriter::try_new(
         object_writer,
-        file_path.to_string(),
         data.schema().as_ref().try_into().unwrap(),
         FileWriterOptions::default(),
     )

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -1388,7 +1388,6 @@ pub mod tests {
 
         let mut file_writer = FileWriter::try_new(
             fs.object_store.create(&fs.tmp_path).await.unwrap(),
-            fs.tmp_path.to_string(),
             lance_schema.clone(),
             FileWriterOptions::default(),
         )

--- a/rust/lance-file/src/v2/testing.rs
+++ b/rust/lance-file/src/v2/testing.rs
@@ -49,13 +49,7 @@ pub async fn write_lance_file(
 
     let lance_schema = lance_core::datatypes::Schema::try_from(data.schema().as_ref()).unwrap();
 
-    let mut file_writer = FileWriter::try_new(
-        writer,
-        fs.tmp_path.to_string(),
-        lance_schema.clone(),
-        options,
-    )
-    .unwrap();
+    let mut file_writer = FileWriter::try_new(writer, lance_schema.clone(), options).unwrap();
 
     let data = data
         .collect::<std::result::Result<Vec<_>, ArrowError>>()

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
@@ -71,13 +72,15 @@ pub struct FileWriterOptions {
 pub struct FileWriter {
     writer: ObjectWriter,
     path: String,
-    schema: LanceSchema,
+    schema: Option<LanceSchema>,
     column_writers: Vec<Box<dyn FieldEncoder>>,
     column_metadata: Vec<pbfile::ColumnMetadata>,
     field_id_to_column_indices: Vec<(i32, i32)>,
     num_columns: u32,
     rows_written: u64,
     global_buffers: Vec<(u64, u64)>,
+    schema_metadata: HashMap<String, String>,
+    options: FileWriterOptions,
 }
 
 fn initial_column_metadata() -> pbfile::ColumnMetadata {
@@ -90,48 +93,36 @@ fn initial_column_metadata() -> pbfile::ColumnMetadata {
 }
 
 impl FileWriter {
-    /// Create a new FileWriter
+    /// Create a new FileWriter with a desired output schema
     pub fn try_new(
         object_writer: ObjectWriter,
         path: String,
         schema: LanceSchema,
         options: FileWriterOptions,
     ) -> Result<Self> {
-        let cache_bytes_per_column = if let Some(data_cache_bytes) = options.data_cache_bytes {
-            data_cache_bytes / schema.fields.len() as u64
-        } else {
-            8 * 1024 * 1024
-        };
+        let mut writer = Self::new_lazy(object_writer, path, options);
+        writer.initialize(schema)?;
+        Ok(writer)
+    }
 
-        schema.validate()?;
-
-        let keep_original_array = options.keep_original_array.unwrap_or(false);
-        let encoding_strategy = options
-            .encoding_strategy
-            .unwrap_or_else(|| Arc::new(CoreFieldEncodingStrategy::default()));
-
-        let encoder = BatchEncoder::try_new(
-            &schema,
-            encoding_strategy.as_ref(),
-            cache_bytes_per_column,
-            keep_original_array,
-        )?;
-        let num_columns = encoder.num_columns();
-
-        let column_writers = encoder.field_encoders;
-        let column_metadata = vec![initial_column_metadata(); num_columns as usize];
-
-        Ok(Self {
+    /// Create a new FileWriter without a desired output schema
+    ///
+    /// The output schema will be set based on the first batch of data to arrive.
+    /// If no data arrives and the writer is finished then the write will fail.
+    pub fn new_lazy(object_writer: ObjectWriter, path: String, options: FileWriterOptions) -> Self {
+        Self {
             writer: object_writer,
             path,
-            schema,
-            column_writers,
-            column_metadata,
-            num_columns,
+            schema: None,
+            column_writers: Vec::new(),
+            column_metadata: Vec::new(),
+            num_columns: 0,
             rows_written: 0,
-            field_id_to_column_indices: encoder.field_id_to_column_index,
+            field_id_to_column_indices: Vec::new(),
             global_buffers: Vec::new(),
-        })
+            schema_metadata: HashMap::new(),
+            options,
+        }
     }
 
     async fn write_page(&mut self, encoded_page: EncodedPage) -> Result<()> {
@@ -208,6 +199,46 @@ impl FileWriter {
         Ok(())
     }
 
+    fn initialize(&mut self, mut schema: LanceSchema) -> Result<()> {
+        let cache_bytes_per_column = if let Some(data_cache_bytes) = self.options.data_cache_bytes {
+            data_cache_bytes / schema.fields.len() as u64
+        } else {
+            8 * 1024 * 1024
+        };
+
+        schema.validate()?;
+
+        let keep_original_array = self.options.keep_original_array.unwrap_or(false);
+        let encoding_strategy = self
+            .options
+            .encoding_strategy
+            .clone()
+            .unwrap_or_else(|| Arc::new(CoreFieldEncodingStrategy::default()));
+
+        let encoder = BatchEncoder::try_new(
+            &schema,
+            encoding_strategy.as_ref(),
+            cache_bytes_per_column,
+            keep_original_array,
+        )?;
+        self.num_columns = encoder.num_columns();
+
+        self.column_writers = encoder.field_encoders;
+        self.column_metadata = vec![initial_column_metadata(); self.num_columns as usize];
+        self.schema_metadata
+            .extend(std::mem::take(&mut schema.metadata));
+        self.schema = Some(schema);
+        Ok(())
+    }
+
+    fn ensure_initialized(&mut self, batch: &RecordBatch) -> Result<&LanceSchema> {
+        if self.schema.is_none() {
+            let schema = LanceSchema::try_from(batch.schema().as_ref())?;
+            self.initialize(schema)?;
+        }
+        Ok(self.schema.as_ref().unwrap())
+    }
+
     /// Schedule a batch of data to be written to the file
     ///
     /// Note: the future returned by this method may complete before the data has been fully
@@ -217,6 +248,8 @@ impl FileWriter {
             "write_batch called with {} bytes of data",
             batch.get_array_memory_size()
         );
+        self.ensure_initialized(batch)?;
+        let schema = self.schema.as_ref().unwrap();
         let num_rows = batch.num_rows() as u64;
         if num_rows == 0 {
             return Ok(());
@@ -235,8 +268,7 @@ impl FileWriter {
         };
         // First we push each array into its column writer.  This may or may not generate enough
         // data to trigger an encoding task.  We collect any encoding tasks into a queue.
-        let encoding_tasks = self
-            .schema
+        let encoding_tasks = schema
             .fields
             .iter()
             .zip(self.column_writers.iter_mut())
@@ -300,7 +332,9 @@ impl FileWriter {
     }
 
     async fn write_global_buffers(&mut self) -> Result<Vec<(u64, u64)>> {
-        let file_descriptor = Self::make_file_descriptor(&self.schema, self.rows_written)?;
+        let schema = self.schema.as_mut().ok_or(Error::invalid_input("No schema provided on writer open and no data provided.  Schema is unknown and file cannot be created", location!()))?;
+        schema.metadata = std::mem::take(&mut self.schema_metadata);
+        let file_descriptor = Self::make_file_descriptor(schema, self.rows_written)?;
         let file_descriptor_bytes = file_descriptor.encode_to_vec();
         let file_descriptor_len = file_descriptor_bytes.len() as u64;
         let file_descriptor_position = self.writer.tell().await? as u64;
@@ -317,7 +351,7 @@ impl FileWriter {
     /// data has been written.  This method allows you to alter the schema metadata.  It
     /// must be called before `finish` is called.
     pub fn add_schema_metadata(&mut self, key: impl Into<String>, value: impl Into<String>) {
-        self.schema.metadata.insert(key.into(), value.into());
+        self.schema_metadata.insert(key.into(), value.into());
     }
 
     /// Adds a global buffer to the file

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -225,6 +225,7 @@ impl FileWriter {
 
         self.column_writers = encoder.field_encoders;
         self.column_metadata = vec![initial_column_metadata(); self.num_columns as usize];
+        self.field_id_to_column_indices = encoder.field_id_to_column_index;
         self.schema_metadata
             .extend(std::mem::take(&mut schema.metadata));
         self.schema = Some(schema);

--- a/rust/lance-index/src/vector/v3/shuffler.rs
+++ b/rust/lance-index/src/vector/v3/shuffler.rs
@@ -159,7 +159,6 @@ impl Shuffler for IvfShuffler {
                             let writer = object_store.create(&part_path).await?;
                             FileWriter::try_new(
                                 writer,
-                                part_path.to_string(),
                                 lance_core::datatypes::Schema::try_from(schema.as_ref())?,
                                 Default::default(),
                             )

--- a/rust/lance/src/dataset/fragment/write.rs
+++ b/rust/lance/src/dataset/fragment/write.rs
@@ -87,7 +87,6 @@ impl<'a> FragmentCreateBuilder<'a> {
         let obj_writer = object_store.create(&full_path).await?;
         let mut writer = lance_file::v2::writer::FileWriter::try_new(
             obj_writer,
-            full_path.to_string(),
             schema,
             FileWriterOptions::default(),
         )?;

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -412,7 +412,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + Clone + 'static> IvfIndexBuilde
             let writer = object_store.create(&path).await?;
             let mut writer = FileWriter::try_new(
                 writer,
-                path.to_string(),
                 storage.schema().as_ref().try_into()?,
                 Default::default(),
             )?;
@@ -432,7 +431,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + Clone + 'static> IvfIndexBuilde
             let index_batch = sub_index.to_batch()?;
             let mut writer = FileWriter::try_new(
                 writer,
-                path.to_string(),
                 index_batch.schema_ref().as_ref().try_into()?,
                 Default::default(),
             )?;
@@ -463,7 +461,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + Clone + 'static> IvfIndexBuilde
         let mut storage_writer = None;
         let mut index_writer = FileWriter::try_new(
             self.dataset.object_store().create(&index_path).await?,
-            index_path.to_string(),
             S::schema().as_ref().try_into()?,
             Default::default(),
         )?;
@@ -500,7 +497,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + Clone + 'static> IvfIndexBuilde
                 if storage_writer.is_none() {
                     storage_writer = Some(FileWriter::try_new(
                         self.dataset.object_store().create(&storage_path).await?,
-                        storage_path.to_string(),
                         batch.schema_ref().as_ref().try_into()?,
                         Default::default(),
                     )?);


### PR DESCRIPTION
This is needed for some of the index refactoring work I'm doing.  It can be difficult to know the schema in advance and, in many (most) cases, the desired file schema is the same as the data schema and so there is no real benefit to providing it in advance.

This PR also removes the "path" argument from the rust constructor.  The path is already part of the ObjectWriter and there is no need for the file writer to keep a second copy.