### PR TITLE
fix: avoid multiple threads loading same index partition

### DIFF
--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -605,7 +605,7 @@ def test_index_cache_size(tmp_path):
 
     indexed_dataset = lance.dataset(tmp_path / "test", index_cache_size=1)
     # query using the same vector, we should get a very high hit rate
-    query_index(indexed_dataset, 100, q=rng.standard_normal(16))
+    query_index(indexed_dataset, 200, q=rng.standard_normal(16))
     assert indexed_dataset._ds.index_cache_hit_rate() > 0.99
 
     last_hit_rate = indexed_dataset._ds.index_cache_hit_rate()

--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -68,20 +68,22 @@ pub async fn maybe_sample_training_data(
 }
 
 #[derive(Debug)]
-pub (crate) struct PartitionLoadLock {
+pub struct PartitionLoadLock {
     partition_locks: Vec<Arc<Mutex<()>>>,
 }
 
 impl PartitionLoadLock {
     pub fn new(num_partitions: usize) -> Self {
         Self {
-            partition_locks: (0..num_partitions).map(|_| Arc::new(Mutex::new(()))).collect(),
+            partition_locks: (0..num_partitions)
+                .map(|_| Arc::new(Mutex::new(())))
+                .collect(),
         }
     }
 
     pub fn get_partition_mutex(&self, partition_id: usize) -> Arc<Mutex<()>> {
         let mtx = &self.partition_locks[partition_id];
-        
+
         mtx.clone()
     }
 }


### PR DESCRIPTION
Adds locks for loading of index partitions. This voids multiple threads querying concurrently from both allocating memory to load the partition, which can cause memory issues during application startup.