### PR TITLE
feat: add backpressure to v2 I/O scheduler

### DIFF
--- a/rust/lance-encoding-datafusion/src/lib.rs
+++ b/rust/lance-encoding-datafusion/src/lib.rs
@@ -10,7 +10,9 @@ use lance_core::{
 };
 use lance_encoding::{
     decoder::{ColumnInfoIter, DecoderMiddlewareChainCursor, FieldDecoderStrategy, FieldScheduler},
-    encoder::{ColumnIndexSequence, CoreFieldEncodingStrategy, FieldEncodingStrategy},
+    encoder::{
+        ColumnIndexSequence, CoreFieldEncodingStrategy, EncodingOptions, FieldEncodingStrategy,
+    },
     encodings::physical::FileBuffers,
 };
 use zone::{extract_zone_info, UnloadedPushdown, ZoneMapsFieldEncoder, ZoneMapsFieldScheduler};
@@ -170,10 +172,7 @@ impl FieldEncodingStrategy for LanceDfFieldEncodingStrategy {
         encoding_strategy_root: &dyn FieldEncodingStrategy,
         field: &lance_core::datatypes::Field,
         column_index: &mut ColumnIndexSequence,
-        cache_bytes_per_column: u64,
-        max_page_bytes: u64,
-        keep_original_array: bool,
-        config: &std::collections::HashMap<String, String>,
+        options: &EncodingOptions,
     ) -> lance_core::Result<Box<dyn lance_encoding::encoder::FieldEncoder>> {
         let data_type = field.data_type();
         if data_type.is_primitive()
@@ -187,10 +186,7 @@ impl FieldEncodingStrategy for LanceDfFieldEncodingStrategy {
                 &self.core,
                 field,
                 column_index,
-                cache_bytes_per_column,
-                max_page_bytes,
-                keep_original_array,
-                config,
+                options,
             )?;
             Ok(Box::new(ZoneMapsFieldEncoder::try_new(
                 inner_encoder,
@@ -198,15 +194,8 @@ impl FieldEncodingStrategy for LanceDfFieldEncodingStrategy {
                 self.rows_per_map,
             )?))
         } else {
-            self.core.create_field_encoder(
-                encoding_strategy_root,
-                field,
-                column_index,
-                cache_bytes_per_column,
-                max_page_bytes,
-                keep_original_array,
-                config,
-            )
+            self.core
+                .create_field_encoder(encoding_strategy_root, field, column_index, options)
         }
     }
 }

--- a/rust/lance-encoding-datafusion/src/lib.rs
+++ b/rust/lance-encoding-datafusion/src/lib.rs
@@ -171,6 +171,7 @@ impl FieldEncodingStrategy for LanceDfFieldEncodingStrategy {
         field: &lance_core::datatypes::Field,
         column_index: &mut ColumnIndexSequence,
         cache_bytes_per_column: u64,
+        max_page_bytes: u64,
         keep_original_array: bool,
         config: &std::collections::HashMap<String, String>,
     ) -> lance_core::Result<Box<dyn lance_encoding::encoder::FieldEncoder>> {
@@ -187,6 +188,7 @@ impl FieldEncodingStrategy for LanceDfFieldEncodingStrategy {
                 field,
                 column_index,
                 cache_bytes_per_column,
+                max_page_bytes,
                 keep_original_array,
                 config,
             )?;
@@ -201,6 +203,7 @@ impl FieldEncodingStrategy for LanceDfFieldEncodingStrategy {
                 field,
                 column_index,
                 cache_bytes_per_column,
+                max_page_bytes,
                 keep_original_array,
                 config,
             )

--- a/rust/lance-encoding-datafusion/src/zone.rs
+++ b/rust/lance-encoding-datafusion/src/zone.rs
@@ -26,7 +26,7 @@ use lance_encoding::{
     },
     encoder::{
         encode_batch, CoreFieldEncodingStrategy, EncodedBatch, EncodedBuffer, EncodedColumn,
-        FieldEncoder,
+        EncodingOptions, FieldEncoder,
     },
     format::pb,
     EncodingsIo,
@@ -500,8 +500,11 @@ impl ZoneMapsFieldEncoder {
             &zone_maps,
             Arc::new(schema),
             &encoding_strategy,
-            u64::MAX,
-            u64::MAX,
+            &EncodingOptions {
+                cache_bytes_per_column: u64::MAX,
+                max_page_bytes: u64::MAX,
+                keep_original_array: true,
+            },
         )
         .await?;
         let zone_maps_buffer = encoded_zone_maps.try_to_mini_lance()?;

--- a/rust/lance-encoding-datafusion/src/zone.rs
+++ b/rust/lance-encoding-datafusion/src/zone.rs
@@ -496,8 +496,14 @@ impl ZoneMapsFieldEncoder {
         let zone_maps =
             RecordBatch::try_new(Arc::new(zone_map_schema), vec![mins, maxes, null_counts])?;
         let encoding_strategy = CoreFieldEncodingStrategy::default();
-        let encoded_zone_maps =
-            encode_batch(&zone_maps, Arc::new(schema), &encoding_strategy, u64::MAX).await?;
+        let encoded_zone_maps = encode_batch(
+            &zone_maps,
+            Arc::new(schema),
+            &encoding_strategy,
+            u64::MAX,
+            u64::MAX,
+        )
+        .await?;
         let zone_maps_buffer = encoded_zone_maps.try_to_mini_lance()?;
 
         Ok(EncodedBuffer {

--- a/rust/lance-encoding/benches/decoder.rs
+++ b/rust/lance-encoding/benches/decoder.rs
@@ -13,6 +13,8 @@ use lance_encoding::{
 
 use rand::Rng;
 
+const MAX_PAGE_BYTES: u64 = 32 * 1024 * 1024;
+
 const PRIMITIVE_TYPES: &[DataType] = &[
     DataType::Date32,
     DataType::Date64,
@@ -73,6 +75,7 @@ fn bench_decode(c: &mut Criterion) {
                 lance_schema,
                 &encoding_strategy,
                 1024 * 1024,
+                MAX_PAGE_BYTES,
             ))
             .unwrap();
         let func_name = format!("{:?}", data_type).to_lowercase();
@@ -112,6 +115,7 @@ fn bench_decode_fsl(c: &mut Criterion) {
                 lance_schema,
                 &encoding_strategy,
                 1024 * 1024,
+                MAX_PAGE_BYTES,
             ))
             .unwrap();
         let func_name = format!("{:?}", data_type).to_lowercase();
@@ -168,6 +172,7 @@ fn bench_decode_str_with_dict_encoding(c: &mut Criterion) {
             lance_schema,
             &encoding_strategy,
             1024 * 1024,
+            MAX_PAGE_BYTES,
         ))
         .unwrap();
     let func_name = format!("{:?}", data_type).to_lowercase();
@@ -237,6 +242,7 @@ fn bench_decode_packed_struct(c: &mut Criterion) {
             lance_schema,
             &encoding_strategy,
             1024 * 1024,
+            MAX_PAGE_BYTES,
         ))
         .unwrap();
 

--- a/rust/lance-encoding/benches/decoder.rs
+++ b/rust/lance-encoding/benches/decoder.rs
@@ -8,12 +8,10 @@ use arrow_select::take::take;
 use criterion::{criterion_group, criterion_main, Criterion};
 use lance_encoding::{
     decoder::{DecoderMiddlewareChain, FilterExpression},
-    encoder::{encode_batch, CoreFieldEncodingStrategy},
+    encoder::{encode_batch, CoreFieldEncodingStrategy, EncodingOptions},
 };
 
 use rand::Rng;
-
-const MAX_PAGE_BYTES: u64 = 32 * 1024 * 1024;
 
 const PRIMITIVE_TYPES: &[DataType] = &[
     DataType::Date32,
@@ -56,6 +54,12 @@ const PRIMITIVE_TYPES_FOR_FSL: &[DataType] = &[
     DataType::Float64,
 ];
 
+const ENCODING_OPTIONS: EncodingOptions = EncodingOptions {
+    cache_bytes_per_column: 1024 * 1024,
+    max_page_bytes: 32 * 1024 * 1024,
+    keep_original_array: true,
+};
+
 fn bench_decode(c: &mut Criterion) {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let mut group = c.benchmark_group("decode_primitive");
@@ -74,8 +78,7 @@ fn bench_decode(c: &mut Criterion) {
                 &data,
                 lance_schema,
                 &encoding_strategy,
-                1024 * 1024,
-                MAX_PAGE_BYTES,
+                &ENCODING_OPTIONS,
             ))
             .unwrap();
         let func_name = format!("{:?}", data_type).to_lowercase();
@@ -114,8 +117,7 @@ fn bench_decode_fsl(c: &mut Criterion) {
                 &data,
                 lance_schema,
                 &encoding_strategy,
-                1024 * 1024,
-                MAX_PAGE_BYTES,
+                &ENCODING_OPTIONS,
             ))
             .unwrap();
         let func_name = format!("{:?}", data_type).to_lowercase();
@@ -171,8 +173,7 @@ fn bench_decode_str_with_dict_encoding(c: &mut Criterion) {
             &data,
             lance_schema,
             &encoding_strategy,
-            1024 * 1024,
-            MAX_PAGE_BYTES,
+            &ENCODING_OPTIONS,
         ))
         .unwrap();
     let func_name = format!("{:?}", data_type).to_lowercase();
@@ -241,8 +242,7 @@ fn bench_decode_packed_struct(c: &mut Criterion) {
             &data,
             lance_schema,
             &encoding_strategy,
-            1024 * 1024,
-            MAX_PAGE_BYTES,
+            &ENCODING_OPTIONS,
         ))
         .unwrap();
 

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -440,7 +440,7 @@ impl PrimitiveFieldEncoder {
             let array = arrays.into_iter().next().unwrap();
             let size_bytes = array.get_buffer_memory_size();
             let num_parts = bit_util::ceil(size_bytes, self.max_page_bytes as usize);
-            if num_parts == 1 {
+            if num_parts <= 1 {
                 // One part and it fits in a page
                 Ok(vec![self.create_encode_task(vec![array])?])
             } else {

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -18,7 +18,10 @@ use crate::{
         PageInfo, PageScheduler, PrimitivePageDecoder, ScheduledScanLine, SchedulerContext,
         SchedulingJob,
     },
-    encoder::{ArrayEncodingStrategy, EncodeTask, EncodedColumn, EncodedPage, FieldEncoder},
+    encoder::{
+        ArrayEncodingStrategy, EncodeTask, EncodedColumn, EncodedPage, EncodingOptions,
+        FieldEncoder,
+    },
     encodings::physical::{decoder_from_array_encoding, ColumnBuffers, PageBuffers},
 };
 
@@ -393,21 +396,19 @@ pub struct PrimitiveFieldEncoder {
 
 impl PrimitiveFieldEncoder {
     pub fn try_new(
-        cache_bytes: u64,
-        max_page_bytes: u64,
-        keep_original_array: bool,
+        options: &EncodingOptions,
         array_encoding_strategy: Arc<dyn ArrayEncodingStrategy>,
         column_index: u32,
         field: Field,
     ) -> Result<Self> {
         Ok(Self {
             accumulation_queue: AccumulationQueue::new(
-                cache_bytes,
+                options.cache_bytes_per_column,
                 column_index,
-                keep_original_array,
+                options.keep_original_array,
             ),
             column_index,
-            max_page_bytes,
+            max_page_bytes: options.max_page_bytes,
             array_encoding_strategy,
             field,
         })

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -21,7 +21,7 @@ use crate::{
     },
     encoder::{
         ColumnIndexSequence, CoreArrayEncodingStrategy, CoreFieldEncodingStrategy, EncodedBuffer,
-        EncodedPage, FieldEncoder, FieldEncodingStrategy,
+        EncodedPage, EncodingOptions, FieldEncoder, FieldEncodingStrategy,
     },
     encodings::logical::r#struct::SimpleStructDecoder,
     version::LanceFileVersion,
@@ -160,18 +160,19 @@ pub async fn check_round_trip_encoding_generated(
             array_encoding_strategy: Arc::new(CoreArrayEncodingStrategy { version }),
             version,
         };
-        let encoding_config = HashMap::new();
         let encoder_factory = || {
             let mut column_index_seq = ColumnIndexSequence::default();
+            let encoding_options = EncodingOptions {
+                max_page_bytes: MAX_PAGE_BYTES,
+                cache_bytes_per_column: page_size,
+                keep_original_array: true,
+            };
             encoding_strategy
                 .create_field_encoder(
                     &encoding_strategy,
                     &lance_field,
                     &mut column_index_seq,
-                    page_size,
-                    MAX_PAGE_BYTES,
-                    true,
-                    &encoding_config,
+                    &encoding_options,
                 )
                 .unwrap()
         };
@@ -251,17 +252,18 @@ pub async fn check_round_trip_encoding_of_data(
     let lance_field = lance_core::datatypes::Field::try_from(&field).unwrap();
     for page_size in [4096, 1024 * 1024] {
         let encoding_strategy = CoreFieldEncodingStrategy::default();
-        let encoding_config = HashMap::new();
         let mut column_index_seq = ColumnIndexSequence::default();
+        let encoding_options = EncodingOptions {
+            cache_bytes_per_column: page_size,
+            max_page_bytes: MAX_PAGE_BYTES,
+            keep_original_array: true,
+        };
         let encoder = encoding_strategy
             .create_field_encoder(
                 &encoding_strategy,
                 &lance_field,
                 &mut column_index_seq,
-                page_size,
-                MAX_PAGE_BYTES,
-                true,
-                &encoding_config,
+                &encoding_options,
             )
             .unwrap();
         check_round_trip_encoding_inner(encoder, &field, data.clone(), test_cases).await

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -28,6 +28,8 @@ use crate::{
     EncodingsIo,
 };
 
+const MAX_PAGE_BYTES: u64 = 32 * 1024 * 1024;
+
 pub(crate) struct SimulatedScheduler {
     data: Bytes,
 }
@@ -167,6 +169,7 @@ pub async fn check_round_trip_encoding_generated(
                     &lance_field,
                     &mut column_index_seq,
                     page_size,
+                    MAX_PAGE_BYTES,
                     true,
                     &encoding_config,
                 )
@@ -256,6 +259,7 @@ pub async fn check_round_trip_encoding_of_data(
                 &lance_field,
                 &mut column_index_seq,
                 page_size,
+                MAX_PAGE_BYTES,
                 true,
                 &encoding_config,
             )

--- a/rust/lance-file/benches/reader.rs
+++ b/rust/lance-file/benches/reader.rs
@@ -10,7 +10,10 @@ use lance_file::v2::{
     reader::FileReader,
     writer::{FileWriter, FileWriterOptions},
 };
-use lance_io::{object_store::ObjectStore, scheduler::ScanScheduler};
+use lance_io::{
+    object_store::ObjectStore,
+    scheduler::{ScanScheduler, SchedulerConfig},
+};
 
 fn bench_reader(c: &mut Criterion) {
     let mut group = c.benchmark_group("reader");
@@ -44,7 +47,10 @@ fn bench_reader(c: &mut Criterion) {
             let file_path = &file_path;
             let data = &data;
             rt.block_on(async move {
-                let store_scheduler = ScanScheduler::new(Arc::new(object_store.clone()));
+                let store_scheduler = ScanScheduler::new(
+                    Arc::new(object_store.clone()),
+                    SchedulerConfig::default_for_testing(),
+                );
                 let scheduler = store_scheduler.open_file(file_path).await.unwrap();
                 let reader = FileReader::try_open(
                     scheduler.clone(),

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -1117,7 +1117,8 @@ pub mod tests {
             &data,
             lance_schema.clone(),
             &CoreFieldEncodingStrategy::default(),
-            4096,
+            /*cache_bytes_per_column=*/ 4096,
+            /*max_page_bytes=*/ 32 * 1024 * 1024,
         )
         .await
         .unwrap();

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -993,7 +993,7 @@ pub mod tests {
     use lance_datagen::{array, gen, BatchCount, ByteCount, RowCount};
     use lance_encoding::{
         decoder::{decode_batch, DecoderMiddlewareChain, FilterExpression},
-        encoder::{encode_batch, CoreFieldEncodingStrategy, EncodedBatch},
+        encoder::{encode_batch, CoreFieldEncodingStrategy, EncodedBatch, EncodingOptions},
     };
     use lance_io::stream::RecordBatchStream;
     use log::debug;
@@ -1113,12 +1113,16 @@ pub mod tests {
 
         let lance_schema = Arc::new(Schema::try_from(data.schema().as_ref()).unwrap());
 
+        let encoding_options = EncodingOptions {
+            cache_bytes_per_column: 4096,
+            max_page_bytes: 32 * 1024 * 1024,
+            keep_original_array: true,
+        };
         let encoded_batch = encode_batch(
             &data,
             lance_schema.clone(),
             &CoreFieldEncodingStrategy::default(),
-            /*cache_bytes_per_column=*/ 4096,
-            /*max_page_bytes=*/ 32 * 1024 * 1024,
+            &encoding_options,
         )
         .await
         .unwrap();

--- a/rust/lance-file/src/v2/testing.rs
+++ b/rust/lance-file/src/v2/testing.rs
@@ -8,7 +8,11 @@ use arrow_schema::ArrowError;
 use futures::TryStreamExt;
 use lance_core::datatypes::Schema;
 use lance_encoding::decoder::{DecoderMiddlewareChain, FilterExpression};
-use lance_io::{object_store::ObjectStore, scheduler::ScanScheduler, ReadBatchParams};
+use lance_io::{
+    object_store::ObjectStore,
+    scheduler::{ScanScheduler, SchedulerConfig},
+    ReadBatchParams,
+};
 use object_store::path::Path;
 use tempfile::TempDir;
 
@@ -30,7 +34,8 @@ impl Default for FsFixture {
         let tmp_path = Path::parse(tmp_path).unwrap();
         let tmp_path = tmp_path.child("some_file.lance");
         let object_store = Arc::new(ObjectStore::local());
-        let scheduler = ScanScheduler::new(object_store.clone());
+        let scheduler =
+            ScanScheduler::new(object_store.clone(), SchedulerConfig::default_for_testing());
         Self {
             _tmp_dir: tmp_dir,
             object_store,

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -50,6 +50,12 @@ pub struct FileWriterOptions {
     /// The default will use 8MiB per column which should be reasonable for most cases.
     // TODO: Do we need to be able to set this on a per-column basis?
     pub data_cache_bytes: Option<u64>,
+    /// A hint to indicate the max size of a page
+    ///
+    /// This hint can't always be respected.  A single value could be larger than this value
+    /// and we never slice single values.  In addition, there are some cases where it can be
+    /// difficult to know size up-front and so we might not be able to respect this value.
+    pub max_page_bytes: Option<u64>,
     /// The file writer buffers columns until enough data has arrived to flush a page
     /// to disk.
     ///
@@ -211,6 +217,12 @@ impl FileWriter {
             8 * 1024 * 1024
         };
 
+        let max_page_bytes = if let Some(max_page_bytes) = self.options.max_page_bytes {
+            max_page_bytes
+        } else {
+            32 * 1024 * 1024
+        };
+
         schema.validate()?;
 
         let keep_original_array = self.options.keep_original_array.unwrap_or(false);
@@ -229,6 +241,7 @@ impl FileWriter {
             &schema,
             encoding_strategy.as_ref(),
             cache_bytes_per_column,
+            max_page_bytes,
             keep_original_array,
         )?;
         self.num_columns = encoder.num_columns();

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -14,7 +14,7 @@ use lance_core::datatypes::Schema as LanceSchema;
 use lance_core::{Error, Result};
 use lance_encoding::encoder::{
     BatchEncoder, CoreArrayEncodingStrategy, CoreFieldEncodingStrategy, EncodeTask, EncodedBatch,
-    EncodedPage, FieldEncoder, FieldEncodingStrategy,
+    EncodedPage, EncodingOptions, FieldEncoder, FieldEncodingStrategy,
 };
 use lance_encoding::version::LanceFileVersion;
 use lance_io::object_writer::ObjectWriter;
@@ -237,13 +237,13 @@ impl FileWriter {
             })
         });
 
-        let encoder = BatchEncoder::try_new(
-            &schema,
-            encoding_strategy.as_ref(),
+        let encoding_options = EncodingOptions {
             cache_bytes_per_column,
             max_page_bytes,
             keep_original_array,
-        )?;
+        };
+        let encoder =
+            BatchEncoder::try_new(&schema, encoding_strategy.as_ref(), &encoding_options)?;
         self.num_columns = encoder.num_columns();
 
         self.column_writers = encoder.field_encoders;

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -18,7 +18,7 @@ use lance_file::{
     reader::FileReader,
     writer::{FileWriter, FileWriterOptions, ManifestProvider},
 };
-use lance_io::scheduler::ScanScheduler;
+use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_io::{object_store::ObjectStore, ReadBatchParams};
 use lance_table::{format::SelfDescribingFileReader, io::manifest::ManifestDescribing};
 use object_store::path::Path;
@@ -55,7 +55,10 @@ impl LanceIndexStore {
         metadata_cache: Option<FileMetadataCache>,
     ) -> Self {
         let object_store = Arc::new(object_store);
-        let scheduler = ScanScheduler::new(object_store.clone());
+        let scheduler = ScanScheduler::new(
+            object_store.clone(),
+            SchedulerConfig::fast_and_not_too_ram_intensive(),
+        );
         Self {
             object_store,
             index_dir,

--- a/rust/lance-index/src/vector/v3/shuffler.rs
+++ b/rust/lance-index/src/vector/v3/shuffler.rs
@@ -16,7 +16,7 @@ use lance_encoding::decoder::{DecoderMiddlewareChain, FilterExpression};
 use lance_file::v2::{reader::FileReader, writer::FileWriter};
 use lance_io::{
     object_store::ObjectStore,
-    scheduler::ScanScheduler,
+    scheduler::{ScanScheduler, SchedulerConfig},
     stream::{RecordBatchStream, RecordBatchStreamAdapter},
 };
 use object_store::path::Path;
@@ -223,7 +223,10 @@ impl IvfShufflerReader {
         output_dir: Path,
         partition_sizes: Vec<usize>,
     ) -> Self {
-        let scheduler = ScanScheduler::new(object_store);
+        let scheduler = ScanScheduler::new(
+            object_store,
+            SchedulerConfig::fast_and_not_too_ram_intensive(),
+        );
         Self {
             scheduler,
             output_dir,

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -32,6 +32,7 @@ chrono.workspace = true
 deepsize.workspace = true
 futures.workspace = true
 lazy_static.workspace = true
+log.workspace = true
 num_cpus.workspace = true
 object_store = { workspace = true, features = ["aws", "gcp", "azure"] }
 pin-project.workspace = true

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -50,6 +50,7 @@ async-priority-channel = "0.2.0"
 criterion.workspace = true
 parquet.workspace = true
 tempfile.workspace = true
+test-log.workspace = true
 mockall.workspace = true
 
 [build-dependencies]

--- a/rust/lance-io/benches/scheduler.rs
+++ b/rust/lance-io/benches/scheduler.rs
@@ -3,7 +3,10 @@
 
 use bytes::Bytes;
 use lance_core::Result;
-use lance_io::{object_store::ObjectStore, scheduler::ScanScheduler};
+use lance_io::{
+    object_store::ObjectStore,
+    scheduler::{ScanScheduler, SchedulerConfig},
+};
 use object_store::path::Path;
 use rand::{seq::SliceRandom, RngCore};
 use std::{fmt::Display, process::Command, sync::Arc};
@@ -89,7 +92,8 @@ fn bench_full_read(c: &mut Criterion) {
                     }
                     std::env::set_var("IO_THREADS", io_parallelism.to_string());
                     runtime.block_on(async {
-                        let scheduler = ScanScheduler::new(obj_store);
+                        let scheduler =
+                            ScanScheduler::new(obj_store, SchedulerConfig::default_for_testing());
                         let file_scheduler = scheduler.open_file(&tmp_file).await.unwrap();
 
                         let (tx, rx) = mpsc::channel(1024);
@@ -176,7 +180,10 @@ fn bench_random_read(c: &mut Criterion) {
                         }
                         std::env::set_var("IO_THREADS", params.io_parallelism.to_string());
                         runtime.block_on(async {
-                            let scheduler = ScanScheduler::new(obj_store);
+                            let scheduler = ScanScheduler::new(
+                                obj_store,
+                                SchedulerConfig::default_for_testing(),
+                            );
                             let file_scheduler = scheduler.open_file(&tmp_file).await.unwrap();
 
                             let (tx, rx) = mpsc::channel(1024);

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -298,7 +298,7 @@ pub struct SchedulerConfig {
     /// This controls back pressure.  If data is not processed quickly enough then this
     /// buffer will fill up and the I/O loop will pause until the buffer is drained.
     pub io_buffer_size_bytes: u64,
-    /// The backpressure mechansim can potentially lead to deadlock if there are bugs.
+    /// The backpressure mechanism can potentially lead to deadlock if there are bugs.
     /// A complete hang is a pretty bad user experience so we log an error and panic
     /// if the I/O loop is paused for longer than this timeout.
     ///

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -11,7 +11,11 @@ use std::cmp::Reverse;
 use std::fmt::Debug;
 use std::future::Future;
 use std::ops::Range;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::sync::{AcquireError, Semaphore, TryAcquireError};
+use tokio::time::error::Elapsed;
 
 use lance_core::{Error, Result};
 
@@ -22,17 +26,19 @@ use crate::traits::Reader;
 // that make up a single request.  When all the I/O operations complete
 // then the MutableBatch goes out of scope and the batch request is considered
 // complete
-struct MutableBatch<F: FnOnce(Result<Vec<Bytes>>) + Send> {
+struct MutableBatch<F: FnOnce(Response) + Send> {
     when_done: Option<F>,
     data_buffers: Vec<Bytes>,
+    permits_consumed: AtomicU64,
     err: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
 }
 
-impl<F: FnOnce(Result<Vec<Bytes>>) + Send> MutableBatch<F> {
+impl<F: FnOnce(Response) + Send> MutableBatch<F> {
     fn new(when_done: F, num_data_buffers: u32) -> Self {
         Self {
             when_done: Some(when_done),
             data_buffers: vec![Bytes::default(); num_data_buffers as usize],
+            permits_consumed: AtomicU64::from(0),
             err: None,
         }
     }
@@ -42,7 +48,7 @@ impl<F: FnOnce(Result<Vec<Bytes>>) + Send> MutableBatch<F> {
 // can deliver the batch of data we let Rust do that for us.  When all I/O's are
 // done then the MutableBatch will go out of scope and we know we have all the
 // data.
-impl<F: FnOnce(Result<Vec<Bytes>>) + Send> Drop for MutableBatch<F> {
+impl<F: FnOnce(Response) + Send> Drop for MutableBatch<F> {
     fn drop(&mut self) {
         // If we have an error, return that.  Otherwise return the data
         let result = if self.err.is_some() {
@@ -57,20 +63,32 @@ impl<F: FnOnce(Result<Vec<Bytes>>) + Send> Drop for MutableBatch<F> {
         };
         // We don't really care if no one is around to receive it, just let
         // the result go out of scope and get cleaned up
-        (self.when_done.take().unwrap())(result);
+        let response = Response {
+            data: result,
+            permits_acquired: self.permits_consumed.load(Ordering::Acquire),
+        };
+        (self.when_done.take().unwrap())(response);
     }
 }
 
-trait DataSink: Send {
-    fn deliver_data(&mut self, data: Result<(usize, Bytes)>);
+struct DataChunk {
+    task_idx: usize,
+    permits_acquired: u64,
+    data: Result<Bytes>,
 }
 
-impl<F: FnOnce(Result<Vec<Bytes>>) + Send> DataSink for MutableBatch<F> {
+trait DataSink: Send {
+    fn deliver_data(&mut self, data: DataChunk);
+}
+
+impl<F: FnOnce(Response) + Send> DataSink for MutableBatch<F> {
     // Called by worker tasks to add data to the MutableBatch
-    fn deliver_data(&mut self, data: Result<(usize, Bytes)>) {
-        match data {
-            Ok(data) => {
-                self.data_buffers[data.0] = data.1;
+    fn deliver_data(&mut self, data: DataChunk) {
+        self.permits_consumed
+            .fetch_add(data.permits_acquired, Ordering::Release);
+        match data.data {
+            Ok(data_bytes) => {
+                self.data_buffers[data.task_idx] = data_bytes;
             }
             Err(err) => {
                 // This keeps the original error, if present
@@ -80,20 +98,121 @@ impl<F: FnOnce(Result<Vec<Bytes>>) + Send> DataSink for MutableBatch<F> {
     }
 }
 
+// Don't log backpressure warnings more than once / minute
+const BACKPRESSURE_DEBOUNCE: f64 = 60.0;
+
+struct BackpressureThrottle {
+    semaphore: Semaphore,
+    capacity: u64,
+    start: Instant,
+    last_warn: Mutex<f64>,
+    deadlock_prevention_timeout: Option<Duration>,
+}
+
+impl BackpressureThrottle {
+    fn new(
+        semaphore: Semaphore,
+        capacity: u64,
+        deadlock_prevention_timeout: Option<Duration>,
+    ) -> Self {
+        Self {
+            semaphore,
+            capacity,
+            last_warn: Mutex::new(0_f64),
+            start: Instant::now(),
+            deadlock_prevention_timeout,
+        }
+    }
+
+    fn warn_if_needed(&self) {
+        let seconds_elapsed = self.start.elapsed().as_secs_f64();
+        let mut last_warn = self.last_warn.lock().unwrap();
+        let since_last_warn = seconds_elapsed - *last_warn;
+        if *last_warn == 0.0 || since_last_warn > BACKPRESSURE_DEBOUNCE {
+            log::warn!("Backpressure throttle is full, I/O will pause until buffer is drained.  Max I/O bandwidth will not be achieved because CPU is falling behind");
+            *last_warn = seconds_elapsed;
+        }
+    }
+
+    async fn acquire_permit(&self, num_bytes: u64) -> u64 {
+        // First, try and acquire the permit without waiting
+        let permits_needed = num_bytes.min(self.capacity).min(u32::MAX as u64);
+        if permits_needed < num_bytes {
+            log::warn!(
+                "I/O request for {} bytes exceeds the I/O buffer size of {}",
+                num_bytes,
+                self.capacity
+            );
+        }
+        let permit = self.semaphore.try_acquire_many(permits_needed as u32);
+        match permit {
+            Ok(permit) => {
+                permit.forget();
+                return permits_needed;
+            }
+            Err(TryAcquireError::Closed) => {
+                // If we're shutting down the scan, ignore backpressure
+                return 0;
+            }
+            Err(TryAcquireError::NoPermits) => {}
+        };
+        // If backpressure is full we need to alert the user and wait
+        self.warn_if_needed();
+        let wait_for_backpressure = self.semaphore.acquire_many(permits_needed as u32);
+        if let Some(deadline) = self.deadlock_prevention_timeout {
+            match tokio::time::timeout(deadline, wait_for_backpressure).await {
+                Ok(Ok(permit)) => {
+                    permit.forget();
+                    permits_needed
+                }
+                Ok(Err(AcquireError { .. })) => 0,
+                Err(Elapsed { .. }) => {
+                    log::error!(
+                        concat!(
+                            "Waited over {} seconds for backpressure throttle to clear. ",
+                            "Deadlock prevention is kicking in and we will release the I/O. ",
+                            "If your data processing is simply very slow then increase the ",
+                            "deadlock prevention timeout or disable it entirely.  If your ",
+                            "data processing is fast then you may try increasing the size ",
+                            "of your I/O buffer or there may be a bug."
+                        ),
+                        deadline.as_secs()
+                    );
+                    0
+                }
+            }
+        } else {
+            match wait_for_backpressure.await {
+                Ok(permit) => {
+                    permit.forget();
+                    permits_needed
+                }
+                Err(AcquireError { .. }) => 0,
+            }
+        }
+    }
+
+    fn release(&self, num_permits: u64) {
+        self.semaphore.add_permits(num_permits as usize);
+    }
+}
+
 struct IoTask {
     reader: Arc<dyn Reader>,
+    backpressure_throttle: Arc<BackpressureThrottle>,
     to_read: Range<u64>,
-    when_done: Box<dyn FnOnce(Result<Bytes>) + Send>,
+    when_done: Box<dyn FnOnce((Result<Bytes>, u64)) + Send>,
 }
 
 impl IoTask {
     async fn run(self) {
-        let bytes = self
+        let num_bytes = self.to_read.end - self.to_read.start;
+        let permits_acquired = self.backpressure_throttle.acquire_permit(num_bytes).await;
+        let bytes_fut = self
             .reader
-            .get_range(self.to_read.start as usize..self.to_read.end as usize)
-            .await
-            .map_err(Error::from);
-        (self.when_done)(bytes);
+            .get_range(self.to_read.start as usize..self.to_read.end as usize);
+        let bytes = bytes_fut.await.map_err(Error::from);
+        (self.when_done)((bytes, permits_acquired));
     }
 }
 
@@ -134,6 +253,7 @@ pub struct ScanScheduler {
     object_store: Arc<ObjectStore>,
     io_submitter: async_priority_channel::Sender<IoTask, Reverse<u128>>,
     file_counter: Mutex<u32>,
+    backpressure_throttle: Arc<BackpressureThrottle>,
 }
 
 impl Debug for ScanScheduler {
@@ -145,14 +265,60 @@ impl Debug for ScanScheduler {
     }
 }
 
+struct Response {
+    data: Result<Vec<Bytes>>,
+    permits_acquired: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct SchedulerConfig {
+    /// the # of bytes that can be buffered but not yet requested.
+    /// This controls back pressure.  If data is not processed quickly enough then this
+    /// buffer will fill up and the I/O loop will pause until the buffer is drained.
+    pub io_buffer_size_bytes: u64,
+    /// The backpressure mechansim can potentially lead to deadlock if there are bugs.
+    /// A complete hang is a pretty bad user experience so we log an error and panic
+    /// if the I/O loop is paused for longer than this timeout.
+    ///
+    /// On the other hand, the user might be doing some very expensive and slow processing
+    /// and they are just reading the data very very slowly (or maybe they are doing some
+    /// kind of paging).  In these cases we don't want to panic so we allow this to be
+    /// disabled.
+    pub deadlock_prevention_timeout: Option<Duration>,
+}
+
+impl SchedulerConfig {
+    /// Default configuration for that should be suitable for most unit testing purposes
+    ///
+    /// Note, we intentionally do not implement Default here because callers should think
+    /// about these values.
+    pub fn default_for_testing() -> Self {
+        Self {
+            io_buffer_size_bytes: 256 * 1024 * 1024,
+            deadlock_prevention_timeout: Some(Duration::from_secs(30)),
+        }
+    }
+
+    /// We read files for a number of tasks (e.g. creating indices, updating indices, running
+    /// compaction, etc.)  In these cases, if the user has no input on the I/O buffer size we
+    /// should choose something fairly reasonable (256MiB) and our internal scans should all
+    /// be pretty fast and not trigger deadlock.
+    pub fn fast_and_not_too_ram_intensive() -> Self {
+        Self {
+            io_buffer_size_bytes: 256 * 1024 * 1024,
+            deadlock_prevention_timeout: Some(Duration::from_secs(60)),
+        }
+    }
+}
+
 impl ScanScheduler {
     /// Create a new scheduler with the given I/O capacity
     ///
     /// # Arguments
     ///
     /// * object_store - the store to wrap
-    /// * io_capacity - the maximum number of parallel requests that will be allowed
-    pub fn new(object_store: Arc<ObjectStore>) -> Arc<Self> {
+    /// * config - configuration settings for the scheduler
+    pub fn new(object_store: Arc<ObjectStore>, config: SchedulerConfig) -> Arc<Self> {
         // TODO: we don't have any backpressure in place if the compute thread falls
         // behind.  The scheduler thread will schedule ALL of the I/O and then the
         // loaded data will eventually pile up.
@@ -169,6 +335,11 @@ impl ScanScheduler {
             object_store,
             io_submitter: reg_tx,
             file_counter: Mutex::new(0),
+            backpressure_throttle: Arc::new(BackpressureThrottle::new(
+                Semaphore::new(config.io_buffer_size_bytes as usize),
+                config.io_buffer_size_bytes,
+                config.deadlock_prevention_timeout,
+            )),
         };
         tokio::task::spawn(async move { run_io_loop(reg_rx, io_capacity).await });
         Arc::new(scheduler)
@@ -193,14 +364,14 @@ impl ScanScheduler {
         &self,
         reader: Arc<dyn Reader>,
         request: Vec<Range<u64>>,
-        tx: oneshot::Sender<Result<Vec<Bytes>>>,
+        tx: oneshot::Sender<Response>,
         priority: u128,
     ) {
         let num_iops = request.len() as u32;
 
-        let when_all_io_done = move |bytes| {
+        let when_all_io_done = move |bytes_and_permits| {
             // We don't care if the receiver has given up so discard the result
-            let _ = tx.send(bytes);
+            let _ = tx.send(bytes_and_permits);
         };
 
         let dest = Arc::new(Mutex::new(Box::new(MutableBatch::new(
@@ -213,9 +384,15 @@ impl ScanScheduler {
             let task = IoTask {
                 reader: reader.clone(),
                 to_read: iop,
-                when_done: Box::new(move |bytes| {
+                backpressure_throttle: self.backpressure_throttle.clone(),
+                when_done: Box::new(move |(data, permits_acquired)| {
                     let mut dest = dest.lock().unwrap();
-                    dest.deliver_data(bytes.map(|bytes| (task_idx, bytes)));
+                    let chunk = DataChunk {
+                        data,
+                        task_idx,
+                        permits_acquired,
+                    };
+                    dest.deliver_data(chunk);
                 }),
             };
             if self.io_submitter.try_send(task, Reverse(priority)).is_err() {
@@ -230,13 +407,18 @@ impl ScanScheduler {
         request: Vec<Range<u64>>,
         priority: u128,
     ) -> impl Future<Output = Result<Vec<Bytes>>> + Send {
-        let (tx, rx) = oneshot::channel::<Result<Vec<Bytes>>>();
+        let (tx, rx) = oneshot::channel::<Response>();
 
         self.do_submit_request(reader, request, tx, priority);
 
-        // Right now, it isn't possible for I/O to be cancelled so a cancel error should
-        // not occur
-        rx.map(|wrapped_err| wrapped_err.unwrap())
+        let backpressure_throttle = self.backpressure_throttle.clone();
+        rx.map(move |wrapped_rsp| {
+            // Right now, it isn't possible for I/O to be cancelled so a cancel error should
+            // not occur
+            let rsp = wrapped_rsp.unwrap();
+            backpressure_throttle.release(rsp.permits_acquired);
+            rsp.data
+        })
     }
 }
 
@@ -353,8 +535,8 @@ mod tests {
     use rand::RngCore;
     use tempfile::tempdir;
 
-    use object_store::{memory::InMemory, ObjectStore as OSObjectStore};
-    use tokio::time::timeout;
+    use object_store::{memory::InMemory, GetRange, ObjectStore as OSObjectStore};
+    use tokio::{runtime::Handle, time::timeout};
     use url::Url;
 
     use crate::testing::MockObjectStore;
@@ -376,7 +558,12 @@ mod tests {
         rand::thread_rng().fill_bytes(&mut some_data);
         obj_store.put(&tmp_file, &some_data).await.unwrap();
 
-        let scheduler = ScanScheduler::new(obj_store);
+        let config = SchedulerConfig {
+            deadlock_prevention_timeout: None,
+            io_buffer_size_bytes: 1024 * 1024,
+        };
+
+        let scheduler = ScanScheduler::new(obj_store, config);
 
         let file_scheduler = scheduler.open_file(&tmp_file).await.unwrap();
 
@@ -439,7 +626,12 @@ mod tests {
             1,
         ));
 
-        let scan_scheduler = ScanScheduler::new(obj_store);
+        let config = SchedulerConfig {
+            deadlock_prevention_timeout: None,
+            io_buffer_size_bytes: 1024 * 1024,
+        };
+
+        let scan_scheduler = ScanScheduler::new(obj_store, config);
 
         let file_scheduler = scan_scheduler
             .open_file(&Path::parse("foo").unwrap())
@@ -485,5 +677,134 @@ mod tests {
         // Finally, the low priority request
         semaphore_copy.add_permits(1);
         assert!(second_fut.await.unwrap().unwrap().len() == 20);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_backpressure() {
+        let some_path = Path::parse("foo").unwrap();
+        let base_store = Arc::new(InMemory::new());
+        base_store
+            .put(&some_path, vec![0; 100000].into())
+            .await
+            .unwrap();
+
+        let bytes_read = Arc::new(AtomicU64::from(0));
+        let mut obj_store = MockObjectStore::default();
+        let bytes_read_copy = bytes_read.clone();
+        // Wraps the obj_store to keep track of how many bytes have been read
+        obj_store
+            .expect_get_opts()
+            .returning(move |location, options| {
+                let range = options.range.as_ref().unwrap();
+                let num_bytes = match range {
+                    GetRange::Bounded(bounded) => bounded.end - bounded.start,
+                    _ => panic!(),
+                };
+                bytes_read_copy.fetch_add(num_bytes as u64, Ordering::Release);
+                let location = location.clone();
+                let base_store = base_store.clone();
+                async move { base_store.get_opts(&location, options).await }.boxed()
+            });
+        let obj_store = Arc::new(ObjectStore::new(
+            Arc::new(obj_store),
+            Url::parse("mem://").unwrap(),
+            None,
+            None,
+            false,
+            1,
+        ));
+
+        let config = SchedulerConfig {
+            deadlock_prevention_timeout: Some(Duration::from_millis(50)),
+            io_buffer_size_bytes: 10,
+        };
+
+        let scan_scheduler = ScanScheduler::new(obj_store.clone(), config);
+
+        let file_scheduler = scan_scheduler
+            .open_file(&Path::parse("foo").unwrap())
+            .await
+            .unwrap();
+
+        let wait_for_idle = |target: usize| async move {
+            let handle = Handle::current();
+            while handle.metrics().num_alive_tasks() != target {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        };
+        let wait_for_bytes_read_and_idle = |target_bytes: u64, target_tasks: usize| {
+            // We need to move `target` but don't want to move `bytes_read`
+            let bytes_read = &bytes_read;
+            async move {
+                let bytes_read_copy = bytes_read.clone();
+                while bytes_read_copy.load(Ordering::Acquire) < target_bytes {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                wait_for_idle(target_tasks).await;
+            }
+        };
+
+        // This read will begin immediately
+        let first_fut = file_scheduler.submit_single(0..5, 0);
+        // This read should also begin immediately
+        let second_fut = file_scheduler.submit_single(0..5, 0);
+        // This read will be throttled
+        let third_fut = file_scheduler.submit_single(0..3, 0);
+        // Two tasks (third_fut and unit test)
+        wait_for_bytes_read_and_idle(10, 2).await;
+
+        assert_eq!(first_fut.await.unwrap().len(), 5);
+        // One task (unit test)
+        wait_for_bytes_read_and_idle(13, 1).await;
+
+        // 2 bytes are ready but 5 bytes requested, read will be blocked
+        let fourth_fut = file_scheduler.submit_single(0..5, 0);
+        wait_for_bytes_read_and_idle(13, 2).await;
+
+        // Out of order completion is ok, will unblock backpressure
+        assert_eq!(third_fut.await.unwrap().len(), 3);
+        wait_for_bytes_read_and_idle(18, 1).await;
+
+        assert_eq!(second_fut.await.unwrap().len(), 5);
+        // At this point there are 5 bytes available in backpressure queue
+        // Now we issue multi-read that can be partially fulfilled, it will read some bytes but
+        // not all of them. (using large range gap to ensure request not coalesced)
+        //
+        // I'm actually not sure this behavior is great.  It's possible that we should just
+        // block until we can fulfill the entire request.
+        let fifth_fut = file_scheduler.submit_request(vec![0..3, 90000..90007], 0);
+        wait_for_bytes_read_and_idle(21, 1).await;
+
+        // Fifth future should eventually finish due to deadlock prevention
+        let fifth_bytes = tokio::time::timeout(Duration::from_secs(10), fifth_fut)
+            .await
+            .unwrap();
+        assert_eq!(
+            fifth_bytes.unwrap().iter().map(|b| b.len()).sum::<usize>(),
+            10
+        );
+
+        // And now let's just make sure that we can read the rest of the data
+        assert_eq!(fourth_fut.await.unwrap().len(), 5);
+        wait_for_bytes_read_and_idle(28, 1).await;
+
+        // Ensure deadlock prevention timeout can be disabled
+        let config = SchedulerConfig {
+            deadlock_prevention_timeout: None,
+            io_buffer_size_bytes: 10,
+        };
+
+        let scan_scheduler = ScanScheduler::new(obj_store, config);
+        let file_scheduler = scan_scheduler
+            .open_file(&Path::parse("foo").unwrap())
+            .await
+            .unwrap();
+
+        let first_fut = file_scheduler.submit_single(0..10, 0);
+        let second_fut = file_scheduler.submit_single(0..10, 0);
+
+        std::thread::sleep(Duration::from_millis(100));
+        assert_eq!(first_fut.await.unwrap().len(), 10);
+        assert_eq!(second_fut.await.unwrap().len(), 10);
     }
 }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -31,7 +31,7 @@ use lance_index::{
     vector::VectorIndex,
     DatasetIndexExt, Index, IndexType, INDEX_FILE_NAME,
 };
-use lance_io::scheduler::ScanScheduler;
+use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_io::traits::Reader;
 use lance_io::utils::{
     read_last_block, read_message, read_message_from_buf, read_metadata_offset, read_version,
@@ -592,7 +592,10 @@ impl DatasetIndexInternalExt for Dataset {
             }
 
             (0, 3) => {
-                let scheduler = ScanScheduler::new(self.object_store.clone());
+                let scheduler = ScanScheduler::new(
+                    self.object_store.clone(),
+                    SchedulerConfig::fast_and_not_too_ram_intensive(),
+                );
                 let file = scheduler.open_file(&index_file).await?;
                 let reader =
                     v2::reader::FileReader::try_open(file, None, Default::default()).await?;

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -33,6 +33,7 @@ use lance_index::{
     INDEX_AUXILIARY_FILE_NAME, INDEX_FILE_NAME,
 };
 use lance_index::{IndexMetadata, INDEX_METADATA_SCHEMA_KEY};
+use lance_io::scheduler::SchedulerConfig;
 use lance_io::stream::RecordBatchStream;
 use lance_io::{
     object_store::ObjectStore, scheduler::ScanScheduler, stream::RecordBatchStreamAdapter,
@@ -471,7 +472,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + Clone + 'static> IvfIndexBuilde
         let mut index_ivf = IvfModel::new(ivf.centroids.clone().unwrap());
         let mut partition_storage_metadata = Vec::with_capacity(partition_sizes.len());
         let mut partition_index_metadata = Vec::with_capacity(partition_sizes.len());
-        let scheduler = ScanScheduler::new(Arc::new(ObjectStore::local()));
+        let scheduler = ScanScheduler::new(
+            Arc::new(ObjectStore::local()),
+            SchedulerConfig::fast_and_not_too_ram_intensive(),
+        );
         for (part_id, (storage_size, index_size)) in partition_sizes.into_iter().enumerate() {
             log::info!("merging partition {}/{}", part_id, ivf.num_partitions());
             if storage_size == 0 {

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -39,6 +39,7 @@ use lance_index::{
     Index, IndexType, INDEX_AUXILIARY_FILE_NAME, INDEX_FILE_NAME,
 };
 use lance_index::{IndexMetadata, INDEX_METADATA_SCHEMA_KEY};
+use lance_io::scheduler::SchedulerConfig;
 use lance_io::{
     object_store::ObjectStore, scheduler::ScanScheduler, traits::Reader, ReadBatchParams,
 };
@@ -110,7 +111,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         uuid: String,
         session: Weak<Session>,
     ) -> Result<Self> {
-        let scheduler = ScanScheduler::new(object_store);
+        let scheduler = ScanScheduler::new(
+            object_store,
+            SchedulerConfig::fast_and_not_too_ram_intensive(),
+        );
 
         let index_reader = FileReader::try_open(
             scheduler

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -327,7 +327,10 @@ mod tests {
     use arrow_schema::{DataType, Field};
     use tempfile::tempdir;
 
-    use crate::{dataset::WriteParams, io::exec::LanceScanExec};
+    use crate::{
+        dataset::{scanner::DEFAULT_IO_BUFFER_SIZE, WriteParams},
+        io::exec::LanceScanExec,
+    };
 
     async fn create_dataset() -> Arc<Dataset> {
         let schema = Arc::new(ArrowSchema::new(vec![
@@ -386,6 +389,7 @@ mod tests {
             10,
             10,
             Some(4),
+            DEFAULT_IO_BUFFER_SIZE,
             true,
             false,
             false,
@@ -420,6 +424,7 @@ mod tests {
             10,
             10,
             Some(4),
+            DEFAULT_IO_BUFFER_SIZE,
             true,
             false,
             false,
@@ -454,6 +459,7 @@ mod tests {
             10,
             10,
             Some(4),
+            DEFAULT_IO_BUFFER_SIZE,
             false,
             false,
             false,
@@ -473,6 +479,7 @@ mod tests {
             10,
             10,
             Some(4),
+            DEFAULT_IO_BUFFER_SIZE,
             true,
             false,
             false,

--- a/rust/lance/src/utils.rs
+++ b/rust/lance/src/utils.rs
@@ -13,3 +13,20 @@ pub mod tfrecord;
 // Re-export
 pub use lance_datafusion::sql;
 pub use lance_linalg::kmeans;
+
+pub fn default_deadlock_prevention_timeout() -> Option<std::time::Duration> {
+    if let Ok(user_provided) =
+        std::env::var("LANCE_DEADLOCK_PREVENTION").map(|val| val.parse::<u64>().unwrap())
+    {
+        if user_provided == 0 {
+            None
+        } else {
+            Some(std::time::Duration::from_secs(user_provided))
+        }
+    } else {
+        // By default don't do deadlock prevention.  It's too easy for
+        // users to consume data slowly and we don't want to scare them
+        // with a frightening log message
+        None
+    }
+}


### PR DESCRIPTION
Adds backpressure to the I/O scheduler.  The general problem is rather tricky.  If your I/O threads all pause because your I/O buffer is full and then your decode threads are waiting for queued I/O tasks then you will have a deadlock.

I/O priority should allow us to avoid this situation but it is something that will need to be monitored, especially if users want to set really small I/O buffer sizes.  For this reason I haven't made any of the new settings  configurable (except for deadlock detection which we may turn on for debugging purposes if people seem to have encountered a deadlock).

One way you can hit this deadlock is to create a file with 10 pages where each page has 10GB of data.  Even a single read will fill up the I/O buffer.  We submit the reads in priority order but we have 8 I/O threads and so they race to grab the permits.

As a result I've added a much needed option to split primitive arrays into multiple pages if we are given huge chunks of data.  The splitting algorithm is not perfect and could also use some work (perhaps we can do a sort of "binary splitting" where we continuously split the largest chunk in half until all chunks are below a given size)

At the moment I think things are "safe enough" that this PR prevents more problems (avoids OOM) than it introduces (deadlock in esoteric cases).