### PR TITLE
feat: add a blob encoding for large binary values

### DIFF
--- a/protos/encodings.proto
+++ b/protos/encodings.proto
@@ -264,11 +264,18 @@ message ZoneIndex {
   ColumnEncoding inner = 3;
 }
 
+// Marks a column as blob data.  It will contain a packed struct
+// with fields position and size (u64)
+message Blob {
+  ColumnEncoding inner = 1;
+}
+
 // Encodings that describe a column of values
 message ColumnEncoding {
   oneof column_encoding {
     // No special encoding, just column values
     google.protobuf.Empty values = 1;
     ZoneIndex zone_index = 2;
+    Blob blob = 3;
   }
 }

--- a/rust/lance-encoding-datafusion/src/zone.rs
+++ b/rust/lance-encoding-datafusion/src/zone.rs
@@ -625,7 +625,7 @@ impl FieldEncoder for ZoneMapsFieldEncoder {
         let items_columns = self.items_encoder.finish(external_buffers);
 
         async move {
-            let items_columns = self.items_encoder.finish().await?;
+            let items_columns = items_columns.await?;
             if items_columns.is_empty() {
                 return Err(Error::invalid_input("attempt to apply zone maps to a field encoder that generated zero columns of data".to_string(), location!()))
             }

--- a/rust/lance-encoding-datafusion/src/zone.rs
+++ b/rust/lance-encoding-datafusion/src/zone.rs
@@ -620,6 +620,12 @@ impl FieldEncoder for ZoneMapsFieldEncoder {
         &mut self,
         external_buffers: &mut OutOfLineBuffers,
     ) -> BoxFuture<'_, Result<Vec<EncodedColumn>>> {
+        if self.cur_offset > 0 {
+            // Create final map
+            if let Err(err) = self.new_map() {
+                return async move { Err(err) }.boxed();
+            }
+        }
         let maps = std::mem::take(&mut self.maps);
         let rows_per_zone = self.rows_per_map;
         let items_columns = self.items_encoder.finish(external_buffers);

--- a/rust/lance-encoding-datafusion/src/zone.rs
+++ b/rust/lance-encoding-datafusion/src/zone.rs
@@ -31,7 +31,7 @@ use lance_encoding::{
     },
     encoder::{
         encode_batch, CoreFieldEncodingStrategy, EncodedBatch, EncodedColumn, EncodingOptions,
-        FieldEncoder,
+        FieldEncoder, OutOfLineBuffers,
     },
     format::pb,
     EncodingsIo,
@@ -560,8 +560,7 @@ impl ZoneMapsFieldEncoder {
         Ok(())
     }
 
-    async fn maps_to_metadata(&mut self) -> Result<LanceBuffer> {
-        let maps = std::mem::take(&mut self.maps);
+    async fn maps_to_metadata(maps: Vec<CreatedZoneMap>) -> Result<LanceBuffer> {
         let (mins, (maxes, null_counts)): (Vec<_>, (Vec<_>, Vec<_>)) = maps
             .into_iter()
             .map(|mp| (mp.min, (mp.max, mp.null_count)))
@@ -599,6 +598,7 @@ impl FieldEncoder for ZoneMapsFieldEncoder {
     fn maybe_encode(
         &mut self,
         array: ArrayRef,
+        external_buffers: &mut OutOfLineBuffers,
     ) -> Result<Vec<lance_encoding::encoder::EncodeTask>> {
         // TODO: If we do the zone map calculation as part of the encoding task then we can
         // parallelize statistics gathering.  Could be faster too since the encoding task is
@@ -606,35 +606,39 @@ impl FieldEncoder for ZoneMapsFieldEncoder {
         // probably too big for the CPU cache anyways).  We can worry about this if we need
         // to improve write speed.
         self.update(&array)?;
-        self.items_encoder.maybe_encode(array)
+        self.items_encoder.maybe_encode(array, external_buffers)
     }
 
-    fn flush(&mut self) -> Result<Vec<lance_encoding::encoder::EncodeTask>> {
-        self.items_encoder.flush()
+    fn flush(
+        &mut self,
+        external_buffers: &mut OutOfLineBuffers,
+    ) -> Result<Vec<lance_encoding::encoder::EncodeTask>> {
+        self.items_encoder.flush(external_buffers)
     }
 
-    fn finish(&mut self) -> BoxFuture<'_, Result<Vec<EncodedColumn>>> {
+    fn finish(
+        &mut self,
+        external_buffers: &mut OutOfLineBuffers,
+    ) -> BoxFuture<'_, Result<Vec<EncodedColumn>>> {
+        let maps = std::mem::take(&mut self.maps);
+        let rows_per_zone = self.rows_per_map;
+        let items_columns = self.items_encoder.finish(external_buffers);
+
         async move {
-            if self.cur_offset > 0 {
-                // Create final map
-                self.new_map()?;
-            }
             let items_columns = self.items_encoder.finish().await?;
-            if items_columns.len() != 1 {
-                return Err(Error::InvalidInput {
-                    source: format!("attempt to apply zone maps to a field encoder that generated {} columns of data (expected 1)", items_columns.len()).into(),
-                    location: location!()})
+            if items_columns.is_empty() {
+                return Err(Error::invalid_input("attempt to apply zone maps to a field encoder that generated zero columns of data".to_string(), location!()))
             }
             let items_column = items_columns.into_iter().next().unwrap();
             let final_pages = items_column.final_pages;
             let mut column_buffers = items_column.column_buffers;
             let zone_buffer_index = column_buffers.len();
-            column_buffers.push(self.maps_to_metadata().await?);
+            column_buffers.push(Self::maps_to_metadata(maps).await?);
             let column_encoding = pb::ColumnEncoding {
                 column_encoding: Some(pb::column_encoding::ColumnEncoding::ZoneIndex(Box::new(
                     pb::ZoneIndex {
                         inner: Some(Box::new(items_column.encoding)),
-                        rows_per_zone: self.rows_per_map,
+                        rows_per_zone,
                         zone_map_buffer: Some(pb::Buffer {
                             buffer_index: zone_buffer_index as u32,
                             buffer_type: i32::from(pb::buffer::BufferType::Column),

--- a/rust/lance-encoding/Cargo.toml
+++ b/rust/lance-encoding/Cargo.toml
@@ -27,6 +27,7 @@ futures.workspace = true
 fsst.workspace = true
 hex = "0.4.3"
 itertools.workspace = true
+lazy_static.workspace = true
 log.workspace = true
 num-traits.workspace = true
 prost.workspace = true

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -174,8 +174,8 @@ impl OutOfLineBuffers {
         position
     }
 
-    pub fn take_buffers(&mut self) -> Vec<LanceBuffer> {
-        std::mem::take(&mut self.buffers)
+    pub fn take_buffers(self) -> Vec<LanceBuffer> {
+        self.buffers
     }
 
     pub fn reset_position(&mut self, position: u64) {
@@ -908,7 +908,7 @@ pub async fn encode_batch(
                 .or_default()
                 .push(write_page_to_data_buffer(encoded_page, &mut data_buffer));
         }
-        external_buffers.reset_position(data_buffer.len() as u64);
+        let mut external_buffers = OutOfLineBuffers::new(data_buffer.len() as u64);
         let encoded_columns = encoder.finish(&mut external_buffers).await?;
         for buffer in external_buffers.take_buffers() {
             data_buffer.extend_from_slice(&buffer);

--- a/rust/lance-encoding/src/encodings/logical.rs
+++ b/rust/lance-encoding/src/encodings/logical.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 pub mod binary;
+pub mod blob;
 pub mod list;
 pub mod primitive;
 pub mod r#struct;

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -128,6 +128,14 @@ impl FieldScheduler for BlobFieldScheduler {
     fn num_rows(&self) -> u64 {
         self.descriptions_scheduler.num_rows()
     }
+
+    fn initialize<'a>(
+        &'a self,
+        filter: &'a FilterExpression,
+        context: &'a SchedulerContext,
+    ) -> BoxFuture<'a, Result<()>> {
+        self.descriptions_scheduler.initialize(filter, context)
+    }
 }
 
 pub struct BlobFieldDecoder {

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -1,0 +1,463 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{collections::VecDeque, sync::Arc, vec};
+
+use arrow::{array::AsArray, datatypes::UInt64Type};
+use arrow_array::{Array, ArrayRef, LargeBinaryArray, PrimitiveArray, StructArray, UInt64Array};
+use arrow_buffer::{
+    BooleanBuffer, BooleanBufferBuilder, Buffer, NullBuffer, OffsetBuffer, ScalarBuffer,
+};
+use arrow_schema::{DataType, Field, Fields};
+use bytes::Bytes;
+use futures::{future::BoxFuture, FutureExt};
+use snafu::{location, Location};
+
+use lance_core::{Error, Result};
+
+use crate::{
+    buffer::LanceBuffer,
+    decoder::{
+        DecodeArrayTask, DecoderReady, FieldScheduler, FilterExpression, LogicalPageDecoder,
+        NextDecodeTask, PriorityRange, ScheduledScanLine, SchedulerContext, SchedulingJob,
+    },
+    encoder::{EncodeTask, FieldEncoder, OutOfLineBuffers},
+    format::pb::{column_encoding, Blob, ColumnEncoding},
+    EncodingsIo,
+};
+
+lazy_static::lazy_static! {
+    static ref DESC_FIELDS: Fields =
+        Fields::from(vec![
+            Field::new("position", DataType::UInt64, false),
+            Field::new("size", DataType::UInt64, false),
+        ]);
+    pub static ref DESC_FIELD: Field =
+        Field::new("description", DataType::Struct(DESC_FIELDS.clone()), false);
+
+}
+
+/// A field scheduler for large binary data
+///
+/// Large binary data (1MiB+) can be inefficient if we store as a regular primtive.  We
+/// essentially end up with 1 page per row (or a few rows) and the overhead of the
+/// metadata can be significant.
+///
+/// At the same time the benefits of using pages (contiguous arrays) are pretty small since
+/// we can generally perform random access at these sizes without much penalty.
+///
+/// This encoder gives up the random access and stores the large binary data out of line.  This
+/// keeps the metadata small.
+#[derive(Debug)]
+pub struct BlobFieldScheduler {
+    descriptions_scheduler: Arc<dyn FieldScheduler>,
+}
+
+impl BlobFieldScheduler {
+    pub fn new(descriptions_scheduler: Arc<dyn FieldScheduler>) -> Self {
+        Self {
+            descriptions_scheduler,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BlobFieldSchedulingJob<'a> {
+    descriptions_job: Box<dyn SchedulingJob + 'a>,
+}
+
+impl<'a> SchedulingJob for BlobFieldSchedulingJob<'a> {
+    fn schedule_next(
+        &mut self,
+        context: &mut SchedulerContext,
+        priority: &dyn PriorityRange,
+    ) -> Result<ScheduledScanLine> {
+        let next_descriptions = self.descriptions_job.schedule_next(context, priority)?;
+        let mut priority = priority.current_priority();
+        let decoders = next_descriptions.decoders.into_iter().map(|decoder| {
+            let path = decoder.path;
+            let mut decoder = decoder.decoder;
+            let num_rows = decoder.num_rows();
+            let descriptions_fut = async move {
+                decoder
+                    .wait_for_loaded(decoder.num_rows() - 1)
+                    .await
+                    .unwrap();
+                let descriptions_task = decoder.drain(decoder.num_rows()).unwrap();
+                descriptions_task.task.decode()
+            }
+            .boxed();
+            let decoder = Box::new(BlobFieldDecoder {
+                io: context.io().clone(),
+                unloaded_descriptions: Some(descriptions_fut),
+                positions: PrimitiveArray::<UInt64Type>::from_iter_values(vec![]),
+                sizes: PrimitiveArray::<UInt64Type>::from_iter_values(vec![]),
+                num_rows,
+                loaded: VecDeque::new(),
+                validity: VecDeque::new(),
+                rows_loaded: 0,
+                rows_drained: 0,
+                base_priority: priority,
+            });
+            priority += num_rows;
+            DecoderReady { decoder, path }
+        });
+        Ok(ScheduledScanLine {
+            decoders: decoders.collect(),
+            rows_scheduled: next_descriptions.rows_scheduled,
+        })
+    }
+
+    fn num_rows(&self) -> u64 {
+        self.descriptions_job.num_rows()
+    }
+}
+
+impl FieldScheduler for BlobFieldScheduler {
+    fn schedule_ranges<'a>(
+        &'a self,
+        ranges: &[std::ops::Range<u64>],
+        filter: &FilterExpression,
+    ) -> Result<Box<dyn SchedulingJob + 'a>> {
+        let descriptions_job = self
+            .descriptions_scheduler
+            .schedule_ranges(ranges, filter)?;
+        Ok(Box::new(BlobFieldSchedulingJob { descriptions_job }))
+    }
+
+    fn num_rows(&self) -> u64 {
+        self.descriptions_scheduler.num_rows()
+    }
+}
+
+pub struct BlobFieldDecoder {
+    io: Arc<dyn EncodingsIo>,
+    unloaded_descriptions: Option<BoxFuture<'static, Result<ArrayRef>>>,
+    positions: PrimitiveArray<UInt64Type>,
+    sizes: PrimitiveArray<UInt64Type>,
+    num_rows: u64,
+    loaded: VecDeque<Bytes>,
+    validity: VecDeque<BooleanBuffer>,
+    rows_loaded: u64,
+    rows_drained: u64,
+    base_priority: u64,
+}
+
+impl BlobFieldDecoder {
+    fn drain_validity(&mut self, num_values: usize) -> Result<Option<NullBuffer>> {
+        let mut validity = BooleanBufferBuilder::new(num_values);
+        let mut remaining = num_values;
+        while remaining > 0 {
+            let next = self.validity.front_mut().unwrap();
+            if remaining < next.len() {
+                let slice = next.slice(0, remaining);
+                validity.append_buffer(&slice);
+                *next = next.slice(remaining, next.len() - remaining);
+                remaining = 0;
+            } else {
+                validity.append_buffer(next);
+                remaining -= next.len();
+                self.validity.pop_front();
+            }
+        }
+        let nulls = NullBuffer::new(validity.finish());
+        if nulls.null_count() == 0 {
+            Ok(None)
+        } else {
+            Ok(Some(nulls))
+        }
+    }
+}
+
+impl std::fmt::Debug for BlobFieldDecoder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlobFieldDecoder")
+            .field("num_rows", &self.num_rows)
+            .field("rows_loaded", &self.rows_loaded)
+            .field("rows_drained", &self.rows_drained)
+            .finish()
+    }
+}
+
+impl LogicalPageDecoder for BlobFieldDecoder {
+    fn wait_for_loaded(&mut self, loaded_need: u64) -> BoxFuture<Result<()>> {
+        async move {
+            if self.unloaded_descriptions.is_some() {
+                let descriptions = self.unloaded_descriptions.take().unwrap().await?;
+                let descriptions = descriptions.as_struct();
+                self.positions = descriptions.column(0).as_primitive().clone();
+                self.sizes = descriptions.column(1).as_primitive().clone();
+            }
+            let start = self.rows_loaded as usize;
+            let end = (loaded_need + 1).min(self.num_rows) as usize;
+            let positions = self.positions.values().slice(start, end - start);
+            let sizes = self.sizes.values().slice(start, end - start);
+            let ranges = positions
+                .iter()
+                .zip(sizes.iter())
+                .map(|(position, size)| *position..(*position + *size))
+                .collect::<Vec<_>>();
+            let validity = positions
+                .iter()
+                .zip(sizes.iter())
+                .map(|(p, s)| *p != 1 || *s != 0)
+                .collect::<BooleanBuffer>();
+            self.validity.push_back(validity);
+            self.rows_loaded = end as u64;
+            let bytes = self
+                .io
+                .submit_request(ranges, self.base_priority + start as u64)
+                .await?;
+            self.loaded.extend(bytes);
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn rows_loaded(&self) -> u64 {
+        self.rows_loaded
+    }
+
+    fn num_rows(&self) -> u64 {
+        self.num_rows
+    }
+
+    fn rows_drained(&self) -> u64 {
+        self.rows_drained
+    }
+
+    fn drain(&mut self, num_rows: u64) -> Result<NextDecodeTask> {
+        let bytes = self.loaded.drain(0..num_rows as usize).collect::<Vec<_>>();
+        let validity = self.drain_validity(num_rows as usize)?;
+        self.rows_drained += num_rows;
+        Ok(NextDecodeTask {
+            has_more: self.rows_drained < self.num_rows,
+            num_rows,
+            task: Box::new(BlobArrayDecodeTask::new(bytes, validity)),
+        })
+    }
+
+    fn data_type(&self) -> &DataType {
+        &DataType::LargeBinary
+    }
+}
+
+struct BlobArrayDecodeTask {
+    bytes: Vec<Bytes>,
+    validity: Option<NullBuffer>,
+}
+
+impl BlobArrayDecodeTask {
+    fn new(bytes: Vec<Bytes>, validity: Option<NullBuffer>) -> Self {
+        Self { bytes, validity }
+    }
+}
+
+impl DecodeArrayTask for BlobArrayDecodeTask {
+    fn decode(self: Box<Self>) -> Result<ArrayRef> {
+        let num_bytes = self.bytes.iter().map(|b| b.len()).sum::<usize>();
+        let offsets = self
+            .bytes
+            .iter()
+            .scan(0, |state, b| {
+                let start = *state;
+                *state += b.len();
+                Some(start as i64)
+            })
+            .chain(std::iter::once(num_bytes as i64))
+            .collect::<Vec<_>>();
+        let offsets = OffsetBuffer::new(ScalarBuffer::from(offsets));
+        let mut buffer = Vec::with_capacity(num_bytes);
+        for bytes in self.bytes {
+            buffer.extend_from_slice(&bytes);
+        }
+        let data_buf = Buffer::from_vec(buffer);
+        Ok(Arc::new(LargeBinaryArray::new(
+            offsets,
+            data_buf,
+            self.validity,
+        )))
+    }
+}
+
+// impl DecodeArrayTask for BlobFieldDecodeTask {
+//     fn decode(self: Box<Self>) -> Result<ArrayRef> {
+//     }
+// }
+
+// impl LogicalPageDecoder for PrimitiveFieldDecoder {
+//     // TODO: In the future, at some point, we may consider partially waiting for primitive pages by
+//     // breaking up large I/O into smaller I/O as a way to accelerate the "time-to-first-decode"
+//     fn wait_for_loaded(&mut self, loaded_need: u64) -> BoxFuture<Result<()>> {
+//     }
+
+//     fn drain(&mut self, num_rows: u64) -> Result<NextDecodeTask> {
+//     }
+
+//     fn rows_loaded(&self) -> u64 {
+//     }
+
+//     fn rows_drained(&self) -> u64 {
+//     }
+
+//     fn num_rows(&self) -> u64 {
+//     }
+
+//     fn data_type(&self) -> &DataType {
+//     }
+// }
+
+pub struct BlobFieldEncoder {
+    description_encoder: Box<dyn FieldEncoder>,
+}
+
+impl BlobFieldEncoder {
+    pub fn new(description_encoder: Box<dyn FieldEncoder>) -> Self {
+        Self {
+            description_encoder,
+        }
+    }
+
+    fn write_bins(array: ArrayRef, external_buffers: &mut OutOfLineBuffers) -> Result<ArrayRef> {
+        let binarray = array
+            .as_binary_opt::<i64>()
+            .ok_or_else(|| Error::InvalidInput {
+                source: format!("Expected large_binary and received {}", array.data_type()).into(),
+                location: location!(),
+            })?;
+        let mut positions = Vec::with_capacity(array.len());
+        let mut sizes = Vec::with_capacity(array.len());
+        let data = binarray.values();
+        let nulls = binarray
+            .nulls()
+            .cloned()
+            .unwrap_or(NullBuffer::new_valid(binarray.len()));
+        for (w, is_valid) in binarray.value_offsets().windows(2).zip(nulls.into_iter()) {
+            if is_valid {
+                let start = w[0] as u64;
+                let end = w[1] as u64;
+                let size = end - start;
+                if size > 0 {
+                    let val = data.slice_with_length(start as usize, size as usize);
+                    let position = external_buffers.add_buffer(LanceBuffer::Borrowed(val));
+                    positions.push(position);
+                    sizes.push(size);
+                } else {
+                    // Empty values are always (0,0)
+                    positions.push(0);
+                    sizes.push(0);
+                }
+            } else {
+                // Null values are always (1, 0)
+                positions.push(1);
+                sizes.push(0);
+            }
+        }
+        let positions = Arc::new(UInt64Array::from(positions));
+        let sizes = Arc::new(UInt64Array::from(sizes));
+        let descriptions = Arc::new(StructArray::new(
+            DESC_FIELDS.clone(),
+            vec![positions, sizes],
+            None,
+        ));
+        Ok(descriptions)
+    }
+}
+
+impl FieldEncoder for BlobFieldEncoder {
+    fn maybe_encode(
+        &mut self,
+        array: ArrayRef,
+        external_buffers: &mut OutOfLineBuffers,
+    ) -> Result<Vec<EncodeTask>> {
+        let descriptions = Self::write_bins(array, external_buffers)?;
+        self.description_encoder
+            .maybe_encode(descriptions, external_buffers)
+    }
+
+    // If there is any data left in the buffer then create an encode task from it
+    fn flush(&mut self, external_buffers: &mut OutOfLineBuffers) -> Result<Vec<EncodeTask>> {
+        self.description_encoder.flush(external_buffers)
+    }
+
+    fn num_columns(&self) -> u32 {
+        self.description_encoder.num_columns()
+    }
+
+    fn finish(
+        &mut self,
+        external_buffers: &mut OutOfLineBuffers,
+    ) -> BoxFuture<'_, Result<Vec<crate::encoder::EncodedColumn>>> {
+        let inner_finished = self.description_encoder.finish(external_buffers);
+        async move {
+            let mut cols = inner_finished.await?;
+            assert_eq!(cols.len(), 1);
+            let encoding = std::mem::take(&mut cols[0].encoding);
+            let wrapped_encoding = ColumnEncoding {
+                column_encoding: Some(column_encoding::ColumnEncoding::Blob(Box::new(Blob {
+                    inner: Some(Box::new(encoding)),
+                }))),
+            };
+            cols[0].encoding = wrapped_encoding;
+            Ok(cols)
+        }
+        .boxed()
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use arrow_array::LargeBinaryArray;
+    use arrow_schema::{DataType, Field};
+
+    use crate::{
+        encoder::BLOB_META_KEY,
+        format::pb::column_encoding,
+        testing::{check_round_trip_encoding_of_data, check_round_trip_encoding_random, TestCases},
+    };
+
+    lazy_static::lazy_static! {
+    static ref BLOB_META: HashMap<String, String> =
+        [(BLOB_META_KEY.to_string(), "true".to_string())]
+            .iter()
+            .cloned()
+            .collect::<HashMap<_, _>>();
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_blob() {
+        let field = Field::new("", DataType::LargeBinary, false).with_metadata(BLOB_META.clone());
+        check_round_trip_encoding_random(field).await;
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_simple_blob() {
+        let val1: &[u8] = &[1, 2, 3];
+        let val2: &[u8] = &[7, 8, 9];
+        let array = Arc::new(LargeBinaryArray::from(vec![Some(val1), None, Some(val2)]));
+        let test_cases = TestCases::default().with_verify_encoding(Arc::new(|cols| {
+            assert_eq!(cols.len(), 1);
+            let col = &cols[0];
+            assert!(matches!(
+                col.encoding.column_encoding.as_ref().unwrap(),
+                column_encoding::ColumnEncoding::Blob(_)
+            ));
+        }));
+        // Use blob encoding if requested
+        check_round_trip_encoding_of_data(vec![array.clone()], &test_cases, BLOB_META.clone())
+            .await;
+
+        let test_cases = TestCases::default().with_verify_encoding(Arc::new(|cols| {
+            assert_eq!(cols.len(), 1);
+            let col = &cols[0];
+            assert!(!matches!(
+                col.encoding.column_encoding.as_ref().unwrap(),
+                column_encoding::ColumnEncoding::Blob(_)
+            ));
+        }));
+        // Don't use blob encoding if not requested
+        check_round_trip_encoding_of_data(vec![array], &test_cases, Default::default()).await;
+    }
+}

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -9,7 +9,11 @@ use std::{
 
 use arrow_array::{cast::AsArray, Array, ArrayRef, StructArray};
 use arrow_schema::{DataType, Fields};
-use futures::{future::BoxFuture, stream::FuturesOrdered, FutureExt, StreamExt, TryStreamExt};
+use futures::{
+    future::BoxFuture,
+    stream::{FuturesOrdered, FuturesUnordered},
+    FutureExt, StreamExt, TryStreamExt,
+};
 use log::trace;
 use snafu::{location, Location};
 

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -9,7 +9,7 @@ use std::{
 
 use arrow_array::{cast::AsArray, Array, ArrayRef, StructArray};
 use arrow_schema::{DataType, Fields};
-use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt, TryStreamExt};
+use futures::{future::BoxFuture, stream::FuturesOrdered, FutureExt, StreamExt, TryStreamExt};
 use log::trace;
 use snafu::{location, Location};
 
@@ -19,7 +19,9 @@ use crate::{
         DecodeArrayTask, DecoderReady, FieldScheduler, FilterExpression, LogicalPageDecoder,
         NextDecodeTask, PriorityRange, ScheduledScanLine, SchedulerContext, SchedulingJob,
     },
-    encoder::{EncodeTask, EncodedArray, EncodedColumn, EncodedPage, FieldEncoder},
+    encoder::{
+        EncodeTask, EncodedArray, EncodedColumn, EncodedPage, FieldEncoder, OutOfLineBuffers,
+    },
     format::pb,
 };
 use lance_core::{Error, Result};
@@ -553,23 +555,27 @@ impl StructFieldEncoder {
 }
 
 impl FieldEncoder for StructFieldEncoder {
-    fn maybe_encode(&mut self, array: ArrayRef) -> Result<Vec<EncodeTask>> {
+    fn maybe_encode(
+        &mut self,
+        array: ArrayRef,
+        external_buffers: &mut OutOfLineBuffers,
+    ) -> Result<Vec<EncodeTask>> {
         self.num_rows_seen += array.len() as u64;
         let struct_array = array.as_struct();
         let child_tasks = self
             .children
             .iter_mut()
             .zip(struct_array.columns().iter())
-            .map(|(encoder, arr)| encoder.maybe_encode(arr.clone()))
+            .map(|(encoder, arr)| encoder.maybe_encode(arr.clone(), external_buffers))
             .collect::<Result<Vec<_>>>()?;
         Ok(child_tasks.into_iter().flatten().collect::<Vec<_>>())
     }
 
-    fn flush(&mut self) -> Result<Vec<EncodeTask>> {
+    fn flush(&mut self, external_buffers: &mut OutOfLineBuffers) -> Result<Vec<EncodeTask>> {
         let child_tasks = self
             .children
             .iter_mut()
-            .map(|encoder| encoder.flush())
+            .map(|encoder| encoder.flush(external_buffers))
             .collect::<Result<Vec<_>>>()?;
         Ok(child_tasks.into_iter().flatten().collect::<Vec<_>>())
     }
@@ -582,7 +588,17 @@ impl FieldEncoder for StructFieldEncoder {
             + 1
     }
 
-    fn finish(&mut self) -> BoxFuture<'_, Result<Vec<crate::encoder::EncodedColumn>>> {
+    fn finish(
+        &mut self,
+        external_buffers: &mut OutOfLineBuffers,
+    ) -> BoxFuture<'_, Result<Vec<crate::encoder::EncodedColumn>>> {
+        let mut child_columns = self
+            .children
+            .iter_mut()
+            .map(|child| child.finish(external_buffers))
+            .collect::<FuturesOrdered<_>>();
+        let num_rows_seen = self.num_rows_seen;
+        let column_index = self.column_index;
         async move {
             let mut columns = Vec::new();
             // Add a column for the struct header
@@ -590,7 +606,7 @@ impl FieldEncoder for StructFieldEncoder {
             header.final_pages.push(EncodedPage {
                 array: EncodedArray {
                     data: DataBlock::AllNull(AllNullDataBlock {
-                        num_values: self.num_rows_seen,
+                        num_values: num_rows_seen,
                     }),
                     encoding: pb::ArrayEncoding {
                         array_encoding: Some(pb::array_encoding::ArrayEncoding::Struct(
@@ -598,13 +614,13 @@ impl FieldEncoder for StructFieldEncoder {
                         )),
                     },
                 },
-                num_rows: self.num_rows_seen,
-                column_idx: self.column_index,
+                num_rows: num_rows_seen,
+                column_idx: column_index,
             });
             columns.push(header);
             // Now run finish on the children
-            for child in self.children.iter_mut() {
-                columns.extend(child.finish().await?);
+            while let Some(child_cols) = child_columns.next().await {
+                columns.extend(child_cols?);
             }
             Ok(columns)
         }
@@ -634,7 +650,7 @@ mod tests {
             Field::new("b", DataType::Int32, false),
         ]));
         let field = Field::new("", data_type, false);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -648,7 +664,7 @@ mod tests {
             Field::new("outer_int", DataType::Int32, true),
         ]));
         let field = Field::new("row", data_type, false);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -670,7 +686,7 @@ mod tests {
             Field::new("outer_binary", DataType::Binary, true),
         ]));
         let field = Field::new("row", data_type, false);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/encodings/physical.rs
+++ b/rust/lance-encoding/src/encodings/physical.rs
@@ -7,7 +7,10 @@ use fsst::FsstPageScheduler;
 use lance_arrow::DataTypeExt;
 use packed_struct::PackedStructPageScheduler;
 
-use crate::{decoder::PageScheduler, format::pb};
+use crate::{
+    decoder::PageScheduler,
+    format::pb::{self, PackedStruct},
+};
 
 use self::{
     basic::BasicPageScheduler, binary::BinaryPageScheduler, bitmap::DenseBitmapScheduler,
@@ -119,6 +122,41 @@ fn get_bitpacked_for_non_neg_buffer_decoder(
     Box::new(bitpack_fastlanes::BitpackedForNonNegScheduler::new(
         encoding.compressed_bits_per_value,
         encoding.uncompressed_bits_per_value,
+        buffer_offset,
+    ))
+}
+
+fn decoder_from_packed_struct(
+    packed_struct: &PackedStruct,
+    buffers: &PageBuffers,
+    data_type: &DataType,
+) -> Box<dyn PageScheduler> {
+    let inner_encodings = &packed_struct.inner;
+    let fields = match data_type {
+        DataType::Struct(fields) => Some(fields),
+        _ => None,
+    }
+    .unwrap();
+
+    let inner_datatypes = fields
+        .iter()
+        .map(|field| field.data_type())
+        .collect::<Vec<_>>();
+
+    let mut inner_schedulers = Vec::with_capacity(fields.len());
+    for i in 0..fields.len() {
+        let inner_encoding = &inner_encodings[i];
+        let inner_datatype = inner_datatypes[i];
+        let inner_scheduler = decoder_from_array_encoding(inner_encoding, buffers, inner_datatype);
+        inner_schedulers.push(inner_scheduler);
+    }
+
+    let packed_buffer = packed_struct.buffer.as_ref().unwrap();
+    let (buffer_offset, _) = get_buffer(packed_buffer, buffers);
+
+    Box::new(PackedStructPageScheduler::new(
+        inner_schedulers,
+        data_type.clone(),
         buffer_offset,
     ))
 }
@@ -236,35 +274,7 @@ pub fn decoder_from_array_encoding(
             ))
         }
         pb::array_encoding::ArrayEncoding::PackedStruct(packed_struct) => {
-            let inner_encodings = &packed_struct.inner;
-            let fields = match data_type {
-                DataType::Struct(fields) => Some(fields),
-                _ => None,
-            }
-            .unwrap();
-
-            let inner_datatypes = fields
-                .iter()
-                .map(|field| field.data_type())
-                .collect::<Vec<_>>();
-
-            let mut inner_schedulers = Vec::with_capacity(fields.len());
-            for i in 0..fields.len() {
-                let inner_encoding = &inner_encodings[i];
-                let inner_datatype = inner_datatypes[i];
-                let inner_scheduler =
-                    decoder_from_array_encoding(inner_encoding, buffers, inner_datatype);
-                inner_schedulers.push(inner_scheduler);
-            }
-
-            let packed_buffer = packed_struct.buffer.as_ref().unwrap();
-            let (buffer_offset, _) = get_buffer(packed_buffer, buffers);
-
-            Box::new(PackedStructPageScheduler::new(
-                inner_schedulers,
-                data_type.clone(),
-                buffer_offset,
-            ))
+            decoder_from_packed_struct(packed_struct, buffers, data_type)
         }
         pb::array_encoding::ArrayEncoding::BitpackedForNonNeg(bitpacked) => {
             get_bitpacked_for_non_neg_buffer_decoder(bitpacked, buffers)

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -530,7 +530,7 @@ pub mod tests {
     #[test_log::test(tokio::test)]
     async fn test_utf8_binary() {
         let field = Field::new("", DataType::Utf8, false);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test]
@@ -567,19 +567,19 @@ pub mod tests {
     #[test_log::test(tokio::test)]
     async fn test_binary() {
         let field = Field::new("", DataType::Binary, false);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_large_binary() {
         let field = Field::new("", DataType::LargeBinary, true);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_large_utf8() {
         let field = Field::new("", DataType::LargeUtf8, true);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/encodings/physical/bitmap.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitmap.rs
@@ -124,7 +124,6 @@ impl PrimitivePageDecoder for BitmapDecoder {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
 
     use arrow_schema::{DataType, Field};
     use bytes::Bytes;
@@ -138,7 +137,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn test_bitmap_boolean() {
         let field = Field::new("", DataType::Boolean, false);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test]

--- a/rust/lance-encoding/src/encodings/physical/dictionary.rs
+++ b/rust/lance-encoding/src/encodings/physical/dictionary.rs
@@ -445,25 +445,25 @@ pub mod tests {
     #[test_log::test(tokio::test)]
     async fn test_utf8() {
         let field = Field::new("", DataType::Utf8, false);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_binary() {
         let field = Field::new("", DataType::Binary, false);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_large_binary() {
         let field = Field::new("", DataType::LargeBinary, true);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_large_utf8() {
         let field = Field::new("", DataType::LargeUtf8, true);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -569,6 +569,6 @@ pub mod tests {
             DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
             false,
         );
-        check_round_trip_encoding_random(dict_field, HashMap::new()).await;
+        check_round_trip_encoding_random(dict_field).await;
     }
 }

--- a/rust/lance-encoding/src/encodings/physical/fixed_size_binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/fixed_size_binary.rs
@@ -176,25 +176,25 @@ mod tests {
     async fn test_fixed_size_utf8_binary() {
         let field = Field::new("", DataType::Utf8, false);
         // This test only generates fixed size binary arrays anyway
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_fixed_size_binary() {
         let field = Field::new("", DataType::Binary, false);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_fixed_size_large_binary() {
         let field = Field::new("", DataType::LargeBinary, true);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_fixed_size_large_utf8() {
         let field = Field::new("", DataType::LargeUtf8, true);
-        check_round_trip_encoding_random(field, HashMap::new()).await;
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
@@ -130,7 +130,7 @@ impl ArrayEncoder for FslEncoder {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::sync::Arc;
 
     use arrow_schema::{DataType, Field};
 
@@ -144,7 +144,7 @@ mod tests {
             let inner_field = Field::new("item", data_type.clone(), true);
             let data_type = DataType::FixedSizeList(Arc::new(inner_field), 16);
             let field = Field::new("", data_type, false);
-            check_round_trip_encoding_random(field, HashMap::new()).await;
+            check_round_trip_encoding_random(field).await;
         }
     }
 }

--- a/rust/lance-encoding/src/encodings/physical/packed_struct.rs
+++ b/rust/lance-encoding/src/encodings/physical/packed_struct.rs
@@ -269,12 +269,12 @@ pub mod tests {
             Field::new("a", DataType::UInt64, false),
             Field::new("b", DataType::UInt32, false),
         ]));
-        let field = Field::new("", data_type, false);
-
         let mut metadata = HashMap::new();
         metadata.insert("packed".to_string(), "true".to_string());
 
-        check_round_trip_encoding_random(field, metadata).await;
+        let field = Field::new("", data_type, false).with_metadata(metadata);
+
+        check_round_trip_encoding_random(field).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -244,7 +244,6 @@ impl ArrayEncoder for ValueEncoder {
 // public tests module because we share the PRIMITIVE_TYPES constant with fixed_size_list
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::collections::HashMap;
 
     use arrow_schema::{DataType, Field, TimeUnit};
 
@@ -282,7 +281,7 @@ pub(crate) mod tests {
         for data_type in PRIMITIVE_TYPES {
             log::info!("Testing encoding for {:?}", data_type);
             let field = Field::new("", data_type.clone(), false);
-            check_round_trip_encoding_random(field, HashMap::new()).await;
+            check_round_trip_encoding_random(field).await;
         }
     }
 }

--- a/rust/lance-encoding/src/lib.rs
+++ b/rust/lance-encoding/src/lib.rs
@@ -41,6 +41,9 @@ pub trait EncodingsIo: std::fmt::Debug + Send + Sync {
     /// This is important in cases where indirect I/O causes high priority requests to be submitted
     /// after low priority requests.  We want to fulfill the indirect I/O more quickly so that we
     /// can decode as quickly as possible.
+    ///
+    /// The implementation should be able to handle empty ranges, and should return an empty
+    /// byte buffer for each empty range.
     fn submit_request(
         &self,
         range: Vec<Range<u64>>,

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -450,11 +450,14 @@ impl IoTask {
     }
 
     async fn run(self) {
-        let bytes_fut = self
-            .reader
-            .get_range(self.to_read.start as usize..self.to_read.end as usize);
-        let bytes = bytes_fut.await.map_err(Error::from);
-        IOPS_QUOTA.release();
+        let bytes = if self.to_read.start == self.to_read.end {
+            Ok(Bytes::new())
+        } else {
+            let bytes_fut = self
+                .reader
+                .get_range(self.to_read.start as usize..self.to_read.end as usize);
+            bytes_fut.await.map_err(Error::from)
+        };
         (self.when_done)(bytes);
     }
 }

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -458,6 +458,7 @@ impl IoTask {
                 .get_range(self.to_read.start as usize..self.to_read.end as usize);
             bytes_fut.await.map_err(Error::from)
         };
+        IOPS_QUOTA.release();
         (self.when_done)(bytes);
     }
 }


### PR DESCRIPTION
Compared to the regular large binary encoding this will have considerably less metadata (since there will be fewer pages).  In the future it will also be possible to read just the descriptions (allowing for different ways of reading the data such as file objects).

The scheduling algorithm is also more conservative as well.  We don't fetch descriptions until we need them and we only read in one batch of blob data at a time (instead of an entire page).  This means the reader will probably be slightly less performant (though, when reading values this large, it shouldn't be too noticeable) but will use considerably less RAM.