### PR TITLE
chore: fix kernel_suppport clippy warnings

### DIFF
--- a/rust/lance-linalg/build.rs
+++ b/rust/lance-linalg/build.rs
@@ -15,6 +15,9 @@ fn main() -> Result<(), String> {
         println!("cargo:rustc-cfg=feature=\"nightly\"");
     }
 
+    // Let clippy know about our custom cfg attribute
+    println!("cargo::rustc-check-cfg=cfg(kernel_support, values(\"avx512\"))");
+
     println!("cargo:rerun-if-changed=src/simd/f16.c");
 
     if cfg!(not(feature = "fp16kernels")) {
@@ -50,7 +53,7 @@ fn main() -> Result<(), String> {
         } else {
             // We create a special cfg so that we can detect we have in fact
             // generated the AVX512 version of the f16 kernels.
-            println!("cargo:rustc-cfg=kernel_suppport=\"avx512\"");
+            println!("cargo:rustc-cfg=kernel_support=\"avx512\"");
         };
         // Build a version with AVX
         // While GCC doesn't have support for _Float16 until GCC 12, clang

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -78,7 +78,7 @@ mod kernel {
     extern "C" {
         #[cfg(target_arch = "aarch64")]
         pub fn cosine_f16_neon(x: *const f16, x_norm: f32, y: *const f16, dimension: u32) -> f32;
-        #[cfg(all(kernel_suppport = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
         pub fn cosine_f16_avx512(x: *const f16, x_norm: f32, y: *const f16, dimension: u32) -> f32;
         #[cfg(target_arch = "x86_64")]
         pub fn cosine_f16_avx2(x: *const f16, x_norm: f32, y: *const f16, dimension: u32) -> f32;
@@ -98,7 +98,7 @@ impl Cosine for f16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_suppport = "avx512",
+                kernel_support = "avx512",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512 => unsafe {

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -122,7 +122,7 @@ mod kernel {
     extern "C" {
         #[cfg(target_arch = "aarch64")]
         pub fn l2_f16_neon(ptr1: *const f16, ptr2: *const f16, len: u32) -> f32;
-        #[cfg(all(kernel_suppport = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
         pub fn l2_f16_avx512(ptr1: *const f16, ptr2: *const f16, len: u32) -> f32;
         #[cfg(target_arch = "x86_64")]
         pub fn l2_f16_avx2(ptr1: *const f16, ptr2: *const f16, len: u32) -> f32;
@@ -143,7 +143,7 @@ impl L2 for f16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_suppport = "avx512",
+                kernel_support = "avx512",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512 => unsafe {

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -25,7 +25,7 @@ mod kernel {
     extern "C" {
         #[cfg(target_arch = "aarch64")]
         pub fn norm_l2_f16_neon(ptr: *const f16, len: u32) -> f32;
-        #[cfg(all(kernel_suppport = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
         pub fn norm_l2_f16_avx512(ptr: *const f16, len: u32) -> f32;
         #[cfg(target_arch = "x86_64")]
         pub fn norm_l2_f16_avx2(ptr: *const f16, len: u32) -> f32;
@@ -53,7 +53,7 @@ impl Normalize for f16 {
             },
             #[cfg(all(
                 feature = "fp16kernels",
-                kernel_suppport = "avx512",
+                kernel_support = "avx512",
                 target_arch = "x86_64"
             ))]
             SimdSupport::Avx512 => unsafe {


### PR DESCRIPTION
This also renames kernel_suppport to kernel_support