### PR TITLE
feat: do flat search if too many rows are filtered out

### DIFF
--- a/rust/lance-index/src/vector/graph.rs
+++ b/rust/lance-index/src/vector/graph.rs
@@ -163,6 +163,10 @@ impl<'a> Visited<'a> {
         let node_id_usize = node_id as usize;
         self.visited[node_id_usize]
     }
+
+    pub fn count_ones(&self) -> usize {
+        self.visited.count_ones()
+    }
 }
 
 impl<'a> Drop for Visited<'a> {
@@ -230,7 +234,7 @@ pub fn beam_search(
     ep: &OrderedNode,
     k: usize,
     dist_calc: &impl DistCalculator,
-    bitset: Option<&roaring::bitmap::RoaringBitmap>,
+    bitset: Option<&Visited>,
     prefetch_distance: Option<usize>,
     visited: &mut Visited,
 ) -> Vec<OrderedNode> {

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -653,7 +653,8 @@ impl IvfSubIndex for HNSW {
             .unwrap_or(storage.len());
         let results = if remained < self.len() * 10 / 100 {
             log::debug!("too many rows filtered, using flat search");
-            let prefilter_bitset = prefilter_bitset.unwrap();
+            let prefilter_bitset =
+                prefilter_bitset.expect("the prefilter bitset must be set for flat search");
             let node_ids = storage
                 .row_ids()
                 .enumerate()

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -650,7 +650,7 @@ impl IvfSubIndex for HNSW {
         let remained = prefilter_bitset
             .as_ref()
             .map(|b| b.count_ones())
-            .unwrap_or(storage.len()) as usize;
+            .unwrap_or(storage.len());
         let results = if remained < self.len() * 10 / 100 {
             log::debug!("too many rows filtered, using flat search");
             let prefilter_bitset = prefilter_bitset.unwrap();


### PR DESCRIPTION
- replace RoaringBitmap with BitVec
- use pool to avoid allocating bitset for each query with prefilter
- fall back to flat search if too many rows filtered out
- prefetch with flat search