### PR TITLE
refactor: convert scan args into struct

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1999,6 +1999,8 @@ mod tests {
         #[values(LanceFileVersion::Legacy, LanceFileVersion::Stable)]
         data_storage_version: LanceFileVersion,
     ) {
+        use fragment::FragReadConfig;
+
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
 
@@ -2034,7 +2036,7 @@ mod tests {
         for fragment in &fragments {
             assert_eq!(fragment.count_rows().await.unwrap(), 100);
             let reader = fragment
-                .open(dataset.schema(), false, false, None)
+                .open(dataset.schema(), FragReadConfig::default(), None)
                 .await
                 .unwrap();
             // No group / batch concept in v2

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -68,7 +68,7 @@ use snafu::{location, Location};
 #[cfg(feature = "substrait")]
 use lance_datafusion::substrait::parse_substrait;
 
-const BATCH_SIZE_FALLBACK: usize = 8192;
+pub(crate) const BATCH_SIZE_FALLBACK: usize = 8192;
 // For backwards compatibility / historical reasons we re-calculate the default batch size
 // on each call
 pub fn get_default_batch_size() -> Option<usize> {

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -56,8 +56,8 @@ use crate::datatypes::Schema;
 use crate::index::scalar::detect_scalar_index_type;
 use crate::index::DatasetIndexInternalExt;
 use crate::io::exec::fts::FtsExec;
-use crate::io::exec::get_physical_optimizer;
 use crate::io::exec::scalar_index::{MaterializeIndexExec, ScalarIndexExec};
+use crate::io::exec::{get_physical_optimizer, LanceScanConfig};
 use crate::io::exec::{
     knn::new_knn_exec, project, AddRowAddrExec, FilterPlan, KNNVectorDistanceExec,
     LancePushdownScanExec, LanceScanExec, Planner, PreFilterSource, ScanConfig, TakeExec,
@@ -1705,19 +1705,22 @@ impl Scanner {
         range: Option<Range<u64>>,
         ordered: bool,
     ) -> Arc<dyn ExecutionPlan> {
+        let config = LanceScanConfig {
+            batch_size: self.get_batch_size(),
+            batch_readahead: self.batch_readahead,
+            fragment_readahead: self.fragment_readahead,
+            io_buffer_size: self.get_io_buffer_size(),
+            with_row_id,
+            with_row_address,
+            with_make_deletions_null,
+            ordered_output: ordered,
+        };
         Arc::new(LanceScanExec::new(
             self.dataset.clone(),
             fragments,
             range,
             projection,
-            self.get_batch_size(),
-            self.batch_readahead,
-            self.fragment_readahead,
-            self.get_io_buffer_size(),
-            with_row_id,
-            with_row_address,
-            with_make_deletions_null,
-            ordered,
+            config,
         ))
     }
 

--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -3,6 +3,7 @@
 
 use std::{collections::BTreeMap, ops::Range, pin::Pin, sync::Arc};
 
+use crate::dataset::fragment::FragReadConfig;
 use crate::dataset::rowids::get_row_id_index;
 use crate::{Error, Result};
 use arrow::{array::as_struct_array, compute::concat_batches, datatypes::UInt64Type};
@@ -201,7 +202,7 @@ async fn take_rows(builder: TakeBuilder) -> Result<RecordBatch> {
         })?;
 
         let reader = fragment
-            .open(&projection.physical_schema, false, false, None)
+            .open(&projection.physical_schema, FragReadConfig::default(), None)
             .await?;
         reader.legacy_read_range_as_batch(range).await
     } else if row_addr_stats.sorted {

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -71,7 +71,7 @@ use tokio::task::JoinSet;
 use crate::{
     datafusion::dataframe::SessionContextExt,
     dataset::{
-        fragment::FileFragment,
+        fragment::{FileFragment, FragReadConfig},
         transaction::{Operation, Transaction},
         write::open_writer,
     },
@@ -674,7 +674,13 @@ impl MergeInsertJob {
                     if data_storage_version == LanceFileVersion::Legacy {
                         // Need to match the existing batch size exactly, otherwise
                         // we'll get errors.
-                        let reader = fragment.open(dataset.schema(), false, true, None).await?;
+                        let reader = fragment
+                            .open(
+                                dataset.schema(),
+                                FragReadConfig::default().with_row_address(true),
+                                None,
+                            )
+                            .await?;
                         let batch_size = reader.legacy_num_rows_in_batch(0).unwrap();
                         let stream = stream::iter(batches.into_iter().map(Ok));
                         let stream = Box::pin(RecordBatchStreamAdapter::new(

--- a/rust/lance/src/io/exec.rs
+++ b/rust/lance/src/io/exec.rs
@@ -25,6 +25,6 @@ pub use optimizer::get_physical_optimizer;
 pub use projection::project;
 pub use pushdown_scan::{LancePushdownScanExec, ScanConfig};
 pub use rowids::AddRowAddrExec;
-pub use scan::LanceScanExec;
+pub use scan::{LanceScanConfig, LanceScanExec};
 pub use take::TakeExec;
 pub use utils::PreFilterSource;

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -34,6 +34,7 @@ use lance_io::ReadBatchParams;
 use lance_table::format::Fragment;
 use snafu::{location, Location};
 
+use crate::dataset::fragment::FragReadConfig;
 use crate::dataset::scanner::LEGACY_DEFAULT_FRAGMENT_READAHEAD;
 use crate::Error;
 use crate::{
@@ -273,7 +274,9 @@ impl FragmentScanner {
 
         // We will call the reader with projections. In order for this to work
         // we must ensure that we open the fragment with the maximal schema.
-        let mut reader = fragment.open(dataset.schema(), false, false, None).await?;
+        let mut reader = fragment
+            .open(dataset.schema(), FragReadConfig::default(), None)
+            .await?;
         if config.make_deletions_null {
             reader.with_make_deletions_null();
         }

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -30,7 +30,10 @@ use log::debug;
 use snafu::{location, Location};
 
 use crate::dataset::fragment::{FileFragment, FragReadConfig, FragmentReader};
-use crate::dataset::scanner::{DEFAULT_FRAGMENT_READAHEAD, LEGACY_DEFAULT_FRAGMENT_READAHEAD};
+use crate::dataset::scanner::{
+    BATCH_SIZE_FALLBACK, DEFAULT_FRAGMENT_READAHEAD, DEFAULT_IO_BUFFER_SIZE,
+    LEGACY_DEFAULT_FRAGMENT_READAHEAD,
+};
 use crate::dataset::Dataset;
 use crate::datatypes::Schema;
 
@@ -393,6 +396,23 @@ pub struct LanceScanConfig {
     pub with_row_address: bool,
     pub with_make_deletions_null: bool,
     pub ordered_output: bool,
+}
+
+// This is mostly for testing purposes, end users are unlikely to create this
+// on their own.
+impl Default for LanceScanConfig {
+    fn default() -> Self {
+        Self {
+            batch_size: BATCH_SIZE_FALLBACK,
+            batch_readahead: get_num_compute_intensive_cpus(),
+            fragment_readahead: None,
+            io_buffer_size: *DEFAULT_IO_BUFFER_SIZE,
+            with_row_id: false,
+            with_row_address: false,
+            with_make_deletions_null: false,
+            ordered_output: false,
+        }
+    }
 }
 
 /// DataFusion [ExecutionPlan] for scanning one Lance dataset

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -29,7 +29,7 @@ use lance_table::format::Fragment;
 use log::debug;
 use snafu::{location, Location};
 
-use crate::dataset::fragment::{FileFragment, FragmentReader};
+use crate::dataset::fragment::{FileFragment, FragReadConfig, FragmentReader};
 use crate::dataset::scanner::{DEFAULT_FRAGMENT_READAHEAD, LEGACY_DEFAULT_FRAGMENT_READAHEAD};
 use crate::dataset::Dataset;
 use crate::datatypes::Schema;
@@ -37,18 +37,12 @@ use crate::datatypes::Schema;
 async fn open_file(
     file_fragment: FileFragment,
     projection: Arc<Schema>,
-    with_row_id: bool,
-    with_row_address: bool,
+    read_config: FragReadConfig,
     with_make_deletions_null: bool,
     scan_scheduler: Option<(Arc<ScanScheduler>, u64)>,
 ) -> Result<FragmentReader> {
     let mut reader = file_fragment
-        .open(
-            projection.as_ref(),
-            with_row_id,
-            with_row_address,
-            scan_scheduler,
-        )
+        .open(projection.as_ref(), read_config, scan_scheduler)
         .await?;
 
     if with_make_deletions_null {
@@ -69,9 +63,7 @@ pub struct LanceStream {
     /// Manifest of the dataset
     projection: Arc<Schema>,
 
-    with_row_id: bool,
-
-    with_row_address: bool,
+    config: LanceScanConfig,
 }
 
 impl LanceStream {
@@ -98,14 +90,7 @@ impl LanceStream {
         fragments: Arc<Vec<Fragment>>,
         offsets: Option<Range<u64>>,
         projection: Arc<Schema>,
-        read_size: usize,
-        batch_readahead: usize,
-        fragment_readahead: Option<usize>,
-        io_buffer_size: u64,
-        with_row_id: bool,
-        with_row_address: bool,
-        with_make_deletions_null: bool,
-        scan_in_order: bool,
+        config: LanceScanConfig,
     ) -> Result<Self> {
         let is_v2_scan = fragments
             .iter()
@@ -113,31 +98,9 @@ impl LanceStream {
             .next()
             .unwrap_or(false);
         if is_v2_scan {
-            Self::try_new_v2(
-                dataset,
-                fragments,
-                offsets,
-                projection,
-                read_size,
-                fragment_readahead,
-                with_row_id,
-                with_row_address,
-                with_make_deletions_null,
-                io_buffer_size,
-            )
+            Self::try_new_v2(dataset, fragments, offsets, projection, config)
         } else {
-            Self::try_new_v1(
-                dataset,
-                fragments,
-                projection,
-                read_size,
-                batch_readahead,
-                fragment_readahead.unwrap_or(LEGACY_DEFAULT_FRAGMENT_READAHEAD),
-                with_row_id,
-                with_row_address,
-                with_make_deletions_null,
-                scan_in_order,
-            )
+            Self::try_new_v1(dataset, fragments, projection, config)
         }
     }
 
@@ -147,12 +110,7 @@ impl LanceStream {
         fragments: Arc<Vec<Fragment>>,
         offsets: Option<Range<u64>>,
         projection: Arc<Schema>,
-        batch_size: usize,
-        fragment_parallelism: Option<usize>,
-        with_row_id: bool,
-        with_row_address: bool,
-        with_make_deletions_null: bool,
-        io_buffer_size: u64,
+        config: LanceScanConfig,
     ) -> Result<Self> {
         let project_schema = projection.clone();
         let io_parallelism = dataset.object_store.io_parallelism();
@@ -167,7 +125,8 @@ impl LanceStream {
         // As a result, we don't really need to worry too much about fragment readahead.  We also want this
         // to be pretty high.  While we are reading one set of fragments we should be scheduling the next set
         // this should help ensure that we don't have breaks in I/O
-        let frag_parallelism = fragment_parallelism
+        let frag_parallelism = config
+            .fragment_readahead
             .unwrap_or((*DEFAULT_FRAGMENT_READAHEAD).unwrap_or(io_parallelism * 2))
             // fragment_readhead=0 doesn't make sense so we just bump it to 1
             .max(1);
@@ -233,7 +192,7 @@ impl LanceStream {
         let scan_scheduler = ScanScheduler::new(
             dataset.object_store.clone(),
             SchedulerConfig {
-                io_buffer_size_bytes: io_buffer_size,
+                io_buffer_size_bytes: config.io_buffer_size,
             },
         );
 
@@ -248,16 +207,17 @@ impl LanceStream {
                     let reader = open_file(
                         file_fragment.fragment,
                         project_schema,
-                        with_row_id,
-                        with_row_address,
-                        with_make_deletions_null,
+                        FragReadConfig::default()
+                            .with_row_id(config.with_row_id)
+                            .with_row_address(config.with_row_address),
+                        config.with_make_deletions_null,
                         Some((scan_scheduler, priority as u64)),
                     )
                     .await?;
                     let batch_stream = if let Some(range) = file_fragment.range {
-                        reader.read_range(range, batch_size as u32)?.boxed()
+                        reader.read_range(range, config.batch_size as u32)?.boxed()
                     } else {
-                        reader.read_all(batch_size as u32)?.boxed()
+                        reader.read_all(config.batch_size as u32)?.boxed()
                     };
                     let batch_stream: BoxStream<Result<BoxFuture<Result<RecordBatch>>>> =
                         batch_stream
@@ -294,8 +254,7 @@ impl LanceStream {
         Ok(Self {
             inner_stream: batches,
             projection,
-            with_row_id,
-            with_row_address,
+            config,
         })
     }
 
@@ -304,18 +263,15 @@ impl LanceStream {
         dataset: Arc<Dataset>,
         fragments: Arc<Vec<Fragment>>,
         projection: Arc<Schema>,
-        read_size: usize,
-        batch_readahead: usize,
-        fragment_readahead: usize,
-        with_row_id: bool,
-        with_row_address: bool,
-        with_make_deletions_null: bool,
-        scan_in_order: bool,
+        config: LanceScanConfig,
     ) -> Result<Self> {
         let project_schema = projection.clone();
+        let fragment_readahead = config
+            .fragment_readahead
+            .unwrap_or(LEGACY_DEFAULT_FRAGMENT_READAHEAD);
         debug!(
             "Scanning v1 dataset with frag_readahead={} and batch_readahead={}",
-            fragment_readahead, batch_readahead
+            fragment_readahead, config.batch_readahead
         );
 
         let file_fragments = fragments
@@ -323,15 +279,16 @@ impl LanceStream {
             .map(|fragment| FileFragment::new(dataset.clone(), fragment.clone()))
             .collect::<Vec<_>>();
 
-        let inner_stream = if scan_in_order {
+        let inner_stream = if config.ordered_output {
             let readers = stream::iter(file_fragments)
                 .map(move |file_fragment| {
                     Ok(open_file(
                         file_fragment,
                         project_schema.clone(),
-                        with_row_id,
-                        with_row_address,
-                        with_make_deletions_null,
+                        FragReadConfig::default()
+                            .with_row_id(config.with_row_id)
+                            .with_row_address(config.with_row_address),
+                        config.with_make_deletions_null,
                         None,
                     ))
                 })
@@ -339,7 +296,7 @@ impl LanceStream {
             let tasks = readers.and_then(move |reader| {
                 std::future::ready(
                     reader
-                        .read_all(read_size as u32)
+                        .read_all(config.batch_size as u32)
                         .map(|task_stream| task_stream.map(Ok))
                         .map_err(DataFusionError::from),
                 )
@@ -348,7 +305,7 @@ impl LanceStream {
                 // We must be waiting to finish a file before moving onto thenext. That's an issue.
                 .try_flatten()
                 // We buffer up to `batch_readahead` batches across all streams.
-                .try_buffered(batch_readahead)
+                .try_buffered(config.batch_readahead)
                 .stream_in_current_span()
                 .boxed()
         } else {
@@ -357,9 +314,10 @@ impl LanceStream {
                     Ok(open_file(
                         file_fragment,
                         project_schema.clone(),
-                        with_row_id,
-                        with_row_address,
-                        with_make_deletions_null,
+                        FragReadConfig::default()
+                            .with_row_id(config.with_row_id)
+                            .with_row_address(config.with_row_address),
+                        config.with_make_deletions_null,
                         None,
                     ))
                 })
@@ -367,7 +325,7 @@ impl LanceStream {
             let tasks = readers.and_then(move |reader| {
                 std::future::ready(
                     reader
-                        .read_all(read_size as u32)
+                        .read_all(config.batch_size as u32)
                         .map(|task_stream| task_stream.map(Ok))
                         .map_err(DataFusionError::from),
                 )
@@ -375,9 +333,9 @@ impl LanceStream {
             // When we flatten the streams (one stream per fragment), we allow
             // `fragment_readahead` stream to be read concurrently.
             tasks
-                .try_flatten_unordered(fragment_readahead)
+                .try_flatten_unordered(config.fragment_readahead)
                 // We buffer up to `batch_readahead` batches across all streams.
-                .try_buffer_unordered(batch_readahead)
+                .try_buffer_unordered(config.batch_readahead)
                 .stream_in_current_span()
                 .boxed()
         };
@@ -389,8 +347,7 @@ impl LanceStream {
         Ok(Self {
             inner_stream,
             projection,
-            with_row_id,
-            with_row_address,
+            config,
         })
     }
 }
@@ -399,8 +356,8 @@ impl core::fmt::Debug for LanceStream {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LanceStream")
             .field("projection", &self.projection)
-            .field("with_row_id", &self.with_row_id)
-            .field("with_row_address", &self.with_row_address)
+            .field("with_row_id", &self.config.with_row_id)
+            .field("with_row_address", &self.config.with_row_address)
             .finish()
     }
 }
@@ -408,10 +365,10 @@ impl core::fmt::Debug for LanceStream {
 impl RecordBatchStream for LanceStream {
     fn schema(&self) -> SchemaRef {
         let mut schema: ArrowSchema = self.projection.as_ref().into();
-        if self.with_row_id {
+        if self.config.with_row_id {
             schema = schema.try_with_column(ROW_ID_FIELD.clone()).unwrap();
         }
-        if self.with_row_address {
+        if self.config.with_row_address {
             schema = schema.try_with_column(ROW_ADDR_FIELD.clone()).unwrap();
         }
         Arc::new(schema)
@@ -426,6 +383,18 @@ impl Stream for LanceStream {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct LanceScanConfig {
+    pub batch_size: usize,
+    pub batch_readahead: usize,
+    pub fragment_readahead: Option<usize>,
+    pub io_buffer_size: u64,
+    pub with_row_id: bool,
+    pub with_row_address: bool,
+    pub with_make_deletions_null: bool,
+    pub ordered_output: bool,
+}
+
 /// DataFusion [ExecutionPlan] for scanning one Lance dataset
 #[derive(Debug)]
 pub struct LanceScanExec {
@@ -433,16 +402,9 @@ pub struct LanceScanExec {
     fragments: Arc<Vec<Fragment>>,
     range: Option<Range<u64>>,
     projection: Arc<Schema>,
-    read_size: usize,
-    batch_readahead: usize,
-    fragment_readahead: Option<usize>,
-    io_buffer_size: u64,
-    with_row_id: bool,
-    with_row_address: bool,
-    with_make_deletions_null: bool,
-    ordered_output: bool,
     output_schema: Arc<ArrowSchema>,
     properties: PlanProperties,
+    config: LanceScanConfig,
 }
 
 impl DisplayAs for LanceScanExec {
@@ -461,9 +423,9 @@ impl DisplayAs for LanceScanExec {
                     "LanceScan: uri={}, projection=[{}], row_id={}, row_addr={}, ordered={}",
                     self.dataset.data_dir(),
                     columns,
-                    self.with_row_id,
-                    self.with_row_address,
-                    self.ordered_output
+                    self.config.with_row_id,
+                    self.config.with_row_address,
+                    self.config.ordered_output
                 )
             }
         }
@@ -477,21 +439,14 @@ impl LanceScanExec {
         fragments: Arc<Vec<Fragment>>,
         range: Option<Range<u64>>,
         projection: Arc<Schema>,
-        read_size: usize,
-        batch_readahead: usize,
-        fragment_readahead: Option<usize>,
-        io_buffer_size: u64,
-        with_row_id: bool,
-        with_row_address: bool,
-        with_make_deletions_null: bool,
-        ordered_ouput: bool,
+        config: LanceScanConfig,
     ) -> Self {
         let mut output_schema: ArrowSchema = projection.as_ref().into();
 
-        if with_row_id {
+        if config.with_row_id {
             output_schema = output_schema.try_with_column(ROW_ID_FIELD.clone()).unwrap();
         }
-        if with_row_address {
+        if config.with_row_address {
             output_schema = output_schema
                 .try_with_column(ROW_ADDR_FIELD.clone())
                 .unwrap();
@@ -508,16 +463,9 @@ impl LanceScanExec {
             fragments,
             range,
             projection,
-            read_size,
-            batch_readahead,
-            fragment_readahead,
-            io_buffer_size,
-            with_row_id,
-            with_row_address,
-            with_make_deletions_null,
-            ordered_output: ordered_ouput,
             output_schema,
             properties,
+            config,
         }
     }
 }
@@ -563,14 +511,7 @@ impl ExecutionPlan for LanceScanExec {
             self.fragments.clone(),
             self.range.clone(),
             self.projection.clone(),
-            self.read_size,
-            self.batch_readahead,
-            self.fragment_readahead,
-            self.io_buffer_size,
-            self.with_row_id,
-            self.with_row_address,
-            self.with_make_deletions_null,
-            self.ordered_output,
+            self.config.clone(),
         )?))
     }
 

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -396,14 +396,8 @@ mod tests {
 
         // With row id
         let config = LanceScanConfig {
-            batch_size: 10,
-            batch_readahead: 10,
-            fragment_readahead: Some(4),
-            io_buffer_size: *DEFAULT_IO_BUFFER_SIZE,
             with_row_id: true,
-            with_row_address: false,
-            with_make_deletions_null: false,
-            ordered_output: true,
+            ..Default::default()
         };
         let input = Arc::new(LanceScanExec::new(
             dataset.clone(),
@@ -435,14 +429,8 @@ mod tests {
         let extra_schema = Arc::new(Schema::try_from(&extra_arrow_schema).unwrap());
 
         let config = LanceScanConfig {
-            batch_size: 10,
-            batch_readahead: 10,
-            fragment_readahead: Some(4),
-            io_buffer_size: *DEFAULT_IO_BUFFER_SIZE,
             with_row_id: true,
-            with_row_address: false,
-            with_make_deletions_null: false,
-            ordered_output: true,
+            ..Default::default(),
         };
         let input = Arc::new(LanceScanExec::new(
             dataset.clone(),
@@ -473,22 +461,12 @@ mod tests {
         let extra_schema = Arc::new(Schema::try_from(&extra_arrow_schema).unwrap());
 
         // No row ID
-        let config = LanceScanConfig {
-            batch_size: 10,
-            batch_readahead: 10,
-            fragment_readahead: Some(4),
-            io_buffer_size: *DEFAULT_IO_BUFFER_SIZE,
-            with_row_id: false,
-            with_row_address: false,
-            with_make_deletions_null: false,
-            ordered_output: true,
-        };
         let input = Arc::new(LanceScanExec::new(
             dataset.clone(),
             dataset.fragments().clone(),
             None,
             scan_schema,
-            config,
+            ..Default::default(),
         ));
         assert!(TakeExec::try_new(dataset, input, extra_schema, 10).is_err());
     }

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -341,7 +341,7 @@ mod tests {
     use tempfile::tempdir;
 
     use crate::{
-        dataset::{scanner::DEFAULT_IO_BUFFER_SIZE, WriteParams},
+        dataset::WriteParams,
         io::exec::{LanceScanConfig, LanceScanExec},
     };
 
@@ -430,7 +430,7 @@ mod tests {
 
         let config = LanceScanConfig {
             with_row_id: true,
-            ..Default::default(),
+            ..Default::default()
         };
         let input = Arc::new(LanceScanExec::new(
             dataset.clone(),
@@ -466,7 +466,7 @@ mod tests {
             dataset.fragments().clone(),
             None,
             scan_schema,
-            ..Default::default(),
+            LanceScanConfig::default(),
         ));
         assert!(TakeExec::try_new(dataset, input, extra_schema, 10).is_err());
     }
@@ -477,7 +477,7 @@ mod tests {
 
         let config = LanceScanConfig {
             with_row_id: true,
-            ..Default::default(),
+            ..Default::default()
         };
         let input = Arc::new(LanceScanExec::new(
             dataset.clone(),

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -498,14 +498,8 @@ mod tests {
         let dataset = create_dataset().await;
 
         let config = LanceScanConfig {
-            batch_size: 10,
-            batch_readahead: 10,
-            fragment_readahead: Some(4),
-            io_buffer_size: *DEFAULT_IO_BUFFER_SIZE,
             with_row_id: true,
-            with_row_address: false,
-            with_make_deletions_null: false,
-            ordered_output: true,
+            ..Default::default(),
         };
         let input = Arc::new(LanceScanExec::new(
             dataset.clone(),

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -342,7 +342,7 @@ mod tests {
 
     use crate::{
         dataset::{scanner::DEFAULT_IO_BUFFER_SIZE, WriteParams},
-        io::exec::LanceScanExec,
+        io::exec::{LanceScanConfig, LanceScanExec},
     };
 
     async fn create_dataset() -> Arc<Dataset> {
@@ -395,19 +395,22 @@ mod tests {
         let extra_schema = Arc::new(Schema::try_from(&extra_arrow_schema).unwrap());
 
         // With row id
+        let config = LanceScanConfig {
+            batch_size: 10,
+            batch_readahead: 10,
+            fragment_readahead: Some(4),
+            io_buffer_size: *DEFAULT_IO_BUFFER_SIZE,
+            with_row_id: true,
+            with_row_address: false,
+            with_make_deletions_null: false,
+            ordered_output: true,
+        };
         let input = Arc::new(LanceScanExec::new(
             dataset.clone(),
             dataset.fragments().clone(),
             None,
             scan_schema,
-            10,
-            10,
-            Some(4),
-            *DEFAULT_IO_BUFFER_SIZE,
-            true,
-            false,
-            false,
-            true,
+            config,
         ));
         let take_exec = TakeExec::try_new(dataset, input, extra_schema, 10).unwrap();
         let schema = take_exec.schema();
@@ -431,19 +434,22 @@ mod tests {
         let extra_arrow_schema = ArrowSchema::new(vec![Field::new("s", DataType::Int32, false)]);
         let extra_schema = Arc::new(Schema::try_from(&extra_arrow_schema).unwrap());
 
+        let config = LanceScanConfig {
+            batch_size: 10,
+            batch_readahead: 10,
+            fragment_readahead: Some(4),
+            io_buffer_size: *DEFAULT_IO_BUFFER_SIZE,
+            with_row_id: true,
+            with_row_address: false,
+            with_make_deletions_null: false,
+            ordered_output: true,
+        };
         let input = Arc::new(LanceScanExec::new(
             dataset.clone(),
             dataset.fragments().clone(),
             None,
             scan_schema,
-            10,
-            10,
-            Some(4),
-            *DEFAULT_IO_BUFFER_SIZE,
-            true,
-            false,
-            false,
-            true,
+            config,
         ));
         let take_exec = TakeExec::try_new(dataset, input, extra_schema, 10).unwrap();
         let schema = take_exec.schema();
@@ -467,19 +473,22 @@ mod tests {
         let extra_schema = Arc::new(Schema::try_from(&extra_arrow_schema).unwrap());
 
         // No row ID
+        let config = LanceScanConfig {
+            batch_size: 10,
+            batch_readahead: 10,
+            fragment_readahead: Some(4),
+            io_buffer_size: *DEFAULT_IO_BUFFER_SIZE,
+            with_row_id: false,
+            with_row_address: false,
+            with_make_deletions_null: false,
+            ordered_output: true,
+        };
         let input = Arc::new(LanceScanExec::new(
             dataset.clone(),
             dataset.fragments().clone(),
             None,
             scan_schema,
-            10,
-            10,
-            Some(4),
-            *DEFAULT_IO_BUFFER_SIZE,
-            false,
-            false,
-            false,
-            true,
+            config,
         ));
         assert!(TakeExec::try_new(dataset, input, extra_schema, 10).is_err());
     }
@@ -488,19 +497,22 @@ mod tests {
     async fn test_with_new_children() -> Result<()> {
         let dataset = create_dataset().await;
 
+        let config = LanceScanConfig {
+            batch_size: 10,
+            batch_readahead: 10,
+            fragment_readahead: Some(4),
+            io_buffer_size: *DEFAULT_IO_BUFFER_SIZE,
+            with_row_id: true,
+            with_row_address: false,
+            with_make_deletions_null: false,
+            ordered_output: true,
+        };
         let input = Arc::new(LanceScanExec::new(
             dataset.clone(),
             dataset.fragments().clone(),
             None,
             Arc::new(dataset.schema().project(&["i"])?),
-            10,
-            10,
-            Some(4),
-            *DEFAULT_IO_BUFFER_SIZE,
-            true,
-            false,
-            false,
-            true,
+            config,
         ));
         assert_eq!(input.schema().field_names(), vec!["i", ROW_ID],);
         let take_exec = TakeExec::try_new(


### PR DESCRIPTION
I was trying to add a new option (load_blobs) to the scan exec and realized the args had gotten a little out of control.  I refactored them into a struct.  I've since abandoned my original idea (load_blobs) but wanted to see if others felt the refactor was worth keeping.