### PR TITLE
ci: run rust benchmark and generate report

### DIFF
--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -49,4 +49,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Push and deploy GitHub pages branch automatically
           auto-push: true
-          gh-repository: "lancedb/lance-benchmark-results"
+          gh-repository: "github.com/lancedb/lance-benchmark-results"

--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -1,0 +1,52 @@
+name: Benchmark Lance Repo
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/benchmark.yml"
+
+permissions:
+  # deployments permission to deploy GitHub pages website
+  deployments: write
+  # contents permission to update benchmark contents in gh-pages branch
+  contents: write
+
+env:
+  # This env var is used by Swatinem/rust-cache@v2 for the cache
+  # key, so we set it to make sure it is always consistent.
+  CARGO_TERM_COLOR: always
+  # Disable full debug symbol generation to speed up CI build and keep memory down
+  # "1" means line tables only, which is useful for panic tracebacks.
+  RUSTFLAGS: "-C debuginfo=1 -C target-cpu=native"
+  RUST_BACKTRACE: "1"
+  # according to: https://matklad.github.io/2021/09/04/fast-rust-builds.html
+  # CI builds are faster with incremental disabled.
+  CARGO_INCREMENTAL: "0"
+  CARGO_BUILD_JOBS: "4"
+
+jobs:
+  linux:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run benchmarks
+        working-directory: ./rust/lance-linalg
+        run: |
+          # TODO: a few benchmarks are failing. Re-enable everything once they are fixed.
+          cargo bench --bench l2 --output-format bencher | tee ../../output.txt
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Lance Rust Benchmarks
+          tool: "cargo"
+          output-file-path: output.txt
+          # Access token to deploy GitHub Pages branch
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Push and deploy GitHub pages branch automatically
+          auto-push: true
+          gh-repository: "lancedb/lance-benchmark-results"

--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -1,4 +1,4 @@
-name: Benchmark Lance Repo
+name: Rust Benchmark
 
 on:
   workflow_dispatch:

--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -38,7 +38,7 @@ jobs:
         working-directory: ./rust/lance-linalg
         run: |
           # TODO: a few benchmarks are failing. Re-enable everything once they are fixed.
-          cargo bench --bench l2 --output-format bencher | tee -a ../../output.txt
+          cargo bench --bench l2 -- --output-format bencher | tee -a ../../output.txt
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -28,7 +28,7 @@ env:
   CARGO_BUILD_JOBS: "4"
 
 jobs:
-  linux:
+  Benchmark:
     runs-on: [self-hosted, linux, x64]
     timeout-minutes: 120
     steps:
@@ -38,7 +38,7 @@ jobs:
         working-directory: ./rust/lance-linalg
         run: |
           # TODO: a few benchmarks are failing. Re-enable everything once they are fixed.
-          cargo bench --bench l2 -- --output-format bencher | tee -a ../../output.txt
+          cargo bench --features "fp16kernels"--bench l2 -- --output-format bencher | tee -a ../../output.txt
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -46,7 +46,7 @@ jobs:
           tool: "cargo"
           output-file-path: output.txt
           # Access token to deploy GitHub Pages branch
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.BENCHMARK_PUSH }}
           # Push and deploy GitHub pages branch automatically
           auto-push: true
           gh-repository: "github.com/lancedb/lance-benchmark-results"

--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -34,11 +34,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Run benchmarks
+      - name: Run linalg benchmarks
         working-directory: ./rust/lance-linalg
         run: |
           # TODO: a few benchmarks are failing. Re-enable everything once they are fixed.
-          cargo bench --features "fp16kernels" --bench l2 -- --output-format bencher | tee -a ../../output.txt
+          cargo bench --features "fp16kernels" --bench l2 --bench cosine --bench dot --bench kmeans --bench norm_l2 -- --output-format bencher | tee -a ../../output.txt
+      - name: Run index benchmarks
+        working-directory: ./rust/lance-index
+        run: |
+          # TODO: a few benchmarks are failing. Re-enable everything once they are fixed.
+          cargo bench --features "fp16kernels" --bench sq --bench hnsw --bench inverted --bench pq_dist_table --bench pq_assignment -- --output-format bencher | tee -a ../../output.txt
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -6,7 +6,7 @@ on:
     - cron: "0 2 * * *"
   pull_request:
     paths:
-      - ".github/workflows/benchmark.yml"
+      - ".github/workflows/rust-benchmark.yml"
 
 permissions:
   # deployments permission to deploy GitHub pages website

--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -3,7 +3,7 @@ name: Rust Benchmark
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 2 * * *"
+    - cron: "0 9 * * *" # 9AM UTC = 2AM PST
   pull_request:
     paths:
       - ".github/workflows/rust-benchmark.yml"

--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -38,7 +38,7 @@ jobs:
         working-directory: ./rust/lance-linalg
         run: |
           # TODO: a few benchmarks are failing. Re-enable everything once they are fixed.
-          cargo bench --features "fp16kernels"--bench l2 -- --output-format bencher | tee -a ../../output.txt
+          cargo bench --features "fp16kernels" --bench l2 -- --output-format bencher | tee -a ../../output.txt
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -38,7 +38,7 @@ jobs:
         working-directory: ./rust/lance-linalg
         run: |
           # TODO: a few benchmarks are failing. Re-enable everything once they are fixed.
-          cargo bench --bench l2 --output-format bencher | tee ../../output.txt
+          cargo bench --bench l2 --output-format bencher | tee -a ../../output.txt
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -43,7 +43,7 @@ jobs:
         working-directory: ./rust/lance-index
         run: |
           # TODO: a few benchmarks are failing. Re-enable everything once they are fixed.
-          cargo bench --features "fp16kernels" --bench sq --bench hnsw --bench inverted --bench pq_dist_table --bench pq_assignment -- --output-format bencher | tee -a ../../output.txt
+          cargo bench --bench sq --bench hnsw --bench inverted --bench pq_dist_table --bench pq_assignment -- --output-format bencher | tee -a ../../output.txt
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:


### PR DESCRIPTION
Cronjob to generate report on https://lancedb.github.io/lance-benchmark-results/dev/bench/