### PR TITLE
chore: change the level of log of reading large batch to debug

### DIFF
--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -1233,7 +1233,7 @@ impl BatchDecodeStream {
                 if size_bytes > BATCH_SIZE_BYTES_WARNING {
                     emitted_batch_size_warning.call_once(|| {
                         let size_mb = size_bytes / 1024 / 1024;
-                        warn!("Lance read in a single batch that contained more than {}MiB of data.  You may want to consider reducing the batch size.", size_mb);
+                        debug!("Lance read in a single batch that contained more than {}MiB of data.  You may want to consider reducing the batch size.", size_mb);
                     });
                 }
                 Ok(batch)


### PR DESCRIPTION
The FTS index would read the entire posting list at once, for very large dataset this log would be printed many times for each query