### PR TITLE
feat: allow users to specify late/early materialization, adjust default threshold

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -2396,38 +2396,36 @@ def test_late_materialization_param(tmp_path: Path):
     filt = "filter % 2 == 0"
 
     assert "(values)" in dataset.scanner(
-        filter=filt, materialization_style=None
+        filter=filt, late_materialization=None
     ).explain_plan(True)
     assert ", values" in dataset.scanner(
-        filter=filt, materialization_style=False
+        filter=filt, late_materialization=False
     ).explain_plan(True)
     assert "(values)" in dataset.scanner(
-        filter=filt, materialization_style=True
+        filter=filt, late_materialization=True
     ).explain_plan(True)
     assert "(values)" in dataset.scanner(
-        filter=filt, materialization_style=["values"]
+        filter=filt, late_materialization=["values"]
     ).explain_plan(True)
     assert ", values" in dataset.scanner(
-        filter=filt, materialization_style=["filter"]
+        filter=filt, late_materialization=["filter"]
     ).explain_plan(True)
 
     # These tests just make sure we can pass in the parameter.  There's no great
     # way to know if late materialization happened or not.  That will have to be
     # for benchmarks
     expected = dataset.to_table(filter=filt)
-    assert dataset.to_table(filter=filt, materialization_style=None) == expected
-    assert dataset.to_table(filter=filt, materialization_style=False) == expected
-    assert dataset.to_table(filter=filt, materialization_style=True) == expected
-    assert dataset.to_table(filter=filt, materialization_style=["values"]) == expected
+    assert dataset.to_table(filter=filt, late_materialization=None) == expected
+    assert dataset.to_table(filter=filt, late_materialization=False) == expected
+    assert dataset.to_table(filter=filt, late_materialization=True) == expected
+    assert dataset.to_table(filter=filt, late_materialization=["values"]) == expected
 
     expected = list(dataset.to_batches(filter=filt))
-    assert list(dataset.to_batches(filter=filt, materialization_style=None)) == expected
+    assert list(dataset.to_batches(filter=filt, late_materialization=None)) == expected
+    assert list(dataset.to_batches(filter=filt, late_materialization=False)) == expected
+    assert list(dataset.to_batches(filter=filt, late_materialization=True)) == expected
     assert (
-        list(dataset.to_batches(filter=filt, materialization_style=False)) == expected
-    )
-    assert list(dataset.to_batches(filter=filt, materialization_style=True)) == expected
-    assert (
-        list(dataset.to_batches(filter=filt, materialization_style=["values"]))
+        list(dataset.to_batches(filter=filt, late_materialization=["values"]))
         == expected
     )
 
@@ -2441,7 +2439,7 @@ def test_late_materialization_batch_size(tmp_path: Path):
         columns=["values"],
         filter="filter % 2 == 0",
         batch_size=32,
-        materialization_style=True,
+        late_materialization=True,
     ):
         assert batch.num_rows == 32
 

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -2383,13 +2383,65 @@ def test_legacy_dataset(tmp_path: Path):
     assert "major_version: 2" not in format_fragment(fragment.metadata, dataset)
 
 
+def test_late_materialization_param(tmp_path: Path):
+    table = pa.table(
+        {
+            "filter": np.arange(4),
+            "values": pa.array([b"abcd", b"efgh", b"ijkl", b"mnop"]),
+        }
+    )
+    dataset = lance.write_dataset(
+        table, tmp_path, data_storage_version="stable", max_rows_per_file=10000
+    )
+    filt = "filter % 2 == 0"
+
+    assert "(values)" in dataset.scanner(
+        filter=filt, materialization_style=None
+    ).explain_plan(True)
+    assert ", values" in dataset.scanner(
+        filter=filt, materialization_style=False
+    ).explain_plan(True)
+    assert "(values)" in dataset.scanner(
+        filter=filt, materialization_style=True
+    ).explain_plan(True)
+    assert "(values)" in dataset.scanner(
+        filter=filt, materialization_style=["values"]
+    ).explain_plan(True)
+    assert ", values" in dataset.scanner(
+        filter=filt, materialization_style=["filter"]
+    ).explain_plan(True)
+
+    # These tests just make sure we can pass in the parameter.  There's no great
+    # way to know if late materialization happened or not.  That will have to be
+    # for benchmarks
+    expected = dataset.to_table(filter=filt)
+    assert dataset.to_table(filter=filt, materialization_style=None) == expected
+    assert dataset.to_table(filter=filt, materialization_style=False) == expected
+    assert dataset.to_table(filter=filt, materialization_style=True) == expected
+    assert dataset.to_table(filter=filt, materialization_style=["values"]) == expected
+
+    expected = list(dataset.to_batches(filter=filt))
+    assert list(dataset.to_batches(filter=filt, materialization_style=None)) == expected
+    assert (
+        list(dataset.to_batches(filter=filt, materialization_style=False)) == expected
+    )
+    assert list(dataset.to_batches(filter=filt, materialization_style=True)) == expected
+    assert (
+        list(dataset.to_batches(filter=filt, materialization_style=["values"]))
+        == expected
+    )
+
+
 def test_late_materialization_batch_size(tmp_path: Path):
     table = pa.table({"filter": np.arange(32 * 32), "values": np.arange(32 * 32)})
     dataset = lance.write_dataset(
         table, tmp_path, data_storage_version="stable", max_rows_per_file=10000
     )
     for batch in dataset.to_batches(
-        columns=["values"], filter="filter % 2 == 0", batch_size=32
+        columns=["values"],
+        filter="filter % 2 == 0",
+        batch_size=32,
+        materialization_style=True,
     ):
         assert batch.num_rows == 32
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -28,6 +28,7 @@ use arrow_array::Array;
 use futures::{StreamExt, TryFutureExt};
 use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::refs::{Ref, TagContents};
+use lance::dataset::scanner::MaterializationStyle;
 use lance::dataset::transaction::{
     validate_operation, RewriteGroup as LanceRewriteGroup, RewrittenIndex as LanceRewrittenIndex,
 };
@@ -544,6 +545,7 @@ impl Dataset {
         substrait_filter: Option<Vec<u8>>,
         fast_search: Option<bool>,
         full_text_query: Option<&PyDict>,
+        materialization_style: Option<PyObject>,
     ) -> PyResult<Scanner> {
         let mut scanner: LanceScanner = self_.ds.scan();
         match (columns, columns_with_transform) {
@@ -652,6 +654,25 @@ impl Dataset {
                 })
                 .collect();
             scanner.with_fragments(fragments);
+        }
+
+        if let Some(materialization_style) = materialization_style {
+            if let Ok(style_as_bool) = materialization_style.extract::<bool>(self_.py()) {
+                if style_as_bool {
+                    scanner.materialization_style(MaterializationStyle::AllLate);
+                } else {
+                    scanner.materialization_style(MaterializationStyle::AllEarly);
+                }
+            } else if let Ok(columns) = materialization_style.extract::<Vec<String>>(self_.py()) {
+                scanner.materialization_style(
+                    MaterializationStyle::all_early_except(&columns, self_.ds.schema())
+                        .infer_error()?,
+                );
+            } else {
+                return Err(PyValueError::new_err(
+                    "materialization_style must be a bool or a list of strings",
+                ));
+            }
         }
 
         if let Some(nearest) = nearest {

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -545,7 +545,7 @@ impl Dataset {
         substrait_filter: Option<Vec<u8>>,
         fast_search: Option<bool>,
         full_text_query: Option<&PyDict>,
-        materialization_style: Option<PyObject>,
+        late_materialization: Option<PyObject>,
     ) -> PyResult<Scanner> {
         let mut scanner: LanceScanner = self_.ds.scan();
         match (columns, columns_with_transform) {
@@ -656,21 +656,21 @@ impl Dataset {
             scanner.with_fragments(fragments);
         }
 
-        if let Some(materialization_style) = materialization_style {
-            if let Ok(style_as_bool) = materialization_style.extract::<bool>(self_.py()) {
+        if let Some(late_materialization) = late_materialization {
+            if let Ok(style_as_bool) = late_materialization.extract::<bool>(self_.py()) {
                 if style_as_bool {
                     scanner.materialization_style(MaterializationStyle::AllLate);
                 } else {
                     scanner.materialization_style(MaterializationStyle::AllEarly);
                 }
-            } else if let Ok(columns) = materialization_style.extract::<Vec<String>>(self_.py()) {
+            } else if let Ok(columns) = late_materialization.extract::<Vec<String>>(self_.py()) {
                 scanner.materialization_style(
                     MaterializationStyle::all_early_except(&columns, self_.ds.schema())
                         .infer_error()?,
                 );
             } else {
                 return Err(PyValueError::new_err(
-                    "materialization_style must be a bool or a list of strings",
+                    "late_materialization must be a bool or a list of strings",
                 ));
             }
         }

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -159,6 +159,13 @@ impl Schema {
         }
     }
 
+    /// Convert to a compact string representation.
+    ///
+    /// This is intended for display purposes and not for serialization.
+    pub fn to_compact_string(&self, indent: Indentation) -> String {
+        ArrowSchema::from(self).to_compact_string(indent)
+    }
+
     /// Project the columns over the schema.
     ///
     /// ```ignore

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -495,6 +495,10 @@ impl ObjectStore {
         self.scheme == "file"
     }
 
+    pub fn is_cloud(&self) -> bool {
+        self.scheme != "file" && self.scheme != "memory"
+    }
+
     pub fn block_size(&self) -> usize {
         self.block_size
     }


### PR DESCRIPTION
Previously we always used late materialization.  In many cases this resulted in far too many IOPS which impacted the performance (and the cost) of queries.

The new approach uses early materialization for cloud storage (except for variable sized fields)
For local storage any field that has 10 or fewer bytes per value is early materialized