### PR TITLE
Clear field meta data during reading so that it can be processed

### DIFF
--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -420,10 +420,13 @@ impl TryFrom<pb::Manifest> for Manifest {
                 .collect::<Result<Vec<_>>>()?,
         );
         let fragment_offsets = compute_fragment_offsets(fragments.as_slice());
-        let fields_with_meta = FieldsWithMeta {
+        let mut fields_with_meta = FieldsWithMeta {
             fields: Fields(p.fields),
             metadata: p.metadata,
         };
+        for f in fields_with_meta.fields.0.iter_mut() {
+            f.metadata.clear();
+        }
 
         if FLAG_MOVE_STABLE_ROW_IDS & p.reader_feature_flags != 0
             && !fragments.iter().all(|frag| frag.row_id_meta.is_some())


### PR DESCRIPTION
This PR aims to demonstrate the issue described in [LanceDB/lance#2947](https://github.com/lancedb/lance/issues/2947), where a dataset containing a nested field with associated metadata can be written successfully but cannot be read correctly by Lance.

In this PR, I propose a quick fix that clears the field metadata when reading from the manifest. However, this approach doesn't seem to be a perfect solution to the issue. I also attempted to remove the field metadata right before the `decode` method’s `StructArray::try_new` call, but there appear to be multiple places with similar issues, so I opted to clear the metadata once when reading the field from the manifest instead. 

It would be great if we have better solution to this issue. Thanks.