### PR TITLE
docs: clean up quickstart notebook and add tags example usage

### DIFF
--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -145,9 +145,9 @@
     }
    ],
    "source": [
-    "shutil.rmtree(\"/tmp/test_df.lance\", ignore_errors=True)\n",
+    "shutil.rmtree(\"/tmp/test.lance\", ignore_errors=True)\n",
     "\n",
-    "dataset = lance.write_dataset(df, \"/tmp/test_df.lance\")\n",
+    "dataset = lance.write_dataset(df, \"/tmp/test.lance\")\n",
     "dataset.to_table().to_pandas()"
    ]
   },
@@ -210,7 +210,7 @@
    ],
    "source": [
     "shutil.rmtree(\"/tmp/test.parquet\", ignore_errors=True)\n",
-    "shutil.rmtree(\"/tmp/test_parquet.lance\", ignore_errors=True)\n",
+    "shutil.rmtree(\"/tmp/test.lance\", ignore_errors=True)\n",
     "\n",
     "tbl = pa.Table.from_pandas(df)\n",
     "pa.dataset.write_dataset(tbl, \"/tmp/test.parquet\", format='parquet')\n",
@@ -234,7 +234,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset = lance.write_dataset(parquet, \"/tmp/test_parquet.lance\")"
+    "dataset = lance.write_dataset(parquet, \"/tmp/test.lance\")"
    ]
   },
   {
@@ -314,13 +314,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[2024-07-31T13:51:06Z WARN  lance::dataset] No existing dataset at /tmp/test.lance, it will be created\n"
-     ]
-    },
-    {
      "data": {
       "text/html": [
        "<div>\n",
@@ -347,6 +340,10 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
        "      <td>10</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -355,7 +352,8 @@
       ],
       "text/plain": [
        "    a\n",
-       "0  10"
+       "0   5\n",
+       "1  10"
       ]
      },
      "execution_count": 7,
@@ -467,10 +465,13 @@
      "data": {
       "text/plain": [
        "[{'version': 1,\n",
-       "  'timestamp': datetime.datetime(2024, 7, 31, 23, 21, 6, 355179),\n",
+       "  'timestamp': datetime.datetime(2024, 8, 15, 21, 22, 31, 453453),\n",
        "  'metadata': {}},\n",
        " {'version': 2,\n",
-       "  'timestamp': datetime.datetime(2024, 7, 31, 23, 21, 6, 374206),\n",
+       "  'timestamp': datetime.datetime(2024, 8, 15, 21, 22, 35, 475152),\n",
+       "  'metadata': {}},\n",
+       " {'version': 3,\n",
+       "  'timestamp': datetime.datetime(2024, 8, 15, 21, 22, 45, 32922),\n",
        "  'metadata': {}}]"
       ]
      },
@@ -516,15 +517,15 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>10</td>\n",
+       "      <td>5</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "    a\n",
-       "0  10"
+       "   a\n",
+       "0  5"
       ]
      },
      "execution_count": 11,
@@ -569,20 +570,20 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>50</td>\n",
+       "      <td>5</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>100</td>\n",
+       "      <td>10</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "     a\n",
-       "0   50\n",
-       "1  100"
+       "    a\n",
+       "0   5\n",
+       "1  10"
       ]
      },
      "execution_count": 12,
@@ -611,8 +612,8 @@
     {
      "data": {
       "text/plain": [
-       "{'stable': {'version': 1, 'manifest_size': 613},\n",
-       " 'nightly': {'version': 2, 'manifest_size': 613}}"
+       "{'nightly': {'version': 3, 'manifest_size': 628},\n",
+       " 'stable': {'version': 2, 'manifest_size': 684}}"
       ]
      },
      "execution_count": 13,
@@ -621,8 +622,8 @@
     }
    ],
    "source": [
-    "dataset.tags.create(\"stable\", 1)\n",
-    "dataset.tags.create(\"nightly\", 2)\n",
+    "dataset.tags.create(\"stable\", 2)\n",
+    "dataset.tags.create(\"nightly\", 3)\n",
     "dataset.tags.list()"
    ]
   },
@@ -667,6 +668,10 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
        "      <td>10</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -675,7 +680,8 @@
       ],
       "text/plain": [
        "    a\n",
-       "0  10"
+       "0   5\n",
+       "1  10"
       ]
      },
      "execution_count": 14,

--- a/notebooks/quickstart.ipynb
+++ b/notebooks/quickstart.ipynb
@@ -7,13 +7,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import shutil\n",
+    "\n",
     "import lance\n",
-    "import duckdb\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "import pyarrow as pa\n",
-    "import pyarrow.dataset\n",
-    "import shutil"
+    "import pyarrow as pa"
    ]
   },
   {
@@ -315,6 +314,13 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[2024-07-31T13:51:06Z WARN  lance::dataset] No existing dataset at /tmp/test.lance, it will be created\n"
+     ]
+    },
+    {
      "data": {
       "text/html": [
        "<div>\n",
@@ -341,14 +347,6 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>50</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>100</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
        "      <td>10</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -356,10 +354,8 @@
        "</div>"
       ],
       "text/plain": [
-       "     a\n",
-       "0   50\n",
-       "1  100\n",
-       "2   10"
+       "    a\n",
+       "0  10"
       ]
      },
      "execution_count": 7,
@@ -470,38 +466,11 @@
     {
      "data": {
       "text/plain": [
-       "[{'version': 10,\n",
-       "  'timestamp': datetime.datetime(2023, 2, 13, 16, 54, 50),\n",
-       "  'metadata': {}},\n",
-       " {'version': 11,\n",
-       "  'timestamp': datetime.datetime(2023, 2, 13, 16, 54, 50),\n",
-       "  'metadata': {}},\n",
-       " {'version': 8,\n",
-       "  'timestamp': datetime.datetime(2023, 2, 13, 16, 54, 50),\n",
-       "  'metadata': {}},\n",
-       " {'version': 9,\n",
-       "  'timestamp': datetime.datetime(2023, 2, 13, 16, 54, 50),\n",
+       "[{'version': 1,\n",
+       "  'timestamp': datetime.datetime(2024, 7, 31, 23, 21, 6, 355179),\n",
        "  'metadata': {}},\n",
        " {'version': 2,\n",
-       "  'timestamp': datetime.datetime(2023, 2, 13, 16, 54, 50),\n",
-       "  'metadata': {}},\n",
-       " {'version': 3,\n",
-       "  'timestamp': datetime.datetime(2023, 2, 13, 16, 54, 50),\n",
-       "  'metadata': {}},\n",
-       " {'version': 5,\n",
-       "  'timestamp': datetime.datetime(2023, 2, 13, 16, 54, 50),\n",
-       "  'metadata': {}},\n",
-       " {'version': 4,\n",
-       "  'timestamp': datetime.datetime(2023, 2, 13, 16, 54, 50),\n",
-       "  'metadata': {}},\n",
-       " {'version': 1,\n",
-       "  'timestamp': datetime.datetime(2023, 2, 13, 16, 54, 50),\n",
-       "  'metadata': {}},\n",
-       " {'version': 6,\n",
-       "  'timestamp': datetime.datetime(2023, 2, 13, 16, 54, 50),\n",
-       "  'metadata': {}},\n",
-       " {'version': 7,\n",
-       "  'timestamp': datetime.datetime(2023, 2, 13, 16, 54, 50),\n",
+       "  'timestamp': datetime.datetime(2024, 7, 31, 23, 21, 6, 374206),\n",
        "  'metadata': {}}]"
       ]
      },
@@ -547,15 +516,15 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>5</td>\n",
+       "      <td>10</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   a\n",
-       "0  5"
+       "    a\n",
+       "0  10"
       ]
      },
      "execution_count": 11,
@@ -600,20 +569,20 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>5</td>\n",
+       "      <td>50</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>10</td>\n",
+       "      <td>100</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "    a\n",
-       "0   5\n",
-       "1  10"
+       "     a\n",
+       "0   50\n",
+       "1  100"
       ]
      },
      "execution_count": 12,
@@ -623,6 +592,99 @@
    ],
    "source": [
     "lance.dataset('/tmp/test.lance', version=2).to_table().to_pandas()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2065df4b",
+   "metadata": {},
+   "source": [
+    "We can create tags"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "bdeae709",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'stable': {'version': 1, 'manifest_size': 613},\n",
+       " 'nightly': {'version': 2, 'manifest_size': 613}}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dataset.tags.create(\"stable\", 1)\n",
+    "dataset.tags.create(\"nightly\", 2)\n",
+    "dataset.tags.list()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d60b9c04",
+   "metadata": {},
+   "source": [
+    "which can be checked out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "1852c5b3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    a\n",
+       "0  10"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lance.dataset('/tmp/test.lance', version=\"stable\").to_table().to_pandas()"
    ]
   },
   {
@@ -655,7 +717,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "2ac159fa",
    "metadata": {},
    "outputs": [
@@ -697,7 +759,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "63993672",
    "metadata": {},
    "outputs": [
@@ -707,7 +769,7 @@
        "<lance.dataset.LanceDataset at 0x13859fe20>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -729,7 +791,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "6b164493",
    "metadata": {},
    "outputs": [],
@@ -756,7 +818,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "0c7132b8",
    "metadata": {
     "pycharm": {
@@ -781,7 +843,7 @@
        "Name: vector, Length: 100, dtype: object"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -803,7 +865,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "879875b8",
    "metadata": {
     "pycharm": {
@@ -877,7 +939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "id": "c99fdd57",
    "metadata": {
     "pycharm": {
@@ -915,10 +977,12 @@
    "source": [
     "%%time \n",
     "\n",
-    "sift1m.create_index(\"vector\",\n",
-    "                    index_type=\"IVF_PQ\", # IVF_PQ, IVF_HNSW_PQ and IVF_HNSW_SQ are supported\n",
-    "                    num_partitions=256,  # IVF\n",
-    "                    num_sub_vectors=16)  # PQ"
+    "sift1m.create_index(\n",
+    "    \"vector\",\n",
+    "    index_type=\"IVF_PQ\", # IVF_PQ, IVF_HNSW_PQ and IVF_HNSW_SQ are supported\n",
+    "    num_partitions=256,  # IVF\n",
+    "    num_sub_vectors=16,  # PQ\n",
+    ")"
    ]
   },
   {
@@ -941,7 +1005,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "5e99289f",
    "metadata": {
     "pycharm": {
@@ -955,7 +1019,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "id": "166c7f7f",
    "metadata": {
     "pycharm": {
@@ -1016,7 +1080,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "id": "d26e2b27",
    "metadata": {
     "pycharm": {
@@ -1137,7 +1201,7 @@
        "9  113073  [0.0, 0.0, 0.0, 64.0, 65.0, 30.0, 12.0, 33.0, ...  99572.0"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1145,11 +1209,15 @@
    "source": [
     "%%time\n",
     "\n",
-    "sift1m.to_table(nearest={\"column\": \"vector\", \n",
-    "                         \"q\": samples[0], \n",
-    "                         \"k\": 10, \n",
-    "                         \"nprobes\": 10, \n",
-    "                         \"refine_factor\": 5}).to_pandas()"
+    "sift1m.to_table(\n",
+    "    nearest={\n",
+    "        \"column\": \"vector\",\n",
+    "        \"q\": samples[0],\n",
+    "        \"k\": 10,\n",
+    "        \"nprobes\": 10,\n",
+    "        \"refine_factor\": 5,\n",
+    "    }\n",
+    ").to_pandas()"
    ]
   },
   {
@@ -1182,12 +1250,12 @@
     "### Features and vector can be retrieved together\n",
     "\n",
     "Usually we have other feature or metadata columns that need to be stored and fetched together.\n",
-    "If you're managing data and the index separately, you to do a bunch of annoying plumbing to put stuff together. With Lance it's a single call"
+    "If you're managing data and the index separately, you have to do a bunch of annoying plumbing to put stuff together. With Lance it's a single call"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "id": "846ea382",
    "metadata": {
     "pycharm": {
@@ -1335,7 +1403,7 @@
        "[1000000 rows x 4 columns]"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1349,7 +1417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "id": "2a1fefe2",
    "metadata": {
     "pycharm": {
@@ -1363,7 +1431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "id": "4bca1a31",
    "metadata": {
     "pycharm": {
@@ -1476,7 +1544,7 @@
        "9  6742.810395  [0.0, 0.0, 0.0, 64.0, 65.0, 30.0, 12.0, 33.0, ...  99572.0"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1484,18 +1552,6 @@
    "source": [
     "sift1m.to_table(columns=[\"revenue\"], nearest={\"column\": \"vector\", \"q\": samples[0], \"k\": 10}).to_pandas()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "75ae2d1f",
-   "metadata": {
-    "pycharm": {
-     "is_executing": true
-    }
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR was primarily intended to add an example showing lance's new tag features. While adding this example, I found a few issues that I decided to clean up at the same time:

From top to bottom:
- Remove unnecessary imports and clean up the import order.
- Fix paths for saving and loading datasets in the first half of the notebook.
- Rerun the first half of the notebook so the outputs are all correct (they were mangled before).
- Update execution numbers for second half of notebook (from execution 15 onwards) so they are consistent with the first half (I wanted to rerun the entire notebook, but I wasn't able to get good results on the indexing example due to only having an M1 - on my setup, using the ANN index was slower than not using it).
- Minor formatting fixes for index creations to align with black/ruff standard.
- Add missing word in ### Features and vector can be retrieved together.
- Remove the final empty cell.