### PR TITLE
chore: Revert "chore: bump aws package versions (#2567)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,9 +72,9 @@ arrow-schema = "51.0"
 arrow-select = "51.0"
 async-recursion = "1.0"
 async-trait = "0.1"
-aws-config = "1.5"
-aws-credential-types = "1.2"
-aws-sdk-dynamodb = "1.36"
+aws-config = "0.57"
+aws-credential-types = "0.57"
+aws-sdk-dynamodb = "0.35"
 half = { "version" = "2.4.1", default-features = false, features = [
     "num-traits",
     "std",


### PR DESCRIPTION
This reverts commit 751867cba6923fc55e652e7b038d811b393b0427.

Failed on aws integration test.