### PR TITLE
fix: optimize cosine IVF_PQ index

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2322,7 +2322,7 @@ class ScannerBuilder:
         Users can use `Table::optimize()` or `create_index()` to include the new data
         into index, thus make new data searchable.
         """
-        self.fast_search = flag
+        self._fast_search = flag
         return self
 
     def full_text_search(

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -71,6 +71,10 @@ impl ProductQuantizer {
     }
 
     pub fn from_proto(proto: &pb::Pq, distance_type: DistanceType) -> Result<Self> {
+        let distance_type = match distance_type {
+            DistanceType::Cosine => DistanceType::L2,
+            _ => distance_type,
+        };
         let codebook = match proto.codebook_tensor.as_ref() {
             Some(tensor) => FixedSizeListArray::try_from(tensor)?,
             None => FixedSizeListArray::try_new_from_values(


### PR DESCRIPTION
we loaded PQ with distance type `cosine`, but actually always expect normalized vectors and use L2 for all cases PQ, this PR fixes this issue.