### PR TITLE
perf: cache default session contexts

### DIFF
--- a/rust/lance-datafusion/Cargo.toml
+++ b/rust/lance-datafusion/Cargo.toml
@@ -25,6 +25,7 @@ datafusion-substrait = { version = "40.0", optional = true }
 futures.workspace = true
 lance-arrow.workspace = true
 lance-core = { workspace = true, features = ["datafusion"] }
+lazy_static.workspace = true
 log.workspace = true
 prost.workspace = true
 snafu.workspace = true

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -210,9 +210,9 @@ pub fn new_session_context(options: LanceExecutionOptions) -> SessionContext {
 }
 
 lazy_static! {
-    static ref DEFAULT_SESSION_CONTEXT: SessionContext =
+    pub static ref DEFAULT_SESSION_CONTEXT: SessionContext =
         new_session_context(LanceExecutionOptions::default());
-    static ref DEFAULT_SESSION_CONTEXT_WITH_SPILLING: SessionContext = {
+    pub static ref DEFAULT_SESSION_CONTEXT_WITH_SPILLING: SessionContext = {
         new_session_context(LanceExecutionOptions {
             use_spilling: true,
             ..Default::default()

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -210,9 +210,9 @@ pub fn new_session_context(options: LanceExecutionOptions) -> SessionContext {
 }
 
 lazy_static! {
-    pub static ref DEFAULT_SESSION_CONTEXT: SessionContext =
+    static ref DEFAULT_SESSION_CONTEXT: SessionContext =
         new_session_context(LanceExecutionOptions::default());
-    pub static ref DEFAULT_SESSION_CONTEXT_WITH_SPILLING: SessionContext = {
+    static ref DEFAULT_SESSION_CONTEXT_WITH_SPILLING: SessionContext = {
         new_session_context(LanceExecutionOptions {
             use_spilling: true,
             ..Default::default()

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -230,9 +230,9 @@ pub fn execute_plan(
     let session_ctx: SessionContext;
     if options.mem_pool_size() == DEFAULT_LANCE_MEM_POOL_SIZE {
         if options.use_spilling() {
-            session_ctx = DEFAULT_SESSION_CONTEXT.clone();
-        } else {
             session_ctx = DEFAULT_SESSION_CONTEXT_WITH_SPILLING.clone();
+        } else {
+            session_ctx = DEFAULT_SESSION_CONTEXT.clone();
         }
     } else {
         session_ctx = new_session_context(options)

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -210,7 +210,8 @@ pub fn new_session_context(options: LanceExecutionOptions) -> SessionContext {
 }
 
 lazy_static! {
-    static ref DEFAULT_SESSION_CONTEXT: SessionContext = new_session_context(LanceExecutionOptions::default());
+    static ref DEFAULT_SESSION_CONTEXT: SessionContext =
+        new_session_context(LanceExecutionOptions::default());
     static ref DEFAULT_SESSION_CONTEXT_WITH_SPILLING: SessionContext = {
         new_session_context(LanceExecutionOptions {
             use_spilling: true,

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -220,13 +220,7 @@ lazy_static! {
     };
 }
 
-/// Executes a plan using default session & runtime configuration
-///
-/// Only executes a single partition.  Panics if the plan has more than one partition.
-pub fn execute_plan(
-    plan: Arc<dyn ExecutionPlan>,
-    options: LanceExecutionOptions,
-) -> Result<SendableRecordBatchStream> {
+pub fn get_session_context(options: LanceExecutionOptions) -> SessionContext {
     let session_ctx: SessionContext;
     if options.mem_pool_size() == DEFAULT_LANCE_MEM_POOL_SIZE {
         if options.use_spilling() {
@@ -237,6 +231,17 @@ pub fn execute_plan(
     } else {
         session_ctx = new_session_context(options)
     }
+    session_ctx
+}
+
+/// Executes a plan using default session & runtime configuration
+///
+/// Only executes a single partition.  Panics if the plan has more than one partition.
+pub fn execute_plan(
+    plan: Arc<dyn ExecutionPlan>,
+    options: LanceExecutionOptions,
+) -> Result<SendableRecordBatchStream> {
+    let session_ctx = get_session_context(options);
 
     // NOTE: we are only executing the first partition here. Therefore, if
     // the plan has more than one partition, we will be missing data.

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -43,9 +43,7 @@ use datafusion::{
 };
 
 use lance_arrow::{interleave_batches, RecordBatchExt, SchemaExt};
-use lance_datafusion::{
-    chunker::chunk_stream, dataframe::DataFrameExt, exec::DEFAULT_SESSION_CONTEXT_WITH_SPILLING,
-};
+use lance_datafusion::{chunker::chunk_stream, dataframe::DataFrameExt, exec::get_session_context};
 
 use datafusion_physical_expr::expressions::Column;
 use futures::{
@@ -594,7 +592,10 @@ impl MergeInsertJob {
     ) -> Result<Vec<Fragment>> {
         // Expected source schema: _rowaddr, updated_cols*
         use datafusion::logical_expr::{col, lit};
-        let session_ctx = DEFAULT_SESSION_CONTEXT_WITH_SPILLING.clone();
+        let session_ctx = get_session_context(LanceExecutionOptions {
+            use_spilling: true,
+            ..Default::default()
+        });
         let mut group_stream = session_ctx
             .read_one_shot(source)?
             .sort(vec![col(ROW_ADDR).sort(true, true)])?

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -43,7 +43,9 @@ use datafusion::{
 };
 
 use lance_arrow::{interleave_batches, RecordBatchExt, SchemaExt};
-use lance_datafusion::{chunker::chunk_stream, dataframe::DataFrameExt, exec::new_session_context};
+use lance_datafusion::{
+    chunker::chunk_stream, dataframe::DataFrameExt, exec::DEFAULT_SESSION_CONTEXT_WITH_SPILLING,
+};
 
 use datafusion_physical_expr::expressions::Column;
 use futures::{
@@ -592,10 +594,7 @@ impl MergeInsertJob {
     ) -> Result<Vec<Fragment>> {
         // Expected source schema: _rowaddr, updated_cols*
         use datafusion::logical_expr::{col, lit};
-        let session_ctx = new_session_context(LanceExecutionOptions {
-            use_spilling: true,
-            ..Default::default()
-        });
+        let session_ctx = DEFAULT_SESSION_CONTEXT_WITH_SPILLING.clone();
         let mut group_stream = session_ctx
             .read_one_shot(source)?
             .sort(vec![col(ROW_ADDR).sort(true, true)])?


### PR DESCRIPTION
Closes #2705.

This PR uses `lazy_static` to introduce two default session contexts:

- `DEFAULT_SESSION_CONTEXT`
- `DEFAULT_SESSION_CONTEXT_WITH_SPILLING`

Users request the session context via the new `get_session_context` function. If the user requests a session context with the default memory pool size, then one of the above contexts are returned. Otherwise, we compute a new session context like before.