### PR TITLE
chore: pin ray version <2.38 and remove numpy pin

### DIFF
--- a/.github/workflows/run_integtests/action.yml
+++ b/.github/workflows/run_integtests/action.yml
@@ -8,7 +8,7 @@ runs:
     working-directory: python
     shell: bash
     run: |
-      pip3 install $(ls target/wheels/pylance-*.whl)[tests]
+      pip3 install $(ls target/wheels/pylance-*.whl)[tests,ray]
   - name: Run python tests
     shell: bash
     working-directory: python

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pylance"
-dependencies = ["pyarrow>=12", "numpy>=1.22,<2"]
+dependencies = ["pyarrow>=12", "numpy>=1.22"]
 description = "python wrapper for Lance columnar format"
 authors = [{ name = "Lance Devs", email = "dev@lancedb.com" }]
 license = { file = "LICENSE" }
@@ -62,7 +62,7 @@ benchmarks = ["pytest-benchmark"]
 torch = ["torch"]
 cuvs-cu11 = ["cuvs-cu11", "pylibraft-cu11"]
 cuvs-cu12 = ["cuvs-cu12", "pylibraft-cu12"]
-ray = ["ray[data]; python_version<'3.12'"]
+ray = ["ray[data]<'2.38'; python_version<'3.12'"]
 
 [tool.ruff]
 lint.select = ["F", "E", "W", "I", "G", "TCH", "PERF", "B019"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -62,7 +62,7 @@ benchmarks = ["pytest-benchmark"]
 torch = ["torch"]
 cuvs-cu11 = ["cuvs-cu11", "pylibraft-cu11"]
 cuvs-cu12 = ["cuvs-cu12", "pylibraft-cu12"]
-ray = ["ray[data]<'2.38'; python_version<'3.12'"]
+ray = ["ray[data]<2.38; python_version<'3.12'"]
 
 [tool.ruff]
 lint.select = ["F", "E", "W", "I", "G", "TCH", "PERF", "B019"]


### PR DESCRIPTION
The ray pin is due to #3042 

The numpy pin was previously added because pyarrow was not compatible with numpy 2.  However, I believe that problem has since been resolved.