### PR TITLE
chore(python): set minimal pyarrow to 14.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "pylance"
-dependencies = ["pyarrow>=12", "numpy>=1.22"]
+dependencies = ["pyarrow>=14", "numpy>=1.22"]
 description = "python wrapper for Lance columnar format"
 authors = [{ name = "Lance Devs", email = "dev@lancedb.com" }]
 license = { file = "LICENSE" }
-repository = "https://github.com/eto-ai/lance"
+repository = "https://github.com/lancedb/lance"
 readme = "README.md"
 requires-python = ">=3.9"
 keywords = [


### PR DESCRIPTION
https://github.com/lancedb/lancedb/issues/1324 requires minimal pyarrow to be 14.0

https://arrow.apache.org/docs/14.0/python/generated/pyarrow.concat_tables.html