### PR TITLE
feat: make it possible to add columns from existing data

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -16,6 +16,7 @@ arrow = { version = "52.2", features = ["pyarrow"] }
 arrow-array = "52.2"
 arrow-data = "52.2"
 arrow-schema = "52.2"
+arrow-select = "52.2"
 object_store = "0.10.1"
 async-trait = "0.1"
 chrono = "0.4.31"
@@ -42,7 +43,11 @@ lance-table = { path = "../rust/lance-table" }
 lazy_static = "1"
 log = "0.4"
 prost = "0.12.2"
-pyo3 = { version = "0.21", features = ["extension-module", "abi3-py39", "gil-refs"] }
+pyo3 = { version = "0.21", features = [
+    "extension-module",
+    "abi3-py39",
+    "gil-refs",
+] }
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 uuid = "1.3.0"
 serde_json = "1"

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -914,23 +914,28 @@ class LanceDataset(pa.dataset.Dataset):
 
     def add_columns(
         self,
-        transforms: Dict[str, str] | BatchUDF,
+        transforms: Dict[str, str] | BatchUDF | ReaderLike,
         read_columns: List[str] | None = None,
+        reader_schema: Optional[pa.Schema] = None,
     ):
         """
         Add new columns with defined values.
 
-        There are two ways to specify the new columns. First, you can provide
+        There are several ways to specify the new columns. First, you can provide
         SQL expressions for each new column. Second you can provide a UDF that
         takes a batch of existing data and returns a new batch with the new
         columns. These new columns will be appended to the dataset.
+
+        You can also provide a RecordBatchReader which will read the new column
+        values from some external source.  This is often useful when the new column
+        values have already been staged to files (often by some distributed process)
 
         See the :func:`lance.add_columns_udf` decorator for more information on
         writing UDFs.
 
         Parameters
         ----------
-        transforms : dict or AddColumnsUDF
+        transforms : dict or AddColumnsUDF or ReaderLike
             If this is a dictionary, then the keys are the names of the new
             columns and the values are SQL expression strings. These strings can
             reference existing columns in the dataset.
@@ -940,6 +945,9 @@ class LanceDataset(pa.dataset.Dataset):
             The names of the columns that the UDF will read. If None, then the
             UDF will read all columns. This is only used when transforms is a
             UDF. Otherwise, the read columns are inferred from the SQL expressions.
+        reader_scheam: pa.Schema, optional
+            Only valid if transforms is a `ReaderLike` object.  This will be used to
+            determine the schema of the reader.
 
         Examples
         --------
@@ -988,7 +996,17 @@ class LanceDataset(pa.dataset.Dataset):
                         f"Column expressions must be a string. Got {type(k)}"
                     )
         else:
-            raise TypeError("transforms must be a dict or AddColumnsUDF")
+            try:
+                reader = _coerce_reader(transforms, reader_schema)
+                self._ds.add_columns_from_reader(reader)
+                return
+
+            except TypeError as inner_err:
+                raise TypeError(
+                    "transforms must be a dict, AddColumnsUDF, or a ReaderLike value.  "
+                    f"Received {type(transforms)}.  Could not coerce to a "
+                    f"reader: {inner_err}"
+                )
 
         self._ds.add_columns(transforms, read_columns)
 
@@ -1673,17 +1691,20 @@ class LanceDataset(pa.dataset.Dataset):
             logging.info("Doing one-pass ivfpq accelerated computations")
 
             timers["ivf+pq_train:start"] = time.time()
-            ivf_centroids, ivf_kmeans, pq_codebook, pq_kmeans_list = (
-                one_pass_train_ivf_pq_on_accelerator(
-                    self,
-                    column[0],
-                    num_partitions,
-                    metric,
-                    accelerator,
-                    num_sub_vectors=num_sub_vectors,
-                    batch_size=20480,
-                    filter_nan=filter_nan,
-                )
+            (
+                ivf_centroids,
+                ivf_kmeans,
+                pq_codebook,
+                pq_kmeans_list,
+            ) = one_pass_train_ivf_pq_on_accelerator(
+                self,
+                column[0],
+                num_partitions,
+                metric,
+                accelerator,
+                num_sub_vectors=num_sub_vectors,
+                batch_size=20480,
+                filter_nan=filter_nan,
             )
             timers["ivf+pq_train:end"] = time.time()
             ivfpq_train_time = timers["ivf+pq_train:end"] - timers["ivf+pq_train:start"]

--- a/python/python/lance/file.py
+++ b/python/python/lance/file.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
+from pathlib import Path
 from typing import Dict, Optional, Union
 
 import pyarrow as pa
@@ -69,6 +70,8 @@ class LanceFileReader:
             Extra options to be used for a particular storage connection. This is
             used to store connection parameters like credentials, endpoint, etc.
         """
+        if isinstance(path, Path):
+            path = str(path)
         self._reader = _LanceFileReader(path, storage_options=storage_options)
 
     def read_all(self, *, batch_size: int = 1024, batch_readahead=16) -> ReaderResults:
@@ -202,6 +205,8 @@ class LanceFileWriter:
             Extra options to be used for a particular storage connection. This is
             used to store connection parameters like credentials, endpoint, etc.
         """
+        if isinstance(path, Path):
+            path = str(path)
         self._writer = _LanceFileWriter(
             path,
             schema,

--- a/python/python/tests/test_schema_evolution.py
+++ b/python/python/tests/test_schema_evolution.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
+from lance.file import LanceFileReader, LanceFileWriter
 
 
 def test_drop_columns(tmp_path: Path):
@@ -84,6 +85,32 @@ def test_add_columns_udf(tmp_path):
     dataset.add_columns(triple_a, read_columns=["a"])
 
     expected = expected.append_column("triple_a", pa.array([3 * x for x in range(100)]))
+    assert expected == dataset.to_table()
+
+
+def test_add_columns_from_file(tmp_path):
+    tab = pa.table({"a": range(100), "b": range(100)})
+    dataset = lance.write_dataset(tab, tmp_path / "dataset", max_rows_per_file=25)
+
+    tbl_one = dataset.to_table(columns={"double_b": "b * 2"}, limit=50)
+    with LanceFileWriter(tmp_path / "tbl_0") as writer:
+        writer.write_batch(tbl_one)
+
+    tbl_two = dataset.to_table(columns={"double_b": "b * 2"}, offset=50, limit=50)
+    with LanceFileWriter(tmp_path / "tbl_1") as writer:
+        writer.write_batch(tbl_two)
+
+    def data_gen():
+        for i in range(2):
+            reader = LanceFileReader(str(tmp_path / f"tbl_{i}"))
+            for batch in reader.read_all().to_batches():
+                yield batch
+
+    reader_schema = pa.schema([pa.field("double_b", pa.int64())])
+
+    dataset.add_columns(data_gen(), reader_schema=reader_schema)
+
+    expected = tab.append_column("double_b", pa.array([2 * x for x in range(100)]))
     assert expected == dataset.to_table()
 
 

--- a/python/python/tests/test_schema_evolution.py
+++ b/python/python/tests/test_schema_evolution.py
@@ -88,6 +88,75 @@ def test_add_columns_udf(tmp_path):
     assert expected == dataset.to_table()
 
 
+def test_add_columns_from_rbr(tmp_path):
+    tab = pa.table({"a": range(100), "b": range(100)})
+    dataset = lance.write_dataset(tab, tmp_path / "dataset", max_rows_per_file=25)
+
+    # New data in smaller chunks than old data
+    def gen_data():
+        for i in range(34):
+            num_rows = 3
+            if i == 33:
+                num_rows = 1
+            yield pa.record_batch(
+                [pa.array(range(num_rows)), pa.array(range(num_rows))], ["c", "d"]
+            )
+
+    dataset.add_columns(
+        gen_data(),
+        reader_schema=pa.schema([pa.field("c", pa.int64()), pa.field("d", pa.int64())]),
+    )
+
+    expected = tab.append_column(
+        "c", pa.array([i % 3 for i in range(100)])
+    ).append_column("d", pa.array([i % 3 for i in range(100)]))
+
+    assert expected == dataset.to_table()
+
+    # New data in larger chunks than old data
+    def gen_data():
+        for i in range(3):
+            num_rows = 40
+            if i == 2:
+                num_rows = 20
+            yield pa.record_batch([pa.array(range(num_rows))], ["e"])
+
+    dataset.add_columns(
+        gen_data(),
+        reader_schema=pa.schema([pa.field("e", pa.int64())]),
+    )
+
+    expected = expected.append_column("e", pa.array([i % 40 for i in range(100)]))
+
+    assert expected == dataset.to_table()
+
+    # Insufficient number of rows
+
+    def gen_data():
+        yield pa.record_batch([pa.array(range(50))], ["f"])
+
+    with pytest.raises(
+        OSError, match="Stream ended before producing values for all rows in dataset"
+    ):
+        dataset.add_columns(
+            gen_data(),
+            reader_schema=pa.schema([pa.field("f", pa.int64())]),
+        )
+
+    # Too many rows
+
+    def gen_data():
+        yield pa.record_batch([pa.array(range(101))], ["f"])
+
+    with pytest.raises(
+        OSError, match="Stream produced more values than expected for dataset"
+    ):
+        dataset.add_columns(
+            gen_data(),
+            reader_schema=pa.schema([pa.field("f", pa.int64())]),
+        )
+
+
 def test_add_columns_from_file(tmp_path):
     tab = pa.table({"a": range(100), "b": range(100)})
     dataset = lance.write_dataset(tab, tmp_path / "dataset", max_rows_per_file=25)

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -326,9 +326,10 @@ async fn add_columns_from_stream(
     let mut last_seen_batch: Option<RecordBatch> = None;
     for fragment in fragments {
         let mut updater = fragment
-            .updater::<String>(None, schemas.clone(), batch_size)
+            .updater::<String>(Some(&[]), schemas.clone(), batch_size)
             .await?;
         while let Some(batch) = updater.next().await? {
+            debug_assert_eq!(batch.num_columns(), 1);
             let mut rows_remaining = batch.num_rows();
 
             let mut batches = Vec::new();

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -376,10 +376,10 @@ async fn add_columns_from_stream(
 
     // Ensure the stream is fully consumed
     if last_seen_batch.is_some() || stream.next().await.is_some() {
-        return Err(Error::invalid_input(
-            format!("Stream produced more values than expected for dataset"),
-            location!(),
-        ));
+        return Err(Error::InvalidInput {
+            source: "Stream produced more values than expected for dataset".into(),
+            location: location!(),
+        });
     }
 
     Ok(new_fragments)

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -375,6 +375,15 @@ async fn add_columns_from_stream(
         }
         new_fragments.push(updater.finish().await?);
     }
+
+    // Ensure the stream is fully consumed
+    if last_seen_batch.is_some() || stream.next().await.is_some() {
+        return Err(Error::invalid_input(
+            format!("Stream produced more values than expected for dataset"),
+            location!(),
+        ));
+    }
+
     Ok(new_fragments)
 }
 


### PR DESCRIPTION
The existing `add_columns` capability works well when you have a UDF or SQL function that you want Lance to run for you.  However, there are times when the new column values have already been determined (e.g. when a cluster farmed out the calculation of the values).  In this case we want a simple way to add new columns from existing values.