### PR TITLE
feat: expand tags api

### DIFF
--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -46,7 +46,7 @@ __all__ = [
 
 def dataset(
     uri: Union[str, Path],
-    version: Optional[int] = None,
+    version: Optional[int | str] = None,
     asof: Optional[ts_types] = None,
     block_size: Optional[int] = None,
     commit_lock: Optional[CommitLock] = None,
@@ -60,9 +60,9 @@ def dataset(
     ----------
     uri : str
         Address to the Lance dataset.
-    version : optional, int
+    version : optional, int | str
         If specified, load a specific version of the Lance dataset. Else, loads the
-        latest version.
+        latest version. A version number (`int`) or a tag (`str`) can be provided.
     asof : optional, datetime or str
         If specified, find the latest version created on or earlier than the given
         argument value. If a version is already specified, this arg is ignored.

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -155,7 +155,7 @@ class LanceDataset(pa.dataset.Dataset):
     def __init__(
         self,
         uri: Union[str, Path],
-        version: Optional[int] = None,
+        version: Optional[int | str] = None,
         block_size: Optional[int] = None,
         index_cache_size: Optional[int] = None,
         metadata_cache_size: Optional[int] = None,

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -283,6 +283,12 @@ def test_tag(tmp_path: Path):
 
     assert ds.checkout_version("tag1").version == 1
 
+    ds = lance.dataset(base_dir, "tag1")
+    assert ds.version == 1
+
+    with pytest.raises(ValueError):
+        lance.dataset(base_dir, "missing-tag")
+
 
 def test_sample(tmp_path: Path):
     table1 = pa.Table.from_pydict({"x": [0, 10, 20, 30, 40, 50], "y": range(6)})

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3051,6 +3051,13 @@ mod tests {
 
         dataset = dataset.checkout_version("tag1").await.unwrap();
         assert_eq!(dataset.manifest.version, 1);
+
+        let first_ver = DatasetBuilder::from_uri(test_uri)
+            .with_tag("tag1")
+            .load()
+            .await
+            .unwrap();
+        assert_eq!(first_ver.version().version, 1);
     }
 
     #[rstest]


### PR DESCRIPTION
This PR expands upon the new tags API so that we can load from tags using the top-level `lance.dataset` Python API. Once accepted, the changes from this PR will be used to update the quickstart notebook to demonstrate the new tags functionality.