### PR TITLE
feat: add `max_bytes_per_file` and `batch_size` to CompactionOptions

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2506,9 +2506,11 @@ class DatasetOptimizer:
         *,
         target_rows_per_fragment: int = 1024 * 1024,
         max_rows_per_group: int = 1024,
+        max_bytes_per_file: Optional[int] = None,
         materialize_deletions: bool = True,
         materialize_deletions_threshold: float = 0.1,
         num_threads: Optional[int] = None,
+        batch_size: Optional[int] = None,
     ) -> CompactionMetrics:
         """Compacts small files in the dataset, reducing total number of files.
 
@@ -2532,6 +2534,13 @@ class DatasetOptimizer:
         max_rows_per_group: int, default 1024
             Max number of rows per group. This does not affect which fragments
             need compaction, but does affect how they are re-written if selected.
+        max_bytes_per_file: Optional[int], default None
+            Max number of bytes in a single file.  This does not affect which
+            fragments need compaction, but does affect how they are re-written if
+            selected.  If this value is too small you may end up with fragments
+            that are smaller than `target_rows_per_fragment`.
+
+            The default will use the default from ``write_dataset``.
         materialize_deletions: bool, default True
             Whether to compact fragments with soft deleted rows so they are no
             longer present in the file.
@@ -2541,6 +2550,11 @@ class DatasetOptimizer:
         num_threads: int, optional
             The number of threads to use when performing compaction. If not
             specified, defaults to the number of cores on the machine.
+        batch_size: int, optional
+            The batch size to use when scanning input fragments.  You may want
+            to reduce this if you are running out of memory during compaction.
+
+            The default will use the same default from ``scanner``.
 
         Returns
         -------
@@ -2554,9 +2568,11 @@ class DatasetOptimizer:
         opts = dict(
             target_rows_per_fragment=target_rows_per_fragment,
             max_rows_per_group=max_rows_per_group,
+            max_bytes_per_file=max_bytes_per_file,
             materialize_deletions=materialize_deletions,
             materialize_deletions_threshold=materialize_deletions_threshold,
             num_threads=num_threads,
+            batch_size=batch_size,
         )
         return Compaction.execute(self._dataset, opts)
 

--- a/python/src/dataset/optimize.rs
+++ b/python/src/dataset/optimize.rs
@@ -36,6 +36,9 @@ fn parse_compaction_options(options: &PyDict) -> PyResult<CompactionOptions> {
             "max_rows_per_group" => {
                 opts.max_rows_per_group = value.extract()?;
             }
+            "max_bytes_per_file" => {
+                opts.max_bytes_per_file = value.extract()?;
+            }
             "materialize_deletions" => {
                 opts.materialize_deletions = value.extract()?;
             }
@@ -46,6 +49,9 @@ fn parse_compaction_options(options: &PyDict) -> PyResult<CompactionOptions> {
                 opts.num_threads = value
                     .extract::<Option<usize>>()?
                     .unwrap_or_else(num_cpus::get);
+            }
+            "batch_size" => {
+                opts.batch_size = value.extract()?;
             }
             _ => {
                 return Err(PyValueError::new_err(format!(

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -122,6 +122,13 @@ pub struct CompactionOptions {
     /// This does not affect which fragments need compaction, but does affect
     /// how they are re-written if selected.
     pub max_rows_per_group: usize,
+    /// Max number of bytes per file
+    ///
+    /// This does not affect which frgamnets need compaction, but does affect
+    /// how they are re-written if selected.
+    ///
+    /// If not specified then the default (see [`WriteParams`]) will be used.
+    pub max_bytes_per_file: Option<usize>,
     /// Whether to compact fragments with deletions so there are no deletions.
     /// Defaults to true.
     pub materialize_deletions: bool,
@@ -132,6 +139,10 @@ pub struct CompactionOptions {
     pub materialize_deletions_threshold: f32,
     /// The number of threads to use. Defaults to the number of cores.
     pub num_threads: usize,
+    /// The batch size to use when scanning the input fragments.  If not
+    /// specified then the default (see
+    /// [`crate::dataset::Scanner::batch_size`]) will be used.
+    pub batch_size: Option<usize>,
 }
 
 impl Default for CompactionOptions {
@@ -143,6 +154,8 @@ impl Default for CompactionOptions {
             materialize_deletions: true,
             materialize_deletions_threshold: 0.1,
             num_threads: num_cpus::get(),
+            max_bytes_per_file: None,
+            batch_size: None,
         }
     }
 }
@@ -630,6 +643,9 @@ async fn rewrite_files(
     // If we aren't using move-stable row ids, then we need to remap indices.
     let needs_remapping = !dataset.manifest.uses_move_stable_row_ids();
     let mut scanner = dataset.scan();
+    if let Some(batch_size) = options.batch_size {
+        scanner.batch_size(batch_size);
+    }
     scanner
         .with_fragments(fragments.clone())
         .scan_in_order(true);
@@ -644,12 +660,15 @@ async fn rewrite_files(
         (None, data)
     };
 
-    let params = WriteParams {
+    let mut params = WriteParams {
         max_rows_per_file: options.target_rows_per_fragment,
         max_rows_per_group: options.max_rows_per_group,
         mode: WriteMode::Append,
         ..Default::default()
     };
+    if let Some(max_bytes_per_file) = options.max_bytes_per_file {
+        params.max_bytes_per_file = max_bytes_per_file;
+    }
     let mut new_fragments = write_fragments_internal(
         Some(dataset.as_ref()),
         dataset.object_store.clone(),


### PR DESCRIPTION
Another approach could be to always set `max_bytes_per_file` large enough to handle the compaction but I'm not sure if that would be a good idea or not.

Currently we will just silently "undercompact" (and potentially create runt files)
However, if we enable it, then we could potentially create huge files