### PR TITLE
fix: out of bounds error in bitpacking

### DIFF
--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -647,6 +647,16 @@ pub(crate) mod tests {
                     ),
                 ),
             ),
+            // check byte aligned where the num bits doesn't divide evenly into the byte length
+            (
+                DataType::UInt64,
+                Box::new(
+                    DistributionArrayGeneratorProvider::<UInt64Type, Uniform<u64>>::new(
+                        // this range should always give 24 hits
+                        Uniform::new(200 << 16, 250 << 16),
+                    ),
+                ),
+            ),
             // check that we can still encode an all-0 array
             (
                 DataType::UInt32,


### PR DESCRIPTION
resolves https://github.com/lancedb/lancedb/issues/1490

There was a bug in the calculation that moved the offset of uncompressed buffer forward. This occurred when the number of bits was byte aligned but did not divide evenly into the number of uncompressed bits.