### PR TITLE
chore: scan unordered chunks for training FTS index

### DIFF
--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -16,7 +16,7 @@ pub async fn train_inverted_index(
     data_source: Box<dyn TrainingSource>,
     index_store: &dyn IndexStore,
 ) -> Result<()> {
-    let batch_stream = data_source.scan_ordered_chunks(4096).await?;
+    let batch_stream = data_source.scan_unordered_chunks(4096).await?;
     // mapping from item to list of the row ids where it is present
     let mut inverted_index = InvertedIndexBuilder::default();
     inverted_index.update(batch_stream, index_store).await


### PR DESCRIPTION
The FTS index doesn't require the data to be sorted, this could save much memory for large dataset