### PR TITLE
chore: relax the check in test_index_cache_size

### DIFF
--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -673,8 +673,11 @@ def test_index_cache_size(tmp_path):
 
     indexed_dataset = lance.dataset(tmp_path / "test", index_cache_size=1)
     # query using the same vector, we should get a very high hit rate
+    # it isn't always exactly 199/200 perhaps because the stats counter
+    # is a relaxed atomic counter and may lag behind the true value or perhaps
+    # because the cache takes some time to get populated by background threads
     query_index(indexed_dataset, 200, q=rng.standard_normal(16))
-    assert indexed_dataset._ds.index_cache_hit_rate() > 0.99
+    assert indexed_dataset._ds.index_cache_hit_rate() > 0.95
 
     last_hit_rate = indexed_dataset._ds.index_cache_hit_rate()
 


### PR DESCRIPTION
It sometimes fails with:

```
 FAILED python/tests/test_vector_index.py::test_index_cache_size - assert 0.9889441728591919 > 0.99
 +  where 0.9889441728591919 = <built-in method index_cache_hit_rate of _lib._Dataset object at 0xfffe31904af0>()
 +    where <built-in method index_cache_hit_rate of _lib._Dataset object at 0xfffe31904af0> = <_lib._Dataset object at 0xfffe31904af0>.index_cache_hit_rate
 +      where <_lib._Dataset object at 0xfffe31904af0> = <lance.dataset.LanceDataset object at 0xfffe31930340>._ds
```

Since the failures are always on ARM I think the root cause might be the relaxed nature of the counter.  We could just make the counter and acquire / consume counter but I don't think super accurate index stats are all that important (indeed, metric stats like this are often the example given for relaxed memory model).