### PR TITLE
fix: upgrade AWS SDK

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,9 +73,9 @@ arrow-schema = "52.1"
 arrow-select = "52.1"
 async-recursion = "1.0"
 async-trait = "0.1"
-aws-config = "0.57"
-aws-credential-types = "0.57"
-aws-sdk-dynamodb = "0.35"
+aws-config = "1.2.0"
+aws-credential-types = "1.2.0"
+aws-sdk-dynamodb = "1.38.0"
 half = { "version" = "2.4.1", default-features = false, features = [
     "num-traits",
     "std",


### PR DESCRIPTION
There seems to be an issue now with the older version of the AWS SDK and AWS SSO. Upgrading to a newer version fixed this.

Fixes #2614