### PR TITLE
fix: update cursor correctly in blob file API

### DIFF
--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -93,6 +93,22 @@ def test_blob_file_seek(tmp_path, dataset_with_blobs):
         assert f.read(1) == b"a"
 
 
+def test_blob_file_read_middle(tmp_path, dataset_with_blobs):
+    # This regresses an issue where we were not setting the cursor
+    # correctly after a call to `read` when the blob was not the
+    # first thing in the file.
+    row_ids = (
+        dataset_with_blobs.to_table(columns=[], with_row_id=True)
+        .column("_rowid")
+        .to_pylist()
+    )
+    blobs = dataset_with_blobs.take_blobs(row_ids, "blobs")
+    with blobs[1] as f:
+        assert f.read(1) == b"b"
+        assert f.read(1) == b"a"
+        assert f.read(1) == b"r"
+
+
 def test_take_deleted_blob(tmp_path, dataset_with_blobs):
     row_ids = (
         dataset_with_blobs.to_table(columns=[], with_row_id=True)

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -124,10 +124,10 @@ impl BlobFile {
         let size = self.size;
         self.do_with_reader(|cursor, reader| async move {
             let start = position as usize + cursor as usize;
-            let size = len.min((size - cursor) as usize);
-            let end = start + size;
+            let read_size = len.min((size - cursor) as usize);
+            let end = start + read_size;
             let data = reader.get_range(start..end).await?;
-            Ok((end as u64, data))
+            Ok((end as u64 - position, data))
         })
         .await
     }


### PR DESCRIPTION
When `read` returns it should update the cursor to the end of the data just read.  However, we were calculating this as `end` and not `end - position`.

The cursor is supposed to be relative to the start of the blob in the file (e.g. 0 == `position`).