### PR TITLE
fix: ensure the v2 file writer does not mix up the order of a column

### DIFF
--- a/python/python/tests/test_file.py
+++ b/python/python/tests/test_file.py
@@ -326,9 +326,9 @@ def test_writer_maintains_order(tmp_path):
     # 100Ki strings, each string is a couple of KiBs
     big_strings = [f"{i}" * 1024 for i in range(100 * 1024)]
     table = pa.table({"big_strings": big_strings})
-    path = tmp_path / "foo.lance"
 
     for i in range(4):
+        path = tmp_path / f"foo-{i}.lance"
         with LanceFileWriter(str(path)) as writer:
             writer.write_batch(table)
 

--- a/python/python/tests/test_file.py
+++ b/python/python/tests/test_file.py
@@ -320,3 +320,18 @@ def test_write_read_additional_schema_metadata(tmp_path):
         reader.metadata().schema.metadata.get(schema_metadata_key.encode()).decode()
         == schema_metadata_value
     )
+
+
+def test_writer_maintains_order(tmp_path):
+    # 100Ki strings, each string is a couple of KiBs
+    big_strings = [f"{i}" * 1024 for i in range(100 * 1024)]
+    table = pa.table({"big_strings": big_strings})
+    path = tmp_path / "foo.lance"
+
+    for i in range(4):
+        with LanceFileWriter(str(path)) as writer:
+            writer.write_batch(table)
+
+        reader = LanceFileReader(str(path))
+        result = reader.read_all().to_table()
+        assert result == table

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -228,6 +228,10 @@ pub trait FieldEncoder: Send {
     fn maybe_encode(&mut self, array: ArrayRef) -> Result<Vec<EncodeTask>>;
     /// Flush any remaining data from the buffers into encoding tasks
     ///
+    /// Each encode task produces a single page.  The order of these pages will be maintained
+    /// in the file (we do not worry about order between columns but all pages in the same
+    /// column should maintain order)
+    ///
     /// This may be called intermittently throughout encoding but will always be called
     /// once at the end of encoding just before calling finish
     fn flush(&mut self) -> Result<Vec<EncodeTask>>;


### PR DESCRIPTION
Sometimes the v2 writer will split a batch into multiple pages.  When it does this it encodes those pages in parallel.  It is possible those encoding tasks finish out of order and the writer was then writing the pages out of order.  This mean the order of one column could get out of sync with the order of another column.