### PR TITLE
feat: support storage options for spark read and write

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -1,1 +1,2 @@
 *.iml
+spark/dependency-reduced-pom.xml

--- a/java/core/lance-jni/src/blocking_dataset.rs
+++ b/java/core/lance-jni/src/blocking_dataset.rs
@@ -86,13 +86,16 @@ impl BlockingDataset {
         Ok(Self { inner })
     }
 
-    pub fn commit(uri: &str, operation: Operation, read_version: Option<u64>) -> Result<Self> {
+    pub fn commit(uri: &str, operation: Operation, read_version: Option<u64>,
+                  storage_options: HashMap<String, String>,) -> Result<Self> {
         let object_store_registry = Arc::new(ObjectStoreRegistry::default());
+        let mut object_params = ObjectStoreParams::default();
+        object_params.storage_options = Some(storage_options);
         let inner = RT.block_on(Dataset::commit(
             uri,
             operation,
             read_version,
-            None,
+            Some(object_params),
             None,
             object_store_registry,
             false, // TODO: support enable_v2_manifest_paths
@@ -146,6 +149,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiSchema<'local
     max_rows_per_group: JObject, // Optional<Integer>
     max_bytes_per_file: JObject, // Optional<Long>
     mode: JObject,               // Optional<String>
+    storage_options_obj: JObject, // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -156,7 +160,8 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiSchema<'local
             max_rows_per_file,
             max_rows_per_group,
             max_bytes_per_file,
-            mode
+            mode,
+            storage_options_obj
         )
     )
 }
@@ -169,6 +174,7 @@ fn inner_create_with_ffi_schema<'local>(
     max_rows_per_group: JObject, // Optional<Integer>
     max_bytes_per_file: JObject, // Optional<Long>
     mode: JObject,               // Optional<String>
+    storage_options_obj: JObject, // Map<String, String>
 ) -> Result<JObject<'local>> {
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
     let c_schema = unsafe { FFI_ArrowSchema::from_raw(c_schema_ptr) };
@@ -182,6 +188,7 @@ fn inner_create_with_ffi_schema<'local>(
         max_rows_per_group,
         max_bytes_per_file,
         mode,
+        storage_options_obj,
         reader,
     )
 }
@@ -196,6 +203,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiStream<'local
     max_rows_per_group: JObject, // Optional<Integer>
     max_bytes_per_file: JObject, // Optional<Long>
     mode: JObject,               // Optional<String>
+    storage_options_obj: JObject, // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -206,7 +214,8 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiStream<'local
             max_rows_per_file,
             max_rows_per_group,
             max_bytes_per_file,
-            mode
+            mode,
+            storage_options_obj
         )
     )
 }
@@ -219,6 +228,7 @@ fn inner_create_with_ffi_stream<'local>(
     max_rows_per_group: JObject, // Optional<Integer>
     max_bytes_per_file: JObject, // Optional<Long>
     mode: JObject,               // Optional<String>
+    storage_options_obj: JObject, // Map<String, String>
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
@@ -229,6 +239,7 @@ fn inner_create_with_ffi_stream<'local>(
         max_rows_per_group,
         max_bytes_per_file,
         mode,
+        storage_options_obj,
         reader,
     )
 }
@@ -240,6 +251,7 @@ fn create_dataset<'local>(
     max_rows_per_group: JObject,
     max_bytes_per_file: JObject,
     mode: JObject,
+    storage_options_obj: JObject,
     reader: impl RecordBatchReader + Send + 'static,
 ) -> Result<JObject<'local>> {
     let path_str = path.extract(env)?;
@@ -250,6 +262,7 @@ fn create_dataset<'local>(
         &max_rows_per_group,
         &max_bytes_per_file,
         &mode,
+        &storage_options_obj,
     )?;
 
     let dataset = BlockingDataset::write(reader, &path_str, Some(write_params))?;
@@ -292,10 +305,11 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_commitAppend<'local>(
     path: JString,
     read_version_obj: JObject, // Optional<Long>
     fragments_obj: JObject,    // List<String>, String is json serialized Fragment
+    storage_options_obj: JObject, // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
-        inner_commit_append(&mut env, path, read_version_obj, fragments_obj)
+        inner_commit_append(&mut env, path, read_version_obj, fragments_obj, storage_options_obj)
     )
 }
 
@@ -304,6 +318,7 @@ pub fn inner_commit_append<'local>(
     path: JString,
     read_version_obj: JObject, // Optional<Long>
     fragments_obj: JObject,    // List<String>, String is json serialized Fragment)
+    storage_options_obj: JObject, // Map<String, String>
 ) -> Result<JObject<'local>> {
     let json_fragments = env.get_strings(&fragments_obj)?;
     let mut fragments: Vec<Fragment> = Vec::new();
@@ -314,7 +329,20 @@ pub fn inner_commit_append<'local>(
     let op = Operation::Append { fragments };
     let path_str = path.extract(env)?;
     let read_version = env.get_u64_opt(&read_version_obj)?;
-    let dataset = BlockingDataset::commit(&path_str, op, read_version)?;
+    let jmap = JMap::from_env(env, &storage_options_obj)?;
+    let storage_options: HashMap<String, String> = env.with_local_frame(16, |env| {
+        let mut map = HashMap::new();
+        let mut iter = jmap.iter(env)?;
+        while let Some((key, value)) = iter.next(env)? {
+            let key_jstring = JString::from(key);
+            let value_jstring = JString::from(value);
+            let key_string: String = env.get_string(&key_jstring)?.into();
+            let value_string: String = env.get_string(&value_jstring)?.into();
+            map.insert(key_string, value_string);
+        }
+        Ok::<_, Error>(map)
+    })?;
+    let dataset = BlockingDataset::commit(&path_str, op, read_version, storage_options)?;
     dataset.into_java(env)
 }
 

--- a/java/core/lance-jni/src/blocking_dataset.rs
+++ b/java/core/lance-jni/src/blocking_dataset.rs
@@ -86,8 +86,12 @@ impl BlockingDataset {
         Ok(Self { inner })
     }
 
-    pub fn commit(uri: &str, operation: Operation, read_version: Option<u64>,
-                  storage_options: HashMap<String, String>,) -> Result<Self> {
+    pub fn commit(
+        uri: &str,
+        operation: Operation,
+        read_version: Option<u64>,
+        storage_options: HashMap<String, String>,
+    ) -> Result<Self> {
         let object_store_registry = Arc::new(ObjectStoreRegistry::default());
         let mut object_params = ObjectStoreParams::default();
         object_params.storage_options = Some(storage_options);
@@ -145,10 +149,10 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiSchema<'local
     _obj: JObject,
     arrow_schema_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,  // Optional<Integer>
-    max_rows_per_group: JObject, // Optional<Integer>
-    max_bytes_per_file: JObject, // Optional<Long>
-    mode: JObject,               // Optional<String>
+    max_rows_per_file: JObject,   // Optional<Integer>
+    max_rows_per_group: JObject,  // Optional<Integer>
+    max_bytes_per_file: JObject,  // Optional<Long>
+    mode: JObject,                // Optional<String>
     storage_options_obj: JObject, // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw!(
@@ -170,10 +174,10 @@ fn inner_create_with_ffi_schema<'local>(
     env: &mut JNIEnv<'local>,
     arrow_schema_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,  // Optional<Integer>
-    max_rows_per_group: JObject, // Optional<Integer>
-    max_bytes_per_file: JObject, // Optional<Long>
-    mode: JObject,               // Optional<String>
+    max_rows_per_file: JObject,   // Optional<Integer>
+    max_rows_per_group: JObject,  // Optional<Integer>
+    max_bytes_per_file: JObject,  // Optional<Long>
+    mode: JObject,                // Optional<String>
     storage_options_obj: JObject, // Map<String, String>
 ) -> Result<JObject<'local>> {
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
@@ -199,10 +203,10 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiStream<'local
     _obj: JObject,
     arrow_array_stream_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,  // Optional<Integer>
-    max_rows_per_group: JObject, // Optional<Integer>
-    max_bytes_per_file: JObject, // Optional<Long>
-    mode: JObject,               // Optional<String>
+    max_rows_per_file: JObject,   // Optional<Integer>
+    max_rows_per_group: JObject,  // Optional<Integer>
+    max_bytes_per_file: JObject,  // Optional<Long>
+    mode: JObject,                // Optional<String>
     storage_options_obj: JObject, // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw!(
@@ -224,10 +228,10 @@ fn inner_create_with_ffi_stream<'local>(
     env: &mut JNIEnv<'local>,
     arrow_array_stream_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,  // Optional<Integer>
-    max_rows_per_group: JObject, // Optional<Integer>
-    max_bytes_per_file: JObject, // Optional<Long>
-    mode: JObject,               // Optional<String>
+    max_rows_per_file: JObject,   // Optional<Integer>
+    max_rows_per_group: JObject,  // Optional<Integer>
+    max_bytes_per_file: JObject,  // Optional<Long>
+    mode: JObject,                // Optional<String>
     storage_options_obj: JObject, // Map<String, String>
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
@@ -303,21 +307,27 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_commitAppend<'local>(
     mut env: JNIEnv<'local>,
     _obj: JObject,
     path: JString,
-    read_version_obj: JObject, // Optional<Long>
-    fragments_obj: JObject,    // List<String>, String is json serialized Fragment
+    read_version_obj: JObject,    // Optional<Long>
+    fragments_obj: JObject,       // List<String>, String is json serialized Fragment
     storage_options_obj: JObject, // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
-        inner_commit_append(&mut env, path, read_version_obj, fragments_obj, storage_options_obj)
+        inner_commit_append(
+            &mut env,
+            path,
+            read_version_obj,
+            fragments_obj,
+            storage_options_obj
+        )
     )
 }
 
 pub fn inner_commit_append<'local>(
     env: &mut JNIEnv<'local>,
     path: JString,
-    read_version_obj: JObject, // Optional<Long>
-    fragments_obj: JObject,    // List<String>, String is json serialized Fragment)
+    read_version_obj: JObject,    // Optional<Long>
+    fragments_obj: JObject,       // List<String>, String is json serialized Fragment)
     storage_options_obj: JObject, // Map<String, String>
 ) -> Result<JObject<'local>> {
     let json_fragments = env.get_strings(&fragments_obj)?;

--- a/java/core/lance-jni/src/blocking_dataset.rs
+++ b/java/core/lance-jni/src/blocking_dataset.rs
@@ -171,6 +171,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiSchema<'local
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn inner_create_with_ffi_schema<'local>(
     env: &mut JNIEnv<'local>,
     arrow_schema_addr: jlong,
@@ -225,6 +226,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiStream<'local
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn inner_create_with_ffi_stream<'local>(
     env: &mut JNIEnv<'local>,
     arrow_array_stream_addr: jlong,
@@ -249,6 +251,7 @@ fn inner_create_with_ffi_stream<'local>(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn create_dataset<'local>(
     env: &mut JNIEnv<'local>,
     path: JString,

--- a/java/core/lance-jni/src/blocking_dataset.rs
+++ b/java/core/lance-jni/src/blocking_dataset.rs
@@ -93,13 +93,14 @@ impl BlockingDataset {
         storage_options: HashMap<String, String>,
     ) -> Result<Self> {
         let object_store_registry = Arc::new(ObjectStoreRegistry::default());
-        let mut object_params = ObjectStoreParams::default();
-        object_params.storage_options = Some(storage_options);
         let inner = RT.block_on(Dataset::commit(
             uri,
             operation,
             read_version,
-            Some(object_params),
+            Some(ObjectStoreParams {
+                storage_options: Some(storage_options),
+                ..Default::default()
+            }),
             None,
             object_store_registry,
             false, // TODO: support enable_v2_manifest_paths

--- a/java/core/lance-jni/src/fragment.rs
+++ b/java/core/lance-jni/src/fragment.rs
@@ -76,11 +76,11 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiArray<'local
     dataset_uri: JString,
     arrow_array_addr: jlong,
     arrow_schema_addr: jlong,
-    fragment_id: JObject,        // Optional<Integer>
-    max_rows_per_file: JObject,  // Optional<Integer>
-    max_rows_per_group: JObject, // Optional<Integer>
-    max_bytes_per_file: JObject, // Optional<Long>
-    mode: JObject,               // Optional<String>
+    fragment_id: JObject,         // Optional<Integer>
+    max_rows_per_file: JObject,   // Optional<Integer>
+    max_rows_per_group: JObject,  // Optional<Integer>
+    max_bytes_per_file: JObject,  // Optional<Long>
+    mode: JObject,                // Optional<String>
     storage_options_obj: JObject, // Map<String, String>
 ) -> JString<'local> {
     ok_or_throw_with_return!(
@@ -107,11 +107,11 @@ fn inner_create_with_ffi_array<'local>(
     dataset_uri: JString,
     arrow_array_addr: jlong,
     arrow_schema_addr: jlong,
-    fragment_id: JObject,        // Optional<Integer>
-    max_rows_per_file: JObject,  // Optional<Integer>
-    max_rows_per_group: JObject, // Optional<Integer>
-    max_bytes_per_file: JObject, // Optional<Long>
-    mode: JObject,               // Optional<String>
+    fragment_id: JObject,         // Optional<Integer>
+    max_rows_per_file: JObject,   // Optional<Integer>
+    max_rows_per_group: JObject,  // Optional<Integer>
+    max_bytes_per_file: JObject,  // Optional<Long>
+    mode: JObject,                // Optional<String>
     storage_options_obj: JObject, // Map<String, String>
 ) -> Result<JString<'local>> {
     let c_array_ptr = arrow_array_addr as *mut FFI_ArrowArray;
@@ -146,11 +146,11 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiStream<'a>(
     _obj: JObject,
     dataset_uri: JString,
     arrow_array_stream_addr: jlong,
-    fragment_id: JObject,        // Optional<Integer>
-    max_rows_per_file: JObject,  // Optional<Integer>
-    max_rows_per_group: JObject, // Optional<Integer>
-    max_bytes_per_file: JObject, // Optional<Long>
-    mode: JObject,               // Optional<String>
+    fragment_id: JObject,         // Optional<Integer>
+    max_rows_per_file: JObject,   // Optional<Integer>
+    max_rows_per_group: JObject,  // Optional<Integer>
+    max_bytes_per_file: JObject,  // Optional<Long>
+    mode: JObject,                // Optional<String>
     storage_options_obj: JObject, // Map<String, String>
 ) -> JString<'a> {
     ok_or_throw_with_return!(
@@ -175,11 +175,11 @@ fn inner_create_with_ffi_stream<'local>(
     env: &mut JNIEnv<'local>,
     dataset_uri: JString,
     arrow_array_stream_addr: jlong,
-    fragment_id: JObject,        // Optional<Integer>
-    max_rows_per_file: JObject,  // Optional<Integer>
-    max_rows_per_group: JObject, // Optional<Integer>
-    max_bytes_per_file: JObject, // Optional<Long>
-    mode: JObject,               // Optional<String>
+    fragment_id: JObject,         // Optional<Integer>
+    max_rows_per_file: JObject,   // Optional<Integer>
+    max_rows_per_group: JObject,  // Optional<Integer>
+    max_bytes_per_file: JObject,  // Optional<Long>
+    mode: JObject,                // Optional<String>
     storage_options_obj: JObject, // Map<String, String>
 ) -> Result<JString<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
@@ -202,11 +202,11 @@ fn inner_create_with_ffi_stream<'local>(
 fn create_fragment<'a>(
     env: &mut JNIEnv<'a>,
     dataset_uri: JString,
-    fragment_id: JObject,        // Optional<Integer>
-    max_rows_per_file: JObject,  // Optional<Integer>
-    max_rows_per_group: JObject, // Optional<Integer>
-    max_bytes_per_file: JObject, // Optional<Long>
-    mode: JObject,               // Optional<String>
+    fragment_id: JObject,         // Optional<Integer>
+    max_rows_per_file: JObject,   // Optional<Integer>
+    max_rows_per_group: JObject,  // Optional<Integer>
+    max_bytes_per_file: JObject,  // Optional<Long>
+    mode: JObject,                // Optional<String>
     storage_options_obj: JObject, // Map<String, String>
     reader: impl RecordBatchReader + Send + 'static,
 ) -> Result<JString<'a>> {

--- a/java/core/lance-jni/src/fragment.rs
+++ b/java/core/lance-jni/src/fragment.rs
@@ -81,6 +81,7 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiArray<'local
     max_rows_per_group: JObject, // Optional<Integer>
     max_bytes_per_file: JObject, // Optional<Long>
     mode: JObject,               // Optional<String>
+    storage_options_obj: JObject, // Map<String, String>
 ) -> JString<'local> {
     ok_or_throw_with_return!(
         env,
@@ -93,7 +94,8 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiArray<'local
             max_rows_per_file,
             max_rows_per_group,
             max_bytes_per_file,
-            mode
+            mode,
+            storage_options_obj
         ),
         JString::default()
     )
@@ -110,6 +112,7 @@ fn inner_create_with_ffi_array<'local>(
     max_rows_per_group: JObject, // Optional<Integer>
     max_bytes_per_file: JObject, // Optional<Long>
     mode: JObject,               // Optional<String>
+    storage_options_obj: JObject, // Map<String, String>
 ) -> Result<JString<'local>> {
     let c_array_ptr = arrow_array_addr as *mut FFI_ArrowArray;
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
@@ -132,6 +135,7 @@ fn inner_create_with_ffi_array<'local>(
         max_rows_per_group,
         max_bytes_per_file,
         mode,
+        storage_options_obj,
         reader,
     )
 }
@@ -147,6 +151,7 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiStream<'a>(
     max_rows_per_group: JObject, // Optional<Integer>
     max_bytes_per_file: JObject, // Optional<Long>
     mode: JObject,               // Optional<String>
+    storage_options_obj: JObject, // Map<String, String>
 ) -> JString<'a> {
     ok_or_throw_with_return!(
         env,
@@ -158,7 +163,8 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiStream<'a>(
             max_rows_per_file,
             max_rows_per_group,
             max_bytes_per_file,
-            mode
+            mode,
+            storage_options_obj
         ),
         JString::default()
     )
@@ -174,6 +180,7 @@ fn inner_create_with_ffi_stream<'local>(
     max_rows_per_group: JObject, // Optional<Integer>
     max_bytes_per_file: JObject, // Optional<Long>
     mode: JObject,               // Optional<String>
+    storage_options_obj: JObject, // Map<String, String>
 ) -> Result<JString<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
@@ -186,6 +193,7 @@ fn inner_create_with_ffi_stream<'local>(
         max_rows_per_group,
         max_bytes_per_file,
         mode,
+        storage_options_obj,
         reader,
     )
 }
@@ -199,6 +207,7 @@ fn create_fragment<'a>(
     max_rows_per_group: JObject, // Optional<Integer>
     max_bytes_per_file: JObject, // Optional<Long>
     mode: JObject,               // Optional<String>
+    storage_options_obj: JObject, // Map<String, String>
     reader: impl RecordBatchReader + Send + 'static,
 ) -> Result<JString<'a>> {
     let path_str = dataset_uri.extract(env)?;
@@ -211,6 +220,7 @@ fn create_fragment<'a>(
         &max_rows_per_group,
         &max_bytes_per_file,
         &mode,
+        &storage_options_obj,
     )?;
     let fragment = RT.block_on(FileFragment::create(
         &path_str,

--- a/java/core/lance-jni/src/utils.rs
+++ b/java/core/lance-jni/src/utils.rs
@@ -58,7 +58,7 @@ pub fn extract_write_params(
     }
     // Java code always sets the data storage version to Legacy for now
     write_params.data_storage_version = Some(LanceFileVersion::Legacy);
-    let jmap = JMap::from_env(env, &storage_options_obj)?;
+    let jmap = JMap::from_env(env, storage_options_obj)?;
     let storage_options: HashMap<String, String> = env.with_local_frame(16, |env| {
         let mut map = HashMap::new();
         let mut iter = jmap.iter(env)?;
@@ -71,9 +71,11 @@ pub fn extract_write_params(
         }
         Ok::<_, Error>(map)
     })?;
-    let mut object_params = ObjectStoreParams::default();
-    object_params.storage_options = Some(storage_options);
-    write_params.store_params = Some(object_params);
+
+    write_params.store_params = Some(ObjectStoreParams {
+        storage_options: Some(storage_options),
+        ..Default::default()
+    });
     Ok(write_params)
 }
 

--- a/java/core/lance-jni/src/utils.rs
+++ b/java/core/lance-jni/src/utils.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use arrow::array::Float32Array;
-use jni::objects::{JObject, JString};
+use jni::objects::{JMap, JObject, JString};
 use jni::JNIEnv;
 use lance::dataset::{WriteMode, WriteParams};
 use lance::index::vector::{StageParams, VectorIndexParams};
@@ -26,11 +26,13 @@ use lance_index::vector::pq::PQBuildParams;
 use lance_index::vector::sq::builder::SQBuildParams;
 use lance_index::IndexParams;
 use lance_linalg::distance::DistanceType;
+use lance::io::ObjectStoreParams;
 
 use crate::error::{Error, Result};
 use crate::ffi::JNIEnvExt;
 
 use lance_index::vector::Query;
+use std::collections::HashMap;
 
 pub fn extract_write_params(
     env: &mut JNIEnv,
@@ -38,6 +40,7 @@ pub fn extract_write_params(
     max_rows_per_group: &JObject,
     max_bytes_per_file: &JObject,
     mode: &JObject,
+    storage_options_obj: &JObject,
 ) -> Result<WriteParams> {
     let mut write_params = WriteParams::default();
 
@@ -55,6 +58,22 @@ pub fn extract_write_params(
     }
     // Java code always sets the data storage version to Legacy for now
     write_params.data_storage_version = Some(LanceFileVersion::Legacy);
+    let jmap = JMap::from_env(env, &storage_options_obj)?;
+    let storage_options: HashMap<String, String> = env.with_local_frame(16, |env| {
+        let mut map = HashMap::new();
+        let mut iter = jmap.iter(env)?;
+        while let Some((key, value)) = iter.next(env)? {
+            let key_jstring = JString::from(key);
+            let value_jstring = JString::from(value);
+            let key_string: String = env.get_string(&key_jstring)?.into();
+            let value_string: String = env.get_string(&value_jstring)?.into();
+            map.insert(key_string, value_string);
+        }
+        Ok::<_, Error>(map)
+    })?;
+    let mut object_params = ObjectStoreParams::default();
+    object_params.storage_options = Some(storage_options);
+    write_params.store_params = Some(object_params);
     Ok(write_params)
 }
 

--- a/java/core/lance-jni/src/utils.rs
+++ b/java/core/lance-jni/src/utils.rs
@@ -19,6 +19,7 @@ use jni::objects::{JMap, JObject, JString};
 use jni::JNIEnv;
 use lance::dataset::{WriteMode, WriteParams};
 use lance::index::vector::{StageParams, VectorIndexParams};
+use lance::io::ObjectStoreParams;
 use lance_encoding::version::LanceFileVersion;
 use lance_index::vector::hnsw::builder::HnswBuildParams;
 use lance_index::vector::ivf::IvfBuildParams;
@@ -26,7 +27,6 @@ use lance_index::vector::pq::PQBuildParams;
 use lance_index::vector::sq::builder::SQBuildParams;
 use lance_index::IndexParams;
 use lance_linalg::distance::DistanceType;
-use lance::io::ObjectStoreParams;
 
 use crate::error::{Error, Result};
 use crate::ffi::JNIEnvExt;

--- a/java/core/src/main/java/com/lancedb/lance/Fragment.java
+++ b/java/core/src/main/java/com/lancedb/lance/Fragment.java
@@ -14,6 +14,7 @@
 
 package com.lancedb.lance;
 
+import java.util.Map;
 import java.util.Optional;
 import org.apache.arrow.c.ArrowArray;
 import org.apache.arrow.c.ArrowArrayStream;
@@ -51,7 +52,8 @@ public class Fragment {
       Data.exportVectorSchemaRoot(allocator, root, null, arrowArray, arrowSchema);
       return FragmentMetadata.fromJson(createWithFfiArray(datasetUri, arrowArray.memoryAddress(),
           arrowSchema.memoryAddress(), fragmentId, params.getMaxRowsPerFile(),
-          params.getMaxRowsPerGroup(), params.getMaxBytesPerFile(), params.getMode()));
+          params.getMaxRowsPerGroup(), params.getMaxBytesPerFile(), params.getMode(),
+          params.getStorageOptions()));
     }
   }
 
@@ -72,7 +74,7 @@ public class Fragment {
     return FragmentMetadata.fromJson(createWithFfiStream(datasetUri,
         stream.memoryAddress(), fragmentId,
         params.getMaxRowsPerFile(), params.getMaxRowsPerGroup(),
-        params.getMaxBytesPerFile(), params.getMode()));
+        params.getMaxBytesPerFile(), params.getMode(), params.getStorageOptions()));
   }
 
   /**
@@ -83,7 +85,7 @@ public class Fragment {
   private static native String createWithFfiArray(String datasetUri,
       long arrowArrayMemoryAddress, long arrowSchemaMemoryAddress, Optional<Integer> fragmentId,
       Optional<Integer> maxRowsPerFile, Optional<Integer> maxRowsPerGroup,
-      Optional<Long> maxBytesPerFile, Optional<String> mode);
+      Optional<Long> maxBytesPerFile, Optional<String> mode, Map<String, String> storageOptions);
 
   /**
    * Create a fragment from the given arrow stream.
@@ -93,5 +95,5 @@ public class Fragment {
   private static native String createWithFfiStream(String datasetUri, long arrowStreamMemoryAddress,
       Optional<Integer> fragmentId, Optional<Integer> maxRowsPerFile,
       Optional<Integer> maxRowsPerGroup, Optional<Long> maxBytesPerFile,
-      Optional<String> mode);
+      Optional<String> mode, Map<String, String> storageOptions);
 }

--- a/java/core/src/main/java/com/lancedb/lance/FragmentOperation.java
+++ b/java/core/src/main/java/com/lancedb/lance/FragmentOperation.java
@@ -15,6 +15,7 @@
 package com.lancedb.lance;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.arrow.memory.BufferAllocator;
@@ -29,7 +30,7 @@ public abstract class FragmentOperation {
   }
 
   public abstract Dataset commit(BufferAllocator allocator, String path,
-      Optional<Long> readVersion);
+      Optional<Long> readVersion, Map<String, String> storageOptions);
 
   /** Fragment append operation. */
   public static class Append extends FragmentOperation {
@@ -41,12 +42,14 @@ public abstract class FragmentOperation {
     }
 
     @Override
-    public Dataset commit(BufferAllocator allocator, String path, Optional<Long> readVersion) {
+    public Dataset commit(BufferAllocator allocator, String path, Optional<Long> readVersion,
+                          Map<String, String> storageOptions) {
       Preconditions.checkNotNull(allocator);
       Preconditions.checkNotNull(path);
       Preconditions.checkNotNull(readVersion);
       return Dataset.commitAppend(path, readVersion,
-          fragments.stream().map(FragmentMetadata::getJsonMetadata).collect(Collectors.toList()));
+          fragments.stream().map(FragmentMetadata::getJsonMetadata).collect(Collectors.toList()),
+          storageOptions);
     }
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/WriteParams.java
+++ b/java/core/src/main/java/com/lancedb/lance/WriteParams.java
@@ -16,6 +16,7 @@ package com.lancedb.lance;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -36,13 +37,16 @@ public class WriteParams {
   private final Optional<Integer> maxRowsPerGroup;
   private final Optional<Long> maxBytesPerFile;
   private final Optional<WriteMode> mode;
+  private final Map<String, String> storageOptions;
 
   private WriteParams(Optional<Integer> maxRowsPerFile, Optional<Integer> maxRowsPerGroup,
-      Optional<Long> maxBytesPerFile, Optional<WriteMode> mode) {
+      Optional<Long> maxBytesPerFile, Optional<WriteMode> mode,
+      Map<String, String> storageOptions) {
     this.maxRowsPerFile = maxRowsPerFile;
     this.maxRowsPerGroup = maxRowsPerGroup;
     this.maxBytesPerFile = maxBytesPerFile;
     this.mode = mode;
+    this.storageOptions = storageOptions;
   }
 
   public Optional<Integer> getMaxRowsPerFile() {
@@ -65,6 +69,10 @@ public class WriteParams {
     return mode.map(Enum::name);
   }
 
+  public Map<String, String> getStorageOptions() {
+    return storageOptions;
+  }
+
   @Override
   public String toString() {
     return new ToStringBuilder(this)
@@ -83,6 +91,7 @@ public class WriteParams {
     private Optional<Integer> maxRowsPerGroup = Optional.empty();
     private Optional<Long> maxBytesPerFile = Optional.empty();
     private Optional<WriteMode> mode = Optional.empty();
+    private Map<String, String> storageOptions;
 
     public Builder withMaxRowsPerFile(int maxRowsPerFile) {
       this.maxRowsPerFile = Optional.of(maxRowsPerFile);
@@ -104,8 +113,14 @@ public class WriteParams {
       return this;
     }
 
+    public Builder withStorageOptions(Map<String, String> storageOptions) {
+      this.storageOptions = storageOptions;
+      return this;
+    }
+
     public WriteParams build() {
-      return new WriteParams(maxRowsPerFile, maxRowsPerGroup, maxBytesPerFile, mode);
+      return new WriteParams(maxRowsPerFile, maxRowsPerGroup, maxBytesPerFile, mode,
+              storageOptions);
     }
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/WriteParams.java
+++ b/java/core/src/main/java/com/lancedb/lance/WriteParams.java
@@ -16,6 +16,7 @@ package com.lancedb.lance;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -37,7 +38,7 @@ public class WriteParams {
   private final Optional<Integer> maxRowsPerGroup;
   private final Optional<Long> maxBytesPerFile;
   private final Optional<WriteMode> mode;
-  private final Map<String, String> storageOptions;
+  private Map<String, String> storageOptions = new HashMap<>();
 
   private WriteParams(Optional<Integer> maxRowsPerFile, Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile, Optional<WriteMode> mode,
@@ -91,7 +92,7 @@ public class WriteParams {
     private Optional<Integer> maxRowsPerGroup = Optional.empty();
     private Optional<Long> maxBytesPerFile = Optional.empty();
     private Optional<WriteMode> mode = Optional.empty();
-    private Map<String, String> storageOptions;
+    private Map<String, String> storageOptions = new HashMap<>();
 
     public Builder withMaxRowsPerFile(int maxRowsPerFile) {
       this.maxRowsPerFile = Optional.of(maxRowsPerFile);

--- a/java/core/src/test/java/com/lancedb/lance/FragmentTest.java
+++ b/java/core/src/test/java/com/lancedb/lance/FragmentTest.java
@@ -21,6 +21,7 @@ import com.lancedb.lance.ipc.LanceScanner;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Optional;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.types.pojo.Schema;

--- a/java/core/src/test/java/com/lancedb/lance/TestUtils.java
+++ b/java/core/src/test/java/com/lancedb/lance/TestUtils.java
@@ -38,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
@@ -169,6 +170,7 @@ public class TestUtils {
                 .withMaxRowsPerFile(10)
                 .withMaxRowsPerGroup(20)
                 .withMode(WriteParams.WriteMode.CREATE)
+                .withStorageOptions(new HashMap<>())
                 .build())) {
           assertEquals(ROW_COUNT, dataset.countRows());
           schema = reader.getVectorSchemaRoot().getSchema();

--- a/java/spark/src/main/java/com/lancedb/lance/spark/LanceConfig.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/LanceConfig.java
@@ -33,13 +33,15 @@ public class LanceConfig implements Serializable {
   private final String datasetName;
   private final String datasetUri;
   private final boolean pushDownFilters;
+  private final Map<String, String> options;
 
   private LanceConfig(String dbPath, String datasetName,
-      String datasetUri, boolean pushDownFilters) {
+      String datasetUri, boolean pushDownFilters, CaseInsensitiveStringMap options) {
     this.dbPath = dbPath;
     this.datasetName = datasetName;
     this.datasetUri = datasetUri;
     this.pushDownFilters = pushDownFilters;
+    this.options = options.asCaseSensitiveMap();
   }
 
   public static LanceConfig from(Map<String, String> properties) {
@@ -65,7 +67,7 @@ public class LanceConfig implements Serializable {
     boolean pushDownFilters = options.getBoolean(CONFIG_PUSH_DOWN_FILTERS,
         DEFAULT_PUSH_DOWN_FILTERS);
     String[] paths = extractDbPathAndDatasetName(datasetUri);
-    return new LanceConfig(paths[0], paths[1], datasetUri, pushDownFilters);
+    return new LanceConfig(paths[0], paths[1], datasetUri, pushDownFilters, options);
   }
 
   public static String getDatasetUri(String dbPath, String datasetUri) {
@@ -106,5 +108,9 @@ public class LanceConfig implements Serializable {
 
   public boolean isPushDownFilters() {
     return pushDownFilters;
+  }
+
+  public Map<String, String> getOptions() {
+    return options;
   }
 }

--- a/java/spark/src/main/java/com/lancedb/lance/spark/SparkOptions.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/SparkOptions.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lancedb.lance.spark;
+
+import com.lancedb.lance.ReadOptions;
+import com.lancedb.lance.WriteParams;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SparkOptions {
+    private static final String ak = "access_key_id";
+    private static final String sk = "secret_access_key";
+    private static final String endpoint = "aws_region";
+    private static final String region = "aws_endpoint";
+    private static final String virtual_hosted_style = "virtual_hosted_style_request";
+    private static final String block_size = "block_size";
+    private static final String version = "version";
+    private static final String index_cache_size = "index_cache_size";
+    private static final String metadata_cache_size = "metadata_cache_size";
+    private static final String write_mode = "write_mode";
+    private static final String max_row_per_file = "max_row_per_file";
+    private static final String max_rows_per_group = "max_rows_per_group";
+    private static final String max_bytes_per_file = "max_bytes_per_file";
+
+    public static ReadOptions genReadOptionFromConfig(LanceConfig config) {
+        ReadOptions.Builder builder = new ReadOptions.Builder();
+        Map<String, String> maps = config.getOptions();
+        if (maps.containsKey(block_size)) {
+            builder.setBlockSize(Integer.parseInt(maps.get(block_size)));
+        }
+        if (maps.containsKey(version)) {
+            builder.setVersion(Integer.parseInt(maps.get(version)));
+        }
+        if (maps.containsKey(index_cache_size)) {
+            builder.setIndexCacheSize(Integer.parseInt(maps.get(index_cache_size)));
+        }
+        if (maps.containsKey(metadata_cache_size)) {
+            builder.setMetadataCacheSize(Integer.parseInt(maps.get(metadata_cache_size)));
+        }
+        builder.setStorageOptions(genStorageOptions(config));
+        return builder.build();
+    }
+
+    public static WriteParams genWriteParamsFromConfig(LanceConfig config) {
+        WriteParams.Builder builder = new WriteParams.Builder();
+        Map<String, String> maps = config.getOptions();
+        if (maps.containsKey(write_mode)) {
+            builder.withMode(WriteParams.WriteMode.valueOf(maps.get(write_mode)));
+        }
+        if (maps.containsKey(max_row_per_file)) {
+            builder.withMaxRowsPerFile(Integer.parseInt(maps.get(max_row_per_file)));
+        }
+        if (maps.containsKey(max_rows_per_group)) {
+            builder.withMaxRowsPerGroup(Integer.parseInt(maps.get(max_rows_per_group)));
+        }
+        if (maps.containsKey(max_bytes_per_file)) {
+            builder.withMaxBytesPerFile(Long.parseLong(maps.get(max_bytes_per_file)));
+        }
+        builder.withStorageOptions(genStorageOptions(config));
+        return builder.build();
+    }
+
+    private static Map<String, String> genStorageOptions(LanceConfig config) {
+        Map<String, String> maps = config.getOptions();
+        Map<String, String> storageOptions = new HashMap<>();
+        if (maps.containsKey(ak) && maps.containsKey(sk) && maps.containsKey(endpoint)) {
+            storageOptions.put(ak, maps.get(ak));
+            storageOptions.put(sk, maps.get(sk));
+            storageOptions.put(endpoint, maps.get(endpoint));
+            storageOptions.put(region, maps.get(region));
+            storageOptions.put(virtual_hosted_style, maps.get(virtual_hosted_style));
+        }
+        return storageOptions;
+    }
+
+}

--- a/java/spark/src/main/java/com/lancedb/lance/spark/internal/LanceFragmentScanner.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/internal/LanceFragmentScanner.java
@@ -16,9 +16,12 @@ package com.lancedb.lance.spark.internal;
 
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.DatasetFragment;
+import com.lancedb.lance.ReadOptions;
 import com.lancedb.lance.ipc.LanceScanner;
 import com.lancedb.lance.ipc.ScanOptions;
+import com.lancedb.lance.spark.LanceConfig;
 import com.lancedb.lance.spark.read.LanceInputPartition;
+import com.lancedb.lance.spark.SparkOptions;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.spark.sql.types.StructField;
@@ -46,7 +49,9 @@ public class LanceFragmentScanner implements AutoCloseable {
     DatasetFragment fragment = null;
     LanceScanner scanner = null;
     try {
-      dataset = Dataset.open(inputPartition.getConfig().getDatasetUri(), allocator);
+      LanceConfig config = inputPartition.getConfig();
+      ReadOptions options = SparkOptions.genReadOptionFromConfig(config);
+      dataset = Dataset.open(allocator, config.getDatasetUri(), options);
       fragment = dataset.getFragments().get(fragmentId);
       ScanOptions.Builder scanOptions = new ScanOptions.Builder();
       scanOptions.columns(getColumnNames(inputPartition.getSchema()));

--- a/java/spark/src/main/java/com/lancedb/lance/spark/write/LanceDataWriter.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/write/LanceDataWriter.java
@@ -15,7 +15,9 @@
 package com.lancedb.lance.spark.write;
 
 import com.lancedb.lance.FragmentMetadata;
+import com.lancedb.lance.WriteParams;
 import com.lancedb.lance.spark.LanceConfig;
+import com.lancedb.lance.spark.SparkOptions;
 import com.lancedb.lance.spark.internal.LanceDatasetAdapter;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.write.DataWriter;
@@ -90,8 +92,9 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
     @Override
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
       LanceArrowWriter arrowWriter = LanceDatasetAdapter.getArrowWriter(schema, 1024);
+      WriteParams params = SparkOptions.genWriteParamsFromConfig(config);
       Callable<FragmentMetadata> fragmentCreator
-          = () -> LanceDatasetAdapter.createFragment(config.getDatasetUri(), arrowWriter);
+          = () -> LanceDatasetAdapter.createFragment(config.getDatasetUri(), arrowWriter, params);
       FutureTask<FragmentMetadata> fragmentCreationTask = new FutureTask<>(fragmentCreator);
       Thread fragmentCreationThread = new Thread(fragmentCreationTask);
       fragmentCreationThread.start();


### PR DESCRIPTION
#2854
Set storage options configuration in spark-default
```
spark.sql.catalog.lance com.lancedb.lance.spark.LanceCatalog
spark.sql.catalog.lance.access_key_id AKAKAKAKAKAKAKAKAKAKAKAKAKAKAKAKAKAKAKAK
spark.sql.catalog.lance.secret_access_key SKSKSKSKSKSKSKSKSKSKSKSKSKSKSKSKSKSK
spark.sql.catalog.lance.aws_region region
spark.sql.catalog.lance.aws_endpoint https://Endpoint
spark.sql.catalog.lance.virtual_hosted_style_request true
```
Then you can read and write lance file for object store.
```scala
val df = Seq(
  ("Alice", 1),
  ("Bob", 2)
).toDF("name", "id")

df.write.format("lance").option("path", "s3://test/lance/demo.lance").save()


val data = spark.read.format("lance").option("path", "s3://test/lance/demo.lance").load();

data.show(10)
```