### PR TITLE
perf: reduce the minimum chunk size for l2 distance calculations

### DIFF
--- a/python/python/lance/torch/distance.py
+++ b/python/python/lance/torch/distance.py
@@ -220,7 +220,7 @@ def l2_distance(
     A tuple of Tensors, for centroids id, and distance to the centroids.
     """
     split = _suggest_batch_size(centroids)
-    while split >= 256:
+    while split >= 128:
         try:
             return _l2_distance(vectors, centroids, split_size=split, y2=y2)
         except RuntimeError as e:  # noqa: PERF203


### PR DESCRIPTION
Else we get OOMs with too many centroids + too many dimensions + not enough vram