### PR TITLE
fix: limit/offset pushdown was not working correctly in the presence of deletions

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -452,10 +452,10 @@ def test_limit_offset(tmp_path: Path, data_storage_version: str):
     full_ds_version = dataset.version
     dataset.delete("a % 2 = 0")
     filt_table = table.filter((pa.compute.bit_wise_and(pa.compute.field("a"), 1)) != 0)
-    # assert (
-    #     dataset.to_table(offset=10).combine_chunks()
-    #     == filt_table.slice(10).combine_chunks()
-    # )
+    assert (
+        dataset.to_table(offset=10).combine_chunks()
+        == filt_table.slice(10).combine_chunks()
+    )
 
     dataset = dataset.checkout_version(full_ds_version)
     dataset.restore()

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -449,6 +449,22 @@ def test_limit_offset(tmp_path: Path, data_storage_version: str):
     with pytest.raises(ValueError, match="Limit must be non-negative"):
         assert dataset.to_table(offset=10, limit=-1) == table.slice(50, 50)
 
+    full_ds_version = dataset.version
+    dataset.delete("a % 2 = 0")
+    filt_table = table.filter((pa.compute.bit_wise_and(pa.compute.field("a"), 1)) != 0)
+    # assert (
+    #     dataset.to_table(offset=10).combine_chunks()
+    #     == filt_table.slice(10).combine_chunks()
+    # )
+
+    dataset = dataset.checkout_version(full_ds_version)
+    dataset.restore()
+    dataset.delete("a > 2 AND a < 7")
+    print(dataset.to_table(offset=3, limit=1))
+    filt_table = table.slice(7, 1)
+
+    assert dataset.to_table(offset=3, limit=1) == filt_table
+
 
 def test_relative_paths(tmp_path: Path):
     # relative paths get coerced to the full absolute path

--- a/rust/lance-core/src/utils/deletion.rs
+++ b/rust/lance-core/src/utils/deletion.rs
@@ -83,6 +83,17 @@ impl DeletionVector {
         }
     }
 
+    /// Create an iterator that iterates over the values in the deletion vector in sorted order.
+    pub fn to_sorted_iter<'a>(&'a self) -> Box<dyn Iterator<Item = u32> + Send + 'a> {
+        match self {
+            Self::NoDeletions => Box::new(std::iter::empty()),
+            // We have to make a clone when we're using a set
+            // but sets should be relatively small.
+            Self::Set(_) => self.clone().into_sorted_iter(),
+            Self::Bitmap(bitmap) => Box::new(bitmap.iter()),
+        }
+    }
+
     // Note: deletion vectors are based on 32-bit offsets.  However, this function works
     // even when given 64-bit row addresses.  That is because `id as u32` returns the lower
     // 32 bits (the row offset) and the upper 32 bits are ignored.


### PR DESCRIPTION
We need to push back the scan start and potentially grab more rows than requested to make sure we fulfill the request.  For v2 files we could also convert the row range into multiple ranges instead of grabbing more rows than required.  This might be something to investigate in the future.