### PR TITLE
feat: add add_columns job

### DIFF
--- a/python/python/lance/_datagen.py
+++ b/python/python/lance/_datagen.py
@@ -15,10 +15,28 @@ def is_datagen_supported():
 
 
 def rand_batches(
-    schema: pa.Schema, *, num_batches: int = None, batch_size_bytes: int = None
+    schema: pa.Schema,
+    *,
+    num_batches: int = None,
+    batch_size_bytes: int = None,
+    batch_size_rows: int = None,
 ):
     if not datagen.is_datagen_supported():
         raise NotImplementedError(
             "This version of lance was not built with the datagen feature"
         )
-    return datagen.rand_batches(schema, num_batches, batch_size_bytes)
+    return datagen.rand_batches(schema, num_batches, batch_size_bytes, batch_size_rows)
+
+
+def rand_reader(
+    schema: pa.Schema,
+    *,
+    num_batches: int = None,
+    batch_size_bytes: int = None,
+    batch_size_rows: int = None,
+):
+    if not datagen.is_datagen_supported():
+        raise NotImplementedError(
+            "This version of lance was not built with the datagen feature"
+        )
+    return datagen.rand_reader(schema, num_batches, batch_size_bytes, batch_size_rows)

--- a/python/python/lance/evolution.py
+++ b/python/python/lance/evolution.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+from typing import TYPE_CHECKING, Any, Dict, List
+
+import pyarrow as pa
+
+from . import LanceDataset, LanceOperation, write_dataset
+from .fragment import write_fragments
+from .lance.align import (
+    AlignFragmentsPlan,
+)
+from .types import _coerce_reader
+
+if TYPE_CHECKING:
+    from .types import ReaderLike
+
+
+class DataShard:
+    """
+    A shard of new data to be added to a dataset.
+
+    This is returned by the ``add_data`` method of an ``AddColumnsJob``.  This should
+    be collected and passed to the ``finish_adding_data`` method of the job.
+
+    This should be treated as an opaque pickleable object.
+    """
+
+    def __init__(self, fragments):
+        self._fragments = fragments
+
+
+class AddColumnsJob:
+    """
+    A job to add new columns to a dataset.
+
+    This job can be used to distribute the work of adding new columns to a dataset
+    across multiple workers.  The job is created by calling the ``create`` method.
+    This job operates in two phases.
+
+    In the first phase the new data is calculated.  The new data is written to a
+    temporary dataset.  Once all the new data is calculated the job enters the second
+    phase where the new data is aligned with the target dataset.  The alignment phase
+    reads from the temporary dataset and rewrites the data in fragments aligned with
+    the target dataset.  Both phases can be distributed across multiple workers.
+
+    The job itself should be pickled and sent to any number of workers.  The workers
+    can then call the ``add_data`` method to create a data shard containing some new
+    values for the new columns.  These data shards should be collected and passed to
+    some finalization step which will call the ``finish_adding_data`` method to create
+    an ``AlignColumnsPlan`` which can be used to commit the new data to the dataset.
+    Details on the alignment phase can be found in the documentation for
+    ``AlignColumnsPlan``.
+
+    It is not required that a value be given for every row in the target dataset.  If a
+    value is not given for a row then the value for the new columns will be set to null.
+    New columns created using the ``AddColumnsJob`` will be appended to the end of the
+    schema of the target dataset and will always be nullable columns.  If desired, then
+    ``LanceDataset.alter_columns`` can be used to change the nullability of the new
+    columns after they are added.
+
+    Modifications to he target dataset can be tolerated while the new data is being.
+    Any new rows added after the job has been distributed to workers will have null for
+    the new columns.  New values calculated for rows that have since been deleted will
+    be ignored.  Note: if a row is used to calculate new values, and then that row is
+    updated before the new data is committed, then the new values (based on the old row)
+    will still be inserted.
+    """
+
+    def __init__(
+        self,
+        target: LanceDataset,
+        source: LanceDataset,
+        join_key: str,
+    ):
+        self.target = target
+        self.source = source
+        self.join_key = join_key
+
+    @staticmethod
+    def create(
+        target,
+        source_uri: str,
+        new_schema: pa.Schema,
+        join_key: str,
+        *,
+        overwrite_tmp: bool = False,
+    ) -> "AddColumnsJob":
+        """
+        Creates a new AddColumnsJob instance to add new columns to ``target``.
+
+        Parameters
+        ----------
+
+        target : LanceDataset
+            The dataset to which the new columns will be added.
+
+        source_uri: str
+            The URI of the temporary dataset to which the new data will be written.
+
+            There must not be a dataset at this URI unless ``overwrite_tmp`` is set
+            to True in which case the existing dataset will be overwritten.
+
+            The temporary dataset must be in a location that is accessible to all
+            workers that will be adding data to the job.
+
+        new_schema : pa.Schema
+            The schema of the new columns to be added.  This schema must contain
+            the join key column.
+
+        join_key : str
+            The column used to join the new data with the existing data.  There are
+            special values that can be used here that will affect the behavior of the
+            job.
+
+            If the join_key value is ``_dataset_offset`` then the new data should have
+            a ``_dataset_offset`` column which indicates the offset of the data in the
+            target dataset.
+
+            If the join key value is ``_rowid`` then the new data should have a
+            ``_rowid`` column which indicates the row id of the data in the target
+            dataset.
+
+            If the join key value is anything else then the both the new data and the
+            target dataset must have a column with the same name.  A join will be
+            performed on this column.
+        """
+        if new_schema.field(0).name != join_key:
+            if any(f.name == join_key for f in new_schema):
+                raise ValueError(
+                    f"If the join_key ({join_key}) is in the new_schema it "
+                    "must be the first column"
+                )
+            if join_key == "_rowid" or join_key == "_dataset_offset":
+                new_schema = pa.schema(
+                    [pa.field(join_key, pa.uint64())] + list(iter(new_schema))
+                )
+            else:
+                # We can't infer type so we require it to be in the schema
+                raise ValueError(
+                    f"join_key ({join_key}) must be included in new_schema "
+                    "when not using _rowid or _dataset_offset"
+                )
+        source = write_dataset(
+            [],
+            source_uri,
+            schema=new_schema,
+            mode="create",
+            data_storage_version=target.data_storage_version,
+        )
+        return AddColumnsJob(target, source, join_key)
+
+    @staticmethod
+    def _disallow_arg(args: Dict[Any, Any], arg: str):
+        if arg in args:
+            raise TypeError(f"{arg} cannot be used in add_data")
+
+    def add_data(self, data: "ReaderLike", **kwargs) -> DataShard:
+        """
+        Adds new data.  The new data must contain the join key column.
+
+        Returns a DataShard.  This can be pickled and should be collected and
+        passed to the ``finish_adding_data`` method.
+        """
+        # This must always be append
+        self._disallow_arg(kwargs, "mode")
+        # This is inherited from the base dataset
+        self._disallow_arg(kwargs, "data_storage_version")
+        # Soon to be deprecated
+        self._disallow_arg(kwargs, "use_legacy_format")
+
+        reader = _coerce_reader(data)
+        first_col = reader.schema.field(0)
+        if first_col.name != self.join_key:
+            raise ValueError(
+                "First column in the new data must be "
+                f"the join key column {self.join_key}"
+            )
+
+        frags = write_fragments(data, self.source)
+        return DataShard(frags)
+
+    def finish_adding_data(
+        self, shards: List[DataShard]
+    ) -> (AlignFragmentsPlan, LanceDataset):
+        all_frags = []
+        for shard in shards:
+            all_frags.extend(shard._fragments)
+
+        op = LanceOperation.Append(all_frags)
+        # TODO: Ideally we should fail here if finish_adding_data is called twice
+        # but we don't have a good way to do that yet (two appends will be allowed)
+        source = LanceDataset.commit(self.source, op, read_version=1)
+        return (
+            AlignFragmentsPlan.create(source._ds, self.target._ds, self.join_key),
+            source,
+        )

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -23,6 +23,9 @@ def infer_tfrecord_schema(
 ) -> pa.Schema: ...
 def read_tfrecord(uri: str, schema: pa.Schema) -> pa.RecordBatchReader: ...
 
+class _Dataset:
+    pass
+
 class CleanupStats:
     bytes_removed: int
     old_versions: int

--- a/python/python/lance/lance/align/__init__.pyi
+++ b/python/python/lance/lance/align/__init__.pyi
@@ -1,0 +1,26 @@
+from typing import List
+
+from ... import _Dataset
+
+class AlignFragmentsPlan:
+    tasks: List["AlignFragmentsTask"]
+    @staticmethod
+    def create(
+        source: _Dataset, target: _Dataset, join_key: str
+    ) -> AlignFragmentsPlan: ...
+    def commit(
+        self,
+        results: List[AlignFragmentsTaskResult],
+        source: _Dataset,
+        target: _Dataset,
+    ) -> None: ...
+    def __repr__(self) -> str: ...
+
+class AlignFragmentsTask:
+    def execute(
+        self, source: _Dataset, target: _Dataset
+    ) -> AlignFragmentsTaskResult: ...
+    def __repr__(self) -> str: ...
+
+class AlignFragmentsTaskResult:
+    def __repr__(self) -> str: ...

--- a/python/src/datagen.rs
+++ b/python/src/datagen.rs
@@ -1,7 +1,7 @@
 use arrow::pyarrow::PyArrowType;
-use arrow_array::RecordBatch;
+use arrow_array::{RecordBatch, RecordBatchReader};
 use arrow_schema::Schema;
-use lance_datagen::{BatchCount, ByteCount};
+use lance_datagen::{BatchCount, ByteCount, RowCount};
 use pyo3::{pyfunction, types::PyModule, wrap_pyfunction, PyResult, Python};
 
 const DEFAULT_BATCH_SIZE_BYTES: u64 = 32 * 1024;
@@ -12,21 +12,61 @@ pub fn is_datagen_supported() -> bool {
     true
 }
 
+pub fn rand_reader_internal(
+    schema: PyArrowType<Schema>,
+    batch_count: Option<u32>,
+    bytes_in_batch: Option<u64>,
+    rows_in_batch: Option<u64>,
+) -> PyResult<Box<dyn RecordBatchReader + Send>> {
+    let batch_count = BatchCount::from(batch_count.unwrap_or(DEFAULT_BATCH_COUNT));
+    let gen = lance_datagen::rand(&schema.0);
+    Ok(match (bytes_in_batch, rows_in_batch) {
+        (Some(_), Some(_)) => {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "Only one of bytes_in_batch or rows_in_batch can be specified",
+            ))
+        }
+        (None, None) => Box::new(
+            gen.into_reader_bytes(
+                ByteCount::from(DEFAULT_BATCH_SIZE_BYTES),
+                batch_count,
+                lance_datagen::RoundingBehavior::RoundUp,
+            )
+            .map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "Failed to generate batches: {}",
+                    e
+                ))
+            })?,
+        ),
+        (Some(bytes_in_batch), None) => Box::new(
+            gen.into_reader_bytes(
+                ByteCount::from(bytes_in_batch),
+                batch_count,
+                lance_datagen::RoundingBehavior::RoundUp,
+            )
+            .map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "Failed to generate batches: {}",
+                    e
+                ))
+            })?,
+        ),
+        (None, Some(rows_in_batch)) => {
+            Box::new(gen.into_reader_rows(RowCount::from(rows_in_batch), batch_count))
+        }
+    })
+}
+
 #[pyfunction]
 pub fn rand_batches(
     schema: PyArrowType<Schema>,
     batch_count: Option<u32>,
     bytes_in_batch: Option<u64>,
+    rows_in_batch: Option<u64>,
 ) -> PyResult<Vec<PyArrowType<RecordBatch>>> {
-    lance_datagen::rand(&schema.0)
-        .into_reader_bytes(
-            ByteCount::from(bytes_in_batch.unwrap_or(DEFAULT_BATCH_SIZE_BYTES)),
-            BatchCount::from(batch_count.unwrap_or(DEFAULT_BATCH_COUNT)),
-            lance_datagen::RoundingBehavior::RoundUp,
-        )
-        .map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!("Failed to generate batches: {}", e))
-        })?
+    let reader = rand_reader_internal(schema, batch_count, bytes_in_batch, rows_in_batch)?;
+    reader
         .map(|item| {
             item.map(PyArrowType::from).map_err(|e| {
                 pyo3::exceptions::PyValueError::new_err(format!("Failed to generate batch: {}", e))
@@ -35,10 +75,22 @@ pub fn rand_batches(
         .collect::<PyResult<Vec<PyArrowType<RecordBatch>>>>()
 }
 
+#[pyfunction]
+pub fn rand_reader(
+    schema: PyArrowType<Schema>,
+    batch_count: Option<u32>,
+    bytes_in_batch: Option<u64>,
+    rows_in_batch: Option<u64>,
+) -> PyResult<PyArrowType<Box<dyn RecordBatchReader + Send>>> {
+    let reader = rand_reader_internal(schema, batch_count, bytes_in_batch, rows_in_batch)?;
+    Ok(PyArrowType(Box::new(reader)))
+}
+
 pub fn register_datagen(py: Python, m: &PyModule) -> PyResult<()> {
     let datagen = PyModule::new(py, "datagen")?;
     datagen.add_wrapped(wrap_pyfunction!(is_datagen_supported))?;
     datagen.add_wrapped(wrap_pyfunction!(rand_batches))?;
+    datagen.add_wrapped(wrap_pyfunction!(rand_reader))?;
     m.add_submodule(datagen)?;
     Ok(())
 }

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -85,6 +85,7 @@ use crate::{LanceReader, Scanner};
 use self::cleanup::CleanupStats;
 use self::commit::PyCommitLock;
 
+pub mod align;
 pub mod blob;
 pub mod cleanup;
 pub mod commit;

--- a/python/src/dataset/align.rs
+++ b/python/src/dataset/align.rs
@@ -1,0 +1,277 @@
+// Copyright 2023 Lance Developers.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use pyo3::{
+    exceptions::PyValueError,
+    pyclass, pymethods,
+    types::{PyModule, PyTuple},
+    PyObject, PyRef, PyResult, Python,
+};
+
+use lance::dataset::align::{
+    AlignFragmentsPlan as LanceAlignFragmentsPlan, AlignFragmentsTask as LanceAlignFragmentsTask,
+    AlignFragmentsTaskResult as LanceAlignFragmentsTaskResult,
+};
+
+use crate::{error::PythonErrorExt, RT};
+
+use super::Dataset;
+
+#[pyclass(module = "lance.lance.align")]
+pub struct AlignFragmentsPlan {
+    inner: Arc<LanceAlignFragmentsPlan>,
+}
+
+#[pymethods]
+impl AlignFragmentsPlan {
+    #[staticmethod]
+    pub fn create(
+        py: Python<'_>,
+        source: &Dataset,
+        target: &Dataset,
+        join_key: &str,
+    ) -> PyResult<Self> {
+        let inner = RT
+            .block_on(
+                Some(py),
+                LanceAlignFragmentsPlan::new(source.ds.clone(), target.ds.clone(), join_key),
+            )?
+            .infer_error()?;
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
+    }
+
+    #[getter]
+    pub fn tasks(&self) -> Vec<AlignFragmentsTask> {
+        self.inner
+            .tasks()
+            .iter()
+            .map(|task| AlignFragmentsTask {
+                inner: Arc::new(task.clone()),
+            })
+            .collect()
+    }
+
+    pub fn commit(
+        slf: PyRef<'_, Self>,
+        results: Vec<AlignFragmentsTaskResult>,
+        source: &Dataset,
+        target: &Dataset,
+    ) -> PyResult<()> {
+        let results = results
+            .into_iter()
+            .map(|result| result.inner.as_ref().clone())
+            .collect::<Vec<_>>();
+        RT.block_on(
+            Some(slf.py()),
+            slf.inner
+                .commit(results, source.ds.clone(), target.ds.clone()),
+        )?
+        .infer_error()?;
+        Ok(())
+    }
+
+    fn __repr__(&self) -> String {
+        format!("AlignFragmentsPlan({} tasks)", self.tasks().len())
+    }
+
+    /// Get a JSON representation of the plan.
+    ///
+    /// Returns
+    /// -------
+    /// str
+    ///
+    /// Warning
+    /// -------
+    /// The JSON representation is not guaranteed to be stable across versions.
+    pub fn json(&self) -> PyResult<String> {
+        serde_json::to_string(self.inner.as_ref()).map_err(|err| {
+            PyValueError::new_err(format!(
+                "Could not dump AlignFragmentsPlan due to error: {}",
+                err
+            ))
+        })
+    }
+
+    /// Load a plan from a JSON representation.
+    #[staticmethod]
+    pub fn from_json(json: String) -> PyResult<Self> {
+        let result = serde_json::from_str(&json).map_err(|err| {
+            PyValueError::new_err(format!(
+                "Could not load AlignFragmentsPlan due to error: {}",
+                err
+            ))
+        })?;
+        Ok(Self {
+            inner: Arc::new(result),
+        })
+    }
+
+    pub fn __reduce__(&self, py: Python<'_>) -> PyResult<(PyObject, PyObject)> {
+        let state = self.json()?;
+        let state = PyTuple::new(py, vec![state]).extract()?;
+        let from_json = PyModule::import(py, "lance.lance.align")?
+            .getattr("AlignFragmentsPlan")?
+            .getattr("from_json")?
+            .extract()?;
+        Ok((from_json, state))
+    }
+}
+
+#[pyclass(module = "lance.lance.align")]
+pub struct AlignFragmentsTask {
+    inner: Arc<LanceAlignFragmentsTask>,
+}
+
+#[pymethods]
+impl AlignFragmentsTask {
+    pub fn execute(
+        slf: PyRef<'_, Self>,
+        source: &Dataset,
+        target: &Dataset,
+    ) -> PyResult<AlignFragmentsTaskResult> {
+        let inner = RT
+            .block_on(
+                Some(slf.py()),
+                slf.inner.execute(source.ds.clone(), target.ds.clone()),
+            )?
+            .infer_error()?;
+        Ok(AlignFragmentsTaskResult {
+            inner: Arc::new(inner),
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "AlignFragmentsTask(target_frag_id={})",
+            self.inner.target_id
+        )
+    }
+
+    /// Get a JSON representation of the task.
+    ///
+    /// Returns
+    /// -------
+    /// str
+    ///
+    /// Warning
+    /// -------
+    /// The JSON representation is not guaranteed to be stable across versions.
+    pub fn json(&self) -> PyResult<String> {
+        serde_json::to_string(self.inner.as_ref()).map_err(|err| {
+            PyValueError::new_err(format!(
+                "Could not dump AlignFragmentsTask due to error: {}",
+                err
+            ))
+        })
+    }
+
+    /// Load a task from a JSON representation.
+    #[staticmethod]
+    pub fn from_json(json: String) -> PyResult<Self> {
+        let result = serde_json::from_str(&json).map_err(|err| {
+            PyValueError::new_err(format!(
+                "Could not load AlignFragmentsTask due to error: {}",
+                err
+            ))
+        })?;
+        Ok(Self {
+            inner: Arc::new(result),
+        })
+    }
+
+    pub fn __reduce__(slf: PyRef<'_, Self>, py: Python<'_>) -> PyResult<(PyObject, PyObject)> {
+        let state = slf.json()?;
+        let state = PyTuple::new(py, vec![state]).extract()?;
+        let from_json = PyModule::import(py, "lance.lance.align")?
+            .getattr("AlignFragmentsTask")?
+            .getattr("from_json")?
+            .extract()?;
+        Ok((from_json, state))
+    }
+}
+
+#[pyclass(module = "lance.lance.align")]
+#[derive(Clone)]
+pub struct AlignFragmentsTaskResult {
+    inner: Arc<LanceAlignFragmentsTaskResult>,
+}
+
+#[pymethods]
+impl AlignFragmentsTaskResult {
+    fn __repr__(&self) -> String {
+        format!(
+            "AlignFragmentsTaskResult(path={}, target_frag_id={})",
+            self.inner.data_file.path, self.inner.target_id
+        )
+    }
+
+    /// Get a JSON representation of the task.
+    ///
+    /// Returns
+    /// -------
+    /// str
+    ///
+    /// Warning
+    /// -------
+    /// The JSON representation is not guaranteed to be stable across versions.
+    pub fn json(&self) -> PyResult<String> {
+        serde_json::to_string(self.inner.as_ref()).map_err(|err| {
+            PyValueError::new_err(format!(
+                "Could not dump AlignFragmentsTaskResult due to error: {}",
+                err
+            ))
+        })
+    }
+
+    /// Load a task from a JSON representation.
+    #[staticmethod]
+    pub fn from_json(json: String) -> PyResult<Self> {
+        let result = serde_json::from_str(&json).map_err(|err| {
+            PyValueError::new_err(format!(
+                "Could not load AlignFragmentsTaskResult due to error: {}",
+                err
+            ))
+        })?;
+        Ok(Self {
+            inner: Arc::new(result),
+        })
+    }
+
+    pub fn __reduce__(&self, py: Python<'_>) -> PyResult<(PyObject, PyObject)> {
+        let state = self.json()?;
+        let state = PyTuple::new(py, vec![state]).extract()?;
+        let from_json = PyModule::import(py, "lance.lance.align")?
+            .getattr("AlignFragmentsTaskResult")?
+            .getattr("from_json")?
+            .extract()?;
+        Ok((from_json, state))
+    }
+}
+
+pub fn register_align(py: Python, m: &PyModule) -> PyResult<()> {
+    let align = PyModule::new(py, "align")?;
+    align.add_class::<AlignFragmentsPlan>()?;
+    align.add_class::<AlignFragmentsTask>()?;
+    align.add_class::<AlignFragmentsTaskResult>()?;
+    m.add_submodule(align)?;
+    // See https://github.com/PyO3/pyo3/issues/759#issuecomment-977835119
+    py.import("sys")?
+        .getattr("modules")?
+        .set_item("lance.lance.align", align)?;
+    Ok(())
+}

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -29,6 +29,7 @@ use arrow_array::{RecordBatch, RecordBatchIterator};
 use arrow_schema::ArrowError;
 #[cfg(feature = "datagen")]
 use datagen::register_datagen;
+use dataset::align::register_align;
 use dataset::blob::LanceBlobFile;
 use dataset::cleanup::CleanupStats;
 use dataset::optimize::{
@@ -153,6 +154,7 @@ fn lance(py: Python, m: &PyModule) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     register_datagen(py, m)?;
     register_indices(py, m)?;
+    register_align(py, m)?;
     Ok(())
 }
 

--- a/rust/lance-core/src/lib.rs
+++ b/rust/lance-core/src/lib.rs
@@ -13,6 +13,8 @@ pub use error::{ArrowResult, Error, Result};
 
 /// Column name for the meta row ID.
 pub const ROW_ID: &str = "_rowid";
+/// Column name for the meta dataset offset.
+pub const DATASET_OFFSET: &str = "_dataset_offset";
 /// Column name for the meta row address.
 pub const ROW_ADDR: &str = "_rowaddr";
 
@@ -23,4 +25,6 @@ lazy_static::lazy_static! {
     /// Row address field. This is nullable because its validity bitmap is sometimes used
     /// as a selection vector.
     pub static ref ROW_ADDR_FIELD: ArrowField = ArrowField::new(ROW_ADDR, DataType::UInt64, true);
+    /// Dataset offset field.
+    pub static ref DATASET_OFFSETS_FIELD: ArrowField = ArrowField::new(DATASET_OFFSET, DataType::UInt64, true);
 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -42,6 +42,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use tracing::instrument;
 
+pub mod align;
 mod blob;
 pub mod builder;
 pub mod cleanup;
@@ -456,6 +457,21 @@ impl Dataset {
         builder
             .execute_stream(Box::new(batches) as Box<dyn RecordBatchReader + Send>)
             .await
+    }
+
+    /// Create an empty [Dataset] with a given [Schema].
+    ///
+    /// Utility function that calls [Self::write] with an empty reader.
+    pub async fn write_empty(
+        schema: Schema,
+        dest: impl Into<WriteDestination<'_>>,
+        params: Option<WriteParams>,
+    ) -> Result<Self> {
+        let mut builder = InsertBuilder::new(dest);
+        if let Some(params) = &params {
+            builder = builder.with_params(params);
+        }
+        builder.execute_empty(schema).await
     }
 
     /// Append to existing [Dataset] with a stream of [RecordBatch]s

--- a/rust/lance/src/dataset/align.rs
+++ b/rust/lance/src/dataset/align.rs
@@ -1,0 +1,587 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{collections::HashMap, ops::Range, sync::Arc};
+
+use arrow::{array::AsArray, datatypes::UInt64Type};
+use arrow_array::{new_null_array, RecordBatch};
+use arrow_schema::Schema as ArrowSchema;
+use datafusion::{
+    execution::SendableRecordBatchStream, physical_plan::stream::RecordBatchStreamAdapter,
+};
+use futures::{StreamExt, TryStreamExt};
+use lance_core::{datatypes::Schema, DATASET_OFFSET, ROW_ID};
+use serde::{Deserialize, Serialize};
+use snafu::{location, Location};
+
+use crate::{
+    dataset::transaction::{Operation, Transaction},
+    Error, Result,
+};
+use lance_table::format::{DataFile, Fragment};
+
+use super::{write::open_writer, CommitBuilder, Dataset};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct FragmentTakeRange {
+    /// The source fragment id
+    fragment_id: u32,
+    /// The range of offsets to take from the fragment
+    offset_range: Range<u32>,
+    /// Offset into the target that this range begins
+    target_offset: u32,
+}
+
+/// An item in an [`AlignFragmentsTask`]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+enum AlignmentItem {
+    /// Insert rows from the source fragment
+    SourceFragmentRange(FragmentTakeRange),
+    /// Insert nulls
+    Nulls(u32),
+}
+
+#[derive(Clone, Debug)]
+struct AlignmentConfig {
+    source: Arc<Dataset>,
+    target: Arc<Dataset>,
+}
+
+impl AlignmentConfig {
+    fn join_key(&self) -> &str {
+        &self.source.schema().fields.first().unwrap().name
+    }
+
+    // Returns the schema of the target dataset, minus the join key
+    fn new_columns_schema(&self) -> Schema {
+        self.source
+            .schema()
+            .exclude(self.source.schema().project(&[self.join_key()]).unwrap())
+            .unwrap()
+    }
+
+    // Returns the combined schema of the two datasets
+    fn combined_schema(&self) -> Schema {
+        let new_columns = self.new_columns_schema();
+        let target_columns = self.target.schema();
+        target_columns.merge(&new_columns).unwrap()
+    }
+}
+
+impl AlignmentItem {
+    fn target_offset(&self) -> u32 {
+        match self {
+            AlignmentItem::SourceFragmentRange(range) => range.target_offset,
+            _ => unreachable!(),
+        }
+    }
+
+    fn num_rows(&self) -> u32 {
+        match self {
+            AlignmentItem::SourceFragmentRange(range) => {
+                range.offset_range.end - range.offset_range.start
+            }
+            AlignmentItem::Nulls(count) => *count,
+        }
+    }
+
+    async fn into_stream(
+        self,
+        src_dataset: Arc<Dataset>,
+        schema: Arc<Schema>,
+    ) -> Result<SendableRecordBatchStream> {
+        match self {
+            Self::Nulls(count) => {
+                let arrow_schema = Arc::new(ArrowSchema::from(schema.as_ref()));
+                let arrays = arrow_schema
+                    .fields
+                    .iter()
+                    .map(|f| new_null_array(f.data_type(), count as usize))
+                    .collect::<Vec<_>>();
+                let batch = RecordBatch::try_new(arrow_schema.clone(), arrays).unwrap();
+                Ok(Box::pin(RecordBatchStreamAdapter::new(
+                    arrow_schema,
+                    futures::stream::iter(vec![Ok(batch)]),
+                )))
+            }
+            Self::SourceFragmentRange(frag_range) => {
+                let columns = src_dataset
+                    .schema()
+                    .fields
+                    .iter()
+                    .skip(1)
+                    .map(|f| &f.name)
+                    .collect::<Vec<_>>();
+                let limit = frag_range.offset_range.end - frag_range.offset_range.start;
+                let offset = frag_range.offset_range.start;
+                let stream = src_dataset
+                    .scan()
+                    .with_fragments(vec![
+                        src_dataset
+                            .get_fragment(frag_range.fragment_id as usize)
+                            .unwrap()
+                            .metadata,
+                    ])
+                    .project(&columns)
+                    .unwrap()
+                    .limit(Some(limit as i64), Some(offset as i64))
+                    .unwrap()
+                    .try_into_stream()
+                    .await?;
+                Ok(SendableRecordBatchStream::from(stream))
+            }
+        }
+    }
+}
+
+/// A task of work to align one or more source fragments into a target fragment
+///
+/// A collection of these tasks make up an [`AlignFragmentsPlan`]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AlignFragmentsTask {
+    /// The source fragments (and nulls) that correspond to the target
+    source: Vec<AlignmentItem>,
+    /// The id of the target fragment
+    pub target_id: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AlignFragmentsTaskResult {
+    /// The newly created data file
+    pub data_file: DataFile,
+    /// The fragment the data file will be added to
+    pub target_id: u32,
+}
+
+impl AlignFragmentsTask {
+    /// Executes the task
+    ///
+    /// This reads from the source fragments and writes a new target fragment
+    pub async fn execute(
+        &self,
+        source: Arc<Dataset>,
+        target: Arc<Dataset>,
+    ) -> Result<AlignFragmentsTaskResult> {
+        let config = AlignmentConfig { source, target };
+        let schema = Arc::new(config.new_columns_schema());
+        let src_dataset = config.source.clone();
+        let capture_schema = schema.clone();
+        let mut stream = futures::stream::iter(self.source.clone())
+            .map(move |item| item.into_stream(src_dataset.clone(), capture_schema.clone()))
+            .buffered(1)
+            .try_flatten()
+            .boxed();
+        let obj_store = config.target.object_store.clone();
+
+        let mut writer = open_writer(
+            &obj_store,
+            &schema,
+            &config.target.base,
+            config
+                .target
+                .manifest
+                .data_storage_format
+                .lance_file_version()
+                .unwrap(),
+        )
+        .await?;
+
+        while let Some(batch) = stream.try_next().await? {
+            writer.write(&[batch]).await?;
+        }
+        let (num_rows, data_file) = writer.finish().await?;
+
+        assert_eq!(
+            num_rows as usize,
+            config
+                .target
+                .get_fragment(self.target_id as usize)
+                .unwrap()
+                .physical_rows()
+                .await
+                .unwrap()
+        );
+
+        Ok(AlignFragmentsTaskResult {
+            data_file,
+            target_id: self.target_id,
+        })
+    }
+
+    /// Called when building the plan and should only be called when building a plan
+    /// with dataset offsets which only uses FragmentTakeRange
+    fn sort_and_fill_nulls(&mut self, target_fragment: &Fragment) -> Result<()> {
+        let mut source = std::mem::take(&mut self.source);
+        source.sort_by_key(|item| item.target_offset());
+        let mut new_source = Vec::with_capacity(source.len() * 2);
+        let mut target_offset = 0;
+        for item in source {
+            let gap = item.target_offset() - target_offset;
+            if gap > 0 {
+                new_source.push(AlignmentItem::Nulls(gap as u32));
+            }
+            target_offset = item.target_offset() + item.num_rows();
+            new_source.push(item);
+        }
+        let frag_num_rows = target_fragment.physical_rows.expect("Alignment cannot be performed on older datasets which do not contain physical row counts") as u32;
+        if target_offset < frag_num_rows {
+            new_source.push(AlignmentItem::Nulls(frag_num_rows - target_offset));
+        }
+        self.source = new_source;
+        Ok(())
+    }
+}
+
+/// Aligns fragments to prepare for a Merge operation
+///
+/// This task aligns fragments from a _source_ dataset to be inserted into a _target_ dataset
+/// using a Merge operation.
+///
+/// Creating a plan requires calculating an alignment.  The alignment is determined by figuring
+/// out which rows in the target dataset are the same as the rows in the source dataset.  This
+/// is done utilizing some kind of join key.
+///
+/// The simplest approach is when the join key is a _dataset_offset.  It is simple because we
+/// can determine the destination address by looking at target fragment metadata.  However, it
+/// is also brittle because it requires that the target dataset has not been modified (beyond
+/// appends) since the source dataset was created.
+///
+/// A more robust approach is to use the _rowid as the join key along with the stable row ids
+/// feature.  If stable row ids are enabled then this we can ignore compaction (and later also
+/// updates).
+///
+/// Another robust, but slower, approach is to use an a custom join key.  This requires us to
+/// run a hash-join operation to determine the alignment.
+#[derive(Serialize, Deserialize)]
+pub struct AlignFragmentsPlan {
+    /// The tasks that need to be executed to create the target fragments
+    tasks: Vec<AlignFragmentsTask>,
+    read_version: u64,
+}
+
+impl AlignFragmentsPlan {
+    /// Creates a new plan by calculating the alignment
+    pub async fn new(
+        source: Arc<Dataset>,
+        target: Arc<Dataset>,
+        join_key: &str,
+    ) -> Result<AlignFragmentsPlan> {
+        let config = AlignmentConfig { source, target };
+        match join_key {
+            DATASET_OFFSET => Self::create_from_dataset_offset(config).await,
+            ROW_ID => Self::create_from_rowid(config).await,
+            _ => Self::create_from_custom_key(config).await,
+        }
+    }
+
+    pub async fn commit(
+        &self,
+        results: Vec<AlignFragmentsTaskResult>,
+        source: Arc<Dataset>,
+        target: Arc<Dataset>,
+    ) -> Result<Dataset> {
+        let config = AlignmentConfig { source, target };
+        let frag_id_to_new_file = results
+            .into_iter()
+            .map(|res| (res.target_id, res.data_file))
+            .collect::<HashMap<_, _>>();
+
+        let fragments = config
+            .target
+            .fragments()
+            .iter()
+            .map(|frag| {
+                if let Some(new_file) = frag_id_to_new_file.get(&(frag.id as u32)) {
+                    let mut all_files = frag.files.clone();
+                    all_files.push(new_file.clone());
+                    Fragment {
+                        deletion_file: frag.deletion_file.clone(),
+                        id: frag.id,
+                        files: all_files,
+                        physical_rows: frag.physical_rows.clone(),
+                        row_id_meta: frag.row_id_meta.clone(),
+                    }
+                } else {
+                    frag.clone()
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let mut schema = config.combined_schema();
+        schema.set_field_id(Some(config.target.manifest.max_field_id()));
+
+        let op = Operation::Merge { fragments, schema };
+
+        let tx = Transaction::new(self.read_version, op, None, None);
+
+        CommitBuilder::new(config.target.clone()).execute(tx).await
+    }
+
+    async fn dataset_offset_range_from_fragment(
+        fragment: &Fragment,
+        dataset: &Dataset,
+    ) -> Result<Range<u64>> {
+        let mut min = u64::MAX;
+        let mut max = u64::MIN;
+        let mut batches = dataset
+            .scan()
+            .with_fragments(vec![fragment.clone()])
+            .project(&[DATASET_OFFSET])?
+            .try_into_stream()
+            .await?;
+        while let Some(batch) = batches.next().await {
+            let batch = batch?;
+            let offsets = batch.column(0).as_primitive::<UInt64Type>();
+            if offsets.is_empty() {
+                continue;
+            }
+            let start = offsets.value(0);
+            if min == u64::MAX {
+                // First batch, set the min
+                min = start;
+            } else {
+                // Not the first batch, ensure it follows the previous
+                if start != max + 1 {
+                    return Err(Error::InvalidInput {
+                        source: "Dataset offsets are not sorted and contiguous.  A batch did not follow the previous batch.".into(),
+                        location: location!(),
+                    });
+                }
+            }
+            max = offsets.value(offsets.len() - 1);
+            for offs in offsets.values().windows(2) {
+                if offs[0] + 1 != offs[1] {
+                    return Err(Error::InvalidInput {
+                        source: "Dataset offsets are not sorted and contiguous".into(),
+                        location: location!(),
+                    });
+                }
+            }
+        }
+        Ok(min..max + 1)
+    }
+
+    async fn create_from_dataset_offset(config: AlignmentConfig) -> Result<AlignFragmentsPlan> {
+        let target_fragments = config.target.fragments();
+        let mut tasks = target_fragments
+            .iter()
+            .map(|frag| AlignFragmentsTask {
+                source: vec![],
+                target_id: frag.id as u32,
+            })
+            .collect::<Vec<_>>();
+
+        // For each new fragment, find which target fragments it overlaps with, and add it to
+        // the list of tasks for that target fragment.
+        for src_fragment in config.source.fragments().iter() {
+            let src_frag_num_rows = src_fragment.num_rows().expect("Alignment cannot be performed on older datasets which do not contain physical row counts") as u32;
+            let off_range =
+                Self::dataset_offset_range_from_fragment(src_fragment, config.source.as_ref())
+                    .await?;
+            let mut rows_to_skip = off_range.start;
+            let mut rows_to_take = off_range.end - off_range.start;
+            let mut src_frag_offset = 0;
+            for (target, task) in target_fragments.iter().zip(tasks.iter_mut()) {
+                let target_num_rows = target.num_rows().expect("Alignment cannot be performed on older datasets which do not contain physical row counts") as u32;
+                let skip_in_this_frag = if rows_to_skip < target_num_rows as u64 {
+                    let skip_in_this_frag = rows_to_skip as u32;
+                    rows_to_skip = 0;
+                    skip_in_this_frag
+                } else {
+                    rows_to_skip -= target_num_rows as u64;
+                    continue;
+                };
+                let remaining_in_target = (target_num_rows - skip_in_this_frag) as u64;
+                let take_in_this_frag = rows_to_take.min(remaining_in_target) as u32;
+                task.source
+                    .push(AlignmentItem::SourceFragmentRange(FragmentTakeRange {
+                        fragment_id: src_fragment.id as u32,
+                        offset_range: src_frag_offset..src_frag_offset + take_in_this_frag,
+                        target_offset: skip_in_this_frag,
+                    }));
+                src_frag_offset += take_in_this_frag;
+                rows_to_take -= take_in_this_frag as u64;
+                if src_frag_offset == src_frag_num_rows {
+                    debug_assert!(rows_to_take == 0);
+                    break;
+                }
+            }
+            if rows_to_take > 0 {
+                log::warn!("Source data in alignment plan has more rows than target data.  Excess rows will be ignored.");
+            }
+        }
+
+        for (task, frag) in tasks.iter_mut().zip(target_fragments.iter()) {
+            task.sort_and_fill_nulls(frag)?;
+        }
+
+        Ok(Self {
+            tasks,
+            read_version: config.target.version().version,
+        })
+    }
+
+    async fn create_from_rowid(_config: AlignmentConfig) -> Result<AlignFragmentsPlan> {
+        todo!()
+    }
+
+    async fn create_from_custom_key(_config: AlignmentConfig) -> Result<AlignFragmentsPlan> {
+        Err(Error::NotSupported { source: "Creating an alignment plan from a custom join key is not yet supported.  Only _rowid and _dataset_offset work today".into(), location: location!() })
+    }
+
+    pub fn tasks(&self) -> &[AlignFragmentsTask] {
+        &self.tasks
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{
+        types::{Int32Type, Int64Type, UInt64Type},
+        RecordBatchIterator,
+    };
+    use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+    use lance_core::{datatypes::Schema, DATASET_OFFSET};
+    use lance_datagen::{array, gen, ArrayGeneratorExt, RowCount};
+    use tempfile::tempdir;
+
+    use crate::{
+        dataset::align::{AlignFragmentsPlan, AlignmentItem, FragmentTakeRange},
+        utils::test::{DatagenExt, FragmentCount, FragmentRowCount},
+        Dataset,
+    };
+
+    #[tokio::test]
+    async fn test_create_plan_from_dataset_offset() {
+        let test_dir = tempdir().unwrap();
+        let target_uri = test_dir.path().join("target");
+        let target_uri = target_uri.to_str().unwrap();
+        let source_uri = test_dir.path().join("source");
+        let source_uri = source_uri.to_str().unwrap();
+
+        // Target dataset: 4 fragments of 10 rows each
+        let target_dataset = gen()
+            .col("a", array::step::<Int32Type>())
+            .into_dataset(
+                target_uri,
+                FragmentCount::from(4),
+                FragmentRowCount::from(10),
+            )
+            .await
+            .unwrap();
+
+        // Source dataset: 2 fragments, with 6 rows each, straddling the target fragments
+        let new_schema = Schema::try_from(&ArrowSchema::new(vec![
+            ArrowField::new(DATASET_OFFSET, DataType::UInt64, false),
+            ArrowField::new("b", DataType::Int64, true),
+        ]))
+        .unwrap();
+        let mut source_dataset = Dataset::write_empty(new_schema, source_uri, None)
+            .await
+            .unwrap();
+
+        let batch1 = gen()
+            .col(
+                DATASET_OFFSET,
+                array::cycle::<UInt64Type>(vec![7, 8, 9, 10, 11, 12]),
+            )
+            .col("b", array::step::<Int64Type>())
+            .into_batch_rows(RowCount::from(6))
+            .unwrap();
+        let batch2 = gen()
+            .col(
+                DATASET_OFFSET,
+                array::cycle::<UInt64Type>(vec![37, 38, 39, 40, 41, 42]),
+            )
+            .col("b", array::step_custom::<Int64Type>(6, 1))
+            .into_batch_rows(RowCount::from(6))
+            .unwrap();
+
+        let schema = batch1.schema();
+        let source_data = RecordBatchIterator::new(vec![Ok(batch1)], schema.clone());
+        source_dataset.append(source_data, None).await.unwrap();
+        let source_data = RecordBatchIterator::new(vec![Ok(batch2)], schema);
+        source_dataset.append(source_data, None).await.unwrap();
+
+        let source_dataset = Arc::new(source_dataset);
+        let target_dataset = Arc::new(target_dataset);
+
+        let plan = AlignFragmentsPlan::new(
+            source_dataset.clone(),
+            target_dataset.clone(),
+            DATASET_OFFSET,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(plan.tasks.len(), 4);
+        let task = &plan.tasks[0];
+        assert_eq!(task.source.len(), 2);
+        assert!(matches!(&task.source[0], AlignmentItem::Nulls(7)));
+        assert!(matches!(
+            &task.source[1],
+            AlignmentItem::SourceFragmentRange(FragmentTakeRange {
+                fragment_id: 0,
+                offset_range: std::ops::Range { start: 0, end: 3 },
+                target_offset: 7
+            })
+        ));
+        let task = &plan.tasks[1];
+        assert_eq!(task.source.len(), 2);
+        assert!(matches!(
+            &task.source[0],
+            AlignmentItem::SourceFragmentRange(FragmentTakeRange {
+                fragment_id: 0,
+                offset_range: std::ops::Range { start: 3, end: 6 },
+                target_offset: 0
+            })
+        ));
+        assert!(matches!(&task.source[1], AlignmentItem::Nulls(7)));
+
+        let mut task_results = Vec::with_capacity(plan.tasks.len());
+        for task in plan.tasks.iter().rev() {
+            task_results.push(
+                task.execute(source_dataset.clone(), target_dataset.clone())
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        plan.commit(task_results, source_dataset.clone(), target_dataset.clone())
+            .await
+            .unwrap();
+
+        let target_dataset = Dataset::open(target_uri).await.unwrap();
+        let data = target_dataset.scan().try_into_batch().await.unwrap();
+
+        let expected = gen()
+            .col("a", array::step::<Int32Type>())
+            .col(
+                "b",
+                array::cycle::<Int64Type>(
+                    [
+                        vec![0; 7],
+                        vec![0, 1, 2, 3, 4, 5],
+                        vec![0; 24],
+                        vec![6, 7, 8],
+                    ]
+                    .concat(),
+                )
+                .with_nulls(
+                    &[
+                        vec![true; 7],
+                        vec![false; 6],
+                        vec![true; 24],
+                        vec![false; 3],
+                    ]
+                    .concat(),
+                ),
+            )
+            .into_batch_rows(RowCount::from(40))
+            .unwrap();
+
+        assert_eq!(data, expected);
+    }
+}


### PR DESCRIPTION
My main goal is to create a flexible add_columns job which is distributed.  Both the calculation of the new columns can be distributed and the eventual alignment can be distributed.  This is done by incurring a penalty that we need to write the data twice.

However, this allows the "adding data" step to be independent of any fragment configuration.