### PR TITLE
docs: fix version table so it renders

### DIFF
--- a/docs/format.rst
+++ b/docs/format.rst
@@ -92,7 +92,7 @@ and benchmarking upcoming features.
 
 The following values are supported:
 
-.. list-table: File Versions
+.. list-table:: File Versions
     :widths: 20 20 20 40
     :header-rows: 1
   


### PR DESCRIPTION
The lack of second colon made it interpret the block as a comment 🤦 .

Fixes #2743