### PR TITLE
chore: remove cardinality statistic gathering for fixed width data block

### DIFF
--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -167,12 +167,11 @@ impl FixedWidthDataBlock {
         info.insert(Stat::BitWidth, max_bit_widths);
     }
 
-
     fn max_bit_widths(&mut self) -> Arc<dyn Array> {
         assert!(self.num_values > 0);
-    
+
         const CHUNK_SIZE: usize = 1024;
-    
+
         fn calculate_max_bit_width<T: PrimInt>(slice: &[T], bits_per_value: u64) -> Vec<u64> {
             slice
                 .chunks(CHUNK_SIZE)
@@ -182,27 +181,39 @@ impl FixedWidthDataBlock {
                 })
                 .collect()
         }
-    
+
         match self.bits_per_value {
             8 => {
                 let u8_slice = self.data.borrow_to_typed_slice::<u8>();
                 let u8_slice = u8_slice.as_ref();
-                Arc::new(UInt64Array::from(calculate_max_bit_width(u8_slice, self.bits_per_value)))
+                Arc::new(UInt64Array::from(calculate_max_bit_width(
+                    u8_slice,
+                    self.bits_per_value,
+                )))
             }
             16 => {
                 let u16_slice = self.data.borrow_to_typed_slice::<u16>();
                 let u16_slice = u16_slice.as_ref();
-                Arc::new(UInt64Array::from(calculate_max_bit_width(u16_slice, self.bits_per_value)))
+                Arc::new(UInt64Array::from(calculate_max_bit_width(
+                    u16_slice,
+                    self.bits_per_value,
+                )))
             }
             32 => {
                 let u32_slice = self.data.borrow_to_typed_slice::<u32>();
                 let u32_slice = u32_slice.as_ref();
-                Arc::new(UInt64Array::from(calculate_max_bit_width(u32_slice, self.bits_per_value)))
+                Arc::new(UInt64Array::from(calculate_max_bit_width(
+                    u32_slice,
+                    self.bits_per_value,
+                )))
             }
             64 => {
                 let u64_slice = self.data.borrow_to_typed_slice::<u64>();
                 let u64_slice = u64_slice.as_ref();
-                Arc::new(UInt64Array::from(calculate_max_bit_width(u64_slice, self.bits_per_value)))
+                Arc::new(UInt64Array::from(calculate_max_bit_width(
+                    u64_slice,
+                    self.bits_per_value,
+                )))
             }
             _ => Arc::new(UInt64Array::from(vec![self.bits_per_value])),
         }

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1022,13 +1022,10 @@ pub fn flat_bm25_search(
     let doc_iter = iter_str_array(&batch[doc_col]);
     let mut scores = Vec::with_capacity(batch.num_rows());
     for doc in doc_iter {
-        let doc = match doc {
-            Some(doc) => doc,
-            None => {
+        let Some(doc) = doc else {
                 scores.push(0.0);
                 continue;
-            }
-        };
+            };
 
         let doc_tokens = collect_tokens(doc, tokenizer, Some(query_tokens));
         let doc_norm = K1 * (1.0 - B + B * doc_tokens.len() as f32 / avgdl);

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1023,9 +1023,9 @@ pub fn flat_bm25_search(
     let mut scores = Vec::with_capacity(batch.num_rows());
     for doc in doc_iter {
         let Some(doc) = doc else {
-                scores.push(0.0);
-                continue;
-            };
+            scores.push(0.0);
+            continue;
+        };
 
         let doc_tokens = collect_tokens(doc, tokenizer, Some(query_tokens));
         let doc_norm = K1 * (1.0 - B + B * doc_tokens.len() as f32 / avgdl);

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -1110,7 +1110,7 @@ impl TryFrom<pb::Transaction> for Transaction {
                             .into_iter()
                             .map(Fragment::try_from)
                             .collect::<Result<Vec<_>>>()?,
-                        schema: Schema::from(&Fields(schema.clone())),
+                        schema: Schema::from(&Fields(schema)),
                         config_upsert_values: config_upsert_option,
                     })
                 }


### PR DESCRIPTION
This PR tries to remove the cardinality calculation for fixed width data block, so we can speed up the write speed.
#3069