### PR TITLE
feat: use a considerably higher default for frag readahead in v2

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -69,8 +69,11 @@ use lance_datafusion::expr::parse_substrait;
 
 pub const DEFAULT_BATCH_SIZE: usize = 8192;
 
-// Same as pyarrow Dataset::scanner()
-pub const DEFAULT_FRAGMENT_READAHEAD: usize = 4;
+pub const LEGACY_DEFAULT_FRAGMENT_READAHEAD: usize = 4;
+lazy_static::lazy_static! {
+    pub static ref DEFAULT_FRAGMENT_READAHEAD: Option<usize> = std::env::var("LANCE_DEFAULT_FRAGMENT_READAHEAD")
+        .map(|val| Some(val.parse().unwrap())).unwrap_or(None);
+}
 
 // We want to support ~256 concurrent reads to maximize throughput on cloud storage systems
 // Our typical page size is 8MiB (though not all reads are this large yet due to offset buffers, validity buffers, etc.)
@@ -1540,7 +1543,7 @@ impl Scanner {
             batch_readahead: self.batch_readahead,
             fragment_readahead: self
                 .fragment_readahead
-                .unwrap_or(DEFAULT_FRAGMENT_READAHEAD),
+                .unwrap_or(LEGACY_DEFAULT_FRAGMENT_READAHEAD),
             with_row_id: self.with_row_id,
             with_row_address: self.with_row_address,
             make_deletions_null,

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -34,7 +34,7 @@ use lance_io::ReadBatchParams;
 use lance_table::format::Fragment;
 use snafu::{location, Location};
 
-use crate::dataset::scanner::DEFAULT_FRAGMENT_READAHEAD;
+use crate::dataset::scanner::LEGACY_DEFAULT_FRAGMENT_READAHEAD;
 use crate::Error;
 use crate::{
     dataset::{
@@ -73,7 +73,7 @@ impl Default for ScanConfig {
     fn default() -> Self {
         Self {
             batch_readahead: get_num_compute_intensive_cpus(),
-            fragment_readahead: DEFAULT_FRAGMENT_READAHEAD,
+            fragment_readahead: LEGACY_DEFAULT_FRAGMENT_READAHEAD,
             with_row_id: false,
             with_row_address: false,
             make_deletions_null: false,


### PR DESCRIPTION
Now that backpressure is working properly we don't really need to limit fragment readahead too much in v2.  It has much less bearing on how much RAM is used.  In fact, we generally want to make sure that fragment readahead is higher than the I/O parallelism.

This PR also adds a new environment variable `LANCE_DEFAULT_FRAGMENT_READAHEAD` that can be used to change the default readahead used.  This can be useful in cases where the user can't set the readahead directly (e.g. duckdb pushdown, compaction, indexing jobs, etc.)