### PR TITLE
build(deps): datafusion 41

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,18 +95,18 @@ criterion = { version = "0.5", features = [
     "html_reports",
 ] }
 crossbeam-queue = "0.3"
-datafusion = { version = "40.0", default-features = false, features = [
+datafusion = { version = "41.0", default-features = false, features = [
     "array_expressions",
     "regex_expressions",
     "unicode_expressions",
 ] }
-datafusion-common = "40.0"
-datafusion-functions = { version = "40.0", features = ["regex_expressions"] }
-datafusion-sql = "40.0"
-datafusion-expr = "40.0"
-datafusion-execution = "40.0"
-datafusion-optimizer = "40.0"
-datafusion-physical-expr = { version = "40.0", features = [
+datafusion-common = "41.0"
+datafusion-functions = { version = "41.0", features = ["regex_expressions"] }
+datafusion-sql = "41.0"
+datafusion-expr = "41.0"
+datafusion-execution = "41.0"
+datafusion-optimizer = "41.0"
+datafusion-physical-expr = { version = "41.0", features = [
     "regex_expressions",
 ] }
 deepsize = "0.2.0"

--- a/rust/lance-datafusion/Cargo.toml
+++ b/rust/lance-datafusion/Cargo.toml
@@ -21,7 +21,7 @@ datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-functions.workspace = true
 datafusion-physical-expr.workspace = true
-datafusion-substrait = { version = "40.0", optional = true }
+datafusion-substrait = { version = "41.0", optional = true }
 futures.workspace = true
 lance-arrow.workspace = true
 lance-core = { workspace = true, features = ["datafusion"] }

--- a/rust/lance-datafusion/src/planner.rs
+++ b/rust/lance-datafusion/src/planner.rs
@@ -163,6 +163,7 @@ impl Default for LanceContextProvider {
         let state = SessionStateBuilder::new()
             .with_config(config)
             .with_runtime_env(runtime)
+            .with_default_features()
             .build();
         Self {
             options: ConfigOptions::default(),

--- a/rust/lance-encoding-datafusion/Cargo.toml
+++ b/rust/lance-encoding-datafusion/Cargo.toml
@@ -22,6 +22,7 @@ arrow-array.workspace = true
 arrow-buffer.workspace = true
 arrow-schema.workspace = true
 bytes.workspace = true
+datafusion.workspace = true
 datafusion-common.workspace = true
 datafusion-expr.workspace = true
 datafusion-functions.workspace = true

--- a/rust/lance-encoding-datafusion/src/zone.rs
+++ b/rust/lance-encoding-datafusion/src/zone.rs
@@ -6,6 +6,7 @@ use std::{collections::VecDeque, ops::Range, sync::Arc};
 use arrow_array::{cast::AsArray, types::UInt32Type, ArrayRef, RecordBatch, UInt32Array};
 use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
 use bytes::Bytes;
+use datafusion::functions_aggregate::min_max::{MaxAccumulator, MinAccumulator};
 use datafusion_common::{arrow::datatypes::DataType, DFSchemaRef, ScalarValue};
 use datafusion_expr::{
     col,
@@ -16,7 +17,6 @@ use datafusion_expr::{
 };
 use datafusion_functions::core::expr_ext::FieldAccessor;
 use datafusion_optimizer::simplify_expressions::ExprSimplifier;
-use datafusion_physical_expr::expressions::{MaxAccumulator, MinAccumulator};
 use futures::{future::BoxFuture, FutureExt};
 use lance_encoding::{
     buffer::LanceBuffer,

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -13,16 +13,16 @@ use std::{
 use arrow_array::{Array, RecordBatch, UInt32Array};
 use arrow_schema::{DataType, Field, Schema, SortOptions};
 use async_trait::async_trait;
-use datafusion::{functions_aggregate::min_max::{MaxAccumulator, MinAccumulator}, physical_plan::{
-    sorts::sort_preserving_merge::SortPreservingMergeExec, stream::RecordBatchStreamAdapter,
-    union::UnionExec, ExecutionPlan, RecordBatchStream, SendableRecordBatchStream,
-}};
+use datafusion::{
+    functions_aggregate::min_max::{MaxAccumulator, MinAccumulator},
+    physical_plan::{
+        sorts::sort_preserving_merge::SortPreservingMergeExec, stream::RecordBatchStreamAdapter,
+        union::UnionExec, ExecutionPlan, RecordBatchStream, SendableRecordBatchStream,
+    },
+};
 use datafusion_common::{DataFusionError, ScalarValue};
 use datafusion_expr::Accumulator;
-use datafusion_physical_expr::{
-    expressions::Column,
-    PhysicalSortExpr,
-};
+use datafusion_physical_expr::{expressions::Column, PhysicalSortExpr};
 use deepsize::DeepSizeOf;
 use futures::{
     future::BoxFuture,

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -13,14 +13,14 @@ use std::{
 use arrow_array::{Array, RecordBatch, UInt32Array};
 use arrow_schema::{DataType, Field, Schema, SortOptions};
 use async_trait::async_trait;
-use datafusion::physical_plan::{
+use datafusion::{functions_aggregate::min_max::{MaxAccumulator, MinAccumulator}, physical_plan::{
     sorts::sort_preserving_merge::SortPreservingMergeExec, stream::RecordBatchStreamAdapter,
     union::UnionExec, ExecutionPlan, RecordBatchStream, SendableRecordBatchStream,
-};
+}};
 use datafusion_common::{DataFusionError, ScalarValue};
 use datafusion_expr::Accumulator;
 use datafusion_physical_expr::{
-    expressions::{Column, MaxAccumulator, MinAccumulator},
+    expressions::Column,
     PhysicalSortExpr,
 };
 use deepsize::DeepSizeOf;

--- a/rust/lance/src/datafusion/dataframe.rs
+++ b/rust/lance/src/datafusion/dataframe.rs
@@ -9,15 +9,10 @@ use std::{
 use arrow_schema::{Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::{
-    dataframe::DataFrame,
-    datasource::{streaming::StreamingTable, TableProvider},
-    error::DataFusionError,
-    execution::{
-        context::{SessionContext, SessionState},
+    catalog::Session, dataframe::DataFrame, datasource::{streaming::StreamingTable, TableProvider}, error::DataFusionError, execution::{
+        context::SessionContext,
         TaskContext,
-    },
-    logical_expr::{Expr, TableProviderFilterPushDown, TableType},
-    physical_plan::{streaming::PartitionStream, ExecutionPlan, SendableRecordBatchStream},
+    }, logical_expr::{Expr, TableProviderFilterPushDown, TableType}, physical_plan::{streaming::PartitionStream, ExecutionPlan, SendableRecordBatchStream}
 };
 use lance_arrow::SchemaExt;
 use lance_core::{ROW_ADDR_FIELD, ROW_ID_FIELD};
@@ -69,7 +64,7 @@ impl TableProvider for LanceTableProvider {
 
     async fn scan(
         &self,
-        _state: &SessionState,
+        _state: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,

--- a/rust/lance/src/datafusion/dataframe.rs
+++ b/rust/lance/src/datafusion/dataframe.rs
@@ -9,10 +9,13 @@ use std::{
 use arrow_schema::{Schema, SchemaRef};
 use async_trait::async_trait;
 use datafusion::{
-    catalog::Session, dataframe::DataFrame, datasource::{streaming::StreamingTable, TableProvider}, error::DataFusionError, execution::{
-        context::SessionContext,
-        TaskContext,
-    }, logical_expr::{Expr, TableProviderFilterPushDown, TableType}, physical_plan::{streaming::PartitionStream, ExecutionPlan, SendableRecordBatchStream}
+    catalog::Session,
+    dataframe::DataFrame,
+    datasource::{streaming::StreamingTable, TableProvider},
+    error::DataFusionError,
+    execution::{context::SessionContext, TaskContext},
+    logical_expr::{Expr, TableProviderFilterPushDown, TableType},
+    physical_plan::{streaming::PartitionStream, ExecutionPlan, SendableRecordBatchStream},
 };
 use lance_arrow::SchemaExt;
 use lance_core::{ROW_ADDR_FIELD, ROW_ID_FIELD};

--- a/rust/lance/src/datafusion/logical_plan.rs
+++ b/rust/lance/src/datafusion/logical_plan.rs
@@ -6,7 +6,12 @@ use std::{any::Any, sync::Arc};
 use arrow_schema::Schema as ArrowSchema;
 use async_trait::async_trait;
 use datafusion::{
-    catalog::Session, datasource::TableProvider, error::Result as DatafusionResult, logical_expr::{LogicalPlan, TableType}, physical_plan::ExecutionPlan, prelude::Expr
+    catalog::Session,
+    datasource::TableProvider,
+    error::Result as DatafusionResult,
+    logical_expr::{LogicalPlan, TableType},
+    physical_plan::ExecutionPlan,
+    prelude::Expr,
 };
 
 use crate::Dataset;

--- a/rust/lance/src/datafusion/logical_plan.rs
+++ b/rust/lance/src/datafusion/logical_plan.rs
@@ -6,12 +6,7 @@ use std::{any::Any, sync::Arc};
 use arrow_schema::Schema as ArrowSchema;
 use async_trait::async_trait;
 use datafusion::{
-    datasource::TableProvider,
-    error::Result as DatafusionResult,
-    execution::context::SessionState,
-    logical_expr::{LogicalPlan, TableType},
-    physical_plan::ExecutionPlan,
-    prelude::Expr,
+    catalog::Session, datasource::TableProvider, error::Result as DatafusionResult, logical_expr::{LogicalPlan, TableType}, physical_plan::ExecutionPlan, prelude::Expr
 };
 
 use crate::Dataset;
@@ -40,7 +35,7 @@ impl TableProvider for Dataset {
 
     async fn scan(
         &self,
-        _: &SessionState,
+        _: &dyn Session,
         projection: Option<&Vec<usize>>,
         _: &[Expr],
         limit: Option<usize>,

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -778,7 +778,7 @@ impl Scanner {
             &[],
             &[],
             &plan.schema(),
-            "",
+            None,
             false,
             false,
         )?;


### PR DESCRIPTION
Upgrades datafusion and associated crates to version 41. 42 was just released which also has an arrow update to 53.

We're looking to adopt lance in our service where we've already upgraded to 41 for some other dependencies.