### PR TITLE
perf: implement fast path for union many row id tree map

### DIFF
--- a/rust/lance-core/src/utils/mask.rs
+++ b/rust/lance-core/src/utils/mask.rs
@@ -10,7 +10,7 @@ use arrow_array::{Array, BinaryArray, GenericBinaryArray};
 use arrow_buffer::{Buffer, NullBuffer, OffsetBuffer};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use deepsize::DeepSizeOf;
-use roaring::RoaringBitmap;
+use roaring::{MultiOps, RoaringBitmap};
 
 use crate::Result;
 
@@ -297,6 +297,26 @@ impl DeepSizeOf for RowIdSelection {
     }
 }
 
+impl RowIdSelection {
+    fn union_all(selections: &[&Self]) -> Self {
+        for selection in selections {
+            if matches!(selection, Self::Full) {
+                return Self::Full;
+            }
+        }
+
+        let bitmaps = selections
+            .iter()
+            .filter_map(|selection| match selection {
+                Self::Full => None,
+                Self::Partial(bitmap) => Some(bitmap),
+            })
+            .collect::<Vec<_>>();
+
+        Self::Partial(bitmaps.union())
+    }
+}
+
 impl RowIdTreeMap {
     /// Create an empty set
     pub fn new() -> Self {
@@ -525,6 +545,26 @@ impl RowIdTreeMap {
             }
         }
         Ok(Self { inner })
+    }
+
+    pub fn union_all(maps: &[&Self]) -> Self {
+        let mut new_map = BTreeMap::new();
+
+        for map in maps {
+            for (fragment, selection) in &map.inner {
+                new_map
+                    .entry(fragment)
+                    .or_insert_with(|| Vec::with_capacity(maps.len()))
+                    .push(selection);
+            }
+        }
+
+        let new_map = new_map
+            .into_iter()
+            .map(|(&fragment, selections)| (fragment, RowIdSelection::union_all(&selections)))
+            .collect();
+
+        Self { inner: new_map }
     }
 }
 

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -168,14 +168,13 @@ impl ScalarIndex for BitmapIndex {
                     Bound::Unbounded => Bound::Unbounded,
                 };
 
-                let range_iter = self.index_map.range((range_start, range_end));
-                let mut union_bitmap = RowIdTreeMap::default();
+                let maps = self
+                    .index_map
+                    .range((range_start, range_end))
+                    .map(|(_, v)| v)
+                    .collect::<Vec<_>>();
 
-                for (_, bitmap) in range_iter {
-                    union_bitmap |= bitmap.clone();
-                }
-
-                union_bitmap
+                RowIdTreeMap::union_all(&maps)
             }
             SargableQuery::IsIn(values) => {
                 let mut union_bitmap = RowIdTreeMap::default();


### PR DESCRIPTION
Use `roaring::MultiOp` for faster union of bitmaps.

TODO:
- [ ] add a benchmark to figure out how much we are saving from this
- [ ] add a row id tree map benchmark to compare `union_all` and regular loop