### PR TITLE
fix: full text search index broken after optimize_indices()

### DIFF
--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -348,7 +348,7 @@ impl InvertedIndexBuilder {
         let start = std::time::Instant::now();
         while let Some(r) = merged_stream.try_next().await? {
             let (token, batch, max_score) = r?;
-            self.tokens.add(token.clone());
+            self.tokens.add(token);
             offsets.push(num_rows);
             max_scores.push(max_score);
             num_rows += batch.num_rows();

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -650,14 +650,11 @@ impl PostingReader {
 
                 // read the posting lists from existing data
                 if let Some(inverted_list) = posting_reader.inverted_list_reader.as_ref() {
-                    match posting_reader.existing_tokens.get(&token) {
-                        Some(token_id) => {
-                            let batch = inverted_list
-                                .posting_batch(*token_id, inverted_list.has_positions())
-                                .await?;
-                            batches.push(batch);
-                        }
-                        None => {}
+                    if let Some(token_id) = posting_reader.existing_tokens.get(&token) {
+                        let batch = inverted_list
+                            .posting_batch(*token_id, inverted_list.has_positions())
+                            .await?;
+                        batches.push(batch);
                     }
                 }
 

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -286,7 +286,7 @@ impl ScalarIndex for InvertedIndex {
         let tokenizer = tokenizer_config.build()?;
         let params = InvertedIndexParams {
             with_position: inverted_list.has_positions(),
-            tokenizer_config: tokenizer_config,
+            tokenizer_config,
         };
         Ok(Arc::new(Self {
             params,

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1328,7 +1328,7 @@ mod tests {
         tokenizer_config = tokenizer_config.stem(false);
         let params = InvertedIndexParams {
             with_position: true,
-            tokenizer_config: tokenizer_config,
+            tokenizer_config,
         };
         dataset
             .create_index(&["text"], IndexType::Inverted, None, &params, true)

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1326,8 +1326,10 @@ mod tests {
             .unwrap_or(TokenizerConfig::default());
         tokenizer_config = tokenizer_config.remove_stop_words(false);
         tokenizer_config = tokenizer_config.stem(false);
-        let mut params = InvertedIndexParams::default();
-        params.tokenizer_config = tokenizer_config;
+        let params = InvertedIndexParams {
+            with_position: true,
+            tokenizer_config: tokenizer_config,
+        };
         dataset
             .create_index(&["text"], IndexType::Inverted, None, &params, true)
             .await


### PR DESCRIPTION
this can be reproduced by optimizing FTS without any new data.
the existing tokens could be reordered then the `offsets` broken, leads to the index would return random results.
existing tests only verify whether the new data can be queried, so we didn't find this bug.
added a test to query existing data