### PR TITLE
chore: lance-encoding test utility now properly aligns buffers

### DIFF
--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -53,6 +53,9 @@ use crate::{
 use hyperloglogplus::{HyperLogLog, HyperLogLogPlus};
 use std::collections::hash_map::RandomState;
 
+/// The minimum alignment for a page buffer.  Writers must respect this.
+pub const MIN_PAGE_BUFFER_ALIGNMENT: u64 = 8;
+
 /// An encoded array
 ///
 /// Maps to a single Arrow array
@@ -1299,9 +1302,14 @@ pub async fn encode_batch(
     encoding_strategy: &dyn FieldEncodingStrategy,
     options: &EncodingOptions,
 ) -> Result<EncodedBatch> {
-    if !is_pwr_two(options.buffer_alignment) || options.buffer_alignment < 8 {
+    if !is_pwr_two(options.buffer_alignment) || options.buffer_alignment < MIN_PAGE_BUFFER_ALIGNMENT
+    {
         return Err(Error::InvalidInput {
-            source: "buffer_alignment must be a power of two and at least 8".into(),
+            source: format!(
+                "buffer_alignment must be a power of two and at least {}",
+                MIN_PAGE_BUFFER_ALIGNMENT
+            )
+            .into(),
             location: location!(),
         });
     }

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -726,7 +726,6 @@ impl MiniBlockDecompressor for BinaryMiniBlockDecompressor {
     // it has so assertion can not be done here and the caller of `decompress` must ensure `num_values` <= number of values in the chunk.
     fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
         assert!(data.len() >= 8);
-        let data = data.to_vec();
         let offsets: &[u32] = try_cast_slice(&data)
             .expect("casting buffer failed during BinaryMiniBlock decompression");
 


### PR DESCRIPTION
We align buffers in the file writer but we were not doing the same thing in the test utility.  This forced encodings to do extra copies.  We remove one such copy in this PR.

Closes #3115 