### PR TITLE
feat: align buffers in 2.1 files

### DIFF
--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -41,7 +41,8 @@ def test_blob_descriptions(tmp_path):
         ),
     )
     ds = lance.write_dataset(table, tmp_path / "test_ds")
-    expected_positions = pa.array([0, 3, 6], pa.uint64())
+    # These positions may be surprising but lance pads buffers to 64-byte boundaries
+    expected_positions = pa.array([0, 64, 128], pa.uint64())
     expected_sizes = pa.array([3, 3, 3], pa.uint64())
     descriptions = ds.to_table().column("blobs").chunk(0)
 

--- a/python/python/tests/test_file.py
+++ b/python/python/tests/test_file.py
@@ -198,7 +198,8 @@ def test_metadata(tmp_path):
     assert metadata.num_rows == 3
     assert metadata.num_global_buffer_bytes > 0
     assert metadata.num_column_metadata_bytes > 0
-    assert metadata.num_data_bytes == 24
+    # 64 and not 24 because we align/pad to 64 bytes
+    assert metadata.num_data_bytes == 64
     assert len(metadata.columns) == 1
 
     column = metadata.columns[0]

--- a/rust/lance-core/src/utils/bit.rs
+++ b/rust/lance-core/src/utils/bit.rs
@@ -4,3 +4,13 @@
 pub fn is_pwr_two(n: u64) -> bool {
     n & (n - 1) == 0
 }
+
+pub fn pad_bytes<const ALIGN: usize>(n: usize) -> usize {
+    debug_assert!(is_pwr_two(ALIGN as u64));
+    (ALIGN - (n & (ALIGN - 1))) & (ALIGN - 1)
+}
+
+pub fn pad_bytes_u64<const ALIGN: u64>(n: u64) -> u64 {
+    debug_assert!(is_pwr_two(ALIGN));
+    (ALIGN - (n & (ALIGN - 1))) & (ALIGN - 1)
+}

--- a/rust/lance-core/src/utils/bit.rs
+++ b/rust/lance-core/src/utils/bit.rs
@@ -10,6 +10,11 @@ pub fn pad_bytes<const ALIGN: usize>(n: usize) -> usize {
     (ALIGN - (n & (ALIGN - 1))) & (ALIGN - 1)
 }
 
+pub fn pad_bytes_to(n: usize, align: usize) -> usize {
+    debug_assert!(is_pwr_two(align as u64));
+    (align - (n & (align - 1))) & (align - 1)
+}
+
 pub fn pad_bytes_u64<const ALIGN: u64>(n: u64) -> u64 {
     debug_assert!(is_pwr_two(ALIGN));
     (ALIGN - (n & (ALIGN - 1))) & (ALIGN - 1)

--- a/rust/lance-encoding-datafusion/src/zone.rs
+++ b/rust/lance-encoding-datafusion/src/zone.rs
@@ -592,6 +592,7 @@ impl ZoneMapsFieldEncoder {
                 cache_bytes_per_column: u64::MAX,
                 max_page_bytes: u64::MAX,
                 keep_original_array: true,
+                buffer_alignment: 8,
             },
         )
         .await?;

--- a/rust/lance-encoding/benches/decoder.rs
+++ b/rust/lance-encoding/benches/decoder.rs
@@ -59,6 +59,7 @@ const ENCODING_OPTIONS: EncodingOptions = EncodingOptions {
     cache_bytes_per_column: 1024 * 1024,
     max_page_bytes: 32 * 1024 * 1024,
     keep_original_array: true,
+    buffer_alignment: 64,
 };
 
 fn bench_decode(c: &mut Criterion) {

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -12,6 +12,7 @@ use lance_core::datatypes::{
     Field, Schema, BLOB_DESC_FIELD, BLOB_META_KEY, COMPRESSION_LEVEL_META_KEY,
     COMPRESSION_META_KEY, PACKED_STRUCT_LEGACY_META_KEY, PACKED_STRUCT_META_KEY,
 };
+use lance_core::utils::bit::{is_pwr_two, pad_bytes_to};
 use lance_core::{Error, Result};
 use snafu::{location, Location};
 
@@ -296,13 +297,15 @@ impl Default for EncodedColumn {
 /// data as a position / size array).
 pub struct OutOfLineBuffers {
     position: u64,
+    buffer_alignment: u64,
     buffers: Vec<LanceBuffer>,
 }
 
 impl OutOfLineBuffers {
-    pub fn new(base_position: u64) -> Self {
+    pub fn new(base_position: u64, buffer_alignment: u64) -> Self {
         Self {
             position: base_position,
+            buffer_alignment,
             buffers: Vec::new(),
         }
     }
@@ -310,6 +313,7 @@ impl OutOfLineBuffers {
     pub fn add_buffer(&mut self, buffer: LanceBuffer) -> u64 {
         let position = self.position;
         self.position += buffer.len() as u64;
+        self.position += pad_bytes_to(buffer.len(), self.buffer_alignment as usize) as u64;
         self.buffers.push(buffer);
         position
     }
@@ -859,6 +863,11 @@ pub struct EncodingOptions {
     /// be discarded safely and helps avoid writer accumulation.  However,
     /// there is an associated cost.
     pub keep_original_array: bool,
+    /// The alignment that the writer is applying to buffers
+    ///
+    /// The encoder needs to know this so it figures the position of out-of-line
+    /// buffers correctly
+    pub buffer_alignment: u64,
 }
 
 /// A trait to pick which kind of field encoding to use for a field
@@ -1271,6 +1280,13 @@ pub async fn encode_batch(
     encoding_strategy: &dyn FieldEncodingStrategy,
     options: &EncodingOptions,
 ) -> Result<EncodedBatch> {
+    if !is_pwr_two(options.buffer_alignment) || options.buffer_alignment < 8 {
+        return Err(Error::InvalidInput {
+            source: "buffer_alignment must be a power of two and at least 8".into(),
+            location: location!(),
+        });
+    }
+
     let mut data_buffer = BytesMut::new();
     let lance_schema = Schema::try_from(batch.schema().as_ref())?;
     let options = EncodingOptions {
@@ -1281,7 +1297,8 @@ pub async fn encode_batch(
     let mut page_table = Vec::new();
     let mut col_idx_offset = 0;
     for (arr, mut encoder) in batch.columns().iter().zip(batch_encoder.field_encoders) {
-        let mut external_buffers = OutOfLineBuffers::new(data_buffer.len() as u64);
+        let mut external_buffers =
+            OutOfLineBuffers::new(data_buffer.len() as u64, options.buffer_alignment);
         let repdef = RepDefBuilder::default();
         let encoder = encoder.as_mut();
         let mut tasks = encoder.maybe_encode(arr.clone(), &mut external_buffers, repdef, 0)?;
@@ -1298,7 +1315,8 @@ pub async fn encode_batch(
                 .or_default()
                 .push(write_page_to_data_buffer(encoded_page, &mut data_buffer));
         }
-        let mut external_buffers = OutOfLineBuffers::new(data_buffer.len() as u64);
+        let mut external_buffers =
+            OutOfLineBuffers::new(data_buffer.len() as u64, options.buffer_alignment);
         let encoded_columns = encoder.finish(&mut external_buffers).await?;
         for buffer in external_buffers.take_buffers() {
             data_buffer.extend_from_slice(&buffer);

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -1580,7 +1580,7 @@ impl PrimitiveStructuralEncoder {
     // P1 - Up to 1 padding byte to ensure `def` is 2-byte aligned
     // P2 - Up to 7 padding bytes to ensure `values` is 8-byte aligned
     // P3 - Up to 7 padding bytes to ensure the chunk is a multiple of 8 bytes (this also ensures
-    //      that the next `rep` is 8-byte aligned)
+    //      that the next `chunk` is 8-byte aligned)
     //
     // rep is guaranteed to be 2-byte aligned
     // def is guaranteed to be 2-byte aligned

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -1607,9 +1607,6 @@ impl PrimitiveStructuralEncoder {
     ) -> (LanceBuffer, LanceBuffer) {
         let bytes_rep = rep.iter().map(|r| r.len()).sum::<usize>();
         let bytes_def = def.iter().map(|d| d.len()).sum::<usize>();
-        // Each chunk ends with the size of the rep buffer (2 bytes) and the size of
-        // the def buffer (2 bytes).  These are put at the end so as to not disturb
-        // the alignment guarantees given to the compressor.
         let max_bytes_repdef_len = rep.len() * 4;
         let max_padding = miniblocks.chunks.len() * (1 + (2 * MINIBLOCK_MAX_PADDING));
         let mut data_buffer = Vec::with_capacity(
@@ -1633,6 +1630,8 @@ impl PrimitiveStructuralEncoder {
             let bytes_def = def.len() as u16;
             let bytes_val = chunk.num_bytes;
 
+            // Each chunk starts with the size of the rep buffer (2 bytes) the size of
+            // the def buffer (2 bytes) and the size of the values buffer (2 bytes)
             data_buffer.extend_from_slice(&bytes_rep.to_le_bytes());
             data_buffer.extend_from_slice(&bytes_def.to_le_bytes());
             data_buffer.extend_from_slice(&bytes_val.to_le_bytes());

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -9,6 +9,7 @@ use arrow_buffer::{bit_util, BooleanBuffer, NullBuffer};
 use arrow_schema::{DataType, Field as ArrowField};
 use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, TryStreamExt};
 use lance_arrow::deepcopy::deep_copy_array;
+use lance_core::utils::bit::pad_bytes;
 use log::{debug, trace};
 use snafu::{location, Location};
 
@@ -376,17 +377,26 @@ impl DecodePageTask for DecodeMiniBlockTask {
         for chunk in self.chunks.into_iter() {
             // We always decode the entire chunk
             let buf = chunk.data.into_buffer();
-            // The first 4 bytes describe the size of the rep/def buffers
+            // The first 6 bytes describe the size of the remaining buffers
             let bytes_rep = u16::from_le_bytes([buf[0], buf[1]]) as usize;
             let bytes_def = u16::from_le_bytes([buf[2], buf[3]]) as usize;
             let bytes_val = u16::from_le_bytes([buf[4], buf[5]]) as usize;
+
             debug_assert!(buf.len() >= bytes_rep + bytes_def + bytes_val + 6);
             debug_assert!(
-                buf.len() <= bytes_rep + bytes_def + bytes_val + 6 + MINIBLOCK_MAX_PADDING as usize
+                buf.len()
+                    <= bytes_rep
+                        + bytes_def
+                        + bytes_val
+                        + 6
+                        + 1 // P1
+                        + (2 * MINIBLOCK_MAX_PADDING) // P2/P3
             );
+            let p1 = bytes_rep % 2;
             let rep = buf.slice_with_length(6, bytes_rep);
-            let def = buf.slice_with_length(6 + bytes_rep, bytes_def);
-            let values = buf.slice_with_length(6 + bytes_rep + bytes_def, bytes_val);
+            let def = buf.slice_with_length(6 + bytes_rep + p1, bytes_def);
+            let p2 = pad_bytes::<MINIBLOCK_ALIGNMENT>(6 + bytes_rep + p1 + bytes_def);
+            let values = buf.slice_with_length(6 + bytes_rep + bytes_def + p2, bytes_val);
 
             let values = self
                 .value_decompressor
@@ -655,8 +665,7 @@ impl StructuralPageScheduler for MiniBlockScheduler {
             for (word_idx, word) in words.iter().enumerate() {
                 let log_num_values = word & 0x0F;
                 let divided_bytes = word >> 4;
-                let num_bytes =
-                    divided_bytes as u64 * MINIBLOCK_SIZE_MULTIPLIER + MINIBLOCK_SIZE_MULTIPLIER;
+                let num_bytes = (divided_bytes as usize + 1) * MINIBLOCK_ALIGNMENT;
                 debug_assert!(num_bytes > 0);
                 let num_values = if word_idx < words.len() - 1 {
                     debug_assert!(log_num_values > 0);
@@ -669,7 +678,7 @@ impl StructuralPageScheduler for MiniBlockScheduler {
 
                 self.chunk_meta.push(ChunkMeta {
                     num_values,
-                    chunk_size_bytes: num_bytes,
+                    chunk_size_bytes: num_bytes as u64,
                 });
             }
             Ok(())
@@ -1463,15 +1472,27 @@ impl FieldEncoder for PrimitiveFieldEncoder {
     }
 }
 
-// If we just record the size in bytes with 12 bits we would be limited to
-// 4KiB which is too small.  As a compromise we divide the size by this
-// constant which gives us up to 24KiB be introduces some padding into each
-// miniblock.  We want 24KiB so we can handle even the worst case of
+// We align and pad mini-blocks to 8 byte boundaries for two reasons.  First,
+// to allow us to store a chunk size in 12 bits.
+//
+// If we directly record the size in bytes with 12 bits we would be limited to
+// 4KiB which is too small.  Since we know each mini-block consists of 8 byte
+// words we can store the # of words instead which gives us 32KiB.  We want
+// at least 24KiB so we can handle even the worst case of
 // - 4Ki values compressed into an 8186 byte buffer
 // - 4 bytes to describe rep & def lengths
-// - 16KiB of rep & def buffer (this will almost never happen)
-const MINIBLOCK_SIZE_MULTIPLIER: u64 = 6;
-const MINIBLOCK_MAX_PADDING: u64 = MINIBLOCK_SIZE_MULTIPLIER - 1;
+// - 16KiB of rep & def buffer (this will almost never happen but life is easier if we
+//   plan for it)
+//
+// Second, each chunk in a mini-block is aligned to 8 bytes.  This allows multi-byte
+// values like offsets to be stored in a mini-block and safely read back out.  It also
+// helps ensure zero-copy reads in cases where zero-copy is possible (e.g. no decoding
+// needed).
+//
+// Note: by "aligned to 8 bytes" we mean BOTH "aligned to 8 bytes from the start of
+// the page" and "aligned to 8 bytes from the start of the file."
+const MINIBLOCK_ALIGNMENT: usize = 8;
+const MINIBLOCK_MAX_PADDING: usize = MINIBLOCK_ALIGNMENT - 1;
 
 /// An encoder for primitive (leaf) arrays
 ///
@@ -1554,21 +1575,28 @@ impl PrimitiveStructuralEncoder {
     // which tells us the size of each block.
     //
     // Each chunk is serialized as:
-    // | rep_len (2 bytes) | def_len (2 bytes) | values_len (2 byte) | rep | def | values |
+    // | rep_len (2 bytes) | def_len (2 bytes) | values_len (2 bytes) | rep | P1 | def | P2 | values | P3 |
+    //
+    // P1 - Up to 1 padding byte to ensure `def` is 2-byte aligned
+    // P2 - Up to 7 padding bytes to ensure `values` is 8-byte aligned
+    // P3 - Up to 7 padding bytes to ensure the chunk is a multiple of 8 bytes (this also ensures
+    //      that the next `rep` is 8-byte aligned)
+    //
+    // rep is guaranteed to be 2-byte aligned
+    // def is guaranteed to be 2-byte aligned
+    // values is guaranteed to be 8-byte aligned
+    // rep_len, def_len, and values_len are guaranteed to be 2-byte aligned but this shouldn't matter.
     //
     // Each block has a u16 word of metadata.  The upper 12 bits contain 1/6 the
     // # of bytes in the block (if the block does not have an even number of bytes
-    // then up to 5 bytes of padding are added).  The lower 4 bits describe the log_2
-    // number of value (e.g. if there are 1024 then the lower 4 bits will be
+    // then up to 7 bytes of padding are added).  The lower 4 bits describe the log_2
+    // number of values (e.g. if there are 1024 then the lower 4 bits will be
     // 0xA)  All blocks except the last must have power-of-two number of values.
     // This not only makes metadata smaller but it makes decoding easier since
     // batch sizes are typically a power of 2.  4 bits would allow us to express
     // up to 16Ki values but we restrict this further to 4Ki values.
     //
-    // This means blocks can have 1 to 4Ki values and 6 - 24Ki bytes.  E.g.
-    // the worst case will have 2 bytes each of repetition and definition
-    // which means a block would be limited to 1024 values (giving 4KiB for
-    // value data and 4KiB for rep/def)
+    // This means blocks can have 1 to 4Ki values and 8 - 32Ki bytes.
     //
     // All metadata words are serialized (as little endian) into a single buffer
     // of metadata values.
@@ -1579,32 +1607,25 @@ impl PrimitiveStructuralEncoder {
     ) -> (LanceBuffer, LanceBuffer) {
         let bytes_rep = rep.iter().map(|r| r.len()).sum::<usize>();
         let bytes_def = def.iter().map(|d| d.len()).sum::<usize>();
-        // Each chunk starts with the size of the rep buffer (2 bytes) and the size of
-        // the def buffer (2 bytes)
+        // Each chunk ends with the size of the rep buffer (2 bytes) and the size of
+        // the def buffer (2 bytes).  These are put at the end so as to not disturb
+        // the alignment guarantees given to the compressor.
         let max_bytes_repdef_len = rep.len() * 4;
+        let max_padding = miniblocks.chunks.len() * (1 + (2 * MINIBLOCK_MAX_PADDING));
         let mut data_buffer = Vec::with_capacity(
-            miniblocks.data.len()
-                + bytes_rep
-                + bytes_def
-                + max_bytes_repdef_len
-                + MINIBLOCK_MAX_PADDING as usize,
+            miniblocks.data.len()      // `values`
+                + bytes_rep            // `rep_len * num_blocks`
+                + bytes_def            // `def_len * num_blocks`
+                + max_bytes_repdef_len // `rep` and `def`
+                + max_padding, // `P1`, `P2`, and `P3` for each block
         );
         let mut meta_buffer = Vec::with_capacity(miniblocks.data.len() * 2);
 
         let mut value_offset = 0;
         for ((chunk, rep), def) in miniblocks.chunks.into_iter().zip(rep).zip(def) {
-            let chunk_bytes = chunk.num_bytes as u64 + rep.len() as u64 + def.len() as u64 + 6;
-            assert!(chunk_bytes <= 16 * 1024);
-            assert!(chunk_bytes > 0);
-            // We subtract 1 here from chunk_bytes because we want to be able to express
-            // a size of 24KiB and not (24Ki - 6)B which is what we'd get otherwise with
-            // 0xFFF
-            let divided_bytes = chunk_bytes.div_ceil(MINIBLOCK_SIZE_MULTIPLIER);
-            let pad_bytes = (MINIBLOCK_SIZE_MULTIPLIER * divided_bytes) - chunk_bytes;
-            let divided_bytes_minus_one = divided_bytes - 1;
-
-            let metadata = ((divided_bytes_minus_one << 4) | chunk.log_num_values as u64) as u16;
-            meta_buffer.extend_from_slice(&metadata.to_le_bytes());
+            let start_len = data_buffer.len();
+            // Start of chunk should be aligned
+            debug_assert_eq!(start_len % MINIBLOCK_ALIGNMENT, 0);
 
             assert!(rep.len() < u16::MAX as usize);
             assert!(def.len() < u16::MAX as usize);
@@ -1617,16 +1638,37 @@ impl PrimitiveStructuralEncoder {
             data_buffer.extend_from_slice(&bytes_val.to_le_bytes());
 
             data_buffer.extend_from_slice(&rep);
+            // In theory we should insert P1 here.  However, since we do not have bit-packing of rep
+            // def levels yet we can skip this step.
+            debug_assert_eq!(data_buffer.len() % 2, 0);
             data_buffer.extend_from_slice(&def);
+
+            let p2 = pad_bytes::<MINIBLOCK_ALIGNMENT>(data_buffer.len());
+            // SAFETY: We ensured the data buffer would be large enough when we allocated
+            data_buffer.extend(iter::repeat(0).take(p2));
 
             let num_value_bytes = chunk.num_bytes as usize;
             let values =
                 &miniblocks.data[value_offset as usize..value_offset as usize + num_value_bytes];
+            debug_assert_eq!(data_buffer.len() % MINIBLOCK_ALIGNMENT, 0);
             data_buffer.extend_from_slice(values);
 
-            data_buffer.extend(iter::repeat(0).take(pad_bytes as usize));
-
+            let p3 = pad_bytes::<MINIBLOCK_ALIGNMENT>(data_buffer.len());
+            data_buffer.extend(iter::repeat(0).take(p3));
             value_offset += num_value_bytes as u64;
+
+            let chunk_bytes = data_buffer.len() - start_len;
+            assert!(chunk_bytes <= 16 * 1024);
+            assert!(chunk_bytes > 0);
+            assert_eq!(chunk_bytes % 8, 0);
+            // We subtract 1 here from chunk_bytes because we want to be able to express
+            // a size of 32KiB and not (32Ki - 8)B which is what we'd get otherwise with
+            // 0xFFF
+            let divided_bytes = chunk_bytes / MINIBLOCK_ALIGNMENT;
+            let divided_bytes_minus_one = (divided_bytes - 1) as u64;
+
+            let metadata = ((divided_bytes_minus_one << 4) | chunk.log_num_values as u64) as u16;
+            meta_buffer.extend_from_slice(&metadata.to_le_bytes());
         }
 
         (

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -281,6 +281,7 @@ pub async fn check_round_trip_encoding_generated(
                 max_page_bytes: MAX_PAGE_BYTES,
                 cache_bytes_per_column: page_size,
                 keep_original_array: true,
+                buffer_alignment: 64,
             };
             encoding_strategy
                 .create_field_encoder(
@@ -412,6 +413,7 @@ pub async fn check_round_trip_encoding_of_data(
             cache_bytes_per_column: *page_size,
             max_page_bytes: test_cases.get_max_page_size(),
             keep_original_array: true,
+            buffer_alignment: 64,
         };
         let encoder = encoding_strategy
             .create_field_encoder(
@@ -472,7 +474,7 @@ impl SimulatedWriter {
     }
 
     fn new_external_buffers(&self) -> OutOfLineBuffers {
-        OutOfLineBuffers::new(self.encoded_data.len() as u64)
+        OutOfLineBuffers::new(self.encoded_data.len() as u64, /*buffer_alignment=*/ 1)
     }
 }
 

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -42,6 +42,7 @@ use lance_io::{
 use crate::{
     datatypes::{Fields, FieldsWithMeta},
     format::{pb, pbfile, MAGIC, MAJOR_VERSION, MINOR_VERSION},
+    v2::writer::PAGE_BUFFER_ALIGNMENT,
 };
 
 use super::io::LanceEncodingsIo;
@@ -426,12 +427,19 @@ impl FileReader {
         }
     }
 
-    fn do_decode_gbo_table(gbo_bytes: &Bytes, footer: &Footer) -> Result<Vec<BufferDescriptor>> {
+    fn do_decode_gbo_table(
+        gbo_bytes: &Bytes,
+        footer: &Footer,
+        version: LanceFileVersion,
+    ) -> Result<Vec<BufferDescriptor>> {
         let mut global_bufs_cursor = Cursor::new(gbo_bytes);
 
         let mut global_buffers = Vec::with_capacity(footer.num_global_buffers as usize);
         for _ in 0..footer.num_global_buffers {
             let buf_pos = global_bufs_cursor.read_u64::<LittleEndian>()?;
+            assert!(
+                version < LanceFileVersion::V2_1 || buf_pos % PAGE_BUFFER_ALIGNMENT as u64 == 0
+            );
             let buf_size = global_bufs_cursor.read_u64::<LittleEndian>()?;
             global_buffers.push(BufferDescriptor {
                 position: buf_pos,
@@ -447,6 +455,7 @@ impl FileReader {
         file_len: u64,
         scheduler: &FileScheduler,
         footer: &Footer,
+        version: LanceFileVersion,
     ) -> Result<Vec<BufferDescriptor>> {
         // This could, in theory, trigger another IOP but the GBO table should never be large
         // enough for that to happen
@@ -457,7 +466,7 @@ impl FileReader {
             file_len,
         )
         .await?;
-        Self::do_decode_gbo_table(&gbo_bytes, footer)
+        Self::do_decode_gbo_table(&gbo_bytes, footer, version)
     }
 
     fn decode_schema(schema_bytes: Bytes) -> Result<(u64, lance_core::datatypes::Schema)> {
@@ -490,7 +499,13 @@ impl FileReader {
         let (tail_bytes, file_len) = Self::read_tail(scheduler).await?;
         let footer = Self::decode_footer(&tail_bytes)?;
 
-        let gbo_table = Self::decode_gbo_table(&tail_bytes, file_len, scheduler, &footer).await?;
+        let file_version = LanceFileVersion::try_from_major_minor(
+            footer.major_version as u32,
+            footer.minor_version as u32,
+        )?;
+
+        let gbo_table =
+            Self::decode_gbo_table(&tail_bytes, file_len, scheduler, &footer, file_version).await?;
         if gbo_table.is_empty() {
             return Err(Error::Internal {
                 message: "File did not contain any global buffers, schema expected".to_string(),
@@ -521,11 +536,6 @@ impl FileReader {
         let num_global_buffer_bytes = gbo_table.iter().map(|buf| buf.size).sum::<u64>();
         let num_data_bytes = footer.column_meta_start - num_global_buffer_bytes;
         let num_column_metadata_bytes = footer.global_buff_offsets_start - footer.column_meta_start;
-
-        let file_version = LanceFileVersion::try_from_major_minor(
-            footer.major_version as u32,
-            footer.minor_version as u32,
-        )?;
 
         let column_infos = Self::meta_to_col_infos(column_metadatas.as_slice(), file_version);
 
@@ -586,7 +596,14 @@ impl FileReader {
                             page.buffer_offsets
                                 .iter()
                                 .zip(page.buffer_sizes.iter())
-                                .map(|(offset, size)| (*offset, *size))
+                                .map(|(offset, size)| {
+                                    // Starting with version 2.1 we can assert that page buffers are aligned
+                                    assert!(
+                                        file_version < LanceFileVersion::V2_1
+                                            || offset % PAGE_BUFFER_ALIGNMENT as u64 == 0
+                                    );
+                                    (*offset, *size)
+                                })
                                 .collect::<Vec<_>>(),
                         );
                         PageInfo {
@@ -1092,6 +1109,7 @@ impl EncodedBatchReaderExt for EncodedBatch {
         let gbo_table = FileReader::do_decode_gbo_table(
             &bytes.slice(footer.global_buff_offsets_start as usize..),
             &footer,
+            file_version,
         )?;
         if gbo_table.is_empty() {
             return Err(Error::Internal {

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -1294,6 +1294,7 @@ pub mod tests {
             cache_bytes_per_column: 4096,
             max_page_bytes: 32 * 1024 * 1024,
             keep_original_array: true,
+            buffer_alignment: 64,
         };
         let encoded_batch = encode_batch(
             &data,

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -12,6 +12,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use futures::stream::FuturesOrdered;
 use futures::StreamExt;
 use lance_core::datatypes::{Field, Schema as LanceSchema};
+use lance_core::utils::bit::pad_bytes;
 use lance_core::{Error, Result};
 use lance_encoding::decoder::PageEncoding;
 use lance_encoding::encoder::{
@@ -34,6 +35,10 @@ use crate::format::pb;
 use crate::format::pbfile;
 use crate::format::pbfile::DirectEncoding;
 use crate::format::MAGIC;
+
+/// Pages buffers are aligned to 64 bytes
+pub(crate) const PAGE_BUFFER_ALIGNMENT: usize = 64;
+const PAD_BUFFER: [u8; PAGE_BUFFER_ALIGNMENT] = [72; PAGE_BUFFER_ALIGNMENT];
 
 #[derive(Debug, Clone, Default)]
 pub struct FileWriterOptions {
@@ -138,6 +143,13 @@ impl FileWriter {
         }
     }
 
+    async fn do_write_buffer(writer: &mut ObjectWriter, buf: &[u8]) -> Result<()> {
+        writer.write_all(buf).await?;
+        let pad_bytes = pad_bytes::<PAGE_BUFFER_ALIGNMENT>(buf.len());
+        writer.write_all(&PAD_BUFFER[..pad_bytes]).await?;
+        Ok(())
+    }
+
     /// Returns the format version that will be used when writing the file
     pub fn version(&self) -> LanceFileVersion {
         self.options.format_version.unwrap_or_default()
@@ -150,7 +162,7 @@ impl FileWriter {
         for buffer in buffers {
             buffer_offsets.push(self.writer.tell().await? as u64);
             buffer_sizes.push(buffer.len() as u64);
-            self.writer.write_all(&buffer).await?;
+            Self::do_write_buffer(&mut self.writer, &buffer).await?;
         }
         let encoded_encoding = match encoded_page.description {
             PageEncoding::Legacy(array_encoding) => Any::from_msg(&array_encoding)?.encode_to_vec(),
@@ -333,7 +345,7 @@ impl FileWriter {
         let encoding_tasks = self.encode_batch(batch, &mut external_buffers)?;
         // Next, write external buffers
         for external_buffer in external_buffers.take_buffers() {
-            self.writer.write_all(&external_buffer).await?;
+            Self::do_write_buffer(&mut self.writer, &external_buffer).await?;
         }
 
         let encoding_tasks = encoding_tasks
@@ -419,7 +431,7 @@ impl FileWriter {
     pub async fn add_global_buffer(&mut self, buffer: Bytes) -> Result<u32> {
         let position = self.writer.tell().await? as u64;
         let len = buffer.len() as u64;
-        self.writer.write_all(&buffer).await?;
+        Self::do_write_buffer(&mut self.writer, &buffer).await?;
         self.global_buffers.push((position, len));
         Ok(self.global_buffers.len() as u32)
     }
@@ -449,7 +461,7 @@ impl FileWriter {
                 for buffer in column.column_buffers {
                     column_metadata.buffer_offsets.push(buffer_pos);
                     let mut size = 0;
-                    self.writer.write_all(&buffer).await?;
+                    Self::do_write_buffer(&mut self.writer, &buffer).await?;
                     size += buffer.len() as u64;
                     buffer_pos += size;
                     column_metadata.buffer_sizes.push(size);
@@ -500,7 +512,7 @@ impl FileWriter {
             .map(|writer| writer.flush(&mut external_buffers))
             .collect::<Result<Vec<_>>>()?;
         for external_buffer in external_buffers.take_buffers() {
-            self.writer.write_all(&external_buffer).await?;
+            Self::do_write_buffer(&mut self.writer, &external_buffer).await?;
         }
         let encoding_tasks = encoding_tasks
             .into_iter()


### PR DESCRIPTION
This ensures that all file buffers are aligned to 64 bytes (these are generally 8MiB buffers and so 64 bytes is trivial)

We also ensure that all mini-block chunks are aligned to 8 bytes.  This introduced a bit more padding but makes it easier to do things like store offsets into mini-block chunks.