### PR TITLE
feat: add full zip encoding for wide data types

### DIFF
--- a/protos/encodings.proto
+++ b/protos/encodings.proto
@@ -314,6 +314,19 @@ message MiniBlockLayout {
   ArrayEncoding value_compression = 3;
 }
 
+/// A layout used for pages where the data is large
+///
+/// In this case the cost of transposing the data is relatively small (compared to the cost of writing the data)
+/// and so we just zip the buffers together
+message FullZipLayout {
+  // The number of bits of repetition info (0 if there is no repetition)
+  uint32 bits_rep = 1;
+  // The number of bits of definition info (0 if there is no definition)
+  uint32 bits_def = 2;
+  // Description of the compression of values
+  ArrayEncoding value_compression = 3;
+}
+
 /// A layout used for pages where all values are null
 ///
 /// In addition, there can be no repetition levels and only a single definition level
@@ -327,5 +340,6 @@ message PageLayout {
   oneof layout {
     MiniBlockLayout mini_block_layout = 1;
     AllNullLayout all_null_layout = 2;
+    FullZipLayout full_zip_layout = 3;
   }
 }

--- a/rust/lance-core/src/utils/bit.rs
+++ b/rust/lance-core/src/utils/bit.rs
@@ -19,3 +19,78 @@ pub fn pad_bytes_u64<const ALIGN: u64>(n: u64) -> u64 {
     debug_assert!(is_pwr_two(ALIGN));
     (ALIGN - (n & (ALIGN - 1))) & (ALIGN - 1)
 }
+
+// This is a lookup table for the log2 of the first 256 numbers
+const LOG_TABLE_256: [u8; 256] = [
+    0, 1, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+    6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+    7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+    7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+    8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+    8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+    8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+    8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+];
+
+/// Returns the number of bits needed to represent the given number
+///
+/// Inspired by https://graphics.stanford.edu/~seander/bithacks.html
+pub fn log_2_ceil(val: u32) -> u32 {
+    assert!(val > 0);
+    let upper_half = val >> 16;
+    if upper_half == 0 {
+        let third_quarter = val >> 8;
+        if third_quarter == 0 {
+            // Use lowest 8 bits (upper 24 are 0)
+            LOG_TABLE_256[val as usize] as u32
+        } else {
+            // Use bits 16..24 (0..16 are 0)
+            LOG_TABLE_256[third_quarter as usize] as u32 + 8
+        }
+    } else {
+        let first_quarter = upper_half >> 8;
+        if first_quarter == 0 {
+            // Use bits 8..16 (0..8 are 0)
+            16 + LOG_TABLE_256[upper_half as usize] as u32
+        } else {
+            // Use most significant bits (it's a big number!)
+            24 + LOG_TABLE_256[first_quarter as usize] as u32
+        }
+    }
+}
+
+/// Asserts if the currently running system is not little_endian
+pub fn check_little_endian() {
+    assert_eq!(
+        1u16.to_le_bytes(),
+        [1, 0],
+        "This code is for little-endian systems only"
+    );
+}
+
+#[cfg(test)]
+
+pub mod tests {
+    use crate::utils::bit::log_2_ceil;
+
+    #[test]
+    fn test_log_2_ceil() {
+        fn classic_approach(mut val: u32) -> u32 {
+            let mut counter = 0;
+            while val > 0 {
+                val >>= 1;
+                counter += 1;
+            }
+            counter
+        }
+
+        for i in 1..(16 * 1024) {
+            assert_eq!(log_2_ceil(i), classic_approach(i));
+        }
+        assert_eq!(log_2_ceil(50 * 1024), classic_approach(50 * 1024));
+        assert_eq!(
+            log_2_ceil(1024 * 1024 * 1024),
+            classic_approach(1024 * 1024 * 1024)
+        );
+    }
+}

--- a/rust/lance-core/src/utils/bit.rs
+++ b/rust/lance-core/src/utils/bit.rs
@@ -59,15 +59,6 @@ pub fn log_2_ceil(val: u32) -> u32 {
     }
 }
 
-/// Asserts if the currently running system is not little_endian
-pub fn check_little_endian() {
-    assert_eq!(
-        1u16.to_le_bytes(),
-        [1, 0],
-        "This code is for little-endian systems only"
-    );
-}
-
 #[cfg(test)]
 
 pub mod tests {

--- a/rust/lance-encoding/src/buffer.rs
+++ b/rust/lance-encoding/src/buffer.rs
@@ -8,7 +8,10 @@ use std::{ops::Deref, ptr::NonNull, sync::Arc};
 use arrow_buffer::{ArrowNativeType, Buffer, MutableBuffer, ScalarBuffer};
 use snafu::{location, Location};
 
-use lance_core::{utils::bit::is_pwr_two, Error, Result};
+use lance_core::{
+    utils::bit::{check_little_endian, is_pwr_two},
+    Error, Result,
+};
 
 /// A copy-on-write byte buffer
 ///
@@ -223,6 +226,7 @@ impl LanceBuffer {
     ///
     /// If the underlying buffer is not properly aligned, this will involve a copy of the data
     pub fn borrow_to_typed_slice<T: ArrowNativeType>(&mut self) -> impl AsRef<[T]> {
+        check_little_endian();
         let align = std::mem::align_of::<T>();
         let is_aligned = self.as_ptr().align_offset(align) == 0;
         if self.len() % std::mem::size_of::<T>() != 0 {

--- a/rust/lance-encoding/src/buffer.rs
+++ b/rust/lance-encoding/src/buffer.rs
@@ -222,7 +222,11 @@ impl LanceBuffer {
     /// Reinterprets a LanceBuffer into a Vec<T>
     ///
     /// If the underlying buffer is not properly aligned, this will involve a copy of the data
-    #[cfg(target_endian = "little")]
+    ///
+    /// Note: doing this sort of re-interpretation generally makes assumptions about the endianness
+    /// of the data.  Lance does not support big-endian machines so this is safe.  However, if we end
+    /// up supporting big-endian machines in the future, then any use of this method will need to be
+    /// carefully reviewed.
     pub fn borrow_to_typed_slice<T: ArrowNativeType>(&mut self) -> impl AsRef<[T]> {
         let align = std::mem::align_of::<T>();
         let is_aligned = self.as_ptr().align_offset(align) == 0;

--- a/rust/lance-encoding/src/buffer.rs
+++ b/rust/lance-encoding/src/buffer.rs
@@ -8,10 +8,7 @@ use std::{ops::Deref, ptr::NonNull, sync::Arc};
 use arrow_buffer::{ArrowNativeType, Buffer, MutableBuffer, ScalarBuffer};
 use snafu::{location, Location};
 
-use lance_core::{
-    utils::bit::{check_little_endian, is_pwr_two},
-    Error, Result,
-};
+use lance_core::{utils::bit::is_pwr_two, Error, Result};
 
 /// A copy-on-write byte buffer
 ///
@@ -225,8 +222,8 @@ impl LanceBuffer {
     /// Reinterprets a LanceBuffer into a Vec<T>
     ///
     /// If the underlying buffer is not properly aligned, this will involve a copy of the data
+    #[cfg(target_endian = "little")]
     pub fn borrow_to_typed_slice<T: ArrowNativeType>(&mut self) -> impl AsRef<[T]> {
-        check_little_endian();
         let align = std::mem::align_of::<T>();
         let is_aligned = self.as_ptr().align_offset(align) == 0;
         if self.len() % std::mem::size_of::<T>() != 0 {

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -248,6 +248,7 @@ use crate::encodings::logical::r#struct::{
 };
 use crate::encodings::physical::binary::BinaryMiniBlockDecompressor;
 use crate::encodings::physical::bitpack_fastlanes::BitpackMiniBlockDecompressor;
+use crate::encodings::physical::fixed_size_list::FslPerValueDecompressor;
 use crate::encodings::physical::value::{ConstantDecompressor, ValueDecompressor};
 use crate::encodings::physical::{ColumnBuffers, FileBuffers};
 use crate::format::pb::{self, column_encoding};
@@ -454,8 +455,14 @@ pub trait MiniBlockDecompressor: std::fmt::Debug + Send + Sync {
     fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock>;
 }
 
-pub trait FixedPerValueDecompressor: std::fmt::Debug + Send + Sync {
+pub trait PerValueDecompressor: std::fmt::Debug + Send + Sync {
+    /// Decompress one or more values
     fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock>;
+    /// The number of bits in each value
+    ///
+    /// Returns 0 if the data type is variable-width
+    ///
+    /// Currently (and probably long term) this must be a multiple of 8
     fn bits_per_value(&self) -> u64;
 }
 
@@ -469,10 +476,10 @@ pub trait DecompressorStrategy: std::fmt::Debug + Send + Sync {
         description: &pb::ArrayEncoding,
     ) -> Result<Box<dyn MiniBlockDecompressor>>;
 
-    fn create_fixed_per_value_decompressor(
+    fn create_per_value_decompressor(
         &self,
         description: &pb::ArrayEncoding,
-    ) -> Result<Box<dyn FixedPerValueDecompressor>>;
+    ) -> Result<Box<dyn PerValueDecompressor>>;
 
     fn create_block_decompressor(
         &self,
@@ -502,13 +509,21 @@ impl DecompressorStrategy for CoreDecompressorStrategy {
         }
     }
 
-    fn create_fixed_per_value_decompressor(
+    fn create_per_value_decompressor(
         &self,
         description: &pb::ArrayEncoding,
-    ) -> Result<Box<dyn FixedPerValueDecompressor>> {
+    ) -> Result<Box<dyn PerValueDecompressor>> {
         match description.array_encoding.as_ref().unwrap() {
             pb::array_encoding::ArrayEncoding::Flat(flat) => {
                 Ok(Box::new(ValueDecompressor::new(flat)))
+            }
+            pb::array_encoding::ArrayEncoding::FixedSizeList(fsl) => {
+                let items_decompressor =
+                    self.create_per_value_decompressor(fsl.items.as_ref().unwrap())?;
+                Ok(Box::new(FslPerValueDecompressor::new(
+                    items_decompressor,
+                    fsl.dimension as u64,
+                )))
             }
             _ => todo!(),
         }

--- a/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
@@ -9,10 +9,10 @@ use lance_core::Result;
 use log::trace;
 
 use crate::{
-    data::{DataBlock, FixedSizeListBlock},
-    decoder::{PageScheduler, PrimitivePageDecoder},
-    encoder::{ArrayEncoder, EncodedArray},
-    format::ProtobufUtils,
+    data::{BlockInfo, DataBlock, FixedSizeListBlock, FixedWidthDataBlock, UsedEncoding},
+    decoder::{PageScheduler, PerValueDecompressor, PrimitivePageDecoder},
+    encoder::{ArrayEncoder, EncodedArray, PerValueCompressor, PerValueDataBlock},
+    format::{pb, ProtobufUtils},
     EncodingsIo,
 };
 
@@ -123,8 +123,103 @@ impl ArrayEncoder for FslEncoder {
             dimension: self.dimension as u64,
         });
 
-        let encoding = ProtobufUtils::fixed_size_list(encoded_data.encoding, self.dimension);
+        let encoding = ProtobufUtils::fixed_size_list(encoded_data.encoding, self.dimension as u64);
         Ok(EncodedArray { data, encoding })
+    }
+}
+
+/// A compressor for primitive FSLs that flattens each list into a
+/// single value.  If the inner list has validity then the validity
+/// is zipped in with the values.
+///
+/// In other words, if the list is FSL<u8?, 2> [[0, NULL], [4, 10]] then the
+/// two buffers start as:
+///
+/// values: 0x00 0x?? 0x04 0x0A
+/// validity: 0b1011
+///
+/// The output will be:
+///
+/// zipped: 0x01 0x00 0x00 0x?? 0x01 0x04 0x01 0x0A
+///
+/// Note that we expand validity to be at least a byte per value so this
+/// approach is not ideal for small lists, though we should be using mini-block
+/// for small lists anyways.
+#[derive(Debug)]
+pub struct FslPerValueCompressor {
+    items_compressor: Box<dyn PerValueCompressor>,
+    dimension: u64,
+}
+
+impl FslPerValueCompressor {
+    pub fn new(items_compressor: Box<dyn PerValueCompressor>, dimension: u64) -> Self {
+        Self {
+            items_compressor,
+            dimension,
+        }
+    }
+}
+
+impl PerValueCompressor for FslPerValueCompressor {
+    fn compress(&self, data: DataBlock) -> Result<(PerValueDataBlock, pb::ArrayEncoding)> {
+        let mut data = data.as_fixed_size_list().unwrap();
+        let flattened = match data.child.as_mut() {
+            DataBlock::FixedWidth(fixed_width) => DataBlock::FixedWidth(FixedWidthDataBlock {
+                bits_per_value: fixed_width.bits_per_value * self.dimension,
+                data: fixed_width.data.borrow_and_clone(),
+                block_info: BlockInfo::new(),
+                num_values: fixed_width.num_values / self.dimension,
+                used_encoding: UsedEncoding::new(),
+            }),
+            DataBlock::VariableWidth(_) => todo!("GH-3111: FSL with variable inner type"),
+            DataBlock::Nullable(_) => todo!("GH-3112: FSL with nullable inner type"),
+            DataBlock::FixedSizeList(_) => todo!("GH-3113: Nested FSLs"),
+            _ => unreachable!(),
+        };
+        let (compressed, encoding) = self.items_compressor.compress(flattened)?;
+        let wrapped_encoding = ProtobufUtils::fixed_size_list(encoding, self.dimension);
+
+        Ok((compressed, wrapped_encoding))
+    }
+}
+
+/// Reversed the process described in [`FslPerValueCompressor`]
+#[derive(Debug)]
+pub struct FslPerValueDecompressor {
+    items_decompressor: Box<dyn PerValueDecompressor>,
+    dimension: u64,
+}
+
+impl FslPerValueDecompressor {
+    pub fn new(items_decompressor: Box<dyn PerValueDecompressor>, dimension: u64) -> Self {
+        Self {
+            items_decompressor,
+            dimension,
+        }
+    }
+}
+
+impl PerValueDecompressor for FslPerValueDecompressor {
+    fn decompress(&self, data: crate::buffer::LanceBuffer, num_values: u64) -> Result<DataBlock> {
+        let decompressed = self.items_decompressor.decompress(data, num_values)?;
+        let unflattened = match decompressed {
+            DataBlock::FixedWidth(fixed_width) => DataBlock::FixedWidth(FixedWidthDataBlock {
+                bits_per_value: fixed_width.bits_per_value / self.dimension,
+                data: fixed_width.data,
+                block_info: BlockInfo::new(),
+                num_values: fixed_width.num_values * self.dimension,
+                used_encoding: UsedEncoding::new(),
+            }),
+            _ => todo!(),
+        };
+        Ok(DataBlock::FixedSizeList(FixedSizeListBlock {
+            child: Box::new(unflattened),
+            dimension: self.dimension,
+        }))
+    }
+
+    fn bits_per_value(&self) -> u64 {
+        self.items_decompressor.bits_per_value()
     }
 }
 

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -12,10 +12,10 @@ use std::sync::{Arc, Mutex};
 
 use crate::buffer::LanceBuffer;
 use crate::data::{BlockInfo, ConstantDataBlock, DataBlock, FixedWidthDataBlock, UsedEncoding};
-use crate::decoder::{BlockDecompressor, FixedPerValueDecompressor, MiniBlockDecompressor};
+use crate::decoder::{BlockDecompressor, MiniBlockDecompressor, PerValueDecompressor};
 use crate::encoder::{
-    BlockCompressor, FixedPerValueCompressor, MiniBlockChunk, MiniBlockCompressed,
-    MiniBlockCompressor, MAX_MINIBLOCK_BYTES, MAX_MINIBLOCK_VALUES,
+    BlockCompressor, MiniBlockChunk, MiniBlockCompressed, MiniBlockCompressor, PerValueCompressor,
+    PerValueDataBlock, MAX_MINIBLOCK_BYTES, MAX_MINIBLOCK_VALUES,
 };
 use crate::format::pb::{self, ArrayEncoding};
 use crate::format::ProtobufUtils;
@@ -425,7 +425,7 @@ impl MiniBlockDecompressor for ValueDecompressor {
     }
 }
 
-impl FixedPerValueDecompressor for ValueDecompressor {
+impl PerValueDecompressor for ValueDecompressor {
     fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
         MiniBlockDecompressor::decompress(self, data, num_values)
     }
@@ -435,12 +435,12 @@ impl FixedPerValueDecompressor for ValueDecompressor {
     }
 }
 
-impl FixedPerValueCompressor for ValueEncoder {
-    fn compress(&self, data: DataBlock) -> Result<(FixedWidthDataBlock, ArrayEncoding)> {
+impl PerValueCompressor for ValueEncoder {
+    fn compress(&self, data: DataBlock) -> Result<(PerValueDataBlock, ArrayEncoding)> {
         let (data, encoding) = match data {
             DataBlock::FixedWidth(fixed_width) => {
                 let encoding = ProtobufUtils::flat_encoding(fixed_width.bits_per_value, 0, None);
-                (fixed_width, encoding)
+                (PerValueDataBlock::Fixed(fixed_width), encoding)
             }
             _ => unimplemented!(
                 "Cannot compress block of type {} with ValueEncoder",
@@ -498,6 +498,25 @@ pub(crate) mod tests {
         #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
     ) {
         for data_type in PRIMITIVE_TYPES {
+            log::info!("Testing encoding for {:?}", data_type);
+            let field = Field::new("", data_type.clone(), false);
+            check_round_trip_encoding_random(field, version).await;
+        }
+    }
+
+    lazy_static::lazy_static! {
+        static ref LARGE_TYPES: Vec<DataType> = vec![DataType::FixedSizeList(
+            Arc::new(Field::new("", DataType::Int32, false)),
+            128,
+        )];
+    }
+
+    #[rstest]
+    #[test_log::test(tokio::test)]
+    async fn test_large_primitive(
+        #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
+    ) {
+        for data_type in LARGE_TYPES.iter() {
             log::info!("Testing encoding for {:?}", data_type);
             let field = Field::new("", data_type.clone(), false);
             check_round_trip_encoding_random(field, version).await;

--- a/rust/lance-encoding/src/format.rs
+++ b/rust/lance-encoding/src/format.rs
@@ -193,10 +193,10 @@ impl ProtobufUtils {
         }
     }
 
-    pub fn fixed_size_list(data: ArrayEncoding, dimension: u32) -> ArrayEncoding {
+    pub fn fixed_size_list(data: ArrayEncoding, dimension: u64) -> ArrayEncoding {
         ArrayEncoding {
             array_encoding: Some(ArrayEncodingEnum::FixedSizeList(Box::new(FixedSizeList {
-                dimension,
+                dimension: dimension.try_into().unwrap(),
                 items: Some(Box::new(data)),
             }))),
         }
@@ -220,6 +220,20 @@ impl ProtobufUtils {
             layout: Some(Layout::MiniBlockLayout(MiniBlockLayout {
                 def_compression: Some(def_encoding),
                 rep_compression: Some(rep_encoding),
+                value_compression: Some(value_encoding),
+            })),
+        }
+    }
+
+    pub fn full_zip_layout(
+        bits_rep: u8,
+        bits_def: u8,
+        value_encoding: ArrayEncoding,
+    ) -> PageLayout {
+        PageLayout {
+            layout: Some(Layout::FullZipLayout(pb::FullZipLayout {
+                bits_rep: bits_rep as u32,
+                bits_def: bits_def as u32,
                 value_compression: Some(value_encoding),
             })),
         }

--- a/rust/lance-encoding/src/lib.rs
+++ b/rust/lance-encoding/src/lib.rs
@@ -21,6 +21,12 @@ pub mod statistics;
 pub mod testing;
 pub mod version;
 
+// We can definitely add support for big-endian machines someday.  However, it's not a priority and
+// would involve extensive testing (probably through emulation) to ensure that the encodings are
+// correct.
+#[cfg(not(target_endian = "little"))]
+compile_error!("Lance encodings only support little-endian systems.");
+
 /// A trait for an I/O service
 ///
 /// This represents the I/O API that the encoders and decoders need in order to operate.

--- a/rust/lance-encoding/src/repdef.rs
+++ b/rust/lance-encoding/src/repdef.rs
@@ -92,13 +92,13 @@
 // This means we end up with 3 bits per level instead of 2.  We could instead record
 // the layers that are all null somewhere else and not require wider rep levels.
 
-use std::sync::Arc;
+use std::{iter::Zip, sync::Arc};
 
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::{
     ArrowNativeType, BooleanBuffer, BooleanBufferBuilder, NullBuffer, OffsetBuffer, ScalarBuffer,
 };
-use lance_core::{Error, Result};
+use lance_core::{utils::bit::log_2_ceil, Error, Result};
 use snafu::{location, Location};
 
 // We assume 16 bits is good enough for rep-def levels.  This gives us
@@ -541,6 +541,442 @@ impl RepDefUnraveler {
     }
 }
 
+/// A [`ControlWordIterator`] when there are both repetition and definition levels
+///
+/// The iterator will put the repetition level in the upper bits and the definition
+/// level in the lower bits.  The number of bits used for each level is determined
+/// by the width of the repetition and definition levels.
+#[derive(Debug)]
+pub struct BinaryControlWordIterator<I: Iterator<Item = (u16, u16)>, W> {
+    repdef: I,
+    def_width: usize,
+    rep_mask: u16,
+    def_mask: u16,
+    bits_rep: u8,
+    bits_def: u8,
+    phantom: std::marker::PhantomData<W>,
+}
+
+impl<I: Iterator<Item = (u16, u16)>> BinaryControlWordIterator<I, u8> {
+    fn append_next(&mut self, buf: &mut Vec<u8>) {
+        let next = self.repdef.next().unwrap();
+        let control_word: u8 =
+            (((next.0 & self.rep_mask) as u8) << self.def_width) + ((next.1 & self.def_mask) as u8);
+        buf.push(control_word);
+    }
+}
+
+impl<I: Iterator<Item = (u16, u16)>> BinaryControlWordIterator<I, u16> {
+    fn append_next(&mut self, buf: &mut Vec<u8>) {
+        let next = self.repdef.next().unwrap();
+        let control_word: u16 =
+            ((next.0 & self.rep_mask) << self.def_width) + (next.1 & self.def_mask);
+        let control_word = control_word.to_le_bytes();
+        buf.push(control_word[0]);
+        buf.push(control_word[1]);
+    }
+}
+
+impl<I: Iterator<Item = (u16, u16)>> BinaryControlWordIterator<I, u32> {
+    fn append_next(&mut self, buf: &mut Vec<u8>) {
+        let next = self.repdef.next().unwrap();
+        let control_word: u32 = (((next.0 & self.rep_mask) as u32) << self.def_width)
+            + ((next.1 & self.def_mask) as u32);
+        let control_word = control_word.to_le_bytes();
+        buf.push(control_word[0]);
+        buf.push(control_word[1]);
+        buf.push(control_word[2]);
+        buf.push(control_word[3]);
+    }
+}
+
+/// A [`ControlWordIterator`] when there are only definition levels or only repetition levels
+#[derive(Debug)]
+pub struct UnaryControlWordIterator<I: Iterator<Item = u16>, W> {
+    repdef: I,
+    level_mask: u16,
+    bits_rep: u8,
+    bits_def: u8,
+    phantom: std::marker::PhantomData<W>,
+}
+
+impl<I: Iterator<Item = u16>> UnaryControlWordIterator<I, u8> {
+    fn append_next(&mut self, buf: &mut Vec<u8>) {
+        let next = self.repdef.next().unwrap();
+        buf.push((next & self.level_mask) as u8);
+    }
+}
+
+impl<I: Iterator<Item = u16>> UnaryControlWordIterator<I, u16> {
+    fn append_next(&mut self, buf: &mut Vec<u8>) {
+        let next = self.repdef.next().unwrap() & self.level_mask;
+        let control_word = next.to_le_bytes();
+        buf.push(control_word[0]);
+        buf.push(control_word[1]);
+    }
+}
+
+impl<I: Iterator<Item = u16>> UnaryControlWordIterator<I, u32> {
+    fn append_next(&mut self, buf: &mut Vec<u8>) {
+        let next = (self.repdef.next().unwrap() & self.level_mask) as u32;
+        let control_word = next.to_le_bytes();
+        buf.push(control_word[0]);
+        buf.push(control_word[1]);
+        buf.push(control_word[2]);
+        buf.push(control_word[3]);
+    }
+}
+
+/// A [`ControlWordIterator`] when there are no repetition or definition levels
+#[derive(Debug)]
+pub struct NilaryControlWordIterator;
+
+/// Helper function to get a bit mask of the given width
+fn get_mask(width: u16) -> u16 {
+    (1 << width) - 1
+}
+
+/// An iterator that generates control words from repetition and definition levels
+///
+/// "Control word" is just a fancy term for a single u8/u16/u32 that contains both
+/// the repetition and definition in it.
+///
+/// In the large majority of case we only need a single byte to represent both the
+/// repetition and definition levels.  However, if there is deep nesting then we may
+/// need two bytes.  In the worst case we need 4 bytes though this suggests hundreds of
+/// levels of nesting which seems unlikely to encounter in practice.
+#[derive(Debug)]
+pub enum ControlWordIterator {
+    Binary8(BinaryControlWordIterator<Zip<std::vec::IntoIter<u16>, std::vec::IntoIter<u16>>, u8>),
+    Binary16(BinaryControlWordIterator<Zip<std::vec::IntoIter<u16>, std::vec::IntoIter<u16>>, u16>),
+    Binary32(BinaryControlWordIterator<Zip<std::vec::IntoIter<u16>, std::vec::IntoIter<u16>>, u32>),
+    Unary8(UnaryControlWordIterator<std::vec::IntoIter<u16>, u8>),
+    Unary16(UnaryControlWordIterator<std::vec::IntoIter<u16>, u16>),
+    Unary32(UnaryControlWordIterator<std::vec::IntoIter<u16>, u32>),
+    Nilary(NilaryControlWordIterator),
+}
+
+impl ControlWordIterator {
+    /// Appends the next control word to the buffer
+    pub fn append_next(&mut self, buf: &mut Vec<u8>) {
+        match self {
+            Self::Binary8(iter) => iter.append_next(buf),
+            Self::Binary16(iter) => iter.append_next(buf),
+            Self::Binary32(iter) => iter.append_next(buf),
+            Self::Unary8(iter) => iter.append_next(buf),
+            Self::Unary16(iter) => iter.append_next(buf),
+            Self::Unary32(iter) => iter.append_next(buf),
+            Self::Nilary(_) => {}
+        }
+    }
+
+    /// Returns the number of bytes per control word
+    pub fn bytes_per_word(&self) -> usize {
+        match self {
+            Self::Binary8(_) => 1,
+            Self::Binary16(_) => 2,
+            Self::Binary32(_) => 4,
+            Self::Unary8(_) => 1,
+            Self::Unary16(_) => 2,
+            Self::Unary32(_) => 4,
+            Self::Nilary(_) => 0,
+        }
+    }
+
+    /// Returns the number of bits used for the repetition level
+    pub fn bits_rep(&self) -> u8 {
+        match self {
+            Self::Binary8(iter) => iter.bits_rep,
+            Self::Binary16(iter) => iter.bits_rep,
+            Self::Binary32(iter) => iter.bits_rep,
+            Self::Unary8(iter) => iter.bits_rep,
+            Self::Unary16(iter) => iter.bits_rep,
+            Self::Unary32(iter) => iter.bits_rep,
+            Self::Nilary(_) => 0,
+        }
+    }
+
+    /// Returns the number of bits used for the definition level
+    pub fn bits_def(&self) -> u8 {
+        match self {
+            Self::Binary8(iter) => iter.bits_def,
+            Self::Binary16(iter) => iter.bits_def,
+            Self::Binary32(iter) => iter.bits_def,
+            Self::Unary8(iter) => iter.bits_def,
+            Self::Unary16(iter) => iter.bits_def,
+            Self::Unary32(iter) => iter.bits_def,
+            Self::Nilary(_) => 0,
+        }
+    }
+}
+
+/// Builds a [`ControlWordIterator`] from repetition and definition levels
+/// by first calculating the width needed and then creating the iterator
+/// with the appropriate width
+pub fn build_control_word_iterator(
+    rep: Option<Vec<u16>>,
+    max_rep: u16,
+    def: Option<Vec<u16>>,
+    max_def: u16,
+) -> ControlWordIterator {
+    let rep_width = if max_rep == 0 {
+        0
+    } else {
+        log_2_ceil(max_rep as u32) as u16
+    };
+    let rep_mask = if max_rep == 0 { 0 } else { get_mask(rep_width) };
+    let def_width = if max_def == 0 {
+        0
+    } else {
+        log_2_ceil(max_def as u32) as u16
+    };
+    let def_mask = if max_def == 0 { 0 } else { get_mask(def_width) };
+    let total_width = rep_width + def_width;
+    match (rep, def) {
+        (Some(rep), Some(def)) => {
+            let iter = rep.into_iter().zip(def);
+            let def_width = def_width as usize;
+            if total_width <= 8 {
+                ControlWordIterator::Binary8(BinaryControlWordIterator {
+                    repdef: iter,
+                    rep_mask,
+                    def_mask,
+                    def_width,
+                    bits_rep: rep_width as u8,
+                    bits_def: def_width as u8,
+                    phantom: std::marker::PhantomData,
+                })
+            } else if total_width <= 16 {
+                ControlWordIterator::Binary16(BinaryControlWordIterator {
+                    repdef: iter,
+                    rep_mask,
+                    def_mask,
+                    def_width,
+                    bits_rep: rep_width as u8,
+                    bits_def: def_width as u8,
+                    phantom: std::marker::PhantomData,
+                })
+            } else {
+                ControlWordIterator::Binary32(BinaryControlWordIterator {
+                    repdef: iter,
+                    rep_mask,
+                    def_mask,
+                    def_width,
+                    bits_rep: rep_width as u8,
+                    bits_def: def_width as u8,
+                    phantom: std::marker::PhantomData,
+                })
+            }
+        }
+        (Some(lev), None) => {
+            let iter = lev.into_iter();
+            if total_width <= 8 {
+                ControlWordIterator::Unary8(UnaryControlWordIterator {
+                    repdef: iter,
+                    level_mask: rep_mask,
+                    bits_rep: total_width as u8,
+                    bits_def: 0,
+                    phantom: std::marker::PhantomData,
+                })
+            } else if total_width <= 16 {
+                ControlWordIterator::Unary16(UnaryControlWordIterator {
+                    repdef: iter,
+                    level_mask: rep_mask,
+                    bits_rep: total_width as u8,
+                    bits_def: 0,
+                    phantom: std::marker::PhantomData,
+                })
+            } else {
+                ControlWordIterator::Unary32(UnaryControlWordIterator {
+                    repdef: iter,
+                    level_mask: rep_mask,
+                    bits_rep: total_width as u8,
+                    bits_def: 0,
+                    phantom: std::marker::PhantomData,
+                })
+            }
+        }
+        (None, Some(lev)) => {
+            let iter = lev.into_iter();
+            if total_width <= 8 {
+                ControlWordIterator::Unary8(UnaryControlWordIterator {
+                    repdef: iter,
+                    level_mask: def_mask,
+                    bits_rep: 0,
+                    bits_def: total_width as u8,
+                    phantom: std::marker::PhantomData,
+                })
+            } else if total_width <= 16 {
+                ControlWordIterator::Unary16(UnaryControlWordIterator {
+                    repdef: iter,
+                    level_mask: def_mask,
+                    bits_rep: 0,
+                    bits_def: total_width as u8,
+                    phantom: std::marker::PhantomData,
+                })
+            } else {
+                ControlWordIterator::Unary32(UnaryControlWordIterator {
+                    repdef: iter,
+                    level_mask: def_mask,
+                    bits_rep: 0,
+                    bits_def: total_width as u8,
+                    phantom: std::marker::PhantomData,
+                })
+            }
+        }
+        (None, None) => ControlWordIterator::Nilary(NilaryControlWordIterator {}),
+    }
+}
+
+/// A parser to unwrap control words into repetition and definition levels
+///
+/// This is the inverse of the [`ControlWordIterator`].
+#[derive(Copy, Clone, Debug)]
+pub enum ControlWordParser {
+    // First item is the bits to shift, second is the mask to apply (the mask can be
+    // calculated from the bits to shift but we don't want to calculate it each time)
+    BOTH8(u8, u32),
+    BOTH16(u8, u32),
+    BOTH32(u8, u32),
+    REP8,
+    REP16,
+    REP32,
+    DEF8,
+    DEF16,
+    DEF32,
+    NIL,
+}
+
+impl ControlWordParser {
+    fn parse_both<const WORD_SIZE: u8>(
+        src: &[u8],
+        dst_rep: &mut Vec<u16>,
+        dst_def: &mut Vec<u16>,
+        bits_to_shift: u8,
+        mask_to_apply: u32,
+    ) {
+        match WORD_SIZE {
+            1 => {
+                let word = src[0];
+                let rep = word >> bits_to_shift;
+                let def = word & (mask_to_apply as u8);
+                dst_rep.push(rep as u16);
+                dst_def.push(def as u16);
+            }
+            2 => {
+                let word = u16::from_le_bytes([src[0], src[1]]);
+                let rep = word >> bits_to_shift;
+                let def = word & mask_to_apply as u16;
+                dst_rep.push(rep);
+                dst_def.push(def);
+            }
+            4 => {
+                let word = u32::from_le_bytes([src[0], src[1], src[2], src[3]]);
+                let rep = word >> bits_to_shift;
+                let def = word & mask_to_apply;
+                dst_rep.push(rep as u16);
+                dst_def.push(def as u16);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn parse_one<const WORD_SIZE: u8>(src: &[u8], dst: &mut Vec<u16>) {
+        match WORD_SIZE {
+            1 => {
+                let word = src[0];
+                dst.push(word as u16);
+            }
+            2 => {
+                let word = u16::from_le_bytes([src[0], src[1]]);
+                dst.push(word);
+            }
+            4 => {
+                let word = u32::from_le_bytes([src[0], src[1], src[2], src[3]]);
+                dst.push(word as u16);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// Returns the number of bytes per control word
+    pub fn bytes_per_word(&self) -> usize {
+        match self {
+            Self::BOTH8(..) => 1,
+            Self::BOTH16(..) => 2,
+            Self::BOTH32(..) => 4,
+            Self::REP8 => 1,
+            Self::REP16 => 2,
+            Self::REP32 => 4,
+            Self::DEF8 => 1,
+            Self::DEF16 => 2,
+            Self::DEF32 => 4,
+            Self::NIL => 0,
+        }
+    }
+
+    /// Appends the next control word to the rep & def buffers
+    ///
+    /// `src` should be pointing at the first byte (little endian) of the control word
+    ///
+    /// `dst_rep` and `dst_def` are the buffers to append the rep and def levels to.
+    /// They will not be appended to if not needed.
+    pub fn parse(&self, src: &[u8], dst_rep: &mut Vec<u16>, dst_def: &mut Vec<u16>) {
+        match self {
+            Self::BOTH8(bits_to_shift, mask_to_apply) => {
+                Self::parse_both::<1>(src, dst_rep, dst_def, *bits_to_shift, *mask_to_apply)
+            }
+            Self::BOTH16(bits_to_shift, mask_to_apply) => {
+                Self::parse_both::<2>(src, dst_rep, dst_def, *bits_to_shift, *mask_to_apply)
+            }
+            Self::BOTH32(bits_to_shift, mask_to_apply) => {
+                Self::parse_both::<4>(src, dst_rep, dst_def, *bits_to_shift, *mask_to_apply)
+            }
+            Self::REP8 => Self::parse_one::<1>(src, dst_rep),
+            Self::REP16 => Self::parse_one::<2>(src, dst_rep),
+            Self::REP32 => Self::parse_one::<4>(src, dst_rep),
+            Self::DEF8 => Self::parse_one::<1>(src, dst_def),
+            Self::DEF16 => Self::parse_one::<2>(src, dst_def),
+            Self::DEF32 => Self::parse_one::<4>(src, dst_def),
+            Self::NIL => {}
+        }
+    }
+
+    /// Creates a new parser from the number of bits used for the repetition and definition levels
+    pub fn new(bits_rep: u8, bits_def: u8) -> Self {
+        let total_bits = bits_rep + bits_def;
+
+        enum WordSize {
+            One,
+            Two,
+            Four,
+        }
+
+        let word_size = if total_bits <= 8 {
+            WordSize::One
+        } else if total_bits <= 16 {
+            WordSize::Two
+        } else {
+            WordSize::Four
+        };
+
+        match (bits_rep > 0, bits_def > 0, word_size) {
+            (false, false, _) => Self::NIL,
+            (false, true, WordSize::One) => Self::DEF8,
+            (false, true, WordSize::Two) => Self::DEF16,
+            (false, true, WordSize::Four) => Self::DEF32,
+            (true, false, WordSize::One) => Self::REP8,
+            (true, false, WordSize::Two) => Self::REP16,
+            (true, false, WordSize::Four) => Self::REP32,
+            (true, true, WordSize::One) => Self::BOTH8(bits_def, get_mask(bits_def as u16) as u32),
+            (true, true, WordSize::Two) => Self::BOTH16(bits_def, get_mask(bits_def as u16) as u32),
+            (true, true, WordSize::Four) => {
+                Self::BOTH32(bits_def, get_mask(bits_def as u16) as u32)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use arrow_buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
@@ -687,5 +1123,109 @@ mod tests {
 
         assert_eq!(vec![2, 1, 0, 2, 0, 2, 0, 1, 0], rep);
         assert_eq!(vec![0, 0, 0, 3, 3, 2, 2, 0, 1], def);
+    }
+
+    #[test]
+    fn test_control_words() {
+        // Convert to control words, verify expected, convert back, verify same as original
+        fn check(
+            rep: Vec<u16>,
+            def: Vec<u16>,
+            expected_values: Vec<u8>,
+            expected_bytes_per_word: usize,
+            expected_bits_rep: u8,
+            expected_bits_def: u8,
+        ) {
+            let num_vals = rep.len().max(def.len());
+            let max_rep = rep.iter().max().copied().unwrap_or(0);
+            let max_def = def.iter().max().copied().unwrap_or(0);
+
+            let in_rep = if rep.is_empty() {
+                None
+            } else {
+                Some(rep.clone())
+            };
+            let in_def = if def.is_empty() {
+                None
+            } else {
+                Some(def.clone())
+            };
+
+            let mut iter = super::build_control_word_iterator(in_rep, max_rep, in_def, max_def);
+            assert_eq!(iter.bytes_per_word(), expected_bytes_per_word);
+            assert_eq!(iter.bits_rep(), expected_bits_rep);
+            assert_eq!(iter.bits_def(), expected_bits_def);
+            let mut cw_vec = Vec::with_capacity(num_vals * iter.bytes_per_word());
+
+            for _ in 0..num_vals {
+                iter.append_next(&mut cw_vec);
+            }
+
+            assert_eq!(expected_values, cw_vec);
+
+            let parser = super::ControlWordParser::new(expected_bits_rep, expected_bits_def);
+
+            let mut rep_out = Vec::with_capacity(num_vals);
+            let mut def_out = Vec::with_capacity(num_vals);
+
+            if expected_bytes_per_word > 0 {
+                for slice in cw_vec.chunks_exact(expected_bytes_per_word) {
+                    parser.parse(slice, &mut rep_out, &mut def_out);
+                }
+            }
+
+            assert_eq!(rep, rep_out);
+            assert_eq!(def, def_out);
+        }
+
+        // Each will need 4 bits and so we should get 1-byte control words
+        let rep = vec![0_u16, 7, 3, 2, 9, 8, 12, 5];
+        let def = vec![5_u16, 3, 1, 2, 12, 15, 0, 2];
+        let expected = vec![
+            0b00000101, // 0, 5
+            0b01110011, // 7, 3
+            0b00110001, // 3, 1
+            0b00100010, // 2, 2
+            0b10011100, // 9, 12
+            0b10001111, // 8, 15
+            0b11000000, // 12, 0
+            0b01010010, // 5, 2
+        ];
+        check(rep, def, expected, 1, 4, 4);
+
+        // Now we need 5 bits for def so we get 2-byte control words
+        let rep = vec![0_u16, 7, 3, 2, 9, 8, 12, 5];
+        let def = vec![5_u16, 3, 1, 2, 12, 22, 0, 2];
+        let expected = vec![
+            0b00000101, 0b00000000, // 0, 5
+            0b11100011, 0b00000000, // 7, 3
+            0b01100001, 0b00000000, // 3, 1
+            0b01000010, 0b00000000, // 2, 2
+            0b00101100, 0b00000001, // 9, 12
+            0b00010110, 0b00000001, // 8, 22
+            0b10000000, 0b00000001, // 12, 0
+            0b10100010, 0b00000000, // 5, 2
+        ];
+        check(rep, def, expected, 2, 4, 5);
+
+        // Just rep, 4 bits so 1 byte each
+        let levels = vec![0_u16, 7, 3, 2, 9, 8, 12, 5];
+        let expected = vec![
+            0b00000000, // 0
+            0b00000111, // 7
+            0b00000011, // 3
+            0b00000010, // 2
+            0b00001001, // 9
+            0b00001000, // 8
+            0b00001100, // 12
+            0b00000101, // 5
+        ];
+        check(levels.clone(), Vec::default(), expected.clone(), 1, 4, 0);
+
+        // Just def
+        check(Vec::default(), levels, expected, 1, 0, 4);
+
+        // No rep, no def, no bytes
+        check(Vec::default(), Vec::default(), Vec::default(), 0, 0, 0);
     }
 }


### PR DESCRIPTION
The encoding is only tested on tensors for now.  It should encode variable-width data but, without a repetition index, we are not yet able to schedule / decode variable width data.  In addition, I've created a few todos for follow-up.