### PR TITLE
fix: pin numpy version to avoid numpy >= 2.0 until pyarrow supports it

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylance"
-dependencies = ["pyarrow>=12", "numpy>=1.22"]
+dependencies = ["pyarrow>=12", "numpy>=1.22,<2"]
 description = "python wrapper for Lance columnar format"
 authors = [{ name = "Lance Devs", email = "dev@lancedb.com" }]
 license = { file = "LICENSE" }


### PR DESCRIPTION
Pyarrow does not seem to support numpy 2.0.  We need to avoid it until they are ready.