### PR TITLE
perf: add prefetching to hnsw greedy_search

### DIFF
--- a/rust/lance-index/src/vector/graph.rs
+++ b/rust/lance-index/src/vector/graph.rs
@@ -205,6 +205,32 @@ impl VisitedGenerator {
     }
 }
 
+fn process_neighbors_with_look_ahead<F>(
+    neighbors: &[u32],
+    mut process_neighbor: F,
+    look_ahead: Option<usize>,
+    dist_calc: &impl DistCalculator,
+) where
+    F: FnMut(u32),
+{
+    match look_ahead {
+        Some(look_ahead) => {
+            for i in 0..neighbors.len().saturating_sub(look_ahead) {
+                dist_calc.prefetch(neighbors[i + look_ahead]);
+                process_neighbor(neighbors[i]);
+            }
+            for neighbor in &neighbors[neighbors.len().saturating_sub(look_ahead)..] {
+                process_neighbor(*neighbor);
+            }
+        }
+        None => {
+            for neighbor in neighbors.iter() {
+                process_neighbor(*neighbor);
+            }
+        }
+    }
+}
+
 /// Beam search over a graph
 ///
 /// This is the same as ``search-layer`` in HNSW.
@@ -272,7 +298,7 @@ pub fn beam_search(
             .copied()
             .collect();
 
-        let mut process_neighbor = |neighbor: u32| {
+        let process_neighbor = |neighbor: u32| {
             visited.insert(neighbor);
             let dist = dist_calc.distance(neighbor).into();
             if dist <= furthest || results.len() < k {
@@ -290,25 +316,12 @@ pub fn beam_search(
                 candidates.push(Reverse((dist, neighbor).into()));
             }
         };
-
-        match prefetch_distance {
-            Some(look_ahead) => {
-                for i in 0..unvisited_neighbors.len().saturating_sub(look_ahead) {
-                    dist_calc.prefetch(unvisited_neighbors[i + look_ahead]);
-                    process_neighbor(unvisited_neighbors[i]);
-                }
-                for neighbor in
-                    &unvisited_neighbors[unvisited_neighbors.len().saturating_sub(look_ahead)..]
-                {
-                    process_neighbor(*neighbor);
-                }
-            }
-            None => {
-                for neighbor in unvisited_neighbors {
-                    process_neighbor(neighbor);
-                }
-            }
-        };
+        process_neighbors_with_look_ahead(
+            &unvisited_neighbors,
+            process_neighbor,
+            prefetch_distance,
+            dist_calc,
+        );
     }
 
     results.into_sorted_vec()
@@ -344,29 +357,19 @@ pub fn greedy_search(
         let neighbors = graph.neighbors(current);
         let mut next = None;
 
-        let mut process_neighbor = |neighbor: u32| {
+        let process_neighbor = |neighbor: u32| {
             let dist = dist_calc.distance(neighbor).into();
             if dist < closest_dist {
                 closest_dist = dist;
                 next = Some(neighbor);
             }
         };
-        match prefetch_distance {
-            Some(look_ahead) => {
-                for i in 0..neighbors.len().saturating_sub(look_ahead) {
-                    dist_calc.prefetch(neighbors[i + look_ahead]);
-                    process_neighbor(neighbors[i]);
-                }
-                for neighbor in &neighbors[neighbors.len().saturating_sub(look_ahead)..] {
-                    process_neighbor(*neighbor);
-                }
-            }
-            None => {
-                for neighbor in neighbors.iter() {
-                    process_neighbor(*neighbor);
-                }
-            }
-        };
+        process_neighbors_with_look_ahead(
+            &neighbors,
+            process_neighbor,
+            prefetch_distance,
+            dist_calc,
+        );
 
         if let Some(next) = next {
             current = next;

--- a/rust/lance-index/src/vector/graph.rs
+++ b/rust/lance-index/src/vector/graph.rs
@@ -358,7 +358,7 @@ pub fn greedy_search(
         let mut next = None;
 
         let process_neighbor = |neighbor: u32| {
-            let dist = dist_calc.distance(neighbor).into();
+            let dist = dist_calc.distance(neighbor);
             if dist < closest_dist {
                 closest_dist = dist;
                 next = Some(neighbor);

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -174,7 +174,12 @@ impl HNSW {
         let nodes = &self.nodes();
         for level in (0..self.max_level()).rev() {
             let cur_level = HnswLevelView::new(level, nodes);
-            ep = greedy_search(&cur_level, ep, &dist_calc);
+            ep = greedy_search(
+                &cur_level,
+                ep,
+                &dist_calc,
+                self.inner.params.prefetch_distance,
+            );
         }
 
         let bottom_level = HnswBottomView::new(nodes);
@@ -403,7 +408,7 @@ impl HnswBuilder {
         let dist_calc = storage.dist_calculator_from_id(node);
         for level in (target_level + 1..self.params.max_level).rev() {
             let cur_level = HnswLevelView::new(level, nodes);
-            ep = greedy_search(&cur_level, ep, &dist_calc);
+            ep = greedy_search(&cur_level, ep, &dist_calc, self.params.prefetch_distance);
         }
 
         let mut pruned_neighbors_per_level: Vec<Vec<_>> =


### PR DESCRIPTION
The HNSW implementation has two core search functions:
- `greedy_search`
- `beam_search` (somewhat of a misnomer as-implemented, but that's not not relevant here)

Adding prefetching was key to speeding up the latter, which is where the bulk of the work happens. This is a small PR adding it to the former as well, resulting in a small speedup to HNSW (more pronounced with small values of `k`).
No algorithmic changes here.
`greedy_search` on its own is sped up by about 80% on SIFT1M after this PR.