### PR TITLE
chore: add rust format in precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,7 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
 
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+    - id: fmt


### PR DESCRIPTION
Address feature request https://github.com/lancedb/lance/issues/2739 (which is created by myself).

The `cargo` formatter I used comes from https://lancedb.github.io/lance/contributing.html#rust-development
Precommit hook mainly borrows from https://github.com/doublify/pre-commit-rust

git diff to show effect:
![image](https://github.com/user-attachments/assets/162a0fbb-0ab7-479c-9eb3-d41c550db6fa)
