### PR TITLE
fix: fix release versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ lance-encoding-datafusion = { version = "=0.18.1", path = "./rust/lance-encoding
 lance-file = { version = "=0.18.1", path = "./rust/lance-file" }
 lance-index = { version = "=0.18.1", path = "./rust/lance-index" }
 lance-io = { version = "=0.18.1", path = "./rust/lance-io" }
+lance-jni = { version = "=0.18.1", path = "./java/core/lance-jni" }
 lance-linalg = { version = "=0.18.1", path = "./rust/lance-linalg" }
 lance-table = { version = "=0.18.1", path = "./rust/lance-table" }
 lance-test-macros = { version = "=0.18.1", path = "./rust/lance-test-macros" }

--- a/java/core/lance-jni/Cargo.toml
+++ b/java/core/lance-jni/Cargo.toml
@@ -14,9 +14,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 lance = { workspace = true, features = ["substrait"] }
-lance-encoding = { path = "../../../rust/lance-encoding" }
-lance-linalg = { path = "../../../rust/lance-linalg" }
-lance-index = { path = "../../../rust/lance-index" }
+lance-encoding = { workspace = true }
+lance-linalg = { workspace = true }
+lance-index = { workspace = true }
 lance-io.workspace = true
 arrow = { workspace = true, features = ["ffi"] }
 arrow-schema.workspace = true

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lancedb</groupId>
         <artifactId>lance-parent</artifactId>
-        <version>0.0.5</version>
+        <version>0.18.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.lancedb</groupId>
     <artifactId>lance-parent</artifactId>
-    <version>0.0.5</version>
+    <version>0.18.1</version>
     <packaging>pom</packaging>
 
     <name>Lance Parent</name>

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lancedb</groupId>
         <artifactId>lance-parent</artifactId>
-        <version>0.0.5</version>
+        <version>0.18.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Solve the issue when publishing rust
```
- cargo package -v --no-verify                            ✔
error: all dependencies must have a version specified when packaging.
dependency `lance-encoding` does not specify a version
Note: The packaged dependency will use the version from crates.io,
the `path` specification will be removed from the dependency declaration.
```
Give the java pom correct versions