### PR TITLE
fix: calculate decode priority correctly

### DIFF
--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -30,11 +30,19 @@ def pytest_addoption(parser):
         default=False,
         help="Run integration tests (requires S3 buckets to be setup with access)",
     )
+    parser.addoption(
+        "--run-slow",
+        action="store_true",
+        default=False,
+        help="Run slow tests",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
     if not config.getoption("--run-integration"):
         disable_items_with_mark(items, "integration", "--run-integration not specified")
+    if not config.getoption("--run-slow"):
+        disable_items_with_mark(items, "slow", "--run-slow not specified")
     try:
         import torch
 

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -692,11 +692,10 @@ impl LogicalPageDecoder for ListPageDecoder {
                 return Ok(());
             }
 
-            let mut boundary = loaded_need as usize;
+            let boundary = loaded_need as usize;
             debug_assert!(boundary < self.num_rows as usize);
-            while boundary + 2 < self.offsets.len() && self.offsets[boundary] == self.offsets[boundary + 1] {
-                boundary += 1;
-            }
+            // We need more than X lists which means we need at least X+1 lists which means
+            // we need at least offsets[X+1] items which means we need more than offsets[X+1]-1 items.
             let items_needed = self.offsets[boundary + 1].saturating_sub(1);
             trace!(
                 "List decoder is waiting for more than {} rows to be loaded and {}/{} are already loaded.  To satisfy this we need more than {} loaded items",


### PR DESCRIPTION
When decoding we have to "wait until more than X rows are ready"

There was an issue with how we handled empty lists.  For example, if the list offsets are:

```
# List sizes = [10, 20, 30, 0, 40]
0 10 30 60 60 100
```

The question is what do we do when we need to wait until more than 3 rows are ready.  3 rows means we have 60 items.  The old logic looked for the next offset greater than 60 (i.e. 100) and waited until we had 100 items.  This mirrors some logic we do on the reverse side when we calculate how many rows are available based on how many items we have.

However, that is wrong.  If we have 60 items we actually have 4 rows available and so we have more than 3 rows available.  The logic is much simpler.  Just wait until we have at least `offsets[desired_rows + 1]` items.  If that value is equal to `offsets[desired_rows]` it doesn't matter, we don't need to do any special logic.

If we wait for too many rows it can lead to deadlock in certain situations.