### PR TITLE
feat: merge_insert update subcolumns

### DIFF
--- a/protos/table.proto
+++ b/protos/table.proto
@@ -200,6 +200,11 @@ message DataFile {
   string path = 1;
   // The ids of the fields/columns in this file.
   //
+  // -1 is used for "unassigned" while in memory. It is not meant to be written
+  // to disk. -2 is used for "tombstoned", meaningful a field that is no longer
+  // in use. This is often because the original field id was reassigned to a
+  // different data file.
+  //
   // In Lance v1 IDs are assigned based on position in the file, offset by the max
   // existing field id in the table (if any already). So when a fragment is first
   // created with one file of N columns, the field ids will be 1, 2, ..., N. If a

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1073,9 +1073,13 @@ def test_merge_insert_subcols(tmp_path: Path):
     assert fragments[1].fragment_id == original_fragments[1].fragment_id
 
     assert len(fragments[0].data_files()) == 2
-    assert fragments[0].data_files()[0] == original_fragments[0].data_files()[0]
+    assert str(fragments[0].data_files()[0]) == str(
+        original_fragments[0].data_files()[0]
+    )
     assert len(fragments[1].data_files()) == 1
-    assert fragments[1].data_files()[0] == original_fragments[1].data_files()[0]
+    assert str(fragments[1].data_files()[0]) == str(
+        original_fragments[1].data_files()[0]
+    )
 
 
 def test_flat_vector_search_with_delete(tmp_path: Path):
@@ -1258,7 +1262,10 @@ def test_merge_insert_incompatible_schema(tmp_path: Path):
 
     with pytest.raises(OSError):
         merge_dict = (
-            dataset.merge_insert("a").when_matched_update_all().execute(new_table)
+            dataset.merge_insert("a")
+            .when_matched_update_all()
+            .when_not_matched_insert_all()
+            .execute(new_table)
         )
         check_merge_stats(merge_dict, (None, None, None))
 

--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -15,7 +15,7 @@ use arrow_array::{
 };
 use arrow_data::ArrayDataBuilder;
 use arrow_schema::{ArrowError, DataType, Field, FieldRef, Fields, IntervalUnit, Schema};
-use arrow_select::take::take;
+use arrow_select::{interleave::interleave, take::take};
 use rand::prelude::*;
 
 pub mod deepcopy;
@@ -606,6 +606,33 @@ fn get_sub_array<'a>(array: &'a ArrayRef, components: &[&str]) -> Option<&'a Arr
     struct_arr
         .column_by_name(components[0])
         .and_then(|arr| get_sub_array(arr, &components[1..]))
+}
+
+/// Interleave multiple RecordBatches into a single RecordBatch.
+///
+/// Behaves like [`arrow::compute::interleave`], but for RecordBatches.
+pub fn interleave_batches(
+    batches: &[RecordBatch],
+    indices: &[(usize, usize)],
+) -> Result<RecordBatch> {
+    let first_batch = batches.first().ok_or_else(|| {
+        ArrowError::InvalidArgumentError("Cannot interleave zero RecordBatches".to_string())
+    })?;
+    let schema = first_batch.schema().clone();
+    let num_columns = first_batch.num_columns();
+    let mut columns = Vec::with_capacity(num_columns);
+    let mut chunks = Vec::with_capacity(batches.len());
+
+    for i in 0..num_columns {
+        for batch in batches {
+            chunks.push(batch.column(i).as_ref());
+        }
+        let new_column = interleave(&chunks, indices)?;
+        columns.push(new_column);
+        chunks.clear();
+    }
+
+    RecordBatch::try_new(schema, columns)
 }
 
 #[cfg(test)]

--- a/rust/lance-core/src/utils/tokio.rs
+++ b/rust/lance-core/src/utils/tokio.rs
@@ -35,7 +35,6 @@ lazy_static::lazy_static! {
         .worker_threads(1)
         // keep the thread alive "forever"
         .thread_keep_alive(Duration::from_secs(u64::MAX))
-        .enable_all()
         .build()
         .unwrap();
 }

--- a/rust/lance-core/src/utils/tokio.rs
+++ b/rust/lance-core/src/utils/tokio.rs
@@ -35,7 +35,7 @@ lazy_static::lazy_static! {
         .worker_threads(1)
         // keep the thread alive "forever"
         .thread_keep_alive(Duration::from_secs(u64::MAX))
-        .enable_time()
+        .enable_all()
         .build()
         .unwrap();
 }

--- a/rust/lance-core/src/utils/tokio.rs
+++ b/rust/lance-core/src/utils/tokio.rs
@@ -35,6 +35,7 @@ lazy_static::lazy_static! {
         .worker_threads(1)
         // keep the thread alive "forever"
         .thread_keep_alive(Duration::from_secs(u64::MAX))
+        .enable_time()
         .build()
         .unwrap();
 }

--- a/rust/lance-datafusion/src/dataframe.rs
+++ b/rust/lance-datafusion/src/dataframe.rs
@@ -116,8 +116,8 @@ impl BatchStreamGrouper {
     }
 
     /// Get the output schema of the stream.
-    pub fn schema(&self) -> Arc<Schema> {
-        self.input.schema()
+    pub fn schema(&self) -> &Arc<Schema> {
+        &self.schema
     }
 
     /// Given a record batch, find the distinct ranges of partition values.

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -195,7 +195,7 @@ impl LanceExecutionOptions {
     }
 }
 
-pub fn get_session_context(options: LanceExecutionOptions) -> SessionContext {
+pub fn new_session_context(options: LanceExecutionOptions) -> SessionContext {
     let session_config = SessionConfig::new();
     let mut runtime_config = RuntimeConfig::new();
     if options.use_spilling() {
@@ -215,7 +215,10 @@ pub fn execute_plan(
     plan: Arc<dyn ExecutionPlan>,
     options: LanceExecutionOptions,
 ) -> Result<SendableRecordBatchStream> {
-    let session_ctx = get_session_context(options);
+    let session_ctx = new_session_context(options);
+    // NOTE: we are only executing the first partition here. Therefore, if
+    // the plan has more than one partition, we will be missing data.
+    assert_eq!(plan.properties().partitioning.partition_count(), 1);
     Ok(plan.execute(0, session_ctx.task_ctx())?)
 }
 

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -11,7 +11,7 @@ use datafusion::{
     dataframe::DataFrame,
     datasource::streaming::StreamingTable,
     execution::{
-        context::{SessionConfig, SessionContext, SessionState},
+        context::{SessionConfig, SessionContext},
         disk_manager::DiskManagerConfig,
         memory_pool::FairSpillPool,
         runtime_env::{RuntimeConfig, RuntimeEnv},
@@ -195,13 +195,7 @@ impl LanceExecutionOptions {
     }
 }
 
-/// Executes a plan using default session & runtime configuration
-///
-/// Only executes a single partition.  Panics if the plan has more than one partition.
-pub fn execute_plan(
-    plan: Arc<dyn ExecutionPlan>,
-    options: LanceExecutionOptions,
-) -> Result<SendableRecordBatchStream> {
+pub fn get_session_context(options: LanceExecutionOptions) -> SessionContext {
     let session_config = SessionConfig::new();
     let mut runtime_config = RuntimeConfig::new();
     if options.use_spilling() {
@@ -210,12 +204,19 @@ pub fn execute_plan(
             options.mem_pool_size() as usize
         )));
     }
-    let runtime_env = Arc::new(RuntimeEnv::new(runtime_config)?);
-    let session_state = SessionState::new_with_config_rt(session_config, runtime_env);
-    // NOTE: we are only executing the first partition here. Therefore, if
-    // the plan has more than one partition, we will be missing data.
-    assert_eq!(plan.properties().partitioning.partition_count(), 1);
-    Ok(plan.execute(0, session_state.task_ctx())?)
+    let runtime_env = Arc::new(RuntimeEnv::new(runtime_config).unwrap());
+    SessionContext::new_with_config_rt(session_config, runtime_env)
+}
+
+/// Executes a plan using default session & runtime configuration
+///
+/// Only executes a single partition.  Panics if the plan has more than one partition.
+pub fn execute_plan(
+    plan: Arc<dyn ExecutionPlan>,
+    options: LanceExecutionOptions,
+) -> Result<SendableRecordBatchStream> {
+    let session_ctx = get_session_context(options);
+    Ok(plan.execute(0, session_ctx.task_ctx())?)
 }
 
 pub trait SessionContextExt {

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1035,7 +1035,8 @@ impl FileFragment {
         schemas: Option<(Schema, Schema)>,
     ) -> Result<Updater> {
         let mut schema = self.dataset.schema().clone();
-        let mut with_row_addr = schema.fields.is_empty();
+
+        let mut with_row_addr = false;
         if let Some(columns) = columns {
             let mut projection = Vec::new();
             for column in columns {
@@ -1047,11 +1048,9 @@ impl FileFragment {
             }
             schema = schema.project(&projection)?;
         }
-        // if let Some(columns) = columns {
-        //     schema = schema.project(columns)?;
-        // }
         // If there is no projection, we at least need to read the row addresses
-        // let with_row_addr = schema.fields.is_empty();
+        with_row_addr |= schema.fields.is_empty();
+
         let reader = self.open(&schema, false, with_row_addr, None);
         let deletion_vector = read_deletion_file(
             &self.dataset.base,

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1035,11 +1035,23 @@ impl FileFragment {
         schemas: Option<(Schema, Schema)>,
     ) -> Result<Updater> {
         let mut schema = self.dataset.schema().clone();
+        let mut with_row_addr = schema.fields.is_empty();
         if let Some(columns) = columns {
-            schema = schema.project(columns)?;
+            let mut projection = Vec::new();
+            for column in columns {
+                if column.as_ref() == ROW_ADDR {
+                    with_row_addr = true;
+                } else {
+                    projection.push(column.as_ref());
+                }
+            }
+            schema = schema.project(&projection)?;
         }
+        // if let Some(columns) = columns {
+        //     schema = schema.project(columns)?;
+        // }
         // If there is no projection, we at least need to read the row addresses
-        let with_row_addr = schema.fields.is_empty();
+        // let with_row_addr = schema.fields.is_empty();
         let reader = self.open(&schema, false, with_row_addr, None);
         let deletion_vector = read_deletion_file(
             &self.dataset.base,

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -53,7 +53,10 @@ use futures::{
 use lance_core::{
     datatypes::SchemaCompareOptions,
     error::{box_error, InvalidInputSnafu},
-    utils::{futures::Capacity, tokio::CPU_RUNTIME},
+    utils::{
+        futures::Capacity,
+        tokio::{get_num_compute_intensive_cpus, CPU_RUNTIME},
+    },
     Error, Result, ROW_ADDR, ROW_ADDR_FIELD, ROW_ID,
 };
 use lance_datafusion::{
@@ -578,7 +581,7 @@ impl MergeInsertJob {
         let updated_fragments = Arc::new(Mutex::new(Vec::new()));
         let mut tasks = JoinSet::new();
         let handle = CPU_RUNTIME.handle();
-        let task_limit = handle.metrics().num_workers();
+        let task_limit = get_num_compute_intensive_cpus();
         let mut reservation =
             MemoryConsumer::new("MergeInsert").register(session_ctx.task_ctx().memory_pool());
         while let Some((frag_id, batches)) = group_stream.next().await.transpose()? {

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -53,10 +53,7 @@ use futures::{
 use lance_core::{
     datatypes::SchemaCompareOptions,
     error::{box_error, InvalidInputSnafu},
-    utils::{
-        futures::Capacity,
-        tokio::{get_num_compute_intensive_cpus, CPU_RUNTIME},
-    },
+    utils::{futures::Capacity, tokio::get_num_compute_intensive_cpus},
     Error, Result, ROW_ADDR, ROW_ADDR_FIELD, ROW_ID, ROW_ID_FIELD,
 };
 use lance_datafusion::{
@@ -608,7 +605,6 @@ impl MergeInsertJob {
         // Can update the fragments in parallel.
         let updated_fragments = Arc::new(Mutex::new(Vec::new()));
         let mut tasks = JoinSet::new();
-        let handle = CPU_RUNTIME.handle();
         let task_limit = get_num_compute_intensive_cpus();
         let mut reservation =
             MemoryConsumer::new("MergeInsert").register(session_ctx.task_ctx().memory_pool());
@@ -816,7 +812,7 @@ impl MergeInsertJob {
                 updated_fragments.clone(),
                 memory_size,
             );
-            tasks.spawn_on(fut, handle);
+            tasks.spawn(fut);
         }
 
         while let Some(res) = tasks.join_next().await {

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -206,7 +206,7 @@ fn fix_schema(manifest: &mut Manifest) -> Result<()> {
     for fragment in manifest.fragments.iter() {
         for file in fragment.files.iter() {
             for field_id in file.fields.iter() {
-                if !seen_fields.insert(*field_id) && *field_id != -2 {
+                if *field_id >= 0 && !seen_fields.insert(*field_id) {
                     fields_with_duplicate_ids.insert(*field_id);
                 }
             }

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -206,7 +206,7 @@ fn fix_schema(manifest: &mut Manifest) -> Result<()> {
     for fragment in manifest.fragments.iter() {
         for file in fragment.files.iter() {
             for field_id in file.fields.iter() {
-                if !seen_fields.insert(*field_id) {
+                if !seen_fields.insert(*field_id) && *field_id != -2 {
                     fields_with_duplicate_ids.insert(*field_id);
                 }
             }


### PR DESCRIPTION
Closes #2610

* Supports subschemas in `merge_insert` for updates only
  * Inserts and deletes left as TODO
* Field id `-2` is now reserved as a field "tombstone". These tombstones are fields that are no longer in the schema, usually because those fields are now in a different data file.
* Fixed a bug in `Merger` where statistics were reset on each batch.