### PR TITLE
fix: revert Bump version f3eef61

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.18.1"
+version = "0.18.0"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 license = "Apache-2.0"
@@ -44,21 +44,21 @@ categories = [
 rust-version = "1.78"
 
 [workspace.dependencies]
-lance = { version = "=0.18.1", path = "./rust/lance" }
-lance-arrow = { version = "=0.18.1", path = "./rust/lance-arrow" }
-lance-core = { version = "=0.18.1", path = "./rust/lance-core" }
-lance-datafusion = { version = "=0.18.1", path = "./rust/lance-datafusion" }
-lance-datagen = { version = "=0.18.1", path = "./rust/lance-datagen" }
-lance-encoding = { version = "=0.18.1", path = "./rust/lance-encoding" }
-lance-encoding-datafusion = { version = "=0.18.1", path = "./rust/lance-encoding-datafusion" }
-lance-file = { version = "=0.18.1", path = "./rust/lance-file" }
-lance-index = { version = "=0.18.1", path = "./rust/lance-index" }
-lance-io = { version = "=0.18.1", path = "./rust/lance-io" }
-lance-jni = { version = "=0.18.1", path = "./java/core/lance-jni" }
-lance-linalg = { version = "=0.18.1", path = "./rust/lance-linalg" }
-lance-table = { version = "=0.18.1", path = "./rust/lance-table" }
-lance-test-macros = { version = "=0.18.1", path = "./rust/lance-test-macros" }
-lance-testing = { version = "=0.18.1", path = "./rust/lance-testing" }
+lance = { version = "=0.18.0", path = "./rust/lance" }
+lance-arrow = { version = "=0.18.0", path = "./rust/lance-arrow" }
+lance-core = { version = "=0.18.0", path = "./rust/lance-core" }
+lance-datafusion = { version = "=0.18.0", path = "./rust/lance-datafusion" }
+lance-datagen = { version = "=0.18.0", path = "./rust/lance-datagen" }
+lance-encoding = { version = "=0.18.0", path = "./rust/lance-encoding" }
+lance-encoding-datafusion = { version = "=0.18.0", path = "./rust/lance-encoding-datafusion" }
+lance-file = { version = "=0.18.0", path = "./rust/lance-file" }
+lance-index = { version = "=0.18.0", path = "./rust/lance-index" }
+lance-io = { version = "=0.18.0", path = "./rust/lance-io" }
+lance-jni = { version = "=0.18.0", path = "./java/core/lance-jni" }
+lance-linalg = { version = "=0.18.0", path = "./rust/lance-linalg" }
+lance-table = { version = "=0.18.0", path = "./rust/lance-table" }
+lance-test-macros = { version = "=0.18.0", path = "./rust/lance-test-macros" }
+lance-testing = { version = "=0.18.0", path = "./rust/lance-testing" }
 approx = "0.5.1"
 # Note that this one does not include pyarrow
 arrow = { version = "52.2", optional = false, features = ["prettyprint"] }
@@ -111,7 +111,7 @@ datafusion-physical-expr = { version = "40.0", features = [
 ] }
 deepsize = "0.2.0"
 either = "1.0"
-fsst = { version = "=0.18.1", path = "./rust/lance-encoding/compression-algo/fsst" }
+fsst = { version = "=0.18.0", path = "./rust/lance-encoding/compression-algo/fsst" }
 futures = "0.3"
 http = "0.2.9"
 hyperloglogplus = { version = "0.4.1", features = ["const-loop"] }

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lancedb</groupId>
         <artifactId>lance-parent</artifactId>
-        <version>0.18.1</version>
+        <version>0.18.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.lancedb</groupId>
     <artifactId>lance-parent</artifactId>
-    <version>0.18.1</version>
+    <version>0.18.0</version>
     <packaging>pom</packaging>
 
     <name>Lance Parent</name>

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lancedb</groupId>
         <artifactId>lance-parent</artifactId>
-        <version>0.18.1</version>
+        <version>0.18.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.lancedb</groupId>
             <artifactId>lance-core</artifactId>
-            <version>0.0.5</version>
+            <version>0.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pylance"
-version = "0.18.1"
+version = "0.18.0"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 rust-version = "1.65"


### PR DESCRIPTION
Revert "Bump version"
This reverts commit https://github.com/lancedb/lance/commit/f3eef61e29e3c2211ace2d1fa47ef553d63cb8f6.