### PR TITLE
fix: list_indices never updated after first call

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2788,6 +2788,15 @@ class DatasetOptimizer:
         the new data to existing partitions.  This means an update is much quicker
         than retraining the entire index but may have less accuracy (especially
         if the new data exhibits new patterns, concepts, or trends)
+
+        Parameters
+        ----------
+        num_indices_to_merge: int, default 1
+            The number of indices to merge.
+            If set to 0, new delta index will be created.
+        indexe_names: List[str], default None
+            The names of the indices to optimize.
+            If None, all indices will be optimized.
         """
         self._dataset._ds.optimize_indices(**kwargs)
 

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -218,9 +218,7 @@ class LanceDataset(pa.dataset.Dataset):
         return Tags(self._ds)
 
     def list_indices(self) -> List[Dict[str, Any]]:
-        if getattr(self, "_list_indices_res", None) is None:
-            self._list_indices_res = self._ds.load_indices()
-        return self._list_indices_res
+        return self._ds.load_indices()
 
     def index_statistics(self, index_name: str) -> Dict[str, Any]:
         warnings.warn(

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2794,7 +2794,7 @@ class DatasetOptimizer:
         num_indices_to_merge: int, default 1
             The number of indices to merge.
             If set to 0, new delta index will be created.
-        indexe_names: List[str], default None
+        index_names: List[str], default None
             The names of the indices to optimize.
             If None, all indices will be optimized.
         """

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -888,3 +888,13 @@ def test_load_indices(dataset):
     )
     indices = dataset.list_indices()
     assert len(indices) == 1
+
+
+def test_optimize_indices(indexed_dataset):
+    data = create_table()
+    indexed_dataset = lance.write_dataset(data, indexed_dataset.uri, mode="append")
+    indices = indexed_dataset.list_indices()
+    assert len(indices) == 1
+    indexed_dataset.optimize.optimize_indices(num_indices_to_merge=0)
+    indices = indexed_dataset.list_indices()
+    assert len(indices) == 2

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -877,3 +877,14 @@ def test_fragment_scan_disallowed_on_ann_with_index_scan_prefilter(tmp_path):
             fragments=[LanceFragment(dataset, 0)],
         )
         scanner.explain_plan(True)
+
+
+def test_load_indices(dataset):
+    indices = dataset.list_indices()
+    assert len(indices) == 0
+
+    dataset.create_index(
+        "vector", index_type="IVF_PQ", num_partitions=4, num_sub_vectors=16
+    )
+    indices = dataset.list_indices()
+    assert len(indices) == 1

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1142,6 +1142,13 @@ impl Dataset {
             if let Some(num_indices_to_merge) = kwargs.get_item("num_indices_to_merge")? {
                 options.num_indices_to_merge = num_indices_to_merge.extract()?;
             }
+            if let Some(index_names) = kwargs.get_item("index_names")? {
+                options.index_names = Some(
+                    index_names
+                        .extract::<Vec<String>>()
+                        .map_err(|err| PyValueError::new_err(err.to_string()))?,
+                );
+            }
         }
         RT.block_on(
             None,

--- a/rust/lance-index/src/optimize.rs
+++ b/rust/lance-index/src/optimize.rs
@@ -17,12 +17,16 @@ pub struct OptimizeOptions {
     /// A common usage pattern will be that, the caller can keep a large snapshot of the index of the base version,
     /// and accumulate a few delta indices, then merge them into the snapshot.
     pub num_indices_to_merge: usize,
+
+    /// the index names to optimize. If None, all indices will be optimized.
+    pub index_names: Option<Vec<String>>,
 }
 
 impl Default for OptimizeOptions {
     fn default() -> Self {
         Self {
             num_indices_to_merge: 1,
+            index_names: None,
         }
     }
 }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -428,16 +428,13 @@ impl DatasetIndexExt for Dataset {
         let indices_to_optimize = options
             .index_names
             .as_ref()
-            .map(|names| names.into_iter().collect::<HashSet<_>>());
+            .map(|names| names.iter().collect::<HashSet<_>>());
         let name_to_indices = indices
             .iter()
-            .filter_map(|idx| {
-                if let Some(indices_to_optimize) = &indices_to_optimize {
-                    if !indices_to_optimize.contains(&idx.name) {
-                        return None;
-                    }
-                }
-                Some(idx)
+            .filter(|idx| {
+                indices_to_optimize
+                    .as_ref()
+                    .map_or(true, |names| names.contains(&idx.name))
             })
             .map(|idx| (idx.name.clone(), idx))
             .into_group_map();

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -370,6 +370,7 @@ mod tests {
         dataset
             .optimize_indices(&OptimizeOptions {
                 num_indices_to_merge: 0,
+                ..Default::default()
             })
             .await
             .unwrap();


### PR DESCRIPTION
lance in rust would cache the index metadata so no need to cache it in python.

- also added an option to control which indices to optimize
- also added tests for optimize_indices