### PR TITLE
feat: Add configuration to create v3 ivf_pq indices via python

### DIFF
--- a/java/core/lance-jni/src/utils.rs
+++ b/java/core/lance-jni/src/utils.rs
@@ -244,6 +244,7 @@ pub fn get_index_params(
         Some(VectorIndexParams {
             metric_type: distance_type,
             stages,
+            force_use_new_index_format: None,
         })
     } else {
         None

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1503,8 +1503,8 @@ class LanceDataset(pa.dataset.Dataset):
             Extra options that make sense for a particular storage connection. This is
             used to store connection parameters like credentials, endpoint, etc.
         use_new_vector_index_format : bool, optional
-            Allows to use the new V3 index format. Default is False. This is most for
-            IVF_PQ indices which still default to use the legacy format.
+            Allows to use the new V3 index format. Default is False. This is mostly for
+            IVF_PQ indices which still defaults to use the legacy format.
         kwargs :
             Parameters passed to the index building process.
 

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1445,6 +1445,7 @@ class LanceDataset(pa.dataset.Dataset):
         ivf_centroids_file: Optional[str] = None,
         precomputed_partiton_dataset: Optional[str] = None,
         storage_options: Optional[Dict[str, str]] = None,
+        use_new_vector_index_format: Optional[bool] = None,
         **kwargs,
     ) -> LanceDataset:
         """Create index on column.
@@ -1501,6 +1502,9 @@ class LanceDataset(pa.dataset.Dataset):
         storage_options : optional, dict
             Extra options that make sense for a particular storage connection. This is
             used to store connection parameters like credentials, endpoint, etc.
+        use_new_vector_index_format : bool, optional
+            Allows to use the new V3 index format. Default is False. This is most for
+            IVF_PQ indices which still default to use the legacy format.
         kwargs :
             Parameters passed to the index building process.
 
@@ -1757,6 +1761,9 @@ class LanceDataset(pa.dataset.Dataset):
                     [pq_codebook], ["_pq_codebook"]
                 )
                 kwargs["pq_codebook"] = pq_codebook_batch
+
+        if index_type == "IVF_PQ" and use_new_vector_index_format is not None:
+            kwargs["use_new_vector_index_format"] = use_new_vector_index_format
 
         if shuffle_partition_batches is not None:
             kwargs["shuffle_partition_batches"] = shuffle_partition_batches

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -662,6 +662,22 @@ mod tests {
 
     #[rstest]
     #[case(4, DistanceType::L2, 0.9)]
+    #[case(4, DistanceType::Cosine, 0.6)]
+    #[case(4, DistanceType::Dot, 0.2)]
+    #[tokio::test]
+    async fn test_build_ivf_pq_v3(
+        #[case] nlist: usize,
+        #[case] distance_type: DistanceType,
+        #[case] recall_requirement: f32,
+    ) {
+        let ivf_params = IvfBuildParams::new(nlist);
+        let pq_params = PQBuildParams::default();
+        let params = VectorIndexParams::with_ivf_pq_params_v3(distance_type, ivf_params, pq_params);
+        test_index(params, nlist, recall_requirement).await;
+    }
+
+    #[rstest]
+    #[case(4, DistanceType::L2, 0.9)]
     #[case(4, DistanceType::Cosine, 0.9)]
     #[case(4, DistanceType::Dot, 0.9)]
     #[tokio::test]


### PR DESCRIPTION
PR adds the ability to create v3 ivf_pq indices from python by passing in a bool parameter via the VectorIndexParams python. Right now it just sets the value to true for IVF_PQ but it can be used for other indices as well. Also, it doesn't change the JNI side for IVF_PQ for now, but can be added as a follow-up PR.  

Added a bunch of tests in python and rust to test this. 