### PR TITLE
fix: enlarge cargo release timeout and add workflow dispatch

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -5,6 +5,12 @@ on:
     # Use released instead of published, since we don't publish preview/beta
     # versions. Users instead install them from the git repo.
     types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g., v1.0.0)'
+        required: true
+        type: string
 
 env:
   # This env var is used by Swatinem/rust-cache@v2 for the cache
@@ -14,7 +20,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     env:
       # Need up-to-date compilers for kernels
       CC: gcc-12
@@ -27,6 +33,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
+      - name: Checkout specified tag
+        if: github.event_name == 'workflow_dispatch'
+        run: git checkout ${{ github.event.inputs.tag }}
       - name: Install dependencies
         run: |
           sudo apt update


### PR DESCRIPTION
https://github.com/lancedb/lance/actions/runs/10908634424
v0.18.0 cargo release failed with timeout
enlarge the timeout and add workflow dispatch with tag