### PR TITLE
feat: nested list access

### DIFF
--- a/docs/read_and_write.rst
+++ b/docs/read_and_write.rst
@@ -517,8 +517,12 @@ For example, the following filter string is acceptable:
 
 .. code-block:: SQL
 
-  ((label IN [10, 20]) AND (note.email IS NOT NULL))
-      OR NOT note.created
+  ((label IN [10, 20]) AND (note['email'] IS NOT NULL))
+      OR NOT note['created']
+
+Nested fields can be accessed using the subscripts. Struct fields can be 
+subscripted using field names, while list fields can be subscripted using
+indices.
 
 If your column name contains special characters or is a `SQL Keyword <https://docs.rs/sqlparser/latest/sqlparser/keywords/index.html>`_,
 you can use backtick (`````) to escape it. For nested fields, each segment of the

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -576,6 +576,29 @@ def test_nested_projection(tmp_path: Path):
         {"struct.y": [i % 2 == 0 for i in range(100)]}
     )
 
+def test_nested_projection_list(tmp_path: Path):
+    table = pa.Table.from_pydict(
+        {
+            "a": range(100),
+            "b": range(100),
+            "list_struct": [[{"x": counter, "y": counter % 2 == 0}] for counter in range(100)],
+        }
+    )
+    base_dir = tmp_path / "test"
+    lance.write_dataset(table, base_dir)
+
+    dataset = lance.dataset(base_dir)
+
+    scanner = dataset.scanner(columns={"list_struct": "list_struct[1].x"})
+    print(scanner.explain_plan(True))
+
+    projected = dataset.to_table(columns={"list_struct": "list_struct[1]['x']"})
+    assert projected == pa.Table.from_pydict({"list_struct": range(100)})
+
+    projected = dataset.to_table(columns={"list_struct": "list_struct[1].y"})
+    assert projected == pa.Table.from_pydict(
+        {"list_struct": [i % 2 == 0 for i in range(100)]}
+    )
 
 def test_polar_scan(tmp_path: Path):
     some_structs = [{"x": counter, "y": counter} for counter in range(100)]

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -576,12 +576,15 @@ def test_nested_projection(tmp_path: Path):
         {"struct.y": [i % 2 == 0 for i in range(100)]}
     )
 
+
 def test_nested_projection_list(tmp_path: Path):
     table = pa.Table.from_pydict(
         {
             "a": range(100),
             "b": range(100),
-            "list_struct": [[{"x": counter, "y": counter % 2 == 0}] for counter in range(100)],
+            "list_struct": [
+                [{"x": counter, "y": counter % 2 == 0}] for counter in range(100)
+            ],
         }
     )
     base_dir = tmp_path / "test"
@@ -594,10 +597,12 @@ def test_nested_projection_list(tmp_path: Path):
 
     # FIXME: sqlparser seems to ignore the .y part, but I can't create a simple
     # reproducible example for sqlparser. Possibly an issue in our dialect.
-    # projected = dataset.to_table(columns={"list_struct": "array_element(list_struct, 1).y"})
+    # projected = dataset.to_table(
+    #   columns={"list_struct": "array_element(list_struct, 1).y"})
     # assert projected == pa.Table.from_pydict(
     #     {"list_struct": [i % 2 == 0 for i in range(100)]}
     # )
+
 
 def test_polar_scan(tmp_path: Path):
     some_structs = [{"x": counter, "y": counter} for counter in range(100)]

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -589,16 +589,15 @@ def test_nested_projection_list(tmp_path: Path):
 
     dataset = lance.dataset(base_dir)
 
-    scanner = dataset.scanner(columns={"list_struct": "list_struct[1].x"})
-    print(scanner.explain_plan(True))
-
     projected = dataset.to_table(columns={"list_struct": "list_struct[1]['x']"})
     assert projected == pa.Table.from_pydict({"list_struct": range(100)})
 
-    projected = dataset.to_table(columns={"list_struct": "list_struct[1].y"})
-    assert projected == pa.Table.from_pydict(
-        {"list_struct": [i % 2 == 0 for i in range(100)]}
-    )
+    # FIXME: sqlparser seems to ignore the .y part, but I can't create a simple
+    # reproducible example for sqlparser. Possibly an issue in our dialect.
+    # projected = dataset.to_table(columns={"list_struct": "array_element(list_struct, 1).y"})
+    # assert projected == pa.Table.from_pydict(
+    #     {"list_struct": [i % 2 == 0 for i in range(100)]}
+    # )
 
 def test_polar_scan(tmp_path: Path):
     some_structs = [{"x": counter, "y": counter} for counter in range(100)]

--- a/rust/lance-datafusion/src/planner.rs
+++ b/rust/lance-datafusion/src/planner.rs
@@ -26,16 +26,17 @@ use datafusion::execution::context::SessionState;
 use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::logical_expr::expr::ScalarFunction;
-use datafusion::logical_expr::planner::ExprPlanner;
+use datafusion::logical_expr::planner::{ExprPlanner, PlannerResult, RawFieldAccessExpr};
 use datafusion::logical_expr::{
-    AggregateUDF, ColumnarValue, ScalarUDF, ScalarUDFImpl, Signature, Volatility, WindowUDF,
+    AggregateUDF, ColumnarValue, GetFieldAccess, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+    WindowUDF,
 };
 use datafusion::optimizer::simplify_expressions::SimplifyContext;
 use datafusion::sql::planner::{ContextProvider, ParserOptions, PlannerContext, SqlToRel};
 use datafusion::sql::sqlparser::ast::{
     Array as SQLArray, BinaryOperator, DataType as SQLDataType, ExactNumberInfo, Expr as SQLExpr,
-    Function, FunctionArg, FunctionArgExpr, FunctionArguments, Ident, TimezoneInfo, UnaryOperator,
-    Value,
+    Function, FunctionArg, FunctionArgExpr, FunctionArguments, Ident, MapAccessKey, Subscript,
+    TimezoneInfo, UnaryOperator, Value,
 };
 use datafusion::{
     common::Column,
@@ -238,11 +239,15 @@ impl ContextProvider for LanceContextProvider {
 
 pub struct Planner {
     schema: SchemaRef,
+    context_provider: LanceContextProvider,
 }
 
 impl Planner {
     pub fn new(schema: SchemaRef) -> Self {
-        Self { schema }
+        Self {
+            schema,
+            context_provider: LanceContextProvider::default(),
+        }
     }
 
     fn column(idents: &[Ident]) -> Expr {
@@ -403,9 +408,8 @@ impl Planner {
                 return self.legacy_parse_function(function);
             }
         }
-        let context_provider = LanceContextProvider::default();
         let sql_to_rel = SqlToRel::new_with_options(
-            &context_provider,
+            &self.context_provider,
             ParserOptions {
                 parse_float_as_decimal: false,
                 enable_ident_normalization: false,
@@ -514,6 +518,22 @@ impl Planner {
                 location!(),
             )),
         }
+    }
+
+    fn plan_field_access(&self, mut field_access_expr: RawFieldAccessExpr) -> Result<Expr> {
+        let df_schema = DFSchema::try_from(self.schema.as_ref().clone())?;
+        for planner in self.context_provider.get_expr_planners() {
+            match planner.plan_field_access(field_access_expr, &df_schema)? {
+                PlannerResult::Planned(expr) => return Ok(expr),
+                PlannerResult::Original(expr) => {
+                    field_access_expr = expr;
+                }
+            }
+        }
+        Err(Error::invalid_input(
+            "Field access could not be planned",
+            location!(),
+        ))
     }
 
     fn parse_sql_expr(&self, expr: &SQLExpr) -> Result<Expr> {
@@ -665,10 +685,89 @@ impl Planner {
                 expr: Box::new(self.parse_sql_expr(expr)?),
                 data_type: self.parse_type(data_type)?,
             })),
-            _ => Err(Error::invalid_input(
-                format!("Expression '{expr}' is not supported SQL in lance"),
-                location!(),
-            )),
+            SQLExpr::MapAccess { column, keys } => {
+                let mut expr = self.parse_sql_expr(column)?;
+
+                for key in keys {
+                    let field_access = match &key.key {
+                        SQLExpr::Value(
+                            Value::SingleQuotedString(s) | Value::DoubleQuotedString(s),
+                        ) => GetFieldAccess::NamedStructField {
+                            name: ScalarValue::from(s.as_str()),
+                        },
+                        SQLExpr::JsonAccess { .. } => {
+                            return Err(Error::invalid_input(
+                                "JSON access is not supported",
+                                location!(),
+                            ));
+                        }
+                        key => {
+                            let key = Box::new(self.parse_sql_expr(key)?);
+                            GetFieldAccess::ListIndex { key }
+                        }
+                    };
+
+                    let field_access_expr = RawFieldAccessExpr { expr, field_access };
+
+                    expr = self.plan_field_access(field_access_expr)?;
+                }
+
+                Ok(expr)
+            }
+            SQLExpr::Subscript { expr, subscript } => {
+                let expr = self.parse_sql_expr(expr)?;
+
+                let field_access = match subscript.as_ref() {
+                    Subscript::Index { index } => match index {
+                        SQLExpr::Value(
+                            Value::SingleQuotedString(s) | Value::DoubleQuotedString(s),
+                        ) => GetFieldAccess::NamedStructField {
+                            name: ScalarValue::from(s.as_str()),
+                        },
+                        SQLExpr::JsonAccess { .. } => {
+                            return Err(Error::invalid_input(
+                                "JSON access is not supported",
+                                location!(),
+                            ));
+                        }
+                        _ => {
+                            let key = Box::new(self.parse_sql_expr(index)?);
+                            GetFieldAccess::ListIndex { key }
+                        }
+                    },
+                    Subscript::Slice { .. } => {
+                        return Err(Error::invalid_input(
+                            "Slice subscript is not supported",
+                            location!(),
+                        ));
+                    }
+                };
+
+                let mut field_access_expr = RawFieldAccessExpr { expr, field_access };
+
+                let df_schema = DFSchema::try_from(self.schema.as_ref().clone())?;
+
+                for planner in self.context_provider.get_expr_planners() {
+                    match planner.plan_field_access(field_access_expr, &df_schema)? {
+                        PlannerResult::Planned(expr) => return Ok(expr),
+                        PlannerResult::Original(expr) => {
+                            field_access_expr = expr;
+                        }
+                    }
+                }
+
+                Err(Error::invalid_input(
+                    "Field access could not be planned",
+                    location!(),
+                ))
+            }
+            _ => {
+                dbg!(expr);
+                Err(Error::invalid_input(
+                    format!("Expression '{expr}' is not supported SQL in lance"),
+                    location!(),
+                ))
+            }
         }
     }
 

--- a/rust/lance-datafusion/src/planner.rs
+++ b/rust/lance-datafusion/src/planner.rs
@@ -743,23 +743,8 @@ impl Planner {
                     }
                 };
 
-                let mut field_access_expr = RawFieldAccessExpr { expr, field_access };
-
-                let df_schema = DFSchema::try_from(self.schema.as_ref().clone())?;
-
-                for planner in self.context_provider.get_expr_planners() {
-                    match planner.plan_field_access(field_access_expr, &df_schema)? {
-                        PlannerResult::Planned(expr) => return Ok(expr),
-                        PlannerResult::Original(expr) => {
-                            field_access_expr = expr;
-                        }
-                    }
-                }
-
-                Err(Error::invalid_input(
-                    "Field access could not be planned",
-                    location!(),
-                ))
+                let field_access_expr = RawFieldAccessExpr { expr, field_access };
+                self.plan_field_access(field_access_expr)
             }
             _ => Err(Error::invalid_input(
                 format!("Expression '{expr}' is not supported SQL in lance"),
@@ -790,7 +775,6 @@ impl Planner {
         let expr = self.parse_sql_expr(&ast_expr)?;
         let schema = Schema::try_from(self.schema.as_ref())?;
         let resolved = resolve_expr(&expr, &schema)?;
-        // dbg!(&resolved);
         Ok(resolved)
     }
 

--- a/rust/lance-datafusion/src/planner.rs
+++ b/rust/lance-datafusion/src/planner.rs
@@ -761,12 +761,10 @@ impl Planner {
                     location!(),
                 ))
             }
-            _ => {
-                Err(Error::invalid_input(
-                    format!("Expression '{expr}' is not supported SQL in lance"),
-                    location!(),
-                ))
-            }
+            _ => Err(Error::invalid_input(
+                format!("Expression '{expr}' is not supported SQL in lance"),
+                location!(),
+            )),
         }
     }
 
@@ -1102,9 +1100,18 @@ mod tests {
 
         let planner = Planner::new(schema.clone());
 
-        let expected = get_field(array_element(col("l"), lit(0)), "f1");
-        let expr = planner.parse_expr("l[0].f1").unwrap();
+        let expected = array_element(col("l"), lit(0_i64));
+        let expr = planner.parse_expr("l[0]").unwrap();
         assert_eq!(expr, expected);
+
+        let expected = get_field(array_element(col("l"), lit(0_i64)), "f1");
+        let expr = planner.parse_expr("l[0]['f1']").unwrap();
+        assert_eq!(expr, expected);
+
+        // FIXME: This should work, but sqlparser doesn't recognize anything
+        // after the period for some reason.
+        // let expr = planner.parse_expr("l[0].f1").unwrap();
+        // assert_eq!(expr, expected);
     }
 
     #[test]


### PR DESCRIPTION
Adds support for accessing list items and struct fields with subscripting: `x[0]` and `x['field_name']`. These can be chained.

Unfortunately there is an issue with our SQL parser related to using `.` I wasn't able to figure out. Follow up issue here: https://github.com/lancedb/lance/issues/2967