### PR TITLE
feat: provide param to control whether to build FTS index with positions

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1208,6 +1208,7 @@ class LanceDataset(pa.dataset.Dataset):
         name: Optional[str] = None,
         *,
         replace: bool = True,
+        **kwargs,
     ):
         """Create a scalar index on a column.
 
@@ -1279,6 +1280,15 @@ class LanceDataset(pa.dataset.Dataset):
             column name.
         replace : bool, default True
             Replace the existing index if it exists.
+
+        Optional Parameters
+        -------------------
+        with_positions: bool, default False
+            This is for the ``INVERTED`` index. If True, the index will store the
+            positions of the words in the document, so that you can conduct phrase
+            query. This will significantly increase the index size.
+            It won't impact the performance of non-phrase queries even if it is set to
+            True.
 
         Examples
         --------
@@ -1364,7 +1374,7 @@ class LanceDataset(pa.dataset.Dataset):
                 f"Scalar index column {column} cannot currently be a duration"
             )
 
-        self._ds.create_index([column], index_type, name, replace)
+        self._ds.create_index([column], index_type, name, replace, None, kwargs)
 
     def create_index(
         self,

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1283,7 +1283,7 @@ class LanceDataset(pa.dataset.Dataset):
 
         Optional Parameters
         -------------------
-        with_positions: bool, default False
+        with_position: bool, default True
             This is for the ``INVERTED`` index. If True, the index will store the
             positions of the words in the document, so that you can conduct phrase
             query. This will significantly increase the index size.

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -211,8 +211,11 @@ def test_lance_mem_pool_env_var(tmp_path):
         del os.environ["LANCE_BYPASS_SPILLING"]
 
 
-def test_full_text_search(dataset):
-    dataset.create_scalar_index("doc", index_type="INVERTED")
+@pytest.mark.parametrize("with_positions", [True, False])
+def test_full_text_search(dataset, with_positions):
+    dataset.create_scalar_index(
+        "doc", index_type="INVERTED", with_positions=with_positions
+    )
     row = dataset.take(indices=[0], columns=["doc"])
     query = row.column(0)[0].as_py()
     query = query.split(" ")[0]

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -211,10 +211,10 @@ def test_lance_mem_pool_env_var(tmp_path):
         del os.environ["LANCE_BYPASS_SPILLING"]
 
 
-@pytest.mark.parametrize("with_positions", [True, False])
-def test_full_text_search(dataset, with_positions):
+@pytest.mark.parametrize("with_position", [True, False])
+def test_full_text_search(dataset, with_position):
     dataset.create_scalar_index(
-        "doc", index_type="INVERTED", with_positions=with_positions
+        "doc", index_type="INVERTED", with_position=with_position
     )
     row = dataset.take(indices=[0], columns=["doc"])
     query = row.column(0)[0].as_py()

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1080,8 +1080,8 @@ impl Dataset {
             "INVERTED" => {
                 let mut params = InvertedIndexParams::default();
                 if let Some(kwargs) = kwargs {
-                    if let Some(with_positions) = kwargs.get_item("with_positions")? {
-                        params.with_positions = with_positions.extract()?;
+                    if let Some(with_position) = kwargs.get_item("with_position")? {
+                        params.with_position = with_position.extract()?;
                     }
                 }
                 Box::new(params)

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -91,18 +91,26 @@ impl IndexParams for ScalarIndexParams {
     }
 }
 
-#[derive(Debug, Clone, Default, DeepSizeOf)]
+#[derive(Debug, Clone, DeepSizeOf)]
 pub struct InvertedIndexParams {
-    // Set it to true if you need to perform phrase query,
-    // this could significantly increase the index size,
-    // non-phrase query performance won't be impacted
-    // even the index was built with positions.
-    pub with_positions: bool,
+    /// If true, store the position of the term in the document
+    /// This can significantly increase the size of the index
+    /// If false, only store the frequency of the term in the document
+    /// Default is true
+    pub with_position: bool,
+}
+
+impl Default for InvertedIndexParams {
+    fn default() -> Self {
+        Self {
+            with_position: true,
+        }
+    }
 }
 
 impl InvertedIndexParams {
-    pub fn with_positions(mut self, with_positions: bool) -> Self {
-        self.with_positions = with_positions;
+    pub fn with_position(mut self, with_position: bool) -> Self {
+        self.with_position = with_position;
         self
     }
 }

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -91,6 +91,36 @@ impl IndexParams for ScalarIndexParams {
     }
 }
 
+#[derive(Debug, Clone, Default, DeepSizeOf)]
+pub struct InvertedIndexParams {
+    // Set it to true if you need to perform phrase query,
+    // this could significantly increase the index size,
+    // non-phrase query performance won't be impacted
+    // even the index was built with positions.
+    pub with_positions: bool,
+}
+
+impl InvertedIndexParams {
+    pub fn with_positions(mut self, with_positions: bool) -> Self {
+        self.with_positions = with_positions;
+        self
+    }
+}
+
+impl IndexParams for InvertedIndexParams {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn index_type(&self) -> IndexType {
+        IndexType::Inverted
+    }
+
+    fn index_name(&self) -> &str {
+        "INVERTED"
+    }
+}
+
 /// Trait for storing an index (or parts of an index) into storage
 #[async_trait]
 pub trait IndexWriter: Send {

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -10,14 +10,15 @@ pub use index::*;
 use lance_core::Result;
 
 use super::btree::TrainingSource;
-use super::IndexStore;
+use super::{IndexStore, InvertedIndexParams};
 
 pub async fn train_inverted_index(
     data_source: Box<dyn TrainingSource>,
     index_store: &dyn IndexStore,
+    params: InvertedIndexParams,
 ) -> Result<()> {
     let batch_stream = data_source.scan_unordered_chunks(4096).await?;
     // mapping from item to list of the row ids where it is present
-    let mut inverted_index = InvertedIndexBuilder::default();
+    let mut inverted_index = InvertedIndexBuilder::new(params);
     inverted_index.update(batch_stream, index_store).await
 }

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-use crate::scalar::{IndexReader, IndexStore};
+use crate::scalar::{IndexReader, IndexStore, InvertedIndexParams};
 use crate::vector::graph::OrderedFloat;
 use arrow::array::AsArray;
 use arrow::compute::concat_batches;
@@ -24,26 +24,72 @@ use super::index::*;
 
 #[derive(Debug, Clone, Default, DeepSizeOf)]
 pub struct InvertedIndexBuilder {
+    params: InvertedIndexParams,
+
     pub(crate) tokens: TokenSet,
     pub(crate) invert_list: InvertedList,
     pub(crate) docs: DocSet,
 }
 
 impl InvertedIndexBuilder {
+    pub fn new(params: InvertedIndexParams) -> Self {
+        Self {
+            params,
+            tokens: TokenSet::default(),
+            invert_list: InvertedList::default(),
+            docs: DocSet::default(),
+        }
+    }
+
+    pub fn from_existing_index(tokens: TokenSet, invert_list: InvertedList, docs: DocSet) -> Self {
+        let params = InvertedIndexParams::default().with_positions(invert_list.with_positions);
+        Self {
+            params,
+            tokens,
+            invert_list,
+            docs,
+        }
+    }
+
     pub async fn update(
         &mut self,
         new_data: SendableRecordBatchStream,
         dest_store: &dyn IndexStore,
     ) -> Result<()> {
-        update_index(
-            new_data,
-            &mut self.tokens,
-            &mut self.invert_list,
-            &mut self.docs,
-        )
-        .await?;
-
+        self.update_index(new_data).await?;
         self.save(dest_store).await?;
+        Ok(())
+    }
+
+    async fn update_index(&mut self, new_data: SendableRecordBatchStream) -> Result<()> {
+        let mut tokenizer = TOKENIZER.clone();
+        let mut stream = new_data;
+        while let Some(batch) = stream.try_next().await? {
+            let doc_iter = iter_str_array(batch.column(0));
+            let row_id_col = batch[ROW_ID].as_primitive::<datatypes::UInt64Type>();
+
+            for (doc, row_id) in doc_iter.zip(row_id_col.values().iter()) {
+                let Some(doc) = doc else { continue };
+                let row_id = *row_id;
+                let mut token_stream = tokenizer.token_stream(doc);
+                let mut token_occurrences = HashMap::new();
+                let mut token_cnt = 0;
+                while let Some(token) = token_stream.next() {
+                    let token_id = self.tokens.add(token.text.to_owned());
+                    token_occurrences
+                        .entry(token_id)
+                        .and_modify(|positions: &mut Vec<i32>| {
+                            positions.push(token.position as i32)
+                        })
+                        .or_insert_with(|| vec![token.position as i32]);
+                    token_cnt += 1;
+                }
+                self.invert_list
+                    .add(token_occurrences, row_id, &self.params);
+                self.docs.add(row_id, token_cnt);
+            }
+        }
+
         Ok(())
     }
 
@@ -99,46 +145,13 @@ impl InvertedIndexBuilder {
     }
 }
 
-pub async fn update_index(
-    new_data: SendableRecordBatchStream,
-    token_set: &mut TokenSet,
-    invert_list: &mut InvertedList,
-    docs: &mut DocSet,
-) -> Result<()> {
-    let mut tokenizer = TOKENIZER.clone();
-    let mut stream = new_data;
-    while let Some(batch) = stream.try_next().await? {
-        let doc_iter = iter_str_array(batch.column(0));
-        let row_id_col = batch[ROW_ID].as_primitive::<datatypes::UInt64Type>();
-
-        for (doc, row_id) in doc_iter.zip(row_id_col.values().iter()) {
-            let Some(doc) = doc else { continue };
-            let row_id = *row_id;
-            let mut token_stream = tokenizer.token_stream(doc);
-            let mut token_occurrences = HashMap::new();
-            let mut token_cnt = 0;
-            while let Some(token) = token_stream.next() {
-                let token_id = token_set.add(token.text.to_owned());
-                token_occurrences
-                    .entry(token_id)
-                    .and_modify(|positions: &mut Vec<i32>| positions.push(token.position as i32))
-                    .or_insert_with(|| vec![token.position as i32]);
-                token_cnt += 1;
-            }
-            invert_list.add(token_occurrences, row_id);
-            docs.add(row_id, token_cnt);
-        }
-    }
-
-    Ok(())
-}
-
 // InvertedList is a mapping from token ids to row ids
 // it's used to retrieve the documents that contain a token
 #[derive(Debug, Clone, Default, DeepSizeOf)]
 pub struct InvertedList {
     // the index is the token id
     inverted_list: Vec<PostingListBuilder>,
+    pub(crate) with_positions: bool,
 }
 
 impl InvertedList {
@@ -209,7 +222,11 @@ impl InvertedList {
             ));
         }
 
-        Ok(Self { inverted_list })
+        Ok(Self {
+            inverted_list,
+            // the index could be empty so we need to check by the schema
+            with_positions: reader.schema().field(POSITION_COL).is_some(),
+        })
     }
 
     pub fn remap(&mut self, mapping: &HashMap<u64, Option<u64>>) {
@@ -244,12 +261,18 @@ impl InvertedList {
 
     // for efficiency, we don't check if the row_id exists
     // we assume that the row_id is unique and doesn't exist in the list
-    pub fn add(&mut self, token_occurrences: HashMap<u32, Vec<i32>>, row_id: u64) {
+    pub fn add(
+        &mut self,
+        token_occurrences: HashMap<u32, Vec<i32>>,
+        row_id: u64,
+        params: &InvertedIndexParams,
+    ) {
         for (token_id, term_positions) in token_occurrences {
             let token_id = token_id as usize;
             if token_id >= self.inverted_list.len() {
-                self.inverted_list
-                    .resize_with(token_id + 1, PostingListBuilder::default);
+                self.inverted_list.resize_with(token_id + 1, || {
+                    PostingListBuilder::empty(params.with_positions)
+                });
             }
             let list = &mut self.inverted_list[token_id];
             list.row_ids.push(row_id);
@@ -300,14 +323,15 @@ mod tests {
     use object_store::path::Path;
 
     use crate::scalar::lance_format::LanceIndexStore;
-    use crate::scalar::{FullTextSearchQuery, SargableQuery, ScalarIndex};
+    use crate::scalar::{FullTextSearchQuery, InvertedIndexParams, SargableQuery, ScalarIndex};
 
     async fn test_inverted_index<Offset: arrow::array::OffsetSizeTrait>() {
         let tempdir = tempfile::tempdir().unwrap();
         let index_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
         let store = LanceIndexStore::new(ObjectStore::local(), index_dir, None);
 
-        let mut invert_index = super::InvertedIndexBuilder::default();
+        let mut invert_index =
+            super::InvertedIndexBuilder::new(InvertedIndexParams::default().with_positions(true));
         let doc_col = GenericStringArray::<Offset>::from(vec![
             "lance database search",
             "lance database",

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -535,11 +535,11 @@ impl PostingListBuilder {
         }
     }
 
-    pub fn empty(with_positions: bool) -> Self {
+    pub fn empty(with_position: bool) -> Self {
         Self {
             row_ids: Vec::new(),
             frequencies: Vec::new(),
-            positions: with_positions.then(Vec::new),
+            positions: with_position.then(Vec::new),
         }
     }
 

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -539,7 +539,7 @@ impl PostingListBuilder {
         Self {
             row_ids: Vec::new(),
             frequencies: Vec::new(),
-            positions: with_positions.then(|| Vec::new()),
+            positions: with_positions.then(Vec::new),
         }
     }
 

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -163,11 +163,11 @@ impl InvertedIndex {
         let tokens = self.tokens.clone();
         let invert_list = InvertedList::load(self.inverted_list.reader.clone()).await?;
         let docs = self.docs.clone();
-        Ok(InvertedIndexBuilder {
+        Ok(InvertedIndexBuilder::from_existing_index(
             tokens,
             invert_list,
             docs,
-        })
+        ))
     }
 }
 
@@ -352,6 +352,7 @@ impl std::fmt::Debug for InvertedListReader {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InvertedListReader")
             .field("offsets", &self.offsets)
+            .field("max_scores", &self.max_scores)
             .finish()
     }
 }
@@ -525,22 +526,20 @@ pub struct PostingListBuilder {
     pub positions: Option<Vec<Vec<i32>>>,
 }
 
-impl Default for PostingListBuilder {
-    fn default() -> Self {
-        Self {
-            row_ids: Vec::new(),
-            frequencies: Vec::new(),
-            positions: Some(Vec::new()),
-        }
-    }
-}
-
 impl PostingListBuilder {
     pub fn new(row_ids: Vec<u64>, frequencies: Vec<f32>, positions: Option<Vec<Vec<i32>>>) -> Self {
         Self {
             row_ids,
             frequencies,
             positions,
+        }
+    }
+
+    pub fn empty(with_positions: bool) -> Self {
+        Self {
+            row_ids: Vec::new(),
+            frequencies: Vec::new(),
+            positions: with_positions.then(|| Vec::new()),
         }
     }
 

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -111,6 +111,14 @@ pub(super) async fn build_scalar_index(
         Some(ScalarIndexType::LabelList) => {
             train_label_list_index(training_request, &index_store).await
         }
+        Some(ScalarIndexType::Inverted) => {
+            train_inverted_index(
+                training_request,
+                &index_store,
+                InvertedIndexParams::default(),
+            )
+            .await
+        }
         _ => {
             // The BTree index implementation leverages the legacy format's batch offset,
             // which has been removed from new format, so keep using the legacy format for now.

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use lance_core::{Error, Result};
 use lance_datafusion::{chunker::chunk_concat_stream, exec::LanceExecutionOptions};
+use lance_index::scalar::InvertedIndexParams;
 use lance_index::scalar::{
     bitmap::{train_bitmap_index, BitmapIndex, BITMAP_LOOKUP_NAME},
     btree::{train_btree_index, BTreeIndex, TrainingSource},
@@ -110,9 +111,6 @@ pub(super) async fn build_scalar_index(
         Some(ScalarIndexType::LabelList) => {
             train_label_list_index(training_request, &index_store).await
         }
-        Some(ScalarIndexType::Inverted) => {
-            train_inverted_index(training_request, &index_store).await
-        }
         _ => {
             // The BTree index implementation leverages the legacy format's batch offset,
             // which has been removed from new format, so keep using the legacy format for now.
@@ -121,6 +119,22 @@ pub(super) async fn build_scalar_index(
             train_btree_index(training_request, &flat_index_trainer, &index_store).await
         }
     }
+}
+
+/// Build a Scalar Index
+#[instrument(level = "debug", skip_all)]
+pub(super) async fn build_inverted_index(
+    dataset: &Dataset,
+    column: &str,
+    uuid: &str,
+    params: &InvertedIndexParams,
+) -> Result<()> {
+    let training_request = Box::new(TrainingRequest {
+        dataset: Arc::new(dataset.clone()),
+        column: column.to_string(),
+    });
+    let index_store = LanceIndexStore::from_dataset(dataset, uuid);
+    train_inverted_index(training_request, &index_store, params.clone()).await
 }
 
 pub async fn open_scalar_index(


### PR DESCRIPTION
The positions can be very large, it's a waste for users who don't need phrase query, so provide a param to build the index without positions, don't build FTS index with positions by default