### PR TITLE
perf: add v2 fragment file metadata to the FileMetadataCache

### DIFF
--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -6,6 +6,7 @@ use std::{collections::BTreeSet, io::Cursor, ops::Range, pin::Pin, sync::Arc};
 use arrow_schema::Schema as ArrowSchema;
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
 use bytes::{Bytes, BytesMut};
+use deepsize::{Context, DeepSizeOf};
 use futures::{stream::BoxStream, Stream, StreamExt};
 use lance_encoding::{
     decoder::{
@@ -71,6 +72,15 @@ pub struct CachedFileMetadata {
     pub major_version: u16,
     pub minor_version: u16,
 }
+
+impl DeepSizeOf for CachedFileMetadata {
+    // TODO: include size for `column_metadatas` and `column_infos`.
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.file_schema.deep_size_of_children(context)
+            + self.file_buffers.iter().map(|file_buffer| file_buffer.deep_size_of_children(context)).sum::<usize>()
+    }
+}
+
 /// Selecting columns from a lance file requires specifying both the
 /// index of the column and the data type of the column
 ///
@@ -307,7 +317,7 @@ impl FileReader {
     //
     // Also, if the number of columns is fairly small, it's faster to read them as a
     // single IOP, but we can fix this through coalescing.
-    async fn read_all_metadata(scheduler: &FileScheduler) -> Result<CachedFileMetadata> {
+    pub async fn read_all_metadata(scheduler: &FileScheduler) -> Result<CachedFileMetadata> {
         // 1. read the footer
         let (tail_bytes, file_len) = Self::read_tail(scheduler).await?;
         let footer = Self::decode_footer(&tail_bytes)?;
@@ -497,6 +507,16 @@ impl FileReader {
         decoder_strategy: DecoderMiddlewareChain,
     ) -> Result<Self> {
         let file_metadata = Arc::new(Self::read_all_metadata(&scheduler).await?);
+        Self::try_open_with_file_metadata(scheduler, base_projection, decoder_strategy, file_metadata).await
+    }
+
+    /// Same as `try_open` but with the file metadata already loaded.
+    pub async fn try_open_with_file_metadata(
+        scheduler: FileScheduler,
+        base_projection: Option<ReaderProjection>,
+        decoder_strategy: DecoderMiddlewareChain,
+        file_metadata: Arc<CachedFileMetadata>,
+    ) -> Result<Self> {
         if let Some(base_projection) = base_projection.as_ref() {
             Self::validate_projection(base_projection, &file_metadata)?;
         }
@@ -510,6 +530,8 @@ impl FileReader {
             decoder_strategy,
         })
     }
+
+
 
     // The actual decoder needs all the column infos that make up a type.  In other words, if
     // the first type in the schema is Struct<i32, i32> then the decoder will need 3 column infos.

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -960,7 +960,7 @@ impl FileFragment {
         let file_metadata = cache
             .get_or_insert(path, |_path| async {
                 let file_metadata: CachedFileMetadata =
-                    v2::reader::FileReader::read_all_metadata(&file_scheduler).await?;
+                    v2::reader::FileReader::read_all_metadata(file_scheduler).await?;
                 Ok(file_metadata)
             })
             .await?;

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -24,9 +24,9 @@ use lance_core::{ROW_ADDR, ROW_ADDR_FIELD, ROW_ID_FIELD};
 use lance_encoding::decoder::DecoderMiddlewareChain;
 use lance_file::reader::{read_batch, FileReader};
 use lance_file::v2;
-use lance_file::v2::reader::ReaderProjection;
+use lance_file::v2::reader::{CachedFileMetadata, ReaderProjection};
 use lance_io::object_store::ObjectStore;
-use lance_io::scheduler::ScanScheduler;
+use lance_io::scheduler::{FileScheduler, ScanScheduler};
 use lance_io::ReadBatchParams;
 use lance_table::format::{DataFile, DeletionFile, Fragment};
 use lance_table::io::deletion::{deletion_file_path, read_deletion_file, write_deletion_file};
@@ -542,11 +542,13 @@ impl FileFragment {
             let store_scheduler = scan_scheduler
                 .unwrap_or_else(|| ScanScheduler::new(self.dataset.object_store.clone()));
             let file_scheduler = store_scheduler.open_file(&path).await?;
+            let file_metadata = self.get_file_metadata(&file_scheduler).await?;
             let reader = Arc::new(
-                v2::reader::FileReader::try_open(
+                v2::reader::FileReader::try_open_with_file_metadata(
                     file_scheduler,
                     None,
                     DecoderMiddlewareChain::default(),
+                    file_metadata
                 )
                 .await?,
             );
@@ -945,6 +947,17 @@ impl FileFragment {
                 None => Ok(None),
             }
         }
+    }
+
+    /// Get the file metadata for this fragment, using the cache if available.
+    async fn get_file_metadata(&self, file_scheduler: &FileScheduler) -> Result<Arc<CachedFileMetadata>> {
+        let cache = &self.dataset.session.file_metadata_cache;
+        let path = file_scheduler.reader().path();
+
+        cache.get_or_insert(path, |_path| async {
+            let file_metadata = Arc::new(v2::reader::FileReader::read_all_metadata(&file_scheduler).await?);
+            file_metadata
+        }).await
     }
 
     /// Take rows based on internal local row offsets


### PR DESCRIPTION
After this cache, we can remove two S3 reads from an ANN query, which can reduce ~100ms query latency.

See https://github.com/lancedb/lance/issues/2642