### PR TITLE
ci: fix version check CI job

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           # pull_request_target checks out the base branch by default, not
           # the PR branch.
-          ref: "${{ github.event.pull_request.merge_commit_sha }}"
+          ref: "${{ github.event.pull_request.head.sha }}"
           path: pr
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Part of the job checks out the pull request (this isn't done automatically because this runs with `pull_request_target` which checks out the base by default).

That step was using `merge_commit_sha` which is not correct (this still checks out the base).  The fix instead checks out `head.sha` which is correct.

It is not possible to get a `merge_commit_sha`  (there is a request for this [here](https://github.com/actions/checkout/issues/518)) but `head.sha` should be good enough for our purposes.