### PR TITLE
perf: calculate the max scores for posting lists then have a tighter upper bound

### DIFF
--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -1233,7 +1233,7 @@ impl BatchDecodeStream {
                 if size_bytes > BATCH_SIZE_BYTES_WARNING {
                     emitted_batch_size_warning.call_once(|| {
                         let size_mb = size_bytes / 1024 / 1024;
-                        warn!("Lance read in a single batch that contained more than {}MiB of data.  You may want to consider reducing the batch size.", size_mb);
+                        debug!("Lance read in a single batch that contained more than {}MiB of data.  You may want to consider reducing the batch size.", size_mb);
                     });
                 }
                 Ok(batch)

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -1233,7 +1233,7 @@ impl BatchDecodeStream {
                 if size_bytes > BATCH_SIZE_BYTES_WARNING {
                     emitted_batch_size_warning.call_once(|| {
                         let size_mb = size_bytes / 1024 / 1024;
-                        debug!("Lance read in a single batch that contained more than {}MiB of data.  You may want to consider reducing the batch size.", size_mb);
+                        warn!("Lance read in a single batch that contained more than {}MiB of data.  You may want to consider reducing the batch size.", size_mb);
                     });
                 }
                 Ok(batch)

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -4,7 +4,6 @@
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::sync::Arc;
-use std::usize;
 
 use itertools::Itertools;
 use lance_core::utils::mask::RowIdMask;


### PR DESCRIPTION
- calculating max score for each posting list and storing them in metadata, this helps WAND to skip more documents
- pick the shortest posting list to move (it's equal to select the one with largest IDF) so we can make less movements

This improves the FTS performance about 2x faster