### PR TITLE
feat: make default batch size configurable via environment variable

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1573,6 +1573,17 @@ def test_scan_with_batch_size(tmp_path: Path):
         df = batch.to_pandas()
         assert df["a"].iloc[0] == idx * 16
 
+    os.environ["LANCE_DEFAULT_BATCH_SIZE"] = "12"
+    batches = dataset.scanner(scan_in_order=True).to_batches()
+    for batch in batches:
+        # The last batch in each file has 4 rows
+        assert batch.num_rows == 12 or batch.num_rows == 4
+
+    del os.environ["LANCE_DEFAULT_BATCH_SIZE"]
+    batches = dataset.scanner(scan_in_order=True).to_batches()
+    for batch in batches:
+        assert batch.num_rows != 12
+
 
 def test_scan_no_columns(tmp_path: Path):
     base_dir = tmp_path / "dataset"

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -257,12 +257,21 @@ impl Scanner {
         // 64KB, this is 16K rows. For local file systems, the default block size
         // is just 4K, which would mean only 1K rows, which might be a little small.
         // So we use a default minimum of 8K rows.
-        self.batch_size.unwrap_or_else(|| {
-            std::cmp::max(
-                self.dataset.object_store().block_size() / 4,
-                DEFAULT_BATCH_SIZE,
-            )
-        })
+        std::env::var("LANCE_DEFAULT_BATCH_SIZE")
+            .map(|bs| {
+                bs.parse().expect(&format!(
+                    "The value of LANCE_DEFAULT_BATCH_SIZE ({}) is not a valid batch size",
+                    bs
+                ))
+            })
+            .unwrap_or_else(|_| {
+                self.batch_size.unwrap_or_else(|| {
+                    std::cmp::max(
+                        self.dataset.object_store().block_size() / 4,
+                        DEFAULT_BATCH_SIZE,
+                    )
+                })
+            })
     }
 
     fn ensure_not_fragment_scan(&self) -> Result<()> {


### PR DESCRIPTION
There's a number of places (updates, compaction, etc.) where the default batch size is used and it is not configurable.  However, the default is too large in many cases.  We should probably eventually make all of these operations configurable (batch size, readahead, etc.) or perhaps change the default batch size to be based on data size but in the meantime this provides a potential workaround.