### PR TITLE
perf: skip documents with WAND

### DIFF
--- a/rust/lance-index/src/prefilter.rs
+++ b/rust/lance-index/src/prefilter.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use lance_core::utils::mask::RowIdMask;
 use lance_core::Result;
@@ -34,6 +36,9 @@ pub trait PreFilter: Send + Sync {
     /// If the filter is empty.
     fn is_empty(&self) -> bool;
 
+    /// Get the row id mask for this prefilter
+    fn mask(&self) -> Arc<RowIdMask>;
+
     /// Check whether a slice of row ids should be included in a query.
     ///
     /// Returns a vector of indices into the input slice that should be included,
@@ -54,6 +59,10 @@ impl PreFilter for NoFilter {
 
     fn is_empty(&self) -> bool {
         true
+    }
+
+    fn mask(&self) -> Arc<RowIdMask> {
+        Arc::new(RowIdMask::all_rows())
     }
 
     fn filter_row_ids<'a>(&self, row_ids: Box<dyn Iterator<Item = &'a u64> + 'a>) -> Vec<u64> {

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -1,0 +1,228 @@
+use std::cmp::Reverse;
+use std::collections::{BTreeSet, BinaryHeap};
+use std::sync::Arc;
+
+use itertools::Itertools;
+use lance_core::utils::mask::RowIdMask;
+
+use crate::vector::graph::OrderedFloat;
+
+use super::{idf, OrderedDoc, PostingList, K1};
+
+#[derive(Clone)]
+pub(crate) struct PostingIterator<'a> {
+    token_id: u32,
+    list: &'a PostingList,
+    index: usize,
+    mask: Arc<RowIdMask>,
+    approximate_upper_bound: f32,
+}
+
+impl PartialEq for PostingIterator<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.token_id == other.token_id && self.index == other.index
+    }
+}
+
+impl Eq for PostingIterator<'_> {}
+
+impl PartialOrd for PostingIterator<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match self.doc().partial_cmp(&other.doc()) {
+            Some(std::cmp::Ordering::Equal) => Some(self.token_id.cmp(&other.token_id)),
+            ord => ord,
+        }
+    }
+}
+
+impl Ord for PostingIterator<'_> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.doc().map(|d| d.0).cmp(&other.doc().map(|d| d.0)) {
+            std::cmp::Ordering::Equal => self.token_id.cmp(&other.token_id),
+            ord => ord,
+        }
+    }
+}
+
+impl<'a> PostingIterator<'a> {
+    pub(crate) fn new(
+        token_id: u32,
+        list: &'a PostingList,
+        num_doc: usize,
+        mask: Arc<RowIdMask>,
+    ) -> Option<Self> {
+        Some(Self {
+            token_id,
+            list,
+            index: 0,
+            mask,
+            approximate_upper_bound: idf(list.len(), num_doc) * (K1 + 1.0),
+        })
+    }
+
+    #[inline]
+    fn approximate_upper_bound(&self) -> f32 {
+        self.approximate_upper_bound
+    }
+
+    fn doc(&self) -> Option<(u64, f32)> {
+        if self.index < self.list.len() {
+            Some((
+                self.list.row_ids[self.index],
+                self.list.frequencies[self.index],
+            ))
+        } else {
+            None
+        }
+    }
+
+    // move to the next row id that is greater than or equal to least_id
+    fn next(&mut self, least_id: u64) -> Option<(u64, usize)> {
+        let block_size = ((self.list.len() - self.index) as f32).sqrt().ceil() as usize;
+        // skip blocks
+        while self.index + block_size < self.list.len()
+            && self.list.row_ids[self.index + block_size] < least_id
+        {
+            self.index += block_size;
+        }
+        // linear search
+        while self.index < self.list.len() {
+            let row_id = self.list.row_ids[self.index];
+            if row_id >= least_id && self.mask.selected(row_id) {
+                return Some((row_id, self.index));
+            }
+            self.index += 1;
+        }
+        None
+    }
+}
+
+pub(crate) struct Wand<'a> {
+    factor: f32,
+    threshold: f32, // multiple of factor and the minimum score of the top-k documents
+    cur_doc: Option<u64>,
+    postings: BTreeSet<PostingIterator<'a>>,
+    candidates: BinaryHeap<Reverse<OrderedDoc>>,
+}
+
+impl<'a> Wand<'a> {
+    pub(crate) fn new(postings: impl Iterator<Item = PostingIterator<'a>>) -> Self {
+        Self {
+            factor: 1.0,
+            threshold: 0.0,
+            cur_doc: None,
+            postings: postings.collect(),
+            candidates: BinaryHeap::new(),
+        }
+    }
+
+    // search the top-k documents that contain the query
+    pub(crate) fn search(&mut self, k: usize, scorer: impl Fn(u64, f32) -> f32) -> Vec<(u64, f32)> {
+        if k == 0 {
+            return vec![];
+        }
+
+        while let Some(doc) = self.next() {
+            log::debug!("candidate doc: {}", doc);
+            let score = self.score(doc, &scorer);
+            if self.candidates.len() < k {
+                self.candidates.push(Reverse(OrderedDoc::new(doc, score)));
+            } else if score > self.threshold {
+                self.candidates.pop();
+                self.candidates.push(Reverse(OrderedDoc::new(doc, score)));
+                self.threshold = self.candidates.peek().unwrap().0.score.0 * self.factor;
+            }
+        }
+
+        self.candidates
+            .iter()
+            .map(|doc| (doc.0.row_id, doc.0.score))
+            .sorted_unstable()
+            .map(|(row_id, score)| (row_id, score.0))
+            .collect()
+    }
+
+    fn score(&self, doc: u64, scorer: &impl Fn(u64, f32) -> f32) -> f32 {
+        let mut score = 0.0;
+        for posting in &self.postings {
+            let (cur_doc, freq) = posting.doc().expect("empty posting list was removed");
+            if cur_doc > doc {
+                // the posting list is sorted by its current doc id,
+                // so we can break early once we find the current doc id is greater than the doc id we are looking for
+                break;
+            }
+            assert!(cur_doc == doc);
+
+            score += posting.approximate_upper_bound() * scorer(doc, freq);
+        }
+        score
+    }
+
+    // find the next doc candidate
+    fn next(&mut self) -> Option<u64> {
+        while let Some((index, pivot_posting)) = self.find_pivot_term() {
+            let (doc, _) = pivot_posting
+                .doc()
+                .expect("pivot posting should have at least one document");
+
+            let cur_doc = self.cur_doc.unwrap_or(0);
+            if self.cur_doc.is_some() && doc <= cur_doc {
+                let posting = self.pick_term(cur_doc + 1, self.postings.iter().take(index + 1));
+                let mut posting = self
+                    .postings
+                    .take(&posting)
+                    .expect("we just found it in the previous step");
+                if posting.next(cur_doc + 1).is_some() {
+                    self.postings.insert(posting);
+                }
+            } else {
+                if self
+                    .postings
+                    .first()
+                    .and_then(|posting| posting.doc().map(|(d, _)| d))
+                    .expect("the postings can't be empty")
+                    == doc
+                {
+                    self.cur_doc = Some(doc);
+                    return Some(doc);
+                } else {
+                    let posting = self.pick_term(doc, self.postings.iter().take(index));
+                    let mut posting = self
+                        .postings
+                        .take(&posting)
+                        .expect("we just found it in the previous step");
+                    if posting.next(doc).is_some() {
+                        self.postings.insert(posting);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn find_pivot_term(&self) -> Option<(usize, PostingIterator<'a>)> {
+        let mut acc = 0.0;
+        for (i, iter) in self.postings.iter().enumerate() {
+            acc += iter.approximate_upper_bound();
+            if acc >= self.threshold {
+                return Some((i, iter.clone()));
+            }
+        }
+        None
+    }
+
+    fn pick_term<'b>(
+        &self,
+        doc: u64,
+        postings: impl Iterator<Item = &'b PostingIterator<'a>>,
+    ) -> PostingIterator<'a>
+    where
+        'a: 'b,
+    {
+        postings
+            .filter(|posting| posting.doc().unwrap().0 < doc)
+            .max_by_key(|posting| OrderedFloat(posting.approximate_upper_bound()))
+            .expect("at least one posting list")
+            .clone()
+    }
+}

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -178,25 +178,23 @@ impl<'a> Wand<'a> {
                 if posting.next(cur_doc + 1).is_some() {
                     self.postings.insert(posting);
                 }
+            } else if self
+                .postings
+                .first()
+                .and_then(|posting| posting.doc().map(|(d, _)| d))
+                .expect("the postings can't be empty")
+                == doc
+            {
+                self.cur_doc = Some(doc);
+                return Some(doc);
             } else {
-                if self
+                let posting = self.pick_term(doc, self.postings.iter().take(index));
+                let mut posting = self
                     .postings
-                    .first()
-                    .and_then(|posting| posting.doc().map(|(d, _)| d))
-                    .expect("the postings can't be empty")
-                    == doc
-                {
-                    self.cur_doc = Some(doc);
-                    return Some(doc);
-                } else {
-                    let posting = self.pick_term(doc, self.postings.iter().take(index));
-                    let mut posting = self
-                        .postings
-                        .take(&posting)
-                        .expect("we just found it in the previous step");
-                    if posting.next(doc).is_some() {
-                        self.postings.insert(posting);
-                    }
+                    .take(&posting)
+                    .expect("we just found it in the previous step");
+                if posting.next(doc).is_some() {
+                    self.postings.insert(posting);
                 }
             }
         }

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
 use std::cmp::Reverse;
 use std::collections::{BTreeSet, BinaryHeap};
 use std::sync::Arc;

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -31,10 +31,7 @@ impl Eq for PostingIterator<'_> {}
 
 impl PartialOrd for PostingIterator<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        match self.doc().partial_cmp(&other.doc()) {
-            Some(std::cmp::Ordering::Equal) => Some(self.token_id.cmp(&other.token_id)),
-            ord => ord,
-        }
+        Some(self.cmp(other))
     }
 }
 

--- a/rust/lance/examples/full_text_search.rs
+++ b/rust/lance/examples/full_text_search.rs
@@ -74,14 +74,12 @@ async fn main() {
             .unwrap();
     }
 
-    let dataset = Dataset::open("/Users/yang/src/lance/fts.lance")
-        .await
-        .unwrap();
+    let dataset = Dataset::open(dataset_dir.as_ref()).await.unwrap();
     let query = tokens[0];
     println!("query: {:?}", query);
     let batch = dataset
         .scan()
-        .full_text_search(FullTextSearchQuery::new(query.to_owned()).limit(Some(10)))
+        .full_text_search(FullTextSearchQuery::new(query.to_owned()))
         .unwrap()
         .try_into_batch()
         .await

--- a/rust/lance/examples/full_text_search.rs
+++ b/rust/lance/examples/full_text_search.rs
@@ -74,12 +74,14 @@ async fn main() {
             .unwrap();
     }
 
-    let dataset = Dataset::open(dataset_dir.as_ref()).await.unwrap();
+    let dataset = Dataset::open("/Users/yang/src/lance/fts.lance")
+        .await
+        .unwrap();
     let query = tokens[0];
     println!("query: {:?}", query);
     let batch = dataset
         .scan()
-        .full_text_search(FullTextSearchQuery::new(query.to_owned()))
+        .full_text_search(FullTextSearchQuery::new(query.to_owned()).limit(Some(10)))
         .unwrap()
         .try_into_batch()
         .await


### PR DESCRIPTION
This improves the full text search 3x faster without recall loss.

With WAND, we don't need to calculate the score for all matched documents, it would skip the documents that are impossible to be in the results.

ref: https://www.researchgate.net/publication/221613425_Efficient_query_evaluation_using_a_two-level_retrieval_process

This also adds a method `mask()` for `PreFilter` trait, to get the `RowIdMask`, because it's hard to use the `filter_row_ids` method in the WAND implementation