### PR TITLE
fix: search results are not correct after appending index

### DIFF
--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -146,7 +146,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + Clone + 'static> IvfIndexBuilde
         }
 
         // step 2. shuffle the dataset
-        if self.partition_sizes.is_empty() {
+        if self.shuffle_reader.is_none() {
             self.shuffle_dataset().await?;
         }
 


### PR DESCRIPTION
Only IVF_HNSW_* is with this bug,
this bug leads to the appending always builds index over the entire dataset, then we may get wrong results.
This fix also means that slow appending would be fixed