### PR TITLE
feat: support 4bit PQ on new IVF_PQ

### DIFF
--- a/rust/lance-index/src/vector/flat/index.rs
+++ b/rust/lance-index/src/vector/flat/index.rs
@@ -78,18 +78,13 @@ impl IvfSubIndex for FlatIndex {
         let dist_calc = storage.dist_calculator(query);
 
         let (row_ids, dists): (Vec<u64>, Vec<f32>) = match prefilter.is_empty() {
-            // true => dist_calc
-            //     .distance_all()
-            //     .into_iter()
-            //     .zip(0..storage.len() as u32)
-            //     .map(|(dist, id)| OrderedNode {
-            //         id,
-            //         dist: OrderedFloat(dist),
-            //     })
-            true => (0..storage.len())
-                .map(|id| OrderedNode {
-                    id: id as u32,
-                    dist: OrderedFloat(dist_calc.distance(id as u32)),
+            true => dist_calc
+                .distance_all()
+                .into_iter()
+                .zip(0..storage.len() as u32)
+                .map(|(dist, id)| OrderedNode {
+                    id,
+                    dist: OrderedFloat(dist),
                 })
                 .sorted_unstable()
                 .take(k)

--- a/rust/lance-index/src/vector/flat/index.rs
+++ b/rust/lance-index/src/vector/flat/index.rs
@@ -78,11 +78,19 @@ impl IvfSubIndex for FlatIndex {
         let dist_calc = storage.dist_calculator(query);
 
         let (row_ids, dists): (Vec<u64>, Vec<f32>) = match prefilter.is_empty() {
-            true => (0..storage.len())
-                .map(|id| OrderedNode {
-                    id: id as u32,
-                    dist: OrderedFloat(dist_calc.distance(id as u32)),
+            true => dist_calc
+                .distance_all()
+                .into_iter()
+                .zip(0..storage.len() as u32)
+                .map(|(dist, id)| OrderedNode {
+                    id,
+                    dist: OrderedFloat(dist),
                 })
+                // true => (0..storage.len())
+                //     .map(|id| OrderedNode {
+                //         id: id as u32,
+                //         dist: OrderedFloat(dist_calc.distance(id as u32)),
+                //     })
                 .sorted_unstable()
                 .take(k)
                 .map(

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -210,6 +210,14 @@ impl DistCalculator for FlatDistanceCal<'_> {
         (self.distance_fn)(&self.query, vector)
     }
 
+    fn distance_all(&self) -> Vec<f32> {
+        let query = &self.query;
+        self.vectors
+            .chunks_exact(self.dimension)
+            .map(|vector| (self.distance_fn)(query, vector))
+            .collect()
+    }
+
     #[inline]
     fn prefetch(&self, id: u32) {
         let vector = self.get_vector(id);

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -11,6 +11,7 @@ use arrow_array::{cast::AsArray, Array, FixedSizeListArray, UInt8Array};
 use arrow_array::{ArrayRef, Float32Array, PrimitiveArray};
 use arrow_schema::DataType;
 use deepsize::DeepSizeOf;
+use distance::compute_dot_distance;
 use lance_arrow::*;
 use lance_core::{Error, Result};
 use lance_linalg::distance::{dot_distance_batch, DistanceType, Dot, L2};
@@ -108,6 +109,15 @@ impl ProductQuantizer {
         let num_sub_vectors = self.num_sub_vectors;
         let dim = self.dimension;
         let num_bits = self.num_bits;
+        if num_bits == 4 && num_sub_vectors % 2 != 0 {
+            return Err(Error::Index {
+                message: format!(
+                    "PQ: num_sub_vectors must be divisible by 2 for num_bits=4, but got {}",
+                    num_sub_vectors,
+                ),
+                location: location!(),
+            });
+        }
         let codebook = self.codebook.values().as_primitive::<T>();
 
         let distance_type = self.distance_type;
@@ -118,7 +128,7 @@ impl ProductQuantizer {
             .values()
             .chunks_exact(dim)
             .flat_map(|vector| {
-                vector
+                let sub_vec_code = vector
                     .chunks_exact(sub_dim)
                     .enumerate()
                     .map(|(sub_idx, sub_vector)| {
@@ -129,15 +139,30 @@ impl ProductQuantizer {
                             num_sub_vectors,
                             sub_idx,
                         );
-                        compute_partition(centroids, sub_vector, distance_type).map(|v| v as u8)
+                        compute_partition(centroids, sub_vector, distance_type).unwrap() as u8
                     })
-                    .collect::<Vec<_>>()
+                    .collect::<Vec<_>>();
+                if num_bits == 4 {
+                    sub_vec_code
+                        .chunks_exact(2)
+                        .map(|v| (v[1] << 4) | v[0])
+                        .collect::<Vec<_>>()
+                } else {
+                    sub_vec_code
+                }
             })
             .collect::<Vec<_>>();
 
+        let real_num_sub_vectors = if num_bits == 4 {
+            num_sub_vectors / 2
+        } else {
+            num_sub_vectors
+        };
+
+        debug_assert_eq!(values.len(), fsl.len() * real_num_sub_vectors);
         Ok(Arc::new(FixedSizeListArray::try_new_from_values(
             UInt8Array::from(values),
-            self.num_sub_vectors as i32,
+            real_num_sub_vectors as i32,
         )?))
     }
 
@@ -150,11 +175,9 @@ impl ProductQuantizer {
         match self.distance_type {
             DistanceType::L2 => self.l2_distances(query, code),
             DistanceType::Cosine => {
-                // L2 over normalized vectors:  ||x - y|| = x^2 + y^2 - 2 * xy = 1 + 1 - 2 * xy = 2 * (1 - xy)
-                // Cosine distance: 1 - |xy| / (||x|| * ||y||) = 1 - xy / (x^2 * y^2) = 1 - xy / (1 * 1) = 1 - xy
-                // Therefore, Cosine = L2 / 2
-                let l2_dists = self.l2_distances(query, code)?;
-                Ok(l2_dists.values().iter().map(|v| *v / 2.0).collect())
+                panic!(
+                    "Cosine distance should be converted to L2 distance by normalizing the vectors"
+                );
             }
             DistanceType::Dot => self.dot_distances(query, code),
             _ => panic!(
@@ -224,18 +247,12 @@ impl ProductQuantizer {
                 distance_table.extend(distances);
             });
 
-        let num_vectors = code.len() / self.num_sub_vectors;
-        let mut distances = vec![0.0; num_vectors];
-        let num_centroids = num_centroids(self.num_bits);
-        for (sub_vec_idx, vec_indices) in code.values().chunks_exact(num_vectors).enumerate() {
-            let dist_table = &distance_table[sub_vec_idx * num_centroids..];
-            vec_indices
-                .iter()
-                .zip(distances.iter_mut())
-                .for_each(|(&centroid_idx, sum)| {
-                    *sum += dist_table[centroid_idx as usize];
-                });
-        }
+        let distances = compute_dot_distance(
+            &distance_table,
+            self.num_bits,
+            self.num_sub_vectors,
+            code.values(),
+        );
         Ok(distances.into())
     }
 

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -195,6 +195,10 @@ impl ProductQuantizationStorage {
             .clone()
             .into();
 
+        let distance_type = match distance_type {
+            DistanceType::Cosine => DistanceType::L2,
+            _ => distance_type,
+        };
         Ok(Self {
             codebook,
             batch,

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -411,6 +411,34 @@ impl<'a> DistCalculator for SQDistCalculator<'a> {
         }
     }
 
+    fn distance_all(&self) -> Vec<f32> {
+        match self.storage.distance_type {
+            DistanceType::L2 | DistanceType::Cosine => self
+                .storage
+                .chunks
+                .iter()
+                .flat_map(|c| {
+                    c.sq_codes
+                        .values()
+                        .chunks_exact(c.dim())
+                        .map(|sq_codes| l2_distance_uint_scalar(sq_codes, &self.query_sq_code))
+                })
+                .collect(),
+            DistanceType::Dot => self
+                .storage
+                .chunks
+                .iter()
+                .flat_map(|c| {
+                    c.sq_codes
+                        .values()
+                        .chunks_exact(c.dim())
+                        .map(|sq_codes| dot_distance(sq_codes, &self.query_sq_code))
+                })
+                .collect(),
+            _ => panic!("We should not reach here: sq distance can only be L2 or Dot"),
+        }
+    }
+
     #[allow(unused_variables)]
     fn prefetch(&self, id: u32) {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -38,6 +38,9 @@ use super::DISTANCE_TYPE_KEY;
 /// </section>
 pub trait DistCalculator {
     fn distance(&self, id: u32) -> f32;
+    fn distance_all(&self) -> Vec<f32> {
+        unimplemented!("Implement this")
+    }
     fn prefetch(&self, _id: u32) {}
 }
 
@@ -61,6 +64,8 @@ pub trait VectorStore: Send + Sync + Sized + Clone {
     where
         Self: 'a;
 
+    /// Create a [VectorStore] from a [RecordBatch].
+    /// The batch should consist of row IDs and quantized vector.
     fn try_from_batch(batch: RecordBatch, distance_type: DistanceType) -> Result<Self>;
 
     fn as_any(&self) -> &dyn Any;

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -38,9 +38,7 @@ use super::DISTANCE_TYPE_KEY;
 /// </section>
 pub trait DistCalculator {
     fn distance(&self, id: u32) -> f32;
-    fn distance_all(&self) -> Vec<f32> {
-        unimplemented!("Implement this")
-    }
+    fn distance_all(&self) -> Vec<f32>;
     fn prefetch(&self, _id: u32) {}
 }
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -5283,6 +5283,7 @@ mod test {
                             ..Default::default()
                         }),
                     ],
+                    index_version: crate::index::vector::IndexVersion::Legacy,
                 },
                 false,
             )

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -428,8 +428,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + Clone + 'static> IvfIndexBuilde
         // build quantized vector storage
         let object_store = ObjectStore::local();
         let storage_len = {
-            let storage = StorageBuilder::new(self.column.clone(), self.distance_type, quantizer)
-                .build(batch)?;
+            let storage =
+                StorageBuilder::new(self.column.clone(), quantizer, quantizer).build(batch)?;
             let path = self.temp_dir.child(format!("storage_part{}", part_id));
             let writer = object_store.create(&path).await?;
             let mut writer = FileWriter::try_new(
@@ -654,15 +654,13 @@ pub(crate) fn index_type_string(sub_index: SubIndexType, quantizer: Quantization
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, ops::Range, sync::Arc};
-
+    use crate::Dataset;
     use arrow::datatypes::Float32Type;
     use arrow_array::{FixedSizeListArray, RecordBatch, RecordBatchIterator};
     use arrow_schema::{DataType, Field, Schema};
     use lance_arrow::FixedSizeListArrayExt;
     use lance_index::vector::hnsw::builder::HnswBuildParams;
     use lance_index::vector::hnsw::HNSW;
-
     use lance_index::vector::pq::{PQBuildParams, ProductQuantizer};
     use lance_index::vector::sq::builder::SQBuildParams;
     use lance_index::vector::sq::ScalarQuantizer;
@@ -674,9 +672,8 @@ mod tests {
     use lance_linalg::distance::DistanceType;
     use lance_testing::datagen::generate_random_array_with_range;
     use object_store::path::Path;
+    use std::{collections::HashMap, ops::Range, sync::Arc};
     use tempfile::tempdir;
-
-    use crate::Dataset;
 
     const DIM: usize = 32;
 

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -678,6 +678,42 @@ mod tests {
     #[case(4, DistanceType::Cosine, 0.9)]
     #[case(4, DistanceType::Dot, 0.9)]
     #[tokio::test]
+    async fn test_build_ivf_pq_v3(
+        #[case] nlist: usize,
+        #[case] distance_type: DistanceType,
+        #[case] recall_requirement: f32,
+    ) {
+        let ivf_params = IvfBuildParams::new(nlist);
+        let pq_params = PQBuildParams::default();
+        let params = VectorIndexParams::with_ivf_pq_params(distance_type, ivf_params, pq_params)
+            .index_version(crate::index::vector::IndexVersion::V3)
+            .clone();
+        test_index(params, nlist, recall_requirement).await;
+    }
+
+    #[rstest]
+    #[case(4, DistanceType::L2, 0.9)]
+    #[case(4, DistanceType::Cosine, 0.9)]
+    #[case(4, DistanceType::Dot, 0.9)]
+    #[tokio::test]
+    async fn test_build_ivf_pq_4bit(
+        #[case] nlist: usize,
+        #[case] distance_type: DistanceType,
+        #[case] recall_requirement: f32,
+    ) {
+        let ivf_params = IvfBuildParams::new(nlist);
+        let pq_params = PQBuildParams::new(16, 4);
+        let params = VectorIndexParams::with_ivf_pq_params(distance_type, ivf_params, pq_params)
+            .index_version(crate::index::vector::IndexVersion::V3)
+            .clone();
+        test_index(params, nlist, recall_requirement).await;
+    }
+
+    #[rstest]
+    #[case(4, DistanceType::L2, 0.9)]
+    #[case(4, DistanceType::Cosine, 0.9)]
+    #[case(4, DistanceType::Dot, 0.9)]
+    #[tokio::test]
     async fn test_create_ivf_hnsw_sq(
         #[case] nlist: usize,
         #[case] distance_type: DistanceType,

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -753,6 +753,28 @@ mod tests {
         test_index(params, nlist, recall_requirement).await;
     }
 
+    #[rstest]
+    #[case(4, DistanceType::L2, 0.9)]
+    #[case(4, DistanceType::Cosine, 0.9)]
+    #[case(4, DistanceType::Dot, 0.8)]
+    #[tokio::test]
+    async fn test_create_ivf_hnsw_pq_4bit(
+        #[case] nlist: usize,
+        #[case] distance_type: DistanceType,
+        #[case] recall_requirement: f32,
+    ) {
+        let ivf_params = IvfBuildParams::new(nlist);
+        let pq_params = PQBuildParams::new(32, 4);
+        let hnsw_params = HnswBuildParams::default();
+        let params = VectorIndexParams::with_ivf_hnsw_pq_params(
+            distance_type,
+            ivf_params,
+            hnsw_params,
+            pq_params,
+        );
+        test_index(params, nlist, recall_requirement).await;
+    }
+
     #[tokio::test]
     async fn test_index_stats() {
         let test_dir = tempdir().unwrap();


### PR DESCRIPTION
also introduces `distance_all` methods to distance calculator, to improve the new IVF_PQ search performance
we store the 4bit PQ codes in half-bytes