### PR TITLE
chore: fix clippy warnings about features / cfg attributes not being recognized

### DIFF
--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -73,6 +73,12 @@ rustc_version.workspace = true
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof.workspace = true
 
+[features]
+default = []
+# This feature is turned on automatically by the build script but listed here
+# so that clippy & other tools know about it
+nightly = []
+
 [[bench]]
 name = "find_partitions"
 harness = false

--- a/rust/lance-linalg/build.rs
+++ b/rust/lance-linalg/build.rs
@@ -10,6 +10,10 @@ fn main() -> Result<(), String> {
             e => Err(e),
         })
         .unwrap();
+
+    // Tell clippy about our custom cfg flags
+    println!("cargo::rustc-check-cfg=cfg(kernel_support, values(\"avx512\"))");
+
     if rust_toolchain.starts_with("nightly") {
         // enable the 'nightly' feature flag
         println!("cargo:rustc-cfg=feature=\"nightly\"");
@@ -50,7 +54,7 @@ fn main() -> Result<(), String> {
         } else {
             // We create a special cfg so that we can detect we have in fact
             // generated the AVX512 version of the f16 kernels.
-            println!("cargo:rustc-cfg=kernel_suppport=\"avx512\"");
+            println!("cargo:rustc-cfg=kernel_support=\"avx512\"");
         };
         // Build a version with AVX
         // While GCC doesn't have support for _Float16 until GCC 12, clang

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -78,7 +78,7 @@ mod kernel {
     extern "C" {
         #[cfg(target_arch = "aarch64")]
         pub fn cosine_f16_neon(x: *const f16, x_norm: f32, y: *const f16, dimension: u32) -> f32;
-        #[cfg(all(kernel_suppport = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
         pub fn cosine_f16_avx512(x: *const f16, x_norm: f32, y: *const f16, dimension: u32) -> f32;
         #[cfg(target_arch = "x86_64")]
         pub fn cosine_f16_avx2(x: *const f16, x_norm: f32, y: *const f16, dimension: u32) -> f32;
@@ -98,7 +98,7 @@ impl Cosine for f16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_suppport = "avx512",
+                kernel_support = "avx512",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512 => unsafe {

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -122,7 +122,7 @@ mod kernel {
     extern "C" {
         #[cfg(target_arch = "aarch64")]
         pub fn l2_f16_neon(ptr1: *const f16, ptr2: *const f16, len: u32) -> f32;
-        #[cfg(all(kernel_suppport = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
         pub fn l2_f16_avx512(ptr1: *const f16, ptr2: *const f16, len: u32) -> f32;
         #[cfg(target_arch = "x86_64")]
         pub fn l2_f16_avx2(ptr1: *const f16, ptr2: *const f16, len: u32) -> f32;
@@ -143,7 +143,7 @@ impl L2 for f16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_suppport = "avx512",
+                kernel_support = "avx512",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512 => unsafe {

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -25,7 +25,7 @@ mod kernel {
     extern "C" {
         #[cfg(target_arch = "aarch64")]
         pub fn norm_l2_f16_neon(ptr: *const f16, len: u32) -> f32;
-        #[cfg(all(kernel_suppport = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
         pub fn norm_l2_f16_avx512(ptr: *const f16, len: u32) -> f32;
         #[cfg(target_arch = "x86_64")]
         pub fn norm_l2_f16_avx2(ptr: *const f16, len: u32) -> f32;
@@ -53,7 +53,7 @@ impl Normalize for f16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_suppport = "avx512",
+                kernel_support = "avx512",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512 => unsafe {

--- a/rust/lance-linalg/src/simd/f32.rs
+++ b/rust/lance-linalg/src/simd/f32.rs
@@ -280,7 +280,7 @@ impl SIMD<f32, 8> for f32x8 {
     }
 
     fn find(&self, val: f32) -> Option<i32> {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             // let tgt = _mm256_set1_ps(val);
             // let mask = _mm256_cmpeq_ps_mask(self.0, tgt);
@@ -289,7 +289,7 @@ impl SIMD<f32, 8> for f32x8 {
             // }
             todo!()
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             for i in 0..8 {
                 if self.as_array().get_unchecked(i) == &val {
@@ -450,11 +450,11 @@ impl Mul for f32x8 {
 
 /// 16 of 32-bit `f32` values. Use 512-bit SIMD if possible.
 #[allow(non_camel_case_types)]
-#[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+#[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
 #[derive(Clone, Copy)]
 pub struct f32x16(__m256, __m256);
 #[allow(non_camel_case_types)]
-#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+#[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
 #[derive(Clone, Copy)]
 pub struct f32x16(__m512);
 
@@ -496,11 +496,11 @@ impl SIMD<f32, 16> for f32x16 {
     #[inline]
 
     fn splat(val: f32) -> Self {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             Self(_mm512_set1_ps(val))
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             Self(_mm256_set1_ps(val), _mm256_set1_ps(val))
         }
@@ -524,11 +524,11 @@ impl SIMD<f32, 16> for f32x16 {
 
     #[inline]
     fn zeros() -> Self {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             Self(_mm512_setzero_ps())
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             Self(_mm256_setzero_ps(), _mm256_setzero_ps())
         }
@@ -544,11 +544,11 @@ impl SIMD<f32, 16> for f32x16 {
 
     #[inline]
     unsafe fn load(ptr: *const f32) -> Self {
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             Self(_mm256_load_ps(ptr), _mm256_load_ps(ptr.add(8)))
         }
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             Self(_mm512_load_ps(ptr))
         }
@@ -567,11 +567,11 @@ impl SIMD<f32, 16> for f32x16 {
 
     #[inline]
     unsafe fn load_unaligned(ptr: *const f32) -> Self {
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             Self(_mm256_loadu_ps(ptr), _mm256_loadu_ps(ptr.add(8)))
         }
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             Self(_mm512_loadu_ps(ptr))
         }
@@ -590,11 +590,11 @@ impl SIMD<f32, 16> for f32x16 {
 
     #[inline]
     unsafe fn store(&self, ptr: *mut f32) {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             _mm512_store_ps(ptr, self.0)
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             _mm256_store_ps(ptr, self.0);
             _mm256_store_ps(ptr.add(8), self.1);
@@ -613,11 +613,11 @@ impl SIMD<f32, 16> for f32x16 {
     #[inline]
 
     unsafe fn store_unaligned(&self, ptr: *mut f32) {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             _mm512_storeu_ps(ptr, self.0)
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             _mm256_storeu_ps(ptr, self.0);
             _mm256_storeu_ps(ptr.add(8), self.1);
@@ -634,11 +634,11 @@ impl SIMD<f32, 16> for f32x16 {
     }
 
     fn reduce_sum(&self) -> f32 {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             _mm512_mask_reduce_add_ps(0xFFFF, self.0)
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             let mut sum = _mm256_add_ps(self.0, self.1);
             // Shift and add vector, until only 1 value left.
@@ -668,11 +668,11 @@ impl SIMD<f32, 16> for f32x16 {
 
     #[inline]
     fn reduce_min(&self) -> f32 {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             _mm512_mask_reduce_min_ps(0xFFFF, self.0)
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             let mut m1 = _mm256_min_ps(self.0, self.1);
             let mut m2 = _mm256_permute2f128_ps(m1, m1, 1);
@@ -706,11 +706,11 @@ impl SIMD<f32, 16> for f32x16 {
 
     #[inline]
     fn min(&self, rhs: &Self) -> Self {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             Self(_mm512_min_ps(self.0, rhs.0))
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             Self(_mm256_min_ps(self.0, rhs.0), _mm256_min_ps(self.1, rhs.1))
         }
@@ -730,7 +730,7 @@ impl SIMD<f32, 16> for f32x16 {
     }
 
     fn find(&self, val: f32) -> Option<i32> {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             // let tgt = _mm512_set1_ps(val);
             // let mask = _mm512_cmpeq_ps_mask(self.0, tgt);
@@ -739,7 +739,7 @@ impl SIMD<f32, 16> for f32x16 {
             // }
             todo!()
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             // _mm256_cmpeq_ps_mask requires "avx512l".
             for i in 0..16 {
@@ -785,11 +785,11 @@ impl SIMD<f32, 16> for f32x16 {
 impl FloatSimd<f32, 16> for f32x16 {
     #[inline]
     fn multiply_add(&mut self, a: Self, b: Self) {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             self.0 = _mm512_fmadd_ps(a.0, b.0, self.0)
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             self.0 = _mm256_fmadd_ps(a.0, b.0, self.0);
             self.1 = _mm256_fmadd_ps(a.1, b.1, self.1);
@@ -814,11 +814,11 @@ impl Add for f32x16 {
 
     #[inline]
     fn add(self, rhs: Self) -> Self::Output {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             Self(_mm512_add_ps(self.0, rhs.0))
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             Self(_mm256_add_ps(self.0, rhs.0), _mm256_add_ps(self.1, rhs.1))
         }
@@ -841,11 +841,11 @@ impl Add for f32x16 {
 impl AddAssign for f32x16 {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             self.0 = _mm512_add_ps(self.0, rhs.0)
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             self.0 = _mm256_add_ps(self.0, rhs.0);
             self.1 = _mm256_add_ps(self.1, rhs.1);
@@ -870,11 +870,11 @@ impl Mul for f32x16 {
 
     #[inline]
     fn mul(self, rhs: Self) -> Self::Output {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             Self(_mm512_mul_ps(self.0, rhs.0))
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             Self(_mm256_mul_ps(self.0, rhs.0), _mm256_mul_ps(self.1, rhs.1))
         }
@@ -899,11 +899,11 @@ impl Sub for f32x16 {
 
     #[inline]
     fn sub(self, rhs: Self) -> Self::Output {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             Self(_mm512_sub_ps(self.0, rhs.0))
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             Self(_mm256_sub_ps(self.0, rhs.0), _mm256_sub_ps(self.1, rhs.1))
         }
@@ -926,11 +926,11 @@ impl Sub for f32x16 {
 impl SubAssign for f32x16 {
     #[inline]
     fn sub_assign(&mut self, rhs: Self) {
-        #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+        #[cfg(all(target_arch = "x86_64", kernel_support = "avx512"))]
         unsafe {
             self.0 = _mm512_sub_ps(self.0, rhs.0)
         }
-        #[cfg(all(target_arch = "x86_64", not(feature = "avx512")))]
+        #[cfg(all(target_arch = "x86_64", not(kernel_support = "avx512")))]
         unsafe {
             self.0 = _mm256_sub_ps(self.0, rhs.0);
             self.1 = _mm256_sub_ps(self.1, rhs.1);


### PR DESCRIPTION
This also renames kernel_suppport to kernel_support