### PR TITLE
feat: bitpack with miniblock

### DIFF
--- a/protos/encodings.proto
+++ b/protos/encodings.proto
@@ -211,6 +211,14 @@ message BitpackedForNonNeg {
   Buffer buffer = 3;
 }
 
+message Bitpack2 {
+  // the number of bits of the uncompressed value. e.g. for a u32, this will be 32
+  uint64 uncompressed_bits_per_value = 2;
+
+  // The items in the list
+  Buffer buffer = 3;
+}
+
 // An array encoding for shredded structs that will never be null
 //
 // There is no actual data in this column.
@@ -263,6 +271,7 @@ message ArrayEncoding {
         FixedSizeBinary fixed_size_binary = 11;
         BitpackedForNonNeg bitpacked_for_non_neg = 12;
         Constant constant = 13;
+        Bitpack2 bitpack2 = 14;
     }
 }
 

--- a/python/play.py
+++ b/python/play.py
@@ -1,0 +1,96 @@
+import pyarrow as pa
+import pyarrow.parquet as pq
+import datetime
+import os
+import numpy as np
+from lance.file import LanceFileReader, LanceFileWriter
+
+def format_throughput(value):
+    return f"{value:.2f} GiB/s"
+
+parquet_file_path = "/home/admin/tmp/int64_column.parquet"
+lance_file_path = "/home/admin/tmp/int64_column.lance"
+
+# Generate 1024 * 1024 * 512 random values modulo 1024 using NumPy
+values = np.random.randint(0, 1024, size=1024 * 1024 * 64 + 1, dtype=np.int64)
+#values = [8] * 1024
+int64_array = pa.array(values, type=pa.int64())
+table = pa.Table.from_arrays([int64_array], names=['int64_column'])
+
+values = np.random.randint(0, 1024, size=1024 * 1024 * 4 + 1, dtype=np.int32)
+#values = [8] * 1024
+int32_array = pa.array(values, type=pa.int32())
+table = pa.Table.from_arrays([int32_array], names=['int_column'])
+
+start = datetime.datetime.now()
+# Write the table to a Parquet file 
+pq.write_table(table, parquet_file_path)
+end = datetime.datetime.now()
+elapsed_parquet = (end - start).total_seconds()
+print(f"Parquet write time: {elapsed_parquet:.2f}s")
+
+start = datetime.datetime.now()
+# Write the table to a Lance file
+with LanceFileWriter(lance_file_path, version="2.1") as writer:
+    writer.write_batch(table)
+end = datetime.datetime.now()
+elapsed_lance = (end - start).total_seconds()
+print(f"Lance write time: {elapsed_lance:.2f}s")
+
+# Flush file from kernel cache
+os.system('sync; echo 3 | sudo tee /proc/sys/vm/drop_caches')
+
+# Measure read time for Parquet file with batch size
+batch_size = 32 * 1024
+start = datetime.datetime.now()
+parquet_file = pq.ParquetFile(parquet_file_path)
+batches = parquet_file.iter_batches(batch_size=batch_size)
+tab_parquet = pa.Table.from_batches(batches)
+end = datetime.datetime.now()
+elapsed_parquet = (end - start).total_seconds()
+
+# Flush file from kernel cache again before reading Lance file
+os.system('sync; echo 3 | sudo tee /proc/sys/vm/drop_caches')
+
+# Measure read time for Lance file with batch size
+start = datetime.datetime.now()
+tab_lance = LanceFileReader(lance_file_path).read_all(batch_size=batch_size).to_table()
+end = datetime.datetime.now()
+elapsed_lance = (end - start).total_seconds()
+
+num_rows = tab_parquet['int_column'].length()
+
+print(f"Number of rows: {num_rows}")
+print(f"Parquet read time: {elapsed_parquet:.2f}s")
+print(f"Lance read time: {elapsed_lance:.2f}s")
+
+# Compute total memory size
+parquet_memory_size = tab_parquet.get_total_buffer_size()
+lance_memory_size = tab_lance.get_total_buffer_size()
+
+# Convert memory size to GiB
+parquet_memory_size_gib = parquet_memory_size / (1024 * 1024 * 1024)
+lance_memory_size_gib = lance_memory_size / (1024 * 1024 * 1024)
+
+# Compute read throughput in GiB/sec
+throughput_parquet_gib = parquet_memory_size_gib / elapsed_parquet
+throughput_lance_gib = lance_memory_size_gib / elapsed_lance
+
+# Format throughput values
+formatted_throughput_parquet_gib = format_throughput(throughput_parquet_gib)
+formatted_throughput_lance_gib = format_throughput(throughput_lance_gib)
+
+print(f"Parquet read throughput: {formatted_throughput_parquet_gib}")
+print(f"Lance read throughput: {formatted_throughput_lance_gib}")
+
+# Check file sizes
+lance_file_size = os.path.getsize(lance_file_path)
+lance_file_size_mib = lance_file_size // 1048576
+parquet_file_size = os.path.getsize(parquet_file_path)
+parquet_file_size_mib = parquet_file_size // 1048576
+
+print(f"Parquet file size: {parquet_file_size} bytes ({parquet_file_size_mib:,} MiB)")
+print(f"Lance file size: {lance_file_size} bytes ({lance_file_size_mib:,} MiB)")
+
+# Assert that the tables are equal
+assert tab_parquet == tab_lance

--- a/rust/lance-encoding/Cargo.toml
+++ b/rust/lance-encoding/Cargo.toml
@@ -42,6 +42,7 @@ bytemuck = "=1.18.0"
 arrayref = "0.3.7"
 paste = "1.0.15"
 seq-macro = "0.3.5"
+byteorder.workspace = true
 
 [dev-dependencies]
 lance-testing.workspace = true

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -246,6 +246,7 @@ use crate::encodings::logical::primitive::{
 use crate::encodings::logical::r#struct::{
     SimpleStructDecoder, SimpleStructScheduler, StructuralStructDecoder, StructuralStructScheduler,
 };
+use crate::encodings::physical::bitpack_fastlanes::BitpackMiniBlockDecompressor;
 use crate::encodings::physical::value::{ConstantDecompressor, ValueDecompressor};
 use crate::encodings::physical::{ColumnBuffers, FileBuffers};
 use crate::format::pb::{self, column_encoding};
@@ -489,6 +490,9 @@ impl DecompressorStrategy for CoreDecompressorStrategy {
         match description.array_encoding.as_ref().unwrap() {
             pb::array_encoding::ArrayEncoding::Flat(flat) => {
                 Ok(Box::new(ValueDecompressor::new(flat)))
+            }
+            pb::array_encoding::ArrayEncoding::Bitpack2(description) => {
+                Ok(Box::new(BitpackMiniBlockDecompressor::new(description)))
             }
             _ => todo!(),
         }

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -22,8 +22,10 @@ use crate::encodings::logical::blob::BlobFieldEncoder;
 use crate::encodings::logical::primitive::PrimitiveStructuralEncoder;
 use crate::encodings::logical::r#struct::StructFieldEncoder;
 use crate::encodings::logical::r#struct::StructStructuralEncoder;
-use crate::encodings::physical::bitpack_fastlanes::compute_compressed_bit_width_for_non_neg;
 use crate::encodings::physical::bitpack_fastlanes::BitpackedForNonNegArrayEncoder;
+use crate::encodings::physical::bitpack_fastlanes::{
+    compute_compressed_bit_width_for_non_neg, BitpackMiniBlockEncoder,
+};
 use crate::encodings::physical::block_compress::{CompressionConfig, CompressionScheme};
 use crate::encodings::physical::dictionary::AlreadyDictionaryEncoder;
 use crate::encodings::physical::fsst::FsstArrayEncoder;
@@ -773,9 +775,14 @@ impl CompressionStrategy for CoreArrayEncodingStrategy {
     fn create_miniblock_compressor(
         &self,
         field: &Field,
-        _data: &DataBlock,
+        data: &DataBlock,
     ) -> Result<Box<dyn MiniBlockCompressor>> {
         assert!(field.data_type().byte_width() > 0);
+        if let DataBlock::FixedWidth(ref fixed_width_data) = data {
+            if fixed_width_data.bits_per_value <= 64 {
+                return Ok(Box::new(BitpackMiniBlockEncoder::default()));
+            }
+        }
         Ok(Box::new(ValueEncoder::default()))
     }
 

--- a/rust/lance-encoding/src/encodings/physical.rs
+++ b/rust/lance-encoding/src/encodings/physical.rs
@@ -283,6 +283,7 @@ pub fn decoder_from_array_encoding(
         pb::array_encoding::ArrayEncoding::Struct(_) => unreachable!(),
         // 2.1 only
         pb::array_encoding::ArrayEncoding::Constant(_) => unreachable!(),
+        pb::array_encoding::ArrayEncoding::Bitpack2(_) => unreachable!(),
     }
 }
 

--- a/rust/lance-encoding/src/format.rs
+++ b/rust/lance-encoding/src/format.rs
@@ -19,7 +19,7 @@ use pb::{
     buffer::BufferType,
     nullable::{AllNull, NoNull, Nullability, SomeNull},
     page_layout::Layout,
-    AllNullLayout, ArrayEncoding, Binary, Bitpacked, BitpackedForNonNeg, Dictionary,
+    AllNullLayout, ArrayEncoding, Binary, Bitpack2, Bitpacked, BitpackedForNonNeg, Dictionary,
     FixedSizeBinary, FixedSizeList, Flat, Fsst, MiniBlockLayout, Nullable, PackedStruct,
     PageLayout,
 };
@@ -117,6 +117,17 @@ impl ProtobufUtils {
         ArrayEncoding {
             array_encoding: Some(ArrayEncodingEnum::BitpackedForNonNeg(BitpackedForNonNeg {
                 compressed_bits_per_value,
+                buffer: Some(pb::Buffer {
+                    buffer_index,
+                    buffer_type: BufferType::Page as i32,
+                }),
+                uncompressed_bits_per_value,
+            })),
+        }
+    }
+    pub fn bitpack2(uncompressed_bits_per_value: u64, buffer_index: u32) -> ArrayEncoding {
+        ArrayEncoding {
+            array_encoding: Some(ArrayEncodingEnum::Bitpack2(Bitpack2 {
                 buffer: Some(pb::Buffer {
                     buffer_index,
                     buffer_type: BufferType::Page as i32,

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -561,7 +561,7 @@ impl IndexWorker {
     }
 }
 
-pub(crate) struct PostingReader {
+pub struct PostingReader {
     tmpdir: Option<TempDir>,
     existing_tokens: HashMap<String, u32>,
     inverted_list_reader: Option<Arc<InvertedListReader>>,
@@ -705,7 +705,7 @@ impl Ord for OrderedDoc {
     }
 }
 
-pub(crate) fn inverted_list_schema(with_position: bool) -> SchemaRef {
+pub fn inverted_list_schema(with_position: bool) -> SchemaRef {
     let mut fields = vec![
         arrow_schema::Field::new(ROW_ID, arrow_schema::DataType::UInt64, false),
         arrow_schema::Field::new(FREQUENCY_COL, arrow_schema::DataType::Float32, false),

--- a/rust/lance-index/src/scalar/inverted/tokenizer.rs
+++ b/rust/lance-index/src/scalar/inverted/tokenizer.rs
@@ -46,7 +46,7 @@ impl Default for TokenizerConfig {
 
 impl TokenizerConfig {
     pub fn new(base_tokenizer: String, language: tantivy::tokenizer::Language) -> Self {
-        TokenizerConfig {
+        Self {
             base_tokenizer,
             language,
             max_token_length: Some(40),


### PR DESCRIPTION
I found that the current implementation to get the `bit_width` of every 1024 is very slow and hurts the write speed significantly, more investigation needed.