### PR TITLE
feat: constant-time manifest lookup on object stores

### DIFF
--- a/docs/format.rst
+++ b/docs/format.rst
@@ -338,6 +338,25 @@ systems and cloud object stores, with the notable except of AWS S3. For ones
 that lack this functionality, an external locking mechanism can be configured
 by the user.
 
+Manifest Naming Schemes
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Manifest files must use a consistent naming scheme. The names correspond to the
+versions. That way we can open the right version of the dataset without having
+to read all the manifests. It also makes it clear which file path is the next
+one to be written.
+
+There are two naming schemes that can be used:
+
+1. V1: ``_versions/{version}.manifest``. This is the legacy naming scheme.
+2. V2: ``_versions/{u64::MAX - version:020}.manifest``. This is the new naming
+   scheme. The version is zero-padded (to 20 digits) and subtracted from
+   ``u64::MAX``. This allows the versions to be sorted in descending order,
+   making it possible to find the latest manifest on object storage using a
+   single list call.
+
+It is an error for there to be a mixture of these two naming schemes.
+
 .. _conflict_resolution:
 
 Conflict resolution

--- a/java/core/lance-jni/src/blocking_dataset.rs
+++ b/java/core/lance-jni/src/blocking_dataset.rs
@@ -92,6 +92,7 @@ impl BlockingDataset {
             None,
             None,
             object_store_registry,
+            false, // TODO: support enable_v2_manifest_paths
         ))?;
         Ok(Self { inner })
     }

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1789,6 +1789,12 @@ class LanceDataset(pa.dataset.Dataset):
         storage_options : optional, dict
             Extra options that make sense for a particular storage connection. This is
             used to store connection parameters like credentials, endpoint, etc.
+        enable_v2_manifest_paths : bool, optional
+            If True, and this is a new dataset, uses the new V2 manifest paths.
+            These paths provide more efficient opening of datasets with many
+            versions on object stores. This parameter has no effect if the dataset
+            already exists. To migrate an existing dataset, instead use the
+            :meth:`migrate_manifest_paths_v2` method. Default is False.
 
         Returns
         -------
@@ -1850,6 +1856,12 @@ class LanceDataset(pa.dataset.Dataset):
         Migrate the manifest paths to the new format.
 
         This will update the manifest to use the new v2 format for paths.
+
+        This function is idempotent, and can be run multiple times without
+        changing the state of the object store.
+
+        However, it should not be run while other concurrent operations are happening.
+        And it should also run until completion before resuming other operations.
         """
         self._ds.migrate_manifest_paths_v2()
 
@@ -2876,6 +2888,12 @@ def write_dataset(
     use_legacy_format : optional, bool, default None
         Deprecated method for setting the data storage version. Use the
         `data_storage_version` parameter instead.
+    enable_v2_manifest_paths : bool, optional
+        If True, and this is a new dataset, uses the new V2 manifest paths.
+        These paths provide more efficient opening of datasets with many
+        versions on object stores. This parameter has no effect if the dataset
+        already exists. To migrate an existing dataset, instead use the
+        :meth:`LanceDataset.migrate_manifest_paths_v2` method. Default is False.
     """
     if use_legacy_format is not None:
         warnings.warn(

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1845,6 +1845,14 @@ class LanceDataset(pa.dataset.Dataset):
         """
         self._ds.validate()
 
+    def migrate_manifest_paths_v2(self):
+        """
+        Migrate the manifest paths to the new format.
+
+        This will update the manifest to use the new v2 format for paths.
+        """
+        self._ds.migrate_manifest_paths_v2()
+
     @property
     def optimize(self) -> "DatasetOptimizer":
         return DatasetOptimizer(self)

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1751,6 +1751,7 @@ class LanceDataset(pa.dataset.Dataset):
         read_version: Optional[int] = None,
         commit_lock: Optional[CommitLock] = None,
         storage_options: Optional[Dict[str, str]] = None,
+        enable_v2_manifest_paths: Optional[bool] = None,
     ) -> LanceDataset:
         """Create a new version of dataset
 
@@ -1831,6 +1832,7 @@ class LanceDataset(pa.dataset.Dataset):
             read_version,
             commit_lock,
             storage_options=storage_options,
+            enable_v2_manifest_paths=enable_v2_manifest_paths,
         )
         return LanceDataset(base_uri, storage_options=storage_options)
 
@@ -2818,6 +2820,7 @@ def write_dataset(
     storage_options: Optional[Dict[str, str]] = None,
     data_storage_version: str = "legacy",
     use_legacy_format: Optional[bool] = None,
+    enable_v2_manifest_paths: bool = False,
 ) -> LanceDataset:
     """Write a given data_obj to the given uri
 
@@ -2897,6 +2900,7 @@ def write_dataset(
         "progress": progress,
         "storage_options": storage_options,
         "data_storage_version": data_storage_version,
+        "enable_v2_manifest_paths": enable_v2_manifest_paths,
     }
 
     if commit_lock:

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1794,7 +1794,9 @@ class LanceDataset(pa.dataset.Dataset):
             These paths provide more efficient opening of datasets with many
             versions on object stores. This parameter has no effect if the dataset
             already exists. To migrate an existing dataset, instead use the
-            :meth:`migrate_manifest_paths_v2` method. Default is False.
+            :meth:`migrate_manifest_paths_v2` method. Default is False. WARNING:
+            turning this on will make the dataset unreadable for older versions
+            of Lance (prior to 0.17.0).
 
         Returns
         -------
@@ -1860,7 +1862,7 @@ class LanceDataset(pa.dataset.Dataset):
         This function is idempotent, and can be run multiple times without
         changing the state of the object store.
 
-        However, it should not be run while other concurrent operations are happening.
+        DANGER: this should not be run while other concurrent operations are happening.
         And it should also run until completion before resuming other operations.
         """
         self._ds.migrate_manifest_paths_v2()

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -251,6 +251,15 @@ def test_asof_checkout(tmp_path: Path):
     assert len(ds.to_table()) == 9
 
 
+def test_v2_manifest_paths(tmp_path: Path):
+    lance.write_dataset(
+        pa.table({"a": range(100)}), tmp_path, enable_v2_manifest_paths=True
+    )
+    manifest_path = os.listdir(tmp_path / "_versions")
+    assert len(manifest_path) == 1
+    assert re.match(r"\d{20}\.manifest", manifest_path[0])
+
+
 def test_tag(tmp_path: Path):
     table = pa.Table.from_pydict({"colA": [1, 2, 3], "colB": [4, 5, 6]})
     base_dir = tmp_path / "test"

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -260,6 +260,21 @@ def test_v2_manifest_paths(tmp_path: Path):
     assert re.match(r"\d{20}\.manifest", manifest_path[0])
 
 
+def test_v2_manifest_paths_migration(tmp_path: Path):
+    # Create a dataset with v1 manifest paths
+    lance.write_dataset(
+        pa.table({"a": range(100)}), tmp_path, enable_v2_manifest_paths=False
+    )
+    manifest_path = os.listdir(tmp_path / "_versions")
+    assert manifest_path == ["1.manifest"]
+
+    # Migrate to v2 manifest paths
+    lance.dataset(tmp_path).migrate_manifest_paths_v2()
+    manifest_path = os.listdir(tmp_path / "_versions")
+    assert len(manifest_path) == 1
+    assert re.match(r"\d{20}\.manifest", manifest_path[0])
+
+
 def test_tag(tmp_path: Path):
     table = pa.Table.from_pydict({"colA": [1, 2, 3], "colB": [4, 5, 6]})
     base_dir = tmp_path / "test"

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1218,6 +1218,7 @@ impl Dataset {
         read_version: Option<u64>,
         commit_lock: Option<&PyAny>,
         storage_options: Option<HashMap<String, String>>,
+        enable_v2_manifest_paths: Option<bool>,
     ) -> PyResult<Self> {
         let object_store_params =
             storage_options
@@ -1255,6 +1256,7 @@ impl Dataset {
                     object_store_params,
                     commit_handler,
                     object_store_registry,
+                    enable_v2_manifest_paths.unwrap_or(false),
                 )
                 .await
             })?
@@ -1462,6 +1464,12 @@ pub fn get_write_params(options: &PyDict) -> PyResult<Option<WriteParams>> {
                 storage_options: Some(storage_options),
                 ..Default::default()
             });
+        }
+
+        if let Some(enable_v2_manifest_paths) =
+            get_dict_opt::<bool>(options, "enable_v2_manifest_paths")?
+        {
+            p.enable_v2_manifest_paths = enable_v2_manifest_paths;
         }
 
         p.commit_handler = get_commit_handler(options);

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1272,6 +1272,14 @@ impl Dataset {
             .map_err(|err| PyIOError::new_err(err.to_string()))
     }
 
+    fn migrate_manifest_paths_v2(&mut self) -> PyResult<()> {
+        let mut new_self = self.ds.as_ref().clone();
+        RT.block_on(None, new_self.migrate_manifest_paths_v2())?
+            .map_err(|err| PyIOError::new_err(err.to_string()))?;
+        self.ds = Arc::new(new_self);
+        Ok(())
+    }
+
     fn drop_columns(&mut self, columns: Vec<&str>) -> PyResult<()> {
         let mut new_self = self.ds.as_ref().clone();
         RT.block_on(None, new_self.drop_columns(&columns))?

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -741,6 +741,7 @@ mod tests {
             None,
             None,
             false,
+            false,
             1,
         ));
 
@@ -827,6 +828,7 @@ mod tests {
             Url::parse("mem://").unwrap(),
             None,
             None,
+            false,
             false,
             1,
         ));

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -17,6 +17,7 @@ use prost_types::Timestamp;
 use super::Fragment;
 use crate::feature_flags::{has_deprecated_v2_feature_flag, FLAG_MOVE_STABLE_ROW_IDS};
 use crate::format::pb;
+use crate::io::commit::ManifestNamingScheme;
 use lance_core::cache::FileMetadataCache;
 use lance_core::datatypes::Schema;
 use lance_core::{Error, Result};
@@ -278,6 +279,15 @@ impl Manifest {
 
     pub fn should_use_legacy_format(&self) -> bool {
         self.data_storage_format.version == LEGACY_FORMAT_VERSION
+    }
+
+    pub fn manifest_naming_scheme(&self) -> ManifestNamingScheme {
+        // TODO: Make this user configurable
+        if std::env::var("LANCE_USE_V2_VERSION_NAMES").is_ok() {
+            ManifestNamingScheme::V2
+        } else {
+            ManifestNamingScheme::V1
+        }
     }
 }
 

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -17,7 +17,6 @@ use prost_types::Timestamp;
 use super::Fragment;
 use crate::feature_flags::{has_deprecated_v2_feature_flag, FLAG_MOVE_STABLE_ROW_IDS};
 use crate::format::pb;
-use crate::io::commit::ManifestNamingScheme;
 use lance_core::cache::FileMetadataCache;
 use lance_core::datatypes::Schema;
 use lance_core::{Error, Result};
@@ -279,15 +278,6 @@ impl Manifest {
 
     pub fn should_use_legacy_format(&self) -> bool {
         self.data_storage_format.version == LEGACY_FORMAT_VERSION
-    }
-
-    pub fn manifest_naming_scheme(&self) -> ManifestNamingScheme {
-        // TODO: Make this user configurable
-        if std::env::var("LANCE_USE_V2_VERSION_NAMES").is_ok() {
-            ManifestNamingScheme::V2
-        } else {
-            ManifestNamingScheme::V1
-        }
     }
 }
 

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -68,7 +68,7 @@ pub enum ManifestNamingScheme {
     ///
     /// Zero-padded and reversed for O(1) lookup of latest version on object stores.
     /// Lexicographically, the first file in the directory should always be the
-    /// latest manifest..
+    /// latest manifest.
     V2,
 }
 
@@ -104,6 +104,14 @@ impl ManifestNamingScheme {
             }
         } else {
             None
+        }
+    }
+
+    pub fn detect_scheme_staging(filename: &str) -> Self {
+        if filename.chars().nth(20) == Some('.') {
+            Self::V2
+        } else {
+            Self::V1
         }
     }
 }

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -60,6 +60,7 @@ use crate::format::{Index, Manifest};
 const VERSIONS_DIR: &str = "_versions";
 const MANIFEST_EXTENSION: &str = "manifest";
 
+/// How manifest files should be named.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ManifestNamingScheme {
     /// `_versions/{version}.manifest`
@@ -67,8 +68,6 @@ pub enum ManifestNamingScheme {
     /// `_manifests/{u64::MAX - version}.manifest`
     ///
     /// Zero-padded and reversed for O(1) lookup of latest version on object stores.
-    /// Lexicographically, the first file in the directory should always be the
-    /// latest manifest.
     V2,
 }
 

--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -246,7 +246,7 @@ impl CommitHandler for ExternalManifestCommitHandler {
                         Ok(_) => {}
                         Err(e) => {
                             warn!(
-                            "could up update external manifest store during load, with error: {}",
+                            "could not update external manifest store during load, with error: {}",
                             e
                         );
                         }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -849,8 +849,9 @@ impl Dataset {
     /// * `enable_v2_manifest_paths`: If set to true, and this is a new dataset, uses the new v2 manifest
     ///   paths. These allow constant-time lookups for the latest manifest on object storage.
     ///   This parameter has no effect on existing datasets. To migrate an existing
-    ///   dataset, use the [`Self::migrate_manifest_paths_v2`] method.
-    ///   Default is False.
+    ///   dataset, use the [`Self::migrate_manifest_paths_v2`] method. WARNING: turning
+    ///   this on will make the dataset unreadable for older versions of Lance
+    ///   (prior to 0.17.0). Default is False.
     pub async fn commit(
         base_uri: &str,
         operation: Operation,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2769,6 +2769,37 @@ mod tests {
         assert_all_manifests_use_scheme(&test_dir, ManifestNamingScheme::V2);
     }
 
+    #[tokio::test]
+    async fn test_v2_manifest_path_commit() {
+        let schema = Schema::try_from(&ArrowSchema::new(vec![ArrowField::new(
+            "x",
+            DataType::Int32,
+            false,
+        )]))
+        .unwrap();
+        let operation = Operation::Overwrite {
+            fragments: vec![],
+            schema,
+        };
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+        let dataset = Dataset::commit(
+            test_uri,
+            operation,
+            None,
+            None,
+            None,
+            Arc::new(ObjectStoreRegistry::default()),
+            true, // enable_v2_manifest_paths
+        )
+        .await
+        .unwrap();
+
+        assert!(dataset.manifest_naming_scheme == ManifestNamingScheme::V2);
+
+        assert_all_manifests_use_scheme(&test_dir, ManifestNamingScheme::V2);
+    }
+
     #[rstest]
     #[tokio::test]
     async fn test_merge(

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -261,6 +261,8 @@ impl DatasetBuilder {
         let cloned_ref = self.version.clone();
         let table_uri = self.table_uri.clone();
 
+        // How do we detect which version scheme is in use?
+
         let manifest = self.manifest.take();
 
         let (object_store, base_path, commit_handler) = self.build_object_store().await?;

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -8,7 +8,7 @@ use lance_io::object_store::{
 };
 use lance_table::{
     format::Manifest,
-    io::commit::{commit_handler_from_url, CommitHandler, ManifestLocation},
+    io::commit::{commit_handler_from_url, CommitHandler},
 };
 use object_store::{aws::AwsCredentialProvider, path::Path, DynObjectStore};
 use prost::Message;
@@ -294,14 +294,9 @@ impl DatasetBuilder {
         } else {
             let manifest_location = match version {
                 Some(version) => {
-                    let path = commit_handler
-                        .resolve_version(&base_path, version, &object_store.inner)
-                        .await?;
-                    ManifestLocation {
-                        version,
-                        path,
-                        size: None,
-                    }
+                    commit_handler
+                        .resolve_version_location(&base_path, version, &object_store.inner)
+                        .await?
                 }
                 None => commit_handler
                     .resolve_latest_location(&base_path, &object_store)

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -228,6 +228,7 @@ impl DatasetBuilder {
                     self.options.block_size,
                     self.options.object_store_wrapper,
                     self.options.use_constant_size_upload_parts,
+                    store.1.scheme() != "file",
                     // If user supplied an object store then we just assume it's probably
                     // cloud-like
                     DEFAULT_CLOUD_IO_PARALLELISM,

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -2246,7 +2246,7 @@ mod tests {
         };
 
         let registry = Arc::new(ObjectStoreRegistry::default());
-        let new_dataset = Dataset::commit(test_uri, op, None, None, None, registry)
+        let new_dataset = Dataset::commit(test_uri, op, None, None, None, registry, false)
             .await
             .unwrap();
 
@@ -2346,7 +2346,7 @@ mod tests {
             };
 
             let registry = Arc::new(ObjectStoreRegistry::default());
-            let dataset = Dataset::commit(test_uri, op, None, None, None, registry)
+            let dataset = Dataset::commit(test_uri, op, None, None, None, registry, false)
                 .await
                 .unwrap();
 
@@ -2572,6 +2572,7 @@ mod tests {
             None,
             None,
             registry,
+            false,
         )
         .await?;
 

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -2700,6 +2700,7 @@ mod tests {
             None,
             None,
             object_store_registry,
+            false,
         )
         .await
         .unwrap();

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -603,6 +603,7 @@ async fn reserve_fragment_ids(
         &transaction,
         &Default::default(),
         &Default::default(),
+        dataset.manifest_naming_scheme,
     )
     .await?;
 
@@ -896,6 +897,7 @@ pub async fn commit_compaction(
         &transaction,
         &Default::default(),
         &Default::default(),
+        dataset.manifest_naming_scheme,
     )
     .await?;
 

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -228,6 +228,7 @@ pub(super) async fn add_columns(
         &transaction,
         &Default::default(),
         &Default::default(),
+        dataset.manifest_naming_scheme,
     )
     .await?;
 
@@ -469,6 +470,7 @@ pub(super) async fn alter_columns(
         &transaction,
         &Default::default(),
         &Default::default(),
+        dataset.manifest_naming_scheme,
     )
     .await?;
 
@@ -517,6 +519,7 @@ pub(super) async fn drop_columns(dataset: &mut Dataset, columns: &[&str]) -> Res
         &transaction,
         &Default::default(),
         &Default::default(),
+        dataset.manifest_naming_scheme,
     )
     .await?;
 

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -111,6 +111,10 @@ pub struct WriteParams {
     /// secondary indices need to be updated to point to new row ids.
     pub enable_move_stable_row_ids: bool,
 
+    /// If set to true, the writer will use v2 manifest paths. These allow
+    /// O(1) lookups for the latest manifest on object storage.
+    pub enable_v2_manifest_paths: bool,
+
     pub object_store_registry: Arc<ObjectStoreRegistry>,
 }
 
@@ -128,6 +132,7 @@ impl Default for WriteParams {
             commit_handler: None,
             data_storage_version: None,
             enable_move_stable_row_ids: false,
+            enable_v2_manifest_paths: false,
             object_store_registry: Arc::new(ObjectStoreRegistry::default()),
         }
     }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -111,8 +111,11 @@ pub struct WriteParams {
     /// secondary indices need to be updated to point to new row ids.
     pub enable_move_stable_row_ids: bool,
 
-    /// If set to true, the writer will use v2 manifest paths. These allow
-    /// O(1) lookups for the latest manifest on object storage.
+    /// If set to true, and this is a new dataset, uses the new v2 manifest paths.
+    /// These allow constant-time lookups for the latest manifest on object storage.
+    /// This parameter has no effect on existing datasets. To migrate an existing
+    /// dataset, use the [`super::Dataset::migrate_manifest_paths_v2`] method.
+    /// Default is False.
     pub enable_v2_manifest_paths: bool,
 
     pub object_store_registry: Arc<ObjectStoreRegistry>,

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -991,6 +991,7 @@ impl MergeInsertJob {
             &transaction,
             &Default::default(),
             &Default::default(),
+            dataset.manifest_naming_scheme,
         )
         .await?;
 

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -335,6 +335,7 @@ impl UpdateJob {
             &transaction,
             &Default::default(),
             &Default::default(),
+            self.dataset.manifest_naming_scheme,
         )
         .await?;
 

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -324,6 +324,7 @@ impl DatasetIndexExt for Dataset {
             &transaction,
             &Default::default(),
             &Default::default(),
+            self.manifest_naming_scheme,
         )
         .await?;
 
@@ -393,6 +394,7 @@ impl DatasetIndexExt for Dataset {
             &transaction,
             &Default::default(),
             &Default::default(),
+            self.manifest_naming_scheme,
         )
         .await?;
 
@@ -479,6 +481,7 @@ impl DatasetIndexExt for Dataset {
             &transaction,
             &Default::default(),
             &Default::default(),
+            self.manifest_naming_scheme,
         )
         .await?;
 

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -29,7 +29,7 @@ use lance_file::version::LanceFileVersion;
 use lance_table::format::{
     pb, DataStorageFormat, DeletionFile, Fragment, Index, Manifest, WriterVersion,
 };
-use lance_table::io::commit::{CommitConfig, CommitError, CommitHandler};
+use lance_table::io::commit::{CommitConfig, CommitError, CommitHandler, ManifestNamingScheme};
 use lance_table::io::deletion::read_deletion_file;
 use rand::Rng;
 use snafu::{location, Location};
@@ -121,6 +121,7 @@ pub(crate) async fn commit_new_dataset(
     base_path: &Path,
     transaction: &Transaction,
     write_config: &ManifestWriteConfig,
+    manifest_naming_scheme: ManifestNamingScheme,
 ) -> Result<Manifest> {
     let transaction_file = write_transaction_file(object_store, base_path, transaction).await?;
 
@@ -138,6 +139,7 @@ pub(crate) async fn commit_new_dataset(
             Some(indices.clone())
         },
         write_config,
+        manifest_naming_scheme,
     )
     .await?;
 
@@ -415,6 +417,7 @@ pub(crate) async fn commit_transaction(
     transaction: &Transaction,
     write_config: &ManifestWriteConfig,
     commit_config: &CommitConfig,
+    manifest_naming_scheme: ManifestNamingScheme,
 ) -> Result<Manifest> {
     // Note: object_store has been configured with WriteParams, but dataset.object_store()
     // has not necessarily. So for anything involving writing, use `object_store`.
@@ -504,6 +507,7 @@ pub(crate) async fn commit_transaction(
                 Some(indices.clone())
             },
             write_config,
+            manifest_naming_scheme,
         )
         .await;
 

--- a/rust/lance/src/io/commit/dynamodb.rs
+++ b/rust/lance/src/io/commit/dynamodb.rs
@@ -47,7 +47,7 @@ mod test {
     use lance_table::io::commit::{
         dynamodb::DynamoDBExternalManifestStore,
         external_manifest::{ExternalManifestCommitHandler, ExternalManifestStore},
-        manifest_path, CommitHandler,
+        CommitHandler, ManifestNamingScheme,
     };
 
     fn read_params(handler: Arc<dyn CommitHandler>) -> ReadParams {

--- a/rust/lance/src/io/commit/dynamodb.rs
+++ b/rust/lance/src/io/commit/dynamodb.rs
@@ -313,7 +313,10 @@ mod test {
         let version_six_staging_location =
             base_path.child(format!("6.manifest-{}", uuid::Uuid::new_v4()));
         localfs
-            .rename(&manifest_path(&ds.base, 6), &version_six_staging_location)
+            .rename(
+                &ManifestNamingScheme::V1.manifest_path(&ds.base, 6),
+                &version_six_staging_location,
+            )
             .await
             .unwrap();
         store

--- a/rust/lance/src/io/commit/external_manifest.rs
+++ b/rust/lance/src/io/commit/external_manifest.rs
@@ -13,7 +13,7 @@ mod test {
     use lance_table::io::commit::external_manifest::{
         ExternalManifestCommitHandler, ExternalManifestStore,
     };
-    use lance_table::io::commit::{manifest_path, CommitHandler};
+    use lance_table::io::commit::{CommitHandler, ManifestNamingScheme};
     use lance_testing::datagen::{BatchGenerator, IncrementingInt32};
     use object_store::local::LocalFileSystem;
     use object_store::path::Path;
@@ -303,7 +303,10 @@ mod test {
         let version_six_staging_location =
             base_path.child(format!("6.manifest-{}", uuid::Uuid::new_v4()));
         localfs
-            .rename(&manifest_path(&ds.base, 6), &version_six_staging_location)
+            .rename(
+                &ManifestNamingScheme::V1.manifest_path(&ds.base, 6),
+                &version_six_staging_location,
+            )
             .await
             .unwrap();
         {

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -113,9 +113,17 @@ impl TestDatasetGenerator {
         let operation = Operation::Overwrite { fragments, schema };
 
         let registry = Arc::new(ObjectStoreRegistry::default());
-        Dataset::commit(uri, operation, None, Default::default(), None, registry)
-            .await
-            .unwrap()
+        Dataset::commit(
+            uri,
+            operation,
+            None,
+            Default::default(),
+            None,
+            registry,
+            false,
+        )
+        .await
+        .unwrap()
     }
 
     fn make_schema(&self, rng: &mut impl Rng) -> Schema {


### PR DESCRIPTION
This introduces `ManifestNamingScheme` with a `V1` and `V2` variant. `V1` is the existing naming scheme. `V2` uses a scheme optimized for object storage listing mechanisms, making looking up the latest manifest constant time.

**On S3, this makes `lance.dataset()` take only  125 ms, regardless of how many versions of the dataset existed. Previously this time grew linearly with number of versions.**

We also provide a method `migrate_manifest_paths_v2`. Because this method alters the manifest path scheme, and agreement on the scheme is critical for the write path, it's important is it not run while any read or write operations happen on that table. That's why this migration can't happen in the background like some other migrations.

Closes #2790