### PR TITLE
fix: copy the unsafe row otherwise the queue will have all the same rows

### DIFF
--- a/java/spark/src/main/java/com/lancedb/lance/spark/write/LanceArrowWriter.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/write/LanceArrowWriter.java
@@ -55,7 +55,7 @@ public class LanceArrowWriter extends ArrowReader {
     Preconditions.checkNotNull(row);
     synchronized (monitor) {
       // TODO(lu) wait if too much elements in rowQueue
-      rowQueue.offer(row);
+      rowQueue.offer(row.copy());
       monitor.notify();
     }
   }


### PR DESCRIPTION
The unsafe row use the same referrence of rows.
When we offer rows to queue, all the rows in queu will be same.

![image](https://github.com/user-attachments/assets/04b2c0ce-9174-4a2b-af8d-a2299088538b)

Copy the internal row to avoid this issue.