### PR TITLE
fix: `refine_factor` should be used in `search_in_partition` for IVF V2 Indices

### DIFF
--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -429,9 +429,11 @@ impl<S: IvfSubIndex + fmt::Debug + 'static, Q: Quantization + fmt::Debug + 'stat
 
         let query = self.preprocess_query(partition_id, query)?;
         let param = (&query).into();
+        let refine_factor = query.refine_factor.unwrap_or(1) as usize;
+        let k = query.k * refine_factor;
         part_entry
             .index
-            .search(query.key, query.k, param, &part_entry.storage, pre_filter)
+            .search(query.key, k, param, &part_entry.storage, pre_filter)
     }
 
     fn is_loadable(&self) -> bool {


### PR DESCRIPTION
In testing we saw that `refine_factor` was not increasing recall even when set to a large enough value that it should be doing brute force search in V3 indices. After tracing through the code we found that `refine_factor` was not being utilized in the individual partitions `search_in_partition` function, so they could only return at most `k` values to be refined. This change makes it so that the `search_in_partition` function will return `refine_factor * k` values for further refinement.