### PR TITLE
feat: add storage_options to _BaseLanceDatasink, LanceDatasink, LanceCommitter

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -218,7 +218,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.11" # TODO: upgrade when ray supports 3.12
     - uses: Swatinem/rust-cache@v2
       with:
         workspaces: python
@@ -226,7 +226,7 @@ jobs:
     - uses: ./.github/workflows/build_linux_wheel
     - name: Install dependencies
       run:
-        pip install torch --index-url https://download.pytorch.org/whl/cpu
+        pip install ray[data] torch --index-url https://download.pytorch.org/whl/cpu
     - uses: ./.github/workflows/run_integtests
     # Make sure wheels are not included in the Rust cache
     - name: Delete wheels

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -225,8 +225,9 @@ jobs:
         prefix-key: "manylinux2014"  # use this to flush the cache
     - uses: ./.github/workflows/build_linux_wheel
     - name: Install dependencies
-      run:
-        pip install ray[data] torch --index-url https://download.pytorch.org/whl/cpu
+      run: |
+        pip install ray[data]
+        pip install torch --index-url https://download.pytorch.org/whl/cpu
     - uses: ./.github/workflows/run_integtests
     # Make sure wheels are not included in the Rust cache
     - name: Delete wheels

--- a/python/python/tests/test_s3_ddb.py
+++ b/python/python/tests/test_s3_ddb.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 """
-Integration tests with S3 and DynamoDB.
+Integration tests with S3 and DynamoDB. Also used to test storage_options are
+passed correctly.
 
 See DEVELOPMENT.md under heading "Integration Tests" for more information.
 """
@@ -16,6 +17,7 @@ from threading import Barrier
 import lance
 import pyarrow as pa
 import pytest
+from lance.dependencies import _RAY_AVAILABLE, ray
 
 # These are all keys that are accepted by storage_options
 CONFIG = {
@@ -221,3 +223,26 @@ def test_s3_unsafe(s3_bucket: str):
     assert len(ds.versions()) == 1
     assert ds.count_rows() == 3
     assert ds.to_table() == data
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _RAY_AVAILABLE, reason="ray is not available")
+def test_ray_committer(s3_bucket: str, ddb_table: str):
+    from lance.ray.sink import write_lance
+
+    table_name = uuid.uuid4().hex
+    table_dir = f"s3+ddb://{s3_bucket}/{table_name}?ddbTableName={ddb_table}"
+
+    schema = pa.schema([pa.field("id", pa.int64()), pa.field("str", pa.string())])
+
+    ds = ray.data.range(10).map(lambda x: {"id": x["id"], "str": f"str-{x['id']}"})
+    write_lance(ds, table_dir, schema=schema, storage_options=CONFIG)
+
+    ds = lance.dataset(table_dir, storage_options=CONFIG)
+    assert ds.count_rows() == 10
+    assert ds.schema == schema
+
+    tbl = ds.to_table()
+    assert sorted(tbl["id"].to_pylist()) == list(range(10))
+    assert set(tbl["str"].to_pylist()) == set([f"str-{i}" for i in range(10)])
+    assert len(ds.get_fragments()) == 2

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1025,10 +1025,13 @@ impl Dataset {
         commit_lock: Option<&PyAny>,
         storage_options: Option<HashMap<String, String>>,
     ) -> PyResult<Self> {
-        let object_store_params = storage_options.map(|storage_options| ObjectStoreParams {
-            storage_options: Some(storage_options),
-            ..Default::default()
-        });
+        let object_store_params =
+            storage_options
+                .as_ref()
+                .map(|storage_options| ObjectStoreParams {
+                    storage_options: Some(storage_options.clone()),
+                    ..Default::default()
+                });
 
         let commit_handler = commit_lock.map(|commit_lock| {
             Arc::new(PyCommitLock::new(commit_lock.to_object(commit_lock.py())))
@@ -1036,7 +1039,14 @@ impl Dataset {
         });
         let ds = RT
             .block_on(commit_lock.map(|cl| cl.py()), async move {
-                let dataset = match DatasetBuilder::from_uri(dataset_uri).load().await {
+                let mut builder = DatasetBuilder::from_uri(dataset_uri);
+                if let Some(storage_options) = storage_options {
+                    builder = builder.with_storage_options(storage_options);
+                }
+                if let Some(read_version) = read_version {
+                    builder = builder.with_version(read_version);
+                }
+                let dataset = match builder.load().await {
                     Ok(ds) => Some(ds),
                     Err(lance::Error::DatasetNotFound { .. }) => None,
                     Err(err) => return Err(err),


### PR DESCRIPTION
Adds the ability to pass `storage_options` to `_BaseLanceDatasink` to allow specifying them for `LanceDatasink` and `LanceCommitter` (`LanceFragmentWriter` already supports passing these).

We need to customize them because some of our datasets are hosted on `R2`