### PR TITLE
feat: support build lance java with rust release mode

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -104,14 +104,14 @@ jobs:
       - name: Dry run
         if: github.event_name == 'pull_request'
         run: |
-          mvn --batch-mode -DskipTests package
+          mvn --batch-mode -DskipTests -Drust.release.build=true package
       - name: Publish with Java 8
         if: github.event_name == 'release'
         run: |
           echo "use-agent" >> ~/.gnupg/gpg.conf
           echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
           export GPG_TTY=$(tty)
-          mvn --batch-mode -DskipTests -DpushChanges=false -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} deploy -P deploy-to-ossrh
+          mvn --batch-mode -DskipTests -Drust.release.build=true -DpushChanges=false -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} deploy -P deploy-to-ossrh
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -15,6 +15,9 @@
     <artifactId>lance-core</artifactId>
     <name>Lance Core</name>
     <packaging>jar</packaging>
+    <properties>
+        <rust.release.build>false</rust.release.build>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -72,7 +75,7 @@
                                 </goals>
                                 <configuration>
                                     <path>lance-jni</path>
-                                    <release>false</release>
+                                    <release>${rust.release.build}</release>
                                     <!-- Copy native libraries to target/classes for runtime access -->
                                     <copyTo>${project.build.directory}/classes/nativelib</copyTo>
                                     <copyWithPlatformDir>true</copyWithPlatformDir>
@@ -85,7 +88,7 @@
                                 </goals>
                                 <configuration>
                                     <path>lance-jni</path>
-                                    <release>false</release>
+                                    <release>${rust.release.build}</release>
                                     <verbosity>-v</verbosity>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
Now the lance java package only support build with debug mode.
Add a propertiy to support build with release mode.
```bash
## release mode
mvn clean package -DskipTests -Drust.release.build=true

## debug mode(default)
mvn clean package -DskipTests
```