### PR TITLE
perf: parallelize FTS indexing

### DIFF
--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -138,6 +138,7 @@ pub trait IndexWriter: Send {
     async fn write_record_batch(&mut self, batch: RecordBatch) -> Result<u64>;
     /// Finishes writing the file and closes the file
     async fn finish(&mut self) -> Result<()>;
+    async fn finish_with_metadata(&mut self, metadata: HashMap<String, String>) -> Result<()>;
 }
 
 /// Trait for reading an index (or parts of an index) from storage

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -138,6 +138,7 @@ pub trait IndexWriter: Send {
     async fn write_record_batch(&mut self, batch: RecordBatch) -> Result<u64>;
     /// Finishes writing the file and closes the file
     async fn finish(&mut self) -> Result<()>;
+    /// Finishes writing the file and closes the file with additional metadata
     async fn finish_with_metadata(&mut self, metadata: HashMap<String, String>) -> Result<()>;
 }
 

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -17,7 +17,7 @@ use deepsize::DeepSizeOf;
 use futures::{stream, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use lance_arrow::iter_str_array;
-use lance_core::utils::tokio::{get_num_compute_intensive_cpus, spawn_cpu, CPU_RUNTIME};
+use lance_core::utils::tokio::{get_num_compute_intensive_cpus, CPU_RUNTIME};
 use lance_core::{Error, Result, ROW_ID};
 use lazy_static::lazy_static;
 use rayon::prelude::*;

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -571,12 +571,6 @@ impl PostingListBuilder {
         self.len() == 0
     }
 
-    pub fn clear(&mut self) {
-        self.row_ids = Vec::new();
-        self.frequencies = Vec::new();
-        self.positions = self.positions.take().map(|_| PositionBuilder::new());
-    }
-
     pub fn calculate_max_score(&self, docs: &DocSet) -> f32 {
         let num_docs = docs.len();
         let avgdl = docs.average_length();
@@ -611,7 +605,6 @@ impl PostingListBuilder {
                 position_builder.append(true);
             }
         }
-        self.clear();
 
         let row_id_col = row_id_builder.finish();
         let freq_col = freq_builder.finish();
@@ -643,6 +636,12 @@ impl PostingListBuilder {
 pub struct PositionBuilder {
     positions: Vec<i32>,
     offsets: Vec<usize>,
+}
+
+impl Default for PositionBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl PositionBuilder {

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -4,14 +4,16 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use arrow::array::{AsArray, Float32Builder, Int32Builder, ListBuilder, UInt64Builder};
+use arrow::array::{
+    AsArray, Float32Builder, Int32Builder, ListBuilder, StringBuilder, UInt32Builder, UInt64Builder,
+};
 use arrow::buffer::ScalarBuffer;
 use arrow::datatypes::{self, Float32Type, Int32Type, UInt64Type};
 use arrow_array::{
-    Array, ArrayRef, ListArray, OffsetSizeTrait, PrimitiveArray, RecordBatch, StringArray,
-    UInt32Array, UInt64Array,
+    Array, ArrayRef, ListArray, OffsetSizeTrait, PrimitiveArray, RecordBatch, UInt32Array,
+    UInt64Array,
 };
-use arrow_schema::{DataType, Field};
+use arrow_schema::{DataType, Field, SchemaRef};
 use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
 use deepsize::DeepSizeOf;
@@ -59,7 +61,6 @@ lazy_static! {
     pub static ref TOKENIZER: tantivy::tokenizer::TextAnalyzer = {
         tantivy::tokenizer::TextAnalyzer::builder(tantivy::tokenizer::SimpleTokenizer::default())
             .filter(tantivy::tokenizer::RemoveLongFilter::limit(40))
-            .filter(tantivy::tokenizer::StopWordFilter::new(Language::English).unwrap())
             .filter(tantivy::tokenizer::LowerCaser)
             .filter(tantivy::tokenizer::Stemmer::new(Language::English))
             .build()
@@ -270,20 +271,19 @@ pub struct TokenSet {
     // token -> (token_id, frequency)
     pub(crate) tokens: HashMap<String, u32>,
     pub(crate) next_id: u32,
+    total_length: usize,
 }
 
 impl TokenSet {
-    pub fn to_batch(&self) -> Result<RecordBatch> {
-        let mut tokens = Vec::with_capacity(self.tokens.len());
-        let mut token_ids = Vec::with_capacity(self.tokens.len());
-        self.tokens.iter().for_each(|(token, token_id)| {
-            tokens.push(token.as_str());
-            token_ids.push(*token_id);
-        });
-        let mut indices = (0..self.tokens.len()).collect_vec();
-        indices.sort_unstable_by_key(|&i| tokens[i]);
-        let token_col = StringArray::from_iter_values(indices.iter().map(|&i| tokens[i]));
-        let token_id_col = UInt32Array::from_iter_values(indices.iter().map(|&i| token_ids[i]));
+    pub fn to_batch(self) -> Result<RecordBatch> {
+        let mut token_builder = StringBuilder::with_capacity(self.tokens.len(), self.total_length);
+        let mut token_id_builder = UInt32Builder::with_capacity(self.tokens.len());
+        for (token, token_id) in self.tokens.into_iter().sorted_unstable() {
+            token_builder.append_value(token);
+            token_id_builder.append_value(token_id);
+        }
+        let token_col = token_builder.finish();
+        let token_id_col = token_id_builder.finish();
 
         let schema = arrow_schema::Schema::new(vec![
             arrow_schema::Field::new(TOKEN_COL, DataType::Utf8, false),
@@ -301,8 +301,9 @@ impl TokenSet {
     }
 
     pub async fn load(reader: Arc<dyn IndexReader>) -> Result<Self> {
-        let mut tokens = HashMap::new();
         let mut next_id = 0;
+        let mut total_length = 0;
+        let mut tokens = HashMap::new();
 
         let batch = reader.read_range(0..reader.num_rows(), None).await?;
         let token_col = batch[TOKEN_COL].as_string::<i32>();
@@ -310,20 +311,27 @@ impl TokenSet {
 
         for (token, &token_id) in token_col.iter().zip(token_id_col.values().iter()) {
             let token = token.unwrap();
-            tokens.insert(token.to_owned(), token_id);
             next_id = next_id.max(token_id + 1);
+            total_length += token.len();
+            tokens.insert(token.to_owned(), token_id);
         }
 
-        Ok(Self { tokens, next_id })
+        Ok(Self {
+            tokens,
+            next_id,
+            total_length,
+        })
     }
 
     pub fn add(&mut self, token: String) -> u32 {
         let next_id = self.next_id();
+        let len = token.len();
         let token_id = *self.tokens.entry(token).or_insert(next_id);
 
         // add token if it doesn't exist
         if token_id == next_id {
             self.next_id += 1;
+            self.total_length += len;
         }
 
         token_id
@@ -335,18 +343,6 @@ impl TokenSet {
 
     pub fn next_id(&self) -> u32 {
         self.next_id
-    }
-}
-
-impl FromIterator<(String, u32)> for TokenSet {
-    fn from_iter<T: IntoIterator<Item = (String, u32)>>(iter: T) -> Self {
-        let mut tokens = HashMap::new();
-        let mut next_id = 0;
-        for (token, token_id) in iter {
-            tokens.insert(token, token_id);
-            next_id = next_id.max(token_id + 1);
-        }
-        Self { tokens, next_id }
     }
 }
 
@@ -588,7 +584,7 @@ impl PostingListBuilder {
         max_score * idf(self.len(), num_docs) * (K1 + 1.0)
     }
 
-    pub fn to_batch(mut self, docs: &DocSet) -> Result<(RecordBatch, f32)> {
+    pub fn to_batch(mut self, schema: SchemaRef, docs: Arc<DocSet>) -> Result<(RecordBatch, f32)> {
         let length = self.len();
         let num_docs = docs.len();
         let avgdl = docs.average_length();
@@ -596,10 +592,9 @@ impl PostingListBuilder {
 
         let mut row_id_builder = UInt64Builder::with_capacity(length);
         let mut freq_builder = Float32Builder::with_capacity(length);
-        let mut position_builder = self
-            .positions
-            .as_mut()
-            .map(|_| ListBuilder::with_capacity(Int32Builder::new(), length));
+        let mut position_builder = self.positions.as_mut().map(|positions| {
+            ListBuilder::with_capacity(Int32Builder::with_capacity(positions.total_len()), length)
+        });
         for index in (0..length).sorted_unstable_by_key(|&i| self.row_ids[i]) {
             let (row_id, freq) = (self.row_ids[index], self.frequencies[index]);
             // reorder the posting list by row id
@@ -622,25 +617,15 @@ impl PostingListBuilder {
         let row_id_col = row_id_builder.finish();
         let freq_col = freq_builder.finish();
 
-        let mut fields = vec![
-            arrow_schema::Field::new(ROW_ID, DataType::UInt64, false),
-            arrow_schema::Field::new(FREQUENCY_COL, DataType::Float32, false),
-        ];
         let mut columns = vec![
             Arc::new(row_id_col) as ArrayRef,
             Arc::new(freq_col) as ArrayRef,
         ];
         if let Some(mut position_builder) = position_builder {
             let position_col = position_builder.finish();
-            fields.push(arrow_schema::Field::new(
-                POSITION_COL,
-                DataType::List(Field::new("item", DataType::Int32, true).into()),
-                false,
-            ));
             columns.push(Arc::new(position_col));
         }
-        let schema = arrow_schema::Schema::new(fields);
-        let batch = RecordBatch::try_new(Arc::new(schema), columns)?;
+        let batch = RecordBatch::try_new(schema, columns)?;
         Ok((batch, max_score))
     }
 }
@@ -663,6 +648,10 @@ impl PositionBuilder {
             positions: Vec::new(),
             offsets: vec![0],
         }
+    }
+
+    pub fn total_len(&self) -> usize {
+        self.positions.len()
     }
 
     pub fn push(&mut self, positions: Vec<i32>) {

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -4,6 +4,7 @@
 //! Utilities for serializing and deserializing scalar indices in the lance format
 
 use std::cmp::min;
+use std::collections::HashMap;
 use std::{any::Any, sync::Arc};
 
 use arrow_array::RecordBatch;
@@ -87,6 +88,12 @@ impl<M: ManifestProvider + Send + Sync> IndexWriter for FileWriter<M> {
     async fn finish(&mut self) -> Result<()> {
         Self::finish(self).await.map(|_| ())
     }
+
+    async fn finish_with_metadata(&mut self, metadata: HashMap<String, String>) -> Result<()> {
+        Self::finish_with_metadata(self, &metadata)
+            .await
+            .map(|_| ())
+    }
 }
 
 #[async_trait]
@@ -98,6 +105,13 @@ impl IndexWriter for v2::writer::FileWriter {
     }
 
     async fn finish(&mut self) -> Result<()> {
+        Self::finish(self).await.map(|_| ())
+    }
+
+    async fn finish_with_metadata(&mut self, metadata: HashMap<String, String>) -> Result<()> {
+        metadata.into_iter().for_each(|(k, v)| {
+            self.add_schema_metadata(k, v);
+        });
         Self::finish(self).await.map(|_| ())
     }
 }


### PR DESCRIPTION
- parallelizing tokenizing
- processing doc's tokens by batch to avoid holding write lock for a long time
- parallelizing collecting token occurrences
- don't concat batches of inverted lists
- don't clone the token strings when writing the `TokenSet` 
- store positions continuously to reduce memory footprint

It's can't fully utilize the CPU cause the indexing process isn't friendly to parallelism, it's about 800% utilization with my 16 cores machine. But this still depends on the data, MS MARCO contains too many tokens that aren't English words.

the indexing time has been reduced to:
- no positions: reduced to ~7min from 25min on MS MARCO dataset.
- with positions: 10.5min on MS MARCO dataset.

the memory footprint has been reduced multiple times, especially with positions.