### PR TITLE
feat: implement DataBlockBuilderImpl for variable width data block

### DIFF
--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -926,7 +926,7 @@ macro_rules! as_type_ref {
     };
 }
 
-macro_rules! as_type_mut_ref {
+macro_rules! as_type_ref_mut {
     ($fn_name:ident, $inner:tt, $inner_type:ident) => {
         pub fn $fn_name(&mut self) -> Option<&mut $inner_type> {
             match self {
@@ -953,17 +953,17 @@ impl DataBlock {
     as_type_ref!(as_variable_width_ref, VariableWidth, VariableWidthBlock);
     as_type_ref!(as_struct_ref, Struct, StructDataBlock);
     as_type_ref!(as_dictionary_ref, Dictionary, DictionaryDataBlock);
-    as_type_mut_ref!(as_all_null_mut_ref, AllNull, AllNullDataBlock);
-    as_type_mut_ref!(as_nullable_mut_ref, Nullable, NullableDataBlock);
-    as_type_mut_ref!(as_fixed_width_mut_ref, FixedWidth, FixedWidthDataBlock);
-    as_type_mut_ref!(
+    as_type_ref_mut!(as_all_null_mut_ref, AllNull, AllNullDataBlock);
+    as_type_ref_mut!(as_nullable_mut_ref, Nullable, NullableDataBlock);
+    as_type_ref_mut!(as_fixed_width_mut_ref, FixedWidth, FixedWidthDataBlock);
+    as_type_ref_mut!(
         as_fixed_size_list_mut_ref,
         FixedSizeList,
         FixedSizeListBlock
     );
-    as_type_mut_ref!(as_variable_width_mut_ref, VariableWidth, VariableWidthBlock);
-    as_type_mut_ref!(as_struct_mut_ref, Struct, StructDataBlock);
-    as_type_mut_ref!(as_dictionary_mut_ref, Dictionary, DictionaryDataBlock);
+    as_type_ref_mut!(as_variable_width_mut_ref, VariableWidth, VariableWidthBlock);
+    as_type_ref_mut!(as_struct_mut_ref, Struct, StructDataBlock);
+    as_type_ref_mut!(as_dictionary_mut_ref, Dictionary, DictionaryDataBlock);
 }
 
 // Methods to convert from Arrow -> DataBlock

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -314,7 +314,8 @@ impl DataBlockBuilderImpl for VariableWidthDataBlockBuilder1 {
 
         let start_offset = offsets[selection.start as usize];
         let end_offset = offsets[selection.end as usize];
-        self.bytes.extend_from_slice(&block.data[start_offset as usize ..end_offset as usize]);
+        self.bytes
+            .extend_from_slice(&block.data[start_offset as usize..end_offset as usize]);
         self.offsets.push(self.bytes.len() as u32);
     }
 
@@ -955,7 +956,11 @@ impl DataBlock {
     as_type_mut_ref!(as_all_null_mut_ref, AllNull, AllNullDataBlock);
     as_type_mut_ref!(as_nullable_mut_ref, Nullable, NullableDataBlock);
     as_type_mut_ref!(as_fixed_width_mut_ref, FixedWidth, FixedWidthDataBlock);
-    as_type_mut_ref!(as_fixed_size_list_mut_ref, FixedSizeList, FixedSizeListBlock);
+    as_type_mut_ref!(
+        as_fixed_size_list_mut_ref,
+        FixedSizeList,
+        FixedSizeListBlock
+    );
     as_type_mut_ref!(as_variable_width_mut_ref, VariableWidth, VariableWidthBlock);
     as_type_mut_ref!(as_struct_mut_ref, Struct, StructDataBlock);
     as_type_mut_ref!(as_dictionary_mut_ref, Dictionary, DictionaryDataBlock);

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -290,6 +290,47 @@ impl FixedWidthDataBlock {
     }
 }
 
+pub struct VariableWidthDataBlockBuilder1 {
+    offsets: Vec<u32>,
+    bytes: Vec<u8>,
+}
+
+impl VariableWidthDataBlockBuilder1 {
+    fn new(estimated_size_bytes: u64) -> Self {
+        Self {
+            offsets: vec![0u32],
+            bytes: Vec::with_capacity(estimated_size_bytes as usize),
+        }
+    }
+}
+
+impl DataBlockBuilderImpl for VariableWidthDataBlockBuilder1 {
+    fn append(&mut self, data_block: &mut DataBlock, selection: Range<u64>) {
+        let block = data_block.as_variable_width_mut_ref().unwrap();
+        assert!(block.bits_per_offset == 32);
+
+        let offsets = block.offsets.borrow_to_typed_slice::<u32>();
+        let offsets = offsets.as_ref();
+
+        let start_offset = offsets[selection.start as usize];
+        let end_offset = offsets[selection.end as usize];
+        self.bytes.extend_from_slice(&block.data[start_offset as usize ..end_offset as usize]);
+        self.offsets.push(self.bytes.len() as u32);
+    }
+
+    fn finish(self: Box<Self>) -> DataBlock {
+        let num_values = (self.offsets.len() - 1) as u64;
+        DataBlock::VariableWidth(VariableWidthBlock {
+            data: LanceBuffer::Owned(self.bytes),
+            offsets: LanceBuffer::reinterpret_vec(self.offsets),
+            bits_per_offset: 32,
+            num_values,
+            block_info: BlockInfo::new(),
+            used_encodings: UsedEncoding::new(),
+        })
+    }
+}
+
 pub struct FixedWidthDataBlockBuilder {
     bits_per_value: u64,
     bytes_per_value: u64,
@@ -308,7 +349,7 @@ impl FixedWidthDataBlockBuilder {
 }
 
 impl DataBlockBuilderImpl for FixedWidthDataBlockBuilder {
-    fn append(&mut self, data_block: &DataBlock, selection: Range<u64>) {
+    fn append(&mut self, data_block: &mut DataBlock, selection: Range<u64>) {
         let block = data_block.as_fixed_width_ref().unwrap();
         assert_eq!(self.bits_per_value, block.bits_per_value);
         let start = selection.start as usize * self.bytes_per_value as usize;
@@ -850,6 +891,13 @@ impl DataBlock {
                 inner.bits_per_value,
                 estimated_size_bytes,
             )),
+            Self::VariableWidth(inner) => {
+                if inner.bits_per_offset == 32 {
+                    Box::new(VariableWidthDataBlockBuilder1::new(estimated_size_bytes))
+                } else {
+                    todo!()
+                }
+            }
             _ => todo!(),
         }
     }
@@ -877,6 +925,17 @@ macro_rules! as_type_ref {
     };
 }
 
+macro_rules! as_type_mut_ref {
+    ($fn_name:ident, $inner:tt, $inner_type:ident) => {
+        pub fn $fn_name(&mut self) -> Option<&mut $inner_type> {
+            match self {
+                Self::$inner(inner) => Some(inner),
+                _ => None,
+            }
+        }
+    };
+}
+
 // Cast implementations
 impl DataBlock {
     as_type!(as_all_null, AllNull, AllNullDataBlock);
@@ -893,6 +952,13 @@ impl DataBlock {
     as_type_ref!(as_variable_width_ref, VariableWidth, VariableWidthBlock);
     as_type_ref!(as_struct_ref, Struct, StructDataBlock);
     as_type_ref!(as_dictionary_ref, Dictionary, DictionaryDataBlock);
+    as_type_mut_ref!(as_all_null_mut_ref, AllNull, AllNullDataBlock);
+    as_type_mut_ref!(as_nullable_mut_ref, Nullable, NullableDataBlock);
+    as_type_mut_ref!(as_fixed_width_mut_ref, FixedWidth, FixedWidthDataBlock);
+    as_type_mut_ref!(as_fixed_size_list_mut_ref, FixedSizeList, FixedSizeListBlock);
+    as_type_mut_ref!(as_variable_width_mut_ref, VariableWidth, VariableWidthBlock);
+    as_type_mut_ref!(as_struct_mut_ref, Struct, StructDataBlock);
+    as_type_mut_ref!(as_dictionary_mut_ref, Dictionary, DictionaryDataBlock);
 }
 
 // Methods to convert from Arrow -> DataBlock
@@ -1349,7 +1415,7 @@ impl From<ArrayRef> for DataBlock {
 }
 
 pub trait DataBlockBuilderImpl {
-    fn append(&mut self, data_block: &DataBlock, selection: Range<u64>);
+    fn append(&mut self, data_block: &mut DataBlock, selection: Range<u64>);
     fn finish(self: Box<Self>) -> DataBlock;
 }
 
@@ -1373,7 +1439,7 @@ impl DataBlockBuilder {
         self.builder.as_mut().unwrap().as_mut()
     }
 
-    pub fn append(&mut self, data_block: &DataBlock, selection: Range<u64>) {
+    pub fn append(&mut self, data_block: &mut DataBlock, selection: Range<u64>) {
         self.get_builder(data_block).append(data_block, selection);
     }
 

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -386,7 +386,7 @@ impl DecodePageTask for DecodeMiniBlockTask {
             let def = buf.slice_with_length(6 + bytes_rep, bytes_def);
             let values = buf.slice_with_length(6 + bytes_rep + bytes_def, bytes_val);
 
-            let values = self
+            let mut values = self
                 .value_decompressor
                 .decompress(LanceBuffer::Borrowed(values), chunk.vals_in_chunk)?;
 
@@ -434,7 +434,7 @@ impl DecodePageTask for DecodeMiniBlockTask {
                     &def,
                     level_offset,
                 );
-                data_builder.append(&values, range);
+                data_builder.append(&mut values, range);
                 remaining -= to_take;
                 offset += to_take;
                 level_offset += to_take as usize;


### PR DESCRIPTION
This PR implements `DataBlockBuilderImpl` trait for Variable Width Data, so we can enable read Variable Width data in Lance 2.1