### PR TITLE
feat: add support for the null data type to v2

### DIFF
--- a/rust/lance-encoding/src/encodings/physical/basic.rs
+++ b/rust/lance-encoding/src/encodings/physical/basic.rs
@@ -204,7 +204,6 @@ impl ArrayEncoder for BasicEncoder {
                 }
             })
             .fold((0, 0), |acc, val| (acc.0 + val.0, acc.1 + val.1));
-        println!("null_count={} row_count={}", null_count, row_count);
         let (buffers, nullability) = if null_count == 0 {
             let arr_encoding = self.values_encoder.encode(arrays, buffer_index)?;
             let encoding = pb::nullable::Nullability::NoNulls(Box::new(pb::nullable::NoNull {

--- a/rust/lance-encoding/src/encodings/physical/basic.rs
+++ b/rust/lance-encoding/src/encodings/physical/basic.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use arrow_array::{ArrayRef, BooleanArray};
 use arrow_buffer::BooleanBuffer;
+use arrow_schema::DataType;
 use futures::{future::BoxFuture, FutureExt};
 use log::trace;
 
@@ -193,8 +194,17 @@ impl ArrayEncoder for BasicEncoder {
     fn encode(&self, arrays: &[ArrayRef], buffer_index: &mut u32) -> Result<EncodedArray> {
         let (null_count, row_count) = arrays
             .iter()
-            .map(|arr| (arr.null_count() as u32, arr.len() as u32))
+            .map(|arr| {
+                if matches!(arr.data_type(), DataType::Null) {
+                    // Arrays with the null datatype report 0 as the null count so we
+                    // need special logic to get the correct null count
+                    (arr.len() as u32, arr.len() as u32)
+                } else {
+                    (arr.null_count() as u32, arr.len() as u32)
+                }
+            })
             .fold((0, 0), |acc, val| (acc.0 + val.0, acc.1 + val.1));
+        println!("null_count={} row_count={}", null_count, row_count);
         let (buffers, nullability) = if null_count == 0 {
             let arr_encoding = self.values_encoder.encode(arrays, buffer_index)?;
             let encoding = pb::nullable::Nullability::NoNulls(Box::new(pb::nullable::NoNull {

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -332,6 +332,7 @@ pub(crate) mod tests {
     };
 
     const PRIMITIVE_TYPES: &[DataType] = &[
+        DataType::Null,
         DataType::FixedSizeBinary(2),
         DataType::Date32,
         DataType::Date64,

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -477,6 +477,10 @@ async fn check_round_trip_field_encoding_random(
 ) {
     for null_rate in [None, Some(0.5), Some(1.0)] {
         for use_slicing in [false, true] {
+            if null_rate != Some(1.0) && matches!(field.data_type(), DataType::Null) {
+                continue;
+            }
+
             let field = if null_rate.is_some() {
                 if !supports_nulls(field.data_type()) {
                     continue;
@@ -510,7 +514,11 @@ async fn check_round_trip_field_encoding_random(
                 if use_slicing {
                     let mut generator = gen().anon_col(array_generator_provider.provide());
                     if let Some(null_rate) = null_rate {
-                        generator.with_random_nulls(null_rate);
+                        // The null generator is the only generator that already inserts nulls
+                        // and attempting to do so again makes arrow-rs grumpy
+                        if !matches!(field.data_type(), DataType::Null) {
+                            generator.with_random_nulls(null_rate);
+                        }
                     }
                     let all_data = generator
                         .into_batch_rows(RowCount::from(10000))
@@ -528,7 +536,11 @@ async fn check_round_trip_field_encoding_random(
                             .with_seed(Seed::from(i as u64))
                             .anon_col(array_generator_provider.provide());
                         if let Some(null_rate) = null_rate {
-                            generator.with_random_nulls(null_rate);
+                            // The null generator is the only generator that already inserts nulls
+                            // and attempting to do so again makes arrow-rs grumpy
+                            if !matches!(field.data_type(), DataType::Null) {
+                                generator.with_random_nulls(null_rate);
+                            }
                         }
                         let arr = generator
                             .into_batch_rows(RowCount::from(rows_per_batch as u64))


### PR DESCRIPTION
Need a tiny bit of extra logic because an array with the null data type will report 0 as its null count.