### PR TITLE
perf: various fixes to improve vector transform performance at high scales

### DIFF
--- a/python/python/benchmarks/test_index.py
+++ b/python/python/benchmarks/test_index.py
@@ -145,15 +145,57 @@ def rand_pq(rand_dataset, rand_ivf):
     return pq
 
 
+def gen_rand_part_ids(dataset, dest_uri):
+    row_ids = dataset.to_table(with_row_address=True, columns=[])
+    part_ids = np.random.randint(0, 35000, size=row_ids.num_rows, dtype=np.uint32)
+    table = pa.table({"row_id": row_ids.column(0), "partition": part_ids})
+    lance.write_dataset(table, dest_uri, max_rows_per_file=row_ids.num_rows)
+
+
 @pytest.mark.benchmark(group="transform_vectors")
-def test_transform_vectors(test_dataset, tmpdir_factory, benchmark):
+def test_transform_vectors_no_precomputed_parts(test, tmpdir, benchmark):
     ivf = rand_ivf(test_dataset)
     pq = rand_pq(test_dataset, ivf)
-    builder = IndicesBuilder(test_dataset)
-    dst_uri = str(tmpdir_factory.mktemp("transformed") / "output.lance")
+    builder = IndicesBuilder(test_dataset, "vector")
+    dst_uri = str(tmpdir / "output.lance")
+
     benchmark.pedantic(
         builder.transform_vectors,
-        args=["vector", ivf, pq, dst_uri],
+        args=[ivf, pq, dst_uri],
+        iterations=1,
+        rounds=1,
+    )
+
+
+@pytest.mark.benchmark(group="transform_vectors")
+def test_transform_vectors_with_precomputed_parts(
+    test_large_dataset, tmpdir, benchmark
+):
+    ivf = rand_ivf(test_large_dataset)
+    pq = rand_pq(test_large_dataset, ivf)
+    builder = IndicesBuilder(test_large_dataset, "vector")
+    dst_uri = str(tmpdir / "output.lance")
+    part_ids_path = str(tmpdir / "part_ids")
+    gen_rand_part_ids(test_large_dataset, part_ids_path)
+    benchmark.pedantic(
+        builder.transform_vectors,
+        args=[ivf, pq, dst_uri, None, part_ids_path],
+        iterations=1,
+        rounds=1,
+    )
+
+
+@pytest.mark.benchmark(group="shuffle_vectors")
+def test_shuffle_vectors(test_large_dataset, tmpdir, benchmark):
+    ivf = rand_ivf(test_dataset)
+    pq = rand_pq(test_dataset, ivf)
+    builder = IndicesBuilder(test_dataset, "vector")
+    transformed_uri = str(tmpdir / "output.lance")
+    builder.transform_vectors(ivf, pq, transformed_uri)
+    shuffle_out = str(tmpdir)
+    benchmark.pedantic(
+        builder.shuffle_transformed_vectors,
+        args=[["output.lance"], shuffle_out, ivf],
         iterations=1,
         rounds=1,
     )

--- a/python/python/lance/indices.py
+++ b/python/python/lance/indices.py
@@ -426,6 +426,7 @@ class IndicesBuilder:
             pq.codebook,
             dest_uri,
             fragments,
+            partition_ds_uri,
         )
 
     def shuffle_transformed_vectors(

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -458,6 +458,7 @@ impl Dataset {
         scan_in_order: Option<bool>,
         fragments: Option<Vec<FileFragment>>,
         with_row_id: Option<bool>,
+        with_row_address: Option<bool>,
         use_stats: Option<bool>,
         substrait_filter: Option<Vec<u8>>,
         fast_search: Option<bool>,
@@ -544,6 +545,10 @@ impl Dataset {
 
         if with_row_id.unwrap_or(false) {
             scanner.with_row_id();
+        }
+
+        if with_row_address.unwrap_or(false) {
+            scanner.with_row_address();
         }
 
         if let Some(use_stats) = use_stats {

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -159,6 +159,7 @@ async fn do_transform_vectors(
     pq_model: ProductQuantizer,
     dst_uri: &str,
     fragments: Vec<FileFragment>,
+    partitions_ds_uri: Option<&str>,
 ) -> PyResult<()> {
     let num_rows = dataset.ds.count_rows(None).await.infer_error()?;
     let fragments = fragments.iter().map(|item| item.metadata().inner).collect();
@@ -177,6 +178,7 @@ async fn do_transform_vectors(
     let (obj_store, path) = object_store_from_uri_or_path(dst_uri).await?;
     let writer = obj_store.create(&path).await.infer_error()?;
     write_vector_storage(
+        &dataset.ds,
         transform_input,
         num_rows as u64,
         ivf_centroids,
@@ -184,6 +186,7 @@ async fn do_transform_vectors(
         distance_type,
         column,
         writer,
+        partitions_ds_uri,
     )
     .await
     .infer_error()?;
@@ -203,6 +206,7 @@ pub fn transform_vectors(
     pq_codebook: PyArrowType<ArrayData>,
     dst_uri: &str,
     fragments: Vec<FileFragment>,
+    partitions_ds_uri: Option<&str>,
 ) -> PyResult<()> {
     let ivf_centroids = ivf_centroids.0;
     let ivf_centroids = FixedSizeListArray::from(ivf_centroids);
@@ -226,6 +230,7 @@ pub fn transform_vectors(
             pq,
             dst_uri,
             fragments,
+            partitions_ds_uri,
         ),
     )?
 }

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -151,6 +151,7 @@ fn train_pq_model(
     codebook.to_pyarrow(py)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn do_transform_vectors(
     dataset: &Dataset,
     column: &str,

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -340,7 +340,8 @@ pub fn load_shuffled_vectors(
     distance_type: &str,
     index_name: Option<&str>,
 ) -> PyResult<()> {
-    let default_idx_name = column.to_string() + "_idx";
+    let mut default_idx_name = column.to_string();
+    default_idx_name.push_str("_idx");
     let idx_name = index_name.unwrap_or(default_idx_name.as_str());
 
     let ivf_centroids = ivf_centroids.0;

--- a/rust/lance-index/src/vector/ivf.rs
+++ b/rust/lance-index/src/vector/ivf.rs
@@ -14,6 +14,7 @@ use lance_linalg::{
     distance::{DistanceType, MetricType},
     kmeans::{compute_partitions_arrow_array, kmeans_find_partitions_arrow_array},
 };
+use tracing::instrument;
 
 use crate::vector::ivf::transform::PartitionTransformer;
 use crate::vector::{
@@ -262,6 +263,7 @@ impl IvfTransformer {
 }
 
 impl Transformer for IvfTransformer {
+    #[instrument(name = "IvfTransformer::transform", level = "debug", skip_all)]
     fn transform(&self, batch: &RecordBatch) -> Result<RecordBatch> {
         let mut batch = batch.clone();
         for transform in self.transforms.as_slice() {

--- a/rust/lance-index/src/vector/ivf/transform.rs
+++ b/rust/lance-index/src/vector/ivf/transform.rs
@@ -53,7 +53,7 @@ impl PartitionTransformer {
 
     /// Compute the partition for each row in the input Matrix.
     ///
-    #[instrument(level = "debug", skip(data))]
+    #[instrument(level = "debug", skip_all)]
     pub(super) fn compute_partitions(&self, data: &FixedSizeListArray) -> UInt32Array {
         compute_partitions_arrow_array(&self.centroids, data, self.distance_type)
             .expect("failed to compute partitions")
@@ -61,6 +61,7 @@ impl PartitionTransformer {
     }
 }
 impl Transformer for PartitionTransformer {
+    #[instrument(name = "PartitionTransformer::transform", level = "debug", skip_all)]
     fn transform(&self, batch: &RecordBatch) -> Result<RecordBatch> {
         if batch.column_by_name(&self.output_column).is_some() {
             // If the partition ID column is already present, we don't need to compute it again.
@@ -125,6 +126,7 @@ impl PartitionFilter {
 }
 
 impl Transformer for PartitionFilter {
+    #[instrument(name = "PartitionFilter::transform", level = "debug", skip_all)]
     fn transform(&self, batch: &RecordBatch) -> Result<RecordBatch> {
         // TODO: use datafusion execute?
         let arr = batch

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -119,7 +119,7 @@ impl ProductQuantizer {
         let values = flatten_data
             .values()
             .chunks_exact(dim)
-            .map(|vector| {
+            .flat_map(|vector| {
                 vector
                     .chunks_exact(sub_dim)
                     .enumerate()
@@ -135,7 +135,6 @@ impl ProductQuantizer {
                     })
                     .collect::<Vec<_>>()
             })
-            .flatten()
             .collect::<Vec<_>>();
 
         Ok(Arc::new(FixedSizeListArray::try_new_from_values(

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -17,9 +17,9 @@ use lance_linalg::distance::{dot_distance_batch, DistanceType, Dot, L2};
 use lance_linalg::kmeans::compute_partition;
 use num_traits::Float;
 use prost::Message;
-use rayon::prelude::*;
 use snafu::{location, Location};
 use storage::{ProductQuantizationMetadata, ProductQuantizationStorage, PQ_METADTA_KEY};
+use tracing::instrument;
 
 pub mod builder;
 mod distance;
@@ -95,6 +95,7 @@ impl ProductQuantizer {
         matches!(self.distance_type, DistanceType::L2 | DistanceType::Cosine)
     }
 
+    #[instrument(name = "ProductQuantizer::transform", level = "debug", skip_all)]
     fn transform<T: ArrowPrimitiveType>(&self, vectors: &dyn Array) -> Result<ArrayRef>
     where
         T::Native: Float + L2 + Dot,
@@ -117,7 +118,7 @@ impl ProductQuantizer {
         let sub_dim = dim / num_sub_vectors;
         let values = flatten_data
             .values()
-            .par_chunks(dim)
+            .chunks_exact(dim)
             .map(|vector| {
                 vector
                     .chunks_exact(sub_dim)

--- a/rust/lance-index/src/vector/pq/transform.rs
+++ b/rust/lance-index/src/vector/pq/transform.rs
@@ -9,6 +9,7 @@ use arrow_schema::Field;
 use lance_arrow::RecordBatchExt;
 use lance_core::{Error, Result};
 use snafu::{location, Location};
+use tracing::instrument;
 
 use super::ProductQuantizer;
 use crate::vector::quantizer::Quantization;
@@ -44,6 +45,7 @@ impl Debug for PQTransformer {
 }
 
 impl Transformer for PQTransformer {
+    #[instrument(name = "PQTransformer::transform", level = "debug", skip_all)]
     fn transform(&self, batch: &RecordBatch) -> Result<RecordBatch> {
         let input_arr = batch
             .column_by_name(&self.input_column)

--- a/rust/lance-index/src/vector/sq/transform.rs
+++ b/rust/lance-index/src/vector/sq/transform.rs
@@ -13,6 +13,7 @@ use arrow_array::{
 };
 use arrow_schema::{DataType, Field};
 use snafu::{location, Location};
+use tracing::instrument;
 
 use crate::vector::transform::Transformer;
 
@@ -48,6 +49,7 @@ impl Debug for SQTransformer {
 }
 
 impl Transformer for SQTransformer {
+    #[instrument(name = "SQTransformer::transform", level = "debug", skip_all)]
     fn transform(&self, batch: &RecordBatch) -> Result<RecordBatch> {
         let input = batch
             .column_by_name(&self.input_column)

--- a/rust/lance-index/src/vector/transform.rs
+++ b/rust/lance-index/src/vector/transform.rs
@@ -16,6 +16,7 @@ use snafu::{location, Location};
 
 use lance_core::{Error, Result};
 use lance_linalg::kernels::normalize_fsl;
+use tracing::instrument;
 
 /// Transform of a Vector Matrix.
 ///
@@ -54,6 +55,7 @@ impl NormalizeTransformer {
 }
 
 impl Transformer for NormalizeTransformer {
+    #[instrument(name = "NormalizeTransformer::transform", level = "debug", skip_all)]
     fn transform(&self, batch: &RecordBatch) -> Result<RecordBatch> {
         let arr = batch
             .column_by_name(&self.input_column)
@@ -107,6 +109,7 @@ where
 }
 
 impl Transformer for KeepFiniteVectors {
+    #[instrument(name = "KeepFiniteVectors::transform", level = "debug", skip_all)]
     fn transform(&self, batch: &RecordBatch) -> Result<RecordBatch> {
         let arr = batch.column_by_name(&self.column).ok_or(Error::Index {
             message: format!(

--- a/rust/lance/src/index/vector/ivf/builder.rs
+++ b/rust/lance/src/index/vector/ivf/builder.rs
@@ -143,7 +143,7 @@ async fn load_precomputed_partitions(
 #[instrument(level = "debug", skip_all)]
 fn add_precomputed_partitions(
     batch: RecordBatch,
-    partition_map: &Vec<Vec<i32>>,
+    partition_map: &[Vec<i32>],
     part_id_field: &ArrowField,
 ) -> Result<RecordBatch> {
     let row_ids = batch.column_by_name(ROW_ID).ok_or(Error::Index {
@@ -191,6 +191,7 @@ async fn apply_precomputed_partitions(
     Ok(RecordBatchStreamAdapter::new(schema_with_part_id, mapped))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn write_vector_storage(
     dataset: &Dataset,
     data: impl RecordBatchStream + Unpin + 'static,


### PR DESCRIPTION
* Adds with_row_address to python bindings (for internal use case)
* Removes rayon from transform functions (there is already plenty of data-parallelism here in the outer loop)
* Use `Vec<Vec<_>>` instead of `HashMap` for partition id lookup.