### PR TITLE
chore: select AWS client version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,9 +73,9 @@ arrow-schema = "52.1"
 arrow-select = "52.1"
 async-recursion = "1.0"
 async-trait = "0.1"
-aws-config = "1.2.0"
+aws-config = { version = "1.2.0", features = ["behavior-version-latest"] }
 aws-credential-types = "1.2.0"
-aws-sdk-dynamodb = "1.38.0"
+aws-sdk-dynamodb = { version = "1.38.0", features = ["behavior-version-latest"] }
 half = { "version" = "2.4.1", default-features = false, features = [
     "num-traits",
     "std",

--- a/python/python/tests/test_s3_ddb.py
+++ b/python/python/tests/test_s3_ddb.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 """
-Integration tests with S3 and DynamoDB.
+Integration tests with S3 and DynamoDB. Also used to test storage_options are
+passed correctly.
 
 See DEVELOPMENT.md under heading "Integration Tests" for more information.
 """


### PR DESCRIPTION
#2616 caused a regression that was only seen in the Python tests. Those aren't run when we just change Rust code, which is why we didn't see it.

Example failure: https://github.com/lancedb/lance/actions/runs/10012094096/job/27678003008?pr=2619

(We didn't release that PR, which is why I'm just labelling this as a chore.)