### PR TITLE
feat: allow creating fragments from v2 files, expose rewrite operation to python

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2177,6 +2177,17 @@ class LanceOperation:
         """
         Operation that rewrites one or more files and indices into one
         or more files and indices.
+
+        Attributes
+        ----------
+        groups: list[RewriteGroup]
+            Groups of files that have been rewritten.
+        rewritten_indices: list[RewrittenIndex]
+            Indices that have been rewritten.
+
+        Warning
+        -------
+        This is an advanced API not intended for general use.
         """
 
         groups: Iterable[LanceOperation.RewriteGroup]

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -114,9 +114,9 @@ class LanceFragment(pa.dataset.Fragment):
     @staticmethod
     def create_from_file(
         filename: Union[str, Path],
-        schema: pa.Schema,
+        dataset: LanceDataset,
         fragment_id: int,
-    ) -> LanceFragment:
+    ) -> FragmentMetadata:
         """Create a fragment from the given datafile uri.
 
         This can be used if the datafile is loss from dataset.
@@ -129,12 +129,13 @@ class LanceFragment(pa.dataset.Fragment):
         ----------
         filename: str
             The filename of the datafile.
-        scheme: pa.Schema
-            The schema for the new datafile.
+        dataset: LanceDataset
+            The dataset that the fragment belongs to.
         fragment_id: int
             The ID of the fragment.
         """
-        return _Fragment.create_from_file(filename, schema, fragment_id)
+        fragment = _Fragment.create_from_file(filename, dataset._ds, fragment_id)
+        return FragmentMetadata(fragment.json())
 
     @staticmethod
     def create(

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -72,7 +72,7 @@ pub use crate::tracing::{trace_to_chrome, TraceGuard};
 use crate::utils::Hnsw;
 use crate::utils::KMeans;
 pub use dataset::write_dataset;
-pub use dataset::{Dataset, Operation};
+pub use dataset::{Dataset, Operation, RewriteGroup, RewrittenIndex};
 pub use fragment::FragmentMetadata;
 use fragment::{DataFile, FileFragment};
 pub use indices::register_indices;
@@ -111,6 +111,8 @@ fn lance(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Scanner>()?;
     m.add_class::<Dataset>()?;
     m.add_class::<Operation>()?;
+    m.add_class::<RewriteGroup>()?;
+    m.add_class::<RewrittenIndex>()?;
     m.add_class::<FileFragment>()?;
     m.add_class::<FragmentMetadata>()?;
     m.add_class::<MergeInsertBuilder>()?;

--- a/rust/lance-encoding/src/version.rs
+++ b/rust/lance-encoding/src/version.rs
@@ -46,6 +46,7 @@ impl LanceFileVersion {
         match (major, minor) {
             (0, 0) => Ok(Self::Legacy),
             (0, 1) => Ok(Self::Legacy),
+            (0, 2) => Ok(Self::Legacy),
             (0, 3) => Ok(Self::V2_0),
             (2, 0) => Ok(Self::V2_0),
             (2, 1) => Ok(Self::V2_1),

--- a/rust/lance-file/src/lib.rs
+++ b/rust/lance-file/src/lib.rs
@@ -8,4 +8,48 @@ pub mod reader;
 pub mod v2;
 pub mod writer;
 
+use format::MAGIC;
 pub use lance_encoding::version;
+
+use lance_core::{Error, Result};
+use lance_encoding::version::LanceFileVersion;
+use lance_io::object_store::ObjectStore;
+use object_store::path::Path;
+use snafu::{location, Location};
+
+pub async fn determine_file_version(
+    store: &ObjectStore,
+    path: &Path,
+    known_size: Option<usize>,
+) -> Result<LanceFileVersion> {
+    let size = match known_size {
+        None => store.size(path).await.unwrap(),
+        Some(size) => size,
+    };
+    if size < 8 {
+        return Err(Error::InvalidInput {
+            source: format!(
+                "the file {} does not appear to be a lance file (too small)",
+                path
+            )
+            .into(),
+            location: location!(),
+        });
+    }
+    let reader = store.open_with_size(path, size).await?;
+    let footer = reader.get_range((size - 8)..size).await?;
+    if &footer[4..] != MAGIC {
+        return Err(Error::InvalidInput {
+            source: format!(
+                "the file {} does not appear to be a lance file (magic mismatch)",
+                path
+            )
+            .into(),
+            location: location!(),
+        });
+    }
+    let major_version = u16::from_le_bytes([footer[0], footer[1]]);
+    let minor_version = u16::from_le_bytes([footer[2], footer[3]]);
+
+    LanceFileVersion::try_from_major_minor(major_version as u32, minor_version as u32)
+}

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -505,7 +505,7 @@ impl FileReader {
 
     /// Loads a default projection for all columns in the file, using the data type that
     /// was provided when the file was written.
-    fn default_projection(lance_schema: &Schema) -> ReaderProjection {
+    pub fn default_projection(lance_schema: &Schema) -> ReaderProjection {
         let schema = Arc::new(lance_schema.clone());
         let mut column_indices = Vec::with_capacity(lance_schema.fields.len());
         let mut column_index = 0;

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -304,6 +304,9 @@ impl Fragment {
     }
 
     // Helper method to infer the Lance version from a set of fragments
+    //
+    // Returns None if there are no data files
+    // Returns an error if the data files have different versions
     pub fn try_infer_version(fragments: &[Self]) -> Result<Option<LanceFileVersion>> {
         // Otherwise we need to check the actual file versions
         // Determine version from first file

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -18,14 +18,16 @@ use datafusion::logical_expr::Expr;
 use datafusion::scalar::ScalarValue;
 use futures::future::try_join_all;
 use futures::{join, stream, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
+use lance_core::datatypes::SchemaCompareOptions;
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use lance_core::{datatypes::Schema, Error, Result};
 use lance_core::{ROW_ADDR, ROW_ADDR_FIELD, ROW_ID_FIELD};
 use lance_encoding::decoder::DecoderMiddlewareChain;
 use lance_file::reader::{read_batch, FileReader};
-use lance_file::v2;
 use lance_file::v2::reader::{CachedFileMetadata, ReaderProjection};
+use lance_file::version::LanceFileVersion;
+use lance_file::{determine_file_version, v2};
 use lance_io::object_store::ObjectStore;
 use lance_io::scheduler::{FileScheduler, ScanScheduler, SchedulerConfig};
 use lance_io::ReadBatchParams;
@@ -423,13 +425,63 @@ impl FileFragment {
 
     pub async fn create_from_file(
         filename: &str,
-        schema: &Schema,
+        dataset: &Dataset,
         fragment_id: usize,
         physical_rows: Option<usize>,
     ) -> Result<Fragment> {
-        let fragment =
-            Fragment::with_file_legacy(fragment_id as u64, filename, schema, physical_rows);
-        Ok(fragment)
+        let filepath = dataset.data_dir().child(filename);
+        let file_version =
+            determine_file_version(dataset.object_store.as_ref(), &filepath, None).await?;
+
+        if file_version != dataset.manifest.data_storage_format.lance_file_version()? {
+            return Err(Error::io(
+                format!(
+                    "File version mismatch. Dataset verison: {:?} Fragment version: {:?}",
+                    dataset.manifest.data_storage_format.lance_file_version()?,
+                    file_version
+                ),
+                location!(),
+            ));
+        }
+
+        if file_version == LanceFileVersion::Legacy {
+            let fragment = Fragment::with_file_legacy(
+                fragment_id as u64,
+                filename,
+                dataset.schema(),
+                physical_rows,
+            );
+            Ok(fragment)
+        } else {
+            // Load the file metadata, confirm the schema is compatible, and
+            // determine the column offsets
+            let mut frag = Fragment::new(fragment_id as u64);
+            let scheduler = ScanScheduler::new(
+                dataset.object_store.clone(),
+                SchedulerConfig::max_bandwidth(&dataset.object_store),
+            );
+            let file_scheduler = scheduler.open_file(&filepath).await?;
+            let reader = v2::reader::FileReader::try_open(
+                file_scheduler,
+                None,
+                DecoderMiddlewareChain::default(),
+            )
+            .await?;
+            // If the schemas are not compatible we can't calculate field id offsets
+            reader
+                .schema()
+                .check_compatible(dataset.schema(), &SchemaCompareOptions::default())?;
+            let projection = v2::reader::FileReader::default_projection(dataset.schema());
+
+            let column_indices = projection
+                .column_indices
+                .into_iter()
+                .map(|c| c as i32)
+                .collect();
+
+            frag.add_file(filename, dataset.schema().field_ids(), column_indices);
+            Ok(frag)
+        }
     }
 
     pub fn dataset(&self) -> &Dataset {
@@ -1756,14 +1808,16 @@ mod tests {
     use arrow_array::{ArrayRef, Int32Array, RecordBatchIterator, StringArray};
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
     use lance_core::ROW_ID;
+    use lance_datagen::{array, gen, RowCount};
     use lance_file::version::LanceFileVersion;
     use lance_io::object_store::ObjectStoreRegistry;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use tempfile::tempdir;
+    use v2::writer::FileWriterOptions;
 
     use super::*;
-    use crate::dataset::transaction::Operation;
+    use crate::{dataset::transaction::Operation, utils::test::TestDatasetGenerator};
 
     async fn create_dataset(test_uri: &str, data_storage_version: LanceFileVersion) -> Dataset {
         let schema = Arc::new(ArrowSchema::new(vec![
@@ -2177,7 +2231,7 @@ mod tests {
 
         let mut fragments: Vec<Fragment> = Vec::new();
         for (idx, path) in paths.iter().enumerate() {
-            let f = FileFragment::create_from_file(path, schema, idx, None)
+            let f = FileFragment::create_from_file(path, &dataset, idx, None)
                 .await
                 .unwrap();
             fragments.push(f)
@@ -2593,5 +2647,65 @@ mod tests {
         assert!(matches!(res, Err(Error::IO { .. })));
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_from_file_v2() {
+        let test_dir = tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let make_gen = || {
+            gen()
+                .col("str", array::rand_type(&DataType::Utf8))
+                .col("int", array::rand_type(&DataType::Int32))
+        };
+
+        let batch = make_gen().into_batch_rows(RowCount::from(128)).unwrap();
+        let dataset = TestDatasetGenerator::new(vec![batch], LanceFileVersion::Stable)
+            .make_hostile(test_uri)
+            .await;
+
+        let new_data = make_gen().into_batch_rows(RowCount::from(128)).unwrap();
+        let store = ObjectStore::local();
+        let file_path = dataset.data_dir().child("some_file.lance");
+        let object_writer = store.create(&file_path).await.unwrap();
+        let mut file_writer =
+            v2::writer::FileWriter::new_lazy(object_writer, FileWriterOptions::default());
+        file_writer.write_batch(&new_data).await.unwrap();
+        file_writer.finish().await.unwrap();
+
+        let frag = FileFragment::create_from_file("some_file.lance", &dataset, 0, Some(128))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            Fragment::try_infer_version(&[frag.clone()])
+                .unwrap()
+                .unwrap(),
+            LanceFileVersion::Stable.resolve()
+        );
+
+        let op = Operation::Append {
+            fragments: vec![frag],
+        };
+        let object_store_registry = Arc::new(ObjectStoreRegistry::default());
+        let dataset = Dataset::commit(
+            &dataset.uri,
+            op,
+            Some(dataset.version().version),
+            None,
+            None,
+            object_store_registry,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            dataset
+                .count_rows(Some("int IS NOT NULL".to_string()))
+                .await
+                .unwrap(),
+            256
+        );
     }
 }

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -472,6 +472,9 @@ impl FileFragment {
                 .schema()
                 .check_compatible(dataset.schema(), &SchemaCompareOptions::default())?;
             let projection = v2::reader::FileReader::default_projection(dataset.schema());
+            let physical_rows = reader.metadata().num_rows as usize;
+            frag.physical_rows = Some(physical_rows);
+            frag.id = fragment_id as u64;
 
             let column_indices = projection
                 .column_indices

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -614,19 +614,6 @@ impl Transaction {
             Manifest::new(schema, Arc::new(final_fragments), data_storage_format)
         };
 
-        if let Some(frag_version) = Fragment::try_infer_version(&manifest.fragments)? {
-            if frag_version != manifest.data_storage_format.lance_file_version()? {
-                return Err(Error::invalid_input(
-                    format!(
-                        "Data storage format version ({}) does not match version in fragments ({})",
-                        manifest.data_storage_format.lance_file_version()?,
-                        frag_version,
-                    ),
-                    location!(),
-                ));
-            }
-        }
-
         manifest.tag.clone_from(&self.tag);
 
         if config.auto_set_feature_flags {

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -614,6 +614,19 @@ impl Transaction {
             Manifest::new(schema, Arc::new(final_fragments), data_storage_format)
         };
 
+        if let Some(frag_version) = Fragment::try_infer_version(&manifest.fragments)? {
+            if frag_version != manifest.data_storage_format.lance_file_version()? {
+                return Err(Error::invalid_input(
+                    format!(
+                        "Data storage format version ({}) does not match version in fragments ({})",
+                        manifest.data_storage_format.lance_file_version()?,
+                        frag_version,
+                    ),
+                    location!(),
+                ));
+            }
+        }
+
         manifest.tag.clone_from(&self.tag);
 
         if config.auto_set_feature_flags {


### PR DESCRIPTION
Previously `LanceFragment.create_from_file` only worked for v1 files.  This makes it possible to use for v2 files.  I also added a check in the commit step to confirm we do not allow files to be added unless they match the dataset version.