### PR TITLE
chore: upgrade arrow-rs to 52.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,17 +60,17 @@ lance-test-macros = { version = "=0.15.1", path = "./rust/lance-test-macros" }
 lance-testing = { version = "=0.15.1", path = "./rust/lance-testing" }
 approx = "0.5.1"
 # Note that this one does not include pyarrow
-arrow = { version = "52.1", optional = false, features = ["prettyprint"] }
-arrow-arith = "52.1"
-arrow-array = "52.1"
-arrow-buffer = "52.1"
-arrow-cast = "52.1"
-arrow-data = "52.1"
-arrow-ipc = { version = "52.1", features = ["zstd"] }
-arrow-ord = "52.1"
-arrow-row = "52.1"
-arrow-schema = "52.1"
-arrow-select = "52.1"
+arrow = { version = "52.2", optional = false, features = ["prettyprint"] }
+arrow-arith = "52.2"
+arrow-array = "52.2"
+arrow-buffer = "52.2"
+arrow-cast = "52.2"
+arrow-data = "52.2"
+arrow-ipc = { version = "52.2", features = ["zstd"] }
+arrow-ord = "52.2"
+arrow-row = "52.2"
+arrow-schema = "52.2"
+arrow-select = "52.2"
 async-recursion = "1.0"
 async-trait = "0.1"
 aws-config = "1.2.0"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -12,10 +12,10 @@ name = "lance"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrow = { version = "52.1", features = ["pyarrow"] }
-arrow-array = "52.1"
-arrow-data = "52.1"
-arrow-schema = "52.1"
+arrow = { version = "52.2", features = ["pyarrow"] }
+arrow-array = "52.2"
+arrow-data = "52.2"
+arrow-schema = "52.2"
 object_store = "0.10.1"
 async-trait = "0.1"
 chrono = "0.4.31"

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -1130,8 +1130,8 @@ impl BtreeTrainingSource for BTreeUpdater {
         let new_input = Arc::new(OneShotExec::new(self.new_data));
         let old_input = Self::into_old_input(self.index);
         debug_assert_eq!(
-            old_input.schema().all_fields().len(),
-            new_input.schema().all_fields().len()
+            old_input.schema().flattened_fields().len(),
+            new_input.schema().flattened_fields().len()
         );
         let sort_expr = PhysicalSortExpr {
             expr: Arc::new(Column::new("values", 0)),


### PR DESCRIPTION
`all_fields` deprecated, replace it with `flattened_fields`