### PR TITLE
feat: reconnect pushdown to v2

### DIFF
--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -331,7 +331,7 @@ impl LanceFileReader {
             },
         );
         let file = scheduler.open_file(&path).await.infer_error()?;
-        let inner = FileReader::try_open(file, None, DecoderMiddlewareChain::default())
+        let inner = FileReader::try_open(file, None, Arc::<DecoderMiddlewareChain>::default())
             .await
             .infer_error()?;
         Ok(Self {

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -19,6 +19,7 @@ use arrow_schema::Schema as ArrowSchema;
 use bytes::Bytes;
 use futures::stream::StreamExt;
 use lance::io::{ObjectStore, RecordBatchStream};
+use lance_core::cache::FileMetadataCache;
 use lance_encoding::decoder::{DecoderMiddlewareChain, FilterExpression};
 use lance_file::{
     v2::{
@@ -331,9 +332,14 @@ impl LanceFileReader {
             },
         );
         let file = scheduler.open_file(&path).await.infer_error()?;
-        let inner = FileReader::try_open(file, None, Arc::<DecoderMiddlewareChain>::default())
-            .await
-            .infer_error()?;
+        let inner = FileReader::try_open(
+            file,
+            None,
+            Arc::<DecoderMiddlewareChain>::default(),
+            &FileMetadataCache::no_cache(),
+        )
+        .await
+        .infer_error()?;
         Ok(Self {
             inner: Arc::new(inner),
         })

--- a/rust/lance-core/src/cache.rs
+++ b/rust/lance-core/src/cache.rs
@@ -11,6 +11,7 @@ use futures::Future;
 use moka::sync::Cache;
 use object_store::path::Path;
 
+use crate::utils::path::LancePathExt;
 use crate::Result;
 
 pub const DEFAULT_INDEX_CACHE_SIZE: usize = 128;
@@ -21,7 +22,7 @@ type ArcAny = Arc<dyn Any + Send + Sync>;
 #[derive(Clone)]
 struct SizedRecord {
     record: ArcAny,
-    size_accessor: Arc<dyn Fn(ArcAny) -> usize + Send + Sync>,
+    size_accessor: Arc<dyn Fn(&ArcAny) -> usize + Send + Sync>,
 }
 
 impl std::fmt::Debug for SizedRecord {
@@ -35,7 +36,7 @@ impl std::fmt::Debug for SizedRecord {
 impl SizedRecord {
     fn new<T: DeepSizeOf + Send + Sync + 'static>(record: Arc<T>) -> Self {
         let size_accessor =
-            |record: ArcAny| -> usize { record.downcast_ref::<T>().unwrap().deep_size_of() };
+            |record: &ArcAny| -> usize { record.downcast_ref::<T>().unwrap().deep_size_of() };
         Self {
             record,
             size_accessor: Arc::new(size_accessor),
@@ -48,38 +49,106 @@ impl SizedRecord {
 /// The cache is keyed by the file path and the type of metadata.
 #[derive(Clone, Debug)]
 pub struct FileMetadataCache {
-    cache: Arc<Cache<(Path, TypeId), SizedRecord>>,
+    cache: Option<Arc<Cache<(Path, TypeId), SizedRecord>>>,
+    base_path: Option<Path>,
 }
 
 impl DeepSizeOf for FileMetadataCache {
     fn deep_size_of_children(&self, _: &mut Context) -> usize {
         self.cache
-            .iter()
-            .map(|(_, v)| (v.size_accessor)(v.record))
-            .sum()
+            .as_ref()
+            .map(|cache| {
+                cache
+                    .iter()
+                    .map(|(_, v)| (v.size_accessor)(&v.record))
+                    .sum()
+            })
+            .unwrap_or(0)
     }
 }
 
+pub enum CapacityMode {
+    Items,
+    Bytes,
+}
+
 impl FileMetadataCache {
+    /// Instantiates a new cache which, for legacy reasons, uses Items capacity mode.
     pub fn new(capacity: usize) -> Self {
         Self {
-            cache: Arc::new(Cache::new(capacity as u64)),
+            cache: Some(Arc::new(Cache::new(capacity as u64))),
+            base_path: None,
+        }
+    }
+
+    /// Instantiates a dummy cache that will never cache anything.
+    pub fn no_cache() -> Self {
+        Self {
+            cache: None,
+            base_path: None,
+        }
+    }
+
+    /// Instantiates a new cache with a given capacity and capacity mode.
+    pub fn with_capacity(capacity: usize, mode: CapacityMode) -> Self {
+        match mode {
+            CapacityMode::Items => Self::new(capacity),
+            CapacityMode::Bytes => Self {
+                cache: Some(Arc::new(
+                    Cache::builder()
+                        .weigher(|_, v: &SizedRecord| {
+                            (v.size_accessor)(&v.record).try_into().unwrap_or(u32::MAX)
+                        })
+                        .build(),
+                )),
+                base_path: None,
+            },
+        }
+    }
+
+    /// Creates a new cache which shares the same underlying cache but prepends `base_path` to all
+    /// keys.
+    pub fn with_base_path(&self, base_path: Path) -> Self {
+        Self {
+            cache: self.cache.clone(),
+            base_path: Some(base_path),
         }
     }
 
     pub fn size(&self) -> usize {
-        self.cache.entry_count() as usize
+        if let Some(cache) = self.cache.as_ref() {
+            cache.entry_count() as usize
+        } else {
+            0
+        }
     }
 
     pub fn get<T: Send + Sync + 'static>(&self, path: &Path) -> Option<Arc<T>> {
-        self.cache
+        let Some(cache) = self.cache.as_ref() else {
+            return None;
+        };
+        let temp: Path;
+        let path = if let Some(base_path) = &self.base_path {
+            temp = base_path.child_path(path);
+            &temp
+        } else {
+            path
+        };
+        cache
             .get(&(path.to_owned(), TypeId::of::<T>()))
             .map(|metadata| metadata.record.clone().downcast::<T>().unwrap())
     }
 
     pub fn insert<T: DeepSizeOf + Send + Sync + 'static>(&self, path: Path, metadata: Arc<T>) {
-        self.cache
-            .insert((path, TypeId::of::<T>()), SizedRecord::new(metadata));
+        let Some(cache) = self.cache.as_ref() else {
+            return;
+        };
+        let path = if let Some(base_path) = &self.base_path {
+            base_path.child_path(&path)
+        } else {
+            path
+        };
+        cache.insert((path, TypeId::of::<T>()), SizedRecord::new(metadata));
     }
 
     /// Get an item

--- a/rust/lance-core/src/cache.rs
+++ b/rust/lance-core/src/cache.rs
@@ -124,9 +124,7 @@ impl FileMetadataCache {
     }
 
     pub fn get<T: Send + Sync + 'static>(&self, path: &Path) -> Option<Arc<T>> {
-        let Some(cache) = self.cache.as_ref() else {
-            return None;
-        };
+        let cache = self.cache.as_ref()?;
         let temp: Path;
         let path = if let Some(base_path) = &self.base_path {
             temp = base_path.child_path(path);

--- a/rust/lance-core/src/utils.rs
+++ b/rust/lance-core/src/utils.rs
@@ -7,6 +7,7 @@ pub mod cpu;
 pub mod deletion;
 pub mod futures;
 pub mod mask;
+pub mod path;
 pub mod testing;
 pub mod tokio;
 pub mod tracing;

--- a/rust/lance-core/src/utils/path.rs
+++ b/rust/lance-core/src/utils/path.rs
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use object_store::path::Path;
+
+pub trait LancePathExt {
+    fn child_path(&self, path: &Path) -> Path;
+}
+
+impl LancePathExt for Path {
+    fn child_path(&self, path: &Path) -> Path {
+        let mut new_path = self.clone();
+        for part in path.parts() {
+            new_path = path.child(part);
+        }
+        new_path
+    }
+}

--- a/rust/lance-encoding-datafusion/src/substrait.rs
+++ b/rust/lance-encoding-datafusion/src/substrait.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 
 use arrow_schema::Schema as ArrowSchema;
 use bytes::Bytes;
-use datafusion_common::DFSchema;
 use datafusion_common::ScalarValue;
 use datafusion_expr::Expr;
 use futures::FutureExt;
@@ -19,7 +18,7 @@ use lance_encoding::decoder::FilterExpression;
 pub trait FilterExpressionExt {
     /// Convert a lance-encoding filter expression (which we assume is
     /// substrait encoded) into a datafusion expr
-    fn substrait_to_df(&self, schema: &Schema) -> Result<(Expr, DFSchema)>;
+    fn substrait_to_df(&self, schema: Arc<ArrowSchema>) -> Result<Expr>;
     /// Convert a datafusion filter expression into a lance-encoding
     /// filter expression (using substrait)
     fn df_to_substrait(expr: Expr, schema: &Schema) -> Result<Self>
@@ -28,19 +27,12 @@ pub trait FilterExpressionExt {
 }
 
 impl FilterExpressionExt for FilterExpression {
-    fn substrait_to_df(&self, schema: &Schema) -> Result<(Expr, DFSchema)> {
+    fn substrait_to_df(&self, schema: Arc<ArrowSchema>) -> Result<Expr> {
         if self.0.is_empty() {
-            return Ok((
-                Expr::Literal(ScalarValue::Boolean(Some(true))),
-                DFSchema::empty(),
-            ));
+            return Ok(Expr::Literal(ScalarValue::Boolean(Some(true))));
         }
-        let input_schema = Arc::new(ArrowSchema::from(schema));
-        let expr = parse_substrait(&self.0, input_schema.clone())
-            .now_or_never()
-            .unwrap()?;
-        let df_schema = DFSchema::try_from(input_schema.as_ref().clone())?;
-        Ok((expr, df_schema))
+        let expr = parse_substrait(&self.0, schema).now_or_never().unwrap()?;
+        Ok(expr)
     }
 
     fn df_to_substrait(expr: Expr, schema: &Schema) -> Result<Self>

--- a/rust/lance-encoding-datafusion/src/zone.rs
+++ b/rust/lance-encoding-datafusion/src/zone.rs
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::{collections::VecDeque, ops::Range, sync::Arc};
+use std::{
+    collections::{HashMap, VecDeque},
+    ops::Range,
+    sync::Arc,
+};
 
 use arrow_array::{cast::AsArray, types::UInt32Type, ArrayRef, RecordBatch, UInt32Array};
 use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
 use bytes::Bytes;
-use datafusion_common::{arrow::datatypes::DataType, DFSchemaRef, ScalarValue};
+use datafusion_common::{arrow::datatypes::DataType, DFSchema, DFSchemaRef, ScalarValue};
 use datafusion_expr::{
     col,
     execution_props::ExecutionProps,
@@ -18,10 +22,11 @@ use datafusion_functions::core::expr_ext::FieldAccessor;
 use datafusion_optimizer::simplify_expressions::ExprSimplifier;
 use datafusion_physical_expr::expressions::{MaxAccumulator, MinAccumulator};
 use futures::{future::BoxFuture, FutureExt};
+use lance_datafusion::planner::Planner;
 use lance_encoding::{
     buffer::LanceBuffer,
     decoder::{
-        decode_batch, ColumnInfo, DecoderMiddlewareChain, FieldScheduler, FilterExpression,
+        decode_batch, ColumnInfoIter, DecoderMiddlewareChain, FieldScheduler, FilterExpression,
         PriorityRange, ScheduledScanLine, SchedulerContext, SchedulingJob,
     },
     encoder::{
@@ -32,7 +37,7 @@ use lance_encoding::{
     EncodingsIo,
 };
 
-use lance_core::{datatypes::Schema, Error, Result};
+use lance_core::{cache::FileMetadataCache, datatypes::Schema, Error, Result};
 use lance_file::v2::{reader::EncodedBatchReaderExt, writer::EncodedBatchWriteExt};
 use snafu::{location, Location};
 
@@ -123,38 +128,42 @@ fn path_to_expr(path: &VecDeque<u32>) -> Expr {
 
 /// If a column has zone info in the encoding description then extract it
 pub(crate) fn extract_zone_info(
-    _column_info: &ColumnInfo,
-    _data_type: &DataType,
-    _cur_path: &VecDeque<u32>,
+    column_info: &mut ColumnInfoIter,
+    data_type: &DataType,
+    cur_path: &VecDeque<u32>,
 ) -> Option<(u32, UnloadedPushdown)> {
-    todo!()
-    // let encoding = column_info.encoding.column_encoding.take().unwrap();
-    // match encoding {
-    //     pb::column_encoding::ColumnEncoding::ZoneIndex(mut zone_index) => {
-    //         let inner = zone_index.inner.take().unwrap();
-    //         let rows_per_zone = zone_index.rows_per_zone;
-    //         let zone_map_buffer = zone_index.zone_map_buffer.as_ref().unwrap().clone();
-    //         assert_eq!(
-    //             zone_map_buffer.buffer_type,
-    //             i32::from(pb::buffer::BufferType::Column)
-    //         );
-    //         let (position, size) =
-    //             column_info.buffer_offsets_and_sizes[zone_map_buffer.buffer_index as usize];
-    //         column_info.encoding = *inner;
-    //         let column = path_to_expr(cur_path);
-    //         let unloaded_pushdown = UnloadedPushdown {
-    //             data_type: data_type.clone(),
-    //             column,
-    //             position,
-    //             size,
-    //         };
-    //         Some((rows_per_zone, unloaded_pushdown))
-    //     }
-    //     _ => {
-    //         column_info.encoding.column_encoding = Some(encoding);
-    //         None
-    //     }
-    // }
+    let mut result: Option<(u32, UnloadedPushdown)> = None;
+    let result_ref = &mut result;
+    column_info.peek_transform(|col_info| {
+        let encoding = col_info.encoding.column_encoding.as_ref().unwrap();
+        match *encoding {
+            pb::column_encoding::ColumnEncoding::ZoneIndex(ref zone_index) => {
+                let mut zone_index = zone_index.clone();
+                let inner = zone_index.inner.take().unwrap();
+                let rows_per_zone = zone_index.rows_per_zone;
+                let zone_map_buffer = zone_index.zone_map_buffer.as_ref().unwrap().clone();
+                assert_eq!(
+                    zone_map_buffer.buffer_type,
+                    i32::from(pb::buffer::BufferType::Column)
+                );
+                let (position, size) =
+                    col_info.buffer_offsets_and_sizes[zone_map_buffer.buffer_index as usize];
+                let mut new_col_info = col_info.as_ref().clone();
+                new_col_info.encoding = *inner;
+                let column = path_to_expr(cur_path);
+                let unloaded_pushdown = UnloadedPushdown {
+                    data_type: data_type.clone(),
+                    column,
+                    position,
+                    size,
+                };
+                *result_ref = Some((rows_per_zone, unloaded_pushdown));
+                col_info
+            }
+            _ => col_info,
+        }
+    });
+    result
 }
 
 /// Extracted pushdown information obtained from the column encoding
@@ -171,23 +180,31 @@ pub struct UnloadedPushdown {
     size: u64,
 }
 
+#[derive(Debug)]
+struct ZoneMap {
+    items: Vec<(Expr, NullableInterval)>,
+}
+
 /// A top level scheduler that refines the requested range based on
 /// pushdown filtering with zone maps
 #[derive(Debug)]
 pub struct ZoneMapsFieldScheduler {
     inner: Arc<dyn FieldScheduler>,
     schema: Arc<Schema>,
-    pushdown_buffers: Vec<UnloadedPushdown>,
-    zone_guarantees: Arc<Vec<Vec<(Expr, NullableInterval)>>>,
+    // A map from field id to unloaded zone map for that field
+    pushdown_buffers: HashMap<u32, UnloadedPushdown>,
     rows_per_zone: u32,
     num_rows: u64,
+    zone_maps: Vec<ZoneMap>,
+    filter: Option<Expr>,
+    df_schema: Option<DFSchemaRef>,
 }
 
 impl ZoneMapsFieldScheduler {
     pub fn new(
         inner: Arc<dyn FieldScheduler>,
         schema: Arc<Schema>,
-        pushdown_buffers: Vec<UnloadedPushdown>,
+        pushdown_buffers: HashMap<u32, UnloadedPushdown>,
         rows_per_zone: u32,
         num_rows: u64,
     ) -> Self {
@@ -195,58 +212,90 @@ impl ZoneMapsFieldScheduler {
             inner,
             schema,
             pushdown_buffers,
-            zone_guarantees: Arc::default(),
             rows_per_zone,
             num_rows,
+            // These are set during initialization
+            zone_maps: Vec::new(),
+            filter: None,
+            df_schema: None,
         }
+    }
+
+    async fn load_pushdowns(
+        &self,
+        io: &dyn EncodingsIo,
+        _cache: &FileMetadataCache,
+        pushdowns: &[&UnloadedPushdown],
+    ) -> Result<Vec<ZoneMap>> {
+        // TODO: Use cache
+        let ranges = pushdowns
+            .iter()
+            .map(|pushdown| pushdown.position..pushdown.position + pushdown.size)
+            .collect();
+        let buffers = io.submit_request(ranges, 0).await?;
+        let maps = buffers
+            .into_iter()
+            .zip(pushdowns.iter())
+            .map(|(buffer, pushdown)| {
+                self.parse_zone(buffer, &pushdown.data_type, &pushdown.column)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        // A this point each item in `maps` is a vector of guarantees for a single field
+        // We need to transpose this so that each item is a vector of guarantees for a single zone
+        let zone_maps = transpose2(maps)
+            .into_iter()
+            .map(|items| ZoneMap { items })
+            .collect();
+        Ok(zone_maps)
     }
 
     /// Load the zone maps from the file
-    ///
-    /// TODO: only load zone maps for columns used in the filter
-    pub fn initialize<'a>(&'a mut self, io: &dyn EncodingsIo) -> BoxFuture<'a, Result<()>> {
-        let ranges = self
-            .pushdown_buffers
+    async fn load_maps(
+        &self,
+        io: &dyn EncodingsIo,
+        cache: &FileMetadataCache,
+        filter_schema: &Schema,
+    ) -> Result<Vec<ZoneMap>> {
+        let pushdowns_to_load = filter_schema
+            .fields
             .iter()
-            .map(|unloaded_pushdown| {
-                unloaded_pushdown.position..(unloaded_pushdown.position + unloaded_pushdown.size)
+            .filter_map(|field| {
+                let field_id = field.id as u32;
+                let unloaded = self.pushdown_buffers.get(&field_id)?;
+                Some(unloaded)
             })
             .collect::<Vec<_>>();
-        let zone_maps_fut = io.submit_request(ranges, 0);
-        async move {
-            let zone_map_buffers = zone_maps_fut.await?;
-            let mut all_fields = Vec::with_capacity(zone_map_buffers.len());
-            for (bytes, unloaded_pushdown) in
-                zone_map_buffers.iter().zip(self.pushdown_buffers.iter())
-            {
-                let guarantees = self
-                    .map_from_buffer(
-                        bytes.clone(),
-                        &unloaded_pushdown.data_type,
-                        &unloaded_pushdown.column,
-                    )
-                    .await?;
-                all_fields.push(guarantees);
-            }
-            self.zone_guarantees = Arc::new(transpose2(all_fields));
-            Ok(())
-        }
-        .boxed()
+        self.load_pushdowns(io, cache, &pushdowns_to_load).await
     }
 
-    fn process_filter(
-        &self,
-        filter: Expr,
-        projection_schema: DFSchemaRef,
-    ) -> Result<impl Fn(u64) -> bool> {
-        let zone_guarantees = self.zone_guarantees.clone();
+    async fn do_initialize(
+        &mut self,
+        io: &dyn EncodingsIo,
+        cache: &FileMetadataCache,
+        filter: &FilterExpression,
+    ) -> Result<()> {
+        let arrow_schema = ArrowSchema::from(self.schema.as_ref());
+        let df_schema = DFSchema::try_from(arrow_schema.clone())?;
+        let df_filter = filter.substrait_to_df(Arc::new(arrow_schema))?;
+
+        let columns = Planner::column_names_in_expr(&df_filter);
+        let referenced_schema = self.schema.project(&columns)?;
+
+        self.df_schema = Some(Arc::new(df_schema));
+        self.zone_maps = self.load_maps(io, cache, &referenced_schema).await?;
+        self.filter = Some(df_filter);
+        Ok(())
+    }
+
+    fn create_filter(&self) -> Result<impl Fn(u64) -> bool + '_> {
         Ok(move |zone_idx| {
-            let guarantees = &zone_guarantees[zone_idx as usize];
+            let zone_map = &self.zone_maps[zone_idx as usize];
             let props = ExecutionProps::new();
-            let context = SimplifyContext::new(&props).with_schema(projection_schema.clone());
+            let context =
+                SimplifyContext::new(&props).with_schema(self.df_schema.as_ref().unwrap().clone());
             let mut simplifier = ExprSimplifier::new(context);
-            simplifier = simplifier.with_guarantees(guarantees.clone());
-            match simplifier.simplify(filter.clone()) {
+            simplifier = simplifier.with_guarantees(zone_map.items.clone());
+            match simplifier.simplify(self.filter.as_ref().unwrap().clone()) {
                 Ok(expr) => match expr {
                     // Predicate, given guarantees, is always false, we can skip the zone
                     Expr::Literal(ScalarValue::Boolean(Some(false))) => false,
@@ -301,7 +350,7 @@ impl ZoneMapsFieldScheduler {
         guarantees
     }
 
-    async fn map_from_buffer(
+    fn parse_zone(
         &self,
         buffer: Bytes,
         data_type: &DataType,
@@ -317,9 +366,8 @@ impl ZoneMapsFieldScheduler {
         let zone_maps_batch = decode_batch(
             &zone_maps_batch,
             &FilterExpression::no_filter(),
-            &DecoderMiddlewareChain::default(),
-        )
-        .await?;
+            Arc::<DecoderMiddlewareChain>::default(),
+        )?;
 
         Ok(Self::extract_guarantees(
             &zone_maps_batch,
@@ -370,13 +418,24 @@ impl SchedulingJob for EmptySchedulingJob {
 }
 
 impl FieldScheduler for ZoneMapsFieldScheduler {
+    fn initialize<'a>(
+        &'a mut self,
+        filter: &'a FilterExpression,
+        context: &'a SchedulerContext,
+    ) -> BoxFuture<'a, Result<()>> {
+        async move {
+            self.do_initialize(context.io().as_ref(), context.cache(), filter)
+                .await
+        }
+        .boxed()
+    }
+
     fn schedule_ranges<'a>(
         &'a self,
         ranges: &[std::ops::Range<u64>],
         filter: &FilterExpression,
     ) -> Result<Box<dyn SchedulingJob + 'a>> {
-        let (df_filter, projection_schema) = filter.substrait_to_df(self.schema.as_ref())?;
-        let zone_filter_fn = self.process_filter(df_filter, Arc::new(projection_schema))?;
+        let zone_filter_fn = self.create_filter()?;
         let zone_filter = ZoneMapsFilter::new(zone_filter_fn, self.rows_per_zone as u64);
         let ranges = zone_filter.refine_ranges(ranges);
         if ranges.is_empty() {
@@ -528,18 +587,20 @@ impl FieldEncoder for ZoneMapsFieldEncoder {
     }
 
     fn flush(&mut self) -> Result<Vec<lance_encoding::encoder::EncodeTask>> {
-        if self.cur_offset > 0 {
-            // Create final map
-            self.new_map()?;
-        }
         self.items_encoder.flush()
     }
 
     fn finish(&mut self) -> BoxFuture<'_, Result<Vec<EncodedColumn>>> {
         async move {
+            if self.cur_offset > 0 {
+                // Create final map
+                self.new_map()?;
+            }
             let items_columns = self.items_encoder.finish().await?;
-            if items_columns.is_empty() {
-                return Err(Error::invalid_input("attempt to apply zone maps to a field encoder that generated zero columns of data".to_string(), location!()))
+            if items_columns.len() != 1 {
+                return Err(Error::InvalidInput {
+                    source: format!("attempt to apply zone maps to a field encoder that generated {} columns of data (expected 1)", items_columns.len()).into(),
+                    location: location!()})
             }
             let items_column = items_columns.into_iter().next().unwrap();
             let final_pages = items_column.final_pages;
@@ -593,8 +654,6 @@ mod tests {
     };
 
     #[test_log::test(tokio::test)]
-    #[ignore] // Stats currently disabled until https://github.com/lancedb/lance/issues/2605
-              // is addressed
     async fn test_basic_stats() {
         let data = lance_datagen::gen()
             .col("0", lance_datagen::array::step::<Int32Type>())
@@ -609,11 +668,13 @@ mod tests {
 
         let written_file = write_lance_file(data, &fs, options).await;
 
-        let decoder_middleware = DecoderMiddlewareChain::new()
-            .add_strategy(Arc::new(LanceDfFieldDecoderStrategy::new(
-                written_file.schema.clone(),
-            )))
-            .add_strategy(Arc::new(CoreFieldDecoderStrategy::default()));
+        let decoder_middleware = Arc::new(
+            DecoderMiddlewareChain::new()
+                .add_strategy(Arc::new(LanceDfFieldDecoderStrategy::new(
+                    written_file.schema.clone(),
+                )))
+                .add_strategy(Arc::new(CoreFieldDecoderStrategy::default())),
+        );
 
         let num_rows = written_file
             .data
@@ -629,15 +690,9 @@ mod tests {
         .await;
         assert_eq!(num_rows, result);
 
-        let decoder_middleware = DecoderMiddlewareChain::new()
-            .add_strategy(Arc::new(LanceDfFieldDecoderStrategy::new(
-                written_file.schema.clone(),
-            )))
-            .add_strategy(Arc::new(CoreFieldDecoderStrategy::default()));
-
         let result = count_lance_file(
             &fs,
-            decoder_middleware,
+            decoder_middleware.clone(),
             FilterExpression::df_to_substrait(
                 Expr::BinaryExpr(BinaryExpr {
                     left: Box::new(col("0")),
@@ -650,12 +705,6 @@ mod tests {
         )
         .await;
         assert_eq!(0, result);
-
-        let decoder_middleware = DecoderMiddlewareChain::new()
-            .add_strategy(Arc::new(LanceDfFieldDecoderStrategy::new(
-                written_file.schema.clone(),
-            )))
-            .add_strategy(Arc::new(CoreFieldDecoderStrategy::default()));
 
         let result = count_lance_file(
             &fs,

--- a/rust/lance-encoding/benches/decoder.rs
+++ b/rust/lance-encoding/benches/decoder.rs
@@ -84,12 +84,13 @@ fn bench_decode(c: &mut Criterion) {
         let func_name = format!("{:?}", data_type).to_lowercase();
         group.bench_function(func_name, |b| {
             b.iter(|| {
-                let batch = lance_encoding::decoder::decode_batch(
-                    &encoded,
-                    &FilterExpression::no_filter(),
-                    Arc::<DecoderMiddlewareChain>::default(),
-                )
-                .unwrap();
+                let batch = rt
+                    .block_on(lance_encoding::decoder::decode_batch(
+                        &encoded,
+                        &FilterExpression::no_filter(),
+                        Arc::<DecoderMiddlewareChain>::default(),
+                    ))
+                    .unwrap();
                 assert_eq!(data.num_rows(), batch.num_rows());
             })
         });
@@ -122,12 +123,13 @@ fn bench_decode_fsl(c: &mut Criterion) {
         let func_name = format!("{:?}", data_type).to_lowercase();
         group.bench_function(func_name, |b| {
             b.iter(|| {
-                let batch = lance_encoding::decoder::decode_batch(
-                    &encoded,
-                    &FilterExpression::no_filter(),
-                    Arc::<DecoderMiddlewareChain>::default(),
-                )
-                .unwrap();
+                let batch = rt
+                    .block_on(lance_encoding::decoder::decode_batch(
+                        &encoded,
+                        &FilterExpression::no_filter(),
+                        Arc::<DecoderMiddlewareChain>::default(),
+                    ))
+                    .unwrap();
                 assert_eq!(data.num_rows(), batch.num_rows());
             })
         });
@@ -177,12 +179,13 @@ fn bench_decode_str_with_dict_encoding(c: &mut Criterion) {
     let func_name = format!("{:?}", data_type).to_lowercase();
     group.bench_function(func_name, |b| {
         b.iter(|| {
-            let batch = lance_encoding::decoder::decode_batch(
-                &encoded,
-                &FilterExpression::no_filter(),
-                Arc::<DecoderMiddlewareChain>::default(),
-            )
-            .unwrap();
+            let batch = rt
+                .block_on(lance_encoding::decoder::decode_batch(
+                    &encoded,
+                    &FilterExpression::no_filter(),
+                    Arc::<DecoderMiddlewareChain>::default(),
+                ))
+                .unwrap();
             assert_eq!(data.num_rows(), batch.num_rows());
         })
     });
@@ -215,7 +218,6 @@ fn bench_decode_packed_struct(c: &mut Criterion) {
         .iter()
         .map(|field| {
             if matches!(field.data_type(), &DataType::Struct(_)) {
-                println!("Match");
                 let mut metadata = HashMap::new();
                 metadata.insert("packed".to_string(), "true".to_string());
                 let field =
@@ -246,12 +248,13 @@ fn bench_decode_packed_struct(c: &mut Criterion) {
     let func_name = "struct";
     group.bench_function(func_name, |b| {
         b.iter(|| {
-            let batch = lance_encoding::decoder::decode_batch(
-                &encoded,
-                &FilterExpression::no_filter(),
-                Arc::<DecoderMiddlewareChain>::default(),
-            )
-            .unwrap();
+            let batch = rt
+                .block_on(lance_encoding::decoder::decode_batch(
+                    &encoded,
+                    &FilterExpression::no_filter(),
+                    Arc::<DecoderMiddlewareChain>::default(),
+                ))
+                .unwrap();
             assert_eq!(data.num_rows(), batch.num_rows());
         })
     });
@@ -293,12 +296,13 @@ fn bench_decode_str_with_fixed_size_binary_encoding(c: &mut Criterion) {
     let func_name = "fixed-utf8".to_string();
     group.bench_function(func_name, |b| {
         b.iter(|| {
-            let batch = lance_encoding::decoder::decode_batch(
-                &encoded,
-                &FilterExpression::no_filter(),
-                Arc::<DecoderMiddlewareChain>::default(),
-            )
-            .unwrap();
+            let batch = rt
+                .block_on(lance_encoding::decoder::decode_batch(
+                    &encoded,
+                    &FilterExpression::no_filter(),
+                    Arc::<DecoderMiddlewareChain>::default(),
+                ))
+                .unwrap();
             assert_eq!(data.num_rows(), batch.num_rows());
         })
     });

--- a/rust/lance-encoding/benches/decoder.rs
+++ b/rust/lance-encoding/benches/decoder.rs
@@ -84,13 +84,12 @@ fn bench_decode(c: &mut Criterion) {
         let func_name = format!("{:?}", data_type).to_lowercase();
         group.bench_function(func_name, |b| {
             b.iter(|| {
-                let batch = rt
-                    .block_on(lance_encoding::decoder::decode_batch(
-                        &encoded,
-                        &FilterExpression::no_filter(),
-                        &DecoderMiddlewareChain::default(),
-                    ))
-                    .unwrap();
+                let batch = lance_encoding::decoder::decode_batch(
+                    &encoded,
+                    &FilterExpression::no_filter(),
+                    Arc::<DecoderMiddlewareChain>::default(),
+                )
+                .unwrap();
                 assert_eq!(data.num_rows(), batch.num_rows());
             })
         });
@@ -123,13 +122,12 @@ fn bench_decode_fsl(c: &mut Criterion) {
         let func_name = format!("{:?}", data_type).to_lowercase();
         group.bench_function(func_name, |b| {
             b.iter(|| {
-                let batch = rt
-                    .block_on(lance_encoding::decoder::decode_batch(
-                        &encoded,
-                        &FilterExpression::no_filter(),
-                        &DecoderMiddlewareChain::default(),
-                    ))
-                    .unwrap();
+                let batch = lance_encoding::decoder::decode_batch(
+                    &encoded,
+                    &FilterExpression::no_filter(),
+                    Arc::<DecoderMiddlewareChain>::default(),
+                )
+                .unwrap();
                 assert_eq!(data.num_rows(), batch.num_rows());
             })
         });
@@ -179,13 +177,12 @@ fn bench_decode_str_with_dict_encoding(c: &mut Criterion) {
     let func_name = format!("{:?}", data_type).to_lowercase();
     group.bench_function(func_name, |b| {
         b.iter(|| {
-            let batch = rt
-                .block_on(lance_encoding::decoder::decode_batch(
-                    &encoded,
-                    &FilterExpression::no_filter(),
-                    &DecoderMiddlewareChain::default(),
-                ))
-                .unwrap();
+            let batch = lance_encoding::decoder::decode_batch(
+                &encoded,
+                &FilterExpression::no_filter(),
+                Arc::<DecoderMiddlewareChain>::default(),
+            )
+            .unwrap();
             assert_eq!(data.num_rows(), batch.num_rows());
         })
     });
@@ -249,13 +246,12 @@ fn bench_decode_packed_struct(c: &mut Criterion) {
     let func_name = "struct";
     group.bench_function(func_name, |b| {
         b.iter(|| {
-            let batch = rt
-                .block_on(lance_encoding::decoder::decode_batch(
-                    &encoded,
-                    &FilterExpression::no_filter(),
-                    &DecoderMiddlewareChain::default(),
-                ))
-                .unwrap();
+            let batch = lance_encoding::decoder::decode_batch(
+                &encoded,
+                &FilterExpression::no_filter(),
+                Arc::<DecoderMiddlewareChain>::default(),
+            )
+            .unwrap();
             assert_eq!(data.num_rows(), batch.num_rows());
         })
     });
@@ -297,13 +293,12 @@ fn bench_decode_str_with_fixed_size_binary_encoding(c: &mut Criterion) {
     let func_name = "fixed-utf8".to_string();
     group.bench_function(func_name, |b| {
         b.iter(|| {
-            let batch = rt
-                .block_on(lance_encoding::decoder::decode_batch(
-                    &encoded,
-                    &FilterExpression::no_filter(),
-                    &DecoderMiddlewareChain::default(),
-                ))
-                .unwrap();
+            let batch = lance_encoding::decoder::decode_batch(
+                &encoded,
+                &FilterExpression::no_filter(),
+                Arc::<DecoderMiddlewareChain>::default(),
+            )
+            .unwrap();
             assert_eq!(data.num_rows(), batch.num_rows());
         })
     });

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -349,10 +349,7 @@ impl DecoderMiddlewareChain {
 
     /// Obtain a cursor into the chain that can be used to create
     /// field schedulers
-    pub(crate) fn cursor<'a>(
-        &'a self,
-        io: Arc<dyn EncodingsIo>,
-    ) -> DecoderMiddlewareChainCursor<'a> {
+    pub(crate) fn cursor(&self, io: Arc<dyn EncodingsIo>) -> DecoderMiddlewareChainCursor<'_> {
         DecoderMiddlewareChainCursor {
             chain: self,
             io,
@@ -881,6 +878,7 @@ fn root_column(num_rows: u64) -> ColumnInfo {
 impl DecodeBatchScheduler {
     /// Creates a new decode scheduler with the expected schema and the column
     /// metadata of the file.
+    #[allow(clippy::too_many_arguments)]
     pub async fn try_new<'a>(
         schema: &'a Schema,
         column_indices: &[u32],
@@ -898,7 +896,7 @@ impl DecodeBatchScheduler {
         let root_fields = arrow_schema.fields().clone();
         let mut columns = Vec::with_capacity(column_infos.len() + 1);
         columns.push(Arc::new(root_column(num_rows)));
-        columns.extend(column_infos.iter().map(|col| col.clone()));
+        columns.extend(column_infos.iter().cloned());
         let adjusted_column_indices = [0_u32]
             .into_iter()
             .chain(column_indices.iter().map(|i| *i + 1))
@@ -1305,8 +1303,8 @@ pub enum RequestedRows {
 impl RequestedRows {
     pub fn num_rows(&self) -> u64 {
         match self {
-            RequestedRows::Ranges(ranges) => ranges.iter().map(|r| r.end - r.start).sum(),
-            RequestedRows::Indices(indices) => indices.len() as u64,
+            Self::Ranges(ranges) => ranges.iter().map(|r| r.end - r.start).sum(),
+            Self::Indices(indices) => indices.len() as u64,
         }
     }
 }

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -744,6 +744,7 @@ impl BatchEncoder {
 /// An encoded batch of data and a page table describing it
 ///
 /// This is returned by [`crate::encoder::encode_batch`]
+#[derive(Debug)]
 pub struct EncodedBatch {
     pub data: Bytes,
     pub page_table: Vec<Arc<ColumnInfo>>,

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -565,7 +565,7 @@ impl FieldScheduler for ListFieldScheduler {
     }
 
     fn initialize<'a>(
-        &'a mut self,
+        &'a self,
         _filter: &'a FilterExpression,
         _context: &'a SchedulerContext,
     ) -> BoxFuture<'a, Result<()>> {

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -16,7 +16,7 @@ use log::trace;
 use snafu::{location, Location};
 use tokio::task::JoinHandle;
 
-use lance_core::{Error, Result};
+use lance_core::{cache::FileMetadataCache, Error, Result};
 
 use crate::{
     buffer::LanceBuffer,
@@ -321,6 +321,7 @@ async fn indirect_schedule_task(
     items_scheduler: Arc<dyn FieldScheduler>,
     items_type: DataType,
     io: Arc<dyn EncodingsIo>,
+    cache: Arc<FileMetadataCache>,
     priority: Box<dyn PriorityRange>,
 ) -> Result<IndirectlyLoaded> {
     let num_offsets = offsets_decoder.num_rows();
@@ -357,7 +358,7 @@ async fn indirect_schedule_task(
     let indirect_root_scheduler =
         SimpleStructScheduler::new(vec![items_scheduler], root_fields.clone());
     let mut indirect_scheduler =
-        DecodeBatchScheduler::from_scheduler(Arc::new(indirect_root_scheduler), root_fields);
+        DecodeBatchScheduler::from_scheduler(Arc::new(indirect_root_scheduler), root_fields, cache);
     let mut root_decoder = indirect_scheduler.new_root_decoder_ranges(&item_ranges);
 
     let priority = Box::new(ListPriorityRange::new(priority, offsets.clone()));
@@ -440,6 +441,7 @@ impl<'a> SchedulingJob for ListFieldSchedulingJob<'a> {
         let items_scheduler = self.scheduler.items_scheduler.clone();
         let items_type = self.scheduler.items_type.clone();
         let io = context.io().clone();
+        let cache = context.cache().clone();
 
         // Immediately spawn the indirect scheduling
         let indirect_fut = tokio::spawn(indirect_schedule_task(
@@ -449,6 +451,7 @@ impl<'a> SchedulingJob for ListFieldSchedulingJob<'a> {
             items_scheduler,
             items_type,
             io,
+            cache,
             priority.box_clone(),
         ));
 
@@ -558,6 +561,15 @@ impl FieldScheduler for ListFieldScheduler {
 
     fn num_rows(&self) -> u64 {
         self.offsets_scheduler.num_rows()
+    }
+
+    fn initialize<'a>(
+        &'a mut self,
+        _filter: &'a FilterExpression,
+        _context: &'a SchedulerContext,
+    ) -> BoxFuture<'a, Result<()>> {
+        // 2.0 schedulers do not need to initialize
+        std::future::ready(Ok(())).boxed()
     }
 }
 

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -314,6 +314,7 @@ fn decode_offsets(
 ///
 /// This task does not wait for the items data.  That happens on the main decode loop (unless
 /// we have list of list of ... in which case it happens in the outer indirect decode loop)
+#[allow(clippy::too_many_arguments)]
 async fn indirect_schedule_task(
     mut offsets_decoder: Box<dyn LogicalPageDecoder>,
     list_requests: Vec<ListRequest>,

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -227,7 +227,7 @@ impl FieldScheduler for PrimitiveFieldScheduler {
     }
 
     fn initialize<'a>(
-        &'a mut self,
+        &'a self,
         _filter: &'a FilterExpression,
         _context: &'a SchedulerContext,
     ) -> BoxFuture<'a, Result<()>> {

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -225,6 +225,15 @@ impl FieldScheduler for PrimitiveFieldScheduler {
             ranges.to_vec(),
         )))
     }
+
+    fn initialize<'a>(
+        &'a mut self,
+        _filter: &'a FilterExpression,
+        _context: &'a SchedulerContext,
+    ) -> BoxFuture<'a, Result<()>> {
+        // 2.0 schedulers do not need to initialize
+        std::future::ready(Ok(())).boxed()
+    }
 }
 
 pub struct PrimitiveFieldDecoder {

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -9,7 +9,7 @@ use std::{
 
 use arrow_array::{cast::AsArray, Array, ArrayRef, StructArray};
 use arrow_schema::{DataType, Fields};
-use futures::{future::BoxFuture, FutureExt};
+use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, StreamExt, TryStreamExt};
 use log::trace;
 use snafu::{location, Location};
 
@@ -201,12 +201,23 @@ impl FieldScheduler for SimpleStructScheduler {
     }
 
     fn initialize<'a>(
-        &'a mut self,
+        &'a self,
         _filter: &'a FilterExpression,
         _context: &'a SchedulerContext,
     ) -> BoxFuture<'a, Result<()>> {
-        // 2.0 schedulers do not need to initialize
-        std::future::ready(Ok(())).boxed()
+        let futures = self
+            .children
+            .iter()
+            .map(|child| child.initialize(_filter, _context))
+            .collect::<FuturesUnordered<_>>();
+        async move {
+            futures
+                .map(|res| res.map(|_| ()))
+                .try_collect::<Vec<_>>()
+                .await?;
+            Ok(())
+        }
+        .boxed()
     }
 }
 

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -199,6 +199,15 @@ impl FieldScheduler for SimpleStructScheduler {
     fn num_rows(&self) -> u64 {
         self.num_rows
     }
+
+    fn initialize<'a>(
+        &'a mut self,
+        _filter: &'a FilterExpression,
+        _context: &'a SchedulerContext,
+    ) -> BoxFuture<'a, Result<()>> {
+        // 2.0 schedulers do not need to initialize
+        std::future::ready(Ok(())).boxed()
+    }
 }
 
 #[derive(Debug)]

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -144,6 +144,7 @@ async fn test_decode(
         decode_and_validate,
         io,
         cache,
+        &FilterExpression::no_filter(),
     )
     .await
     .unwrap();

--- a/rust/lance-file/benches/reader.rs
+++ b/rust/lance-file/benches/reader.rs
@@ -8,6 +8,7 @@ use futures::StreamExt;
 use lance_encoding::decoder::{DecoderMiddlewareChain, FilterExpression};
 use lance_file::v2::{
     reader::FileReader,
+    testing::test_cache,
     writer::{FileWriter, FileWriterOptions},
 };
 use lance_io::{
@@ -55,7 +56,8 @@ fn bench_reader(c: &mut Criterion) {
                 let reader = FileReader::try_open(
                     scheduler.clone(),
                     None,
-                    DecoderMiddlewareChain::default(),
+                    Arc::<DecoderMiddlewareChain>::default(),
+                    &test_cache(),
                 )
                 .await
                 .unwrap();

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -733,6 +733,7 @@ impl FileReader {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn do_take_rows(
         column_infos: Vec<Arc<ColumnInfo>>,
         io: Arc<dyn EncodingsIo>,

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -1224,6 +1224,7 @@ pub mod tests {
             &FilterExpression::no_filter(),
             Arc::<DecoderMiddlewareChain>::default(),
         )
+        .await
         .unwrap();
 
         assert_eq!(data, decoded);
@@ -1237,6 +1238,7 @@ pub mod tests {
             &FilterExpression::no_filter(),
             Arc::<DecoderMiddlewareChain>::default(),
         )
+        .await
         .unwrap();
 
         assert_eq!(data, decoded);
@@ -1524,6 +1526,7 @@ pub mod tests {
             Arc::<DecoderMiddlewareChain>::default(),
             file_reader.scheduler.clone(),
             test_cache(),
+            &FilterExpression::no_filter(),
         )
         .await
         .unwrap();

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -13,14 +13,11 @@ use arrow_schema::Schema as ArrowSchema;
 use byteorder::{ByteOrder, LittleEndian, ReadBytesExt};
 use bytes::{Bytes, BytesMut};
 use deepsize::{Context, DeepSizeOf};
-use futures::{
-    stream::{self, BoxStream},
-    Stream, StreamExt,
-};
+use futures::{stream::BoxStream, Stream, StreamExt};
 use lance_encoding::{
     decoder::{
-        BatchDecodeStream, ColumnInfo, DecodeBatchScheduler, DecoderMiddlewareChain,
-        FilterExpression, PageInfo, ReadBatchTask,
+        schedule_and_decode, ColumnInfo, DecoderMiddlewareChain, FilterExpression, PageInfo,
+        ReadBatchTask, RequestedRows, SchedulerDecoderConfig,
     },
     encoder::EncodedBatch,
     version::LanceFileVersion,
@@ -31,6 +28,7 @@ use prost::{Message, Name};
 use snafu::{location, Location};
 
 use lance_core::{
+    cache::FileMetadataCache,
     datatypes::{Field, Schema},
     Error, Result,
 };
@@ -40,7 +38,6 @@ use lance_io::{
     stream::{RecordBatchStream, RecordBatchStreamAdapter},
     ReadBatchParams,
 };
-use tokio::sync::mpsc;
 
 use crate::{
     datatypes::{Fields, FieldsWithMeta},
@@ -256,7 +253,8 @@ pub struct FileReader {
     base_projection: ReaderProjection,
     num_rows: u64,
     metadata: Arc<CachedFileMetadata>,
-    decoder_strategy: DecoderMiddlewareChain,
+    decoder_strategy: Arc<DecoderMiddlewareChain>,
+    cache: Arc<FileMetadataCache>,
 }
 
 #[derive(Debug)]
@@ -614,7 +612,8 @@ impl FileReader {
     pub async fn try_open(
         scheduler: FileScheduler,
         base_projection: Option<ReaderProjection>,
-        decoder_strategy: DecoderMiddlewareChain,
+        decoder_strategy: Arc<DecoderMiddlewareChain>,
+        cache: &FileMetadataCache,
     ) -> Result<Self> {
         let file_metadata = Arc::new(Self::read_all_metadata(&scheduler).await?);
         Self::try_open_with_file_metadata(
@@ -622,6 +621,7 @@ impl FileReader {
             base_projection,
             decoder_strategy,
             file_metadata,
+            cache,
         )
         .await
     }
@@ -630,9 +630,12 @@ impl FileReader {
     pub async fn try_open_with_file_metadata(
         scheduler: FileScheduler,
         base_projection: Option<ReaderProjection>,
-        decoder_strategy: DecoderMiddlewareChain,
+        decoder_strategy: Arc<DecoderMiddlewareChain>,
         file_metadata: Arc<CachedFileMetadata>,
+        cache: &FileMetadataCache,
     ) -> Result<Self> {
+        let cache = Arc::new(cache.with_base_path(scheduler.reader().path().clone()));
+
         if let Some(base_projection) = base_projection.as_ref() {
             Self::validate_projection(base_projection, &file_metadata)?;
         }
@@ -645,6 +648,7 @@ impl FileReader {
             num_rows,
             metadata: file_metadata,
             decoder_strategy,
+            cache,
         })
     }
 
@@ -668,35 +672,16 @@ impl FileReader {
         Ok(self.metadata.column_infos.to_vec())
     }
 
-    fn check_scheduler_on_drop(
-        stream: BoxStream<'static, ReadBatchTask>,
-        scheduler_handle: tokio::task::JoinHandle<()>,
-    ) -> BoxStream<'static, ReadBatchTask> {
-        // This is a bit weird but we create an "empty stream" that unwraps the scheduler handle (which
-        // will panic if the scheduler panicked).  This let's us check if the scheduler panicked
-        // when the stream finishes.
-        let mut scheduler_handle = Some(scheduler_handle);
-        let check_scheduler = stream::unfold((), move |_| {
-            let handle = scheduler_handle.take();
-            async move {
-                if let Some(handle) = handle {
-                    handle.await.unwrap();
-                }
-                None
-            }
-        });
-        stream.chain(check_scheduler).boxed()
-    }
-
     #[allow(clippy::too_many_arguments)]
     fn do_read_range(
         column_infos: Vec<Arc<ColumnInfo>>,
-        scheduler: Arc<dyn EncodingsIo>,
+        io: Arc<dyn EncodingsIo>,
+        cache: Arc<FileMetadataCache>,
         num_rows: u64,
-        decoder_strategy: DecoderMiddlewareChain,
+        decoder_strategy: Arc<DecoderMiddlewareChain>,
         range: Range<u64>,
         batch_size: u32,
-        projection: &ReaderProjection,
+        projection: ReaderProjection,
         filter: FilterExpression,
     ) -> Result<BoxStream<'static, ReadBatchTask>> {
         debug!(
@@ -708,74 +693,55 @@ impl FileReader {
             projection.schema.fields.len(),
         );
 
-        if range.is_empty() {
-            return Err(Error::InvalidInput {
-                source: format!("Cannot read empty range {:?} from file", range).into(),
-                location: location!(),
-            });
-        }
+        let config = SchedulerDecoderConfig {
+            batch_size,
+            cache,
+            decoder_strategy,
+            io,
+        };
 
-        let mut decode_scheduler = DecodeBatchScheduler::try_new(
-            &projection.schema,
-            &projection.column_indices,
-            &column_infos,
-            &vec![],
-            num_rows,
-            &decoder_strategy,
-            &scheduler,
-        )?;
+        let requested_rows = RequestedRows::Ranges(vec![range]);
 
-        let root_decoder = decode_scheduler.new_root_decoder_ranges(&[range.clone()]);
-
-        let (tx, rx) = mpsc::unbounded_channel();
-
-        let num_rows_to_read = range.end - range.start;
-
-        let scheduler_handle = tokio::task::spawn(async move {
-            decode_scheduler.schedule_range(range, &filter, tx, scheduler);
-        });
-
-        let batches =
-            BatchDecodeStream::new(rx, batch_size, num_rows_to_read, root_decoder).into_stream();
-
-        Ok(Self::check_scheduler_on_drop(batches, scheduler_handle))
+        Ok(schedule_and_decode(
+            column_infos,
+            requested_rows,
+            filter,
+            projection.column_indices,
+            projection.schema,
+            config,
+        ))
     }
 
     fn read_range(
         &self,
         range: Range<u64>,
         batch_size: u32,
-        projection: &ReaderProjection,
+        projection: ReaderProjection,
         filter: FilterExpression,
     ) -> Result<BoxStream<'static, ReadBatchTask>> {
-        // Grab what we need to initialize the stream
-        let range = range.clone();
-        let projection = projection.clone();
-        let column_infos = self.collect_columns_from_projection(&projection)?;
-        let scheduler = self.scheduler.clone();
-        let num_rows = self.num_rows;
-        let decoder_strategy = self.decoder_strategy.clone();
         // Create and initialize the stream
         Self::do_read_range(
-            column_infos,
-            scheduler,
-            num_rows,
-            decoder_strategy,
+            self.collect_columns_from_projection(&projection)?,
+            self.scheduler.clone(),
+            self.cache.clone(),
+            self.num_rows,
+            self.decoder_strategy.clone(),
             range,
             batch_size,
-            &projection,
+            projection,
             filter,
         )
     }
 
     fn do_take_rows(
         column_infos: Vec<Arc<ColumnInfo>>,
-        scheduler: Arc<dyn EncodingsIo>,
-        num_rows: u64,
-        decoder_strategy: DecoderMiddlewareChain,
+        io: Arc<dyn EncodingsIo>,
+        cache: Arc<FileMetadataCache>,
+        decoder_strategy: Arc<DecoderMiddlewareChain>,
         indices: Vec<u64>,
         batch_size: u32,
-        projection: &ReaderProjection,
+        projection: ReaderProjection,
+        filter: FilterExpression,
     ) -> Result<BoxStream<'static, ReadBatchTask>> {
         debug!(
             "Taking {} rows spread across range {}..{} with batch_size {} from columns {:?}",
@@ -786,53 +752,41 @@ impl FileReader {
             column_infos.iter().map(|ci| ci.index).collect::<Vec<_>>()
         );
 
-        let mut decode_scheduler = DecodeBatchScheduler::try_new(
-            &projection.schema,
-            &projection.column_indices,
-            &column_infos,
-            &vec![],
-            num_rows,
-            &decoder_strategy,
-            &scheduler,
-        )?;
+        let config = SchedulerDecoderConfig {
+            batch_size,
+            cache,
+            decoder_strategy,
+            io,
+        };
 
-        let root_decoder = decode_scheduler.new_root_decoder_indices(&indices);
+        let requested_rows = RequestedRows::Indices(indices);
 
-        let (tx, rx) = mpsc::unbounded_channel();
-
-        let num_rows_to_read = indices.len() as u64;
-
-        let scheduler_handle = tokio::task::spawn(async move {
-            decode_scheduler.schedule_take(&indices, &FilterExpression::no_filter(), tx, scheduler)
-        });
-
-        let batches =
-            BatchDecodeStream::new(rx, batch_size, num_rows_to_read, root_decoder).into_stream();
-
-        Ok(Self::check_scheduler_on_drop(batches, scheduler_handle))
+        Ok(schedule_and_decode(
+            column_infos,
+            requested_rows,
+            filter,
+            projection.column_indices,
+            projection.schema,
+            config,
+        ))
     }
 
     fn take_rows(
         &self,
         indices: Vec<u64>,
         batch_size: u32,
-        projection: &ReaderProjection,
+        projection: ReaderProjection,
     ) -> Result<BoxStream<'static, ReadBatchTask>> {
-        // Grab what we need to initialize the stream
-        let projection = projection.clone();
-        let column_infos = self.collect_columns_from_projection(&projection)?;
-        let scheduler = self.scheduler.clone();
-        let num_rows = self.num_rows;
-        let decoder_strategy = self.decoder_strategy.clone();
         // Create and initialize the stream
         Self::do_take_rows(
-            column_infos,
-            scheduler,
-            num_rows,
-            decoder_strategy,
+            self.collect_columns_from_projection(&projection)?,
+            self.scheduler.clone(),
+            self.cache.clone(),
+            self.decoder_strategy.clone(),
             indices,
             batch_size,
-            &projection,
+            projection,
+            FilterExpression::no_filter(),
         )
     }
 
@@ -850,10 +804,10 @@ impl FileReader {
         &self,
         params: ReadBatchParams,
         batch_size: u32,
-        projection: &ReaderProjection,
+        projection: ReaderProjection,
         filter: FilterExpression,
     ) -> Result<Pin<Box<dyn Stream<Item = ReadBatchTask> + Send>>> {
-        Self::validate_projection(projection, &self.metadata)?;
+        Self::validate_projection(&projection, &self.metadata)?;
         let verify_bound = |params: &ReadBatchParams, bound: u64, inclusive: bool| {
             if bound > self.num_rows || bound == self.num_rows && inclusive {
                 Err(Error::invalid_input(
@@ -939,15 +893,15 @@ impl FileReader {
         params: ReadBatchParams,
         batch_size: u32,
         batch_readahead: u32,
-        projection: &ReaderProjection,
+        projection: ReaderProjection,
         filter: FilterExpression,
     ) -> Result<Pin<Box<dyn RecordBatchStream>>> {
+        let arrow_schema = Arc::new(ArrowSchema::from(projection.schema.as_ref()));
         let tasks_stream = self.read_tasks(params, batch_size, projection, filter)?;
         let batch_stream = tasks_stream
             .map(|task| task.task)
             .buffered(batch_readahead as usize)
             .boxed();
-        let arrow_schema = Arc::new(ArrowSchema::from(projection.schema.as_ref()));
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             arrow_schema,
             batch_stream,
@@ -970,7 +924,7 @@ impl FileReader {
             params,
             batch_size,
             batch_readahead,
-            &self.base_projection,
+            self.base_projection.clone(),
             filter,
         )
     }
@@ -1121,7 +1075,6 @@ pub mod tests {
     use lance_encoding::{
         decoder::{decode_batch, DecodeBatchScheduler, DecoderMiddlewareChain, FilterExpression},
         encoder::{encode_batch, CoreFieldEncodingStrategy, EncodedBatch, EncodingOptions},
-        EncodingsIo,
     };
     use lance_io::stream::RecordBatchStream;
     use log::debug;
@@ -1129,7 +1082,7 @@ pub mod tests {
 
     use crate::v2::{
         reader::{EncodedBatchReaderExt, FileReader, ReaderProjection},
-        testing::{write_lance_file, FsFixture, WrittenFile},
+        testing::{test_cache, write_lance_file, FsFixture, WrittenFile},
         writer::{EncodedBatchWriteExt, FileWriter, FileWriterOptions},
     };
 
@@ -1211,10 +1164,14 @@ pub mod tests {
 
         for read_size in [32, 1024, 1024 * 1024] {
             let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
-            let file_reader =
-                FileReader::try_open(file_scheduler, None, DecoderMiddlewareChain::default())
-                    .await
-                    .unwrap();
+            let file_reader = FileReader::try_open(
+                file_scheduler,
+                None,
+                Arc::<DecoderMiddlewareChain>::default(),
+                &test_cache(),
+            )
+            .await
+            .unwrap();
 
             let schema = file_reader.schema();
             assert_eq!(schema.metadata.get("foo").unwrap(), "bar");
@@ -1264,9 +1221,8 @@ pub mod tests {
         let decoded = decode_batch(
             &decoded_batch,
             &FilterExpression::no_filter(),
-            &DecoderMiddlewareChain::default(),
+            Arc::<DecoderMiddlewareChain>::default(),
         )
-        .await
         .unwrap();
 
         assert_eq!(data, decoded);
@@ -1278,9 +1234,8 @@ pub mod tests {
         let decoded = decode_batch(
             &decoded_batch,
             &FilterExpression::no_filter(),
-            &DecoderMiddlewareChain::default(),
+            Arc::<DecoderMiddlewareChain>::default(),
         )
-        .await
         .unwrap();
 
         assert_eq!(data, decoded);
@@ -1314,7 +1269,8 @@ pub mod tests {
             let file_reader = FileReader::try_open(
                 file_scheduler.clone(),
                 None,
-                DecoderMiddlewareChain::default(),
+                Arc::<DecoderMiddlewareChain>::default(),
+                &test_cache(),
             )
             .await
             .unwrap();
@@ -1328,7 +1284,7 @@ pub mod tests {
                     lance_io::ReadBatchParams::RangeFull,
                     1024,
                     16,
-                    &projection,
+                    projection.clone(),
                     FilterExpression::no_filter(),
                 )
                 .unwrap();
@@ -1348,7 +1304,8 @@ pub mod tests {
             let file_reader = FileReader::try_open(
                 file_scheduler.clone(),
                 Some(projection.clone()),
-                DecoderMiddlewareChain::default(),
+                Arc::<DecoderMiddlewareChain>::default(),
+                &test_cache(),
             )
             .await
             .unwrap();
@@ -1382,7 +1339,8 @@ pub mod tests {
         assert!(FileReader::try_open(
             file_scheduler.clone(),
             Some(empty_projection),
-            DecoderMiddlewareChain::default()
+            Arc::<DecoderMiddlewareChain>::default(),
+            &test_cache()
         )
         .await
         .is_err());
@@ -1401,7 +1359,8 @@ pub mod tests {
         assert!(FileReader::try_open(
             file_scheduler.clone(),
             Some(projection_with_dupes),
-            DecoderMiddlewareChain::default()
+            Arc::<DecoderMiddlewareChain>::default(),
+            &test_cache()
         )
         .await
         .is_err());
@@ -1418,7 +1377,8 @@ pub mod tests {
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
-            DecoderMiddlewareChain::default(),
+            Arc::<DecoderMiddlewareChain>::default(),
+            &test_cache(),
         )
         .await
         .unwrap();
@@ -1439,7 +1399,7 @@ pub mod tests {
                 lance_io::ReadBatchParams::RangeFull,
                 1024,
                 16,
-                &projection,
+                projection.clone(),
                 FilterExpression::no_filter(),
             )
             .unwrap();
@@ -1466,7 +1426,8 @@ pub mod tests {
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
-            DecoderMiddlewareChain::default(),
+            Arc::<DecoderMiddlewareChain>::default(),
+            &test_cache(),
         )
         .await
         .unwrap();
@@ -1496,7 +1457,8 @@ pub mod tests {
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
-            DecoderMiddlewareChain::default(),
+            Arc::<DecoderMiddlewareChain>::default(),
+            &test_cache(),
         )
         .await
         .unwrap();
@@ -1542,7 +1504,8 @@ pub mod tests {
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
-            DecoderMiddlewareChain::default(),
+            Arc::<DecoderMiddlewareChain>::default(),
+            &test_cache(),
         )
         .await
         .unwrap();
@@ -1557,9 +1520,11 @@ pub mod tests {
             &column_infos,
             &vec![],
             total_rows as u64,
-            &DecoderMiddlewareChain::default(),
-            &(file_reader.scheduler.clone() as Arc<dyn EncodingsIo>),
+            Arc::<DecoderMiddlewareChain>::default(),
+            file_reader.scheduler.clone(),
+            test_cache(),
         )
+        .await
         .unwrap();
 
         let range = 0..total_rows as u64;
@@ -1612,7 +1577,8 @@ pub mod tests {
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
-            DecoderMiddlewareChain::default(),
+            Arc::<DecoderMiddlewareChain>::default(),
+            &test_cache(),
         )
         .await
         .unwrap();

--- a/rust/lance-index/benches/inverted.rs
+++ b/rust/lance-index/benches/inverted.rs
@@ -12,6 +12,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::stream;
 use itertools::Itertools;
+use lance_core::cache::FileMetadataCache;
 use lance_core::ROW_ID;
 use lance_index::prefilter::NoFilter;
 use lance_index::scalar::inverted::{InvertedIndex, InvertedIndexBuilder};
@@ -29,8 +30,13 @@ fn bench_inverted(c: &mut Criterion) {
 
     let tempdir = tempfile::tempdir().unwrap();
     let index_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
-    let store = rt
-        .block_on(async { Arc::new(LanceIndexStore::new(ObjectStore::local(), index_dir, None)) });
+    let store = rt.block_on(async {
+        Arc::new(LanceIndexStore::new(
+            ObjectStore::local(),
+            index_dir,
+            FileMetadataCache::no_cache(),
+        ))
+    });
 
     let mut builder = InvertedIndexBuilder::default();
     // generate 2000 different tokens

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -489,6 +489,7 @@ mod tests {
     use arrow_array::{Array, ArrayRef, GenericStringArray, RecordBatch, UInt64Array};
     use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
     use futures::stream;
+    use lance_core::cache::{CapacityMode, FileMetadataCache};
     use lance_core::ROW_ID_FIELD;
     use lance_io::object_store::ObjectStore;
     use object_store::path::Path;
@@ -503,7 +504,8 @@ mod tests {
     ) -> Arc<InvertedIndex> {
         let tempdir = tempfile::tempdir().unwrap();
         let index_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
-        let store = LanceIndexStore::new(ObjectStore::local(), index_dir, None);
+        let cache = FileMetadataCache::with_capacity(128 * 1024 * 1024, CapacityMode::Bytes);
+        let store = LanceIndexStore::new(ObjectStore::local(), index_dir, cache);
 
         let params = super::InvertedIndexParams::default().with_position(with_position);
         let mut invert_index = super::InvertedIndexBuilder::new(params);

--- a/rust/lance-index/src/vector/v3/shuffler.rs
+++ b/rust/lance-index/src/vector/v3/shuffler.rs
@@ -12,6 +12,7 @@ use future::join_all;
 use futures::prelude::*;
 use lance_arrow::RecordBatchExt;
 use lance_core::{
+    cache::FileMetadataCache,
     utils::tokio::{get_num_compute_intensive_cpus, spawn_cpu},
     Error, Result,
 };
@@ -247,7 +248,8 @@ impl ShuffleReader for IvfShufflerReader {
         let reader = FileReader::try_open(
             self.scheduler.open_file(&partition_path).await?,
             None,
-            DecoderMiddlewareChain::default(),
+            Arc::<DecoderMiddlewareChain>::default(),
+            &FileMetadataCache::no_cache(),
         )
         .await?;
         let schema = reader.schema().as_ref().into();

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -12,7 +12,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use datafusion::{physical_plan::SendableRecordBatchStream, scalar::ScalarValue};
 use futures::TryStreamExt;
 use lance::{io::ObjectStore, Dataset};
-use lance_core::Result;
+use lance_core::{cache::FileMetadataCache, Result};
 use lance_datafusion::utils::reader_to_stream;
 use lance_datagen::{array, gen, BatchCount, RowCount};
 use lance_index::scalar::{
@@ -65,14 +65,21 @@ impl BenchmarkFixture {
         let test_path = tempdir.path();
         let (object_store, test_path) =
             ObjectStore::from_path(test_path.as_os_str().to_str().unwrap()).unwrap();
-        Arc::new(LanceIndexStore::new(object_store, test_path, None))
+        Arc::new(LanceIndexStore::new(
+            object_store,
+            test_path,
+            FileMetadataCache::no_cache(),
+        ))
     }
 
     fn legacy_test_store(tempdir: &TempDir) -> Arc<dyn IndexStore> {
         let test_path = tempdir.path();
         let (object_store, test_path) =
             ObjectStore::from_path(test_path.as_os_str().to_str().unwrap()).unwrap();
-        Arc::new(LanceIndexStore::new(object_store, test_path, None).with_legacy_format(true))
+        Arc::new(
+            LanceIndexStore::new(object_store, test_path, FileMetadataCache::no_cache())
+                .with_legacy_format(true),
+        )
     }
 
     async fn write_baseline_data(tempdir: &TempDir) -> Arc<Dataset> {

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -299,7 +299,7 @@ mod v2_adapter {
                 .read_tasks(
                     ReadBatchParams::Range(range.start as usize..range.end as usize),
                     batch_size,
-                    &projection,
+                    projection,
                     FilterExpression::no_filter(),
                 )?
                 .map(|v2_task| ReadBatchTask {
@@ -323,7 +323,7 @@ mod v2_adapter {
                 .read_tasks(
                     ReadBatchParams::RangeFull,
                     batch_size,
-                    &projection,
+                    projection,
                     FilterExpression::no_filter(),
                 )?
                 .map(|v2_task| ReadBatchTask {
@@ -349,7 +349,7 @@ mod v2_adapter {
                 .read_tasks(
                     ReadBatchParams::Indices(indices),
                     batch_size,
-                    &projection,
+                    projection,
                     FilterExpression::no_filter(),
                 )?
                 .map(|v2_task| ReadBatchTask {
@@ -454,7 +454,8 @@ impl FileFragment {
             let reader = v2::reader::FileReader::try_open(
                 file_scheduler,
                 None,
-                DecoderMiddlewareChain::default(),
+                Arc::<DecoderMiddlewareChain>::default(),
+                &dataset.session.file_metadata_cache,
             )
             .await?;
             // If the schemas are not compatible we can't calculate field id offsets
@@ -639,8 +640,9 @@ impl FileFragment {
                 v2::reader::FileReader::try_open_with_file_metadata(
                     file_scheduler,
                     None,
-                    DecoderMiddlewareChain::default(),
+                    Arc::<DecoderMiddlewareChain>::default(),
                     file_metadata,
+                    &self.dataset.session.file_metadata_cache,
                 )
                 .await?,
             );

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -80,7 +80,7 @@ impl LanceIndexStoreExt for LanceIndexStore {
         Self::new(
             dataset.object_store.as_ref().clone(),
             index_dir,
-            Some(dataset.session.file_metadata_cache.clone()),
+            dataset.session.file_metadata_cache.clone(),
         )
     }
 }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -675,8 +675,13 @@ impl DatasetIndexInternalExt for Dataset {
                     SchedulerConfig::max_bandwidth(&self.object_store),
                 );
                 let file = scheduler.open_file(&index_file).await?;
-                let reader =
-                    v2::reader::FileReader::try_open(file, None, Default::default()).await?;
+                let reader = v2::reader::FileReader::try_open(
+                    file,
+                    None,
+                    Default::default(),
+                    &self.session.file_metadata_cache,
+                )
+                .await?;
                 let index_metadata = reader
                     .schema()
                     .metadata

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -8,6 +8,7 @@ use arrow_array::{RecordBatch, UInt64Array};
 use futures::prelude::stream::{StreamExt, TryStreamExt};
 use itertools::Itertools;
 use lance_arrow::RecordBatchExt;
+use lance_core::cache::FileMetadataCache;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use lance_core::{Error, Result, ROW_ID_FIELD};
 use lance_encoding::decoder::{DecoderMiddlewareChain, FilterExpression};
@@ -499,7 +500,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + Clone + 'static> IvfIndexBuilde
                 let reader = FileReader::try_open(
                     scheduler.open_file(&storage_part_path).await?,
                     None,
-                    DecoderMiddlewareChain::default(),
+                    Arc::<DecoderMiddlewareChain>::default(),
+                    &FileMetadataCache::no_cache(),
                 )
                 .await?;
                 let batches = reader
@@ -531,7 +533,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + Clone + 'static> IvfIndexBuilde
                 let reader = FileReader::try_open(
                     scheduler.open_file(&index_part_path).await?,
                     None,
-                    DecoderMiddlewareChain::default(),
+                    Arc::<DecoderMiddlewareChain>::default(),
+                    &FileMetadataCache::no_cache(),
                 )
                 .await?;
                 let batches = reader

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -121,7 +121,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         let file_metadata_cache = session
             .upgrade()
             .map(|sess| sess.file_metadata_cache.clone())
-            .unwrap_or_else(|| FileMetadataCache::no_cache());
+            .unwrap_or_else(FileMetadataCache::no_cache);
         let index_reader = FileReader::try_open(
             scheduler
                 .open_file(&index_dir.child(uuid.as_str()).child(INDEX_FILE_NAME))


### PR DESCRIPTION
There is still a bit more testing work to do before pushdown is fully supported in v2 and until we start using `LanceDfFieldDecoderStrategy` in the file reader it won't be accessible to users.  However, this PR has a number of structural refactors for v2 and is big enough as it is.

This adds a cache to the v2 schedulers.  This is needed in this PR because we want to use the cache to store zone maps.  However, it will be needed in future 2.1 work as well because we want to cache things like "rows per chunk" and "dictionaries".

This adds an initialization routine to v2 schedulers.  Again, this is needed for zone maps but will also be used by 2.1 features.

Lastly, this PR does, in fact, reconnect the zone maps feature, restoring blocks that had been commented out.