### PR TITLE
perf: improve PQ computing distances

### DIFF
--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -83,6 +83,10 @@ name = "pq_dist_table"
 harness = false
 
 [[bench]]
+name = "4bitpq_dist_table"
+harness = false
+
+[[bench]]
 name = "pq_assignment"
 harness = false
 

--- a/rust/lance-index/benches/4bitpq_dist_table.rs
+++ b/rust/lance-index/benches/4bitpq_dist_table.rs
@@ -19,7 +19,7 @@ use pprof::criterion::{Output, PProfProfiler};
 
 const PQ: usize = 96;
 const DIM: usize = 1536;
-const TOTAL: usize = 500 * 1000;
+const TOTAL: usize = 16 * 1000;
 
 fn dist_table(c: &mut Criterion) {
     let codebook = generate_random_array_with_seed::<Float32Type>(256 * DIM, [88; 32]);

--- a/rust/lance-index/benches/4bitpq_dist_table.rs
+++ b/rust/lance-index/benches/4bitpq_dist_table.rs
@@ -19,7 +19,7 @@ use pprof::criterion::{Output, PProfProfiler};
 
 const PQ: usize = 96;
 const DIM: usize = 1536;
-const TOTAL: usize = 5 * 1024 * 1024;
+const TOTAL: usize = 500 * 1000;
 
 fn dist_table(c: &mut Criterion) {
     let codebook = generate_random_array_with_seed::<Float32Type>(256 * DIM, [88; 32]);
@@ -28,37 +28,24 @@ fn dist_table(c: &mut Criterion) {
     let mut rnd = StdRng::from_seed([32; 32]);
     let code = UInt8Array::from_iter_values(repeat(rnd.gen::<u8>()).take(TOTAL * PQ));
 
-    let l2_pq = ProductQuantizer::new(
-        PQ,
-        4,
-        DIM,
-        FixedSizeListArray::try_new_from_values(codebook.clone(), DIM as i32).unwrap(),
-        DistanceType::L2,
-    );
-    c.bench_function(
-        format!("{},L2,4bitPQ={},DIM={}", TOTAL, PQ, DIM).as_str(),
-        |b| {
-            b.iter(|| {
-                black_box(l2_pq.compute_distances(&query, &code).unwrap().len());
-            })
-        },
-    );
+    for dt in [DistanceType::L2, DistanceType::Cosine, DistanceType::Dot].iter() {
+        let pq = ProductQuantizer::new(
+            PQ,
+            4,
+            DIM,
+            FixedSizeListArray::try_new_from_values(codebook.clone(), DIM as i32).unwrap(),
+            *dt,
+        );
 
-    let cosine_pq = ProductQuantizer::new(
-        PQ,
-        4,
-        DIM,
-        FixedSizeListArray::try_new_from_values(codebook, DIM as i32).unwrap(),
-        DistanceType::Cosine,
-    );
-    c.bench_function(
-        format!("{},Cosine,4bitPQ={},DIM={}", TOTAL, PQ, DIM).as_str(),
-        |b| {
-            b.iter(|| {
-                black_box(cosine_pq.compute_distances(&query, &code).unwrap());
-            })
-        },
-    );
+        c.bench_function(
+            format!("{},{},PQ={},DIM={}", TOTAL, dt, PQ, DIM).as_str(),
+            |b| {
+                b.iter(|| {
+                    black_box(pq.compute_distances(&query, &code).unwrap());
+                })
+            },
+        );
+    }
 }
 
 #[cfg(target_os = "linux")]

--- a/rust/lance-index/benches/4bitpq_dist_table.rs
+++ b/rust/lance-index/benches/4bitpq_dist_table.rs
@@ -48,7 +48,7 @@ fn dist_table(c: &mut Criterion) {
         PQ,
         4,
         DIM,
-        FixedSizeListArray::try_new_from_values(codebook.clone(), DIM as i32).unwrap(),
+        FixedSizeListArray::try_new_from_values(codebook, DIM as i32).unwrap(),
         DistanceType::Cosine,
     );
     c.bench_function(

--- a/rust/lance-index/benches/4bitpq_dist_table.rs
+++ b/rust/lance-index/benches/4bitpq_dist_table.rs
@@ -30,13 +30,13 @@ fn dist_table(c: &mut Criterion) {
 
     let l2_pq = ProductQuantizer::new(
         PQ,
-        8,
+        4,
         DIM,
         FixedSizeListArray::try_new_from_values(codebook.clone(), DIM as i32).unwrap(),
         DistanceType::L2,
     );
     c.bench_function(
-        format!("{},L2,PQ={},DIM={}", TOTAL, PQ, DIM).as_str(),
+        format!("{},L2,4bitPQ={},DIM={}", TOTAL, PQ, DIM).as_str(),
         |b| {
             b.iter(|| {
                 black_box(l2_pq.compute_distances(&query, &code).unwrap().len());
@@ -46,13 +46,13 @@ fn dist_table(c: &mut Criterion) {
 
     let cosine_pq = ProductQuantizer::new(
         PQ,
-        8,
+        4,
         DIM,
         FixedSizeListArray::try_new_from_values(codebook.clone(), DIM as i32).unwrap(),
         DistanceType::Cosine,
     );
     c.bench_function(
-        format!("{},Cosine,PQ={},DIM={}", TOTAL, PQ, DIM).as_str(),
+        format!("{},Cosine,4bitPQ={},DIM={}", TOTAL, PQ, DIM).as_str(),
         |b| {
             b.iter(|| {
                 black_box(cosine_pq.compute_distances(&query, &code).unwrap());

--- a/rust/lance-index/benches/pq_dist_table.rs
+++ b/rust/lance-index/benches/pq_dist_table.rs
@@ -48,7 +48,7 @@ fn dist_table(c: &mut Criterion) {
         PQ,
         8,
         DIM,
-        FixedSizeListArray::try_new_from_values(codebook.clone(), DIM as i32).unwrap(),
+        FixedSizeListArray::try_new_from_values(codebook, DIM as i32).unwrap(),
         DistanceType::Cosine,
     );
     c.bench_function(

--- a/rust/lance-index/benches/pq_dist_table.rs
+++ b/rust/lance-index/benches/pq_dist_table.rs
@@ -19,7 +19,7 @@ use pprof::criterion::{Output, PProfProfiler};
 
 const PQ: usize = 96;
 const DIM: usize = 1536;
-const TOTAL: usize = 500 * 1000;
+const TOTAL: usize = 16 * 1000;
 
 fn dist_table(c: &mut Criterion) {
     let codebook = generate_random_array_with_seed::<Float32Type>(256 * DIM, [88; 32]);

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -128,28 +128,30 @@ impl ProductQuantizer {
             .values()
             .chunks_exact(dim)
             .flat_map(|vector| {
-                let sub_vec_code = vector
-                    .chunks_exact(sub_dim)
-                    .enumerate()
-                    .map(|(sub_idx, sub_vector)| {
-                        let centroids = get_sub_vector_centroids(
-                            codebook.values(),
-                            dim,
-                            num_bits,
-                            num_sub_vectors,
-                            sub_idx,
-                        );
-                        compute_partition(centroids, sub_vector, distance_type).unwrap() as u8
-                    })
-                    .collect::<Vec<_>>();
-                if num_bits == 4 {
-                    sub_vec_code
-                        .chunks_exact(2)
-                        .map(|v| (v[1] << 4) | v[0])
-                        .collect::<Vec<_>>()
-                } else {
-                    sub_vec_code
-                }
+                let sub_vec_code =
+                    vector
+                        .chunks_exact(sub_dim)
+                        .enumerate()
+                        .map(|(sub_idx, sub_vector)| {
+                            let centroids = get_sub_vector_centroids(
+                                codebook.values(),
+                                dim,
+                                num_bits,
+                                num_sub_vectors,
+                                sub_idx,
+                            );
+                            compute_partition(centroids, sub_vector, distance_type).unwrap() as u8
+                        });
+                sub_vec_code
+                // .collect::<Vec<_>>();
+                // if num_bits == 4 {
+                //     sub_vec_code
+                //         .chunks_exact(2)
+                //         .map(|v| (v[1] << 4) | v[0])
+                //         .collect::<Vec<_>>()
+                // } else {
+                //     sub_vec_code
+                // }
             })
             .collect::<Vec<_>>();
 

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -128,30 +128,28 @@ impl ProductQuantizer {
             .values()
             .chunks_exact(dim)
             .flat_map(|vector| {
-                let sub_vec_code =
-                    vector
-                        .chunks_exact(sub_dim)
-                        .enumerate()
-                        .map(|(sub_idx, sub_vector)| {
-                            let centroids = get_sub_vector_centroids(
-                                codebook.values(),
-                                dim,
-                                num_bits,
-                                num_sub_vectors,
-                                sub_idx,
-                            );
-                            compute_partition(centroids, sub_vector, distance_type).unwrap() as u8
-                        });
-                sub_vec_code
-                // .collect::<Vec<_>>();
-                // if num_bits == 4 {
-                //     sub_vec_code
-                //         .chunks_exact(2)
-                //         .map(|v| (v[1] << 4) | v[0])
-                //         .collect::<Vec<_>>()
-                // } else {
-                //     sub_vec_code
-                // }
+                let sub_vec_code = vector
+                    .chunks_exact(sub_dim)
+                    .enumerate()
+                    .map(|(sub_idx, sub_vector)| {
+                        let centroids = get_sub_vector_centroids(
+                            codebook.values(),
+                            dim,
+                            num_bits,
+                            num_sub_vectors,
+                            sub_idx,
+                        );
+                        compute_partition(centroids, sub_vector, distance_type).unwrap() as u8
+                    })
+                    .collect::<Vec<_>>();
+                if num_bits == 4 {
+                    sub_vec_code
+                        .chunks_exact(2)
+                        .map(|v| (v[1] << 4) | v[0])
+                        .collect::<Vec<_>>()
+                } else {
+                    sub_vec_code
+                }
             })
             .collect::<Vec<_>>();
 

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -80,9 +80,10 @@ pub(super) fn compute_l2_distance(
     // so code[i * num_vectors + j] is the code of i-th sub-vector of the j-th vector.
     let num_vectors = code.len() / num_sub_vectors;
     let mut distances = vec![0.0_f32; num_vectors];
-    let num_centroids = 2_usize.pow(num_bits);
+    const NUM_CENTROIDS: usize = 2_usize.pow(8);
     for (sub_vec_idx, vec_indices) in code.chunks_exact(num_vectors).enumerate() {
-        let dist_table = &distance_table[sub_vec_idx * num_centroids..];
+        let dist_table =
+            &distance_table[sub_vec_idx * NUM_CENTROIDS..(sub_vec_idx + 1) * NUM_CENTROIDS];
         debug_assert_eq!(vec_indices.len(), distances.len());
         vec_indices
             .iter()
@@ -103,9 +104,16 @@ pub(super) fn compute_l2_distance_4bit(
 ) -> Vec<f32> {
     let num_vectors = code.len() * 2 / num_sub_vectors;
     let mut distances = vec![0.0_f32; num_vectors];
-    let num_centroids = 2_usize.pow(4);
+    const NUM_CENTROIDS: usize = 2_usize.pow(4);
     for (sub_vec_idx, vec_indices) in code.chunks_exact(num_vectors).enumerate() {
-        let dist_table = &distance_table[sub_vec_idx * 2 * num_centroids..];
+        let dist_table: &[f32; NUM_CENTROIDS] = &distance_table
+            [sub_vec_idx * 2 * NUM_CENTROIDS..(sub_vec_idx * 2 + 1) * NUM_CENTROIDS]
+            .try_into()
+            .unwrap();
+        let dist_table_next: &[f32; NUM_CENTROIDS] = &distance_table
+            [(sub_vec_idx * 2 + 1) * NUM_CENTROIDS..(sub_vec_idx * 2 + 2) * NUM_CENTROIDS]
+            .try_into()
+            .unwrap();
         debug_assert_eq!(vec_indices.len(), distances.len());
         vec_indices
             .iter()
@@ -115,7 +123,7 @@ pub(super) fn compute_l2_distance_4bit(
                 let current_idx = centroid_idx & 0xF;
                 let next_idx = centroid_idx >> 4;
                 *sum += dist_table[current_idx as usize];
-                *sum += dist_table[num_centroids + next_idx as usize];
+                *sum += dist_table_next[next_idx as usize];
             });
     }
 

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -80,6 +80,7 @@ pub(super) fn compute_l2_distance(
     // so code[i * num_vectors + j] is the code of i-th sub-vector of the j-th vector.
     let num_vectors = code.len() / num_sub_vectors;
     let mut distances = vec![0.0_f32; num_vectors];
+    // it must be 8
     const NUM_CENTROIDS: usize = 2_usize.pow(8);
     for (sub_vec_idx, vec_indices) in code.chunks_exact(num_vectors).enumerate() {
         let dist_table =


### PR DESCRIPTION
this is done by make the compiler know the size of distance table slice
```
5242880,L2,PQ=96,DIM=1536
                        time:   [148.44 ms 149.47 ms 150.50 ms]
                        change: [-53.716% -53.486% -53.252%] (p = 0.00 < 0.10)
                        Performance has improved.

5242880,Cosine,PQ=96,DIM=1536
                        time:   [191.84 ms 192.21 ms 192.75 ms]
                        change: [-46.738% -46.621% -46.461%] (p = 0.00 < 0.10)
                        Performance has improved.
```