### PR TITLE
refactor: move planner.rs, logical_expr.rs, and sql.rs from lance to lance_datafusion

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -622,6 +622,7 @@ impl Dataset {
         self_: PyRef<'_, Self>,
         row_indices: Vec<u64>,
         columns: Option<Vec<String>>,
+        columns_with_transform: Option<Vec<(String, String)>,
     ) -> PyResult<PyObject> {
         let projection = if let Some(columns) = columns {
             self_.ds.schema().project(&columns)

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -622,7 +622,6 @@ impl Dataset {
         self_: PyRef<'_, Self>,
         row_indices: Vec<u64>,
         columns: Option<Vec<String>>,
-        columns_with_transform: Option<Vec<(String, String)>,
     ) -> PyResult<PyObject> {
         let projection = if let Some(columns) = columns {
             self_.ds.schema().project(&columns)

--- a/rust/lance-datafusion/Cargo.toml
+++ b/rust/lance-datafusion/Cargo.toml
@@ -12,7 +12,9 @@ description = "Internal utilities used by other lance modules to simplify workin
 [dependencies]
 arrow.workspace = true
 arrow-array.workspace = true
+arrow-buffer.workspace = true
 arrow-schema.workspace = true
+arrow-select.workspace = true
 arrow-ord.workspace = true
 async-trait.workspace = true
 datafusion.workspace = true

--- a/rust/lance-datafusion/src/lib.rs
+++ b/rust/lance-datafusion/src/lib.rs
@@ -5,4 +5,7 @@ pub mod chunker;
 pub mod dataframe;
 pub mod exec;
 pub mod expr;
+pub mod logical_expr;
+pub mod planner;
+pub mod sql;
 pub mod utils;

--- a/rust/lance-datafusion/src/sql.rs
+++ b/rust/lance-datafusion/src/sql.rs
@@ -10,7 +10,7 @@ use datafusion::sql::sqlparser::{
     tokenizer::{Token, Tokenizer},
 };
 
-use crate::{Error, Result};
+use lance_core::{Error, Result};
 use snafu::{location, Location};
 #[derive(Debug, Default)]
 struct LanceDialect(GenericDialect);

--- a/rust/lance/src/datafusion.rs
+++ b/rust/lance/src/datafusion.rs
@@ -5,5 +5,4 @@
 //!
 
 pub(crate) mod dataframe;
-pub(crate) mod logical_expr;
 pub(crate) mod logical_plan;

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -35,6 +35,7 @@ use futures::TryStreamExt;
 use lance_arrow::floats::{coerce_float_vector, FloatType};
 use lance_core::{ROW_ADDR, ROW_ADDR_FIELD, ROW_ID, ROW_ID_FIELD};
 use lance_datafusion::exec::{execute_plan, LanceExecutionOptions};
+use lance_index::scalar::expression::PlannerIndexExt;
 use lance_index::vector::{Query, DIST_COL};
 use lance_index::{scalar::expression::ScalarIndexExpr, DatasetIndexExt};
 use lance_io::stream::RecordBatchStream;
@@ -47,6 +48,7 @@ use tracing::{info_span, instrument, Span};
 use super::Dataset;
 use crate::datatypes::Schema;
 use crate::index::DatasetIndexInternalExt;
+use crate::io::exec::get_physical_optimizer;
 use crate::io::exec::scalar_index::{MaterializeIndexExec, ScalarIndexExec};
 use crate::io::exec::{
     knn::new_knn_exec, FilterPlan, KNNVectorDistanceExec, LancePushdownScanExec, LanceScanExec,
@@ -1026,7 +1028,7 @@ impl Scanner {
         // Stage 7: final projection
         plan = Arc::new(DFProjectionExec::try_new(self.output_expr()?, plan)?);
 
-        let optimizer = Planner::get_physical_optimizer();
+        let optimizer = get_physical_optimizer();
         let options = Default::default();
         for rule in optimizer.rules {
             plan = rule.optimize(plan, &options)?;

--- a/rust/lance/src/io/exec.rs
+++ b/rust/lance/src/io/exec.rs
@@ -7,7 +7,6 @@
 
 pub(crate) mod knn;
 mod optimizer;
-mod planner;
 mod projection;
 mod pushdown_scan;
 pub mod scalar_index;
@@ -18,7 +17,9 @@ pub mod testing;
 pub mod utils;
 
 pub use knn::{ANNIvfPartitionExec, ANNIvfSubIndexExec, KNNVectorDistanceExec, PreFilterSource};
-pub use planner::{FilterPlan, Planner};
+pub use lance_datafusion::planner::Planner;
+pub use lance_index::scalar::expression::FilterPlan;
+pub use optimizer::get_physical_optimizer;
 pub use projection::ProjectionExec;
 pub use pushdown_scan::{LancePushdownScanExec, ScanConfig};
 pub use scan::LanceScanExec;

--- a/rust/lance/src/io/exec/optimizer.rs
+++ b/rust/lance/src/io/exec/optimizer.rs
@@ -10,7 +10,7 @@ use datafusion::{
     common::tree_node::{Transformed, TreeNode},
     config::ConfigOptions,
     error::Result as DFResult,
-    physical_optimizer::PhysicalOptimizerRule,
+    physical_optimizer::{optimizer::PhysicalOptimizer, PhysicalOptimizerRule},
     physical_plan::{projection::ProjectionExec as DFProjectionExec, ExecutionPlan},
 };
 use datafusion_physical_expr::expressions::Column;
@@ -98,4 +98,11 @@ impl PhysicalOptimizerRule for SimplifyProjection {
     fn schema_check(&self) -> bool {
         true
     }
+}
+
+pub fn get_physical_optimizer() -> PhysicalOptimizer {
+    PhysicalOptimizer::with_rules(vec![
+        Arc::new(crate::io::exec::optimizer::CoalesceTake),
+        Arc::new(crate::io::exec::optimizer::SimplifyProjection),
+    ])
 }

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -682,7 +682,8 @@ mod test {
     use pretty_assertions::assert_eq;
     use tempfile::tempdir;
 
-    use crate::{datafusion::logical_expr::tests::ExprExt, dataset::WriteParams};
+    use crate::dataset::WriteParams;
+    use lance_datafusion::logical_expr::ExprExt;
 
     use super::*;
 

--- a/rust/lance/src/utils.rs
+++ b/rust/lance/src/utils.rs
@@ -4,7 +4,6 @@
 //! Various utilities
 
 pub(crate) mod future;
-pub mod sql;
 pub(crate) mod temporal;
 #[cfg(test)]
 pub(crate) mod test;
@@ -12,4 +11,5 @@ pub(crate) mod test;
 pub mod tfrecord;
 
 // Re-export
+pub use lance_datafusion::sql;
 pub use lance_linalg::kmeans;


### PR DESCRIPTION
This is purely a refactor and I inserted the appropriate re-exports into `lance` that there is no API change.  There were two minor extractions that were not purely moves:

`get_physical_optimizer` went from a static function on `Planner` to a free function in `optimizer.rs`
`create_filter_plan` and `FilterPlan` moved into `lance_index` as `PlannerIndexExt`