### PR TITLE
feat: support decimal 128 and 256 json types

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -99,7 +99,7 @@ jobs:
           fail_ci_if_error: false
   linux-arm:
     runs-on: warp-ubuntu-latest-arm64-4x
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -160,7 +160,7 @@ jobs:
           workspaces: rust
       - name: Select new xcode
         # Default XCode right now is 15.0.1, which contains a bug that causes
-        # backtraces to not show properly. See: 
+        # backtraces to not show properly. See:
         # https://github.com/rust-lang/rust/issues/113783
         run: sudo xcode-select -s /Applications/Xcode_15.4.app
       - name: Install dependencies
@@ -171,7 +171,7 @@ jobs:
           rustup component add rustfmt
       - name: Run tests
         # Check all benches, even though we aren't going to run them.
-        run: |  
+        run: |
           cargo build --tests --benches --all-features --workspace
           cargo test --all-features
   windows-build:

--- a/rust/lance/src/arrow/json.rs
+++ b/rust/lance/src/arrow/json.rs
@@ -48,6 +48,8 @@ impl TryFrom<&DataType> for JsonDataType {
             | DataType::Float16
             | DataType::Float32
             | DataType::Float64
+            | DataType::Decimal128(_, _)
+            | DataType::Decimal256(_, _)
             | DataType::Utf8
             | DataType::Binary
             | DataType::LargeUtf8
@@ -63,7 +65,6 @@ impl TryFrom<&DataType> for JsonDataType {
                 let logical_type: LogicalType = dt.try_into()?;
                 (logical_type.to_string(), None)
             }
-
             DataType::List(f) => {
                 let fields = vec![JsonField::try_from(f.as_ref())?];
                 ("list".to_string(), Some(fields))
@@ -119,7 +120,8 @@ impl TryFrom<&JsonDataType> for DataType {
                 || dt.starts_with("time64:")
                 || dt.starts_with("timestamp:")
                 || dt.starts_with("duration:")
-                || dt.starts_with("dict:") =>
+                || dt.starts_with("dict:")
+                || dt.starts_with("decimal:") =>
             {
                 let logical_type: LogicalType = dt.into();
                 (&logical_type).try_into()
@@ -312,6 +314,10 @@ mod test {
         assert_primitive_types(DataType::Date32, "date32:day");
         assert_primitive_types(DataType::Date64, "date64:ms");
         assert_primitive_types(DataType::Time32(TimeUnit::Second), "time32:s");
+        assert_primitive_types(DataType::Decimal128(38, 10), "decimal:128:38:10");
+        assert_primitive_types(DataType::Decimal256(76, 20), "decimal:256:76:20");
+        assert_primitive_types(DataType::Decimal128(18, 6), "decimal:128:18:6");
+        assert_primitive_types(DataType::Decimal256(50, 15), "decimal:256:50:15");
     }
 
     #[test]


### PR DESCRIPTION
Fix: #2872