### PR TITLE
feat: add table config

### DIFF
--- a/protos/table.proto
+++ b/protos/table.proto
@@ -85,6 +85,7 @@ message Manifest {
   // * 1: deletion files are present
   // * 2: move_stable_row_ids: row IDs are tracked and stable after move operations
   //       (such as compaction), but not updates.
+  // * 8: table metadata are present
   uint64 reader_feature_flags = 9;
 
   // Feature flags for writers.
@@ -137,6 +138,9 @@ message Manifest {
   //
   // This specifies what format is used to store the data files.
   DataStorageFormat data_format = 15;
+  
+  // Table metadata.
+  map<string, string> table_metadata = 16;
 } // Manifest
 
 // Auxiliary Data attached to a version.

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -86,7 +86,7 @@ message Manifest {
   // * 2: move_stable_row_ids: row IDs are tracked and stable after move operations
   //       (such as compaction), but not updates.
   // * 4: use v2 format (deprecated)
-  // * 8: table metadata are present
+  // * 8: table config is present
   uint64 reader_feature_flags = 9;
 
   // Feature flags for writers.
@@ -140,12 +140,12 @@ message Manifest {
   // This specifies what format is used to store the data files.
   DataStorageFormat data_format = 15;
   
-  // Table metadata.
+  // Table config.
   //
   // Keys with the prefix "lance." are reserved for the Lance library. Other
   // libraries may wish to similarly prefix their configuration keys
   // appropriately.
-  map<string, string> table_metadata = 16;
+  map<string, string> config = 16;
 } // Manifest
 
 // Auxiliary Data attached to a version.

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -141,6 +141,10 @@ message Manifest {
   DataStorageFormat data_format = 15;
   
   // Table metadata.
+  //
+  // Keys with the prefix "lance." are reserved for the Lance library. Other
+  // libraries may wish to similarly prefix their configuration keys
+  // appropriately.
   map<string, string> table_metadata = 16;
 } // Manifest
 

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -85,6 +85,7 @@ message Manifest {
   // * 1: deletion files are present
   // * 2: move_stable_row_ids: row IDs are tracked and stable after move operations
   //       (such as compaction), but not updates.
+  // * 4: use v2 format (deprecated)
   // * 8: table metadata are present
   uint64 reader_feature_flags = 9;
 

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -156,6 +156,17 @@ message Transaction {
     // The new fragments where updated rows have been moved to.
     repeated DataFragment new_fragments = 3;
   }
+  
+  // An operation that sets table metadata.
+  message SetMetadata {
+    map<string, string> metadata = 1;
+  }
+  
+  // An operation that deletes table metadata.
+  message DeleteMetadata {
+    repeated string metadata_keys = 1;
+  }
+
 
   // The operation of this transaction.
   oneof operation {
@@ -169,5 +180,7 @@ message Transaction {
     ReserveFragments reserve_fragments = 107;
     Update update = 108;
     Project project = 109;
+    SetMetadata set_metadata = 110;
+    DeleteMetadata delete_metadata = 111;
   }
 }

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -61,6 +61,8 @@ message Transaction {
     repeated lance.file.Field schema = 2;
     // Schema metadata.
     map<string, bytes> schema_metadata = 3;
+    // Table metadata to merge with existing table metadata.
+    map<string, string> table_metadata = 4;
   }
 
   // Add or replace a new secondary index.

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -61,8 +61,8 @@ message Transaction {
     repeated lance.file.Field schema = 2;
     // Schema metadata.
     map<string, bytes> schema_metadata = 3;
-    // Table metadata to merge with existing table metadata.
-    map<string, string> table_metadata = 4;
+    // Key-value pairs to merge with existing config.
+    map<string, string> config_upsert_values = 4;
   }
 
   // Add or replace a new secondary index.
@@ -159,16 +159,11 @@ message Transaction {
     repeated DataFragment new_fragments = 3;
   }
   
-  // An operation that sets table metadata.
-  message SetMetadata {
-    map<string, string> metadata = 1;
+  // An operation that updates the table config.
+  message UpdateConfig {
+    map<string, string> upsert_values = 1;
+    repeated string delete_keys = 2;
   }
-  
-  // An operation that deletes table metadata.
-  message DeleteMetadata {
-    repeated string metadata_keys = 1;
-  }
-
 
   // The operation of this transaction.
   oneof operation {
@@ -182,7 +177,6 @@ message Transaction {
     ReserveFragments reserve_fragments = 107;
     Update update = 108;
     Project project = 109;
-    SetMetadata set_metadata = 110;
-    DeleteMetadata delete_metadata = 111;
+    UpdateConfig update_config = 110;
   }
 }

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -269,7 +269,11 @@ impl Operation {
     ) -> PyResult<Self> {
         let schema = convert_schema(&schema.0)?;
         let fragments = into_fragments(fragments);
-        let op = LanceOperation::Overwrite { fragments, schema };
+        let op = LanceOperation::Overwrite {
+            fragments,
+            schema,
+            table_metadata: None,
+        };
         Ok(Self(op))
     }
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -272,7 +272,7 @@ impl Operation {
         let op = LanceOperation::Overwrite {
             fragments,
             schema,
-            table_metadata: None,
+            config_upsert_values: None,
         };
         Ok(Self(op))
     }

--- a/rust/lance-table/README.md
+++ b/rust/lance-table/README.md
@@ -1,6 +1,6 @@
-# lance-file
+# lance-table
 
-`lance-file` is an internal sub-crate, containing readers and writers for the
+`lance-table` is an internal sub-crate for the
 [Lance table format](https://lancedb.github.io/lance/format.html).
 
 **Important Note**: This crate is **not intended for external usage**.

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -58,7 +58,7 @@ pub fn apply_feature_flags(manifest: &mut Manifest, enable_stable_row_id: bool) 
     }
 
     // Test whether any table metadata has been set
-    if !manifest.table_metadata.is_empty() {
+    if !manifest.config.is_empty() {
         manifest.reader_feature_flags |= FLAG_TABLE_METADATA;
         manifest.writer_feature_flags |= FLAG_TABLE_METADATA;
     }

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -16,8 +16,8 @@ pub const FLAG_DELETION_FILES: u64 = 1;
 pub const FLAG_MOVE_STABLE_ROW_IDS: u64 = 2;
 /// Files are written with the new v2 format (this flag is no longer used)
 pub const FLAG_USE_V2_FORMAT_DEPRECATED: u64 = 4;
-/// Table metadata is present
-pub const FLAG_TABLE_METADATA: u64 = 8;
+/// Table config is present
+pub const FLAG_TABLE_CONFIG: u64 = 8;
 /// The first bit that is unknown as a feature flag
 pub const FLAG_UNKNOWN: u64 = 16;
 
@@ -59,8 +59,7 @@ pub fn apply_feature_flags(manifest: &mut Manifest, enable_stable_row_id: bool) 
 
     // Test whether any table metadata has been set
     if !manifest.config.is_empty() {
-        manifest.reader_feature_flags |= FLAG_TABLE_METADATA;
-        manifest.writer_feature_flags |= FLAG_TABLE_METADATA;
+        manifest.writer_feature_flags |= FLAG_TABLE_CONFIG;
     }
 
     Ok(())
@@ -88,12 +87,10 @@ mod tests {
         assert!(can_read_dataset(super::FLAG_DELETION_FILES));
         assert!(can_read_dataset(super::FLAG_MOVE_STABLE_ROW_IDS));
         assert!(can_read_dataset(super::FLAG_USE_V2_FORMAT_DEPRECATED));
-        assert!(can_read_dataset(super::FLAG_TABLE_METADATA));
         assert!(can_read_dataset(
             super::FLAG_DELETION_FILES
                 | super::FLAG_MOVE_STABLE_ROW_IDS
                 | super::FLAG_USE_V2_FORMAT_DEPRECATED
-                | super::FLAG_TABLE_METADATA
         ));
         assert!(!can_read_dataset(super::FLAG_UNKNOWN));
     }
@@ -104,12 +101,12 @@ mod tests {
         assert!(can_write_dataset(super::FLAG_DELETION_FILES));
         assert!(can_write_dataset(super::FLAG_MOVE_STABLE_ROW_IDS));
         assert!(can_write_dataset(super::FLAG_USE_V2_FORMAT_DEPRECATED));
-        assert!(can_write_dataset(super::FLAG_TABLE_METADATA));
+        assert!(can_write_dataset(super::FLAG_TABLE_CONFIG));
         assert!(can_write_dataset(
             super::FLAG_DELETION_FILES
                 | super::FLAG_MOVE_STABLE_ROW_IDS
                 | super::FLAG_USE_V2_FORMAT_DEPRECATED
-                | super::FLAG_TABLE_METADATA
+                | super::FLAG_TABLE_CONFIG
         ));
         assert!(!can_write_dataset(super::FLAG_UNKNOWN));
     }

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -16,8 +16,10 @@ pub const FLAG_DELETION_FILES: u64 = 1;
 pub const FLAG_MOVE_STABLE_ROW_IDS: u64 = 2;
 /// Files are written with the new v2 format (this flag is no longer used)
 pub const FLAG_USE_V2_FORMAT_DEPRECATED: u64 = 4;
+/// Table metadata is present
+pub const FLAG_TABLE_METADATA: u64 = 8;
 /// The first bit that is unknown as a feature flag
-pub const FLAG_UNKNOWN: u64 = 8;
+pub const FLAG_UNKNOWN: u64 = 16;
 
 /// Set the reader and writer feature flags in the manifest based on the contents of the manifest.
 pub fn apply_feature_flags(manifest: &mut Manifest, enable_stable_row_id: bool) -> Result<()> {
@@ -55,6 +57,12 @@ pub fn apply_feature_flags(manifest: &mut Manifest, enable_stable_row_id: bool) 
         manifest.writer_feature_flags |= FLAG_MOVE_STABLE_ROW_IDS;
     }
 
+    // Test whether any table metadata has been set
+    if !manifest.table_metadata.is_empty() {
+        manifest.reader_feature_flags |= FLAG_TABLE_METADATA;
+        manifest.writer_feature_flags |= FLAG_TABLE_METADATA;
+    }
+
     Ok(())
 }
 
@@ -80,8 +88,12 @@ mod tests {
         assert!(can_read_dataset(super::FLAG_DELETION_FILES));
         assert!(can_read_dataset(super::FLAG_MOVE_STABLE_ROW_IDS));
         assert!(can_read_dataset(super::FLAG_USE_V2_FORMAT_DEPRECATED));
+        assert!(can_read_dataset(super::FLAG_TABLE_METADATA));
         assert!(can_read_dataset(
-            super::FLAG_DELETION_FILES | super::FLAG_MOVE_STABLE_ROW_IDS
+            super::FLAG_DELETION_FILES
+                | super::FLAG_MOVE_STABLE_ROW_IDS
+                | super::FLAG_USE_V2_FORMAT_DEPRECATED
+                | super::FLAG_TABLE_METADATA
         ));
         assert!(!can_read_dataset(super::FLAG_UNKNOWN));
     }
@@ -91,11 +103,13 @@ mod tests {
         assert!(can_write_dataset(0));
         assert!(can_write_dataset(super::FLAG_DELETION_FILES));
         assert!(can_write_dataset(super::FLAG_MOVE_STABLE_ROW_IDS));
-        assert!(can_read_dataset(super::FLAG_USE_V2_FORMAT_DEPRECATED));
+        assert!(can_write_dataset(super::FLAG_USE_V2_FORMAT_DEPRECATED));
+        assert!(can_write_dataset(super::FLAG_TABLE_METADATA));
         assert!(can_write_dataset(
             super::FLAG_DELETION_FILES
                 | super::FLAG_MOVE_STABLE_ROW_IDS
                 | super::FLAG_USE_V2_FORMAT_DEPRECATED
+                | super::FLAG_TABLE_METADATA
         ));
         assert!(!can_write_dataset(super::FLAG_UNKNOWN));
     }

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -167,16 +167,15 @@ impl Manifest {
         self.timestamp_nanos = nanos;
     }
 
-    /// Set the `table_metadata` from a metadata HashMap
-    pub fn set_metadata(&mut self, metadata: HashMap<String, String>) {
+    /// Set the `table_metadata` from a metadata iterator
+    pub fn set_metadata(&mut self, metadata: impl IntoIterator<Item = (String, String)>) {
         self.table_metadata.extend(metadata);
     }
 
-    /// Delete `table_metadata` keys using a Vec of metadata keys
-    pub fn delete_metadata(&mut self, metadata_keys: Vec<String>) {
-        for key in metadata_keys {
-            self.table_metadata.remove(&key);
-        }
+    /// Delete `table_metadata` keys using a slice of metadata keys
+    pub fn delete_metadata(&mut self, metadata_keys: &[&str]) {
+        self.table_metadata
+            .retain(|key, _| !metadata_keys.contains(&key.as_str()));
     }
 
     /// Check the current fragment list and update the high water mark
@@ -737,7 +736,7 @@ mod tests {
         assert_eq!(manifest.table_metadata, metadata.clone());
 
         metadata.remove("other-key");
-        manifest.delete_metadata(vec!["other-key".to_string()]);
+        manifest.delete_metadata(&["other-key"]);
         assert_eq!(manifest.table_metadata, metadata);
     }
 }

--- a/rust/lance-table/src/io/manifest.rs
+++ b/rust/lance-table/src/io/manifest.rs
@@ -244,8 +244,8 @@ mod test {
             ArrowSchema::new(vec![ArrowField::new(long_name, DataType::Int64, false)]);
         let schema = Schema::try_from(&arrow_schema).unwrap();
 
-        let mut table_metadata = HashMap::new();
-        table_metadata.insert("key".to_string(), "value".to_string());
+        let mut config = HashMap::new();
+        config.insert("key".to_string(), "value".to_string());
 
         let mut manifest = Manifest::new(schema, Arc::new(vec![]), DataStorageFormat::default());
         let pos = write_manifest(&mut writer, &mut manifest, None)

--- a/rust/lance-table/src/io/manifest.rs
+++ b/rust/lance-table/src/io/manifest.rs
@@ -243,6 +243,10 @@ mod test {
         let arrow_schema =
             ArrowSchema::new(vec![ArrowField::new(long_name, DataType::Int64, false)]);
         let schema = Schema::try_from(&arrow_schema).unwrap();
+
+        let mut table_metadata = HashMap::new();
+        table_metadata.insert("key".to_string(), "value".to_string());
+
         let mut manifest = Manifest::new(schema, Arc::new(vec![]), DataStorageFormat::default());
         let pos = write_manifest(&mut writer, &mut manifest, None)
             .await

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -2357,6 +2357,7 @@ mod tests {
         let op = Operation::Overwrite {
             schema: schema.clone(),
             fragments,
+            table_metadata: None,
         };
 
         let registry = Arc::new(ObjectStoreRegistry::default());
@@ -2457,6 +2458,7 @@ mod tests {
             let op = Operation::Overwrite {
                 fragments: vec![new_fragment],
                 schema: full_schema.clone(),
+                table_metadata: None,
             };
 
             let registry = Arc::new(ObjectStoreRegistry::default());

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -2357,7 +2357,7 @@ mod tests {
         let op = Operation::Overwrite {
             schema: schema.clone(),
             fragments,
-            table_metadata: None,
+            config_upsert_values: None,
         };
 
         let registry = Arc::new(ObjectStoreRegistry::default());
@@ -2458,7 +2458,7 @@ mod tests {
             let op = Operation::Overwrite {
                 fragments: vec![new_fragment],
                 schema: full_schema.clone(),
-                table_metadata: None,
+                config_upsert_values: None,
             };
 
             let registry = Arc::new(ObjectStoreRegistry::default());

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -916,6 +916,123 @@ mod tests {
         }
     }
 
+    async fn get_empty_dataset() -> Dataset {
+        let test_dir = tempfile::tempdir().unwrap();
+        let test_uri = test_dir.path().to_str().unwrap();
+
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "i",
+            DataType::Int32,
+            false,
+        )]));
+
+        Dataset::write(
+            RecordBatchIterator::new(vec![].into_iter().map(Ok), schema.clone()),
+            test_uri,
+            None,
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_good_concurrent_config_writes() {
+        let dataset = get_empty_dataset().await;
+
+        // Test successful concurrent set operations
+        let futures: Vec<_> = ["key1", "key2", "key3", "key4", "key5"]
+            .iter()
+            .map(|key| {
+                let mut dataset = dataset.clone();
+                tokio::spawn(async move {
+                    dataset
+                        .set_table_metadata(vec![(key.to_string(), "value".to_string())])
+                        .await
+                })
+            })
+            .collect();
+        let results = join_all(futures).await;
+
+        // Assert all succeeded
+        for result in results {
+            assert!(matches!(result, Ok(Ok(_))), "{:?}", result);
+        }
+
+        let dataset = dataset.checkout_version(6).await.unwrap();
+        assert_eq!(dataset.manifest.table_metadata.len(), 5);
+
+        dataset.validate().await.unwrap();
+
+        // Test successful concurrent delete operations. If multiple delete
+        // operations attempt to delete the same key, they are all successful.
+        let futures: Vec<_> = ["key1", "key1", "key1", "key2", "key2"]
+            .iter()
+            .map(|key| {
+                let mut dataset = dataset.clone();
+                tokio::spawn(async move {
+                    dataset
+                        .delete_table_metadata(&[key])
+                        .await
+                })
+            })
+            .collect();
+        let results = join_all(futures).await;
+
+        // Assert all succeeded
+        for result in results {
+            assert!(matches!(result, Ok(Ok(_))), "{:?}", result);
+        }
+
+        let dataset = dataset.checkout_version(11).await.unwrap();
+
+        // There are now two fewer keys
+        assert_eq!(dataset.manifest.table_metadata.len(), 3);
+
+        dataset.validate().await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_bad_concurrent_config_writes() {
+        // If two concurrent set metadata operations occur for the same key, a 
+        // `CommitConflict` should be returned
+        let dataset = get_empty_dataset().await;
+
+        let futures: Vec<_> = ["key1", "key1", "key2", "key3", "key4"]
+            .iter()
+            .map(|key| {
+                let mut dataset = dataset.clone();
+                tokio::spawn(async move {
+                    dataset
+                        .set_table_metadata(vec![(key.to_string(), "value".to_string())])
+                        .await
+                })
+            })
+            .collect();
+        
+        let results = join_all(futures).await;
+
+        // Assert that either the first or the second operation fails
+        let mut first_operation_failed = false;
+        let error_fragment = "Commit conflict for version";
+        for (i, result) in results.into_iter().enumerate() {
+            match i {
+                0 => {
+                    if !matches!(result, Ok(Ok(_))) {
+                        first_operation_failed = true;
+                        assert!(result.unwrap().err().unwrap().to_string().contains(error_fragment));
+                    }
+                },
+                1 => {
+                    match first_operation_failed {
+                        true => assert!(matches!(result, Ok(Ok(_))), "{:?}", result),
+                        false => assert!(result.unwrap().err().unwrap().to_string().contains(error_fragment))
+                    }
+                },
+                _ => assert!(matches!(result, Ok(Ok(_))), "{:?}", result)
+            }
+        }
+    }
+
     #[test]
     fn test_fix_schema() {
         // Manifest has a fragment with no fields in use

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -110,7 +110,11 @@ impl TestDatasetGenerator {
             }
         }
 
-        let operation = Operation::Overwrite { fragments, schema };
+        let operation = Operation::Overwrite {
+            fragments,
+            schema,
+            table_metadata: None,
+        };
 
         let registry = Arc::new(ObjectStoreRegistry::default());
         Dataset::commit(

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -113,7 +113,7 @@ impl TestDatasetGenerator {
         let operation = Operation::Overwrite {
             fragments,
             schema,
-            table_metadata: None,
+            config_upsert_values: None,
         };
 
         let registry = Arc::new(ObjectStoreRegistry::default());


### PR DESCRIPTION
Closes #2200 

#2200 reference the concept of "table metadata". This PR uses the name "config" to avoid potential confusion with other uses of the word "metadata" throughout the Lance format.

This PR introduces:
- A new `table.proto` field called `config`.
- New `Dataset` methods: `update_config` and `delete_config_keys`.
- `config` field in `Manifest` with public methods for updating and deleting.
- A new transaction operation `UpdateConfig` along with conflict logic that returns an error if an operation mutates a key that is being upserted by another operation.
- A new writer feature flag called `FLAG_TABLE_CONFIG`.
- Unit tests for new `Dataset` methods, concurrent config updaters, and conflict resolution logic.