### PR TITLE
perf: use total cmp for ordered float

### DIFF
--- a/rust/lance-index/src/vector/graph.rs
+++ b/rust/lance-index/src/vector/graph.rs
@@ -54,6 +54,7 @@ impl<I> From<I> for GraphNode<I> {
 pub struct OrderedFloat(pub f32);
 
 impl PartialOrd for OrderedFloat {
+    #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
@@ -62,8 +63,9 @@ impl PartialOrd for OrderedFloat {
 impl Eq for OrderedFloat {}
 
 impl Ord for OrderedFloat {
+    #[inline(always)]
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.partial_cmp(&other.0).unwrap()
+        self.0.total_cmp(&other.0)
     }
 }
 


### PR DESCRIPTION
TL;DR: `PartialOrd` impl for `f32` requires two cmp instructions and `PartialOrd::lt` is not reduced to a single instruction. With `total_cmp` we avoid this overhead. See https://godbolt.org/z/ez4EaEs3W

Note: maybe we could gain more perf by implementing a `NaN-less` cmp?

V1:
```
Running query with nprobes: 1, refine_factor: 0
Time: 652.877µs

Running query with nprobes: 10, refine_factor: 0
Time: 818.418µs

Running query with nprobes: 50, refine_factor: 0
Time: 1.406433ms

Running query with nprobes: 100, refine_factor: 0
Time: 1.747243ms

Running query with nprobes: 512, refine_factor: 0
Time: 5.754752ms
```

V3 before perf fix
```
Running query with nprobes: 1, refine_factor: 0
Time: 752.659µs

Running query with nprobes: 10, refine_factor: 0
Time: 2.379638ms

Running query with nprobes: 50, refine_factor: 0
Time: 9.518057ms

Running query with nprobes: 100, refine_factor: 0
Time: 17.623498ms

Running query with nprobes: 512, refine_factor: 0
Time: 39.43036ms
```

V3 after perf fix
```
Running query with nprobes: 1, refine_factor: 0
Time: 644.933µs

Running query with nprobes: 10, refine_factor: 0
Time: 1.512715ms

Running query with nprobes: 50, refine_factor: 0
Time: 5.974101ms

Running query with nprobes: 100, refine_factor: 0
Time: 9.848213ms

Running query with nprobes: 512, refine_factor: 0
Time: 23.058848ms
```