### PR TITLE
perf: speed up fsst decompression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,9 +73,9 @@ arrow-schema = "52.1"
 arrow-select = "52.1"
 async-recursion = "1.0"
 async-trait = "0.1"
-aws-config = "0.57"
-aws-credential-types = "0.57"
-aws-sdk-dynamodb = "0.35"
+aws-config = "1.2.0"
+aws-credential-types = "1.2.0"
+aws-sdk-dynamodb = "1.38.0"
 half = { "version" = "2.4.1", default-features = false, features = [
     "num-traits",
     "std",

--- a/rust/lance-encoding/compression-algo/fsst/examples/benchmark.rs
+++ b/rust/lance-encoding/compression-algo/fsst/examples/benchmark.rs
@@ -4,7 +4,7 @@
 use fsst::fsst::{compress, decompress, FSST_SYMBOL_TABLE_SIZE};
 use rand::Rng;
 
-const TEST_NUM: usize = 10;
+const TEST_NUM: usize = 20;
 const BUFFER_SIZE: usize = 8 * 1024 * 1024;
 
 use arrow::array::StringArray;

--- a/rust/lance-encoding/compression-algo/fsst/src/fsst.rs
+++ b/rust/lance-encoding/compression-algo/fsst/src/fsst.rs
@@ -1384,7 +1384,7 @@ mod tests {
             What might be toward, that this sweaty haste  
             Doth make the night joint-labourer with the day?
             Who is't that can inform me?";
-    
+
     const TEST_PARAGRAPH2: &str = "Towards the end of November, during a thaw, at nine o’clock one morning, a train on the Warsaw and Petersburg railway was approaching the latter city at full speed.
 The morning was so damp and misty that it was only with great difficulty that the day succeeded in breaking; 
 and it was impossible to distinguish anything more than a few yards away from the carriage windows. 
@@ -1469,12 +1469,12 @@ But exactly how the acquaintance and friendship came about, we cannot say.";
     async fn test_fsst() {
         let test_input_size = 8 * 1024 * 1024;
         let repeat_num = test_input_size / TEST_PARAGRAPH.len();
-        let test_input = TEST_PARAGRAPH.repeat(repeat_num); 
+        let test_input = TEST_PARAGRAPH.repeat(repeat_num);
         helper(&test_input);
 
         let test_input_size = 16 * 1024 * 1024;
         let repeat_num = test_input_size / TEST_PARAGRAPH.len();
-        let test_input = TEST_PARAGRAPH.repeat(repeat_num); 
+        let test_input = TEST_PARAGRAPH.repeat(repeat_num);
         helper(&test_input);
 
         let test_input_size = 8 * 1024 * 1024;
@@ -1484,7 +1484,7 @@ But exactly how the acquaintance and friendship came about, we cannot say.";
 
         let test_input_size = 16 * 1024 * 1024;
         let repeat_num = test_input_size / TEST_PARAGRAPH2.len();
-        let test_input = TEST_PARAGRAPH2.repeat(repeat_num); 
+        let test_input = TEST_PARAGRAPH2.repeat(repeat_num);
         helper(&test_input);
 
         let test_input_size = 8 * 1024 * 1024;


### PR DESCRIPTION
before:
<img width="710" alt="Screenshot 2024-07-21 at 4 24 44 PM" src="https://github.com/user-attachments/assets/65a953ac-bbbf-4244-b3fa-d5b7c368806e">

after:
<img width="589" alt="Screenshot 2024-07-21 at 4 28 49 PM" src="https://github.com/user-attachments/assets/16a20200-d8f2-4e5a-8e59-2be42281222e">


to reproduce:
`cargo run --release --example benchmark `
in `rust/lance-encoding/compression-algo/fsst`

machine info:
`11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz`
`Linux 192 5.10.0-28-amd64 #1 SMP Debian 5.10.209-2 (2024-01-31) x86_64 GNU/Linux`