### PR TITLE
perf: improve dot distance computing

### DIFF
--- a/rust/lance-index/benches/4bitpq_dist_table.rs
+++ b/rust/lance-index/benches/4bitpq_dist_table.rs
@@ -9,6 +9,7 @@ use arrow_array::types::Float32Type;
 use arrow_array::{FixedSizeListArray, UInt8Array};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use lance_arrow::FixedSizeListArrayExt;
+use lance_index::vector::pq::distance::{build_distance_table_dot, build_distance_table_l2};
 use lance_index::vector::pq::ProductQuantizer;
 use lance_linalg::distance::DistanceType;
 use lance_testing::datagen::generate_random_array_with_seed;
@@ -21,7 +22,54 @@ const PQ: usize = 96;
 const DIM: usize = 1536;
 const TOTAL: usize = 16 * 1000;
 
-fn dist_table(c: &mut Criterion) {
+fn construct_dist_table(c: &mut Criterion) {
+    let codebook = generate_random_array_with_seed::<Float32Type>(256 * DIM, [88; 32]);
+    let query = generate_random_array_with_seed::<Float32Type>(DIM, [32; 32]);
+
+    c.bench_function(
+        format!(
+            "construct_dist_table: {},PQ={}x{},DIM={}",
+            DistanceType::L2,
+            PQ,
+            4,
+            DIM
+        )
+        .as_str(),
+        |b| {
+            b.iter(|| {
+                black_box(build_distance_table_l2(
+                    codebook.values(),
+                    4,
+                    PQ,
+                    query.values(),
+                ));
+            })
+        },
+    );
+
+    c.bench_function(
+        format!(
+            "construct_dist_table: {},PQ={}x{},DIM={}",
+            DistanceType::Dot,
+            PQ,
+            4,
+            DIM
+        )
+        .as_str(),
+        |b| {
+            b.iter(|| {
+                black_box(build_distance_table_dot(
+                    codebook.values(),
+                    4,
+                    PQ,
+                    query.values(),
+                ));
+            })
+        },
+    );
+}
+
+fn compute_distances(c: &mut Criterion) {
     let codebook = generate_random_array_with_seed::<Float32Type>(256 * DIM, [88; 32]);
     let query = generate_random_array_with_seed::<Float32Type>(DIM, [32; 32]);
 
@@ -38,7 +86,7 @@ fn dist_table(c: &mut Criterion) {
         );
 
         c.bench_function(
-            format!("{},{},PQ={},DIM={}", TOTAL, dt, PQ, DIM).as_str(),
+            format!("{},{},PQ={}x{},DIM={}", TOTAL, dt, PQ, 4, DIM).as_str(),
             |b| {
                 b.iter(|| {
                     black_box(pq.compute_distances(&query, &code).unwrap());
@@ -53,12 +101,12 @@ criterion_group!(
     name=benches;
     config = Criterion::default().significance_level(0.1).sample_size(10)
         .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = dist_table);
+    targets = construct_dist_table, compute_distances);
 
 #[cfg(not(target_os = "linux"))]
 criterion_group!(
     name=benches;
     config = Criterion::default().significance_level(0.1).sample_size(10);
-    targets = dist_table);
+    targets = construct_dist_table, compute_distances);
 
 criterion_main!(benches);

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -60,6 +60,7 @@ pub fn build_distance_table_dot<T: Dot>(
     }
 }
 
+#[inline]
 pub fn build_distance_table_dot_impl<const NUM_BITS: u32, T: Dot>(
     codebook: &[T],
     num_sub_vectors: usize,
@@ -204,6 +205,7 @@ fn compute_l2_distance_without_transposing<const C: usize, const V: usize>(
     distances.chain(remainder).collect()
 }
 
+#[inline]
 pub fn compute_dot_distance(
     distance_table: &[f32],
     num_bits: u32,
@@ -229,6 +231,7 @@ pub fn compute_dot_distance(
     distances
 }
 
+#[inline]
 pub fn compute_dot_distance_4bit(
     distance_table: &[f32],
     num_sub_vectors: usize,

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -138,14 +138,10 @@ pub(super) fn compute_l2_distance_4bit(
     let mut distances = vec![0.0_f32; num_vectors];
     const NUM_CENTROIDS: usize = 2_usize.pow(4);
     for (sub_vec_idx, vec_indices) in code.chunks_exact(num_vectors).enumerate() {
-        let dist_table: &[f32; NUM_CENTROIDS] = &distance_table
-            [sub_vec_idx * 2 * NUM_CENTROIDS..(sub_vec_idx * 2 + 1) * NUM_CENTROIDS]
-            .try_into()
-            .unwrap();
-        let dist_table_next: &[f32; NUM_CENTROIDS] = &distance_table
-            [(sub_vec_idx * 2 + 1) * NUM_CENTROIDS..(sub_vec_idx * 2 + 2) * NUM_CENTROIDS]
-            .try_into()
-            .unwrap();
+        let dist_table =
+            &distance_table[sub_vec_idx * 2 * NUM_CENTROIDS..(sub_vec_idx * 2 + 1) * NUM_CENTROIDS];
+        let dist_table_next = &distance_table
+            [(sub_vec_idx * 2 + 1) * NUM_CENTROIDS..(sub_vec_idx * 2 + 2) * NUM_CENTROIDS];
         debug_assert_eq!(vec_indices.len(), distances.len());
         vec_indices
             .iter()
@@ -239,9 +235,13 @@ pub fn compute_dot_distance_4bit(
 ) -> Vec<f32> {
     let num_vectors = code.len() * 2 / num_sub_vectors;
     let mut distances = vec![0.0; num_vectors];
-    let num_centroids = 2_usize.pow(4);
+    const NUM_CENTROIDS: usize = 2_usize.pow(4);
     for (sub_vec_idx, vec_indices) in code.chunks_exact(num_vectors).enumerate() {
-        let dist_table = &distance_table[sub_vec_idx * 2 * num_centroids..];
+        let dist_table =
+            &distance_table[sub_vec_idx * 2 * NUM_CENTROIDS..(sub_vec_idx * 2 + 1) * NUM_CENTROIDS];
+        let dist_table_next = &distance_table
+            [(sub_vec_idx * 2 + 1) * NUM_CENTROIDS..(sub_vec_idx * 2 + 2) * NUM_CENTROIDS];
+        debug_assert_eq!(vec_indices.len(), distances.len());
         vec_indices
             .iter()
             .zip(distances.iter_mut())
@@ -250,7 +250,7 @@ pub fn compute_dot_distance_4bit(
                 let current_idx = centroid_idx & 0xF;
                 let next_idx = centroid_idx >> 4;
                 *sum += dist_table[current_idx as usize];
-                *sum += dist_table[num_centroids + next_idx as usize];
+                *sum += dist_table_next[next_idx as usize];
             });
     }
 


### PR DESCRIPTION
for 8bit:
                        time:   [582.61 µs 585.08 µs 587.42 µs]
                        change: [-9.7495% -6.2223% -2.3288%] (p = 0.01 < 0.10)
                        Performance has improved.

for 4bit:
                        time:   [549.20 µs 551.13 µs 553.55 µs]
                        change: [-38.117% -37.734% -37.350%] (p = 0.00 < 0.10)
                        Performance has improved.