### PR TITLE
fix: v2 deadlock when there are multiple data files

### DIFF
--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -167,9 +167,10 @@ impl IoQueue {
 
     fn push(&self, task: IoTask) {
         log::trace!(
-            "Inserting I/O request for {} bytes with priority {} into I/O queue",
+            "Inserting I/O request for {} bytes with priority ({},{}) into I/O queue",
             task.num_bytes(),
-            task.priority
+            task.priority >> 64,
+            task.priority & 0xFFFFFFFFFFFFFFFF
         );
         let mut state = self.state.lock().unwrap();
         state.pending_requests.push(task);

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -237,15 +237,8 @@ impl LanceStream {
             },
         );
 
-        let mut priorities = Vec::with_capacity(file_fragments.len());
-        let mut current_priority = 0;
-        for frag in &file_fragments {
-            priorities.push(current_priority);
-            current_priority += frag.fragment.num_data_files();
-        }
-
-        let batches = stream::iter(file_fragments.into_iter().zip(priorities))
-            .map(move |(file_fragment, priority)| {
+        let batches = stream::iter(file_fragments.into_iter().enumerate())
+            .map(move |(priority, file_fragment)| {
                 let project_schema = project_schema.clone();
                 let scan_scheduler = scan_scheduler.clone();
                 #[allow(clippy::type_complexity)]


### PR DESCRIPTION
We read batches from data files in a round-robin fashion.  With the old priority mechanism all data in file 1 would be scheduled before file 2.  This means we'd deadlock if file 1 was bigger than the I/O buffer size.

Now, each fragment has a unique priority, but the priority within the fragment is the same for all data files.

This should avoid deadlock as long as the I/O buffer size is larger than any given batch (may want to issue warning or fail if we can detect when the batch size is too large).