### PR TITLE
feat: allow async stream for writing and appending to a dataset

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3369,6 +3369,7 @@ dependencies = [
  "datafusion",
  "jni",
  "lance",
+ "lance-datafusion",
  "lance-encoding",
  "lance-index",
  "lance-io",

--- a/java/core/lance-jni/Cargo.toml
+++ b/java/core/lance-jni/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 lance = { workspace = true, features = ["substrait"] }
+lance-datafusion = { workspace = true }
 lance-encoding = { workspace = true }
 lance-linalg = { workspace = true }
 lance-index = { workspace = true }

--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -6,6 +6,8 @@ use snafu::{Location, Snafu};
 
 type BoxedError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+/// Allocates error on the heap and then places `e` into it.
+#[inline]
 pub fn box_error(e: impl std::error::Error + Send + Sync + 'static) -> BoxedError {
     Box::new(e)
 }

--- a/rust/lance-datafusion/src/utils.rs
+++ b/rust/lance-datafusion/src/utils.rs
@@ -1,13 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use arrow_array::{RecordBatchIterator, RecordBatchReader};
-use datafusion::physical_plan::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream};
+use arrow::ffi_stream::ArrowArrayStreamReader;
+use arrow_array::{RecordBatch, RecordBatchIterator, RecordBatchReader};
+use arrow_schema::{ArrowError, SchemaRef};
+use async_trait::async_trait;
+use datafusion::{
+    execution::RecordBatchStream,
+    physical_plan::{stream::RecordBatchStreamAdapter, SendableRecordBatchStream},
+};
 use datafusion_common::DataFusionError;
 use futures::{stream, Stream, StreamExt, TryFutureExt, TryStreamExt};
 use lance_core::datatypes::Schema;
-use lance_core::{Error, Result};
-use tokio::task::spawn_blocking;
+use lance_core::Result;
+use tokio::task::{spawn, spawn_blocking};
 
 fn background_iterator<I: Iterator + Send + 'static>(iter: I) -> impl Stream<Item = I::Item>
 where
@@ -20,44 +26,123 @@ where
     .fuse()
 }
 
-/// Infer the Lance schema from the first batch.
+/// A trait for [BatchRecord] iterators, readers and streams
+/// that can be converted to a concrete stream type [SendableRecordBatchStream].
 ///
-/// This will peek the first batch to get the dictionaries for dictionary columns.
-///
-/// NOTE: this does not validate the schema. For example, for appends the schema
-/// should be checked to make sure it matches the existing dataset schema before
-/// writing.
-pub async fn peek_reader_schema(
-    batches: Box<dyn RecordBatchReader + Send>,
-) -> Result<(Box<dyn RecordBatchReader + Send>, Schema)> {
-    let arrow_schema = batches.schema();
-    let (peekable, schema) = spawn_blocking(move || {
-        let mut schema: Schema = Schema::try_from(batches.schema().as_ref())?;
-        let mut peekable = batches.peekable();
-        if let Some(batch) = peekable.peek() {
-            if let Ok(b) = batch {
-                schema.set_dictionary(b)?;
-            } else {
-                return Err(Error::from(batch.as_ref().unwrap_err()));
+/// This also cam read the schema from the first batch
+/// and then update the schema to reflect the dictionary columns.
+#[async_trait]
+pub trait StreamingWriteSource: Send {
+    /// Infer the Lance schema from the first batch stream.
+    ///
+    /// This will peek the first batch to get the dictionaries for dictionary columns.
+    ///
+    /// NOTE: this does not validate the schema. For example, for appends the schema
+    /// should be checked to make sure it matches the existing dataset schema before
+    /// writing.
+    async fn into_stream_and_schema(self) -> Result<(SendableRecordBatchStream, Schema)>
+    where
+        Self: Sized,
+    {
+        let mut stream = self.into_stream();
+        let (stream, arrow_schema, schema) = spawn(async move {
+            let arrow_schema = stream.schema();
+            let mut schema: Schema = Schema::try_from(arrow_schema.as_ref())?;
+            let first_batch = stream.try_next().await?;
+            if let Some(batch) = &first_batch {
+                schema.set_dictionary(batch)?;
             }
-        }
-        Ok((peekable, schema))
-    })
-    .await
-    .unwrap()?;
-    schema.validate()?;
-    let reader = RecordBatchIterator::new(peekable, arrow_schema);
-    Ok((
-        Box::new(reader) as Box<dyn RecordBatchReader + Send>,
-        schema,
-    ))
+            let stream = stream::iter(first_batch.map(Ok)).chain(stream);
+            Result::Ok((stream, arrow_schema, schema))
+        })
+        .await
+        .unwrap()?;
+        schema.validate()?;
+        let adapter = RecordBatchStreamAdapter::new(arrow_schema, stream);
+        Ok((Box::pin(adapter), schema))
+    }
+
+    /// Returns the arrow schema.
+    fn arrow_schema(&self) -> SchemaRef;
+
+    /// Convert to a stream.
+    ///
+    /// The conversion will be conducted in a background thread.
+    fn into_stream(self) -> SendableRecordBatchStream;
+}
+
+impl StreamingWriteSource for ArrowArrayStreamReader {
+    #[inline]
+    fn arrow_schema(&self) -> SchemaRef {
+        RecordBatchReader::schema(self)
+    }
+
+    #[inline]
+    fn into_stream(self) -> SendableRecordBatchStream {
+        reader_to_stream(Box::new(self))
+    }
+}
+
+impl<I> StreamingWriteSource for RecordBatchIterator<I>
+where
+    Self: Send,
+    I: IntoIterator<Item = ::core::result::Result<RecordBatch, ArrowError>> + Send + 'static,
+{
+    #[inline]
+    fn arrow_schema(&self) -> SchemaRef {
+        RecordBatchReader::schema(self)
+    }
+
+    #[inline]
+    fn into_stream(self) -> SendableRecordBatchStream {
+        reader_to_stream(Box::new(self))
+    }
+}
+
+impl<T> StreamingWriteSource for Box<T>
+where
+    T: StreamingWriteSource,
+{
+    #[inline]
+    fn arrow_schema(&self) -> SchemaRef {
+        T::arrow_schema(&**self)
+    }
+
+    #[inline]
+    fn into_stream(self) -> SendableRecordBatchStream {
+        T::into_stream(*self)
+    }
+}
+
+impl StreamingWriteSource for Box<dyn RecordBatchReader + Send> {
+    #[inline]
+    fn arrow_schema(&self) -> SchemaRef {
+        RecordBatchReader::schema(self)
+    }
+
+    #[inline]
+    fn into_stream(self) -> SendableRecordBatchStream {
+        reader_to_stream(self)
+    }
+}
+
+impl StreamingWriteSource for SendableRecordBatchStream {
+    #[inline]
+    fn arrow_schema(&self) -> SchemaRef {
+        RecordBatchStream::schema(&**self)
+    }
+
+    #[inline]
+    fn into_stream(self) -> SendableRecordBatchStream {
+        self
+    }
 }
 
 /// Convert reader to a stream.
 ///
 /// The reader will be called in a background thread.
 pub fn reader_to_stream(batches: Box<dyn RecordBatchReader + Send>) -> SendableRecordBatchStream {
-    let arrow_schema = batches.schema();
+    let arrow_schema = batches.arrow_schema();
     let stream = RecordBatchStreamAdapter::new(
         arrow_schema,
         background_iterator(batches).map_err(DataFusionError::from),

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -444,7 +444,9 @@ impl Dataset {
         if let Some(params) = &params {
             builder = builder.with_params(params);
         }
-        builder.execute_stream(batches).await
+        builder
+            .execute_stream(Box::new(batches) as Box<dyn RecordBatchReader + Send>)
+            .await
     }
 
     /// Append to existing [Dataset] with a stream of [RecordBatch]s
@@ -462,7 +464,7 @@ impl Dataset {
 
         let new_dataset = InsertBuilder::new(WriteDestination::Dataset(Arc::new(self.clone())))
             .with_params(&write_params)
-            .execute_stream(batches)
+            .execute_stream(Box::new(batches) as Box<dyn RecordBatchReader + Send>)
             .await?;
 
         *self = new_dataset;

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -12,7 +12,7 @@ use datafusion::execution::SendableRecordBatchStream;
 use futures::stream::{StreamExt, TryStreamExt};
 use lance_arrow::SchemaExt;
 use lance_core::datatypes::{Field, Schema};
-use lance_datafusion::utils::reader_to_stream;
+use lance_datafusion::utils::StreamingWriteSource;
 use lance_table::format::Fragment;
 use snafu::{location, Location};
 
@@ -234,7 +234,7 @@ pub(super) async fn add_columns_to_fragments(
         NewColumnTransform::Reader(reader) => {
             let output_schema = reader.schema();
             check_names(output_schema.as_ref())?;
-            let stream = reader_to_stream(reader);
+            let stream = reader.into_stream();
             let fragments = add_columns_from_stream(fragments, stream, None, batch_size).await?;
             Ok((output_schema, fragments))
         }


### PR DESCRIPTION
This PR allows end-users to use `SendableRecordBatchStream` and `Schema` directly for writing or appending a dataset.

It's vital to write&append async streams to a dataset.

## Related Issues

Partially resolves #1792.

## Side-effects

This PR has a side-effect like below.

### Changed

* peek_stream_schema => abstracted by `StreamingWriteSource::into_stream_and_schema`.

### Added

* StreamingWriteSource
    - StreamingWriteSource::into_stream => Prior `reader_to_stream` but also supports Streams.
    - StreamingWriteSource::into_stream_and_schema => Prior (`reader_to_stream`, `peek_stream_schema`) but also supports Streams.
