### PR TITLE
test: fix `test_vector_index` on Windows

### DIFF
--- a/python/python/tests/test_indices.py
+++ b/python/python/tests/test_indices.py
@@ -139,6 +139,9 @@ def test_vector_transform(tmpdir, rand_dataset, rand_ivf, rand_pq):
     part_id = data.column("__ivf_part_id")
     assert part_id.type == pa.uint32()
 
+    # We need to close the file to be able to overwrite it on Windows.
+    del reader
+
     # test when fragments = None
     builder.transform_vectors(rand_ivf, rand_pq, uri, fragments=None)
     reader = LanceFileReader(uri)


### PR DESCRIPTION
We are close to having green CI on Lance `main`. test_vector_transform is failing ever since we merged #2657

I think this is because we still have the file open but are re-using the same file uri. We need to close it to overwrite it.