### PR TITLE
feat: add initial scanner statistics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.4.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -692,8 +692,7 @@ if TYPE_CHECKING:
         use_legacy_format: Optional[bool] = None,
         storage_options: Optional[Dict[str, str]] = None,
         enable_move_stable_row_ids: bool = False,
-    ) -> Transaction:
-        ...
+    ) -> Transaction: ...
 
     @overload
     def write_fragments(
@@ -711,8 +710,7 @@ if TYPE_CHECKING:
         use_legacy_format: Optional[bool] = None,
         storage_options: Optional[Dict[str, str]] = None,
         enable_move_stable_row_ids: bool = False,
-    ) -> List[FragmentMetadata]:
-        ...
+    ) -> List[FragmentMetadata]: ...
 
 
 def write_fragments(

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -692,7 +692,8 @@ if TYPE_CHECKING:
         use_legacy_format: Optional[bool] = None,
         storage_options: Optional[Dict[str, str]] = None,
         enable_move_stable_row_ids: bool = False,
-    ) -> Transaction: ...
+    ) -> Transaction:
+        ...
 
     @overload
     def write_fragments(
@@ -710,7 +711,8 @@ if TYPE_CHECKING:
         use_legacy_format: Optional[bool] = None,
         storage_options: Optional[Dict[str, str]] = None,
         enable_move_stable_row_ids: bool = False,
-    ) -> List[FragmentMetadata]: ...
+    ) -> List[FragmentMetadata]:
+        ...
 
 
 def write_fragments(

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -452,3 +452,12 @@ def bfloat16_array(values: List[str | None]) -> BFloat16Array: ...
 
 __version__: str
 language_model_home: Callable[[], str]
+
+class LanceScanStats:
+    start: int
+    end: int
+    wall_clock_duration: float
+    wall_clock_throughput: float
+    output_rows: int
+    estimated_output_bytes: int
+    plan: Optional[str]

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -79,7 +79,7 @@ use snafu::{location, Location};
 
 use crate::error::PythonErrorExt;
 use crate::file::object_store_from_uri_or_path;
-use crate::fragment::{FileFragment, FragmentMetadata};
+use crate::fragment::FileFragment;
 use crate::scanner::LanceScanStats;
 use crate::schema::LanceSchema;
 use crate::session::Session;
@@ -487,7 +487,7 @@ impl Dataset {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature=(columns=None, columns_with_transform=None, filter=None, prefilter=None, limit=None, offset=None, nearest=None, batch_size=None, io_buffer_size=None, batch_readahead=None, fragment_readahead=None, scan_in_order=None, fragments=None, with_row_id=None, with_row_address=None, use_stats=None, substrait_filter=None, fast_search=None, full_text_query=None, late_materialization=None, use_scalar_index=None))]
+    #[pyo3(signature=(columns=None, columns_with_transform=None, filter=None, prefilter=None, limit=None, offset=None, nearest=None, batch_size=None, io_buffer_size=None, batch_readahead=None, fragment_readahead=None, scan_in_order=None, fragments=None, with_row_id=None, with_row_address=None, use_stats=None, substrait_filter=None, fast_search=None, full_text_query=None, late_materialization=None, use_scalar_index=None, stats_handler=None))]
     fn scanner(
         self_: PyRef<'_, Self>,
         columns: Option<Vec<String>>,
@@ -606,7 +606,7 @@ impl Dataset {
                     let wrapped_stats = LanceScanStats::new(stats);
                     let stats_handler = stats_handler.clone();
                     Python::with_gil(move |py| {
-                        let args = PyTuple::new(py, vec![wrapped_stats.into_py(py)]);
+                        let args = PyTuple::new_bound(py, vec![wrapped_stats.into_py(py)]);
                         stats_handler.call1(py, args)
                     })
                     .map_err(|err| lance_core::Error::Wrapped {

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -604,8 +604,7 @@ impl Dataset {
                 let stats_handler = stats_handler.unbind();
                 let stats_handler = ScanStatisticsHandler::Custom(Arc::new(move |stats| {
                     let wrapped_stats = LanceScanStats::new(stats);
-                    let stats_handler = stats_handler.clone();
-                    Python::with_gil(move |py| {
+                    Python::with_gil(|py| {
                         let args = PyTuple::new_bound(py, vec![wrapped_stats.into_py(py)]);
                         stats_handler.call1(py, args)
                     })

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -44,6 +44,7 @@ use futures::StreamExt;
 use lance_index::DatasetIndexExt;
 use pyo3::exceptions::{PyIOError, PyValueError};
 use pyo3::prelude::*;
+use scanner::LanceScanStats;
 use session::Session;
 
 #[macro_use]
@@ -122,6 +123,7 @@ fn lance(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<LanceColumnMetadata>()?;
     m.add_class::<LancePageMetadata>()?;
     m.add_class::<LanceBufferDescriptor>()?;
+    m.add_class::<LanceScanStats>()?;
     m.add_class::<BFloat16>()?;
     m.add_class::<CleanupStats>()?;
     m.add_class::<KMeans>()?;

--- a/python/src/scanner.rs
+++ b/python/src/scanner.rs
@@ -19,6 +19,8 @@ use std::sync::Arc;
 
 use arrow::pyarrow::*;
 use arrow_array::RecordBatchReader;
+use lance::dataset::scanner::stats::ScannerStats;
+use lance::dataset::scanner::stats::ThroughputUnit;
 use pyo3::prelude::*;
 use pyo3::pyclass;
 
@@ -27,6 +29,129 @@ use pyo3::exceptions::PyValueError;
 
 use crate::reader::LanceReader;
 use crate::RT;
+
+#[pyclass]
+pub struct LanceScanStats {
+    inner: ScannerStats,
+}
+
+impl LanceScanStats {
+    pub fn new(inner: ScannerStats) -> Self {
+        Self { inner }
+    }
+}
+
+#[pymethods]
+impl LanceScanStats {
+    /// The start of the scan
+    ///
+    /// This is when the stream is constructed, not when it is first consumed.
+    ///
+    /// Returned as milliseconds since the UNIX epoch
+    #[getter]
+    fn start(&self) -> PyResult<u64> {
+        Ok(self
+            .inner
+            .start
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+            .try_into()
+            .unwrap())
+    }
+
+    /// The end of the scan
+    ///
+    /// This is when the last batch is provided to the consumer which may be
+    /// well after the I/O has finished (if there is a slow consumer or expensive
+    /// decode).
+    ///
+    /// Returned as milliseconds since the UNIX epoch
+    #[getter]
+    fn end(&self) -> PyResult<u64> {
+        Ok(self
+            .inner
+            .end
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+            .try_into()
+            .unwrap())
+    }
+
+    /// The wall clock duration of the scan
+    ///
+    /// NOTE: This is not the time that the scanner was actually doing work, and not the amount
+    /// of time spent in I/O but simply the time from when the scanner was created to when the
+    /// last batch was provided to the consumer.
+    ///
+    /// As an example, if a consumer is slow to consume the data (e.g. they are writing the data
+    /// back out to disk or doing expensive processing) then this will be much larger than the
+    /// actual time to read the data.
+    ///
+    /// Returned as floating point seconds
+    #[getter]
+    fn wall_clock_duration(&self) -> PyResult<f64> {
+        Ok(self.inner.wall_clock_duration.as_secs_f64())
+    }
+
+    /// This is an estimate of the "wall clock throughput" in GiB/s
+    ///
+    /// Note: this is based both on :ref:`wall_clock_duration` (see note on that method) and
+    /// :ref:`estimated_output_bytes` (see note on that field).
+    ///
+    /// It is not safe, for example, to assume that this is the rate at which data was pulled down
+    /// from storage.
+    ///
+    /// Returned as floating point GiB/s
+    #[getter]
+    fn wall_clock_throughput(&self) -> PyResult<f64> {
+        Ok(self.inner.wall_clock_throughput().gigabytes_per_second())
+    }
+
+    /// The number of rows output by the scanner
+    #[getter]
+    fn output_rows(&self) -> PyResult<u64> {
+        Ok(self.inner.output_rows)
+    }
+
+    /// The estimated size of the output in bytes
+    ///
+    /// "Estimated" is used here because there may be some instances where multiple
+    /// batches will share the same underlying buffer (e.g. a dictionary) and so the
+    /// actual data size may be less than the reported size.
+    ///
+    /// Also, this is very different than "input bytes" which may be much smaller since
+    /// the input may be compressed or encoded.
+    ///
+    /// This will always be greater than or equal to the actual size.
+    #[getter]
+    fn estimated_output_bytes(&self) -> PyResult<u64> {
+        Ok(self.inner.estimated_output_bytes)
+    }
+
+    /// The plan that was used to generate the scan
+    ///
+    /// There are some instances where we generate a scan without a plan and some handlers
+    /// do not need the plan and so we may not gather it.  In these cases this will be None.
+    #[getter]
+    fn plan(&self) -> PyResult<Option<String>> {
+        Ok(self.inner.plan.clone())
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "LanceScanStats(start={}, end={}, wall_clock_duration={}, wall_clock_throughput={}, output_rows={}, estimated_output_bytes={}, plan={:?})",
+            self.start().unwrap(),
+            self.end().unwrap(),
+            self.wall_clock_duration().unwrap(),
+            self.wall_clock_throughput().unwrap(),
+            self.output_rows().unwrap(),
+            self.estimated_output_bytes().unwrap(),
+            self.plan().unwrap()
+        )
+    }
+}
 
 /// This will be wrapped by a python class to provide
 /// additional functionality

--- a/rust/lance/src/dataset/scanner/stats.rs
+++ b/rust/lance/src/dataset/scanner/stats.rs
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{
+    str::FromStr,
+    sync::Arc,
+    time::{Duration, Instant, SystemTime},
+};
+
+use arrow_array::RecordBatch;
+use lance_core::{Error, Result};
+use snafu::{location, Location};
+
+pub struct ScannerStats {
+    /// The start of the scan
+    ///
+    /// This is when the stream is constructed, not when it is first consumed.
+    pub start: SystemTime,
+    /// The end of the scan
+    ///
+    /// This is when the last batch is provided to the consumer which may be
+    /// well after the I/O has finished (if there is a slow consumer or expensive
+    /// decode).
+    pub end: SystemTime,
+    /// The wall clock duration of the scan
+    ///
+    /// NOTE: This is not the time that the scanner was actually doing work, and not the amount
+    /// of time spent in I/O but simply the time from when the scanner was created to when the
+    /// last batch was provided to the consumer.
+    ///
+    /// As an example, if a consumer is slow to consume the data (e.g. they are writing the data
+    /// back out to disk or doing expensive processing) then this will be much larger than the
+    /// actual time to read the data.
+    pub wall_clock_duration: Duration,
+    /// The number of rows output by the scanner
+    pub output_rows: u64,
+    /// The estimated size of the output in bytes
+    ///
+    /// "Estimated" is used here because there may be some instances where multiple
+    /// batches will share the same underlying buffer (e.g. a dictionary) and so the
+    /// actual data size may be less than the reported size.
+    ///
+    /// Also, this is very different than "input bytes" which may be much smaller since
+    /// the input may be compressed or encoded.
+    ///
+    /// This will always be greater than or equal to the actual size.
+    pub estimated_output_bytes: u64,
+    /// The plan that was used to generate the scan
+    ///
+    /// There are some instances where we generate a scan without a plan and some handlers
+    /// do not need the plan and so we may not gather it.  In these cases this will be None.
+    pub plan: Option<String>,
+}
+
+impl ScannerStats {
+    /// This is an estimate of the "wall clock throughput" in GiB/s
+    ///
+    /// Note: this is based both on [`Self::wall_clock_duration`] (see note on that method) and
+    /// [`Self::estimated_output_bytes`] (see note on that field).
+    ///
+    /// It is not safe, for example, to assume that this is the rate at which data was pulled down
+    /// from storage.
+    pub fn wall_clock_throughput(&self) -> impl ThroughputUnit {
+        let duration_secs = self.wall_clock_duration.as_secs_f64();
+        if duration_secs == 0.0 {
+            return 0.0;
+        }
+        self.estimated_output_bytes as f64 / duration_secs
+    }
+}
+
+pub trait ThroughputUnit {
+    fn gigabytes_per_second(&self) -> f64;
+}
+
+/// Here we assume that the throughput is in B/s
+impl ThroughputUnit for f64 {
+    fn gigabytes_per_second(&self) -> f64 {
+        self / (1024.0 * 1024.0 * 1024.0)
+    }
+}
+
+pub(super) struct ScannerStatsCollector {
+    start: Instant,
+    start_time: SystemTime,
+    output_rows: u64,
+    estimated_output_bytes: u64,
+    plan: Option<String>,
+    handler: ScanStatisticsHandler,
+}
+
+impl ScannerStatsCollector {
+    pub fn new(handler: ScanStatisticsHandler, plan: Option<String>) -> Self {
+        let start = Instant::now();
+        let start_time = SystemTime::now();
+        Self {
+            start,
+            start_time,
+            output_rows: 0,
+            estimated_output_bytes: 0,
+            plan,
+            handler,
+        }
+    }
+
+    pub fn observe_batch(&mut self, batch: &RecordBatch) {
+        self.output_rows += batch.num_rows() as u64;
+        self.estimated_output_bytes += batch
+            .columns()
+            .iter()
+            .map(|c| c.get_buffer_memory_size() as u64)
+            .sum::<u64>();
+    }
+
+    pub fn finish(self) -> Result<()> {
+        let end = Instant::now();
+        let end_time = SystemTime::now();
+        let stats = ScannerStats {
+            start: self.start_time,
+            end: end_time,
+            wall_clock_duration: (end - self.start),
+            output_rows: self.output_rows,
+            estimated_output_bytes: self.estimated_output_bytes,
+            plan: self.plan,
+        };
+        match self.handler {
+            ScanStatisticsHandler::DoNotReport => Ok(()),
+            ScanStatisticsHandler::LogBrief => {
+                log::debug!(
+                    "Scan wall time {}s ({} GiB/s), output {} rows, estimated output size {} bytes",
+                    stats.wall_clock_throughput().gigabytes_per_second(),
+                    stats.wall_clock_duration.as_secs_f64(),
+                    stats.output_rows,
+                    stats.estimated_output_bytes
+                );
+                Ok(())
+            }
+            ScanStatisticsHandler::LogFull => {
+                log::debug!(
+                    "Scan wall time {}s ({} GiB/s), output {} rows, estimated output size {} bytes, plan: {}",
+                    stats.wall_clock_duration.as_secs_f64(),
+                    stats.wall_clock_throughput().gigabytes_per_second(),
+                    stats.output_rows,
+                    stats.estimated_output_bytes,
+                    stats.plan.as_deref().unwrap_or("N/A")
+                );
+                Ok(())
+            }
+            ScanStatisticsHandler::Custom(handler) => handler(stats),
+        }
+    }
+}
+
+/// Describes how statistics should be handled
+#[derive(Clone)]
+pub enum ScanStatisticsHandler {
+    /// Do not report (and possibly even do not gather) any statistics
+    DoNotReport,
+    /// Log the scan statistics at the end of the scan
+    LogBrief,
+    /// Log the scan statistics (and the scan plan) at the end of the scan
+    LogFull,
+    /// Call a custom function with the statistics at the end of the scan
+    Custom(Arc<dyn Fn(ScannerStats) -> Result<()> + Send + Sync>),
+}
+
+impl std::fmt::Debug for ScanStatisticsHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DoNotReport => write!(f, "DoNotReport"),
+            Self::LogBrief => write!(f, "LogBrief"),
+            Self::LogFull => write!(f, "LogFull"),
+            Self::Custom(_) => write!(f, "Custom"),
+        }
+    }
+}
+
+impl FromStr for ScanStatisticsHandler {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "brief" => Ok(Self::LogBrief),
+            "full" => Ok(Self::LogFull),
+            _ => Err(Error::InvalidInput {
+                source: format!("invalid value for ScanStatisticsHandler: {}", s).into(),
+                location: location!(),
+            }),
+        }
+    }
+}
+
+lazy_static::lazy_static! {
+    pub(crate) static ref DEFAULT_STATS_HANDLER: ScanStatisticsHandler = match std::env::var("LANCE_SCAN_STATISTICS") {
+        Ok(val) => match val.as_str() {
+            "brief" => ScanStatisticsHandler::LogBrief,
+            "full" => ScanStatisticsHandler::LogFull,
+            _ => ScanStatisticsHandler::DoNotReport,
+        },
+        Err(_) => ScanStatisticsHandler::DoNotReport,
+    };
+}

--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -421,10 +421,11 @@ pub fn take_scan(
         })
         .buffered(batch_readahead);
 
-    DatasetRecordBatchStream::new(Box::pin(RecordBatchStreamAdapter::new(
-        arrow_schema,
-        batch_stream,
-    )))
+    DatasetRecordBatchStream::new(
+        Box::pin(RecordBatchStreamAdapter::new(arrow_schema, batch_stream)),
+        /*stats_handler=*/ None, // TODO: might want to allow custom handlers
+        /*plan=*/ None,
+    )
 }
 
 struct RowAddressStats {


### PR DESCRIPTION
This just captures some very basic statistics.  I'd like to eventually add bytes read, decode time, and time waiting on I/O to the mix.  However, those will need to wait for https://github.com/lancedb/lance/issues/2977 because those stats will go in the scheduler and we want one scan scheduler to be used in the entire plan first.