### PR TITLE
feat: fsst compression with mini-block

### DIFF
--- a/protos/encodings.proto
+++ b/protos/encodings.proto
@@ -233,6 +233,11 @@ message Binary {
 message BinaryMiniBlock {
 }
 
+message FsstMiniBlock {
+  ArrayEncoding BinaryMiniBlock = 1;
+  bytes symbol_table = 2;
+}
+
 message Fsst {
   ArrayEncoding binary = 1;
   bytes symbol_table = 2;
@@ -273,6 +278,7 @@ message ArrayEncoding {
         Constant constant = 13;
         Bitpack2 bitpack2 = 14;
         BinaryMiniBlock binary_mini_block = 15;
+        FsstMiniBlock fsst_mini_block = 16;
     }
 }
 

--- a/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
+++ b/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
@@ -18,8 +18,11 @@ const FSST_CODE_MASK: u16 = FSST_CODE_MAX - 1;
 const FSST_SAMPLETARGET: usize = 1 << 14;
 const FSST_SAMPLEMAXSZ: usize = 2 * FSST_SAMPLETARGET;
 
-// the the input size is less than 4MB, we mark the file header and copy the input to the output as is
-const FSST_LEAST_INPUT_SIZE: usize = 4 * 1024 * 1024; // 4MB
+// if the input size is less than 4MB, we mark the file header and copy the input to the output as is
+pub const FSST_LEAST_INPUT_SIZE: usize = 4 * 1024 * 1024; // 4MB
+
+// if the max length of the input strings are less than `FSST_LEAST_INPUT_MAX_LENGTH`, we shouldn't use FSST.
+pub const FSST_LEAST_INPUT_MAX_LENGTH: u64 = 5;
 
 // we only use the lower 32 bits in icl, so we can use 1 << 32 to represent a free slot in the hash table
 const FSST_ICL_FREE: u64 = 1 << 32;

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -248,6 +248,7 @@ use crate::encodings::logical::r#struct::{
 };
 use crate::encodings::physical::binary::BinaryMiniBlockDecompressor;
 use crate::encodings::physical::bitpack_fastlanes::BitpackMiniBlockDecompressor;
+use crate::encodings::physical::fsst::FsstMiniBlockDecompressor;
 use crate::encodings::physical::value::{ConstantDecompressor, ValueDecompressor};
 use crate::encodings::physical::{ColumnBuffers, FileBuffers};
 use crate::format::pb::{self, column_encoding};
@@ -497,6 +498,9 @@ impl DecompressorStrategy for CoreDecompressorStrategy {
             }
             pb::array_encoding::ArrayEncoding::BinaryMiniBlock(_) => {
                 Ok(Box::new(BinaryMiniBlockDecompressor::default()))
+            }
+            pb::array_encoding::ArrayEncoding::FsstMiniBlock(description) => {
+                Ok(Box::new(FsstMiniBlockDecompressor::new(description)))
             }
             _ => todo!(),
         }

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -248,8 +248,8 @@ use crate::encodings::logical::r#struct::{
 };
 use crate::encodings::physical::binary::BinaryMiniBlockDecompressor;
 use crate::encodings::physical::bitpack_fastlanes::BitpackMiniBlockDecompressor;
-use crate::encodings::physical::fsst::FsstMiniBlockDecompressor;
 use crate::encodings::physical::fixed_size_list::FslPerValueDecompressor;
+use crate::encodings::physical::fsst::FsstMiniBlockDecompressor;
 use crate::encodings::physical::value::{ConstantDecompressor, ValueDecompressor};
 use crate::encodings::physical::{ColumnBuffers, FileBuffers};
 use crate::format::pb::{self, column_encoding};

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -49,6 +49,7 @@ use crate::{
     },
     format::pb,
 };
+use fsst::fsst::{FSST_LEAST_INPUT_MAX_LENGTH, FSST_LEAST_INPUT_SIZE};
 
 use hyperloglogplus::{HyperLogLog, HyperLogLogPlus};
 use std::collections::hash_map::RandomState;
@@ -820,7 +821,7 @@ impl CompressionStrategy for CoreArrayEncodingStrategy {
                 );
                 let max_len = max_len.as_primitive::<UInt64Type>().value(0);
 
-                if max_len > 4 && data_size >= 4 * 1024 * 1024 {
+                if max_len >= FSST_LEAST_INPUT_MAX_LENGTH && data_size >= FSST_LEAST_INPUT_SIZE as u64 {
                     return Ok(Box::new(FsstMiniBlockEncoder::default()));
                 }
                 return Ok(Box::new(BinaryMiniBlockEncoder::default()));

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -30,8 +30,8 @@ use crate::encodings::physical::bitpack_fastlanes::{
 };
 use crate::encodings::physical::block_compress::{CompressionConfig, CompressionScheme};
 use crate::encodings::physical::dictionary::AlreadyDictionaryEncoder;
-use crate::encodings::physical::fsst::{FsstArrayEncoder, FsstMiniBlockEncoder};
 use crate::encodings::physical::fixed_size_list::FslPerValueCompressor;
+use crate::encodings::physical::fsst::{FsstArrayEncoder, FsstMiniBlockEncoder};
 use crate::encodings::physical::packed_struct::PackedStructEncoder;
 use crate::format::ProtobufUtils;
 use crate::repdef::RepDefBuilder;
@@ -822,7 +822,9 @@ impl CompressionStrategy for CoreArrayEncodingStrategy {
                 );
                 let max_len = max_len.as_primitive::<UInt64Type>().value(0);
 
-                if max_len >= FSST_LEAST_INPUT_MAX_LENGTH && data_size >= FSST_LEAST_INPUT_SIZE as u64 {
+                if max_len >= FSST_LEAST_INPUT_MAX_LENGTH
+                    && data_size >= FSST_LEAST_INPUT_SIZE as u64
+                {
                     return Ok(Box::new(FsstMiniBlockEncoder::default()));
                 }
                 return Ok(Box::new(BinaryMiniBlockEncoder::default()));

--- a/rust/lance-encoding/src/encodings/physical.rs
+++ b/rust/lance-encoding/src/encodings/physical.rs
@@ -285,6 +285,7 @@ pub fn decoder_from_array_encoding(
         pb::array_encoding::ArrayEncoding::Constant(_) => unreachable!(),
         pb::array_encoding::ArrayEncoding::Bitpack2(_) => unreachable!(),
         pb::array_encoding::ArrayEncoding::BinaryMiniBlock(_) => unreachable!(),
+        pb::array_encoding::ArrayEncoding::FsstMiniBlock(_) => unreachable!(),
     }
 }
 

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -245,7 +245,7 @@ impl MiniBlockCompressor for FsstMiniBlockEncoder {
                     used_encodings: UsedEncoding::new(),
                 });
 
-                // compress the fsst compressed data using `BinaryMiniBlockEnocder`
+                // compress the fsst compressed data using `BinaryMiniBlockEncoder`
                 let binary_compressor =
                     Box::new(BinaryMiniBlockEncoder::default()) as Box<dyn MiniBlockCompressor>;
 

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -288,9 +288,8 @@ impl MiniBlockDecompressor for FsstMiniBlockDecompressor {
         let binary_decompressor =
             Box::new(BinaryMiniBlockDecompressor::default()) as Box<dyn MiniBlockDecompressor>;
         let compressed_data_block = binary_decompressor.decompress(data, num_values)?;
-        let mut compressed_data_block = match compressed_data_block {
-            DataBlock::VariableWidth(variable) => variable,
-            _ => panic!("Received non-variable width data from BinaryMiniBlockDecompressor."),
+        let DataBlock::VariableWidth(mut compressed_data_block) = compressed_data_block else {
+            panic!("BinaryMiniBlockDecompressor should output VariableWidth DataBlock")
         };
 
         // Step 2. FSST decompress

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -7,16 +7,22 @@ use arrow_buffer::ScalarBuffer;
 use arrow_schema::DataType;
 use futures::{future::BoxFuture, FutureExt};
 
-use lance_core::Result;
+use lance_core::{Error, Result};
+use snafu::{location, Location};
 
 use crate::{
     buffer::LanceBuffer,
     data::{BlockInfo, DataBlock, NullableDataBlock, UsedEncoding, VariableWidthBlock},
-    decoder::{PageScheduler, PrimitivePageDecoder},
-    encoder::{ArrayEncoder, EncodedArray},
-    format::ProtobufUtils,
+    decoder::{MiniBlockDecompressor, PageScheduler, PrimitivePageDecoder},
+    encoder::{ArrayEncoder, EncodedArray, MiniBlockCompressed, MiniBlockCompressor},
+    format::{
+        pb::{self},
+        ProtobufUtils,
+    },
     EncodingsIo,
 };
+
+use super::binary::{BinaryMiniBlockDecompressor, BinaryMiniBlockEncoder};
 
 #[derive(Debug)]
 pub struct FsstPageScheduler {
@@ -201,6 +207,121 @@ impl ArrayEncoder for FsstArrayEncoder {
     }
 }
 
+#[derive(Debug, Default)]
+pub struct FsstMiniBlockEncoder {}
+
+impl MiniBlockCompressor for FsstMiniBlockEncoder {
+    fn compress(
+        &self,
+        data: DataBlock,
+    ) -> Result<(MiniBlockCompressed, crate::format::pb::ArrayEncoding)> {
+        match data {
+            DataBlock::VariableWidth(mut variable_width) => {
+                let offsets = variable_width.offsets.borrow_to_typed_slice::<i32>();
+                let offsets_slice = offsets.as_ref();
+                let bytes_data = variable_width.data.into_buffer();
+
+                // prepare compression output buffer
+                let mut dest_offsets = vec![0_i32; offsets_slice.len() * 2];
+                let mut dest_values = vec![0_u8; bytes_data.len() * 2];
+                let mut symbol_table = vec![0_u8; fsst::fsst::FSST_SYMBOL_TABLE_SIZE];
+
+                // fsst compression
+                fsst::fsst::compress(
+                    &mut symbol_table,
+                    bytes_data.as_slice(),
+                    offsets_slice,
+                    &mut dest_values,
+                    &mut dest_offsets,
+                )?;
+
+                // construct `DataBlock` for BinaryMiniBlockEncoder, we may want some `DataBlock` construct methods later
+                let data_block = DataBlock::VariableWidth(VariableWidthBlock {
+                    data: LanceBuffer::reinterpret_vec(dest_values),
+                    bits_per_offset: 32,
+                    offsets: LanceBuffer::reinterpret_vec(dest_offsets),
+                    num_values: variable_width.num_values,
+                    block_info: BlockInfo::new(),
+                    used_encodings: UsedEncoding::new(),
+                });
+
+                // compress the fsst compressed data using `BinaryMiniBlockEnocder`
+                let binary_compressor =
+                    Box::new(BinaryMiniBlockEncoder::default()) as Box<dyn MiniBlockCompressor>;
+
+                let (binary_miniblock_compressed, binary_array_encoding) =
+                    binary_compressor.compress(data_block)?;
+
+                Ok((
+                    binary_miniblock_compressed,
+                    ProtobufUtils::fsst_mini_block(binary_array_encoding, symbol_table),
+                ))
+            }
+            _ => Err(Error::InvalidInput {
+                source: format!(
+                    "Cannot compress a data block of type {} with BinaryMiniBlockEncoder",
+                    data.name()
+                )
+                .into(),
+                location: location!(),
+            }),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct FsstMiniBlockDecompressor {
+    symbol_table: Vec<u8>,
+}
+
+impl FsstMiniBlockDecompressor {
+    pub fn new(description: &pb::FsstMiniBlock) -> Self {
+        Self {
+            symbol_table: description.symbol_table.clone(),
+        }
+    }
+}
+
+impl MiniBlockDecompressor for FsstMiniBlockDecompressor {
+    fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
+        let binary_decompressor =
+            Box::new(BinaryMiniBlockDecompressor::default()) as Box<dyn MiniBlockDecompressor>;
+
+        let compressed_data_block = binary_decompressor.decompress(data, num_values)?;
+
+        let mut compressed_data_block = match compressed_data_block {
+            DataBlock::VariableWidth(variable) => variable,
+            _ => panic!("Received non-variable width data from BinaryMiniBlockDecompressor."),
+        };
+
+        let bytes = compressed_data_block.data.borrow_to_typed_slice::<u8>();
+        let bytes = bytes.as_ref();
+
+        let offsets = compressed_data_block.offsets.borrow_to_typed_slice::<i32>();
+        let offsets = offsets.as_ref();
+
+        let mut decompress_bytes_buf = vec![0u8; 4 * 1024 * 8];
+        let mut decompress_offset_buf = vec![0i32; 1024];
+
+        fsst::fsst::decompress(
+            &self.symbol_table,
+            &bytes,
+            &offsets,
+            &mut decompress_bytes_buf,
+            &mut decompress_offset_buf,
+        )?;
+
+        Ok(DataBlock::VariableWidth(VariableWidthBlock {
+            data: LanceBuffer::Owned(decompress_bytes_buf),
+            offsets: LanceBuffer::reinterpret_vec(decompress_offset_buf),
+            bits_per_offset: 32,
+            num_values,
+            block_info: BlockInfo::new(),
+            used_encodings: UsedEncoding::new(),
+        }))
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -208,7 +329,10 @@ mod tests {
 
     use lance_datagen::{ByteCount, RowCount};
 
-    use crate::testing::{check_round_trip_encoding_of_data, TestCases};
+    use crate::{
+        testing::{check_round_trip_encoding_of_data, TestCases},
+        version::LanceFileVersion,
+    };
 
     #[test_log::test(tokio::test)]
     async fn test_fsst() {
@@ -218,6 +342,24 @@ mod tests {
             .unwrap()
             .column(0)
             .clone();
-        check_round_trip_encoding_of_data(vec![arr], &TestCases::default(), HashMap::new()).await;
+        check_round_trip_encoding_of_data(
+            vec![arr],
+            &TestCases::default().with_file_version(LanceFileVersion::V2_1),
+            HashMap::new(),
+        )
+        .await;
+
+        let arr = lance_datagen::gen()
+            .anon_col(lance_datagen::array::rand_utf8(ByteCount::from(64), false))
+            .into_batch_rows(RowCount::from(1_000_000))
+            .unwrap()
+            .column(0)
+            .clone();
+        check_round_trip_encoding_of_data(
+            vec![arr],
+            &TestCases::default().with_file_version(LanceFileVersion::V2_1),
+            HashMap::new(),
+        )
+        .await;
     }
 }

--- a/rust/lance-encoding/src/format.rs
+++ b/rust/lance-encoding/src/format.rs
@@ -139,7 +139,7 @@ impl ProtobufUtils {
         }
     }
 
-    // Construct a `FsstMiniBlock` ArrayEncoding, the inner `binary_mini_block` encoding is actually 
+    // Construct a `FsstMiniBlock` ArrayEncoding, the inner `binary_mini_block` encoding is actually
     // not used and `FsstMiniBlockDecompressor` constructs a `binary_mini_block` in a `hard-coded` fashion.
     // This can be an optimization later.
     pub fn fsst_mini_block(data: ArrayEncoding, symbol_table: Vec<u8>) -> ArrayEncoding {

--- a/rust/lance-encoding/src/format.rs
+++ b/rust/lance-encoding/src/format.rs
@@ -20,8 +20,8 @@ use pb::{
     nullable::{AllNull, NoNull, Nullability, SomeNull},
     page_layout::Layout,
     AllNullLayout, ArrayEncoding, Binary, BinaryMiniBlock, Bitpack2, Bitpacked, BitpackedForNonNeg,
-    Dictionary, FixedSizeBinary, FixedSizeList, Flat, Fsst, MiniBlockLayout, Nullable,
-    PackedStruct, PageLayout,
+    Dictionary, FixedSizeBinary, FixedSizeList, Flat, Fsst, FsstMiniBlock, MiniBlockLayout,
+    Nullable, PackedStruct, PageLayout,
 };
 
 use crate::encodings::physical::block_compress::CompressionConfig;
@@ -136,6 +136,18 @@ impl ProtobufUtils {
     pub fn binary_miniblock() -> ArrayEncoding {
         ArrayEncoding {
             array_encoding: Some(ArrayEncodingEnum::BinaryMiniBlock(BinaryMiniBlock {})),
+        }
+    }
+
+    // Construct a `FsstMiniBlock` ArrayEncoding, the inner `binary_mini_block` encoding is actually 
+    // not used and `FsstMiniBlockDecompressor` constructs a `binary_mini_block` in a `hard-coded` fashion.
+    // This can be an optimization later.
+    pub fn fsst_mini_block(data: ArrayEncoding, symbol_table: Vec<u8>) -> ArrayEncoding {
+        ArrayEncoding {
+            array_encoding: Some(ArrayEncodingEnum::FsstMiniBlock(Box::new(FsstMiniBlock {
+                binary_mini_block: Some(Box::new(data)),
+                symbol_table,
+            }))),
         }
     }
 


### PR DESCRIPTION
This PR tries to integrate mini-block page layout with FSST compression.

During compression, it first FSST compresses the input data then write out the data use `BinaryMiniBlockEncoder`.
During decompression, it first uses `BinaryMiniBlockDecompressor` to decode the raw data read from disk, it then applies `FSST decompression`.