### PR TITLE
feat: enable write variable width data in 2.1

### DIFF
--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -29,7 +29,10 @@ use snafu::{location, Location};
 
 use lance_core::{Error, Result};
 
-use crate::{buffer::LanceBuffer, statistics::Stat};
+use crate::{
+    buffer::LanceBuffer,
+    statistics::{ComputeStat, Stat},
+};
 
 /// `Encoding` enum serves as a encoding registration center.
 ///
@@ -1232,7 +1235,7 @@ impl DataBlock {
             return Self::AllNull(AllNullDataBlock { num_values });
         }
 
-        let encoded = match data_type {
+        let mut encoded = match data_type {
             DataType::Binary | DataType::Utf8 => arrow_binary_to_data_block(arrays, num_values, 32),
             DataType::BinaryView | DataType::Utf8View => {
                 todo!()
@@ -1318,6 +1321,10 @@ impl DataBlock {
                 )
             }
         };
+
+        // compute statistics
+        encoded.compute_stat();
+
         if !matches!(data_type, DataType::Dictionary(_, _)) {
             match nulls {
                 Nullability::None => encoded,

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -1537,7 +1537,6 @@ impl PrimitiveStructuralEncoder {
     //   data doesn't even fit in a mini-block and the block overhead gets
     //   too large and we prefer zipped.
     fn is_narrow(data_block: &DataBlock) -> bool {
-        println!("data_block.name(): {:?}, data_block.get_stat: {:?}", data_block.name(), data_block.get_stat(Stat::MaxLength));
         if let Some(max_len_array) = data_block.get_stat(Stat::MaxLength) {
             let max_len_array = max_len_array
                 .as_any()
@@ -1862,35 +1861,29 @@ impl FieldEncoder for PrimitiveStructuralEncoder {
 mod tests {
     use std::sync::Arc;
 
-    use arrow_array::{
-        ArrayRef, Int16Array, Int32Array, Int64Array, Int8Array, LargeStringArray, StringArray,
-        UInt16Array, UInt32Array, UInt64Array, UInt8Array,
-    };
-    use arrow_schema::{DataType, Field};
-    use lance_arrow::DataTypeExt;
-    use lance_datagen::{array, ArrayGeneratorExt, RowCount, DEFAULT_SEED};
-    use rand::SeedableRng;
+    use arrow_array::{ArrayRef, Int8Array, StringArray};
 
-    use crate::{encodings::logical::primitive::PrimitiveStructuralEncoder, statistics::{GetStat, Stat}};
+    use crate::encodings::logical::primitive::PrimitiveStructuralEncoder;
 
     use super::DataBlock;
 
-    use arrow::{compute::concat, datatypes::Int32Type};
-    use arrow_array::Array;
     #[test]
     fn test_is_narrow() {
         let int8_array = Int8Array::from(vec![1, 2, 3]);
-        let array_ref: ArrayRef = Arc::new(int8_array.clone());
+        let array_ref: ArrayRef = Arc::new(int8_array);
         let block = DataBlock::from_array(array_ref);
 
-        assert_eq!(PrimitiveStructuralEncoder::is_narrow(&block), true);
+        assert!(PrimitiveStructuralEncoder::is_narrow(&block));
 
         let string_array = StringArray::from(vec![Some("hello"), Some("world")]);
-        let block = DataBlock::from_array(string_array.clone());
-        assert_eq!(PrimitiveStructuralEncoder::is_narrow(&block), true);
+        let block = DataBlock::from_array(string_array);
+        assert!(PrimitiveStructuralEncoder::is_narrow(&block));
 
-        let string_array = StringArray::from(vec![Some("hello world".repeat(100)), Some("world".to_string())]);
-        let block = DataBlock::from_array(string_array.clone());
-        assert_eq!(PrimitiveStructuralEncoder::is_narrow(&block), false);
+        let string_array = StringArray::from(vec![
+            Some("hello world".repeat(100)),
+            Some("world".to_string()),
+        ]);
+        let block = DataBlock::from_array(string_array);
+        assert!((!PrimitiveStructuralEncoder::is_narrow(&block)));
     }
 }

--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -1152,13 +1152,11 @@ mod tests {
     fn test_max_length_variable_width_datablock() {
         let string_array = StringArray::from(vec![Some("hello"), Some("world")]);
         let mut block = DataBlock::from_array(string_array.clone());
-        let expected_max_length = Arc::new(UInt64Array::from(vec![5])) as ArrayRef;
+        let expected_max_length =
+            Arc::new(UInt64Array::from(vec![string_array.value_length(0) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
-        assert_eq!(
-            actual_max_length,
-            Some(expected_max_length.clone()),
-        );
+        assert_eq!(actual_max_length, Some(expected_max_length.clone()),);
 
         let string_array = StringArray::from(vec![
             Some("to be named by variables"),
@@ -1170,10 +1168,7 @@ mod tests {
             Arc::new(UInt64Array::from(vec![string_array.value_length(1) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
-        assert_eq!(
-            actual_max_length,
-            Some(expected_max_length.clone()),
-        );
+        assert_eq!(actual_max_length, Some(expected_max_length));
 
         let string_array = StringArray::from(vec![
             Some("Samuel Eilenberg"),
@@ -1185,10 +1180,7 @@ mod tests {
             Arc::new(UInt64Array::from(vec![string_array.value_length(1) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
-        assert_eq!(
-            actual_max_length,
-            Some(expected_max_length.clone()),
-        );
+        assert_eq!(actual_max_length, Some(expected_max_length),);
 
         let string_array = LargeStringArray::from(vec![Some("hello"), Some("world")]);
         let mut block = DataBlock::from_array(string_array.clone());
@@ -1196,10 +1188,7 @@ mod tests {
             Arc::new(UInt64Array::from(vec![string_array.value(0).len() as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
-        assert_eq!(
-            actual_max_length,
-            Some(expected_max_length.clone()),
-        );
+        assert_eq!(actual_max_length, Some(expected_max_length),);
 
         let string_array = LargeStringArray::from(vec![
             Some("to be named by variables"),
@@ -1211,9 +1200,6 @@ mod tests {
             Arc::new(UInt64Array::from(vec![string_array.value_length(1) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
-        assert_eq!(
-            actual_max_length,
-            Some(expected_max_length.clone()),
-        );
+        assert_eq!(actual_max_length, Some(expected_max_length));
     }
 }

--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -1197,7 +1197,7 @@ mod tests {
     fn test_max_length_variable_width_datablock() {
         let string_array = StringArray::from(vec![Some("hello"), Some("world")]);
         let block = DataBlock::from_array(string_array.clone());
-      
+
         let expected_max_length =
             Arc::new(UInt64Array::from(vec![string_array.value_length(0) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);

--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -55,11 +55,9 @@ impl ComputeStat for DataBlock {
             Self::Empty() => {}
             Self::Constant(_) => {}
             Self::AllNull(_) => {}
-            Self::Nullable(_) => {}
+            Self::Nullable(data_block) => data_block.data.compute_stat(),
             Self::FixedWidth(data_block) => data_block.compute_stat(),
-            Self::FixedSizeList(_) => {
-                todo!("compute_stat for FixedSizeList is not implemented yet.")
-            }
+            Self::FixedSizeList(_) => {}
             Self::VariableWidth(data_block) => data_block.compute_stat(),
             Self::Opaque(data_block) => data_block.compute_stat(),
             Self::Struct(_) => {}
@@ -130,12 +128,11 @@ impl GetStat for DataBlock {
                 //  the statistics is not calculated here as this enum is going to deprecated soon anyway
                 None
             }
-            Self::Nullable(_) => {
-                //  the statistics is not calculated here as this enum is going to deprecated soon anyway
-                None
+            Self::Nullable(data_block) => {
+                data_block.data.get_stat(stat)
             }
             Self::FixedWidth(data_block) => data_block.get_stat(stat),
-            Self::FixedSizeList(_) => todo!("get_stat for FixedSizeList is not implemented yet."),
+            Self::FixedSizeList(_) => None,
             Self::VariableWidth(data_block) => data_block.get_stat(stat),
             Self::Opaque(data_block) => data_block.get_stat(stat),
             Self::Struct(data_block) => data_block.get_stat(stat),

--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -1158,9 +1158,6 @@ mod tests {
         assert_eq!(
             actual_max_length,
             Some(expected_max_length.clone()),
-            "Expected Stat::MaxLength to be {:?} for data block generated from array: {:?}",
-            expected_max_length,
-            string_array,
         );
 
         let string_array = StringArray::from(vec![
@@ -1176,9 +1173,6 @@ mod tests {
         assert_eq!(
             actual_max_length,
             Some(expected_max_length.clone()),
-            "Expected Stat::MaxLength to be {:?} for data block generated from array: {:?}",
-            expected_max_length,
-            string_array,
         );
 
         let string_array = StringArray::from(vec![
@@ -1194,9 +1188,6 @@ mod tests {
         assert_eq!(
             actual_max_length,
             Some(expected_max_length.clone()),
-            "Expected Stat::MaxLength to be {:?} for data block generated from array: {:?}",
-            expected_max_length,
-            string_array,
         );
 
         let string_array = LargeStringArray::from(vec![Some("hello"), Some("world")]);
@@ -1208,14 +1199,11 @@ mod tests {
         assert_eq!(
             actual_max_length,
             Some(expected_max_length.clone()),
-            "Expected Stat::MaxLength to be {:?} for data block generated from array: {:?}",
-            expected_max_length,
-            string_array,
         );
 
         let string_array = LargeStringArray::from(vec![
             Some("to be named by variables"),
-            Some("to be passed as arguments to procedures"),
+            Some("to be passed as arguments to procedures"), // string that has max length
             Some("to be returned as values of procedures"),
         ]);
         let mut block = DataBlock::from_array(string_array.clone());
@@ -1226,9 +1214,6 @@ mod tests {
         assert_eq!(
             actual_max_length,
             Some(expected_max_length.clone()),
-            "Expected Stat::MaxLength to be {:?} for data block generated from array: {:?}",
-            expected_max_length,
-            string_array,
         );
     }
 }

--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -163,7 +163,7 @@ impl VariableWidthBlock {
                     .map(|pair| pair[1] - pair[0])
                     .max()
                     .unwrap_or(0);
-                Arc::new(UInt64Array::from(vec![max_len as u64]))
+                Arc::new(UInt64Array::from(vec![max_len]))
             }
             _ => {
                 unreachable!("the type of offsets in VariableWidth can only be u32 or u64");

--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -1170,7 +1170,7 @@ mod tests {
         ]);
         let mut block = DataBlock::from_array(string_array.clone());
         let expected_max_length =
-            Arc::new(UInt64Array::from(vec![string_array.value(1).len() as u64])) as ArrayRef;
+            Arc::new(UInt64Array::from(vec![string_array.value_length(1) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
         assert_eq!(
@@ -1188,7 +1188,7 @@ mod tests {
         ]);
         let mut block = DataBlock::from_array(string_array.clone());
         let expected_max_length =
-            Arc::new(UInt64Array::from(vec![string_array.value(1).len() as u64])) as ArrayRef;
+            Arc::new(UInt64Array::from(vec![string_array.value_length(1) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
         assert_eq!(
@@ -1220,7 +1220,7 @@ mod tests {
         ]);
         let mut block = DataBlock::from_array(string_array.clone());
         let expected_max_length =
-            Arc::new(UInt64Array::from(vec![string_array.value(1).len() as u64])) as ArrayRef;
+            Arc::new(UInt64Array::from(vec![string_array.value_length(1) as u64])) as ArrayRef;
         let actual_max_length = block.get_stat(Stat::MaxLength);
 
         assert_eq!(

--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -128,9 +128,7 @@ impl GetStat for DataBlock {
                 //  the statistics is not calculated here as this enum is going to deprecated soon anyway
                 None
             }
-            Self::Nullable(data_block) => {
-                data_block.data.get_stat(stat)
-            }
+            Self::Nullable(data_block) => data_block.data.get_stat(stat),
             Self::FixedWidth(data_block) => data_block.get_stat(stat),
             Self::FixedSizeList(_) => None,
             Self::VariableWidth(data_block) => data_block.get_stat(stat),


### PR DESCRIPTION
This PR adds a `Compute_Stat` trait to DataBlock, to separate the statistics computation and statistics inquiry.

This PR also modifies `do_flush` and `encode_miniblock` in `PrimitiveStructuralEncoder` to enable write variable width data in 2.1(PrimitiveStructuralEncoder)