### PR TITLE
feat: introduce concept of "storage class" wtih separate dataset for "blob" storage data

### DIFF
--- a/protos/file.proto
+++ b/protos/file.proto
@@ -173,4 +173,17 @@ message Field {
 
   // optional field metadata (e.g. extension type name/parameters)
   map<string, bytes> metadata = 10;
+
+  /// The storage class of the field
+  ///
+  /// This determines the rate at which the field is compacted.
+  ///
+  /// Currently, there are only two storage classes:
+  /// 
+  /// "" - The default storage class.
+  /// "blob" - The field is compacted into fewer rows per fragment.
+  ///
+  /// Fields that have non-default storage classes are stored in different
+  /// datasets (e.g. blob fields are stored in the nested "_blobs" dataset)
+  string storage_class = 11;
 }

--- a/protos/file2.proto
+++ b/protos/file2.proto
@@ -8,7 +8,7 @@ package lance.file.v2;
 import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 
-// # Lance v0.2 File Format
+// # Lance v2.X File Format
 //
 // The Lance file format is a barebones format for serializing columnar data
 // into a file.

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -146,6 +146,14 @@ message Manifest {
   // libraries may wish to similarly prefix their configuration keys
   // appropriately.
   map<string, string> config = 16;
+
+  // The version of the blob dataset associated with this table.  Changes to
+  // blob fields will modify the blob dataset and update this version in the parent
+  // table.
+  //
+  // If this value is 0 then there are no blob fields.
+  uint64 blob_dataset_version = 17;
+
 } // Manifest
 
 // Auxiliary Data attached to a version.

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -179,4 +179,10 @@ message Transaction {
     Project project = 109;
     UpdateConfig update_config = 110;
   }
+
+  // An operation to apply to the blob dataset
+  oneof blob_operation {
+    Append blob_append = 200;
+    Overwrite blob_overwrite = 202;
+  }  
 }

--- a/python/python/tests/test_file.py
+++ b/python/python/tests/test_file.py
@@ -198,7 +198,7 @@ def test_metadata(tmp_path):
     assert metadata.num_rows == 3
     assert metadata.num_global_buffer_bytes > 0
     assert metadata.num_column_metadata_bytes > 0
-    assert metadata.num_data_bytes == 55
+    assert metadata.num_data_bytes == 24
     assert len(metadata.columns) == 1
 
     column = metadata.columns[0]

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -467,11 +467,17 @@ pub fn write_fragments(
         .transpose()?
         .unwrap_or_default();
 
-    let fragments = RT
+    let written = RT
         .block_on(Some(reader.py()), async {
             lance::dataset::write_fragments(dataset_uri, batches, params).await
         })?
         .map_err(|err| PyIOError::new_err(err.to_string()))?;
+
+    assert!(
+        written.blob.is_none(),
+        "Blob writing is not yet supported by the python _write_fragments API"
+    );
+    let fragments = written.default.0;
 
     fragments
         .into_iter()

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -18,10 +18,7 @@ mod field;
 mod schema;
 
 use crate::{Error, Result};
-pub use field::Encoding;
-pub use field::Field;
-pub use field::NullabilityComparison;
-pub use field::SchemaCompareOptions;
+pub use field::{Encoding, Field, NullabilityComparison, SchemaCompareOptions, StorageClass};
 pub use schema::Schema;
 
 pub const COMPRESSION_META_KEY: &str = "lance-encoding:compression";

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -76,8 +76,8 @@ pub enum StorageClass {
 impl Display for StorageClass {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            StorageClass::Default => write!(f, "default"),
-            StorageClass::Blob => write!(f, "blob"),
+            Self::Default => write!(f, "default"),
+            Self::Blob => write!(f, "blob"),
         }
     }
 }
@@ -87,8 +87,8 @@ impl FromStr for StorageClass {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
-            "default" | "" => Ok(StorageClass::Default),
-            "blob" => Ok(StorageClass::Blob),
+            "default" | "" => Ok(Self::Default),
+            "blob" => Ok(Self::Blob),
             _ => Err(Error::Schema {
                 message: format!("Unknown storage class: {}", s),
                 location: location!(),
@@ -417,7 +417,7 @@ impl Field {
             nullable: self.nullable,
             children: vec![],
             dictionary: self.dictionary.clone(),
-            storage_class: self.storage_class.clone(),
+            storage_class: self.storage_class,
         };
         if path_components.is_empty() {
             // Project stops here, copy all the remaining children.
@@ -609,7 +609,7 @@ impl Field {
                 nullable: self.nullable,
                 children,
                 dictionary: self.dictionary.clone(),
-                storage_class: self.storage_class.clone(),
+                storage_class: self.storage_class,
             };
             return Ok(f);
         }
@@ -672,7 +672,7 @@ impl Field {
                 nullable: self.nullable,
                 children,
                 dictionary: self.dictionary.clone(),
-                storage_class: self.storage_class.clone(),
+                storage_class: self.storage_class,
             })
         }
     }

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -6,7 +6,8 @@
 use std::{
     cmp::max,
     collections::{HashMap, HashSet},
-    fmt,
+    fmt::{self, Display},
+    str::FromStr,
     sync::Arc,
 };
 
@@ -24,6 +25,8 @@ use snafu::{location, Location};
 
 use super::{Dictionary, LogicalType};
 use crate::{Error, Result};
+
+pub const LANCE_STORAGE_CLASS_SCHEMA_META_KEY: &str = "lance-schema:storage-class";
 
 #[derive(Debug, Default)]
 pub enum NullabilityComparison {
@@ -60,6 +63,40 @@ pub enum Encoding {
     RLE,
 }
 
+/// Describes the rate at which a column should be compacted
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, DeepSizeOf)]
+pub enum StorageClass {
+    /// Default storage class (stored in primary dataset)
+    #[default]
+    Default,
+    /// Blob storage class (stored in blob dataset)
+    Blob,
+}
+
+impl Display for StorageClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StorageClass::Default => write!(f, "default"),
+            StorageClass::Blob => write!(f, "blob"),
+        }
+    }
+}
+
+impl FromStr for StorageClass {
+    type Err = Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "default" | "" => Ok(StorageClass::Default),
+            "blob" => Ok(StorageClass::Blob),
+            _ => Err(Error::Schema {
+                message: format!("Unknown storage class: {}", s),
+                location: location!(),
+            }),
+        }
+    }
+}
+
 /// Lance Schema Field
 ///
 #[derive(Debug, Clone, PartialEq, DeepSizeOf)]
@@ -77,6 +114,7 @@ pub struct Field {
 
     /// Dictionary value array if this field is dictionary.
     pub dictionary: Option<Dictionary>,
+    pub storage_class: StorageClass,
 }
 
 impl Field {
@@ -103,6 +141,14 @@ impl Field {
     pub fn has_dictionary_types(&self) -> bool {
         matches!(self.data_type(), DataType::Dictionary(_, _))
             || self.children.iter().any(Self::has_dictionary_types)
+    }
+
+    pub fn is_default_storage(&self) -> bool {
+        self.storage_class == StorageClass::Default
+    }
+
+    pub fn storage_class(&self) -> StorageClass {
+        self.storage_class
     }
 
     fn explain_differences(
@@ -371,6 +417,7 @@ impl Field {
             nullable: self.nullable,
             children: vec![],
             dictionary: self.dictionary.clone(),
+            storage_class: self.storage_class.clone(),
         };
         if path_components.is_empty() {
             // Project stops here, copy all the remaining children.
@@ -562,6 +609,7 @@ impl Field {
                 nullable: self.nullable,
                 children,
                 dictionary: self.dictionary.clone(),
+                storage_class: self.storage_class.clone(),
             };
             return Ok(f);
         }
@@ -624,6 +672,7 @@ impl Field {
                 nullable: self.nullable,
                 children,
                 dictionary: self.dictionary.clone(),
+                storage_class: self.storage_class.clone(),
             })
         }
     }
@@ -761,6 +810,12 @@ impl TryFrom<&ArrowField> for Field {
             DataType::LargeList(item) => vec![Self::try_from(item.as_ref())?],
             _ => vec![],
         };
+        let storage_class = field
+            .metadata()
+            .get(LANCE_STORAGE_CLASS_SCHEMA_META_KEY)
+            .map(|s| StorageClass::from_str(s))
+            .unwrap_or(Ok(StorageClass::Default))?;
+
         Ok(Self {
             id: -1,
             parent_id: -1,
@@ -778,6 +833,7 @@ impl TryFrom<&ArrowField> for Field {
             nullable: field.is_nullable(),
             children,
             dictionary: None,
+            storage_class,
         })
     }
 }
@@ -793,6 +849,16 @@ impl TryFrom<ArrowField> for Field {
 impl From<&Field> for ArrowField {
     fn from(field: &Field) -> Self {
         let out = Self::new(&field.name, field.data_type(), field.nullable);
+        let mut metadata = field.metadata.clone();
+        match field.storage_class {
+            StorageClass::Default => {}
+            StorageClass::Blob => {
+                metadata.insert(
+                    LANCE_STORAGE_CLASS_SCHEMA_META_KEY.to_string(),
+                    "blob".to_string(),
+                );
+            }
+        }
         out.with_metadata(field.metadata.clone())
     }
 }

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -14,7 +14,7 @@ use deepsize::DeepSizeOf;
 use lance_arrow::*;
 use snafu::{location, Location};
 
-use super::field::{Field, SchemaCompareOptions};
+use super::field::{Field, SchemaCompareOptions, StorageClass};
 use crate::{Error, Result};
 
 /// Lance Schema.
@@ -139,6 +139,19 @@ impl Schema {
             } else {
                 Some(differences.join(", "))
             }
+        }
+    }
+
+    pub fn retain_storage_class(&self, storage_class: StorageClass) -> Self {
+        let fields = self
+            .fields
+            .iter()
+            .filter(|f| f.storage_class() == storage_class)
+            .cloned()
+            .collect();
+        Self {
+            fields,
+            metadata: self.metadata.clone(),
         }
     }
 

--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -160,6 +160,9 @@ impl ToSnafuLocation for std::panic::Location<'static> {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+pub type ArrowResult<T> = std::result::Result<T, ArrowError>;
+#[cfg(feature = "datafusion")]
+pub type DataFusionResult<T> = std::result::Result<T, datafusion_common::DataFusionError>;
 
 impl From<ArrowError> for Error {
     #[track_caller]

--- a/rust/lance-core/src/lib.rs
+++ b/rust/lance-core/src/lib.rs
@@ -9,7 +9,7 @@ pub mod error;
 pub mod traits;
 pub mod utils;
 
-pub use error::{Error, Result};
+pub use error::{ArrowResult, Error, Result};
 
 /// Column name for the meta row ID.
 pub const ROW_ID: &str = "_rowid";

--- a/rust/lance-file/src/datatypes.rs
+++ b/rust/lance-file/src/datatypes.rs
@@ -44,6 +44,7 @@ impl From<&pb::Field> for Field {
             nullable: field.nullable,
             children: vec![],
             dictionary: field.dictionary.as_ref().map(Dictionary::from),
+            storage_class: field.storage_class.parse().unwrap(),
         }
     }
 }
@@ -76,6 +77,7 @@ impl From<&Field> for pb::Field {
                 .map(|name| name.to_owned())
                 .unwrap_or_default(),
             r#type: 0,
+            storage_class: field.storage_class.to_string(),
         }
     }
 }

--- a/rust/lance-file/src/datatypes.rs
+++ b/rust/lance-file/src/datatypes.rs
@@ -15,6 +15,7 @@ use snafu::{location, Location};
 
 use crate::format::pb;
 
+#[allow(clippy::fallible_impl_from)]
 impl From<&pb::Field> for Field {
     fn from(field: &pb::Field) -> Self {
         let mut lance_metadata: HashMap<String, String> = field

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -518,10 +518,8 @@ impl FileReader {
             all_metadata_bytes.slice(column_metadata_start..column_metadata_end);
         let column_metadatas = Self::read_all_column_metadata(column_metadata_bytes, &footer)?;
 
-        let footer_start = file_len - FOOTER_LEN as u64;
-        let num_data_bytes = footer.column_meta_start;
-        let num_global_buffer_bytes = gbo_table.iter().map(|buf| buf.size).sum::<u64>()
-            + (footer_start - footer.global_buff_offsets_start);
+        let num_global_buffer_bytes = gbo_table.iter().map(|buf| buf.size).sum::<u64>();
+        let num_data_bytes = footer.column_meta_start - num_global_buffer_bytes;
         let num_column_metadata_bytes = footer.global_buff_offsets_start - footer.column_meta_start;
 
         let file_version = LanceFileVersion::try_from_major_minor(

--- a/rust/lance-table/src/io/manifest.rs
+++ b/rust/lance-table/src/io/manifest.rs
@@ -201,6 +201,7 @@ impl ManifestProvider for ManifestDescribing {
             schema.clone(),
             Arc::new(vec![]),
             DataStorageFormat::new(LanceFileVersion::Legacy),
+            /*blob_dataset_version= */ None,
         );
         let pos = do_write_manifest(object_writer, &mut manifest, None).await?;
         Ok(Some(pos))
@@ -247,7 +248,12 @@ mod test {
         let mut config = HashMap::new();
         config.insert("key".to_string(), "value".to_string());
 
-        let mut manifest = Manifest::new(schema, Arc::new(vec![]), DataStorageFormat::default());
+        let mut manifest = Manifest::new(
+            schema,
+            Arc::new(vec![]),
+            DataStorageFormat::default(),
+            /*blob_dataset_version= */ None,
+        );
         let pos = write_manifest(&mut writer, &mut manifest, None)
             .await
             .unwrap();

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -605,7 +605,7 @@ impl Dataset {
         let operation = match params.mode {
             WriteMode::Create | WriteMode::Overwrite => Operation::Overwrite {
                 // Use the full schema, not the written schema
-                schema: schema,
+                schema,
                 fragments: written_frags.default.0,
                 config_upsert_values: None,
             },

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -88,6 +88,7 @@ pub use write::{write_fragments, WriteMode, WriteParams};
 const INDICES_DIR: &str = "_indices";
 
 pub const DATA_DIR: &str = "data";
+pub const BLOB_DIR: &str = "_blobs";
 pub(crate) const DEFAULT_INDEX_CACHE_SIZE: usize = 256;
 pub(crate) const DEFAULT_METADATA_CACHE_SIZE: usize = 256;
 
@@ -591,11 +592,11 @@ impl Dataset {
         }
 
         let object_store = Arc::new(object_store);
-        let fragments = write_fragments_internal(
+        let written_frags = write_fragments_internal(
             dataset.as_ref(),
             object_store.clone(),
             &base,
-            &schema,
+            schema.clone(),
             stream,
             params.clone(),
         )
@@ -603,16 +604,29 @@ impl Dataset {
 
         let operation = match params.mode {
             WriteMode::Create | WriteMode::Overwrite => Operation::Overwrite {
-                schema,
-                fragments,
+                // Use the full schema, not the written schema
+                schema: schema,
+                fragments: written_frags.default.0,
                 config_upsert_values: None,
             },
-            WriteMode::Append => Operation::Append { fragments },
+            WriteMode::Append => Operation::Append {
+                fragments: written_frags.default.0,
+            },
         };
+
+        let blobs_op = written_frags.blob.map(|blob| match params.mode {
+            WriteMode::Create | WriteMode::Overwrite => Operation::Overwrite {
+                schema: blob.1,
+                fragments: blob.0,
+                config_upsert_values: None,
+            },
+            WriteMode::Append => Operation::Append { fragments: blob.0 },
+        });
 
         let transaction = Transaction::new(
             dataset.as_ref().map(|ds| ds.manifest.version).unwrap_or(0),
             operation,
+            blobs_op,
             None,
         );
 
@@ -705,18 +719,28 @@ impl Dataset {
             },
         )?;
 
-        let fragments = write_fragments_internal(
+        let written_frags = write_fragments_internal(
             Some(self),
             self.object_store.clone(),
             &self.base,
-            &schema,
+            schema,
             stream,
             params.clone(),
         )
         .await?;
 
-        let transaction =
-            Transaction::new(self.manifest.version, Operation::Append { fragments }, None);
+        let blobs_op = written_frags
+            .blob
+            .map(|blobs| Operation::Append { fragments: blobs.0 });
+
+        let transaction = Transaction::new(
+            self.manifest.version,
+            Operation::Append {
+                fragments: written_frags.default.0,
+            },
+            blobs_op,
+            None,
+        );
 
         let new_manifest = commit_transaction(
             self,
@@ -756,6 +780,31 @@ impl Dataset {
     /// Get the full manifest of the dataset version.
     pub fn manifest(&self) -> &Manifest {
         &self.manifest
+    }
+
+    // TODO: Cache this
+    pub async fn blobs_dataset(&self) -> Result<Option<Arc<Self>>> {
+        if let Some(blobs_version) = self.manifest.blob_dataset_version {
+            let blobs_path = self.base.child(BLOB_DIR);
+            let blob_manifest_location = self
+                .commit_handler
+                .resolve_version_location(&blobs_path, blobs_version, &self.object_store.inner)
+                .await?;
+            let manifest = read_manifest(&self.object_store, &blob_manifest_location.path).await?;
+            let blobs_dataset = Self::checkout_manifest(
+                self.object_store.clone(),
+                blobs_path,
+                format!("{}/{}", self.uri, BLOB_DIR),
+                manifest,
+                self.session.clone(),
+                self.commit_handler.clone(),
+                ManifestNamingScheme::V2,
+            )
+            .await?;
+            Ok(Some(Arc::new(blobs_dataset)))
+        } else {
+            Ok(None)
+        }
     }
 
     pub(crate) fn is_legacy_storage(&self) -> bool {
@@ -801,6 +850,7 @@ impl Dataset {
             Operation::Restore {
                 version: self.manifest.version,
             },
+            /*blobs_op=*/ None,
             None,
         );
 
@@ -860,6 +910,7 @@ impl Dataset {
     async fn do_commit(
         base_uri: &str,
         operation: Operation,
+        blobs_op: Option<Operation>,
         read_version: Option<u64>,
         store_params: Option<ObjectStoreParams>,
         commit_handler: Option<Arc<dyn CommitHandler>>,
@@ -929,7 +980,7 @@ impl Dataset {
             ManifestNamingScheme::V1
         };
 
-        let transaction = Transaction::new(read_version, operation, None);
+        let transaction = Transaction::new(read_version, operation, blobs_op, None);
 
         let manifest = if let Some(dataset) = &dataset {
             if detached {
@@ -1039,6 +1090,9 @@ impl Dataset {
         Self::do_commit(
             base_uri,
             operation,
+            // TODO: Allow blob operations to be specified? (breaking change?)
+            /*blobs_op=*/
+            None,
             read_version,
             store_params,
             commit_handler,
@@ -1069,6 +1123,9 @@ impl Dataset {
         Self::do_commit(
             base_uri,
             operation,
+            // TODO: Allow blob operations to be specified? (breaking change?)
+            /*blobs_op=*/
+            None,
             read_version,
             store_params,
             commit_handler,
@@ -1239,6 +1296,10 @@ impl Dataset {
                 deleted_fragment_ids,
                 predicate: predicate.to_string(),
             },
+            // No change is needed to the blobs dataset.  The blobs are implicitly deleted since the
+            // rows that reference them are deleted.
+            /*blobs_op=*/
+            None,
             None,
         );
 
@@ -1340,8 +1401,14 @@ impl Dataset {
         self.manifest.fragments.len()
     }
 
+    /// Get the schema of the dataset
     pub fn schema(&self) -> &Schema {
         &self.manifest.schema
+    }
+
+    /// Similar to [Self::schema], but only returns fields with the default storage class
+    pub fn local_schema(&self) -> &Schema {
+        &self.manifest.local_schema
     }
 
     /// Get fragments.
@@ -1577,6 +1644,9 @@ impl Dataset {
                 fragments: updated_fragments,
                 schema: new_schema,
             },
+            // It is not possible to add blob columns using merge
+            /*blobs_op=*/
+            None,
             None,
         );
 
@@ -1628,6 +1698,7 @@ impl Dataset {
                 upsert_values: Some(HashMap::from_iter(upsert_values)),
                 delete_keys: None,
             },
+            /*blobs_op=*/ None,
             None,
         );
 
@@ -1655,6 +1726,7 @@ impl Dataset {
                 upsert_values: None,
                 delete_keys: Some(Vec::from_iter(delete_keys.iter().map(ToString::to_string))),
             },
+            /*blob_op=*/ None,
             None,
         );
 

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -6,11 +6,23 @@ use std::{future::Future, ops::DerefMut, sync::Arc};
 use arrow::array::AsArray;
 use arrow::datatypes::UInt64Type;
 use arrow_schema::DataType;
-use lance_core::{datatypes::BLOB_META_KEY, utils::address::RowAddress, Error, Result};
+use datafusion::execution::SendableRecordBatchStream;
+use futures::StreamExt;
+use lance_core::{
+    datatypes::{Schema, StorageClass, BLOB_META_KEY},
+    error::CloneableResult,
+    utils::{
+        address::RowAddress,
+        futures::{Capacity, SharedStreamExt},
+    },
+    Error, Result,
+};
 use lance_io::traits::Reader;
 use object_store::path::Path;
 use snafu::{location, Location};
 use tokio::sync::Mutex;
+
+use crate::io::exec::{ShareableRecordBatchStream, ShareableRecordBatchStreamAdapter};
 
 use super::Dataset;
 
@@ -216,6 +228,62 @@ pub(super) async fn take_blobs(
             )
         })
         .collect())
+}
+
+pub trait BlobStreamExt: Sized {
+    /// Splits a stream into a regular portion (the first stream)
+    /// and a blob portion (the second stream)
+    ///
+    /// The first stream contains all fields with the default storage class and
+    /// may be identical to self.
+    ///
+    /// The second stream may be None (if there are no fields with the blob storage class)
+    /// or it contains all fields with the blob storage class.
+    fn extract_blob_stream(self, schema: &Schema) -> (Self, Option<Self>);
+}
+
+impl BlobStreamExt for SendableRecordBatchStream {
+    fn extract_blob_stream(self, schema: &Schema) -> (Self, Option<Self>) {
+        let mut indices_with_blob = Vec::with_capacity(schema.fields.len());
+        let mut indices_without_blob = Vec::with_capacity(schema.fields.len());
+        for (idx, field) in schema.fields.iter().enumerate() {
+            if field.storage_class() == StorageClass::Blob {
+                indices_with_blob.push(idx);
+            } else {
+                indices_without_blob.push(idx);
+            }
+        }
+        if indices_with_blob.is_empty() {
+            (self, None)
+        } else {
+            let left_schema = Arc::new(self.schema().project(&indices_without_blob).unwrap());
+            let right_schema = Arc::new(self.schema().project(&indices_with_blob).unwrap());
+
+            let (left, right) = ShareableRecordBatchStream(self)
+                .boxed()
+                // If we are working with blobs then we are probably working with rather large batches
+                // We don't want to read too far ahead.
+                .share(Capacity::Bounded(1));
+
+            let left = left.map(move |batch| match batch {
+                CloneableResult(Ok(batch)) => {
+                    CloneableResult(Ok(batch.project(&indices_without_blob).unwrap()))
+                }
+                CloneableResult(Err(err)) => CloneableResult(Err(err)),
+            });
+
+            let right = right.map(move |batch| match batch {
+                CloneableResult(Ok(batch)) => {
+                    CloneableResult(Ok(batch.project(&indices_with_blob).unwrap()))
+                }
+                CloneableResult(Err(err)) => CloneableResult(Err(err)),
+            });
+
+            let left = ShareableRecordBatchStreamAdapter::new(left_schema, left);
+            let right = ShareableRecordBatchStreamAdapter::new(right_schema, right);
+            (Box::pin(left), Some(Box::pin(right)))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -351,7 +351,7 @@ pub async fn write_fragments_internal(
     let blob_write_params = WriteParams {
         store_params: params.store_params.clone(),
         commit_handler: params.commit_handler.clone(),
-        data_storage_version: params.data_storage_version.clone(),
+        data_storage_version: params.data_storage_version,
         enable_move_stable_row_ids: true,
         // This shouldn't really matter since all commits are detached
         enable_v2_manifest_paths: true,
@@ -372,7 +372,7 @@ pub async fn write_fragments_internal(
     );
 
     let (default, blob) = if let Some(blob_data) = blob_data {
-        let blob_schema = dbg!(schema.retain_storage_class(StorageClass::Blob));
+        let blob_schema = schema.retain_storage_class(StorageClass::Blob);
         let blobs_path = base_dir.child("_blobs");
         let blob_fut = do_write_fragments(
             object_store,

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -315,6 +315,7 @@ impl DatasetIndexExt for Dataset {
                 new_indices: vec![new_idx],
                 removed_indices: vec![],
             },
+            /*blobs_op= */ None,
             None,
         );
 
@@ -385,6 +386,7 @@ impl DatasetIndexExt for Dataset {
                 new_indices: vec![new_idx],
                 removed_indices: vec![],
             },
+            /*blobs_op= */ None,
             None,
         );
 
@@ -481,6 +483,7 @@ impl DatasetIndexExt for Dataset {
                 new_indices,
                 removed_indices,
             },
+            /*blobs_op= */ None,
             None,
         );
 

--- a/rust/lance/src/io/exec.rs
+++ b/rust/lance/src/io/exec.rs
@@ -28,3 +28,4 @@ pub use rowids::AddRowAddrExec;
 pub use scan::{LanceScanConfig, LanceScanExec};
 pub use take::TakeExec;
 pub use utils::PreFilterSource;
+pub(crate) use utils::{ShareableRecordBatchStream, ShareableRecordBatchStreamAdapter};


### PR DESCRIPTION
I'm open to terms other than "storage class" as well.  I also think we might want to use something other than "blob" as it can be easy to confuse the concepts of "blob encoding" (e.g. low page overhead, file-like API) and "blob storage class" (fewer rows per file).  In fact, the thresholds can even be different with the blob encoding threshold being 8-16MB but the blob storage class threshold being closer to 128KB

Closes #3029 