### PR TITLE
feat!: add batch_size option to merge_columns

### DIFF
--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -364,6 +364,7 @@ class LanceFragment(pa.dataset.Fragment):
         self,
         value_func: Callable[[pa.RecordBatch], pa.RecordBatch],
         columns: Optional[list[str]] = None,
+        batch_size: Optional[int] = None,
     ) -> Tuple[FragmentMetadata, LanceSchema]:
         """Add columns to this Fragment.
 
@@ -390,7 +391,7 @@ class LanceFragment(pa.dataset.Fragment):
         Tuple[FragmentMetadata, LanceSchema]
             A new fragment with the added column(s) and the final schema.
         """
-        updater = self._fragment.updater(columns)
+        updater = self._fragment.updater(columns, batch_size)
 
         while True:
             batch = updater.next()

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -210,10 +210,12 @@ impl FileFragment {
         Ok(Scanner::new(scn))
     }
 
-    fn updater(&self, columns: Option<Vec<String>>) -> PyResult<Updater> {
+    fn updater(&self, columns: Option<Vec<String>>, batch_size: Option<u32>) -> PyResult<Updater> {
         let cols = columns.as_deref();
         let inner = RT
-            .block_on(None, async { self.fragment.updater(cols, None).await })?
+            .block_on(None, async {
+                self.fragment.updater(cols, None, batch_size).await
+            })?
             .map_err(|err| PyIOError::new_err(err.to_string()))?;
         Ok(Updater::new(inner))
     }

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -261,7 +261,7 @@ async fn add_columns_impl(
                 }
 
                 let mut updater = fragment
-                    .updater(read_columns_ref, schemas_ref.clone())
+                    .updater(read_columns_ref, schemas_ref.clone(), None)
                     .await?;
 
                 let mut batch_index = 0;

--- a/rust/lance/src/dataset/updater.rs
+++ b/rust/lance/src/dataset/updater.rs
@@ -10,7 +10,7 @@ use lance_table::utils::stream::ReadBatchFutStream;
 use snafu::{location, Location};
 
 use super::fragment::FragmentReader;
-use super::scanner::DEFAULT_BATCH_SIZE;
+use super::scanner::get_default_batch_size;
 use super::write::{open_writer, GenericWriter};
 use super::Dataset;
 use crate::dataset::FileFragment;
@@ -76,7 +76,7 @@ impl Updater {
             // If this is a v2 dataset, let the user pick the batch size
             (None, Some(legacy_batch_size)) => legacy_batch_size,
             // Otherwise, default to 1024 if the user didn't specify anything
-            (None, None) => DEFAULT_BATCH_SIZE.unwrap_or(1024) as u32,
+            (None, None) => get_default_batch_size().unwrap_or(1024) as u32,
         };
 
         let input_stream = reader.read_all(batch_size)?;

--- a/rust/lance/src/dataset/updater.rs
+++ b/rust/lance/src/dataset/updater.rs
@@ -10,6 +10,7 @@ use lance_table::utils::stream::ReadBatchFutStream;
 use snafu::{location, Location};
 
 use super::fragment::FragmentReader;
+use super::scanner::DEFAULT_BATCH_SIZE;
 use super::write::{open_writer, GenericWriter};
 use super::Dataset;
 use crate::dataset::FileFragment;
@@ -59,6 +60,7 @@ impl Updater {
         reader: FragmentReader,
         deletion_vector: DeletionVector,
         schemas: Option<(Schema, Schema)>,
+        batch_size: Option<u32>,
     ) -> Result<Self> {
         let (write_schema, final_schema) = if let Some((write_schema, final_schema)) = schemas {
             (Some(write_schema), Some(final_schema))
@@ -66,9 +68,18 @@ impl Updater {
             (None, None)
         };
 
-        let batch_size = reader.legacy_num_rows_in_batch(0);
+        let legacy_batch_size = reader.legacy_num_rows_in_batch(0);
 
-        let input_stream = reader.read_all(1024)?;
+        let batch_size = match (&legacy_batch_size, batch_size) {
+            // If this is a v1 dataset we must use the row group size of the file
+            (Some(num_rows), _) => *num_rows,
+            // If this is a v2 dataset, let the user pick the batch size
+            (None, Some(legacy_batch_size)) => legacy_batch_size,
+            // Otherwise, default to 1024 if the user didn't specify anything
+            (None, None) => DEFAULT_BATCH_SIZE.unwrap_or(1024) as u32,
+        };
+
+        let input_stream = reader.read_all(batch_size)?;
 
         Ok(Self {
             fragment,
@@ -78,7 +89,7 @@ impl Updater {
             write_schema,
             final_schema,
             finished: false,
-            deletion_restorer: DeletionRestorer::new(deletion_vector, batch_size),
+            deletion_restorer: DeletionRestorer::new(deletion_vector, legacy_batch_size),
         })
     }
 
@@ -226,7 +237,7 @@ struct DeletionRestorer {
     current_row_id: u32,
 
     /// Number of rows in each batch, only used in legacy files for validation
-    batch_size: Option<u32>,
+    legacy_batch_size: Option<u32>,
 
     deletion_vector_iter: Option<Box<dyn Iterator<Item = u32> + Send>>,
 
@@ -234,10 +245,10 @@ struct DeletionRestorer {
 }
 
 impl DeletionRestorer {
-    fn new(deletion_vector: DeletionVector, batch_size: Option<u32>) -> Self {
+    fn new(deletion_vector: DeletionVector, legacy_batch_size: Option<u32>) -> Self {
         Self {
             current_row_id: 0,
-            batch_size,
+            legacy_batch_size,
             deletion_vector_iter: Some(deletion_vector.into_sorted_iter()),
             last_deleted_row_id: None,
         }
@@ -248,12 +259,12 @@ impl DeletionRestorer {
     }
 
     fn is_full(batch_size: Option<u32>, num_rows: u32) -> bool {
-        if let Some(batch_size) = batch_size {
+        if let Some(legacy_batch_size) = batch_size {
             // We should never encounter the case that `batch_size < num_rows` because
             // that would mean we have a v1 writer and it generated a batch with more rows
             // than expected
-            debug_assert!(batch_size >= num_rows);
-            batch_size == num_rows
+            debug_assert!(legacy_batch_size >= num_rows);
+            legacy_batch_size == num_rows
         } else {
             false
         }
@@ -295,7 +306,8 @@ impl DeletionRestorer {
         loop {
             if let Some(next_deleted_id) = next_deleted_id {
                 if next_deleted_id > last_row_id
-                    || (next_deleted_id == last_row_id && Self::is_full(self.batch_size, num_rows))
+                    || (next_deleted_id == last_row_id
+                        && Self::is_full(self.legacy_batch_size, num_rows))
                 {
                     // Either the next deleted id is out of range or it is the next row but
                     // we are full.  Either way, stash it and return
@@ -322,7 +334,7 @@ impl DeletionRestorer {
         let deleted_batch_offsets = self.deleted_batch_offsets_in_range(batch.num_rows() as u32);
         let batch = add_blanks(batch, &deleted_batch_offsets)?;
 
-        if let Some(batch_size) = self.batch_size {
+        if let Some(batch_size) = self.legacy_batch_size {
             // validation just in case, when the input has a fixed batch size then the
             // output should have the same fixed batch size (except the last batch)
             let is_last = self.is_exhausted();

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -701,6 +701,7 @@ impl MergeInsertJob {
                         .updater(
                             Some(&read_columns),
                             Some((write_schema, dataset.schema().clone())),
+                            None,
                         )
                         .await?;
 


### PR DESCRIPTION
There's a few other places where updater is used (e.g. merge_insert / add_columns) and we may want to review those paths as well.

This is technically a breaking change on the rust API and so I will mark it as such.

BREAKING CHANGE: `Fragment::updater` now accepts a new `batch_size` argument