### PR TITLE
feat: make `Debug`  for  useful `Session`

### DIFF
--- a/rust/lance-core/src/cache.rs
+++ b/rust/lance-core/src/cache.rs
@@ -67,6 +67,10 @@ impl FileMetadataCache {
         }
     }
 
+    pub fn size(&self) -> usize {
+        self.cache.entry_count() as usize
+    }
+
     pub fn get<T: Send + Sync + 'static>(&self, path: &Path) -> Option<Arc<T>> {
         self.cache
             .get(&(path.to_owned(), TypeId::of::<T>()))

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -31,7 +31,28 @@ pub struct Session {
 
 impl std::fmt::Debug for Session {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Session()")
+        f.debug_struct("Session")
+            .field(
+                "index_cache",
+                &format!(
+                    "IndexCache(items={}, size_bytes={})",
+                    self.index_cache.get_size(),
+                    self.index_cache.deep_size_of()
+                ),
+            )
+            .field(
+                "file_metadata_cache",
+                &format!(
+                    "FileMetadataCache(items={}, size_bytes={})",
+                    self.file_metadata_cache.size(),
+                    self.file_metadata_cache.deep_size_of()
+                ),
+            )
+            .field(
+                "index_extensions",
+                &self.index_extensions.keys().collect::<Vec<_>>(),
+            )
+            .finish()
     }
 }
 


### PR DESCRIPTION
Right now the `Debug` for `Session` is just `Session()`, which is pretty unhelpful. Needed this recently to debug the cache.