### PR TITLE
feat: add max length statistics to VariableWidth Datablock

### DIFF
--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -1152,13 +1152,11 @@ mod tests {
     fn test_max_length_variable_width_datablock() {
         let string_array = StringArray::from(vec![Some("hello"), Some("world")]);
         let mut block = DataBlock::from_array(string_array.clone());
-        let expected_max_length = Arc::new(UInt64Array::from(vec![5])) as ArrayRef;
+        let expected_max_length =
+            Arc::new(UInt64Array::from(vec![string_array.value_length(0) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
-        assert_eq!(
-            actual_max_length,
-            Some(expected_max_length.clone()),
-        );
+        assert_eq!(actual_max_length, Some(expected_max_length.clone()),);
 
         let string_array = StringArray::from(vec![
             Some("to be named by variables"),
@@ -1170,10 +1168,7 @@ mod tests {
             Arc::new(UInt64Array::from(vec![string_array.value_length(1) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
-        assert_eq!(
-            actual_max_length,
-            Some(expected_max_length.clone()),
-        );
+        assert_eq!(actual_max_length, Some(expected_max_length));
 
         let string_array = StringArray::from(vec![
             Some("Samuel Eilenberg"),
@@ -1185,10 +1180,7 @@ mod tests {
             Arc::new(UInt64Array::from(vec![string_array.value_length(1) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
-        assert_eq!(
-            actual_max_length,
-            Some(expected_max_length.clone()),
-        );
+        assert_eq!(actual_max_length, Some(expected_max_length),);
 
         let string_array = LargeStringArray::from(vec![Some("hello"), Some("world")]);
         let mut block = DataBlock::from_array(string_array.clone());
@@ -1196,10 +1188,7 @@ mod tests {
             Arc::new(UInt64Array::from(vec![string_array.value(0).len() as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
-        assert_eq!(
-            actual_max_length,
-            Some(expected_max_length.clone()),
-        );
+        assert_eq!(actual_max_length, Some(expected_max_length),);
 
         let string_array = LargeStringArray::from(vec![
             Some("to be named by variables"),
@@ -1211,9 +1200,6 @@ mod tests {
             Arc::new(UInt64Array::from(vec![string_array.value_length(1) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
-        assert_eq!(
-            actual_max_length,
-            Some(expected_max_length.clone()),
-        );
+        assert_eq!(actual_max_length, Some(expected_max_length));
     }
 }

--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -1158,9 +1158,6 @@ mod tests {
         assert_eq!(
             actual_max_length,
             Some(expected_max_length.clone()),
-            "Expected Stat::MaxLength to be {:?} for data block generated from array: {:?}",
-            expected_max_length,
-            string_array,
         );
 
         let string_array = StringArray::from(vec![
@@ -1176,9 +1173,6 @@ mod tests {
         assert_eq!(
             actual_max_length,
             Some(expected_max_length.clone()),
-            "Expected Stat::MaxLength to be {:?} for data block generated from array: {:?}",
-            expected_max_length,
-            string_array,
         );
 
         let string_array = StringArray::from(vec![
@@ -1194,9 +1188,6 @@ mod tests {
         assert_eq!(
             actual_max_length,
             Some(expected_max_length.clone()),
-            "Expected Stat::MaxLength to be {:?} for data block generated from array: {:?}",
-            expected_max_length,
-            string_array,
         );
 
         let string_array = LargeStringArray::from(vec![Some("hello"), Some("world")]);
@@ -1208,14 +1199,11 @@ mod tests {
         assert_eq!(
             actual_max_length,
             Some(expected_max_length.clone()),
-            "Expected Stat::MaxLength to be {:?} for data block generated from array: {:?}",
-            expected_max_length,
-            string_array,
         );
 
         let string_array = LargeStringArray::from(vec![
             Some("to be named by variables"),
-            Some("to be passed as arguments to procedures"),
+            Some("to be passed as arguments to procedures"), // string that has max length
             Some("to be returned as values of procedures"),
         ]);
         let mut block = DataBlock::from_array(string_array.clone());
@@ -1226,9 +1214,6 @@ mod tests {
         assert_eq!(
             actual_max_length,
             Some(expected_max_length.clone()),
-            "Expected Stat::MaxLength to be {:?} for data block generated from array: {:?}",
-            expected_max_length,
-            string_array,
         );
     }
 }

--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -163,7 +163,7 @@ impl VariableWidthBlock {
                     .map(|pair| pair[1] - pair[0])
                     .max()
                     .unwrap_or(0);
-                Arc::new(UInt64Array::from(vec![max_len as u64]))
+                Arc::new(UInt64Array::from(vec![max_len]))
             }
             _ => {
                 unreachable!("the type of offsets in VariableWidth can only be u32 or u64");

--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -1170,7 +1170,7 @@ mod tests {
         ]);
         let mut block = DataBlock::from_array(string_array.clone());
         let expected_max_length =
-            Arc::new(UInt64Array::from(vec![string_array.value(1).len() as u64])) as ArrayRef;
+            Arc::new(UInt64Array::from(vec![string_array.value_length(1) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
         assert_eq!(
@@ -1188,7 +1188,7 @@ mod tests {
         ]);
         let mut block = DataBlock::from_array(string_array.clone());
         let expected_max_length =
-            Arc::new(UInt64Array::from(vec![string_array.value(1).len() as u64])) as ArrayRef;
+            Arc::new(UInt64Array::from(vec![string_array.value_length(1) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
         assert_eq!(
@@ -1220,7 +1220,7 @@ mod tests {
         ]);
         let mut block = DataBlock::from_array(string_array.clone());
         let expected_max_length =
-            Arc::new(UInt64Array::from(vec![string_array.value(1).len() as u64])) as ArrayRef;
+            Arc::new(UInt64Array::from(vec![string_array.value_length(1) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
         assert_eq!(


### PR DESCRIPTION
max length statistics can be used to for encoding selection of Variable-Width-Datablock(string, binary, etc.)