### PR TITLE
fix: verify num_sub_vectors is valid before creating index

### DIFF
--- a/python/python/lance/indices.py
+++ b/python/python/lance/indices.py
@@ -545,8 +545,8 @@ class IndicesBuilder:
             )
         if dimension % num_subvectors != 0:
             raise ValueError(
-                "dimension ({dimension}) must be divisible by num_subvectors"
-                " ({num_subvectors}) without remainder"
+                f"dimension ({dimension}) must be divisible by num_subvectors"
+                f" ({num_subvectors}) without remainder"
             )
         return num_subvectors
 

--- a/python/python/tests/test_indices.py
+++ b/python/python/tests/test_indices.py
@@ -16,7 +16,7 @@ DIMENSION = 128
 NUM_SUBVECTORS = 8
 NUM_FRAGMENTS = 3
 NUM_ROWS = NUM_ROWS_PER_FRAGMENT * NUM_FRAGMENTS
-NUM_PARTITIONS = math.ceil(np.sqrt(NUM_ROWS))
+NUM_PARTITIONS = round(np.sqrt(NUM_ROWS))
 
 
 SMALL_ROWS_PER_FRAGMENT = 100
@@ -94,7 +94,9 @@ def test_ivf_centroids_cuda(rand_dataset):
     )
 
     assert ivf.distance_type == "l2"
-    assert len(ivf.centroids) == NUM_PARTITIONS
+    # Can't use NUM_PARTITIONS here because
+    # CUDA uses math.ceil and CPU uses round to calc. num_partitions
+    assert len(ivf.centroids) == math.ceil(np.sqrt(NUM_ROWS))
 
 
 @pytest.mark.cuda

--- a/python/python/tests/test_indices.py
+++ b/python/python/tests/test_indices.py
@@ -156,6 +156,16 @@ def test_gen_pq(tmpdir, rand_dataset, rand_ivf):
     assert pq.codebook == reloaded.codebook
 
 
+def test_pq_invalid_sub_vectors(tmpdir, rand_dataset, rand_ivf):
+    with pytest.raises(
+        ValueError,
+        match="must be divisible by num_subvectors .* without remainder",
+    ):
+        IndicesBuilder(rand_dataset, "vectors").train_pq(
+            rand_ivf, sample_rate=2, num_subvectors=5
+        )
+
+
 def test_gen_pq_mostly_null(mostly_null_dataset):
     centroids = np.random.rand(DIMENSION * 100).astype(np.float32)
     centroids = pa.FixedSizeListArray.from_arrays(centroids, DIMENSION)

--- a/python/python/tests/test_indices.py
+++ b/python/python/tests/test_indices.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
+import math
 import os
 import pathlib
 
@@ -15,7 +16,7 @@ DIMENSION = 128
 NUM_SUBVECTORS = 8
 NUM_FRAGMENTS = 3
 NUM_ROWS = NUM_ROWS_PER_FRAGMENT * NUM_FRAGMENTS
-NUM_PARTITIONS = round(np.sqrt(NUM_ROWS))
+NUM_PARTITIONS = math.ceil(np.sqrt(NUM_ROWS))
 
 
 SMALL_ROWS_PER_FRAGMENT = 100

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -135,6 +135,35 @@ def test_ann_append(tmp_path):
     run(dataset, q=np.array(q), assert_func=func)
 
 
+def test_invalid_subvectors(tmp_path):
+    tbl = create_table()
+    dataset = lance.write_dataset(tbl, tmp_path)
+    with pytest.raises(
+        ValueError,
+        match="dimension .* must be divisible by num_sub_vectors",
+    ):
+        dataset.create_index(
+            "vector", index_type="IVF_PQ", num_partitions=4, num_sub_vectors=15
+        )
+
+
+@pytest.mark.cuda
+def test_invalid_subvectors_cuda(tmp_path):
+    tbl = create_table()
+    dataset = lance.write_dataset(tbl, tmp_path)
+    with pytest.raises(
+        ValueError,
+        match="dimension .* must be divisible by num_sub_vectors",
+    ):
+        dataset.create_index(
+            "vector",
+            index_type="IVF_PQ",
+            num_partitions=4,
+            num_sub_vectors=15,
+            accelerator="cuda",
+        )
+
+
 def test_index_with_nans(tmp_path):
     # 1024 rows, the entire table should be sampled
     tbl = create_table(nvec=1000, nans=24)


### PR DESCRIPTION
This was being checked deep in the Rust code on the CPU path.  However, on the accelerator path it was creating the index which would then give obscure errors when attempts were made to search it.

This PR adds a check early in the python code and adds unit tests for the various ways indices can be created.