### PR TITLE
fix: ignore pages with zero rows

### DIFF
--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -736,6 +736,7 @@ impl FieldDecoderStrategy for CoreFieldDecoderStrategy {
                 let (inner_infos, null_offset_adjustments): (Vec<_>, Vec<_>) = offsets_column
                     .page_infos
                     .iter()
+                    .filter(|offsets_page| offsets_page.num_rows > 0)
                     .map(|offsets_page| {
                         if let Some(pb::array_encoding::ArrayEncoding::List(list_encoding)) =
                             &offsets_page.encoding.array_encoding

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -57,6 +57,8 @@ impl PrimitiveFieldScheduler {
     ) -> Self {
         let page_schedulers = pages
             .iter()
+            // Buggy versions of Lance could sometimes create empty pages
+            .filter(|page| page.num_rows > 0)
             .map(|page| {
                 let page_buffers = PageBuffers {
                     column_buffers: buffers,


### PR DESCRIPTION
I'm not yet entirely certain what creates these but have encountered them at least once now and they can cause the reader to get confused (e.g. we don't await an empty page because `unawaited` is 0 and this causes an unwrap error later)