### PR TITLE
fix: restore ability to write fixed size list of nullable

### DIFF
--- a/python/python/tests/test_file.py
+++ b/python/python/tests/test_file.py
@@ -132,6 +132,12 @@ def test_with_nulls(tmp_path):
             {
                 "some_null_1": pa.array([1, 2, None], pa.int64()),
                 "some_null_2": pa.array([None, None, 3], pa.int64()),
+                "nullable_list": pa.array(
+                    [[1, 2], None, [None, 3]], pa.list_(pa.int64())
+                ),
+                "nullable_fsl": pa.array(
+                    [[1, 2], None, [None, 3]], pa.list_(pa.int64(), 2)
+                ),
                 "all_null": pa.array([None, None, None], pa.int64()),
                 "null_strings": pa.array([None, "foo", None], pa.string()),
             }

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -124,24 +124,11 @@ impl FixedWidthDataBlock {
         num_values: u64,
         validate: bool,
     ) -> Result<ArrayData> {
-        let builder = match &data_type {
-            DataType::FixedSizeList(child_field, dim) => {
-                let child_len = num_values * *dim as u64;
-                let child_data =
-                    self.do_into_arrow(child_field.data_type().clone(), child_len, validate)?;
-                ArrayDataBuilder::new(data_type)
-                    .add_child_data(child_data)
-                    .len(num_values as usize)
-                    .null_count(0)
-            }
-            _ => {
-                let data_buffer = self.data.into_buffer();
-                ArrayDataBuilder::new(data_type)
-                    .add_buffer(data_buffer)
-                    .len(num_values as usize)
-                    .null_count(0)
-            }
-        };
+        let data_buffer = self.data.into_buffer();
+        let builder = ArrayDataBuilder::new(data_type)
+            .add_buffer(data_buffer)
+            .len(num_values as usize)
+            .null_count(0);
         if validate {
             Ok(builder.build()?)
         } else {
@@ -172,6 +159,103 @@ impl FixedWidthDataBlock {
             bits_per_value: self.bits_per_value,
             num_values: self.num_values,
         })
+    }
+}
+
+/// A data block to represent a fixed size list
+#[derive(Debug)]
+pub struct FixedSizeListBlock {
+    /// The child data block
+    pub child: Box<DataBlock>,
+    /// The number of items in each list
+    pub dimension: u64,
+}
+
+impl FixedSizeListBlock {
+    fn borrow_and_clone(&mut self) -> Self {
+        Self {
+            child: Box::new(self.child.borrow_and_clone()),
+            dimension: self.dimension,
+        }
+    }
+
+    fn try_clone(&self) -> Result<Self> {
+        Ok(Self {
+            child: Box::new(self.child.try_clone()?),
+            dimension: self.dimension,
+        })
+    }
+
+    fn num_values(&self) -> u64 {
+        self.child.num_values() / self.dimension
+    }
+
+    /// Try to flatten a FixedSizeListBlock into a FixedWidthDataBlock
+    ///
+    /// Returns None if any children are nullable
+    pub fn try_into_flat(self) -> Option<FixedWidthDataBlock> {
+        match *self.child {
+            // Cannot flatten a nullable child
+            DataBlock::Nullable(_) => None,
+            DataBlock::FixedSizeList(inner) => {
+                let mut flat = inner.try_into_flat()?;
+                flat.bits_per_value *= self.dimension;
+                flat.num_values /= self.dimension;
+                Some(flat)
+            }
+            DataBlock::FixedWidth(mut inner) => {
+                inner.bits_per_value *= self.dimension;
+                inner.num_values /= self.dimension;
+                Some(inner)
+            }
+            _ => panic!(
+                "Expected FixedSizeList or FixedWidth data block but found {:?}",
+                self
+            ),
+        }
+    }
+
+    /// Convert a flattened values block into a FixedSizeListBlock
+    pub fn from_flat(data: FixedWidthDataBlock, data_type: &DataType) -> DataBlock {
+        match data_type {
+            DataType::FixedSizeList(child_field, dimension) => {
+                let mut data = data;
+                data.bits_per_value /= *dimension as u64;
+                data.num_values *= *dimension as u64;
+                let child_data = Self::from_flat(data, child_field.data_type());
+                DataBlock::FixedSizeList(Self {
+                    child: Box::new(child_data),
+                    dimension: *dimension as u64,
+                })
+            }
+            // Base case, we've hit a non-list type
+            _ => DataBlock::FixedWidth(data),
+        }
+    }
+
+    fn into_arrow(self, data_type: DataType, validate: bool) -> Result<ArrayData> {
+        let num_values = self.num_values();
+        let builder = match &data_type {
+            DataType::FixedSizeList(child_field, _) => {
+                let child_data = self
+                    .child
+                    .into_arrow(child_field.data_type().clone(), validate)?;
+                ArrayDataBuilder::new(data_type)
+                    .add_child_data(child_data)
+                    .len(num_values as usize)
+                    .null_count(0)
+            }
+            _ => panic!("Expected FixedSizeList data type and got {:?}", data_type),
+        };
+        if validate {
+            Ok(builder.build()?)
+        } else {
+            Ok(unsafe { builder.build_unchecked() })
+        }
+    }
+
+    fn into_buffers(self) -> Vec<LanceBuffer> {
+        self.child.into_buffers()
     }
 }
 
@@ -401,6 +485,7 @@ pub enum DataBlock {
     AllNull(AllNullDataBlock),
     Nullable(NullableDataBlock),
     FixedWidth(FixedWidthDataBlock),
+    FixedSizeList(FixedSizeListBlock),
     VariableWidth(VariableWidthBlock),
     Opaque(OpaqueBlock),
     Struct(StructDataBlock),
@@ -414,6 +499,7 @@ impl DataBlock {
             Self::AllNull(inner) => inner.into_arrow(data_type, validate),
             Self::Nullable(inner) => inner.into_arrow(data_type, validate),
             Self::FixedWidth(inner) => inner.into_arrow(data_type, validate),
+            Self::FixedSizeList(inner) => inner.into_arrow(data_type, validate),
             Self::VariableWidth(inner) => inner.into_arrow(data_type, validate),
             Self::Struct(inner) => inner.into_arrow(data_type, validate),
             Self::Dictionary(inner) => inner.into_arrow(data_type, validate),
@@ -432,6 +518,7 @@ impl DataBlock {
             Self::AllNull(inner) => inner.into_buffers(),
             Self::Nullable(inner) => inner.into_buffers(),
             Self::FixedWidth(inner) => inner.into_buffers(),
+            Self::FixedSizeList(inner) => inner.into_buffers(),
             Self::VariableWidth(inner) => inner.into_buffers(),
             Self::Struct(inner) => inner.into_buffers(),
             Self::Dictionary(inner) => inner.into_buffers(),
@@ -448,6 +535,7 @@ impl DataBlock {
             Self::AllNull(inner) => Self::AllNull(inner.borrow_and_clone()),
             Self::Nullable(inner) => Self::Nullable(inner.borrow_and_clone()),
             Self::FixedWidth(inner) => Self::FixedWidth(inner.borrow_and_clone()),
+            Self::FixedSizeList(inner) => Self::FixedSizeList(inner.borrow_and_clone()),
             Self::VariableWidth(inner) => Self::VariableWidth(inner.borrow_and_clone()),
             Self::Struct(inner) => Self::Struct(inner.borrow_and_clone()),
             Self::Dictionary(inner) => Self::Dictionary(inner.borrow_and_clone()),
@@ -464,6 +552,7 @@ impl DataBlock {
             Self::AllNull(inner) => Ok(Self::AllNull(inner.try_clone()?)),
             Self::Nullable(inner) => Ok(Self::Nullable(inner.try_clone()?)),
             Self::FixedWidth(inner) => Ok(Self::FixedWidth(inner.try_clone()?)),
+            Self::FixedSizeList(inner) => Ok(Self::FixedSizeList(inner.try_clone()?)),
             Self::VariableWidth(inner) => Ok(Self::VariableWidth(inner.try_clone()?)),
             Self::Struct(inner) => Ok(Self::Struct(inner.try_clone()?)),
             Self::Dictionary(inner) => Ok(Self::Dictionary(inner.try_clone()?)),
@@ -476,6 +565,7 @@ impl DataBlock {
             Self::AllNull(_) => "AllNull",
             Self::Nullable(_) => "Nullable",
             Self::FixedWidth(_) => "FixedWidth",
+            Self::FixedSizeList(_) => "FixedSizeList",
             Self::VariableWidth(_) => "VariableWidth",
             Self::Struct(_) => "Struct",
             Self::Dictionary(_) => "Dictionary",
@@ -488,6 +578,7 @@ impl DataBlock {
             Self::AllNull(inner) => inner.num_values,
             Self::Nullable(inner) => inner.data.num_values(),
             Self::FixedWidth(inner) => inner.num_values,
+            Self::FixedSizeList(inner) => inner.num_values(),
             Self::VariableWidth(inner) => inner.num_values,
             Self::Struct(inner) => inner.children[0].num_values(),
             Self::Dictionary(inner) => inner.indices.num_values,
@@ -498,13 +589,10 @@ impl DataBlock {
 
 macro_rules! as_type {
     ($fn_name:ident, $inner:tt, $inner_type:ident) => {
-        pub fn $fn_name(self) -> Result<$inner_type> {
+        pub fn $fn_name(self) -> Option<$inner_type> {
             match self {
-                Self::$inner(inner) => Ok(inner),
-                _ => Err(Error::Internal {
-                    message: format!("Expected {}, got {}", stringify!($inner), self.name()),
-                    location: location!(),
-                }),
+                Self::$inner(inner) => Some(inner),
+                _ => None,
             }
         }
     };
@@ -515,6 +603,7 @@ impl DataBlock {
     as_type!(as_all_null, AllNull, AllNullDataBlock);
     as_type!(as_nullable, Nullable, NullableDataBlock);
     as_type!(as_fixed_width, FixedWidth, FixedWidthDataBlock);
+    as_type!(as_fixed_size_list, FixedSizeList, FixedSizeListBlock);
     as_type!(as_variable_width, VariableWidth, VariableWidthBlock);
     as_type!(as_struct, Struct, StructDataBlock);
     as_type!(as_dictionary, Dictionary, DictionaryDataBlock);
@@ -917,15 +1006,10 @@ impl DataBlock {
                     .map(|arr| arr.as_fixed_size_list().values().clone())
                     .collect::<Vec<_>>();
                 let child_block = Self::from_arrays(&children, num_values * *dim as u64);
-                match child_block {
-                    Self::FixedWidth(inner) => {
-                        Self::FixedWidth(FixedWidthDataBlock {
-                        data: inner.data,
-                        bits_per_value: inner.bits_per_value * *dim as u64,
-                        num_values,
-                    })},
-                    _ => panic!("FSL of something that is not fixed-width cannot be converted to data block"),
-                }
+                Self::FixedSizeList(FixedSizeListBlock {
+                    child: Box::new(child_block),
+                    dimension: *dim as u64,
+                })
             }
             DataType::LargeList(_)
             | DataType::List(_)

--- a/rust/lance-encoding/src/encodings/physical/basic.rs
+++ b/rust/lance-encoding/src/encodings/physical/basic.rs
@@ -160,7 +160,7 @@ impl PrimitivePageDecoder for BasicPageDecoder {
         match &self.mode {
             DataNullStatus::Some(decoders) => {
                 let validity = decoders.validity.decode(rows_to_skip, num_rows)?;
-                let validity = validity.as_fixed_width()?;
+                let validity = validity.as_fixed_width().unwrap();
                 let values = decoders.values.decode(rows_to_skip, num_rows)?;
                 Ok(DataBlock::Nullable(NullableDataBlock {
                     data: Box::new(values),

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -314,7 +314,7 @@ impl PrimitivePageDecoder for BinaryPageDecoder {
             - bytes_to_skip;
 
         let bytes = self.bytes_decoder.decode(bytes_to_skip, num_bytes)?;
-        let bytes = bytes.as_fixed_width()?;
+        let bytes = bytes.as_fixed_width().unwrap();
         debug_assert_eq!(bytes.bits_per_value, 8);
 
         let string_data = DataBlock::VariableWidth(VariableWidthBlock {
@@ -440,7 +440,7 @@ impl ArrayEncoder for BinaryEncoder {
     ) -> Result<EncodedArray> {
         let (data, nulls) = match data {
             DataBlock::Nullable(nullable) => {
-                let data = nullable.data.as_variable_width()?;
+                let data = nullable.data.as_variable_width().unwrap();
                 (data, Some(nullable.nulls))
             }
             DataBlock::VariableWidth(variable) => (variable, None),
@@ -463,7 +463,7 @@ impl ArrayEncoder for BinaryEncoder {
             self.indices_encoder
                 .encode(indices, &DataType::UInt64, buffer_index)?;
 
-        let encoded_indices_data = encoded_indices.data.as_fixed_width()?;
+        let encoded_indices_data = encoded_indices.data.as_fixed_width().unwrap();
 
         assert!(encoded_indices_data.bits_per_value <= 64);
 

--- a/rust/lance-encoding/src/encodings/physical/block_compress.rs
+++ b/rust/lance-encoding/src/encodings/physical/block_compress.rs
@@ -114,7 +114,7 @@ impl ArrayEncoder for CompressedBufferEncoder {
         _data_type: &DataType,
         buffer_index: &mut u32,
     ) -> Result<EncodedArray> {
-        let uncompressed_data = data.as_fixed_width()?;
+        let uncompressed_data = data.as_fixed_width().unwrap();
 
         let mut compressed_buf = Vec::with_capacity(uncompressed_data.data.len());
         self.compressor

--- a/rust/lance-encoding/src/encodings/physical/dictionary.rs
+++ b/rust/lance-encoding/src/encodings/physical/dictionary.rs
@@ -145,7 +145,8 @@ impl PrimitivePageDecoder for DirectDictionaryPageDecoder {
         let indices = self
             .indices_decoder
             .decode(rows_to_skip, num_rows)?
-            .as_fixed_width()?;
+            .as_fixed_width()
+            .unwrap();
         let dict = self.decoded_dict.try_clone()?;
         Ok(DataBlock::Dictionary(DictionaryDataBlock {
             indices,
@@ -270,7 +271,7 @@ impl ArrayEncoder for AlreadyDictionaryEncoder {
 
         let encoded = DataBlock::Dictionary(DictionaryDataBlock {
             dictionary: Box::new(encoded_items.data),
-            indices: encoded_indices.data.as_fixed_width()?,
+            indices: encoded_indices.data.as_fixed_width().unwrap(),
         });
 
         let encoding = ProtobufUtils::dict_encoding(
@@ -384,7 +385,7 @@ impl ArrayEncoder for DictionaryEncoder {
             .encode(items_data, &DataType::Utf8, buffer_index)?;
 
         let encoded_data = DataBlock::Dictionary(DictionaryDataBlock {
-            indices: encoded_indices.data.as_fixed_width()?,
+            indices: encoded_indices.data.as_fixed_width().unwrap(),
             dictionary: Box::new(encoded_items.data),
         });
 

--- a/rust/lance-encoding/src/encodings/physical/fixed_size_binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/fixed_size_binary.rs
@@ -83,7 +83,7 @@ impl PrimitivePageDecoder for FixedSizeBinaryDecoder {
         let rows_to_skip = rows_to_skip * self.byte_width;
         let num_bytes = num_rows * self.byte_width;
         let bytes = self.bytes_decoder.decode(rows_to_skip, num_bytes)?;
-        let bytes = bytes.as_fixed_width()?;
+        let bytes = bytes.as_fixed_width().unwrap();
         debug_assert_eq!(bytes.bits_per_value, 8);
 
         let offsets_buffer = match self.bytes_per_offset {
@@ -137,7 +137,7 @@ impl ArrayEncoder for FixedSizeBinaryEncoder {
         _data_type: &DataType,
         buffer_index: &mut u32,
     ) -> Result<EncodedArray> {
-        let bytes_data = data.as_variable_width()?;
+        let bytes_data = data.as_variable_width().unwrap();
 
         let fixed_data = DataBlock::FixedWidth(FixedWidthDataBlock {
             bits_per_value: 8 * self.byte_width as u64,

--- a/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
@@ -9,7 +9,7 @@ use lance_core::Result;
 use log::trace;
 
 use crate::{
-    data::DataBlock,
+    data::{DataBlock, FixedSizeListBlock},
     decoder::{PageScheduler, PrimitivePageDecoder},
     encoder::{ArrayEncoder, EncodedArray},
     format::ProtobufUtils,
@@ -78,10 +78,10 @@ impl PrimitivePageDecoder for FixedListDecoder {
         let rows_to_skip = rows_to_skip * self.dimension;
         let num_child_rows = num_rows * self.dimension;
         let child_data = self.items_decoder.decode(rows_to_skip, num_child_rows)?;
-        let mut child_data = child_data.as_fixed_width()?;
-        child_data.num_values = num_rows;
-        child_data.bits_per_value *= self.dimension;
-        Ok(DataBlock::FixedWidth(child_data))
+        Ok(DataBlock::FixedSizeList(FixedSizeListBlock {
+            child: Box::new(child_data),
+            dimension: self.dimension,
+        }))
     }
 }
 
@@ -111,21 +111,17 @@ impl ArrayEncoder for FslEncoder {
             DataType::FixedSizeList(inner_field, _) => inner_field.data_type().clone(),
             _ => panic!("Expected fixed size list data type and got {}", data_type),
         };
-        let mut data = data.as_fixed_width()?;
-        data.bits_per_value /= self.dimension as u64;
-        data.num_values *= self.dimension as u64;
-        let data = DataBlock::FixedWidth(data);
+        let data = data.as_fixed_size_list().unwrap();
+        let child = *data.child;
 
-        let encoded_data = self.items_encoder.encode(data, &inner_type, buffer_index)?;
+        let encoded_data = self
+            .items_encoder
+            .encode(child, &inner_type, buffer_index)?;
 
-        let data = match encoded_data.data {
-            DataBlock::FixedWidth(mut data) => {
-                data.bits_per_value *= self.dimension as u64;
-                data.num_values /= self.dimension as u64;
-                DataBlock::FixedWidth(data)
-            }
-            _ => panic!("Expected fixed width data block"),
-        };
+        let data = DataBlock::FixedSizeList(FixedSizeListBlock {
+            child: Box::new(encoded_data.data),
+            dimension: self.dimension as u64,
+        });
 
         let encoding = ProtobufUtils::fixed_size_list(encoded_data.encoding, self.dimension);
         Ok(EncodedArray { data, encoding })

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -66,7 +66,7 @@ impl PrimitivePageDecoder for FsstPageDecoder {
         let compressed_data = self.inner_decoder.decode(rows_to_skip, num_rows)?;
         let (string_data, nulls) = match compressed_data {
             DataBlock::Nullable(nullable) => {
-                let data = nullable.data.as_variable_width()?;
+                let data = nullable.data.as_variable_width().unwrap();
                 Result::Ok((data, Some(nullable.nulls)))
             }
             DataBlock::VariableWidth(variable) => Ok((variable, None)),


### PR DESCRIPTION
The recent encodings refactor https://github.com/lancedb/lance/pull/2817 broke our ability to write fixed size list arrays of nullable values (we could still handle nullable fixed size list arrays).  This PR restores the capability.