### PR TITLE
perf: allow fragment scan for nearest query if there is a prefilter

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1537,6 +1537,10 @@ impl Scanner {
                 PreFilterSource::FilteredRowIds(filtered_row_ids)
             } // Should be index_scan -> filter
             (Some(index_query), None, true) => {
+                // Index scan doesn't honor the fragment allowlist today.
+                // TODO: we could filter the index scan results to only include the allowed fragments.
+                self.ensure_not_fragment_scan()?;
+
                 // The filter is completely satisfied by the index.  We
                 // only need to search the index to determine the valid row
                 // ids.

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -445,7 +445,9 @@ impl Scanner {
 
     /// Find k-nearest neighbor within the vector column.
     pub fn nearest(&mut self, column: &str, q: &Float32Array, k: usize) -> Result<&mut Self> {
-        self.ensure_not_fragment_scan()?;
+        if !self.prefilter {
+            self.ensure_not_fragment_scan()?;
+        }
 
         if k == 0 {
             return Err(Error::io("k must be positive".to_string(), location!()));

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -446,6 +446,8 @@ impl Scanner {
     /// Find k-nearest neighbor within the vector column.
     pub fn nearest(&mut self, column: &str, q: &Float32Array, k: usize) -> Result<&mut Self> {
         if !self.prefilter {
+            // We can allow fragment scan if the input to nearest is a prefilter.
+            // The fragment scan will be performed by the prefilter.
             self.ensure_not_fragment_scan()?;
         }
 


### PR DESCRIPTION
We want to create a query plan that first runs prefiltering on selected fragments.

Then for rows passing the prefilter, we probe the ANN index with `filter_row_ids`.

In this plan, the returned result rows will only come from the selected fragments, so there will be no violation to the query semantics.
