### PR TITLE
chore: don't be so strict about checking the error type in duckdb test

### DIFF
--- a/python/python/tests/test_integration.py
+++ b/python/python/tests/test_integration.py
@@ -33,7 +33,10 @@ def test_duckdb_pushdown_extension_types(tmp_path):
     # Not the best error message but hopefully this is short lived until datafusion
     # supports substrait extension types.
     with pytest.raises(
-        duckdb.InvalidInputException,
+        # Older versions of duckdb use duckdb.InvalidInputException and newer versions
+        # use duckdb.duckdb.Error but that part isn't really important so just check for
+        # Exception
+        Exception,
         match="referenced a field that is not yet supported by Substrait conversion",
     ):
         duckdb.query("SELECT * FROM ds WHERE largebin = '456'").fetchall()


### PR DESCRIPTION
The error that is raised by DuckDB in this situation changed between versions 1.0.0 and 1.1.0 but we don't really care too much.  We just want to make sure the error text is meaningful.