### PR TITLE
feat: merge-insert supports inserting subset of columns

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1202,6 +1202,11 @@ class LanceDataset(pa.dataset.Dataset):
 
         Examples
         --------
+
+        Use `when_matched_update_all()` and `when_not_matched_insert_all()` to
+        perform an "upsert" operation.  This will update rows that already exist
+        in the dataset and insert rows that do not exist.
+
         >>> import lance
         >>> import pyarrow as pa
         >>> table = pa.table({"a": [2, 1, 3], "b": ["a", "b", "c"]})
@@ -1219,6 +1224,51 @@ class LanceDataset(pa.dataset.Dataset):
         1  2  x
         2  3  y
         3  4  z
+
+        Use `when_not_matched_insert_all()` to perform an "insert if not exists"
+        operation.  This will only insert rows that do not already exist in the
+        dataset.
+
+        >>> import lance
+        >>> import pyarrow as pa
+        >>> table = pa.table({"a": [1, 2, 3], "b": ["a", "b", "c"]})
+        >>> dataset = lance.write_dataset(table, "example2")
+        >>> new_table = pa.table({"a": [2, 3, 4], "b": ["x", "y", "z"]})
+        >>> # Perform an "insert if not exists" operation
+        >>> dataset.merge_insert("a")     \\
+        ...             .when_not_matched_insert_all() \\
+        ...             .execute(new_table)
+        {'num_inserted_rows': 1, 'num_updated_rows': 0, 'num_deleted_rows': 0}
+        >>> dataset.to_table().sort_by("a").to_pandas()
+           a  b
+        0  1  a
+        1  2  b
+        2  3  c
+        3  4  z
+
+        You are not required to provide all the columns. If you only want to
+        updated a subset of columns, you can omit columns you don't want to
+        update. Omitted columns will keep their existing values if they are
+        updated, or will be null if they are inserted.
+
+        >>> import lance
+        >>> import pyarrow as pa
+        >>> table = pa.table({"a": [1, 2, 3], "b": ["a", "b", "c"], \\
+        ...                   "c": ["x", "y", "z"]})
+        >>> dataset = lance.write_dataset(table, "example3")
+        >>> new_table = pa.table({"a": [2, 3, 4], "b": ["x", "y", "z"]})
+        >>> # Perform an "upsert" operation, only updating column "a"
+        >>> dataset.merge_insert("a")     \\
+        ...             .when_matched_update_all()     \\
+        ...             .when_not_matched_insert_all() \\
+        ...             .execute(new_table)
+        {'num_inserted_rows': 1, 'num_updated_rows': 2, 'num_deleted_rows': 0}
+        >>> dataset.to_table().sort_by("a").to_pandas()
+           a  b     c
+        0  1  a     x
+        1  2  x     y
+        2  3  y     z
+        3  4  z  None
         """
         return MergeInsertBuilder(self._ds, on)
 

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1247,7 +1247,7 @@ class LanceDataset(pa.dataset.Dataset):
         3  4  z
 
         You are not required to provide all the columns. If you only want to
-        updated a subset of columns, you can omit columns you don't want to
+        update a subset of columns, you can omit columns you don't want to
         update. Omitted columns will keep their existing values if they are
         updated, or will be null if they are inserted.
 

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1554,34 +1554,6 @@ def test_merge_insert_multiple_keys(tmp_path: Path):
     check_merge_stats(merge_dict, (0, 350, 0))
 
 
-def test_merge_insert_incompatible_schema(tmp_path: Path):
-    nrows = 1000
-    table = pa.Table.from_pydict(
-        {
-            "a": range(nrows),
-            "b": [1 for _ in range(nrows)],
-        }
-    )
-    dataset = lance.write_dataset(
-        table, tmp_path / "dataset", mode="create", max_rows_per_file=100
-    )
-
-    new_table = pa.Table.from_pydict(
-        {
-            "a": range(300, 300 + nrows),
-        }
-    )
-
-    with pytest.raises(OSError):
-        merge_dict = (
-            dataset.merge_insert("a")
-            .when_matched_update_all()
-            .when_not_matched_insert_all()
-            .execute(new_table)
-        )
-        check_merge_stats(merge_dict, (None, None, None))
-
-
 def test_merge_insert_vector_column(tmp_path: Path):
     table = pa.Table.from_pydict(
         {

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1370,6 +1370,29 @@ def test_merge_insert_subcols(tmp_path: Path):
         original_fragments[1].data_files()[0]
     )
 
+    new_values = pa.table(
+        {
+            "a": range(9, 12),
+            "b": range(30, 33),
+        }
+    )
+    (
+        dataset.merge_insert("a")
+        .when_not_matched_insert_all()
+        .when_matched_update_all()
+        .execute(new_values)
+    )
+
+    assert dataset.count_rows() == 12
+    expected = pa.table(
+        {
+            "a": range(0, 12),
+            "b": [0, 1, 2, 20, 21, 5, 6, 7, 8, 30, 31, 32],
+            "c": list(range(10, 20)) + [None] * 2,
+        }
+    )
+    assert dataset.to_table().sort_by("a") == expected
+
 
 def test_flat_vector_search_with_delete(tmp_path: Path):
     table = pa.Table.from_pydict(


### PR DESCRIPTION
In https://github.com/lancedb/lance/pull/2639 we added support for *updating* subcolumns. In https://github.com/lancedb/lance/pull/3041 we added support for *inserting* subcolumns. This PR adds support for upserting them (or doing insert-if-not-exists).

Closes #2904

## Example

```python
import pyarrow as pa
import lance

table = pa.table({
    "id": range(3),
    "a": [1.0, 2.0, 3.0],
    "c": ["x", "x", "x"]
})
dataset = lance.write_dataset(table, "example")

# Upsert: when_matched_update_all + when_not_matched_insert_all
new_data = pa.table({
    "id": [2, 3],
    "c": ["y", "y"]
})
(
    dataset
    .merge_insert(on="id")
    .when_matched_update_all()
    .when_not_matched_insert_all()
    .execute(new_data)
)
dataset.to_table().to_pandas()
```
```
   id    a  c
0   0  1.0  x
1   1  2.0  x
2   2  3.0  y
3   3  NaN  y
```

```python
# Insert-if-not-exists: when_not_matched_insert_all
new_data = pa.table({
    "id": [3, 4],
    "c": ["z", "z"]
})
(
    dataset
    .merge_insert(on="id")
    .when_not_matched_insert_all()
    .execute(new_data)
)
dataset.to_table().to_pandas()

   id    a  c
0   0  1.0  x
1   1  2.0  x
2   2  3.0  y
3   3  NaN  y
4   4  NaN  z
```

