### PR TITLE
fix: fix dynamodb drop table

### DIFF
--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -476,10 +476,7 @@ pub trait CommitHandler: Debug + Send + Sync {
     ) -> std::result::Result<Path, CommitError>;
 
     /// Delete the recorded manifest information for a dataset at the base_path
-    async fn delete(
-        &self,
-        _base_path: &Path,
-    ) ->  Result<()> {
+    async fn delete(&self, _base_path: &Path) -> Result<()> {
         Ok(())
     }
 }

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -474,6 +474,14 @@ pub trait CommitHandler: Debug + Send + Sync {
         manifest_writer: ManifestWriter,
         naming_scheme: ManifestNamingScheme,
     ) -> std::result::Result<(), CommitError>;
+
+    /// Delete the recorded manifest information for a dataset at the base_path
+    async fn delete(
+        &self,
+        _base_path: &Path,
+    ) ->  Result<()> {
+        Ok(())
+    }
 }
 
 async fn default_resolve_version(

--- a/rust/lance-table/src/io/commit/dynamodb.rs
+++ b/rust/lance-table/src/io/commit/dynamodb.rs
@@ -10,11 +10,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::operation::delete_item::builders::DeleteItemFluentBuilder;
+use aws_sdk_dynamodb::operation::RequestId;
 use aws_sdk_dynamodb::operation::{
     get_item::builders::GetItemFluentBuilder, put_item::builders::PutItemFluentBuilder,
     query::builders::QueryFluentBuilder,
 };
-use aws_sdk_dynamodb::operation::{query, RequestId};
 use aws_sdk_dynamodb::types::{AttributeValue, KeyType};
 use aws_sdk_dynamodb::Client;
 use snafu::OptionExt;

--- a/rust/lance-table/src/io/commit/dynamodb.rs
+++ b/rust/lance-table/src/io/commit/dynamodb.rs
@@ -238,9 +238,7 @@ impl DynamoDBExternalManifestStore {
     }
 
     fn ddb_delete(&self) -> DeleteItemFluentBuilder {
-        self.client
-            .delete_item()
-            .table_name(&self.table_name)
+        self.client.delete_item().table_name(&self.table_name)
     }
 }
 
@@ -383,7 +381,8 @@ impl ExternalManifestStore for DynamoDBExternalManifestStore {
 
     /// Delete the manifest information for the given base_uri in dynamodb
     async fn delete(&self, base_uri: &str) -> Result<()> {
-        let query_result = self.ddb_query()
+        let query_result = self
+            .ddb_query()
             .key_condition_expression(format!("{} = :{}", base_uri!(), base_uri!()))
             .expression_attribute_values(
                 format!(":{}", base_uri!()),

--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -72,6 +72,9 @@ pub trait ExternalManifestStore: std::fmt::Debug + Send + Sync {
 
     /// Put the manifest path for a given base_uri and version, should fail if the version **does not** already exist
     async fn put_if_exists(&self, base_uri: &str, version: u64, path: &str) -> Result<()>;
+
+    /// Delete the manifest information for given base_uri from the store
+    async fn delete(&self, base_uri: &str) -> Result<()>;
 }
 
 fn detect_naming_scheme_from_path(path: &Path) -> Result<ManifestNamingScheme> {
@@ -345,5 +348,9 @@ impl CommitHandler for ExternalManifestCommitHandler {
         .await?;
 
         Ok(())
+    }
+
+    async fn delete(&self, base_path: &Path) -> Result<()> {
+        self.external_manifest_store.delete(base_path.as_ref()).await
     }
 }

--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -74,7 +74,9 @@ pub trait ExternalManifestStore: std::fmt::Debug + Send + Sync {
     async fn put_if_exists(&self, base_uri: &str, version: u64, path: &str) -> Result<()>;
 
     /// Delete the manifest information for given base_uri from the store
-    async fn delete(&self, base_uri: &str) -> Result<()>;
+    async fn delete(&self, _base_uri: &str) -> Result<()> {
+        Ok(())
+    }
 }
 
 fn detect_naming_scheme_from_path(path: &Path) -> Result<ManifestNamingScheme> {

--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -350,6 +350,8 @@ impl CommitHandler for ExternalManifestCommitHandler {
     }
 
     async fn delete(&self, base_path: &Path) -> Result<()> {
-        self.external_manifest_store.delete(base_path.as_ref()).await
+        self.external_manifest_store
+            .delete(base_path.as_ref())
+            .await
     }
 }

--- a/rust/lance/src/io/commit/dynamodb.rs
+++ b/rust/lance/src/io/commit/dynamodb.rs
@@ -179,6 +179,9 @@ mod test {
         );
         // get should see new data
         assert_eq!(store.get("test", 2).await.unwrap(), "test");
+
+        store.delete("test").await.unwrap();
+        assert_eq!(store.get_latest_version("test").await.unwrap(), None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
First PR of https://github.com/lancedb/lancedb/issues/1812

Add the delete function to external manifest to delete manifest related metadata during drop_table