### PR TITLE
chore: fix aws-integ-test from running out of disk space

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -9,7 +9,7 @@ test:
 .PHONY: test
 
 integtest:
-	pytest --run-integration $(PYTEST_ARGS) python/tests
+	pytest --run-integration $(PYTEST_ARGS) python/tests/test_s3_ddb.py
 .PHONY: integtest
 
 doctest:


### PR DESCRIPTION
The AWS integration tests were failing because we run out of disk space.  We have about 30GB of disk space per job.  Docker (setting up minio), the rust cache, building the wheels, and running the tests all utilize quite a bit of disk space.

As a (possibly short-term) solution we change the integration tests job to run only the integration tests and not all of the tests.