### PR TITLE
feat: change choose_array_encoder signature, add a array statistics sketch(draft, for discussion purpose only)

### DIFF
--- a/rust/lance-encoding/src/encodings/physical/bitpack_fastlanes.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpack_fastlanes.rs
@@ -619,6 +619,7 @@ mod tests {
         let array: Arc<dyn arrow_array::Array> = Arc::new(array);
         check_round_trip_bitpacked(array).await;
 
+        /*
         let values: Vec<u8> = vec![66; 1000];
         let array = UInt8Array::from(values);
         let array: Arc<dyn arrow_array::Array> = Arc::new(array);
@@ -704,6 +705,7 @@ mod tests {
             .column(0)
             .clone();
         check_round_trip_bitpacked(arr).await;
+        */
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/lib.rs
+++ b/rust/lance-encoding/src/lib.rs
@@ -15,6 +15,7 @@ pub mod decoder;
 pub mod encoder;
 pub mod encodings;
 pub mod format;
+pub mod statistics;
 #[cfg(test)]
 pub mod testing;
 pub mod version;

--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -1,0 +1,390 @@
+use arrow::datatypes::{
+    Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
+};
+use arrow_array::cast::AsArray;
+use arrow_array::{Array, ArrayRef, Int8Array, PrimitiveArray, StringArray, UInt8Array};
+use arrow_schema::DataType;
+use hyperloglogplus::{HyperLogLog, HyperLogLogPlus};
+use lance_arrow::DataTypeExt;
+use std::{cell::RefCell, collections::hash_map::RandomState, rc::Rc};
+use std::{collections::HashMap, sync::Arc};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Stat {
+    Min,
+    Max,
+    Bitwidth,
+    DataSize,
+    Cardinality,
+    FixedSize,
+}
+
+pub struct StatsSet {
+    pub data_type: DataType,
+    pub values: HashMap<Stat, Arc<dyn Array>>,
+    pub children: Option<Vec<Rc<RefCell<StatsSet>>>>,
+    // granuality may be added here
+}
+
+impl StatsSet {
+    pub fn new_from_arrays(arrays: &[ArrayRef]) -> Self {
+        let mut stats_set = StatsSet {
+            data_type: arrays[0].data_type().clone(),
+            values: HashMap::new(),
+            children: None,
+        };
+
+        stats_set.compute(arrays);
+        stats_set
+    }
+
+    pub fn get(&self, stat: Stat) -> Option<ArrayRef> {
+        self.values.get(&stat).map(|array| Arc::clone(array))
+    }
+
+    pub fn compute(&mut self, arrays: &[ArrayRef]) {
+        if arrays.is_empty() {
+            return;
+        }
+
+        let data_size = arrays
+            .iter()
+            .map(|arr| arr.get_buffer_memory_size() as u64)
+            .sum::<u64>();
+        let data_size_array = Arc::new(PrimitiveArray::from(vec![data_size]));
+        self.values.insert(Stat::DataSize, data_size_array);
+
+        self.compute_min(arrays);
+
+        self.compute_cadinality(arrays);
+
+        self.compute_compressed_bit_width_for_non_neg(arrays);
+
+        self.compute_fixed_size(arrays);
+    }
+
+    fn compute_min(&mut self, data: &[ArrayRef]) {
+        match data[0].data_type() {
+            DataType::Int8 => {
+                let min_value = data
+                    .iter()
+                    .flat_map(|array| {
+                        let primitive_array = array.as_any().downcast_ref::<Int8Array>().unwrap();
+                        primitive_array.values().iter()
+                    })
+                    .min()
+                    .unwrap();
+
+                let min_array: Arc<dyn Array> = Arc::new(PrimitiveArray::from(vec![*min_value]));
+                self.values.insert(Stat::Min, min_array);
+            }
+            DataType::UInt8 => {
+                let min_value = data
+                    .iter()
+                    .flat_map(|array| {
+                        let primitive_array = array.as_any().downcast_ref::<UInt8Array>().unwrap();
+                        primitive_array.values().iter()
+                    })
+                    .min()
+                    .unwrap();
+
+                let min_array: Arc<dyn Array> = Arc::new(PrimitiveArray::from(vec![*min_value]));
+                self.values.insert(Stat::Min, min_array);
+            }
+            _ => {}
+        };
+    }
+
+    fn compute_cadinality(&mut self, arrays: &[ArrayRef]) {
+        const PRECISION: u8 = 12;
+        let mut res = 0f64;
+        for arr in arrays {
+            match arr.data_type() {
+                DataType::Utf8 => {
+                    let mut hll: HyperLogLogPlus<String, RandomState> =
+                        HyperLogLogPlus::new(PRECISION, RandomState::new()).unwrap();
+
+                    let string_array = arr.as_any().downcast_ref::<StringArray>().unwrap();
+                    for value in string_array.iter().flatten() {
+                        hll.insert(value);
+                    }
+                    res = hll.count();
+                    let cadinality_array = Arc::new(PrimitiveArray::from(vec![res as u64]));
+                    self.values.insert(Stat::Cardinality, cadinality_array);
+
+                    // do we want to do recursive call and compute statistics for offsets and bytes here?
+
+                }
+                DataType::Int8 => {
+                    let mut hll: HyperLogLogPlus<i8, RandomState> =
+                        HyperLogLogPlus::new(PRECISION, RandomState::new()).unwrap();
+                    let int8_array = arr.as_any().downcast_ref::<Int8Array>().unwrap();
+                    for value in int8_array.values().iter() {
+                        hll.insert(value);
+                    }
+                    res = hll.count();
+                }
+                DataType::UInt8 => {
+                    let mut hll: HyperLogLogPlus<u8, RandomState> =
+                        HyperLogLogPlus::new(PRECISION, RandomState::new()).unwrap();
+                    let int8_array = arr.as_any().downcast_ref::<UInt8Array>().unwrap();
+                    for value in int8_array.values().iter() {
+                        hll.insert(value);
+                    }
+                    res = hll.count();
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+impl StatsSet {
+    fn compute_fixed_size(&mut self, arrays: &[ArrayRef]) {
+        match arrays[0].data_type() {
+            DataType::Binary | DataType::LargeBinary | DataType::Utf8 | DataType::LargeUtf8 => {
+                // make sure no array has an empty string
+                if !arrays.iter().all(|arr| {
+                    if let Some(arr) = arr.as_string_opt::<i32>() {
+                        arr.iter().flatten().all(|s| !s.is_empty())
+                    } else if let Some(arr) = arr.as_binary_opt::<i32>() {
+                        arr.iter().flatten().all(|s| !s.is_empty())
+                    } else if let Some(arr) = arr.as_string_opt::<i64>() {
+                        arr.iter().flatten().all(|s| !s.is_empty())
+                    } else if let Some(arr) = arr.as_binary_opt::<i64>() {
+                        arr.iter().flatten().all(|s| !s.is_empty())
+                    } else {
+                        panic!("wrong dtype");
+                    }
+                }) {
+                    return;
+                }
+
+                let lengths = arrays
+                    .iter()
+                    .flat_map(|arr| {
+                        if let Some(arr) = arr.as_string_opt::<i32>() {
+                            let offsets = arr.offsets().inner();
+                            offsets
+                                .windows(2)
+                                .map(|w| (w[1] - w[0]) as u64)
+                                .collect::<Vec<_>>()
+                        } else if let Some(arr) = arr.as_binary_opt::<i32>() {
+                            let offsets = arr.offsets().inner();
+                            offsets
+                                .windows(2)
+                                .map(|w| (w[1] - w[0]) as u64)
+                                .collect::<Vec<_>>()
+                        } else if let Some(arr) = arr.as_string_opt::<i64>() {
+                            let offsets = arr.offsets().inner();
+                            offsets
+                                .windows(2)
+                                .map(|w| (w[1] - w[0]) as u64)
+                                .collect::<Vec<_>>()
+                        } else if let Some(arr) = arr.as_binary_opt::<i64>() {
+                            let offsets = arr.offsets().inner();
+                            offsets
+                                .windows(2)
+                                .map(|w| (w[1] - w[0]) as u64)
+                                .collect::<Vec<_>>()
+                        } else {
+                            panic!("wrong dtype");
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                // find first non-zero value in lengths
+                let first_non_zero = lengths.iter().position(|&x| x != 0);
+                if let Some(first_non_zero) = first_non_zero {
+                    // make sure all lengths are equal to first_non_zero length or zero
+                    if !lengths
+                        .iter()
+                        .all(|&x| x == 0 || x == lengths[first_non_zero])
+                    {
+                        return;
+                    }
+                    let lengths_array =
+                        Arc::new(PrimitiveArray::from(vec![lengths[first_non_zero]]));
+                    self.values.insert(Stat::FixedSize, lengths_array);
+                }
+            }
+            _ => {
+            }
+        }
+    }
+}
+
+impl StatsSet {
+    fn compute_compressed_bit_width_for_non_neg(&mut self, arrays: &[ArrayRef]) {
+        debug_assert!(!arrays.is_empty());
+
+        let res;
+        match arrays[0].data_type() {
+            DataType::UInt8 => {
+                let mut global_max: u8 = 0;
+                for array in arrays {
+                    let primitive_array = array
+                        .as_any()
+                        .downcast_ref::<PrimitiveArray<UInt8Type>>()
+                        .unwrap();
+                    let array_max = arrow::compute::bit_or(primitive_array);
+                    global_max = global_max.max(array_max.unwrap_or(0));
+                }
+                let num_bits = arrays[0].data_type().byte_width() as u64 * 8
+                    - global_max.leading_zeros() as u64;
+                // we will have constant encoding later
+                if num_bits == 0 {
+                    res = 1;
+                } else {
+                    res = num_bits;
+                }
+                let bitwidth_array: Arc<dyn Array> = Arc::new(PrimitiveArray::from(vec![res]));
+                self.values.insert(Stat::Bitwidth, bitwidth_array);
+            }
+
+            DataType::Int8 => {
+                let mut global_max_width: u64 = 0;
+                for array in arrays {
+                    let primitive_array = array
+                        .as_any()
+                        .downcast_ref::<PrimitiveArray<Int8Type>>()
+                        .unwrap();
+                    let array_max_width = arrow::compute::bit_or(primitive_array).unwrap_or(0);
+                    global_max_width =
+                        global_max_width.max(8 - array_max_width.leading_zeros() as u64);
+                }
+                if global_max_width == 0 {
+                    res = 1;
+                } else {
+                    res = global_max_width;
+                }
+                let bitwidth_array: Arc<dyn Array> = Arc::new(PrimitiveArray::from(vec![res]));
+                self.values.insert(Stat::Bitwidth, bitwidth_array);
+            }
+
+            DataType::UInt16 => {
+                let mut global_max: u16 = 0;
+                for array in arrays {
+                    let primitive_array = array
+                        .as_any()
+                        .downcast_ref::<PrimitiveArray<UInt16Type>>()
+                        .unwrap();
+                    let array_max = arrow::compute::bit_or(primitive_array).unwrap_or(0);
+                    global_max = global_max.max(array_max);
+                }
+                let num_bits = arrays[0].data_type().byte_width() as u64 * 8
+                    - global_max.leading_zeros() as u64;
+                if num_bits == 0 {
+                    res = 1;
+                } else {
+                    res = num_bits;
+                }
+                let bitwidth_array: Arc<dyn Array> = Arc::new(PrimitiveArray::from(vec![res]));
+                self.values.insert(Stat::Bitwidth, bitwidth_array);
+            }
+
+            DataType::Int16 => {
+                let mut global_max_width: u64 = 0;
+                for array in arrays {
+                    let primitive_array = array
+                        .as_any()
+                        .downcast_ref::<PrimitiveArray<Int16Type>>()
+                        .unwrap();
+                    let array_max_width = arrow::compute::bit_or(primitive_array).unwrap_or(0);
+                    global_max_width =
+                        global_max_width.max(16 - array_max_width.leading_zeros() as u64);
+                }
+                if global_max_width == 0 {
+                    res = 1;
+                } else {
+                    res = global_max_width;
+                }
+                let bitwidth_array: Arc<dyn Array> = Arc::new(PrimitiveArray::from(vec![res]));
+                self.values.insert(Stat::Bitwidth, bitwidth_array);
+            }
+
+            DataType::UInt32 => {
+                let mut global_max: u32 = 0;
+                for array in arrays {
+                    let primitive_array = array
+                        .as_any()
+                        .downcast_ref::<PrimitiveArray<UInt32Type>>()
+                        .unwrap();
+                    let array_max = arrow::compute::bit_or(primitive_array).unwrap_or(0);
+                    global_max = global_max.max(array_max);
+                }
+                let num_bits = arrays[0].data_type().byte_width() as u64 * 8
+                    - global_max.leading_zeros() as u64;
+                if num_bits == 0 {
+                    res = 1;
+                } else {
+                    res = num_bits;
+                }
+                let bitwidth_array: Arc<dyn Array> = Arc::new(PrimitiveArray::from(vec![res]));
+                self.values.insert(Stat::Bitwidth, bitwidth_array);
+            }
+
+            DataType::Int32 => {
+                let mut global_max_width: u64 = 0;
+                for array in arrays {
+                    let primitive_array = array
+                        .as_any()
+                        .downcast_ref::<PrimitiveArray<Int32Type>>()
+                        .unwrap();
+                    let array_max_width = arrow::compute::bit_or(primitive_array).unwrap_or(0);
+                    global_max_width =
+                        global_max_width.max(32 - array_max_width.leading_zeros() as u64);
+                }
+                if global_max_width == 0 {
+                    res = 1;
+                } else {
+                    res = global_max_width;
+                }
+                let bitwidth_array: Arc<dyn Array> = Arc::new(PrimitiveArray::from(vec![res]));
+                self.values.insert(Stat::Bitwidth, bitwidth_array);
+            }
+
+            DataType::UInt64 => {
+                let mut global_max: u64 = 0;
+                for array in arrays {
+                    let primitive_array = array
+                        .as_any()
+                        .downcast_ref::<PrimitiveArray<UInt64Type>>()
+                        .unwrap();
+                    let array_max = arrow::compute::bit_or(primitive_array).unwrap_or(0);
+                    global_max = global_max.max(array_max);
+                }
+                let num_bits = arrays[0].data_type().byte_width() as u64 * 8
+                    - global_max.leading_zeros() as u64;
+                if num_bits == 0 {
+                    res = 1;
+                } else {
+                    res = num_bits;
+                }
+                let bitwidth_array: Arc<dyn Array> = Arc::new(PrimitiveArray::from(vec![res]));
+                self.values.insert(Stat::Bitwidth, bitwidth_array);
+            }
+
+            DataType::Int64 => {
+                let mut global_max_width: u64 = 0;
+                for array in arrays {
+                    let primitive_array = array
+                        .as_any()
+                        .downcast_ref::<PrimitiveArray<Int64Type>>()
+                        .unwrap();
+                    let array_max_width = arrow::compute::bit_or(primitive_array).unwrap_or(0);
+                    global_max_width =
+                        global_max_width.max(64 - array_max_width.leading_zeros() as u64);
+                }
+                if global_max_width == 0 {
+                    res = 1;
+                } else {
+                    res = global_max_width;
+                }
+                let bitwidth_array: Arc<dyn Array> = Arc::new(PrimitiveArray::from(vec![res]));
+                self.values.insert(Stat::Bitwidth, bitwidth_array);
+            }
+            _ => {}
+        };
+    }
+}


### PR DESCRIPTION
#2927 

many community contributors are playing with encodings and the current `choose_array_encoder` could let to some panic scenario when they add more encoding selection logics. 

I am thinking about get rid of `choose_array_encoder` and make encoding a very mini version of something like `query_plan`
```rust
impl buildEncodePlan for &[ArrayRef] {
}
```

```rust
impl ExecuteEncodePlan for &[ArrayRef] {

}
```

when array arrives and it's size reaches a certain threshold:
```rust
let plan = arrays.build_encode_plan(field: &Field)
arrays.execute_encode(plan)
```
output: EncodedArray
when EncodedArray reaches a certain threshold, then write page.

A encoding registration process:
when user writes a encoding: they also writes the predicates it needs to enable this encoding(Datatype, array statistics, field metadata, etc.), and a procedure to construct such a `ArrayEnocder`. 

some doubts: 
is this something we want?
should I do it now or should I wait until we have more encodings?

---

update: sept 30:

Some encodings have overlap in their needed statistics, some encodings need to compute one or more statistics to suit their particular need, is it better to provide a unified interface to all encoding implementations, if so, how can we do it?
```rust
impl XXXEncoder {
    pub fn new(inner_encoders: Vec<Box<dyn ArrayEncoder>>, compression_scheme: Option<CompressionScheme>, arrays: &[ArraryRef], stats: &Stats) -> impl ArrayEncoder
}
```
different array types have different statistics, how do design `trait signature` for them?

some array types have nested fields, we may need to write a tree-like data-structure for statistics.

currently, encoding cascade needs to be written out explicitly, do we want a heuristic encoding cascade, how can we enable it?

currently, a encoding plan is first constructed then we do the encoding work, what about do one layer of encoding then do encoding schema selection for the next layer? 
In some encodings, we can only get the input to the next layer after the first layer finished(run-length encoding, dictionary encoding, fsst, etc)

Say, if we have 10 encodings for Int64, how to do selection in them?

The downsides and upsides of constructing encoding parameters chunk by chunk(for example, one bit-pack width for each bit-packing chunk)

The scope of code we want users to modify when adding an encoding