### PR TITLE
feat: propagate `storage_options` to `LanceFileWriter` and `LanceFileReader`

### DIFF
--- a/python/python/lance/file.py
+++ b/python/python/lance/file.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
-from typing import Optional, Union
+from typing import Optional, Union, Dict
 
 import pyarrow as pa
 
@@ -55,7 +55,7 @@ class LanceFileReader:
     """
 
     # TODO: make schema optional
-    def __init__(self, path: str):
+    def __init__(self, path: str, storage_options: Optional[Dict[str, str]] = None):
         """
         Creates a new file reader to read the given file
 
@@ -66,7 +66,7 @@ class LanceFileReader:
             The path to read, can be a pathname for local storage
             or a URI to read from cloud storage.
         """
-        self._reader = _LanceFileReader(path)
+        self._reader = _LanceFileReader(path, storage_options=storage_options)
 
     def read_all(self, *, batch_size: int = 1024, batch_readahead=16) -> ReaderResults:
         """
@@ -173,6 +173,7 @@ class LanceFileWriter:
         *,
         data_cache_bytes: Optional[int] = None,
         version: Optional[str] = None,
+        storage_options: Optional[Dict[str, str]] = None,
         **kwargs,
     ):
         """
@@ -196,7 +197,7 @@ class LanceFileWriter:
             efficient but may not be readable by older versions of the software.
         """
         self._writer = _LanceFileWriter(
-            path, schema, data_cache_bytes=data_cache_bytes, version=version, **kwargs
+            path, schema, data_cache_bytes=data_cache_bytes, version=version, storage_options=storage_options, **kwargs
         )
         self.closed = False
 

--- a/python/python/lance/file.py
+++ b/python/python/lance/file.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
-from typing import Optional, Union, Dict
+from typing import Dict, Optional, Union
 
 import pyarrow as pa
 
@@ -65,6 +65,9 @@ class LanceFileReader:
         path: str
             The path to read, can be a pathname for local storage
             or a URI to read from cloud storage.
+        storage_options : optional, dict
+            Extra options to be used for a particular storage connection. This is
+            used to store connection parameters like credentials, endpoint, etc.
         """
         self._reader = _LanceFileReader(path, storage_options=storage_options)
 
@@ -195,9 +198,17 @@ class LanceFileWriter:
             The version of the file format to write.  If not specified then
             the latest stable version will be used.  Newer versions are more
             efficient but may not be readable by older versions of the software.
+        storage_options : optional, dict
+            Extra options to be used for a particular storage connection. This is
+            used to store connection parameters like credentials, endpoint, etc.
         """
         self._writer = _LanceFileWriter(
-            path, schema, data_cache_bytes=data_cache_bytes, version=version, storage_options=storage_options, **kwargs
+            path,
+            schema,
+            data_cache_bytes=data_cache_bytes,
+            version=version,
+            storage_options=storage_options,
+            **kwargs,
         )
         self.closed = False
 

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
 import pyarrow as pa
 

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 import pyarrow as pa
 
@@ -40,6 +40,7 @@ class LanceFileWriter:
         schema: Optional[pa.Schema],
         data_cache_bytes: Optional[int],
         version: Optional[str],
+        storage_options: Optional[Dict[str, str]],
         keep_original_array: Optional[bool],
     ): ...
     def write_batch(self, batch: pa.RecordBatch) -> None: ...
@@ -48,7 +49,7 @@ class LanceFileWriter:
     def add_global_buffer(self, data: bytes) -> int: ...
 
 class LanceFileReader:
-    def __init__(self, path: str): ...
+    def __init__(self, path: str, storage_options: Optional[Dict[str, str]]): ...
     def read_all(
         self, batch_size: int, batch_readahead: int
     ) -> pa.RecordBatchReader: ...

--- a/python/python/tests/test_s3_ddb.py
+++ b/python/python/tests/test_s3_ddb.py
@@ -18,8 +18,8 @@ import lance
 import pyarrow as pa
 import pytest
 from lance.dependencies import _RAY_AVAILABLE, ray
-from lance.fragment import write_fragments
 from lance.file import LanceFileReader, LanceFileWriter
+from lance.fragment import write_fragments
 
 # These are all keys that are accepted by storage_options
 CONFIG = {
@@ -266,12 +266,13 @@ def test_ray_committer(s3_bucket: str, ddb_table: str):
     assert set(tbl["str"].to_pylist()) == set([f"str-{i}" for i in range(10)])
     assert len(ds.get_fragments()) == 1
 
+
 @pytest.mark.integration
 def test_file_writer_reader(s3_bucket: str):
     storage_options = copy.deepcopy(CONFIG)
     del storage_options["dynamodb_endpoint"]
     table = pa.table({"a": [1, 2, 3]})
-    file_path = uri = f"s3://{s3_bucket}/foo.lance"
+    file_path = f"s3://{s3_bucket}/foo.lance"
     global_buffer_text = "hello"
     global_buffer_bytes = bytes(global_buffer_text, "utf-8")
     with LanceFileWriter(str(file_path), storage_options=storage_options) as writer:
@@ -283,7 +284,6 @@ def test_file_writer_reader(s3_bucket: str):
         global_buffer_bytes
     )
     assert (
-            bytes(reader.read_global_buffer(global_buffer_pos)).decode()
-            == global_buffer_text
+        bytes(reader.read_global_buffer(global_buffer_pos)).decode()
+        == global_buffer_text
     )
-

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::{pin::Pin, sync::Arc};
-
+use std::collections::HashMap;
 use arrow::pyarrow::PyArrowType;
 use arrow_array::{RecordBatch, RecordBatchReader, UInt32Array};
 use arrow_schema::Schema as ArrowSchema;
@@ -39,7 +39,7 @@ use pyo3::{
 };
 use serde::Serialize;
 use url::Url;
-
+use lance_io::object_store::ObjectStoreParams;
 use crate::{error::PythonErrorExt, RT};
 
 #[pyclass(get_all)]
@@ -182,9 +182,10 @@ impl LanceFileWriter {
         schema: Option<PyArrowType<ArrowSchema>>,
         data_cache_bytes: Option<u64>,
         version: Option<String>,
+        storage_options: Option<HashMap<String, String>>,
         keep_original_array: Option<bool>,
     ) -> PyResult<Self> {
-        let (object_store, path) = object_store_from_uri_or_path(uri_or_path).await?;
+        let (object_store, path) = object_store_from_uri_or_path(uri_or_path, storage_options).await?;
         let object_writer = object_store.create(&path).await.infer_error()?;
         let options = FileWriterOptions {
             data_cache_bytes,
@@ -215,6 +216,7 @@ impl LanceFileWriter {
         schema: Option<PyArrowType<ArrowSchema>>,
         data_cache_bytes: Option<u64>,
         version: Option<String>,
+        storage_options: Option<HashMap<String, String>>,
         keep_original_array: Option<bool>,
     ) -> PyResult<Self> {
         RT.runtime.block_on(Self::open(
@@ -222,6 +224,7 @@ impl LanceFileWriter {
             schema,
             data_cache_bytes,
             version,
+            storage_options,
             keep_original_array,
         ))
     }
@@ -265,6 +268,7 @@ fn path_to_parent(path: &Path) -> PyResult<(Path, String)> {
 // to the file.
 pub async fn object_store_from_uri_or_path(
     uri_or_path: impl AsRef<str>,
+    storage_options: Option<HashMap<String, String>>
 ) -> PyResult<(ObjectStore, Path)> {
     if let Ok(mut url) = Url::parse(uri_or_path.as_ref()) {
         if url.scheme().len() > 1 {
@@ -274,8 +278,17 @@ pub async fn object_store_from_uri_or_path(
             let (parent_path, filename) = path_to_parent(&path)?;
             url.set_path(parent_path.as_ref());
 
+            let object_store_registry = Arc::new(lance::io::ObjectStoreRegistry::default());
+            let object_store_params =
+                storage_options
+                    .as_ref()
+                    .map(|storage_options| ObjectStoreParams {
+                        storage_options: Some(storage_options.clone()),
+                        ..Default::default()
+                    });
+
             let (object_store, dir_path) =
-                ObjectStore::from_uri(url.as_str()).await.infer_error()?;
+                ObjectStore::from_uri_and_params(object_store_registry, url.as_str(), &object_store_params.unwrap()).await.infer_error()?;
             let child_path = dir_path.child(filename);
             return Ok((object_store, child_path));
         }
@@ -293,8 +306,8 @@ pub struct LanceFileReader {
 }
 
 impl LanceFileReader {
-    async fn open(uri_or_path: String) -> PyResult<Self> {
-        let (object_store, path) = object_store_from_uri_or_path(uri_or_path).await?;
+    async fn open(uri_or_path: String, storage_options: Option<HashMap<String, String>>) -> PyResult<Self> {
+        let (object_store, path) = object_store_from_uri_or_path(uri_or_path, storage_options).await?;
         let scheduler = ScanScheduler::new(
             Arc::new(object_store),
             SchedulerConfig {
@@ -354,8 +367,8 @@ impl LanceFileReader {
 #[pymethods]
 impl LanceFileReader {
     #[new]
-    pub fn new(path: String) -> PyResult<Self> {
-        RT.runtime.block_on(Self::open(path))
+    pub fn new(path: String, storage_options: Option<HashMap<String, String>>) -> PyResult<Self> {
+        RT.runtime.block_on(Self::open(path, storage_options))
     }
 
     pub fn read_all(

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -20,7 +20,9 @@ use pyo3::{
 };
 
 use crate::fragment::FileFragment;
-use crate::{dataset::Dataset, error::PythonErrorExt, file::object_store_from_uri_or_path, RT};
+use crate::{
+    dataset::Dataset, error::PythonErrorExt, file::object_store_from_uri_or_path_no_options, RT,
+};
 use lance::index::vector::ivf::write_ivf_pq_file_from_existing_index;
 use lance_index::DatasetIndexExt;
 use uuid::Uuid;
@@ -176,7 +178,7 @@ async fn do_transform_vectors(
         .await
         .infer_error()?;
 
-    let (obj_store, path) = object_store_from_uri_or_path(dst_uri, None).await?;
+    let (obj_store, path) = object_store_from_uri_or_path_no_options(dst_uri).await?;
     let writer = obj_store.create(&path).await.infer_error()?;
     write_vector_storage(
         &dataset.ds,
@@ -299,7 +301,7 @@ async fn do_load_shuffled_vectors(
     ivf_model: IvfModel,
     pq_model: ProductQuantizer,
 ) -> PyResult<()> {
-    let (_, path) = object_store_from_uri_or_path(dir_path, None).await?;
+    let (_, path) = object_store_from_uri_or_path_no_options(dir_path).await?;
     let streams = IvfShuffler::load_partitioned_shuffles(&path, filenames)
         .await
         .infer_error()?;

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -176,7 +176,7 @@ async fn do_transform_vectors(
         .await
         .infer_error()?;
 
-    let (obj_store, path) = object_store_from_uri_or_path(dst_uri).await?;
+    let (obj_store, path) = object_store_from_uri_or_path(dst_uri, None).await?;
     let writer = obj_store.create(&path).await.infer_error()?;
     write_vector_storage(
         &dataset.ds,
@@ -299,7 +299,7 @@ async fn do_load_shuffled_vectors(
     ivf_model: IvfModel,
     pq_model: ProductQuantizer,
 ) -> PyResult<()> {
-    let (_, path) = object_store_from_uri_or_path(dir_path).await?;
+    let (_, path) = object_store_from_uri_or_path(dir_path, None).await?;
     let streams = IvfShuffler::load_partitioned_shuffles(&path, filenames)
         .await
         .infer_error()?;


### PR DESCRIPTION
The PR propogates the storage_options to the LanceFileWriter and LanceFileReader and updates the code to create the object reader. 

### How is this tested?
Installed the package with local change:

`maturin develop`

Verified the following code didn't work before but works now

```
from lance.file import LanceFileReader, LanceFileWriter
import pyarrow as pa

uri = 's3://xxxxx'
storage_options = {
    'aws_access_key_id': 'xxx',
    'aws_secret_access_key': 'xxx'
}

table = pa.table({"a": [1, 2, 3]})
path = f"{lance_uri}/foo.lance"
global_buffer_text = "hello"
global_buffer_bytes = bytes(global_buffer_text, "utf-8")
with LanceFileWriter(str(path),storage_options=lance_storage_options) as writer:
    writer.write_batch(table)
    global_buffer_pos = writer.add_global_buffer(global_buffer_bytes)
reader = LanceFileReader(str(path), storage_options=lance_storage_options)
read_table = reader.read_all().to_table
```