### PR TITLE
fix!: low recall with cosine/dot on v3 index types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "fsst"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow-array",
  "lance-datagen",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "all_asserts",
  "approx",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrayref",
  "arrow",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding-datafusion"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "approx",
  "arrow",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "lance-jni"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "approx",
  "arrow-arith",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "lance-test-macros"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "lance-testing"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "fsst"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow-array",
  "lance-datagen",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "all_asserts",
  "approx",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3093,7 +3093,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3138,7 +3138,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrayref",
  "arrow",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding-datafusion"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "approx",
  "arrow",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "lance-jni"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "approx",
  "arrow-arith",
@@ -3411,7 +3411,7 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "lance-test-macros"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "lance-testing"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.19.4"
+version = "0.20.0"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 license = "Apache-2.0"
@@ -44,21 +44,21 @@ categories = [
 rust-version = "1.78"
 
 [workspace.dependencies]
-lance = { version = "=0.19.4", path = "./rust/lance" }
-lance-arrow = { version = "=0.19.4", path = "./rust/lance-arrow" }
-lance-core = { version = "=0.19.4", path = "./rust/lance-core" }
-lance-datafusion = { version = "=0.19.4", path = "./rust/lance-datafusion" }
-lance-datagen = { version = "=0.19.4", path = "./rust/lance-datagen" }
-lance-encoding = { version = "=0.19.4", path = "./rust/lance-encoding" }
-lance-encoding-datafusion = { version = "=0.19.4", path = "./rust/lance-encoding-datafusion" }
-lance-file = { version = "=0.19.4", path = "./rust/lance-file" }
-lance-index = { version = "=0.19.4", path = "./rust/lance-index" }
-lance-io = { version = "=0.19.4", path = "./rust/lance-io" }
-lance-jni = { version = "=0.19.4", path = "./java/core/lance-jni" }
-lance-linalg = { version = "=0.19.4", path = "./rust/lance-linalg" }
-lance-table = { version = "=0.19.4", path = "./rust/lance-table" }
-lance-test-macros = { version = "=0.19.4", path = "./rust/lance-test-macros" }
-lance-testing = { version = "=0.19.4", path = "./rust/lance-testing" }
+lance = { version = "=0.20.0", path = "./rust/lance" }
+lance-arrow = { version = "=0.20.0", path = "./rust/lance-arrow" }
+lance-core = { version = "=0.20.0", path = "./rust/lance-core" }
+lance-datafusion = { version = "=0.20.0", path = "./rust/lance-datafusion" }
+lance-datagen = { version = "=0.20.0", path = "./rust/lance-datagen" }
+lance-encoding = { version = "=0.20.0", path = "./rust/lance-encoding" }
+lance-encoding-datafusion = { version = "=0.20.0", path = "./rust/lance-encoding-datafusion" }
+lance-file = { version = "=0.20.0", path = "./rust/lance-file" }
+lance-index = { version = "=0.20.0", path = "./rust/lance-index" }
+lance-io = { version = "=0.20.0", path = "./rust/lance-io" }
+lance-jni = { version = "=0.20.0", path = "./java/core/lance-jni" }
+lance-linalg = { version = "=0.20.0", path = "./rust/lance-linalg" }
+lance-table = { version = "=0.20.0", path = "./rust/lance-table" }
+lance-test-macros = { version = "=0.20.0", path = "./rust/lance-test-macros" }
+lance-testing = { version = "=0.20.0", path = "./rust/lance-testing" }
 approx = "0.5.1"
 # Note that this one does not include pyarrow
 arrow = { version = "52.2", optional = false, features = ["prettyprint"] }
@@ -111,7 +111,7 @@ datafusion-physical-expr = { version = "41.0", features = [
 ] }
 deepsize = "0.2.0"
 either = "1.0"
-fsst = { version = "=0.19.4", path = "./rust/lance-encoding/src/compression_algo/fsst" }
+fsst = { version = "=0.20.0", path = "./rust/lance-encoding/src/compression_algo/fsst" }
 futures = "0.3"
 http = "0.2.9"
 hyperloglogplus = { version = "0.4.1", features = ["const-loop"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.19.3"
+version = "0.19.4"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 license = "Apache-2.0"
@@ -44,21 +44,21 @@ categories = [
 rust-version = "1.78"
 
 [workspace.dependencies]
-lance = { version = "=0.19.3", path = "./rust/lance" }
-lance-arrow = { version = "=0.19.3", path = "./rust/lance-arrow" }
-lance-core = { version = "=0.19.3", path = "./rust/lance-core" }
-lance-datafusion = { version = "=0.19.3", path = "./rust/lance-datafusion" }
-lance-datagen = { version = "=0.19.3", path = "./rust/lance-datagen" }
-lance-encoding = { version = "=0.19.3", path = "./rust/lance-encoding" }
-lance-encoding-datafusion = { version = "=0.19.3", path = "./rust/lance-encoding-datafusion" }
-lance-file = { version = "=0.19.3", path = "./rust/lance-file" }
-lance-index = { version = "=0.19.3", path = "./rust/lance-index" }
-lance-io = { version = "=0.19.3", path = "./rust/lance-io" }
-lance-jni = { version = "=0.19.3", path = "./java/core/lance-jni" }
-lance-linalg = { version = "=0.19.3", path = "./rust/lance-linalg" }
-lance-table = { version = "=0.19.3", path = "./rust/lance-table" }
-lance-test-macros = { version = "=0.19.3", path = "./rust/lance-test-macros" }
-lance-testing = { version = "=0.19.3", path = "./rust/lance-testing" }
+lance = { version = "=0.19.4", path = "./rust/lance" }
+lance-arrow = { version = "=0.19.4", path = "./rust/lance-arrow" }
+lance-core = { version = "=0.19.4", path = "./rust/lance-core" }
+lance-datafusion = { version = "=0.19.4", path = "./rust/lance-datafusion" }
+lance-datagen = { version = "=0.19.4", path = "./rust/lance-datagen" }
+lance-encoding = { version = "=0.19.4", path = "./rust/lance-encoding" }
+lance-encoding-datafusion = { version = "=0.19.4", path = "./rust/lance-encoding-datafusion" }
+lance-file = { version = "=0.19.4", path = "./rust/lance-file" }
+lance-index = { version = "=0.19.4", path = "./rust/lance-index" }
+lance-io = { version = "=0.19.4", path = "./rust/lance-io" }
+lance-jni = { version = "=0.19.4", path = "./java/core/lance-jni" }
+lance-linalg = { version = "=0.19.4", path = "./rust/lance-linalg" }
+lance-table = { version = "=0.19.4", path = "./rust/lance-table" }
+lance-test-macros = { version = "=0.19.4", path = "./rust/lance-test-macros" }
+lance-testing = { version = "=0.19.4", path = "./rust/lance-testing" }
 approx = "0.5.1"
 # Note that this one does not include pyarrow
 arrow = { version = "52.2", optional = false, features = ["prettyprint"] }
@@ -111,7 +111,7 @@ datafusion-physical-expr = { version = "41.0", features = [
 ] }
 deepsize = "0.2.0"
 either = "1.0"
-fsst = { version = "=0.19.3", path = "./rust/lance-encoding/src/compression_algo/fsst" }
+fsst = { version = "=0.19.4", path = "./rust/lance-encoding/src/compression_algo/fsst" }
 futures = "0.3"
 http = "0.2.9"
 hyperloglogplus = { version = "0.4.1", features = ["const-loop"] }

--- a/java/core/lance-jni/src/utils.rs
+++ b/java/core/lance-jni/src/utils.rs
@@ -18,7 +18,7 @@ use arrow::array::Float32Array;
 use jni::objects::{JMap, JObject, JString};
 use jni::JNIEnv;
 use lance::dataset::{WriteMode, WriteParams};
-use lance::index::vector::{StageParams, VectorIndexParams};
+use lance::index::vector::{IndexFileVersion, StageParams, VectorIndexParams};
 use lance::io::ObjectStoreParams;
 use lance_encoding::version::LanceFileVersion;
 use lance_index::vector::hnsw::builder::HnswBuildParams;
@@ -265,6 +265,7 @@ pub fn get_index_params(
         Some(VectorIndexParams {
             metric_type: distance_type,
             stages,
+            version: IndexFileVersion::V3,
         })
     } else {
         None

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "fsst"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "rand",
 ]
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2843,7 +2843,7 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrayref",
  "arrow",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow-array",
  "arrow-ord",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "pylance"
-version = "0.19.4"
+version = "0.20.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "fsst"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "rand",
 ]
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2843,7 +2843,7 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2879,7 +2879,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrayref",
  "arrow",
@@ -2958,7 +2958,7 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -2992,7 +2992,7 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3082,7 +3082,7 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow-array",
  "arrow-ord",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4103,7 +4103,7 @@ dependencies = [
 
 [[package]]
 name = "pylance"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pylance"
-version = "0.19.3"
+version = "0.19.4"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 rust-version = "1.65"

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pylance"
-version = "0.19.4"
+version = "0.20.0"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 rust-version = "1.65"

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -5283,6 +5283,7 @@ mod test {
                             ..Default::default()
                         }),
                     ],
+                    version: crate::index::vector::IndexFileVersion::Legacy,
                 },
                 false,
             )

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -58,6 +58,15 @@ pub enum StageParams {
     SQ(SQBuildParams),
 }
 
+// The version of the index file.
+// `Legacy` is used for only IVF_PQ index, and is the default value.
+// The other index types are using `V3`.
+#[derive(Debug, Clone)]
+pub enum IndexFileVersion {
+    Legacy,
+    V3,
+}
+
 /// The parameters to build vector index.
 #[derive(Debug, Clone)]
 pub struct VectorIndexParams {
@@ -65,15 +74,24 @@ pub struct VectorIndexParams {
 
     /// Vector distance metrics type.
     pub metric_type: MetricType,
+
+    /// The version of the index file.
+    pub version: IndexFileVersion,
 }
 
 impl VectorIndexParams {
+    pub fn version(&mut self, version: IndexFileVersion) -> &mut Self {
+        self.version = version;
+        self
+    }
+
     pub fn ivf_flat(num_partitions: usize, metric_type: MetricType) -> Self {
         let ivf_params = IvfBuildParams::new(num_partitions);
         let stages = vec![StageParams::Ivf(ivf_params)];
         Self {
             stages,
             metric_type,
+            version: IndexFileVersion::V3,
         }
     }
 
@@ -106,6 +124,7 @@ impl VectorIndexParams {
         Self {
             stages,
             metric_type,
+            version: IndexFileVersion::Legacy,
         }
     }
 
@@ -119,6 +138,7 @@ impl VectorIndexParams {
         Self {
             stages,
             metric_type,
+            version: IndexFileVersion::Legacy,
         }
     }
 
@@ -138,6 +158,7 @@ impl VectorIndexParams {
         Self {
             stages,
             metric_type,
+            version: IndexFileVersion::V3,
         }
     }
 
@@ -157,6 +178,7 @@ impl VectorIndexParams {
         Self {
             stages,
             metric_type,
+            version: IndexFileVersion::V3,
         }
     }
 }
@@ -252,16 +274,34 @@ pub(crate) async fn build_vector_index(
             });
         };
 
-        build_ivf_pq_index(
-            dataset,
-            column,
-            name,
-            uuid,
-            params.metric_type,
-            ivf_params,
-            pq_params,
-        )
-        .await?;
+        match params.version {
+            IndexFileVersion::Legacy => {
+                build_ivf_pq_index(
+                    dataset,
+                    column,
+                    name,
+                    uuid,
+                    params.metric_type,
+                    ivf_params,
+                    pq_params,
+                )
+                .await?;
+            }
+            IndexFileVersion::V3 => {
+                IvfIndexBuilder::<FlatIndex, ProductQuantizer>::new(
+                    dataset.clone(),
+                    column.to_owned(),
+                    dataset.indices_dir().child(uuid),
+                    params.metric_type,
+                    Box::new(shuffler),
+                    Some(ivf_params.clone()),
+                    Some(pq_params.clone()),
+                    (),
+                )?
+                .build()
+                .await?;
+            }
+        }
     } else if is_ivf_hnsw(stages) {
         let len = stages.len();
         let StageParams::Hnsw(hnsw_params) = &stages[1] else {

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -243,7 +243,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + Clone + 'static> IvfIndexBuilde
 
         info!("Start to train quantizer");
         let start = std::time::Instant::now();
-        let quantizer = Q::build(&training_data, dt, quantizer_params)?;
+        let quantizer = Q::build(&training_data, DistanceType::L2, quantizer_params)?;
         info!(
             "Trained quantizer in {:02} seconds",
             start.elapsed().as_secs_f32()
@@ -393,19 +393,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + Clone + 'static> IvfIndexBuilde
             if num_rows == 0 {
                 continue;
             }
-            let mut batch = arrow::compute::concat_batches(&batches[0].schema(), batches.iter())?;
-            if self.distance_type == DistanceType::Cosine {
-                let vectors = batch
-                    .column_by_name(&self.column)
-                    .ok_or(Error::invalid_input(
-                        format!("column {} not found", self.column).as_str(),
-                        location!(),
-                    ))?
-                    .as_fixed_size_list();
-                let vectors = lance_linalg::kernels::normalize_fsl(vectors)?;
-                batch = batch.replace_column_by_name(&self.column, Arc::new(vectors))?;
-            }
-
+            let batch = arrow::compute::concat_batches(&batches[0].schema(), batches.iter())?;
             let sizes = self.build_partition(partition, &batch).await?;
             partition_sizes[partition] = sizes;
             log::info!(

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -629,7 +629,7 @@ mod tests {
             &vectors,
             query.as_primitive::<Float32Type>().values(),
             k,
-            DistanceType::L2,
+            params.metric_type,
         );
         let gt_set = gt.iter().map(|r| r.1).collect::<HashSet<_>>();
 
@@ -670,6 +670,24 @@ mod tests {
         let ivf_params = IvfBuildParams::new(nlist);
         let pq_params = PQBuildParams::default();
         let params = VectorIndexParams::with_ivf_pq_params(distance_type, ivf_params, pq_params);
+        test_index(params, nlist, recall_requirement).await;
+    }
+
+    #[rstest]
+    #[case(4, DistanceType::L2, 0.9)]
+    #[case(4, DistanceType::Cosine, 0.9)]
+    #[case(4, DistanceType::Dot, 0.9)]
+    #[tokio::test]
+    async fn test_build_ivf_pq_v3(
+        #[case] nlist: usize,
+        #[case] distance_type: DistanceType,
+        #[case] recall_requirement: f32,
+    ) {
+        let ivf_params = IvfBuildParams::new(nlist);
+        let pq_params = PQBuildParams::default();
+        let params = VectorIndexParams::with_ivf_pq_params(distance_type, ivf_params, pq_params)
+            .version(crate::index::vector::IndexFileVersion::V3)
+            .clone();
         test_index(params, nlist, recall_requirement).await;
     }
 

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -715,8 +715,8 @@ mod tests {
 
     #[rstest]
     #[case(4, DistanceType::L2, 0.9)]
-    #[case(4, DistanceType::Cosine, 0.6)]
-    #[case(4, DistanceType::Dot, 0.2)]
+    #[case(4, DistanceType::Cosine, 0.9)]
+    #[case(4, DistanceType::Dot, 0.9)]
     #[tokio::test]
     async fn test_create_ivf_hnsw_pq(
         #[case] nlist: usize,


### PR DESCRIPTION
This also supports to create v3 IVF_PQ in Rust, then it introduces a breaking change