### PR TITLE
fix: torch to_tensor for FixedShapeTensorType data

### DIFF
--- a/python/python/lance/torch/data.py
+++ b/python/python/lance/torch/data.py
@@ -46,7 +46,6 @@ def _to_tensor(
         tensor: torch.Tensor = None
         if (
             pa.types.is_fixed_size_list(arr.type)
-            or isinstance(arr.type, pa.FixedShapeTensorType)
         ) and (
             pa.types.is_floating(arr.type.value_type)
             or pa.types.is_integer(arr.type.value_type)
@@ -54,6 +53,15 @@ def _to_tensor(
             np_tensor = arr.values.to_numpy(zero_copy_only=True).reshape(
                 -1, arr.type.list_size
             )
+            tensor = torch.from_numpy(np_tensor)
+            del np_tensor
+        elif (
+            isinstance(arr.type, pa.FixedShapeTensorType)
+        ) and (
+            pa.types.is_floating(arr.type.value_type)
+            or pa.types.is_integer(arr.type.value_type)
+        ):
+            np_tensor = np.stack(arr.to_numpy(zero_copy_only=False))
             tensor = torch.from_numpy(np_tensor)
             del np_tensor
         elif (

--- a/python/python/lance/torch/data.py
+++ b/python/python/lance/torch/data.py
@@ -44,6 +44,12 @@ def _to_tensor(
         arr: pa.Array = batch[col]
 
         tensor: torch.Tensor = None
+        if (isinstance(arr.type, pa.FixedShapeTensorType)) and (
+            pa.types.is_floating(arr.type.value_type)
+            or pa.types.is_integer(arr.type.value_type)
+        ):
+            arr = arr.storage
+
         if (pa.types.is_fixed_size_list(arr.type)) and (
             pa.types.is_floating(arr.type.value_type)
             or pa.types.is_integer(arr.type.value_type)
@@ -51,13 +57,6 @@ def _to_tensor(
             np_tensor = arr.values.to_numpy(zero_copy_only=True).reshape(
                 -1, arr.type.list_size
             )
-            tensor = torch.from_numpy(np_tensor)
-            del np_tensor
-        elif (isinstance(arr.type, pa.FixedShapeTensorType)) and (
-            pa.types.is_floating(arr.type.value_type)
-            or pa.types.is_integer(arr.type.value_type)
-        ):
-            np_tensor = np.stack(arr.to_numpy(zero_copy_only=False))
             tensor = torch.from_numpy(np_tensor)
             del np_tensor
         elif (

--- a/python/python/lance/torch/data.py
+++ b/python/python/lance/torch/data.py
@@ -44,9 +44,7 @@ def _to_tensor(
         arr: pa.Array = batch[col]
 
         tensor: torch.Tensor = None
-        if (
-            pa.types.is_fixed_size_list(arr.type)
-        ) and (
+        if (pa.types.is_fixed_size_list(arr.type)) and (
             pa.types.is_floating(arr.type.value_type)
             or pa.types.is_integer(arr.type.value_type)
         ):
@@ -55,9 +53,7 @@ def _to_tensor(
             )
             tensor = torch.from_numpy(np_tensor)
             del np_tensor
-        elif (
-            isinstance(arr.type, pa.FixedShapeTensorType)
-        ) and (
+        elif (isinstance(arr.type, pa.FixedShapeTensorType)) and (
             pa.types.is_floating(arr.type.value_type)
             or pa.types.is_integer(arr.type.value_type)
         ):

--- a/python/python/tests/torch_tests/test_data.py
+++ b/python/python/tests/torch_tests/test_data.py
@@ -22,7 +22,7 @@ def test_iter_over_dataset_fixed_shape_tensor(tmp_path):
     ids = pa.array(range(0, 10240), type=pa.int32())
     tbl = pa.Table.from_arrays([ids, tensor_array], ["ids", "vec"])
 
-    ds = lance.write_dataset(tbl, tmp_path / "data.lance")
+    lance.write_dataset(tbl, tmp_path / "data.lance")
 
     iter_over_dataset(tmp_path)
 
@@ -35,7 +35,7 @@ def test_iter_over_dataset_fixed_size_lists(tmp_path):
     ids = pa.array(range(0, 10240), type=pa.int32())
     tbl = pa.Table.from_arrays([ids, fsl], ["ids", "vec"])
 
-    ds = lance.write_dataset(tbl, tmp_path / "data.lance", max_rows_per_group=32)
+    lance.write_dataset(tbl, tmp_path / "data.lance", max_rows_per_group=32)
 
     iter_over_dataset(tmp_path)
 

--- a/python/python/tests/torch_tests/test_data.py
+++ b/python/python/tests/torch_tests/test_data.py
@@ -15,7 +15,19 @@ torch = pytest.importorskip("torch")
 from lance.torch.data import LanceDataset  # noqa: E402
 
 
-def test_iter_over_dataset(tmp_path):
+def test_iter_over_dataset_fixed_shape_tensor(tmp_path):
+    data = np.random.random((10240, 32)).astype("f")
+
+    tensor_array = pa.FixedShapeTensorArray.from_numpy_ndarray(data)
+    ids = pa.array(range(0, 10240), type=pa.int32())
+    tbl = pa.Table.from_arrays([ids, tensor_array], ["ids", "vec"])
+
+    ds = lance.write_dataset(tbl, tmp_path / "data.lance")
+
+    iter_over_dataset(tmp_path)
+
+
+def test_iter_over_dataset_fixed_size_lists(tmp_path):
     # 10240 of 32-d vectors.
     data = np.random.random(10240 * 32).astype("f")
 
@@ -24,6 +36,12 @@ def test_iter_over_dataset(tmp_path):
     tbl = pa.Table.from_arrays([ids, fsl], ["ids", "vec"])
 
     ds = lance.write_dataset(tbl, tmp_path / "data.lance", max_rows_per_group=32)
+
+    iter_over_dataset(tmp_path)
+
+
+def iter_over_dataset(tmp_path):
+    ds = lance.dataset(tmp_path / "data.lance")
 
     # test when sample size is smaller than max_takes
     torch_ds_small = LanceDataset(


### PR DESCRIPTION
Fixes #2819

<details>

<summary>Test script</summary>

```py
import lance
import pyarrow as pa
import pyarrow.compute as pc
import time
import lance.torch.data as ltd
import torch
from torch.utils.data import DataLoader
import numpy as np


# Generate data
dims = 128
nrows = 10_000_000

def next_batch(batch_size, offset):
    values = pc.random(dims * batch_size).cast('float32')
    return pa.table({
        'id': pa.array([offset + j for j in range(batch_size)]),
        'vector': pa.FixedSizeListArray.from_arrays(values, dims),
    }).to_batches()[0]

def batch_iter(num_rows):
    i = 0
    while i < num_rows:
        batch_size = min(10_000, num_rows - i)
        yield next_batch(batch_size, i)
        i += batch_size

schema = next_batch(1, 0).schema

ds_path_1 = "./temp-test-torch-1.lance"

lance.write_dataset(batch_iter(nrows), ds_path_1, schema=schema, mode="overwrite")

ds_1 = lance.dataset(ds_path_1)

# Currently broken version (fixed shape tensor array)
ds_path_2 = "./temp-test-torch-2.lance"
nrows_2 = 100_000

table = pa.table({
   "id": pa.array([i for i in range(nrows_2)]),
   "vector": pa.FixedShapeTensorArray.from_numpy_ndarray(
       np.random.rand(nrows_2, dims).astype("float32"))
})
lance.write_dataset(table, ds_path_2, mode="overwrite")

ds_2 = lance.dataset(ds_path_2)

def run_torch_integration(tag, ds):
    # Torch integration
    tdataset = ltd.LanceDataset(
        ds,
        columns=["vector"],
        batch_size=1024,
        batch_readahead=8,
        with_row_id=True,
    )
    
    start_time = time.time()
    
    tdataloader = DataLoader(tdataset)
    for tbatch in tdataloader:
        tvecs = tbatch["vector"]
        trow_ids = tbatch["_rowid"]
    
    end_time = time.time()
    elapsed_time = end_time - start_time
    print(f"{tag} Torch integration elapsed time: {elapsed_time:.6f} seconds")

def run_manual_batches(tag, ds):
    # Manual to_batches and frombuffer
    start_time = time.time()
    
    for batch in ds.to_batches(
            columns=["vector"],
            batch_size=1024,
            batch_readahead=8, 
            with_row_id=True,
    ):
        batch_vecs = batch["vector"]
        
        vecs = torch.frombuffer(batch_vecs.buffers()[2], dtype=torch.float32)
        vecs = vecs.view(len(batch_vecs), dims)
        batch_row_ids = batch["_rowid"]
        row_ids = torch.frombuffer(batch_row_ids.buffers()[1], dtype=torch.int64)
        row_ids = row_ids.view(len(batch_row_ids), 1).squeeze()
    
    end_time = time.time()
    elapsed_time = end_time - start_time
    print(f"{tag} Manual ver elapsed time: {elapsed_time:.6f} seconds")

def run_batch_check(tag, ds):
    # Torch integration
    tdataset = ltd.LanceDataset(
        ds,
        columns=["vector"],
        batch_size=1024,
        batch_readahead=8,
        with_row_id=True,
    )
    # Verify that this actually produces the same data
    max_diff = 0
    
    tdataloader = DataLoader(tdataset)
    for tbatch, batch in zip(tdataloader, ds.to_batches(
            columns=["vector"],
            batch_size=1024,
            batch_readahead=8,
            with_row_id=True,
    )):
        tvecs = tbatch["vector"]
        trow_ids = tbatch["_rowid"]
        
        batch_vecs = batch["vector"]
        vecs = torch.frombuffer(batch_vecs.buffers()[2], dtype=torch.float32)
        vecs = vecs.view(len(batch_vecs), dims)
        batch_row_ids = batch["_rowid"]
        row_ids = torch.frombuffer(batch_row_ids.buffers()[1], dtype=torch.int64)
        row_ids = row_ids.view(len(batch_row_ids), 1).squeeze()
    
        max_diff = max(torch.max(torch.abs(tvecs-vecs)).item(), max_diff)
        max_diff = max(torch.max(torch.abs(trow_ids-row_ids)).item(), max_diff)
    
    print(f"{tag} Should be 0: {max_diff}")

def run_ivfpq_cuda(tag, ds):
    # Build speed test
    start_time = time.time()
    ds.create_index(
        "vector",
        index_type="IVF_PQ",
        num_partitions=128,
        num_sub_vectors=64,
        accelerator="cuda",
    )
    end_time = time.time()
    elapsed_time = end_time - start_time
    print(f"{tag} IVFPQ elapsed time: {elapsed_time:.6f} seconds")

run_torch_integration("(List array version)", ds_1)
run_torch_integration("(Fixed shape version)", ds_2)
run_manual_batches("(List array version)", ds_1)
run_manual_batches("(Fixed shape version)", ds_2)
run_batch_check("(List array version)", ds_1)
run_batch_check("(Fixed shape version)", ds_2)
run_ivfpq_cuda("(List array version)", ds_1)
run_ivfpq_cuda("(Fixed shape version)", ds_2)
```

</details>

Test script outputs:
```
main:
(List array version) Torch integration elapsed time: 0.985445 seconds
(crash)
manually reordering to avoid crash to get the list array versions:
(List array version) Torch integration elapsed time: 1.015631 seconds
(List array version) Manual ver elapsed time: 0.388042 seconds
(List array version) Should be 0: 0
(List array version) IVFPQ elapsed time: 49.704247 seconds

0.16.1:
(List array version) Torch integration elapsed time: 5.868160 seconds
(Fixed shape version) Torch integration elapsed time: 0.065993 seconds
(List array version) Manual ver elapsed time: 0.264320 seconds
(Fixed shape version) Manual ver elapsed time: 0.003253 seconds
(List array version) Should be 0: 0
(Fixed shape version) Should be 0: 0
(List array version) IVFPQ elapsed time: 59.084542 seconds
(Fixed shape version) IVFPQ elapsed time: 13.344743 seconds
(no crash)

branch:
(List array version) Torch integration elapsed time: 0.927964 seconds
(Fixed shape version) Torch integration elapsed time: 0.010811 seconds
(List array version) Manual ver elapsed time: 0.356186 seconds
(Fixed shape version) Manual ver elapsed time: 0.004019 seconds
(List array version) Should be 0: 0
(Fixed shape version) Should be 0: 0
(List array version) IVFPQ elapsed time: 49.788106 seconds
(Fixed shape version) IVFPQ elapsed time: 11.678236 seconds
(no crash)
```