### PR TITLE
fix: correct index type of inverted index

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -189,7 +189,7 @@ impl Index for InvertedIndex {
     }
 
     fn index_type(&self) -> crate::IndexType {
-        crate::IndexType::Scalar
+        crate::IndexType::Inverted
     }
 
     async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {


### PR DESCRIPTION
before we had only Scalar/Vector for `IndexType`,
now we've added concrete types for it, so let it be `Inverted`