### PR TITLE
chore: add granularity of 1024 to bit_width stats

### DIFF
--- a/rust/lance-encoding/src/encodings/physical/block_compress.rs
+++ b/rust/lance-encoding/src/encodings/physical/block_compress.rs
@@ -23,8 +23,8 @@ pub struct CompressionConfig {
 }
 
 impl CompressionConfig {
-    pub(crate) fn new(scheme: CompressionScheme, level: Option<i32>) -> CompressionConfig {
-        CompressionConfig { scheme, level }
+    pub(crate) fn new(scheme: CompressionScheme, level: Option<i32>) -> Self {
+        Self { scheme, level }
     }
 }
 

--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -1056,7 +1056,11 @@ mod tests {
         let array1_ref: ArrayRef = Arc::new(int16_array1);
         let array2_ref: ArrayRef = Arc::new(int16_array2);
         let array3_ref: ArrayRef = Arc::new(int16_array3);
-        let arrays: Vec<&dyn arrow::array::Array> = vec![array1_ref.as_ref(), array2_ref.as_ref(), array3_ref.as_ref()];
+        let arrays: Vec<&dyn arrow::array::Array> = vec![
+            array1_ref.as_ref(),
+            array2_ref.as_ref(),
+            array3_ref.as_ref(),
+        ];
         let concatenated = concat(&arrays).unwrap();
         let mut block = DataBlock::from_array(concatenated.clone());
 
@@ -1077,7 +1081,11 @@ mod tests {
         let array1_ref: ArrayRef = Arc::new(int32_array1);
         let array2_ref: ArrayRef = Arc::new(int32_array2);
         let array3_ref: ArrayRef = Arc::new(int32_array3);
-        let arrays: Vec<&dyn arrow::array::Array> = vec![array1_ref.as_ref(), array2_ref.as_ref(), array3_ref.as_ref()];
+        let arrays: Vec<&dyn arrow::array::Array> = vec![
+            array1_ref.as_ref(),
+            array2_ref.as_ref(),
+            array3_ref.as_ref(),
+        ];
         let concatenated = concat(&arrays).unwrap();
         let mut block = DataBlock::from_array(concatenated.clone());
 
@@ -1098,7 +1106,11 @@ mod tests {
         let array1_ref: ArrayRef = Arc::new(int64_array1);
         let array2_ref: ArrayRef = Arc::new(int64_array2);
         let array3_ref: ArrayRef = Arc::new(int64_array3);
-        let arrays: Vec<&dyn arrow::array::Array> = vec![array1_ref.as_ref(), array2_ref.as_ref(), array3_ref.as_ref()];
+        let arrays: Vec<&dyn arrow::array::Array> = vec![
+            array1_ref.as_ref(),
+            array2_ref.as_ref(),
+            array3_ref.as_ref(),
+        ];
         let concatenated = concat(&arrays).unwrap();
         let mut block = DataBlock::from_array(concatenated.clone());
 


### PR DESCRIPTION
This PR tries to add granularity of 1024 for computing bit_width, it can enable more fine grained bit width selection when do bit-packing