### PR TITLE
fix: fix GLIBC version not found in java maven jar

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -113,6 +113,8 @@ jobs:
           git config --global user.name "dev+gha@lancedb.com"
       - name: Publish with Java 8
         run: |
+          mkdir -p ~/.gnupg
+          touch ~/.gnupg/gpg.conf
           echo "use-agent" >> ~/.gnupg/gpg.conf
           echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
           export GPG_TTY=$(tty)

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -92,6 +92,11 @@ jobs:
           server-password: SONATYPE_TOKEN
           gpg-private-key: MAVEN_GPG_PRIVATE_KEY
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
+        env:
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Set up Node.js 16
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -80,10 +80,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up Node.js 16
-        uses: actions/setup-node@v4
-        with:
-          node-version: '16'
       - uses: Swatinem/rust-cache@v2
       - name: Set up Java 8
         uses: actions/setup-java@v4
@@ -96,6 +92,10 @@ jobs:
           server-password: SONATYPE_TOKEN
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Set up Node.js 16
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16'
       - name: Install dependencies
         run: |
           sudo apt -y -qq update

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
+      - name: Set up Node.js 16
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16'
       - name: Install dependencies
         run: |
           brew install protobuf
@@ -40,6 +44,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up Node.js 16
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16'
       - uses: Swatinem/rust-cache@v2
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -72,6 +80,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Set up Node.js 16
+        uses: actions/setup-node@v4
+        with:
+          node-version: '16'
       - uses: Swatinem/rust-cache@v2
       - name: Set up Java 8
         uses: actions/setup-java@v4
@@ -108,3 +120,16 @@ jobs:
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
+      - name: Find Spark Jar
+        run: |
+          RELATIVE_JAR_PATH=$(find spark/target -name 'lance-spark-2.12-*-jar-with-dependencies.jar')
+          JAR_NAME=$(basename $RELATIVE_JAR_PATH)
+          JAR_PATH=$(readlink -f "$RELATIVE_JAR_PATH")
+          echo "SPARK_JAR_PATH=$JAR_PATH" >> $GITHUB_ENV
+          echo "SPARK_JAR_NAME=$JAR_NAME" >> $GITHUB_ENV
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SPARK_JAR_NAME }}
+          path: ${{ env.SPARK_JAR_PATH }}
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -90,8 +90,8 @@ jobs:
           server-id: ossrh
           server-username: SONATYPE_USER
           server-password: SONATYPE_TOKEN
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg-private-key: MAVEN_GPG_PRIVATE_KEY
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Set up Node.js 16
         uses: actions/setup-node@v4
         with:
@@ -122,6 +122,8 @@ jobs:
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Find Spark Jar
         run: |
           RELATIVE_JAR_PATH=$(find spark/target -name 'lance-spark-2.12-*-jar-with-dependencies.jar')

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lancedb</groupId>
         <artifactId>lance-parent</artifactId>
-        <version>0.0.4</version>
+        <version>0.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.lancedb</groupId>
     <artifactId>lance-parent</artifactId>
-    <version>0.0.4</version>
+    <version>0.0.5</version>
     <packaging>pom</packaging>
 
     <name>Lance Parent</name>

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lancedb</groupId>
         <artifactId>lance-parent</artifactId>
-        <version>0.0.4</version>
+        <version>0.0.5</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.lancedb</groupId>
             <artifactId>lance-core</artifactId>
-            <version>0.0.4</version>
+            <version>0.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
Revert nodejs version back to 16 to avoid GLIBC version not found issue in ubuntu and other OS.
Starting from nodejs 18, it requires a much higher GLIBC version and will prevent the application from starting if fail the check.
