### PR TITLE
perf: change scalar index to return RowIdTreeMap instead of u64 array

### DIFF
--- a/python/python/benchmarks/test_search.py
+++ b/python/python/benchmarks/test_search.py
@@ -9,12 +9,9 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
-from lance.tracing import trace_to_chrome
-
-trace_to_chrome(level="debug", file="/tmp/foo.json")
 
 N_DIMS = 768
-NUM_ROWS = 16_000_000
+NUM_ROWS = 100_000
 NEW_ROWS = 10_000
 
 
@@ -54,8 +51,6 @@ def create_table(num_rows, offset) -> pa.Table:
     filterable = pa.array(range(offset, offset + num_rows))
     categories = pa.array(np.random.randint(0, 100, num_rows))
     genres_values = pa.array(np.random.choice(GENRES, num_rows * 3))
-    if isinstance(genres_values, pa.ChunkedArray):
-        genres_values = pa.concat_arrays(genres_values.iterchunks())
     genre_offsets = pa.array(np.arange(0, (num_rows + 1) * 3, 3, dtype=np.int32))
     genres = pa.ListArray.from_arrays(genre_offsets, genres_values)
     return pa.table(

--- a/python/python/benchmarks/test_search.py
+++ b/python/python/benchmarks/test_search.py
@@ -9,9 +9,12 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
+from lance.tracing import trace_to_chrome
+
+trace_to_chrome(level="debug", file="/tmp/foo.json")
 
 N_DIMS = 768
-NUM_ROWS = 100_000
+NUM_ROWS = 16_000_000
 NEW_ROWS = 10_000
 
 
@@ -51,6 +54,8 @@ def create_table(num_rows, offset) -> pa.Table:
     filterable = pa.array(range(offset, offset + num_rows))
     categories = pa.array(np.random.randint(0, 100, num_rows))
     genres_values = pa.array(np.random.choice(GENRES, num_rows * 3))
+    if isinstance(genres_values, pa.ChunkedArray):
+        genres_values = pa.concat_arrays(genres_values.iterchunks())
     genre_offsets = pa.array(np.arange(0, (num_rows + 1) * 3, 3, dtype=np.int32))
     genres = pa.ListArray.from_arrays(genre_offsets, genres_values)
     return pa.table(

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::{any::Any, ops::Bound, sync::Arc};
 
 use arrow::buffer::{OffsetBuffer, ScalarBuffer};
-use arrow_array::{ListArray, RecordBatch, UInt64Array};
+use arrow_array::{ListArray, RecordBatch};
 use arrow_schema::{Field, Schema};
 use async_trait::async_trait;
 use datafusion::physical_plan::SendableRecordBatchStream;
@@ -16,6 +16,7 @@ use datafusion_common::{scalar::ScalarValue, Column};
 use datafusion_expr::expr::ScalarFunction;
 use datafusion_expr::{Expr, ScalarFunctionDefinition};
 use deepsize::DeepSizeOf;
+use lance_core::utils::mask::RowIdTreeMap;
 use lance_core::Result;
 
 use crate::Index;
@@ -300,7 +301,7 @@ pub trait ScalarIndex: Send + Sync + std::fmt::Debug + Index + DeepSizeOf {
     /// Search the scalar index
     ///
     /// Returns all row ids that satisfy the query, these row ids are not neccesarily ordered
-    async fn search(&self, query: &dyn AnyQuery) -> Result<UInt64Array>;
+    async fn search(&self, query: &dyn AnyQuery) -> Result<RowIdTreeMap>;
 
     /// Load the scalar index from storage
     async fn load(store: Arc<dyn IndexStore>) -> Result<Arc<Self>>

--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -14,10 +14,7 @@ use datafusion_expr::{
 };
 
 use futures::join;
-use lance_core::{
-    utils::mask::{RowIdMask, RowIdTreeMap},
-    Result,
-};
+use lance_core::{utils::mask::RowIdMask, Result};
 use lance_datafusion::expr::safe_coerce_scalar;
 use tracing::instrument;
 
@@ -413,10 +410,9 @@ impl ScalarIndexExpr {
             Self::Query(column, query) => {
                 let index = index_loader.load_index(column).await?;
                 let matching_row_ids = index.search(query.as_ref()).await?;
-                let allow_list = RowIdTreeMap::from_iter(matching_row_ids.values().iter());
                 Ok(RowIdMask {
                     block_list: None,
-                    allow_list: Some(allow_list),
+                    allow_list: Some(matching_row_ids),
                 })
             }
         }

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -177,6 +177,7 @@ mod tests {
     use arrow_select::take::TakeOptions;
     use datafusion::physical_plan::SendableRecordBatchStream;
     use datafusion_common::ScalarValue;
+    use lance_core::utils::mask::RowIdTreeMap;
     use lance_datagen::{array, gen, ArrayGeneratorExt, BatchCount, ByteCount, RowCount};
     use tempfile::{tempdir, TempDir};
 
@@ -242,8 +243,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(1, row_ids.len());
-        assert_eq!(Some(10000), row_ids.values().into_iter().copied().next());
+        assert_eq!(Some(1), row_ids.len());
+        assert!(row_ids.contains(10000));
 
         let row_ids = index
             .search(&SargableQuery::Range(
@@ -253,7 +254,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(0, row_ids.len());
+        assert_eq!(Some(0), row_ids.len());
 
         let row_ids = index
             .search(&SargableQuery::Range(
@@ -263,7 +264,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(100, row_ids.len());
+        assert_eq!(Some(100), row_ids.len());
     }
 
     #[tokio::test]
@@ -278,8 +279,8 @@ mod tests {
         let index = BTreeIndex::load(index_store).await.unwrap();
 
         let data = gen()
-            .col("values", array::step::<Int32Type>())
-            .col("row_ids", array::step::<UInt64Type>())
+            .col("values", array::step_custom::<Int32Type>(4096 * 100, 1))
+            .col("row_ids", array::step_custom::<UInt64Type>(4096 * 100, 1))
             .into_reader_rows(RowCount::from(4096), BatchCount::from(100));
 
         let updated_index_dir = tempdir().unwrap();
@@ -298,16 +299,21 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(2, row_ids.len());
-        assert_eq!(
-            vec![10000, 10000],
-            row_ids.values().into_iter().copied().collect::<Vec<_>>()
-        );
+        assert_eq!(Some(1), row_ids.len());
+        assert!(row_ids.contains(10000));
+
+        let row_ids = updated_index
+            .search(&SargableQuery::Equals(ScalarValue::Int32(Some(500_000))))
+            .await
+            .unwrap();
+
+        assert_eq!(Some(1), row_ids.len());
+        assert!(row_ids.contains(500_000));
     }
 
     async fn check(index: &BTreeIndex, query: SargableQuery, expected: &[u64]) {
         let results = index.search(&query).await.unwrap();
-        let expected_arr = UInt64Array::from_iter_values(expected.iter().copied());
+        let expected_arr = RowIdTreeMap::from_iter(expected);
         assert_eq!(results, expected_arr);
     }
 
@@ -589,8 +595,8 @@ mod tests {
             // The random data may have had duplicates so there might be more than 1 result
             // but even for boolean we shouldn't match the entire thing
             assert!(!row_ids.is_empty());
-            assert!(row_ids.len() < data.num_rows());
-            assert!(row_ids.values().iter().any(|val| *val == sample_row_id));
+            assert!(row_ids.len().unwrap() < data.num_rows() as u64);
+            assert!(row_ids.contains(sample_row_id));
         }
     }
 
@@ -629,7 +635,7 @@ mod tests {
                 "values",
                 array::rand_utf8(ByteCount::from(0), false).with_nulls(&[true]),
             )
-            .col("row_ids", array::cycle::<UInt64Type>(vec![0, 1]))
+            .col("row_ids", array::step::<UInt64Type>())
             .into_batch_rows(RowCount::from(4096));
         assert_eq!(batch.as_ref().unwrap()["values"].null_count(), 4096);
         let batches = vec![batch];
@@ -656,7 +662,7 @@ mod tests {
         assert!(row_ids.is_empty());
 
         let row_ids = index.search(&SargableQuery::IsNull()).await.unwrap();
-        assert_eq!(row_ids.len(), 4096);
+        assert_eq!(row_ids.len(), Some(4096));
     }
 
     async fn train_bitmap(
@@ -712,8 +718,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(1, row_ids.len());
-        assert_eq!(2, row_ids.values()[0]);
+        assert_eq!(Some(1), row_ids.len());
+        assert!(row_ids.contains(2));
 
         let row_ids = index
             .search(&SargableQuery::Equals(ScalarValue::Utf8(Some(
@@ -722,11 +728,10 @@ mod tests {
             .await
             .unwrap();
 
-        let expected = vec![1, 3, 6];
-        let expected_arr = UInt64Array::from_iter_values(expected.into_iter());
-
-        assert_eq!(3, row_ids.len());
-        assert_eq!(expected_arr, row_ids);
+        assert_eq!(Some(3), row_ids.len());
+        assert!(row_ids.contains(1));
+        assert!(row_ids.contains(3));
+        assert!(row_ids.contains(6));
     }
 
     #[tokio::test]
@@ -745,8 +750,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(1, row_ids.len());
-        assert_eq!(10000, row_ids.values()[0]);
+        assert_eq!(Some(1), row_ids.len());
+        assert!(row_ids.contains(10000));
 
         let row_ids = index
             .search(&SargableQuery::Range(
@@ -756,7 +761,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(0, row_ids.len());
+        assert!(row_ids.is_empty());
 
         let row_ids = index
             .search(&SargableQuery::Range(
@@ -766,12 +771,12 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(100, row_ids.len());
+        assert_eq!(Some(100), row_ids.len());
     }
 
     async fn check_bitmap(index: &BitmapIndex, query: SargableQuery, expected: &[u64]) {
         let results = index.search(&query).await.unwrap();
-        let expected_arr = UInt64Array::from_iter_values(expected.iter().copied());
+        let expected_arr = RowIdTreeMap::from_iter(expected);
         assert_eq!(results, expected_arr);
     }
 
@@ -1017,11 +1022,8 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(1, row_ids.len());
-        assert_eq!(
-            vec![5000],
-            row_ids.values().into_iter().copied().collect::<Vec<_>>()
-        );
+        assert_eq!(Some(1), row_ids.len());
+        assert!(row_ids.contains(5000));
     }
 
     #[tokio::test]
@@ -1057,14 +1059,11 @@ mod tests {
         let remapped_index = BitmapIndex::load(remapped_store).await.unwrap();
 
         // Remapped to new value
-        assert_eq!(
-            remapped_index
-                .search(&SargableQuery::Equals(ScalarValue::Int32(Some(5))))
-                .await
-                .unwrap()
-                .value(0),
-            65
-        );
+        assert!(remapped_index
+            .search(&SargableQuery::Equals(ScalarValue::Int32(Some(5))))
+            .await
+            .unwrap()
+            .contains(65));
         // Deleted
         assert!(remapped_index
             .search(&SargableQuery::Equals(ScalarValue::Int32(Some(7))))
@@ -1072,14 +1071,11 @@ mod tests {
             .unwrap()
             .is_empty());
         // Not remapped
-        assert_eq!(
-            remapped_index
-                .search(&SargableQuery::Equals(ScalarValue::Int32(Some(3))))
-                .await
-                .unwrap()
-                .value(0),
-            3
-        );
+        assert!(remapped_index
+            .search(&SargableQuery::Equals(ScalarValue::Int32(Some(3))))
+            .await
+            .unwrap()
+            .contains(3));
     }
 
     async fn train_tag(
@@ -1126,9 +1122,9 @@ mod tests {
                 let row_ids = index.search(&query).await.unwrap();
 
                 let row_ids_set = row_ids
-                    .values()
-                    .iter()
-                    .copied()
+                    .row_ids()
+                    .unwrap()
+                    .map(|addr| u64::from(addr))
                     .collect::<std::collections::HashSet<_>>();
 
                 for (list, row_id) in data
@@ -1141,10 +1137,8 @@ mod tests {
                     let row_id = row_id.unwrap();
                     let vals = list.as_primitive::<UInt8Type>().values();
                     if row_ids_set.contains(&row_id) {
-                        println!("Match: {:?}", vals);
                         assert!(match_fn(vals));
                     } else {
-                        println!("NoMatch: {:?}", vals);
                         assert!(no_match_fn(vals));
                     }
                 }

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -1124,7 +1124,7 @@ mod tests {
                 let row_ids_set = row_ids
                     .row_ids()
                     .unwrap()
-                    .map(|addr| u64::from(addr))
+                    .map(u64::from)
                     .collect::<std::collections::HashSet<_>>();
 
                 for (list, row_id) in data

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -117,7 +117,7 @@ async fn warm_indexed_equality_search(index: &BTreeIndex) {
         .search(&SargableQuery::Equals(ScalarValue::UInt32(Some(10000))))
         .await
         .unwrap();
-    assert_eq!(row_ids.len(), 1);
+    assert_eq!(row_ids.len(), Some(1));
 }
 
 async fn baseline_inequality_search(fixture: &BenchmarkFixture) {
@@ -147,7 +147,7 @@ async fn warm_indexed_inequality_search(index: &BTreeIndex) {
         .await
         .unwrap();
     // 100Mi - 50M = 54,857,600
-    assert_eq!(row_ids.len(), 54857600);
+    assert_eq!(row_ids.len(), Some(54857600));
 }
 
 async fn warm_indexed_isin_search(index: &BTreeIndex) {
@@ -161,7 +161,7 @@ async fn warm_indexed_isin_search(index: &BTreeIndex) {
         .await
         .unwrap();
     // Only 3 because 150M is not in dataset
-    assert_eq!(row_ids.len(), 3);
+    assert_eq!(row_ids.len(), Some(3));
 }
 
 fn bench_baseline(c: &mut Criterion) {


### PR DESCRIPTION
The filtering paths that use scalar indices are all built to use `RowIdTreeMap`.  Scalar indices were built to use `UInt64Array`.  This means we have to copy from one to the other (an O(N log(N)) operation.  When we just had btree indices this was a fairly cheap operation since the indices shouldn't be returning large #'s of rows anyways.  Now that we have `BITMAP` and `LABEL_LIST` we can have indices that return very large #'s of rows and this copy was expensive.  By changing the scalar indices to use `RowIdTreeMap` directly we skip the conversion.

NOTE: any `LABEL_LIST` or `BITMAP` index that was previously created will be invalid and will need to be recreated.  Since we haven't had an official release of these index types I am not considering this a breaking change.