### PR TITLE
fix: fix two cases in the v2 decoder where the decode order didn't match the scheduling priority

### DIFF
--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -215,12 +215,12 @@ struct ChildState {
     // or pages are very small
     // TODO: Test this case
     scheduled: VecDeque<Box<dyn LogicalPageDecoder>>,
-    // Rows that should still be coming over the channel source but haven't yet been
-    // put into the awaited queue
-    rows_unawaited: u64,
-    // Rows that have been pulled out of the channel source, awaited, and are ready to
-    // be drained
-    rows_available: u64,
+    // Rows that have been awaited
+    rows_loaded: u64,
+    // Rows that have drained
+    rows_drained: u64,
+    // Total number of rows in the struct
+    num_rows: u64,
     // The field index in the struct (used for debugging / logging)
     field_index: u32,
 }
@@ -254,71 +254,71 @@ impl ChildState {
     fn new(num_rows: u64, field_index: u32) -> Self {
         Self {
             scheduled: VecDeque::new(),
-            rows_unawaited: num_rows,
-            rows_available: 0,
+            rows_loaded: 0,
+            rows_drained: 0,
+            num_rows,
             field_index,
         }
     }
 
     // Wait for the next set of rows to arrive
     //
-    // Wait until we have at least `num_rows` available but stop if
-    // rows_awaited reaches `awaited_limit` (because we need to wait from
-    // other columns at that point)
-    async fn wait(&mut self, num_rows: u64, unawaited_limit: u64) -> Result<()> {
+    // Wait until we have at least `loaded_need` loaded and stop as soon as we
+    // go above that limit.
+    async fn wait_for_loaded(&mut self, loaded_need: u64) -> Result<()> {
         trace!(
-            "Struct child {} waiting for {} rows and {} are available already (but stop if unawaited passes {})",
+            "Struct child {} waiting for at least {} rows to be loaded and {} are loaded already",
             self.field_index,
-            num_rows,
-            self.rows_available,
-            unawaited_limit,
+            loaded_need,
+            self.rows_loaded,
         );
-        let mut remaining = num_rows.saturating_sub(self.rows_available);
-        for next_decoder in &mut self.scheduled {
-            if next_decoder.unawaited() > 0 {
-                let rows_to_wait = remaining.min(next_decoder.unawaited());
+        let mut current_need = loaded_need;
+        let mut loaded = 0;
+        for (page_idx, next_decoder) in self.scheduled.iter_mut().enumerate() {
+            if next_decoder.rows_unloaded() > 0 {
+                let need_for_page = next_decoder.num_rows().min(current_need);
                 trace!(
-                    "Struct child {} await an additional {} rows from the current page",
+                    "Struct child {} page {} will wait until {} rows loaded",
                     self.field_index,
-                    rows_to_wait
+                    page_idx,
+                    need_for_page
                 );
                 // Even though we wait for X rows we might actually end up
                 // loading more than that
-                let previously_avail = next_decoder.avail();
+                let previously_loaded = next_decoder.rows_loaded();
                 // We might only await part of a page.  This is important for things
                 // like the struct<struct<...>> case where we have one outer page, one
                 // middle page, and then a bunch of inner pages.  If we await the entire
                 // middle page then we will have to wait for all the inner pages to arrive
                 // before we can start decoding.
-                next_decoder.wait(rows_to_wait).await?;
-                let newly_avail = next_decoder.avail() - previously_avail;
-                self.rows_available += newly_avail;
+                next_decoder.wait_for_loaded(need_for_page).await?;
+                let newly_loaded = next_decoder.rows_loaded() - previously_loaded;
+                self.rows_loaded += newly_loaded;
+                loaded += newly_loaded;
                 trace!(
-                    "Struct child {} await loaded {} rows and now {} are available",
+                    "Struct child {} page {} await loaded {} rows and now {} are loaded",
                     self.field_index,
-                    newly_avail,
-                    self.rows_available
+                    page_idx,
+                    newly_loaded,
+                    self.rows_loaded
                 );
-                self.rows_unawaited = self.rows_unawaited.checked_sub(newly_avail).unwrap();
-                remaining -= rows_to_wait;
-                if remaining == 0 || self.rows_unawaited < unawaited_limit {
-                    break;
-                }
+            }
+            current_need = current_need.saturating_sub(next_decoder.rows_loaded());
+            if current_need == 0 {
+                break;
             }
         }
-        let awaited = num_rows - remaining;
         trace!(
-            "Struct child {} awaited {} new rows and now {} are available and {} remain unawaited",
+            "Struct child {} loaded {} new rows and now {} are loaded",
             self.field_index,
-            awaited,
-            self.rows_available,
-            self.rows_unawaited,
+            loaded,
+            self.rows_loaded
         );
-        if awaited == 0 {
+        if loaded == 0 {
             return Err(Error::Internal {
                 message: format!(
                     "Ran out of page decoders before satisfying request for {} rows",
-                    num_rows
+                    loaded_need
                 ),
                 location: location!(),
             });
@@ -330,12 +330,10 @@ impl ChildState {
         trace!("Struct draining {} rows", num_rows);
 
         trace!(
-            "Draining {} rows from struct page with {} rows available",
+            "Draining {} rows from struct page with {} rows already drained",
             num_rows,
-            self.rows_available
+            self.rows_drained
         );
-        assert!(self.rows_available >= num_rows);
-        self.rows_available -= num_rows;
         let mut remaining = num_rows;
         let mut composite = CompositeDecodeTask {
             tasks: Vec::new(),
@@ -344,9 +342,9 @@ impl ChildState {
         };
         while remaining > 0 {
             let next = self.scheduled.front_mut().unwrap();
-            let rows_to_take = remaining.min(next.avail());
+            let rows_to_take = remaining.min(next.rows_left());
             let next_task = next.drain(rows_to_take)?;
-            if next.avail() == 0 && next.unawaited() == 0 {
+            if next.rows_left() == 0 {
                 trace!("Completely drained page");
                 self.scheduled.pop_front();
             }
@@ -354,7 +352,8 @@ impl ChildState {
             composite.tasks.push(next_task.task);
             composite.num_rows += next_task.num_rows;
         }
-        composite.has_more = self.rows_available != 0 || self.rows_unawaited != 0;
+        self.rows_drained += num_rows;
+        composite.has_more = self.rows_drained != self.num_rows;
         Ok(composite)
     }
 }
@@ -365,12 +364,13 @@ struct WaitOrder<'a>(&'a mut ChildState);
 impl Eq for WaitOrder<'_> {}
 impl PartialEq for WaitOrder<'_> {
     fn eq(&self, other: &Self) -> bool {
-        self.0.rows_unawaited == other.0.rows_unawaited
+        self.0.rows_loaded == other.0.rows_loaded
     }
 }
 impl Ord for WaitOrder<'_> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.rows_unawaited.cmp(&other.0.rows_unawaited)
+        // Note: this is inverted so we have a min-heap
+        other.0.rows_loaded.cmp(&self.0.rows_loaded)
     }
 }
 impl PartialOrd for WaitOrder<'_> {
@@ -384,6 +384,7 @@ pub struct SimpleStructDecoder {
     children: Vec<ChildState>,
     child_fields: Fields,
     data_type: DataType,
+    num_rows: u64,
 }
 
 impl SimpleStructDecoder {
@@ -397,15 +398,16 @@ impl SimpleStructDecoder {
                 .collect(),
             child_fields,
             data_type,
+            num_rows,
         }
     }
 
-    async fn do_wait(&mut self, num_rows: u64) -> Result<()> {
+    async fn do_waited_for_loaded(&mut self, loaded_need: u64) -> Result<()> {
         let mut wait_orders = self
             .children
             .iter_mut()
             .filter_map(|child| {
-                if child.rows_available < num_rows {
+                if child.rows_loaded < loaded_need {
                     Some(WaitOrder(child))
                 } else {
                     None
@@ -414,14 +416,20 @@ impl SimpleStructDecoder {
             .collect::<BinaryHeap<_>>();
         while !wait_orders.is_empty() {
             let next_waiter = wait_orders.pop().unwrap();
-            let next_limit = wait_orders.peek().map(|w| w.0.rows_unawaited).unwrap_or(0);
-            next_waiter.0.wait(num_rows, next_limit).await?;
+            let next_highest = wait_orders
+                .peek()
+                .map(|w| w.0.rows_loaded)
+                .unwrap_or(u64::MAX - 1);
+            // Wait until you have the number of rows needed, or at least more than the
+            // next highest waiter
+            let limit = loaded_need.min(next_highest + 1);
+            next_waiter.0.wait_for_loaded(limit).await?;
             log::trace!(
-                "Struct child {} finished await pass and now {} are available",
+                "Struct child {} finished await pass and now {} are loaded",
                 next_waiter.0.field_index,
-                next_waiter.0.rows_available
+                next_waiter.0.rows_loaded
             );
-            if next_waiter.0.rows_available < num_rows {
+            if next_waiter.0.rows_loaded < loaded_need {
                 wait_orders.push(next_waiter);
             }
         }
@@ -446,8 +454,8 @@ impl LogicalPageDecoder for SimpleStructDecoder {
         Ok(())
     }
 
-    fn wait(&mut self, num_rows: u64) -> BoxFuture<Result<()>> {
-        self.do_wait(num_rows).boxed()
+    fn wait_for_loaded(&mut self, loaded_need: u64) -> BoxFuture<Result<()>> {
+        self.do_waited_for_loaded(loaded_need).boxed()
     }
 
     fn drain(&mut self, num_rows: u64) -> Result<NextDecodeTask> {
@@ -470,22 +478,21 @@ impl LogicalPageDecoder for SimpleStructDecoder {
         })
     }
 
-    // Rows are available only if they are available in every child column
-    fn avail(&self) -> u64 {
-        self.children
-            .iter()
-            .map(|c| c.rows_available)
-            .min()
-            .unwrap()
+    fn rows_loaded(&self) -> u64 {
+        self.children.iter().map(|c| c.rows_loaded).min().unwrap()
     }
 
-    // Rows are unawaited if they are unawaited in any child column
-    fn unawaited(&self) -> u64 {
-        self.children
+    fn rows_drained(&self) -> u64 {
+        // All children should have the same number of rows drained
+        debug_assert!(self
+            .children
             .iter()
-            .map(|c| c.rows_unawaited)
-            .max()
-            .unwrap()
+            .all(|c| c.rows_drained == self.children[0].rows_drained));
+        self.children[0].rows_drained
+    }
+
+    fn num_rows(&self) -> u64 {
+        self.num_rows
     }
 
     fn data_type(&self) -> &DataType {

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -58,8 +58,6 @@ impl EncodingsIo for SimulatedScheduler {
             })
             .collect();
 
-        // Need to make sure our scheduling priority matches our decode order.  If the decoder does
-        // not decode lowest to highest priority requests then deadlock can occur.
         log::trace!("Scheduled request with priority {}", priority);
         std::future::ready(data)
             .map(move |data| {


### PR DESCRIPTION
This could lead to deadlocks when the io_buffer_size is small (or when page sizes are very large).

Unfortunately, this is not the ideal scheduling algorithm, it uses too much RAM, but it's better to do that than deadlock.  Details in #2753 