### PR TITLE
feat: change the default of use_legacy_format from True to False

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2494,7 +2494,7 @@ def write_dataset(
     commit_lock: Optional[CommitLock] = None,
     progress: Optional[FragmentWriteProgress] = None,
     storage_options: Optional[Dict[str, str]] = None,
-    use_legacy_format: bool = True,
+    use_legacy_format: bool = False,
 ) -> LanceDataset:
     """Write a given data_obj to the given uri
 
@@ -2534,9 +2534,9 @@ def write_dataset(
     storage_options : optional, dict
         Extra options that make sense for a particular storage connection. This is
         used to store connection parameters like credentials, endpoint, etc.
-    use_legacy_format : optional, bool, default True
-        Use the Lance v1 writer to write Lance v1 files.  The default is currently
-        True but will change as we roll out the v2 format.
+    use_legacy_format : optional, bool, default False
+        Use the Lance v1 writer to write Lance v1 files.  This can be turned on
+        if issues are encountered with the new writer.
     """
     if _check_for_hugging_face(data_obj):
         # Huggingface datasets

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -146,7 +146,7 @@ class LanceFragment(pa.dataset.Fragment):
         progress: Optional[FragmentWriteProgress] = None,
         mode: str = "append",
         *,
-        use_legacy_format=True,
+        use_legacy_format=False,
         storage_options: Optional[Dict[str, str]] = None,
     ) -> FragmentMetadata:
         """Create a :class:`FragmentMetadata` from the given data.
@@ -178,9 +178,9 @@ class LanceFragment(pa.dataset.Fragment):
             The write mode. If "append" is specified, the data will be checked
             against the existing dataset's schema. Otherwise, pass "create" or
             "overwrite" to assign new field ids to the schema.
-        use_legacy_format: bool, default True
-            Use the legacy format to write Lance files. The default is True
-            while the v2 format is still in beta.
+        use_legacy_format: bool, default False
+            Use the legacy format to write Lance files.  This can be turned on if
+            issues are encountered with the new writer.
         storage_options : optional, dict
             Extra options that make sense for a particular storage connection. This is
             used to store connection parameters like credentials, endpoint, etc.
@@ -512,7 +512,7 @@ def write_fragments(
     max_rows_per_group: int = 1024,
     max_bytes_per_file: int = DEFAULT_MAX_BYTES_PER_FILE,
     progress: Optional[FragmentWriteProgress] = None,
-    use_legacy_format: bool = True,
+    use_legacy_format: bool = False,
     storage_options: Optional[Dict[str, str]] = None,
 ) -> List[FragmentMetadata]:
     """
@@ -550,9 +550,9 @@ def write_fragments(
         *Experimental API*. Progress tracking for writing the fragment. Pass
         a custom class that defines hooks to be called when each fragment is
         starting to write and finishing writing.
-    use_legacy_format : optional, bool, default True
-        Use the Lance v1 writer to write Lance v1 files.  The default is currently
-        True while the v2 format is in beta.
+    use_legacy_format : optional, bool, default False
+        Use the Lance v1 writer to write Lance v1 files.  This can be turned on
+        if issues are encountered with the new writer.
     storage_options : Optional[Dict[str, str]]
         Extra options that make sense for a particular storage connection. This is
         used to store connection parameters like credentials, endpoint, etc.

--- a/python/python/lance/ray/sink.py
+++ b/python/python/lance/ray/sink.py
@@ -54,7 +54,7 @@ def _write_fragment(
     max_rows_per_file: int = 1024 * 1024,
     max_bytes_per_file: Optional[int] = None,
     max_rows_per_group: int = 1024,  # Only useful for v1 writer.
-    use_legacy_format: bool = True,
+    use_legacy_format: bool = False,
     storage_options: Optional[Dict[str, Any]] = None,
 ) -> Tuple[FragmentMetadata, pa.Schema]:
     from ..dependencies import _PANDAS_AVAILABLE


### PR DESCRIPTION
This is a fairly small change code-wise but has significant meaning in terms of support.

I think the v2 format is at a point where:

 * We have dog-fooded it enough that we have confidence it works
 * We can commit to supporting backwards compatibility as we improve the format

This doesn't mean things are final.  There are still considerable changes to come, especially with how we handle struct & list encodings (I'll be raising a separate issue with my intentions here).  Still, these can be handled by evolving encodings (e.g. we may need "simple struct" to continue even if we add a new "zipped struct" (or whatever)).

This does mean there will be some maintenance going forwards.  We will need to ensure that files written today continue to be readable even in future versions.