### PR TITLE
perf: transpose the PQ codes to improve search performance

### DIFF
--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -398,6 +398,7 @@ impl Quantization for ProductQuantizer {
             dimension: self.dimension,
             codebook: None,
             codebook_tensor: tensor.encode_to_vec(),
+            transposed: false,
         })?)
     }
 

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -141,6 +141,7 @@ impl ProductQuantizer {
         )?))
     }
 
+    // the code must be transposed
     pub fn compute_distances(&self, query: &dyn Array, code: &UInt8Array) -> Result<Float32Array> {
         if code.is_empty() {
             return Ok(Float32Array::from(Vec::<f32>::new()));
@@ -468,6 +469,7 @@ mod tests {
     use lance_linalg::kernels::argmin;
     use lance_testing::datagen::generate_random_array;
     use num_traits::Zero;
+    use storage::transpose;
 
     #[test]
     fn test_f16_pq_to_protobuf() {
@@ -509,7 +511,8 @@ mod tests {
         let pq_code = UInt8Array::from_iter_values((0..16 * TOTAL).map(|v| v as u8));
         let query = generate_random_array(DIM);
 
-        let dists = pq.compute_distances(&query, &pq_code).unwrap();
+        let transposed_pq_codes = transpose(&pq_code, TOTAL, 16);
+        let dists = pq.compute_distances(&query, &transposed_pq_codes).unwrap();
 
         let sub_vec_len = DIM / 16;
         let expected = pq_code

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -384,7 +384,7 @@ impl Quantization for ProductQuantizer {
     }
 
     fn metadata(&self, args: Option<QuantizationMetadata>) -> Result<serde_json::Value> {
-        let codebook_position = match args {
+        let codebook_position = match &args {
             Some(args) => args.codebook_position,
             None => Some(0),
         };
@@ -400,7 +400,7 @@ impl Quantization for ProductQuantizer {
             dimension: self.dimension,
             codebook: None,
             codebook_tensor: tensor.encode_to_vec(),
-            transposed: false,
+            transposed: args.map(|args| args.transposed).unwrap_or_default(),
         })?)
     }
 

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -172,11 +172,11 @@ impl ProductQuantizer {
 
         #[cfg(target_feature = "avx512f")]
         {
-            Ok(self.compute_l2_distance::<16, 64>(&distance_table, code.values()))
+            Ok(self.compute_l2_distance(&distance_table, code.values()))
         }
         #[cfg(not(target_feature = "avx512f"))]
         {
-            Ok(self.compute_l2_distance::<8, 64>(&distance_table, code.values()))
+            Ok(self.compute_l2_distance(&distance_table, code.values()))
         }
     }
 
@@ -289,12 +289,8 @@ impl ProductQuantizer {
     /// -------
     ///  The squared L2 distance.
     #[inline]
-    fn compute_l2_distance<const C: usize, const V: usize>(
-        &self,
-        distance_table: &[f32],
-        code: &[u8],
-    ) -> Float32Array {
-        Float32Array::from(compute_l2_distance::<C, V>(
+    fn compute_l2_distance(&self, distance_table: &[f32], code: &[u8]) -> Float32Array {
+        Float32Array::from(compute_l2_distance(
             distance_table,
             self.num_bits,
             self.num_sub_vectors,

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -142,6 +142,10 @@ impl ProductQuantizer {
     }
 
     pub fn compute_distances(&self, query: &dyn Array, code: &UInt8Array) -> Result<Float32Array> {
+        if code.is_empty() {
+            return Ok(Float32Array::from(Vec::<f32>::new()));
+        }
+
         match self.distance_type {
             DistanceType::L2 => self.l2_distances(query, code),
             DistanceType::Cosine => {

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::cmp::min;
-
 use lance_linalg::distance::{dot_distance_batch, l2_distance_batch, Dot, L2};
 
 use super::{num_centroids, utils::get_sub_vector_centroids};
@@ -80,6 +78,8 @@ pub(super) fn compute_l2_distance<const C: usize, const V: usize>(
     // so code[i][j] is the code of i-th sub-vector of the j-th vector,
     // and `code` is a flatten array of [num_sub_vectors, num_vectors] u8,
     // so code[i * num_vectors + j] is the code of i-th sub-vector of the j-th vector.
+
+    // `distance_table` is a flatten array of [num_sub_vectors, num_centroids] f32,
     let num_vectors = code.len() / num_sub_vectors;
     let mut distances = vec![0.0_f32; num_vectors];
     let num_centroids = num_centroids(num_bits);

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -94,30 +94,4 @@ pub(super) fn compute_l2_distance<const C: usize, const V: usize>(
     }
 
     distances
-
-    // let iter = code.chunks_exact(num_sub_vectors * V);
-    // let distances = iter.clone().flat_map(|c| {
-    //     let mut sums = [0.0_f32; V];
-    //     for i in (0..num_sub_vectors).step_by(C) {
-    //         for (vec_idx, sum) in sums.iter_mut().enumerate() {
-    //             let vec_start = vec_idx * num_sub_vectors;
-    //             let s = c[vec_start + i..]
-    //                 .iter()
-    //                 .take(min(C, num_sub_vectors - i))
-    //                 .enumerate()
-    //                 .map(|(k, c)| distance_table[(i + k) * num_centroids + *c as usize])
-    //                 .sum::<f32>();
-    //             *sum += s;
-    //         }
-    //     }
-    //     sums.into_iter()
-    // });
-    // Remainder
-    // let remainder = iter.remainder().chunks(num_sub_vectors).map(|c| {
-    //     c.iter()
-    //         .enumerate()
-    //         .map(|(sub_vec_idx, code)| distance_table[sub_vec_idx * num_centroids + *code as usize])
-    //         .sum::<f32>()
-    // });
-    // distances.chain(remainder).collect()
 }

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -354,6 +354,10 @@ pub fn transpose<T: ArrowPrimitiveType>(
 where
     PrimitiveArray<T>: From<Vec<T::Native>>,
 {
+    if original.is_empty() {
+        return original.clone();
+    }
+
     let mut transposed_codes = vec![T::default_value(); original.len()];
     for (vec_idx, codes) in original.values().chunks_exact(num_columns).enumerate() {
         for (sub_vec_idx, code) in codes.iter().enumerate() {

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -202,11 +202,11 @@ impl ProductQuantizationStorage {
                 .values()
                 .as_primitive::<UInt8Type>()
                 .values()
-                .chunks_exact(pq_code_fsl.len())
+                .chunks_exact(pq_code_fsl.value_length() as usize)
                 .enumerate()
             {
-                for (cluster_idx, code) in codes.iter().enumerate() {
-                    transposed_code[cluster_idx * pq_code_fsl.len() + vec_idx] = *code;
+                for (sub_vec_idx, code) in codes.iter().enumerate() {
+                    transposed_code[sub_vec_idx * pq_code_fsl.len() + vec_idx] = *code;
                 }
             }
             Arc::new(UInt8Array::from(transposed_code))

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -559,10 +559,15 @@ impl PQDistCalculator {
         }
     }
 
-    fn get_pq_code(&self, id: u32) -> &[u8] {
-        let start = id as usize * self.num_sub_vectors;
-        let end = start + self.num_sub_vectors;
-        &self.pq_code.values()[start..end]
+    fn get_pq_code(&self, id: u32) -> Vec<usize> {
+        let num_vectors = self.pq_code.len() / self.num_sub_vectors;
+        self.pq_code
+            .values()
+            .iter()
+            .skip(id as usize)
+            .step_by(num_vectors)
+            .map(|&c| c as usize)
+            .collect()
     }
 }
 

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -575,9 +575,9 @@ impl DistCalculator for PQDistCalculator {
     fn distance(&self, id: u32) -> f32 {
         let pq_code = self.get_pq_code(id);
         pq_code
-            .iter()
+            .into_iter()
             .enumerate()
-            .map(|(i, &c)| self.distance_table[i * self.num_centroids + c as usize])
+            .map(|(i, c)| self.distance_table[i * self.num_centroids + c])
             .sum()
     }
 }

--- a/rust/lance-index/src/vector/quantizer.rs
+++ b/rust/lance-index/src/vector/quantizer.rs
@@ -161,6 +161,7 @@ pub struct QuantizationMetadata {
     // For PQ
     pub codebook_position: Option<usize>,
     pub codebook: Option<FixedSizeListArray>,
+    pub transposed: bool,
 }
 
 #[async_trait]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -16,7 +16,9 @@ use lance_file::v2::reader::FileReaderOptions;
 use lance_file::v2::{reader::FileReader, writer::FileWriter};
 use lance_index::vector::flat::storage::FlatStorage;
 use lance_index::vector::ivf::storage::IvfModel;
-use lance_index::vector::quantizer::{QuantizationType, QuantizerBuildParams};
+use lance_index::vector::quantizer::{
+    QuantizationMetadata, QuantizationType, QuantizerBuildParams,
+};
 use lance_index::vector::storage::STORAGE_METADATA_KEY;
 use lance_index::vector::v3::shuffler::IvfShufflerReader;
 use lance_index::vector::v3::subindex::SubIndexType;
@@ -573,7 +575,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + Clone + 'static> IvfIndexBuilde
         storage_writer.add_schema_metadata(IVF_METADATA_KEY, ivf_buffer_pos.to_string());
         // For now, each partition's metadata is just the quantizer,
         // it's all the same for now, so we just take the first one
-        let storage_partition_metadata = vec![quantizer.metadata(None)?.to_string()];
+        let storage_partition_metadata = vec![quantizer
+            .metadata(Some(QuantizationMetadata {
+                codebook_position: Some(0),
+                codebook: None,
+                transposed: true,
+            }))?
+            .to_string()];
         storage_writer.add_schema_metadata(
             STORAGE_METADATA_KEY,
             serde_json::to_string(&storage_partition_metadata)?,

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -36,6 +36,7 @@ use lance_file::{
 };
 use lance_index::vector::flat::index::{FlatIndex, FlatQuantizer};
 use lance_index::vector::ivf::storage::IvfModel;
+use lance_index::vector::pq::storage::transpose;
 use lance_index::vector::quantizer::QuantizationType;
 use lance_index::vector::v3::shuffler::IvfShuffler;
 use lance_index::vector::v3::subindex::{IvfSubIndex, SubIndexType};
@@ -1358,7 +1359,12 @@ impl RemapPageTask {
         ivf.offsets.push(writer.tell().await?);
         ivf.lengths
             .push(page.row_ids.as_ref().unwrap().len() as u32);
-        PlainEncoder::write(writer, &[page.code.as_ref().unwrap().as_ref()]).await?;
+        let original_pq = transpose(
+            page.code.as_ref().unwrap(),
+            page.pq.code_dim(),
+            page.row_ids.as_ref().unwrap().len(),
+        );
+        PlainEncoder::write(writer, &[&original_pq]).await?;
         PlainEncoder::write(writer, &[page.row_ids.as_ref().unwrap().as_ref()]).await?;
         Ok(())
     }

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -24,6 +24,7 @@ use lance_index::scalar::IndexWriter;
 use lance_index::vector::hnsw::HNSW;
 use lance_index::vector::hnsw::{builder::HnswBuildParams, HnswMetadata};
 use lance_index::vector::ivf::storage::IvfModel;
+use lance_index::vector::pq::storage::transpose;
 use lance_index::vector::pq::ProductQuantizer;
 use lance_index::vector::quantizer::{Quantization, Quantizer};
 use lance_index::vector::v3::subindex::IvfSubIndex;
@@ -199,9 +200,14 @@ pub(super) async fn write_pq_partitions(
                             location: location!(),
                         })?;
                 if let Some(pq_code) = pq_index.code.as_ref() {
+                    let original_pq_codes = transpose(
+                        &pq_code,
+                        pq_index.pq.num_sub_vectors,
+                        pq_code.len() / pq_index.pq.code_dim(),
+                    );
                     let fsl = Arc::new(
                         FixedSizeListArray::try_new_from_values(
-                            pq_code.as_ref().clone(),
+                            original_pq_codes,
                             pq_index.pq.code_dim() as i32,
                         )
                         .unwrap(),

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -201,7 +201,7 @@ pub(super) async fn write_pq_partitions(
                         })?;
                 if let Some(pq_code) = pq_index.code.as_ref() {
                     let original_pq_codes = transpose(
-                        &pq_code,
+                        pq_code,
                         pq_index.pq.num_sub_vectors,
                         pq_code.len() / pq_index.pq.code_dim(),
                     );

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -659,8 +659,8 @@ mod tests {
 
     #[rstest]
     #[case(4, DistanceType::L2, 0.9)]
-    #[case(4, DistanceType::Cosine, 0.6)]
-    #[case(4, DistanceType::Dot, 0.2)]
+    #[case(4, DistanceType::Cosine, 0.9)]
+    #[case(4, DistanceType::Dot, 0.9)]
     #[tokio::test]
     async fn test_build_ivf_pq(
         #[case] nlist: usize,

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -52,6 +52,8 @@ pub struct PQIndex {
     pub pq: ProductQuantizer,
 
     /// PQ code
+    /// the PQ codes are stored in a transposed way,
+    /// call `Self::get_pq_codes` to get the PQ code for a specific vector.
     pub code: Option<Arc<UInt8Array>>,
 
     /// ROW Id used to refer to the actual row in dataset.

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -448,6 +448,7 @@ pub(crate) fn build_pq_storage(
         pq.code_dim(),
         pq.dimension,
         distance_type,
+        false,
     )?;
 
     Ok(pq_store)


### PR DESCRIPTION
30% improved:
```
5242880,L2,PQ=96,DIM=1536
                        time:   [161.24 ms 162.71 ms 164.08 ms]
                        change: [-30.390% -29.789% -29.192%] (p = 0.00 < 0.10)
                        Performance has improved.

Benchmarking 5242880,Cosine,PQ=96,DIM=1536: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.2s or enable flat sampling.
5242880,Cosine,PQ=96,DIM=1536
                        time:   [165.53 ms 167.12 ms 168.49 ms]
                        change: [-30.725% -30.233% -29.772%] (p = 0.00 < 0.10)
                        Performance has improved.
```