### PR TITLE
feat: expose the table provider

### DIFF
--- a/rust/lance/src/datafusion.rs
+++ b/rust/lance/src/datafusion.rs
@@ -6,3 +6,5 @@
 
 pub(crate) mod dataframe;
 pub(crate) mod logical_plan;
+
+pub use dataframe::LanceTableProvider;


### PR DESCRIPTION
This makes it easier to use `Lance` inside of datafusion (see unit test for example)