### PR TITLE
feat: add label list index

### DIFF
--- a/python/python/benchmarks/test_search.py
+++ b/python/python/benchmarks/test_search.py
@@ -93,7 +93,7 @@ def create_base_dataset(data_dir: Path) -> lance.LanceDataset:
 
     dataset.create_scalar_index("filterable", "BTREE")
     dataset.create_scalar_index("category", "BITMAP")
-    dataset.create_scalar_index("genres", "TAG")
+    dataset.create_scalar_index("genres", "LABEL_LIST")
 
     return lance.dataset(tmp_path, index_cache_size=64 * 1024)
 
@@ -442,7 +442,7 @@ def test_bitmap_index_search(test_dataset, benchmark, filter: str):
     ),
     ids=["none", "one"],
 )
-def test_tag_index_prefilter(test_dataset, benchmark, filter: str):
+def test_label_list_index_prefilter(test_dataset, benchmark, filter: str):
     q = pc.random(N_DIMS).cast(pa.float32())
     if filter is None:
         benchmark(

--- a/python/python/benchmarks/test_search.py
+++ b/python/python/benchmarks/test_search.py
@@ -31,16 +31,34 @@ def find_or_clean(dataset_path: Path) -> Union[lance.LanceDataset, None]:
     return None
 
 
+GENRES = [
+    "action",
+    "comedy",
+    "drama",
+    "horror",
+    "romance",
+    "thriller",
+    "western",
+    "sci-fi",
+    "fantasy",
+    "documentary",
+]
+
+
 def create_table(num_rows, offset) -> pa.Table:
     values = pc.random(num_rows * N_DIMS).cast(pa.float32())
     vectors = pa.FixedSizeListArray.from_arrays(values, N_DIMS)
     filterable = pa.array(range(offset, offset + num_rows))
     categories = pa.array(np.random.randint(0, 100, num_rows))
+    genres_values = pa.array(np.random.choice(GENRES, num_rows * 3))
+    genre_offsets = pa.array(np.arange(0, (num_rows + 1) * 3, 3, dtype=np.int32))
+    genres = pa.ListArray.from_arrays(genre_offsets, genres_values)
     return pa.table(
         {
             "vector": vectors,
             "filterable": filterable,
             "category": categories,
+            "genres": genres,
         }
     )
 
@@ -75,6 +93,7 @@ def create_base_dataset(data_dir: Path) -> lance.LanceDataset:
 
     dataset.create_scalar_index("filterable", "BTREE")
     dataset.create_scalar_index("category", "BITMAP")
+    dataset.create_scalar_index("genres", "TAG")
 
     return lance.dataset(tmp_path, index_cache_size=64 * 1024)
 
@@ -409,6 +428,54 @@ def test_bitmap_index_search(test_dataset, benchmark, filter: str):
             test_dataset.to_table,
             columns=[],
             with_row_id=True,
+            prefilter=True,
+            filter=filter,
+        )
+
+
+@pytest.mark.benchmark(group="query_ann")
+@pytest.mark.parametrize(
+    "filter",
+    (
+        None,
+        "array_has_any(genres, ['comedy'])",
+    ),
+    ids=["none", "one"],
+)
+def test_tag_index_prefilter(test_dataset, benchmark, filter: str):
+    q = pc.random(N_DIMS).cast(pa.float32())
+    if filter is None:
+        benchmark(
+            test_dataset.to_table,
+            columns=[],
+            with_row_id=True,
+            nearest=dict(
+                column="vector",
+                q=q,
+                k=100,
+                nprobes=10,
+            ),
+        )
+    else:
+        print(
+            test_dataset.scanner(
+                columns=[],
+                with_row_id=True,
+                nearest=dict(column="vector", q=q, k=100, nprobes=10),
+                prefilter=True,
+                filter=filter,
+            ).explain_plan(True)
+        )
+        benchmark(
+            test_dataset.to_table,
+            columns=[],
+            with_row_id=True,
+            nearest=dict(
+                column="vector",
+                q=q,
+                k=100,
+                nprobes=10,
+            ),
             prefilter=True,
             filter=filter,
         )

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1103,7 +1103,7 @@ class LanceDataset(pa.dataset.Dataset):
     def create_scalar_index(
         self,
         column: str,
-        index_type: Union[Literal["BTREE"], Literal["BITMAP"], Literal["TAG"]],
+        index_type: Union[Literal["BTREE"], Literal["BITMAP"], Literal["LABEL_LIST"]],
         name: Optional[str] = None,
         *,
         replace: bool = True,
@@ -1169,11 +1169,11 @@ class LanceDataset(pa.dataset.Dataset):
         unique value in the column.  This index is useful for columns with a small
         number of unique values and many rows per value.
 
-        The ``TAG`` index type is a special index that is used to index list columns
-        whose values have small cardinality.  For example, a column that contains
-        lists of tags (e.g. ``["tag1", "tag2", "tag3"]``) can be indexed with a
-        ``TAG`` index.  This index can only speedup queries with ``array_has_any``
-        or ``array_has_all`` filters.
+        The ``LABEL_LIST`` index type is a special index that is used to index list
+        columns whose values have small cardinality.  For example, a column that
+        contains lists of tags (e.g. ``["tag1", "tag2", "tag3"]``) can be indexed
+        with a ``LABEL_LIST`` index.  This index can only speedup queries with
+        ``array_has_any`` or ``array_has_all`` filters.
 
         Note that the ``LANCE_BYPASS_SPILLING`` environment variable can be used to
         bypass spilling to disk. Setting this to true can avoid memory exhaustion
@@ -1220,10 +1220,10 @@ class LanceDataset(pa.dataset.Dataset):
             raise KeyError(f"{column} not found in schema")
 
         index_type = index_type.upper()
-        if index_type not in ["BTREE", "BITMAP", "TAG"]:
+        if index_type not in ["BTREE", "BITMAP", "LABEL_LIST"]:
             raise NotImplementedError(
                 (
-                    'Only "BTREE", "TAG", or "BITMAP" are supported for '
+                    'Only "BTREE", "LABEL_LIST", or "BITMAP" are supported for '
                     f"scalar columns.  Received {index_type}",
                 )
             )
@@ -1241,9 +1241,9 @@ class LanceDataset(pa.dataset.Dataset):
                     f"BTREE/BITMAP index column {column} must be int",
                     ", float, bool, str, or temporal",
                 )
-        elif index_type == "TAG":
+        elif index_type == "LABEL_LIST":
             if not pa.types.is_list(field.type):
-                raise TypeError(f"TAG index column {column} must be a list")
+                raise TypeError(f"LABEL_LIST index column {column} must be a list")
 
         if pa.types.is_duration(field.type):
             raise TypeError(

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -934,7 +934,7 @@ impl Dataset {
     ) -> PyResult<()> {
         let index_type = index_type.to_uppercase();
         let idx_type = match index_type.as_str() {
-            "BTREE" | "BITMAP" | "TAG" => IndexType::Scalar,
+            "BTREE" | "BITMAP" | "LABEL_LIST" => IndexType::Scalar,
             "IVF_PQ" | "IVF_HNSW_PQ" | "IVF_HNSW_SQ" => IndexType::Vector,
             _ => {
                 return Err(PyValueError::new_err(format!(
@@ -951,9 +951,9 @@ impl Dataset {
                 // Temporary workaround until we add support for auto-detection of scalar index type
                 force_index_type: Some(ScalarIndexType::Bitmap),
             })
-        } else if index_type == "TAG" {
+        } else if index_type == "LABEL_LIST" {
             Box::new(ScalarIndexParams {
-                force_index_type: Some(ScalarIndexType::Tag),
+                force_index_type: Some(ScalarIndexType::LabelList),
             })
         } else {
             let column_type = match self.ds.schema().field(columns[0]) {

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -934,7 +934,7 @@ impl Dataset {
     ) -> PyResult<()> {
         let index_type = index_type.to_uppercase();
         let idx_type = match index_type.as_str() {
-            "BTREE" | "BITMAP" => IndexType::Scalar,
+            "BTREE" | "BITMAP" | "TAG" => IndexType::Scalar,
             "IVF_PQ" | "IVF_HNSW_PQ" | "IVF_HNSW_SQ" => IndexType::Vector,
             _ => {
                 return Err(PyValueError::new_err(format!(
@@ -950,6 +950,10 @@ impl Dataset {
             Box::new(ScalarIndexParams {
                 // Temporary workaround until we add support for auto-detection of scalar index type
                 force_index_type: Some(ScalarIndexType::Bitmap),
+            })
+        } else if index_type == "TAG" {
+            Box::new(ScalarIndexParams {
+                force_index_type: Some(ScalarIndexType::Tag),
             })
         } else {
             let column_type = match self.ds.schema().field(columns[0]) {

--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -3,11 +3,15 @@
 
 use std::{ops::Bound, sync::Arc};
 
+use arrow_array::Array;
 use arrow_schema::DataType;
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 use datafusion_common::ScalarValue;
-use datafusion_expr::{expr::InList, Between, BinaryExpr, Expr, Operator};
+use datafusion_expr::{
+    expr::{InList, ScalarFunction},
+    Between, BinaryExpr, Expr, Operator, ScalarFunctionDefinition,
+};
 
 use futures::join;
 use lance_core::{
@@ -17,7 +21,7 @@ use lance_core::{
 use lance_datafusion::expr::safe_coerce_scalar;
 use tracing::instrument;
 
-use super::{ScalarIndex, ScalarQueryType};
+use super::{AnyQuery, SargableQuery, ScalarIndex, TagQuery};
 
 /// An indexed expression consists of a scalar index query with a post-scan filter
 ///
@@ -47,14 +51,174 @@ use super::{ScalarIndex, ScalarQueryType};
 /// When an operation cannot be performed we fallback to the original expression-only
 /// representation
 #[derive(Debug, PartialEq)]
-pub struct IndexedExpression<T: ScalarQueryType> {
+pub struct IndexedExpression {
     /// The portion of the query that can be satisfied by scalar indices
-    pub scalar_query: Option<ScalarIndexExpr<T>>,
+    pub scalar_query: Option<ScalarIndexExpr>,
     /// The portion of the query that cannot be satisfied by scalar indices
     pub refine_expr: Option<Expr>,
 }
 
-impl<T: ScalarQueryType> IndexedExpression<T> {
+pub trait ScalarQueryParser: std::fmt::Debug + Send + Sync {
+    fn visit_between(
+        &self,
+        column: &str,
+        low: ScalarValue,
+        high: ScalarValue,
+    ) -> Option<IndexedExpression>;
+    fn visit_in_list(&self, column: &str, in_list: Vec<ScalarValue>) -> Option<IndexedExpression>;
+    fn visit_is_bool(&self, column: &str, value: bool) -> Option<IndexedExpression>;
+    fn visit_is_null(&self, column: &str) -> Option<IndexedExpression>;
+    fn visit_comparison(
+        &self,
+        column: &str,
+        value: ScalarValue,
+        op: &Operator,
+    ) -> Option<IndexedExpression>;
+    fn visit_scalar_function(
+        &self,
+        column: &str,
+        data_type: &DataType,
+        func: &ScalarFunctionDefinition,
+        args: &[Expr],
+    ) -> Option<IndexedExpression>;
+}
+
+#[derive(Debug, Default)]
+pub struct SargableQueryParser {}
+
+impl ScalarQueryParser for SargableQueryParser {
+    fn visit_between(
+        &self,
+        column: &str,
+        low: ScalarValue,
+        high: ScalarValue,
+    ) -> Option<IndexedExpression> {
+        let query =
+            SargableQuery::Range(Bound::Included(low.clone()), Bound::Included(high.clone()));
+        Some(IndexedExpression::index_query(
+            column.to_string(),
+            Arc::new(query),
+        ))
+    }
+
+    fn visit_in_list(&self, column: &str, in_list: Vec<ScalarValue>) -> Option<IndexedExpression> {
+        let query = SargableQuery::IsIn(in_list);
+        Some(IndexedExpression::index_query(
+            column.to_string(),
+            Arc::new(query),
+        ))
+    }
+
+    fn visit_is_bool(&self, column: &str, value: bool) -> Option<IndexedExpression> {
+        Some(IndexedExpression::index_query(
+            column.to_string(),
+            Arc::new(SargableQuery::Equals(ScalarValue::Boolean(Some(value)))),
+        ))
+    }
+
+    fn visit_is_null(&self, column: &str) -> Option<IndexedExpression> {
+        Some(IndexedExpression::index_query(
+            column.to_string(),
+            Arc::new(SargableQuery::IsNull()),
+        ))
+    }
+
+    fn visit_comparison(
+        &self,
+        column: &str,
+        value: ScalarValue,
+        op: &Operator,
+    ) -> Option<IndexedExpression> {
+        let query = match op {
+            Operator::Lt => SargableQuery::Range(Bound::Unbounded, Bound::Excluded(value)),
+            Operator::LtEq => SargableQuery::Range(Bound::Unbounded, Bound::Included(value)),
+            Operator::Gt => SargableQuery::Range(Bound::Excluded(value), Bound::Unbounded),
+            Operator::GtEq => SargableQuery::Range(Bound::Included(value), Bound::Unbounded),
+            Operator::Eq => SargableQuery::Equals(value),
+            // This will be negated by the caller
+            Operator::NotEq => SargableQuery::Equals(value),
+            _ => unreachable!(),
+        };
+        Some(IndexedExpression::index_query(
+            column.to_string(),
+            Arc::new(query),
+        ))
+    }
+
+    fn visit_scalar_function(
+        &self,
+        _: &str,
+        _: &DataType,
+        _: &ScalarFunctionDefinition,
+        _: &[Expr],
+    ) -> Option<IndexedExpression> {
+        None
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct TagQueryParser {}
+
+impl ScalarQueryParser for TagQueryParser {
+    fn visit_between(&self, _: &str, _: ScalarValue, _: ScalarValue) -> Option<IndexedExpression> {
+        None
+    }
+
+    fn visit_in_list(&self, _: &str, _: Vec<ScalarValue>) -> Option<IndexedExpression> {
+        None
+    }
+
+    fn visit_is_bool(&self, _: &str, _: bool) -> Option<IndexedExpression> {
+        None
+    }
+
+    fn visit_is_null(&self, _: &str) -> Option<IndexedExpression> {
+        None
+    }
+
+    fn visit_comparison(&self, _: &str, _: ScalarValue, _: &Operator) -> Option<IndexedExpression> {
+        None
+    }
+
+    fn visit_scalar_function(
+        &self,
+        column: &str,
+        data_type: &DataType,
+        func: &ScalarFunctionDefinition,
+        args: &[Expr],
+    ) -> Option<IndexedExpression> {
+        if args.len() != 2 {
+            return None;
+        }
+        let tag_list = maybe_scalar(&args[1], data_type)?;
+        if let ScalarValue::List(list_arr) = tag_list {
+            let list_values = list_arr.values();
+            let mut scalars = Vec::with_capacity(list_values.len());
+            for idx in 0..list_values.len() {
+                scalars.push(ScalarValue::try_from_array(list_values.as_ref(), idx).ok()?);
+            }
+            if func.name() == "array_has_all" {
+                let query = TagQuery::HasAllTags(scalars);
+                Some(IndexedExpression::index_query(
+                    column.to_string(),
+                    Arc::new(query),
+                ))
+            } else if func.name() == "array_has_any" {
+                let query = TagQuery::HasOneTag(scalars);
+                Some(IndexedExpression::index_query(
+                    column.to_string(),
+                    Arc::new(query),
+                ))
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl IndexedExpression {
     /// Create an expression that only does refine
     fn refine_only(refine_expr: Expr) -> Self {
         Self {
@@ -64,7 +228,7 @@ impl<T: ScalarQueryType> IndexedExpression<T> {
     }
 
     /// Create an expression that is only an index query
-    fn index_query(column: String, query: T) -> Self {
+    fn index_query(column: String, query: Arc<dyn AnyQuery>) -> Self {
         Self {
             scalar_query: Some(ScalarIndexExpr::Query(column, query)),
             refine_expr: None,
@@ -188,26 +352,38 @@ pub trait ScalarIndexLoader: Send + Sync {
 ///
 /// This is a tree of operations beacause we may need to logically combine or
 /// modify the results of scalar lookups
-#[derive(Debug, Clone, PartialEq)]
-pub enum ScalarIndexExpr<T: ScalarQueryType> {
-    Not(Box<ScalarIndexExpr<T>>),
-    And(Box<ScalarIndexExpr<T>>, Box<ScalarIndexExpr<T>>),
-    Or(Box<ScalarIndexExpr<T>>, Box<ScalarIndexExpr<T>>),
-    Query(String, T),
+#[derive(Debug, Clone)]
+pub enum ScalarIndexExpr {
+    Not(Box<ScalarIndexExpr>),
+    And(Box<ScalarIndexExpr>, Box<ScalarIndexExpr>),
+    Or(Box<ScalarIndexExpr>, Box<ScalarIndexExpr>),
+    Query(String, Arc<dyn AnyQuery>),
 }
 
-impl<T: ScalarQueryType> std::fmt::Display for ScalarIndexExpr<T> {
+impl PartialEq for ScalarIndexExpr {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Not(l0), Self::Not(r0)) => l0 == r0,
+            (Self::And(l0, l1), Self::And(r0, r1)) => l0 == r0 && l1 == r1,
+            (Self::Or(l0, l1), Self::Or(r0, r1)) => l0 == r0 && l1 == r1,
+            (Self::Query(l0, l1), Self::Query(r0, r1)) => l0 == r0 && l1 == r1,
+            _ => false,
+        }
+    }
+}
+
+impl std::fmt::Display for ScalarIndexExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Not(inner) => write!(f, "NOT({})", inner),
             Self::And(lhs, rhs) => write!(f, "AND({},{})", lhs, rhs),
             Self::Or(lhs, rhs) => write!(f, "OR({},{})", lhs, rhs),
-            Self::Query(column, query) => write!(f, "{}", query.fmt_with_col(column)),
+            Self::Query(column, query) => write!(f, "{}", query.format(column)),
         }
     }
 }
 
-impl<T: ScalarQueryType> ScalarIndexExpr<T> {
+impl ScalarIndexExpr {
     /// Evaluates the scalar index expression
     ///
     /// This will result in loading one or more scalar indices and searching them
@@ -236,7 +412,7 @@ impl<T: ScalarQueryType> ScalarIndexExpr<T> {
             }
             Self::Query(column, query) => {
                 let index = index_loader.load_index(column).await?;
-                let matching_row_ids = index.search(query).await?;
+                let matching_row_ids = index.search(query.as_ref()).await?;
                 let allow_list = RowIdTreeMap::from_iter(matching_row_ids.values().iter());
                 Ok(RowIdMask {
                     block_list: None,
@@ -276,10 +452,10 @@ fn maybe_column(expr: &Expr) -> Option<&str> {
 fn maybe_indexed_column<'a, 'b>(
     expr: &'a Expr,
     index_info: &'b dyn IndexInformationProvider,
-) -> Option<(&'a str, &'b DataType)> {
+) -> Option<(&'a str, &'b DataType, &'b dyn ScalarQueryParser)> {
     let col = maybe_column(expr)?;
     let data_type = index_info.get_index(col);
-    data_type.map(|ty| (col, ty))
+    data_type.map(|(ty, parser)| (col, ty, parser))
 }
 
 // Extract a literal scalar value from an expression, if it is a literal, or None
@@ -310,12 +486,12 @@ fn visit_between(
     between: &Between,
     index_info: &dyn IndexInformationProvider,
 ) -> Option<IndexedExpression> {
-    let (column, col_type) = maybe_indexed_column(&between.expr, index_info)?;
+    let (column, col_type, query_parser) = maybe_indexed_column(&between.expr, index_info)?;
     let low = maybe_scalar(&between.low, col_type)?;
     let high = maybe_scalar(&between.high, col_type)?;
 
-    let query = ScalarQuery::Range(Bound::Included(low.clone()), Bound::Included(high.clone()));
-    let indexed_expr = IndexedExpression::index_query(column.to_string(), query);
+    let indexed_expr = query_parser.visit_between(column, low, high)?;
+
     if between.negated {
         indexed_expr.maybe_not()
     } else {
@@ -327,11 +503,11 @@ fn visit_in_list(
     in_list: &InList,
     index_info: &dyn IndexInformationProvider,
 ) -> Option<IndexedExpression> {
-    let (column, col_type) = maybe_indexed_column(&in_list.expr, index_info)?;
+    let (column, col_type, query_parser) = maybe_indexed_column(&in_list.expr, index_info)?;
     let values = maybe_scalar_list(&in_list.list, col_type)?;
 
-    let query = ScalarQuery::IsIn(values);
-    let indexed_expr = IndexedExpression::index_query(column.to_string(), query);
+    let indexed_expr = query_parser.visit_in_list(column, values)?;
+
     if in_list.negated {
         indexed_expr.maybe_not()
     } else {
@@ -344,14 +520,11 @@ fn visit_is_bool(
     index_info: &dyn IndexInformationProvider,
     value: bool,
 ) -> Option<IndexedExpression> {
-    let (column, col_type) = maybe_indexed_column(expr, index_info)?;
+    let (column, col_type, query_parser) = maybe_indexed_column(expr, index_info)?;
     if *col_type != DataType::Boolean {
         None
     } else {
-        Some(IndexedExpression::index_query(
-            column.to_string(),
-            ScalarQuery::Equals(ScalarValue::Boolean(Some(value))),
-        ))
+        query_parser.visit_is_bool(column, value)
     }
 }
 
@@ -360,14 +533,11 @@ fn visit_column(
     col: &Expr,
     index_info: &dyn IndexInformationProvider,
 ) -> Option<IndexedExpression> {
-    let (column, col_type) = maybe_indexed_column(col, index_info)?;
+    let (column, col_type, query_parser) = maybe_indexed_column(col, index_info)?;
     if *col_type != DataType::Boolean {
         None
     } else {
-        Some(IndexedExpression::index_query(
-            column.to_string(),
-            ScalarQuery::Equals(ScalarValue::Boolean(Some(true))),
-        ))
+        query_parser.visit_is_bool(column, true)
     }
 }
 
@@ -376,8 +546,8 @@ fn visit_is_null(
     index_info: &dyn IndexInformationProvider,
     negated: bool,
 ) -> Option<IndexedExpression> {
-    let (column, _) = maybe_indexed_column(expr, index_info)?;
-    let indexed_expr = IndexedExpression::index_query(column.to_string(), ScalarQuery::IsNull());
+    let (column, _, query_parser) = maybe_indexed_column(expr, index_info)?;
+    let indexed_expr = query_parser.visit_is_null(column)?;
     if negated {
         indexed_expr.maybe_not()
     } else {
@@ -390,37 +560,18 @@ fn visit_not(expr: &Expr, index_info: &dyn IndexInformationProvider) -> Option<I
     node.maybe_not()
 }
 
-fn visit_comparison_normalized(scalar: ScalarValue, op: &Operator) -> ScalarQuery {
-    match op {
-        Operator::Lt => ScalarQuery::Range(Bound::Unbounded, Bound::Excluded(scalar)),
-        Operator::LtEq => ScalarQuery::Range(Bound::Unbounded, Bound::Included(scalar)),
-        Operator::Gt => ScalarQuery::Range(Bound::Excluded(scalar), Bound::Unbounded),
-        Operator::GtEq => ScalarQuery::Range(Bound::Included(scalar), Bound::Unbounded),
-        Operator::Eq => ScalarQuery::Equals(scalar),
-        // This will be negated by the caller
-        Operator::NotEq => ScalarQuery::Equals(scalar),
-        _ => unreachable!(),
-    }
-}
-
 fn visit_comparison(
     expr: &BinaryExpr,
     index_info: &dyn IndexInformationProvider,
 ) -> Option<IndexedExpression> {
     let left_col = maybe_indexed_column(&expr.left, index_info);
-    if let Some((column, col_type)) = left_col {
+    if let Some((column, col_type, query_parser)) = left_col {
         let scalar = maybe_scalar(&expr.right, col_type)?;
-        Some(IndexedExpression::index_query(
-            column.to_string(),
-            visit_comparison_normalized(scalar, &expr.op),
-        ))
+        query_parser.visit_comparison(column, scalar, &expr.op)
     } else {
-        let (column, col_type) = maybe_indexed_column(&expr.right, index_info)?;
+        let (column, col_type, query_parser) = maybe_indexed_column(&expr.right, index_info)?;
         let scalar = maybe_scalar(&expr.left, col_type)?;
-        Some(IndexedExpression::index_query(
-            column.to_string(),
-            visit_comparison_normalized(scalar, &expr.op),
-        ))
+        query_parser.visit_comparison(column, scalar, &expr.op)
     }
 }
 
@@ -473,6 +624,17 @@ fn visit_binary_expr(
     }
 }
 
+fn visit_scalar_fn(
+    scalar_fn: &ScalarFunction,
+    index_info: &dyn IndexInformationProvider,
+) -> Option<IndexedExpression> {
+    if scalar_fn.args.is_empty() {
+        return None;
+    }
+    let (col, data_type, query_parser) = maybe_indexed_column(&scalar_fn.args[0], index_info)?;
+    query_parser.visit_scalar_function(col, data_type, &scalar_fn.func_def, &scalar_fn.args)
+}
+
 fn visit_node(expr: &Expr, index_info: &dyn IndexInformationProvider) -> Option<IndexedExpression> {
     match expr {
         Expr::Between(between) => visit_between(between, index_info),
@@ -484,6 +646,7 @@ fn visit_node(expr: &Expr, index_info: &dyn IndexInformationProvider) -> Option<
         Expr::IsNotNull(expr) => visit_is_null(expr.as_ref(), index_info, true),
         Expr::Not(expr) => visit_not(expr.as_ref(), index_info),
         Expr::BinaryExpr(binary_expr) => visit_binary_expr(binary_expr, index_info),
+        Expr::ScalarFunction(scalar_fn) => visit_scalar_fn(scalar_fn, index_info),
         _ => None,
     }
 }
@@ -491,7 +654,7 @@ fn visit_node(expr: &Expr, index_info: &dyn IndexInformationProvider) -> Option<
 /// A trait to be used in `apply_scalar_indices` to inform the function which columns are indexeds
 pub trait IndexInformationProvider {
     /// Check if an index exists for `col` and, if so, return the data type of col
-    fn get_index(&self, col: &str) -> Option<&DataType>;
+    fn get_index(&self, col: &str) -> Option<(&DataType, &dyn ScalarQueryParser)>;
 }
 
 /// Attempt to split a filter expression into a search of scalar indexes and an
@@ -517,12 +680,23 @@ mod tests {
 
     use super::*;
 
+    struct ColInfo {
+        data_type: DataType,
+        parser: Box<dyn ScalarQueryParser>,
+    }
+
+    impl ColInfo {
+        fn new(data_type: DataType, parser: Box<dyn ScalarQueryParser>) -> Self {
+            Self { data_type, parser }
+        }
+    }
+
     struct MockIndexInfoProvider {
-        indexed_columns: HashMap<String, DataType>,
+        indexed_columns: HashMap<String, ColInfo>,
     }
 
     impl MockIndexInfoProvider {
-        fn new(indexed_columns: Vec<(&str, DataType)>) -> Self {
+        fn new(indexed_columns: Vec<(&str, ColInfo)>) -> Self {
             Self {
                 indexed_columns: HashMap::from_iter(
                     indexed_columns
@@ -534,8 +708,10 @@ mod tests {
     }
 
     impl IndexInformationProvider for MockIndexInfoProvider {
-        fn get_index(&self, col: &str) -> Option<&DataType> {
-            self.indexed_columns.get(col)
+        fn get_index(&self, col: &str) -> Option<(&DataType, &dyn ScalarQueryParser)> {
+            self.indexed_columns
+                .get(col)
+                .map(|col_info| (&col_info.data_type, col_info.parser.as_ref()))
         }
     }
 
@@ -620,12 +796,15 @@ mod tests {
         index_info: &dyn IndexInformationProvider,
         expr: &str,
         col: &str,
-        query: ScalarQuery,
+        query: SargableQuery,
     ) {
         check(
             index_info,
             expr,
-            Some(IndexedExpression::index_query(col.to_string(), query)),
+            Some(IndexedExpression::index_query(
+                col.to_string(),
+                Arc::new(query),
+            )),
         )
     }
 
@@ -633,13 +812,13 @@ mod tests {
         index_info: &dyn IndexInformationProvider,
         expr: &str,
         col: &str,
-        query: ScalarQuery,
+        query: SargableQuery,
     ) {
         check(
             index_info,
             expr,
             Some(
-                IndexedExpression::index_query(col.to_string(), query)
+                IndexedExpression::index_query(col.to_string(), Arc::new(query))
                     .maybe_not()
                     .unwrap(),
             ),
@@ -649,10 +828,22 @@ mod tests {
     #[test]
     fn test_expressions() {
         let index_info = MockIndexInfoProvider::new(vec![
-            ("color", DataType::Utf8),
-            ("aisle", DataType::UInt32),
-            ("on_sale", DataType::Boolean),
-            ("price", DataType::Float32),
+            (
+                "color",
+                ColInfo::new(DataType::Utf8, Box::<SargableQueryParser>::default()),
+            ),
+            (
+                "aisle",
+                ColInfo::new(DataType::UInt32, Box::<SargableQueryParser>::default()),
+            ),
+            (
+                "on_sale",
+                ColInfo::new(DataType::Boolean, Box::<SargableQueryParser>::default()),
+            ),
+            (
+                "price",
+                ColInfo::new(DataType::Float32, Box::<SargableQueryParser>::default()),
+            ),
         ]);
 
         check_no_index(&index_info, "size BETWEEN 5 AND 10");
@@ -660,7 +851,7 @@ mod tests {
             &index_info,
             "aisle BETWEEN 5 AND 10",
             "aisle",
-            ScalarQuery::Range(
+            SargableQuery::Range(
                 Bound::Included(ScalarValue::UInt32(Some(5))),
                 Bound::Included(ScalarValue::UInt32(Some(10))),
             ),
@@ -669,31 +860,31 @@ mod tests {
             &index_info,
             "on_sale IS TRUE",
             "on_sale",
-            ScalarQuery::Equals(ScalarValue::Boolean(Some(true))),
+            SargableQuery::Equals(ScalarValue::Boolean(Some(true))),
         );
         check_simple(
             &index_info,
             "on_sale",
             "on_sale",
-            ScalarQuery::Equals(ScalarValue::Boolean(Some(true))),
+            SargableQuery::Equals(ScalarValue::Boolean(Some(true))),
         );
         check_simple_negated(
             &index_info,
             "NOT on_sale",
             "on_sale",
-            ScalarQuery::Equals(ScalarValue::Boolean(Some(true))),
+            SargableQuery::Equals(ScalarValue::Boolean(Some(true))),
         );
         check_simple(
             &index_info,
             "on_sale IS FALSE",
             "on_sale",
-            ScalarQuery::Equals(ScalarValue::Boolean(Some(false))),
+            SargableQuery::Equals(ScalarValue::Boolean(Some(false))),
         );
         check_simple_negated(
             &index_info,
             "aisle NOT BETWEEN 5 AND 10",
             "aisle",
-            ScalarQuery::Range(
+            SargableQuery::Range(
                 Bound::Included(ScalarValue::UInt32(Some(5))),
                 Bound::Included(ScalarValue::UInt32(Some(10))),
             ),
@@ -702,7 +893,7 @@ mod tests {
             &index_info,
             "aisle IN (5, 6, 7)",
             "aisle",
-            ScalarQuery::IsIn(vec![
+            SargableQuery::IsIn(vec![
                 ScalarValue::UInt32(Some(5)),
                 ScalarValue::UInt32(Some(6)),
                 ScalarValue::UInt32(Some(7)),
@@ -712,7 +903,7 @@ mod tests {
             &index_info,
             "NOT aisle IN (5, 6, 7)",
             "aisle",
-            ScalarQuery::IsIn(vec![
+            SargableQuery::IsIn(vec![
                 ScalarValue::UInt32(Some(5)),
                 ScalarValue::UInt32(Some(6)),
                 ScalarValue::UInt32(Some(7)),
@@ -722,7 +913,7 @@ mod tests {
             &index_info,
             "aisle NOT IN (5, 6, 7)",
             "aisle",
-            ScalarQuery::IsIn(vec![
+            SargableQuery::IsIn(vec![
                 ScalarValue::UInt32(Some(5)),
                 ScalarValue::UInt32(Some(6)),
                 ScalarValue::UInt32(Some(7)),
@@ -732,19 +923,19 @@ mod tests {
             &index_info,
             "on_sale is false",
             "on_sale",
-            ScalarQuery::Equals(ScalarValue::Boolean(Some(false))),
+            SargableQuery::Equals(ScalarValue::Boolean(Some(false))),
         );
         check_simple(
             &index_info,
             "on_sale is true",
             "on_sale",
-            ScalarQuery::Equals(ScalarValue::Boolean(Some(true))),
+            SargableQuery::Equals(ScalarValue::Boolean(Some(true))),
         );
         check_simple(
             &index_info,
             "aisle < 10",
             "aisle",
-            ScalarQuery::Range(
+            SargableQuery::Range(
                 Bound::Unbounded,
                 Bound::Excluded(ScalarValue::UInt32(Some(10))),
             ),
@@ -753,7 +944,7 @@ mod tests {
             &index_info,
             "aisle <= 10",
             "aisle",
-            ScalarQuery::Range(
+            SargableQuery::Range(
                 Bound::Unbounded,
                 Bound::Included(ScalarValue::UInt32(Some(10))),
             ),
@@ -762,7 +953,7 @@ mod tests {
             &index_info,
             "aisle > 10",
             "aisle",
-            ScalarQuery::Range(
+            SargableQuery::Range(
                 Bound::Excluded(ScalarValue::UInt32(Some(10))),
                 Bound::Unbounded,
             ),
@@ -771,7 +962,7 @@ mod tests {
             &index_info,
             "aisle >= 10",
             "aisle",
-            ScalarQuery::Range(
+            SargableQuery::Range(
                 Bound::Included(ScalarValue::UInt32(Some(10))),
                 Bound::Unbounded,
             ),
@@ -780,22 +971,24 @@ mod tests {
             &index_info,
             "aisle = 10",
             "aisle",
-            ScalarQuery::Equals(ScalarValue::UInt32(Some(10))),
+            SargableQuery::Equals(ScalarValue::UInt32(Some(10))),
         );
         check_simple_negated(
             &index_info,
             "aisle <> 10",
             "aisle",
-            ScalarQuery::Equals(ScalarValue::UInt32(Some(10))),
+            SargableQuery::Equals(ScalarValue::UInt32(Some(10))),
         );
         // // Common compound case, AND'd clauses
         let left = Box::new(ScalarIndexExpr::Query(
             "aisle".to_string(),
-            ScalarQuery::Equals(ScalarValue::UInt32(Some(10))),
+            Arc::new(SargableQuery::Equals(ScalarValue::UInt32(Some(10)))),
         ));
         let right = Box::new(ScalarIndexExpr::Query(
             "color".to_string(),
-            ScalarQuery::Equals(ScalarValue::Utf8(Some("blue".to_string()))),
+            Arc::new(SargableQuery::Equals(ScalarValue::Utf8(Some(
+                "blue".to_string(),
+            )))),
         ));
         check(
             &index_info,

--- a/rust/lance-index/src/scalar/flat.rs
+++ b/rust/lance-index/src/scalar/flat.rs
@@ -20,7 +20,8 @@ use snafu::{location, Location};
 
 use crate::{Index, IndexType};
 
-use super::{btree::BTreeSubIndex, IndexStore, ScalarIndex, ScalarQuery};
+use super::{btree::BTreeSubIndex, IndexStore, ScalarIndex};
+use super::{AnyQuery, SargableQuery};
 
 /// A flat index is just a batch of value/row-id pairs
 ///
@@ -190,13 +191,14 @@ impl Index for FlatIndex {
 
 #[async_trait]
 impl ScalarIndex for FlatIndex {
-    async fn search(&self, query: &ScalarQuery) -> Result<UInt64Array> {
+    async fn search(&self, query: &dyn AnyQuery) -> Result<UInt64Array> {
+        let query = query.as_any().downcast_ref::<SargableQuery>().unwrap();
         // Since we have all the values in memory we can use basic arrow-rs compute
         // functions to satisfy scalar queries.
         let predicate = match query {
-            ScalarQuery::Equals(value) => arrow_ord::cmp::eq(self.values(), &value.to_scalar()?)?,
-            ScalarQuery::IsNull() => arrow::compute::is_null(self.values())?,
-            ScalarQuery::IsIn(values) => {
+            SargableQuery::Equals(value) => arrow_ord::cmp::eq(self.values(), &value.to_scalar()?)?,
+            SargableQuery::IsNull() => arrow::compute::is_null(self.values())?,
+            SargableQuery::IsIn(values) => {
                 let choices = values
                     .iter()
                     .map(|val| lit(val.clone()))
@@ -215,7 +217,7 @@ impl ScalarIndex for FlatIndex {
                     .expect("InList evaluation should return boolean array")
                     .clone()
             }
-            ScalarQuery::Range(lower_bound, upper_bound) => match (lower_bound, upper_bound) {
+            SargableQuery::Range(lower_bound, upper_bound) => match (lower_bound, upper_bound) {
                 (Bound::Unbounded, Bound::Unbounded) => {
                     panic!("Scalar range query received with no upper or lower bound")
                 }
@@ -248,7 +250,7 @@ impl ScalarIndex for FlatIndex {
                     &arrow_ord::cmp::lt(self.values(), &upper.to_scalar()?)?,
                 )?,
             },
-            ScalarQuery::FullTextSearch(_) => return Err(Error::invalid_input(
+            SargableQuery::FullTextSearch(_) => return Err(Error::invalid_input(
                 "full text search is not supported for flat index, build a inverted index for it",
                 location!(),
             )),
@@ -318,7 +320,7 @@ mod tests {
         }
     }
 
-    async fn check_index(query: &ScalarQuery, expected: &[u64]) {
+    async fn check_index(query: &SargableQuery, expected: &[u64]) {
         let index = example_index();
         let actual = index.search(query).await.unwrap();
         let expected = UInt64Array::from_iter_values(expected.iter().copied());
@@ -327,15 +329,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_equality() {
-        check_index(&ScalarQuery::Equals(ScalarValue::from(100)), &[0]).await;
-        check_index(&ScalarQuery::Equals(ScalarValue::from(10)), &[5]).await;
-        check_index(&ScalarQuery::Equals(ScalarValue::from(5)), &[]).await;
+        check_index(&SargableQuery::Equals(ScalarValue::from(100)), &[0]).await;
+        check_index(&SargableQuery::Equals(ScalarValue::from(10)), &[5]).await;
+        check_index(&SargableQuery::Equals(ScalarValue::from(5)), &[]).await;
     }
 
     #[tokio::test]
     async fn test_range() {
         check_index(
-            &ScalarQuery::Range(
+            &SargableQuery::Range(
                 Bound::Included(ScalarValue::from(100)),
                 Bound::Excluded(ScalarValue::from(1234)),
             ),
@@ -343,17 +345,17 @@ mod tests {
         )
         .await;
         check_index(
-            &ScalarQuery::Range(Bound::Unbounded, Bound::Excluded(ScalarValue::from(1000))),
+            &SargableQuery::Range(Bound::Unbounded, Bound::Excluded(ScalarValue::from(1000))),
             &[5, 0],
         )
         .await;
         check_index(
-            &ScalarQuery::Range(Bound::Included(ScalarValue::from(0)), Bound::Unbounded),
+            &SargableQuery::Range(Bound::Included(ScalarValue::from(0)), Bound::Unbounded),
             &[5, 0, 3, 100],
         )
         .await;
         check_index(
-            &ScalarQuery::Range(Bound::Included(ScalarValue::from(100000)), Bound::Unbounded),
+            &SargableQuery::Range(Bound::Included(ScalarValue::from(100000)), Bound::Unbounded),
             &[],
         )
         .await;
@@ -362,7 +364,7 @@ mod tests {
     #[tokio::test]
     async fn test_is_in() {
         check_index(
-            &ScalarQuery::IsIn(vec![
+            &SargableQuery::IsIn(vec![
                 ScalarValue::from(100),
                 ScalarValue::from(1234),
                 ScalarValue::from(3000),

--- a/rust/lance-index/src/scalar/tag.rs
+++ b/rust/lance-index/src/scalar/tag.rs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{
+    any::Any,
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+    sync::Arc,
+};
+
+use arrow::array::AsArray;
+use arrow_array::{Array, RecordBatch, UInt64Array};
+use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
+use async_trait::async_trait;
+use datafusion::physical_plan::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream};
+use datafusion_common::ScalarValue;
+use deepsize::DeepSizeOf;
+use futures::TryStreamExt;
+use lance_core::{Error, Result};
+use roaring::RoaringBitmap;
+use snafu::{location, Location};
+
+use crate::{Index, IndexType};
+
+use super::{bitmap::train_bitmap_index, SargableQuery};
+use super::{
+    bitmap::BitmapIndex, btree::BtreeTrainingSource, AnyQuery, IndexStore, ScalarIndex, TagQuery,
+};
+
+pub const BITMAP_LOOKUP_NAME: &str = "bitmap_page_lookup.lance";
+
+trait TagSubIndex: ScalarIndex + DeepSizeOf {}
+
+impl<T: ScalarIndex + DeepSizeOf> TagSubIndex for T {}
+
+/// A scalar index that can be used on List<T> columns to
+/// support queries with array_contains_all and array_contains_any
+/// using an underlying bitmap index.
+#[derive(Clone, Debug, DeepSizeOf)]
+pub struct TagIndex {
+    values_index: Arc<dyn TagSubIndex>,
+}
+
+impl TagIndex {
+    fn new(values_index: Arc<dyn TagSubIndex>) -> Self {
+        Self { values_index }
+    }
+}
+
+#[async_trait]
+impl Index for TagIndex {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+        self
+    }
+
+    fn as_vector_index(self: Arc<Self>) -> Result<Arc<dyn crate::vector::VectorIndex>> {
+        Err(Error::NotSupported {
+            source: "TagIndex is not a vector index".into(),
+            location: location!(),
+        })
+    }
+
+    fn index_type(&self) -> IndexType {
+        IndexType::Scalar
+    }
+
+    fn statistics(&self) -> Result<serde_json::Value> {
+        self.values_index.statistics()
+    }
+
+    async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {
+        unimplemented!()
+    }
+}
+
+impl TagIndex {
+    async fn search_values(&self, values: &Vec<ScalarValue>) -> Result<Vec<UInt64Array>> {
+        let mut value_results = Vec::with_capacity(values.len());
+        for value in values {
+            let value_query = SargableQuery::Equals(value.clone());
+            value_results.push(self.values_index.search(&value_query).await?);
+        }
+        Ok(value_results)
+    }
+
+    fn set_union(&self, sets: Vec<UInt64Array>) -> UInt64Array {
+        if sets.len() == 1 {
+            sets.into_iter().next().unwrap()
+        } else {
+            let combined = sets
+                .iter()
+                .flat_map(|arr| arr.values())
+                .copied()
+                .collect::<HashSet<_>>();
+            UInt64Array::from_iter_values(combined)
+        }
+    }
+
+    fn set_intersection(&self, sets: Vec<UInt64Array>) -> UInt64Array {
+        let mut set_iter = sets.into_iter();
+        let mut all: HashSet<_> = set_iter.next().unwrap().into_iter().collect();
+        for next in set_iter {
+            let next_set = next.into_iter().collect::<HashSet<_>>();
+            all.retain(|item| !next_set.contains(item));
+        }
+        all.into_iter().collect()
+    }
+}
+
+#[async_trait]
+impl ScalarIndex for TagIndex {
+    async fn search(&self, query: &dyn AnyQuery) -> Result<UInt64Array> {
+        let query = query.as_any().downcast_ref::<TagQuery>().unwrap();
+
+        match query {
+            TagQuery::HasAllTags(tags) => {
+                let values_results = self.search_values(tags).await?;
+                Ok(self.set_union(values_results))
+            }
+            TagQuery::HasOneTag(tags) => {
+                let values_results = self.search_values(tags).await?;
+                Ok(self.set_intersection(values_results))
+            }
+        }
+    }
+
+    async fn load(store: Arc<dyn IndexStore>) -> Result<Arc<Self>> {
+        BitmapIndex::load(store)
+            .await
+            .map(|index| Arc::new(Self::new(index)))
+    }
+
+    /// Remap the row ids, creating a new remapped version of this index in `dest_store`
+    async fn remap(
+        &self,
+        mapping: &HashMap<u64, Option<u64>>,
+        dest_store: &dyn IndexStore,
+    ) -> Result<()> {
+        self.values_index.remap(mapping, dest_store).await
+    }
+
+    /// Add the new data into the index, creating an updated version of the index in `dest_store`
+    async fn update(
+        &self,
+        new_data: SendableRecordBatchStream,
+        dest_store: &dyn IndexStore,
+    ) -> Result<()> {
+        self.values_index.update(new_data, dest_store).await
+    }
+}
+
+fn extract_flatten_indices(list_arr: &dyn Array) -> UInt64Array {
+    if let Some(list_arr) = list_arr.as_list_opt::<i32>() {
+        let mut indices = Vec::with_capacity(list_arr.values().len());
+        let offsets = list_arr.value_offsets();
+        for (offset_idx, w) in offsets.windows(2).enumerate() {
+            let size = (w[1] - w[0]) as u64;
+            indices.extend((0..size).map(|_| offset_idx as u64));
+        }
+        UInt64Array::from(indices)
+    } else if let Some(list_arr) = list_arr.as_list_opt::<i64>() {
+        let mut indices = Vec::with_capacity(list_arr.values().len());
+        let offsets = list_arr.value_offsets();
+        for (offset_idx, w) in offsets.windows(2).enumerate() {
+            let size = (w[1] - w[0]) as u64;
+            indices.extend((0..size).map(|_| offset_idx as u64));
+        }
+        UInt64Array::from(indices)
+    } else {
+        unreachable!("Should verify that the first column is a list earlier")
+    }
+}
+
+fn unnest_schema(schema: &Schema) -> SchemaRef {
+    let mut fields_iter = schema.fields.iter().cloned();
+    let key_field = fields_iter.next().unwrap();
+    let remaining_fields = fields_iter.collect::<Vec<_>>();
+
+    let new_key_field = if let DataType::List(item_field) = key_field.data_type() {
+        Field::new(
+            key_field.name(),
+            item_field.data_type().clone(),
+            item_field.is_nullable() || key_field.is_nullable(),
+        )
+    } else {
+        unreachable!("Should verify that the first column is a list earlier")
+    };
+
+    let all_fields = vec![Arc::new(new_key_field)]
+        .into_iter()
+        .chain(remaining_fields)
+        .collect::<Vec<_>>();
+
+    Arc::new(Schema::new(Fields::from(all_fields)))
+}
+
+fn unnest_batch(
+    batch: arrow::record_batch::RecordBatch,
+    unnest_schema: SchemaRef,
+) -> datafusion_common::Result<RecordBatch> {
+    let mut columns_iter = batch.columns().iter().cloned();
+    let key_col = columns_iter.next().unwrap();
+    let remaining_cols = columns_iter.collect::<Vec<_>>();
+
+    let remaining_fields = unnest_schema
+        .fields
+        .iter()
+        .skip(1)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let remaining_batch = RecordBatch::try_new(
+        Arc::new(Schema::new(Fields::from(remaining_fields.clone()))),
+        remaining_cols,
+    )?;
+
+    let flatten_indices = extract_flatten_indices(key_col.as_ref());
+
+    let flattened_remaining =
+        arrow_select::take::take_record_batch(&remaining_batch, &flatten_indices)?;
+
+    let new_key_values = if let Some(key_list) = key_col.as_list_opt::<i32>() {
+        let value_start = key_list.value_offsets()[key_list.offset()] as usize;
+        let value_stop = key_list.value_offsets()[key_list.len()] as usize;
+        key_list
+            .values()
+            .slice(value_start, value_stop - value_start)
+            .clone()
+    } else if let Some(key_list) = key_col.as_list_opt::<i64>() {
+        let value_start = key_list.value_offsets()[key_list.offset()] as usize;
+        let value_stop = key_list.value_offsets()[key_list.len()] as usize;
+        key_list
+            .values()
+            .slice(value_start, value_stop - value_start)
+            .clone()
+    } else {
+        unreachable!("Should verify that the first column is a list earlier")
+    };
+
+    let all_columns = vec![new_key_values]
+        .into_iter()
+        .chain(flattened_remaining.columns().iter().cloned())
+        .collect::<Vec<_>>();
+
+    datafusion_common::Result::Ok(arrow::record_batch::RecordBatch::try_new(
+        unnest_schema,
+        all_columns,
+    )?)
+}
+
+struct UnnestTrainingSource {
+    source: Box<dyn BtreeTrainingSource>,
+}
+
+#[async_trait]
+impl BtreeTrainingSource for UnnestTrainingSource {
+    async fn scan_ordered_chunks(
+        self: Box<Self>,
+        chunk_size: u32,
+    ) -> Result<SendableRecordBatchStream> {
+        let source = self.source.scan_ordered_chunks(chunk_size).await?;
+        let unnest_schema = unnest_schema(source.schema().as_ref());
+        let unnest_schema_copy = unnest_schema.clone();
+        let source = source.try_filter_map(move |batch| {
+            std::future::ready(Some(unnest_batch(batch, unnest_schema.clone())).transpose())
+        });
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            unnest_schema_copy.clone(),
+            source,
+        )))
+    }
+}
+
+/// Trains a new tag index
+pub async fn train_tag_index(
+    data_source: Box<dyn BtreeTrainingSource + Send>,
+    index_store: &dyn IndexStore,
+) -> Result<()> {
+    let unnest_source = Box::new(UnnestTrainingSource {
+        source: data_source,
+    });
+
+    train_bitmap_index(unnest_source, index_store).await
+}

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -19,7 +19,7 @@ use lance_index::scalar::{
     btree::{train_btree_index, BTreeIndex, BtreeTrainingSource},
     flat::FlatIndexMetadata,
     lance_format::LanceIndexStore,
-    IndexStore, ScalarIndex, ScalarQuery,
+    IndexStore, SargableQuery, ScalarIndex,
 };
 #[cfg(target_os = "linux")]
 use pprof::criterion::{Output, PProfProfiler};
@@ -114,7 +114,7 @@ async fn baseline_equality_search(fixture: &BenchmarkFixture) {
 
 async fn warm_indexed_equality_search(index: &BTreeIndex) {
     let row_ids = index
-        .search(&ScalarQuery::Equals(ScalarValue::UInt32(Some(10000))))
+        .search(&SargableQuery::Equals(ScalarValue::UInt32(Some(10000))))
         .await
         .unwrap();
     assert_eq!(row_ids.len(), 1);
@@ -140,7 +140,7 @@ async fn baseline_inequality_search(fixture: &BenchmarkFixture) {
 
 async fn warm_indexed_inequality_search(index: &BTreeIndex) {
     let row_ids = index
-        .search(&ScalarQuery::Range(
+        .search(&SargableQuery::Range(
             std::ops::Bound::Included(ScalarValue::UInt32(Some(50_000_000))),
             std::ops::Bound::Unbounded,
         ))
@@ -152,7 +152,7 @@ async fn warm_indexed_inequality_search(index: &BTreeIndex) {
 
 async fn warm_indexed_isin_search(index: &BTreeIndex) {
     let row_ids = index
-        .search(&ScalarQuery::IsIn(vec![
+        .search(&SargableQuery::IsIn(vec![
             ScalarValue::UInt32(Some(10000)),
             ScalarValue::UInt32(Some(50000000)),
             ScalarValue::UInt32(Some(150000000)), // Not found

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -15,7 +15,9 @@ use lance_file::reader::FileReader;
 use lance_file::v2;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::pb::index::Implementation;
-use lance_index::scalar::expression::IndexInformationProvider;
+use lance_index::scalar::expression::{
+    IndexInformationProvider, SargableQueryParser, ScalarQueryParser, TagQueryParser,
+};
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::ScalarIndex;
 use lance_index::vector::flat::index::{FlatIndex, FlatQuantizer};
@@ -127,12 +129,14 @@ pub(crate) async fn remap_index(
 
 #[derive(Debug)]
 pub struct ScalarIndexInfo {
-    indexed_columns: HashMap<String, DataType>,
+    indexed_columns: HashMap<String, (DataType, Box<dyn ScalarQueryParser>)>,
 }
 
 impl IndexInformationProvider for ScalarIndexInfo {
-    fn get_index(&self, col: &str) -> Option<&DataType> {
-        self.indexed_columns.get(col)
+    fn get_index(&self, col: &str) -> Option<(&DataType, &dyn ScalarQueryParser)> {
+        self.indexed_columns
+            .get(col)
+            .map(|(ty, parser)| (ty, parser.as_ref()))
     }
 }
 
@@ -507,12 +511,12 @@ impl DatasetIndexInternalExt for Dataset {
         }
     }
 
-    async fn open_scalar_index(&self, _column: &str, uuid: &str) -> Result<Arc<dyn ScalarIndex>> {
+    async fn open_scalar_index(&self, column: &str, uuid: &str) -> Result<Arc<dyn ScalarIndex>> {
         if let Some(index) = self.session.index_cache.get_scalar(uuid) {
             return Ok(index);
         }
 
-        let index = crate::index::scalar::open_scalar_index(self, uuid).await?;
+        let index = crate::index::scalar::open_scalar_index(self, column, uuid).await?;
         self.session.index_cache.insert_scalar(uuid, index.clone());
         Ok(index)
     }
@@ -656,8 +660,16 @@ impl DatasetIndexInternalExt for Dataset {
         .map(|idx| {
             let field = idx.fields[0];
             let field = schema.field_by_id(field).ok_or_else(|| Error::Internal { message: format!("Index referenced a field with id {field} which did not exist in the schema"), location: location!() });
-            field.map(|field| (field.name.clone(), field.data_type()))
-        }).collect::<Result<Vec<_>>>()?;
+            field.map(|field| {
+                let query_parser = if let DataType::List(_) = field.data_type() {
+                    Box::<TagQueryParser>::default() as Box<dyn ScalarQueryParser>
+                } else {
+                    Box::<SargableQueryParser>::default() as Box<dyn ScalarQueryParser>
+                };
+                (field.name.clone(), (field.data_type(), query_parser))
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
         let index_info_map = HashMap::from_iter(indexed_fields);
         Ok(ScalarIndexInfo {
             indexed_columns: index_info_map,

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -16,7 +16,7 @@ use lance_file::v2;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::pb::index::Implementation;
 use lance_index::scalar::expression::{
-    IndexInformationProvider, SargableQueryParser, ScalarQueryParser, TagQueryParser,
+    IndexInformationProvider, LabelListQueryParser, SargableQueryParser, ScalarQueryParser,
 };
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::ScalarIndex;
@@ -662,7 +662,7 @@ impl DatasetIndexInternalExt for Dataset {
             let field = schema.field_by_id(field).ok_or_else(|| Error::Internal { message: format!("Index referenced a field with id {field} which did not exist in the schema"), location: location!() });
             field.map(|field| {
                 let query_parser = if let DataType::List(_) = field.data_type() {
-                    Box::<TagQueryParser>::default() as Box<dyn ScalarQueryParser>
+                    Box::<LabelListQueryParser>::default() as Box<dyn ScalarQueryParser>
                 } else {
                     Box::<SargableQueryParser>::default() as Box<dyn ScalarQueryParser>
                 };

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -6,6 +6,7 @@
 
 use std::sync::Arc;
 
+use arrow_schema::DataType;
 use async_trait::async_trait;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use lance_datafusion::{chunker::chunk_concat_stream, exec::LanceExecutionOptions};
@@ -15,6 +16,7 @@ use lance_index::{
         btree::{train_btree_index, BTreeIndex, BtreeTrainingSource},
         flat::FlatIndexMetadata,
         lance_format::LanceIndexStore,
+        tag::{train_tag_index, TagIndex},
         ScalarIndex,
     },
     IndexType,
@@ -36,6 +38,7 @@ pub const LANCE_SCALAR_INDEX: &str = "__lance_scalar_index";
 pub enum ScalarIndexType {
     BTree,
     Bitmap,
+    Tag,
 }
 
 #[derive(Default)]
@@ -103,9 +106,11 @@ pub async fn build_scalar_index(
         source: format!("No column with name {}", column).into(),
         location: location!(),
     })?;
-    // In theory it should be possible to create a scalar index (e.g. btree) on a nested field but
+    // In theory it should be possible to create a btree/bitmap index on a nested field but
     // performance would be poor and I'm not sure we want to allow that unless there is a need.
-    if field.data_type().is_nested() {
+    if !matches!(params.force_index_type, Some(ScalarIndexType::Tag))
+        && field.data_type().is_nested()
+    {
         return Err(Error::InvalidInput {
             source: "A scalar index can only be created on a non-nested field.".into(),
             location: location!(),
@@ -114,6 +119,7 @@ pub async fn build_scalar_index(
     let index_store = LanceIndexStore::from_dataset(dataset, uuid);
     match params.force_index_type {
         Some(ScalarIndexType::Bitmap) => train_bitmap_index(training_request, &index_store).await,
+        Some(ScalarIndexType::Tag) => train_tag_index(training_request, &index_store).await,
         _ => {
             let flat_index_trainer = FlatIndexMetadata::new(field.data_type());
             train_btree_index(training_request, &flat_index_trainer, &index_store).await
@@ -121,17 +127,33 @@ pub async fn build_scalar_index(
     }
 }
 
-pub async fn open_scalar_index(dataset: &Dataset, uuid: &str) -> Result<Arc<dyn ScalarIndex>> {
+pub async fn open_scalar_index(
+    dataset: &Dataset,
+    column: &str,
+    uuid: &str,
+) -> Result<Arc<dyn ScalarIndex>> {
     let index_store = Arc::new(LanceIndexStore::from_dataset(dataset, uuid));
     let index_dir = dataset.indices_dir().child(uuid);
-    // This works at the moment, since we only have two index types, may need to introduce better
+    // This works at the moment, since we only have a few index types, may need to introduce better
     // detection method in the future.
-    let bitmap_page_lookup = index_dir.child(BITMAP_LOOKUP_NAME);
-    if dataset.object_store.exists(&bitmap_page_lookup).await? {
-        let bitmap_index = BitmapIndex::load(index_store).await?;
-        Ok(bitmap_index as Arc<dyn ScalarIndex>)
+    let col = dataset.schema().field(column).ok_or(Error::Internal {
+        message: format!(
+            "Index refers to column {} which does not exist in dataset schema",
+            column
+        ),
+        location: location!(),
+    })?;
+    if let DataType::List(_) = col.data_type() {
+        let tag_index = TagIndex::load(index_store).await?;
+        Ok(tag_index as Arc<dyn ScalarIndex>)
     } else {
-        let btree_index = BTreeIndex::load(index_store).await?;
-        Ok(btree_index as Arc<dyn ScalarIndex>)
+        let bitmap_page_lookup = index_dir.child(BITMAP_LOOKUP_NAME);
+        if dataset.object_store.exists(&bitmap_page_lookup).await? {
+            let bitmap_index = BitmapIndex::load(index_store).await?;
+            Ok(bitmap_index as Arc<dyn ScalarIndex>)
+        } else {
+            let btree_index = BTreeIndex::load(index_store).await?;
+            Ok(btree_index as Arc<dyn ScalarIndex>)
+        }
     }
 }

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -26,7 +26,7 @@ use lance_core::{
 use lance_index::{
     scalar::{
         expression::{ScalarIndexExpr, ScalarIndexLoader},
-        ScalarIndex, ScalarQuery,
+        SargableQuery, ScalarIndex,
     },
     DatasetIndexExt,
 };
@@ -205,7 +205,10 @@ impl MapIndexExec {
         let index_vals = (0..index_vals.len())
             .map(|idx| ScalarValue::try_from_array(index_vals, idx))
             .collect::<datafusion::error::Result<Vec<_>>>()?;
-        let query = ScalarIndexExpr::Query(column_name.clone(), ScalarQuery::IsIn(index_vals));
+        let query = ScalarIndexExpr::Query(
+            column_name.clone(),
+            Arc::new(SargableQuery::IsIn(index_vals)),
+        );
         let mut row_addresses = query.evaluate(dataset.as_ref()).await?;
 
         if let Some(deletion_mask) = deletion_mask.as_ref() {


### PR DESCRIPTION
This PR adds a new kind of scalar index, the LABEL_LIST scalar index.  A label list index can only be created on list columns (the item data type has to be one of the data types that can be used for btree/bitmap indices).  The label list index can speed up array_has_any and array_has_all queries.

This is useful for tag-like columns where each row has some number of labels and the overall cardinality of the labels is relatively low (the index in-memory size will depend on the cardinality of the labels).

This PR also introduces the idea that different scalar indices may support different types of queries.  There is now `SargableQuery` (what is used by btree and bitmap) and `LabelListQuery` (used by the new label list index).  Going forward we should probably break the FullTextQuery out of `SargableQuery` and into its own query type.