### PR TITLE
feat: adds support for detached commits

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1388,6 +1388,7 @@ impl Dataset {
         commit_lock: Option<&PyAny>,
         storage_options: Option<HashMap<String, String>>,
         enable_v2_manifest_paths: Option<bool>,
+        detached: Option<bool>,
     ) -> PyResult<Self> {
         let object_store_params =
             storage_options
@@ -1418,16 +1419,29 @@ impl Dataset {
                 let manifest = dataset.as_ref().map(|ds| ds.manifest());
                 validate_operation(manifest, &operation.0)?;
                 let object_store_registry = Arc::new(lance::io::ObjectStoreRegistry::default());
-                LanceDataset::commit(
-                    dataset_uri,
-                    operation.0,
-                    read_version,
-                    object_store_params,
-                    commit_handler,
-                    object_store_registry,
-                    enable_v2_manifest_paths.unwrap_or(false),
-                )
-                .await
+                if detached.unwrap_or(false) {
+                    LanceDataset::commit_detached(
+                        dataset_uri,
+                        operation.0,
+                        read_version,
+                        object_store_params,
+                        commit_handler,
+                        object_store_registry,
+                        enable_v2_manifest_paths.unwrap_or(false),
+                    )
+                    .await
+                } else {
+                    LanceDataset::commit(
+                        dataset_uri,
+                        operation.0,
+                        read_version,
+                        object_store_params,
+                        commit_handler,
+                        object_store_registry,
+                        enable_v2_manifest_paths.unwrap_or(false),
+                    )
+                    .await
+                }
             })?
             .map_err(|e| PyIOError::new_err(e.to_string()))?;
         Ok(Self {

--- a/rust/lance-table/src/format.rs
+++ b/rust/lance-table/src/format.rs
@@ -11,7 +11,10 @@ mod manifest;
 
 pub use fragment::*;
 pub use index::Index;
-pub use manifest::{DataStorageFormat, Manifest, SelfDescribingFileReader, WriterVersion};
+pub use manifest::{
+    is_detached_version, DataStorageFormat, Manifest, SelfDescribingFileReader, WriterVersion,
+    DETACHED_VERSION_MASK,
+};
 
 use lance_core::{Error, Result};
 

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -83,6 +83,13 @@ pub struct Manifest {
     pub config: HashMap<String, String>,
 }
 
+// We use the most significant bit to indicate that a transaction is detached
+pub const DETACHED_VERSION_MASK: u64 = 0x8000_0000_0000_0000;
+
+pub fn is_detached_version(version: u64) -> bool {
+    version & DETACHED_VERSION_MASK != 0
+}
+
 fn compute_fragment_offsets(fragments: &[Fragment]) -> Vec<usize> {
     fragments
         .iter()

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -66,7 +66,7 @@ use self::transaction::{Operation, Transaction};
 use self::write::write_fragments_internal;
 use crate::datatypes::Schema;
 use crate::error::box_error;
-use crate::io::commit::{commit_new_dataset, commit_transaction};
+use crate::io::commit::{commit_detached_transaction, commit_new_dataset, commit_transaction};
 use crate::session::Session;
 use crate::utils::temporal::{timestamp_to_nanos, utc_now, SystemTime};
 use crate::{Error, Result};
@@ -852,6 +852,142 @@ impl Dataset {
         .boxed()
     }
 
+    async fn do_commit(
+        base_uri: &str,
+        operation: Operation,
+        read_version: Option<u64>,
+        store_params: Option<ObjectStoreParams>,
+        commit_handler: Option<Arc<dyn CommitHandler>>,
+        object_store_registry: Arc<ObjectStoreRegistry>,
+        enable_v2_manifest_paths: bool,
+        detached: bool,
+    ) -> Result<Self> {
+        let read_version = read_version.map_or_else(
+            || match operation {
+                Operation::Overwrite { .. } | Operation::Restore { .. } => Ok(0),
+                _ => Err(Error::invalid_input(
+                    "read_version must be specified for this operation",
+                    location!(),
+                )),
+            },
+            Ok,
+        )?;
+
+        let (object_store, base, commit_handler) = Self::params_from_uri(
+            base_uri,
+            &commit_handler,
+            &store_params,
+            object_store_registry.clone(),
+        )
+        .await?;
+
+        // Test if the dataset exists
+        let dataset_exists = match commit_handler
+            .resolve_latest_version(&base, &object_store)
+            .await
+        {
+            Ok(_) => true,
+            Err(Error::NotFound { .. }) => false,
+            Err(e) => return Err(e),
+        };
+
+        if !dataset_exists && !matches!(operation, Operation::Overwrite { .. }) {
+            return Err(Error::DatasetNotFound {
+                path: base.to_string(),
+                source: "The dataset must already exist unless the operation is Overwrite".into(),
+                location: location!(),
+            });
+        }
+
+        let dataset = if dataset_exists {
+            let mut builder = DatasetBuilder::from_uri(base_uri).with_read_params(ReadParams {
+                store_options: store_params.clone(),
+                object_store_registry: object_store_registry.clone(),
+                ..Default::default()
+            });
+            if detached {
+                // If we are making a detached commit then base the commit on the read_version.
+                //
+                // Otherwise, we want to use the latest version of the dataset
+                builder = builder.with_version(read_version);
+            }
+            Some(builder.load().await?)
+        } else {
+            None
+        };
+
+        let manifest_naming_scheme = if let Some(ds) = &dataset {
+            ds.manifest_naming_scheme
+        } else if enable_v2_manifest_paths {
+            ManifestNamingScheme::V2
+        } else {
+            ManifestNamingScheme::V1
+        };
+
+        let transaction = Transaction::new(read_version, operation, None);
+
+        let manifest = if let Some(dataset) = &dataset {
+            if detached {
+                if matches!(manifest_naming_scheme, ManifestNamingScheme::V1) {
+                    return Err(Error::NotSupported {
+                        source: "detached commits cannot be used with v1 manifest paths".into(),
+                        location: location!(),
+                    });
+                }
+                commit_detached_transaction(
+                    dataset,
+                    &object_store,
+                    commit_handler.as_ref(),
+                    &transaction,
+                    &Default::default(),
+                    &Default::default(),
+                )
+                .await?
+            } else {
+                commit_transaction(
+                    dataset,
+                    &object_store,
+                    commit_handler.as_ref(),
+                    &transaction,
+                    &Default::default(),
+                    &Default::default(),
+                    manifest_naming_scheme,
+                )
+                .await?
+            }
+        } else if !detached {
+            commit_new_dataset(
+                &object_store,
+                commit_handler.as_ref(),
+                &base,
+                &transaction,
+                &Default::default(),
+                manifest_naming_scheme,
+            )
+            .await?
+        } else {
+            // I think we may eventually want this, and we can probably handle it, but leaving a TODO for now
+            return Err(Error::NotSupported {
+                source: "detached commits cannot currently be used to create new datasets".into(),
+                location: location!(),
+            });
+        };
+
+        let object_store = Arc::new(object_store);
+        let tags = Tags::new(object_store.clone(), commit_handler.clone(), base.clone());
+
+        Ok(Self {
+            object_store,
+            base,
+            uri: base_uri.to_string(),
+            manifest: Arc::new(manifest.clone()),
+            session: Arc::new(Session::default()),
+            commit_handler,
+            tags,
+            manifest_naming_scheme,
+        })
+    }
+
     /// Commit changes to the dataset
     ///
     /// This operation is not needed if you are using append/write/delete to manipulate the dataset.
@@ -895,104 +1031,47 @@ impl Dataset {
         object_store_registry: Arc<ObjectStoreRegistry>,
         enable_v2_manifest_paths: bool,
     ) -> Result<Self> {
-        let read_version = read_version.map_or_else(
-            || match operation {
-                Operation::Overwrite { .. } | Operation::Restore { .. } => Ok(0),
-                _ => Err(Error::invalid_input(
-                    "read_version must be specified for this operation",
-                    location!(),
-                )),
-            },
-            Ok,
-        )?;
-
-        let (object_store, base, commit_handler) = Self::params_from_uri(
+        Self::do_commit(
             base_uri,
-            &commit_handler,
-            &store_params,
-            object_store_registry.clone(),
-        )
-        .await?;
-
-        // Test if the dataset exists
-        let dataset_exists = match commit_handler
-            .resolve_latest_version(&base, &object_store)
-            .await
-        {
-            Ok(_) => true,
-            Err(Error::NotFound { .. }) => false,
-            Err(e) => return Err(e),
-        };
-
-        if !dataset_exists && !matches!(operation, Operation::Overwrite { .. }) {
-            return Err(Error::DatasetNotFound {
-                path: base.to_string(),
-                source: "The dataset must already exist unless the operation is Overwrite".into(),
-                location: location!(),
-            });
-        }
-
-        let dataset = if dataset_exists {
-            Some(
-                DatasetBuilder::from_uri(base_uri)
-                    .with_read_params(ReadParams {
-                        store_options: store_params.clone(),
-                        object_store_registry: object_store_registry.clone(),
-                        ..Default::default()
-                    })
-                    .load()
-                    .await?,
-            )
-        } else {
-            None
-        };
-
-        let manifest_naming_scheme = if let Some(ds) = &dataset {
-            ds.manifest_naming_scheme
-        } else if enable_v2_manifest_paths {
-            ManifestNamingScheme::V2
-        } else {
-            ManifestNamingScheme::V1
-        };
-
-        let transaction = Transaction::new(read_version, operation, None);
-
-        let manifest = if let Some(dataset) = &dataset {
-            commit_transaction(
-                dataset,
-                &object_store,
-                commit_handler.as_ref(),
-                &transaction,
-                &Default::default(),
-                &Default::default(),
-                manifest_naming_scheme,
-            )
-            .await?
-        } else {
-            commit_new_dataset(
-                &object_store,
-                commit_handler.as_ref(),
-                &base,
-                &transaction,
-                &Default::default(),
-                manifest_naming_scheme,
-            )
-            .await?
-        };
-
-        let object_store = Arc::new(object_store);
-        let tags = Tags::new(object_store.clone(), commit_handler.clone(), base.clone());
-
-        Ok(Self {
-            object_store,
-            base,
-            uri: base_uri.to_string(),
-            manifest: Arc::new(manifest.clone()),
-            session: Arc::new(Session::default()),
+            operation,
+            read_version,
+            store_params,
             commit_handler,
-            tags,
-            manifest_naming_scheme,
-        })
+            object_store_registry,
+            enable_v2_manifest_paths,
+            /*detached=*/ false,
+        )
+        .await
+    }
+
+    /// Commits changes exactly the same as [`Self::commit`] but the commit will
+    /// not be associated with the dataset lineage.
+    ///
+    /// The commit will not show up in the dataset's history and will never be
+    /// the latest version of the dataset.
+    ///
+    /// This can be used to stage changes or to handle "secondary" datasets whose
+    /// lineage is tracked elsewhere.
+    pub async fn commit_detached(
+        base_uri: &str,
+        operation: Operation,
+        read_version: Option<u64>,
+        store_params: Option<ObjectStoreParams>,
+        commit_handler: Option<Arc<dyn CommitHandler>>,
+        object_store_registry: Arc<ObjectStoreRegistry>,
+        enable_v2_manifest_paths: bool,
+    ) -> Result<Self> {
+        Self::do_commit(
+            base_uri,
+            operation,
+            read_version,
+            store_params,
+            commit_handler,
+            object_store_registry,
+            enable_v2_manifest_paths,
+            /*detached=*/ true,
+        )
+        .await
     }
 
     /// Create a Scanner to scan the dataset.

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -852,6 +852,7 @@ impl Dataset {
         .boxed()
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn do_commit(
         base_uri: &str,
         operation: Operation,

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -460,11 +460,11 @@ pub(crate) async fn commit_detached_transaction(
 
         // recompute_stats is always false so far because detached manifests are newer than
         // the old stats bug.
-        migrate_manifest(&dataset, &mut manifest, /*recompute_stats=*/ false).await?;
+        migrate_manifest(dataset, &mut manifest, /*recompute_stats=*/ false).await?;
         // fix_schema and check_storage_version are just for sanity-checking and consistency
         fix_schema(&mut manifest)?;
         check_storage_version(&mut manifest)?;
-        migrate_indices(&dataset, &mut indices).await?;
+        migrate_indices(dataset, &mut indices).await?;
 
         // Try to commit the manifest
         let result = write_manifest_file(

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -427,13 +427,13 @@ pub(crate) async fn commit_detached_transaction(
     write_config: &ManifestWriteConfig,
     commit_config: &CommitConfig,
 ) -> Result<Manifest> {
-    // We don't stricly need a transaction file but we go ahead and create one for
+    // We don't strictly need a transaction file but we go ahead and create one for
     // record-keeping if nothing else.
     let transaction_file = write_transaction_file(object_store, &dataset.base, transaction).await?;
 
     // We still do a loop since we may have conflicts in the random version we pick
     for attempt_i in 0..commit_config.num_retries {
-        // Pick a random u64 with the higest bit set to indicate it is detached
+        // Pick a random u64 with the highest bit set to indicate it is detached
         let random_version = thread_rng().gen::<u64>() | DETACHED_VERSION_MASK;
 
         let (mut manifest, mut indices) = match transaction.operation {


### PR DESCRIPTION
A detached commit is a commit that is not part of the regular dataset lineage.  It will never show up as the latest commit and is completely separate from the linear history of the dataset.

This can be useful for:

 * Making temporary changes to a dataset, like adding a column of values while computing an index without ever truly materializing the column.
 * Situations where the dataset's lineage is managed remotely and all commits are detached commits without any linear history (blob storage will use this)

Closes #2889 