### PR TITLE
ci(rust): enforce no println

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,5 +179,8 @@ use_self = "deny"
 dbg_macro = "deny"
 trait_duplication_in_bounds = "deny"
 redundant_clone = "deny"
+# We should always use log instead of println
+print_stdout = "deny"
+print_stderr = "deny"
 # not too much we can do to avoid multiple crate versions
 multiple-crate-versions = "allow"

--- a/rust/lance-datafusion/src/planner.rs
+++ b/rust/lance-datafusion/src/planner.rs
@@ -953,7 +953,6 @@ mod tests {
             .unwrap();
 
         let physical_expr = planner.create_physical_expr(&expr).unwrap();
-        println!("Physical expr: {:#?}", physical_expr);
 
         let batch = RecordBatch::try_new(
             schema,

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -1571,7 +1571,6 @@ mod tests {
                 LanceBuffer::reinterpret_vec::<i8>(vec![3, 0, 1, 2, 3])
             );
         };
-        println!("Check one");
         check_common(data);
 
         // However, we can manually create a dictionary where nulls are in the dictionary
@@ -1581,7 +1580,6 @@ mod tests {
 
         let data = DataBlock::from_array(dict);
 
-        println!("Check two");
         check_common(data);
     }
 

--- a/rust/lance-io/benches/scheduler.rs
+++ b/rust/lance-io/benches/scheduler.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
+#![allow(clippy::print_stdout)]
 
 use bytes::Bytes;
 use lance_core::Result;

--- a/rust/lance/benches/ivf_pq.rs
+++ b/rust/lance/benches/ivf_pq.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+#![allow(clippy::print_stdout)]
+
 use std::sync::Arc;
 
 use arrow_array::{FixedSizeListArray, RecordBatch, RecordBatchIterator};

--- a/rust/lance/benches/scan.rs
+++ b/rust/lance/benches/scan.rs
@@ -12,6 +12,8 @@
 //!
 //! TODO: Take parameterized input to specify dataset URI from command line.
 
+#![allow(clippy::print_stdout)]
+
 use arrow_array::{
     BinaryArray, FixedSizeListArray, Float32Array, Int32Array, RecordBatch, RecordBatchIterator,
     StringArray,

--- a/rust/lance/benches/vector_index.rs
+++ b/rust/lance/benches/vector_index.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
+#![allow(clippy::print_stdout)]
 
 use std::sync::Arc;
 

--- a/rust/lance/src/bin/lq.rs
+++ b/rust/lance/src/bin/lq.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+#![allow(clippy::print_stdout)]
+
 use arrow::util::pretty::print_batches;
 use arrow_array::RecordBatch;
 use clap::{Parser, Subcommand, ValueEnum};
@@ -59,7 +61,7 @@ enum Commands {
         #[arg(short = 't', long = "type", value_enum, value_name = "TYPE")]
         index_type: Option<IndexType>,
 
-        /// Nunber of IVF partitions. Only useful when the index type is 'ivf-pq'.
+        /// Number of IVF partitions. Only useful when the index type is 'ivf-pq'.
         #[arg(short = 'p', long, default_value_t = 64, value_name = "NUM")]
         num_partitions: usize,
 

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1109,7 +1109,6 @@ impl FileFragment {
         projection: &Schema,
         with_row_address: bool,
     ) -> Result<RecordBatch> {
-        println!("Fragment take (offsets={:?}", row_offsets);
         let reader = self
             .open(
                 projection,

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1672,8 +1672,6 @@ mod tests {
                 .project(&["i"])
                 .unwrap();
 
-            println!("{}", scanner.explain_plan(true).await.unwrap());
-
             scanner.try_into_batch().await.unwrap()
         }
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -2783,8 +2783,6 @@ mod test {
         scan.project(&["i", "vec"]).unwrap();
         scan.refine(5);
 
-        println!("{}", scan.explain_plan(true).await.unwrap());
-
         let results = scan
             .try_into_stream()
             .await

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -2806,7 +2806,6 @@ mod tests {
                 .unwrap()
                 .as_primitive::<UInt64Type>()
                 .value(0);
-            println!("Row id: {} query_id: {}", row_id, query_id);
             if row_id == (query_id as u64) {
                 correct_times += 1;
             }

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -789,7 +789,6 @@ mod tests {
             DistanceType::L2,
         )
         .unwrap();
-        println!("{:?}", idx);
         assert_eq!(
             idx.schema().as_ref(),
             &ArrowSchema::new(vec![


### PR DESCRIPTION
Follow up to #3074

Adds a clippy lint to say no println. Many of the leftovers were in tests.