### PR TITLE
feat: support write multi fragments or empty fragment in one spark task

### DIFF
--- a/java/core/lance-jni/src/fragment.rs
+++ b/java/core/lance-jni/src/fragment.rs
@@ -29,7 +29,6 @@ use lance_datafusion::utils::StreamingWriteSource;
 use crate::error::{Error, Result};
 use crate::{
     blocking_dataset::{BlockingDataset, NATIVE_DATASET},
-    ffi::JNIEnvExt,
     traits::FromJString,
     utils::extract_write_params,
     RT,

--- a/java/core/lance-jni/src/fragment.rs
+++ b/java/core/lance-jni/src/fragment.rs
@@ -77,7 +77,6 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiArray<'local
     dataset_uri: JString,
     arrow_array_addr: jlong,
     arrow_schema_addr: jlong,
-    fragment_id: JObject,         // Optional<Integer>
     max_rows_per_file: JObject,   // Optional<Integer>
     max_rows_per_group: JObject,  // Optional<Integer>
     max_bytes_per_file: JObject,  // Optional<Long>
@@ -91,7 +90,6 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiArray<'local
             dataset_uri,
             arrow_array_addr,
             arrow_schema_addr,
-            fragment_id,
             max_rows_per_file,
             max_rows_per_group,
             max_bytes_per_file,
@@ -108,7 +106,6 @@ fn inner_create_with_ffi_array<'local>(
     dataset_uri: JString,
     arrow_array_addr: jlong,
     arrow_schema_addr: jlong,
-    fragment_id: JObject,         // Optional<Integer>
     max_rows_per_file: JObject,   // Optional<Integer>
     max_rows_per_group: JObject,  // Optional<Integer>
     max_bytes_per_file: JObject,  // Optional<Long>
@@ -131,7 +128,6 @@ fn inner_create_with_ffi_array<'local>(
     create_fragment(
         env,
         dataset_uri,
-        fragment_id,
         max_rows_per_file,
         max_rows_per_group,
         max_bytes_per_file,
@@ -147,7 +143,6 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiStream<'a>(
     _obj: JObject,
     dataset_uri: JString,
     arrow_array_stream_addr: jlong,
-    fragment_id: JObject,         // Optional<Integer>
     max_rows_per_file: JObject,   // Optional<Integer>
     max_rows_per_group: JObject,  // Optional<Integer>
     max_bytes_per_file: JObject,  // Optional<Long>
@@ -160,7 +155,6 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiStream<'a>(
             &mut env,
             dataset_uri,
             arrow_array_stream_addr,
-            fragment_id,
             max_rows_per_file,
             max_rows_per_group,
             max_bytes_per_file,
@@ -176,7 +170,6 @@ fn inner_create_with_ffi_stream<'local>(
     env: &mut JNIEnv<'local>,
     dataset_uri: JString,
     arrow_array_stream_addr: jlong,
-    fragment_id: JObject,         // Optional<Integer>
     max_rows_per_file: JObject,   // Optional<Integer>
     max_rows_per_group: JObject,  // Optional<Integer>
     max_bytes_per_file: JObject,  // Optional<Long>
@@ -189,7 +182,6 @@ fn inner_create_with_ffi_stream<'local>(
     create_fragment(
         env,
         dataset_uri,
-        fragment_id,
         max_rows_per_file,
         max_rows_per_group,
         max_bytes_per_file,
@@ -203,7 +195,6 @@ fn inner_create_with_ffi_stream<'local>(
 fn create_fragment<'a>(
     env: &mut JNIEnv<'a>,
     dataset_uri: JString,
-    fragment_id: JObject,         // Optional<Integer>
     max_rows_per_file: JObject,   // Optional<Integer>
     max_rows_per_group: JObject,  // Optional<Integer>
     max_bytes_per_file: JObject,  // Optional<Long>
@@ -213,8 +204,6 @@ fn create_fragment<'a>(
 ) -> Result<JString<'a>> {
     let path_str = dataset_uri.extract(env)?;
 
-    let fragment_id_opts = env.get_int_opt(&fragment_id)?;
-
     let write_params = extract_write_params(
         env,
         &max_rows_per_file,
@@ -223,9 +212,8 @@ fn create_fragment<'a>(
         &mode,
         &storage_options_obj,
     )?;
-    let fragment = RT.block_on(FileFragment::create(
+    let fragment = RT.block_on(FileFragment::create_fragments(
         &path_str,
-        fragment_id_opts.unwrap_or(0) as usize,
         source,
         Some(write_params),
     ))?;

--- a/java/core/lance-jni/src/utils.rs
+++ b/java/core/lance-jni/src/utils.rs
@@ -56,8 +56,8 @@ pub fn extract_write_params(
     if let Some(mode_val) = env.get_string_opt(mode)? {
         write_params.mode = WriteMode::try_from(mode_val.as_str())?;
     }
-    // Java code always sets the data storage version to Legacy for now
-    write_params.data_storage_version = Some(LanceFileVersion::Legacy);
+    // Java code always sets the data storage version to stable for now
+    write_params.data_storage_version = Some(LanceFileVersion::Stable);
     let jmap = JMap::from_env(env, storage_options_obj)?;
     let storage_options: HashMap<String, String> = env.with_local_frame(16, |env| {
         let mut map = HashMap::new();

--- a/java/core/src/main/java/com/lancedb/lance/Fragment.java
+++ b/java/core/src/main/java/com/lancedb/lance/Fragment.java
@@ -14,6 +14,7 @@
 
 package com.lancedb.lance;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.arrow.c.ArrowArray;
@@ -36,24 +37,22 @@ public class Fragment {
    * @param datasetUri the dataset uri
    * @param allocator the buffer allocator
    * @param root the vector schema root
-   * @param fragmentId the fragment id
    * @param params the write params
    * @return the fragment metadata
    */
-  public static FragmentMetadata create(String datasetUri, BufferAllocator allocator,
-      VectorSchemaRoot root, Optional<Integer> fragmentId, WriteParams params) {
+  public static List<FragmentMetadata> create(String datasetUri, BufferAllocator allocator,
+      VectorSchemaRoot root, WriteParams params) {
     Preconditions.checkNotNull(datasetUri);
     Preconditions.checkNotNull(allocator);
     Preconditions.checkNotNull(root);
-    Preconditions.checkNotNull(fragmentId);
     Preconditions.checkNotNull(params);
     try (ArrowSchema arrowSchema = ArrowSchema.allocateNew(allocator);
          ArrowArray arrowArray = ArrowArray.allocateNew(allocator)) {
       Data.exportVectorSchemaRoot(allocator, root, null, arrowArray, arrowSchema);
-      return FragmentMetadata.fromJson(createWithFfiArray(datasetUri, arrowArray.memoryAddress(),
-          arrowSchema.memoryAddress(), fragmentId, params.getMaxRowsPerFile(),
-          params.getMaxRowsPerGroup(), params.getMaxBytesPerFile(), params.getMode(),
-          params.getStorageOptions()));
+      return FragmentMetadata.fromJsonArray(createWithFfiArray(datasetUri,
+              arrowArray.memoryAddress(), arrowSchema.memoryAddress(),
+              params.getMaxRowsPerFile(), params.getMaxRowsPerGroup(), params.getMaxBytesPerFile(),
+              params.getMode(), params.getStorageOptions()));
     }
   }
 
@@ -61,18 +60,16 @@ public class Fragment {
    * Create a fragment from the given arrow stream.
    * @param datasetUri  the dataset uri
    * @param stream  the arrow stream
-   * @param fragmentId  the fragment id
    * @param params  the write params
    * @return  the fragment metadata
    */
-  public static FragmentMetadata create(String datasetUri, ArrowArrayStream stream,
-      Optional<Integer> fragmentId, WriteParams params) {
+  public static List<FragmentMetadata> create(String datasetUri, ArrowArrayStream stream,
+      WriteParams params) {
     Preconditions.checkNotNull(datasetUri);
     Preconditions.checkNotNull(stream);
-    Preconditions.checkNotNull(fragmentId);
     Preconditions.checkNotNull(params);
-    return FragmentMetadata.fromJson(createWithFfiStream(datasetUri,
-        stream.memoryAddress(), fragmentId,
+    return FragmentMetadata.fromJsonArray(createWithFfiStream(datasetUri,
+        stream.memoryAddress(),
         params.getMaxRowsPerFile(), params.getMaxRowsPerGroup(),
         params.getMaxBytesPerFile(), params.getMode(), params.getStorageOptions()));
   }
@@ -83,7 +80,7 @@ public class Fragment {
    * @return the json serialized fragment metadata
    */
   private static native String createWithFfiArray(String datasetUri,
-      long arrowArrayMemoryAddress, long arrowSchemaMemoryAddress, Optional<Integer> fragmentId,
+      long arrowArrayMemoryAddress, long arrowSchemaMemoryAddress,
       Optional<Integer> maxRowsPerFile, Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile, Optional<String> mode, Map<String, String> storageOptions);
 
@@ -93,7 +90,7 @@ public class Fragment {
    * @return the json serialized fragment metadata
    */
   private static native String createWithFfiStream(String datasetUri, long arrowStreamMemoryAddress,
-      Optional<Integer> fragmentId, Optional<Integer> maxRowsPerFile,
+      Optional<Integer> maxRowsPerFile,
       Optional<Integer> maxRowsPerGroup, Optional<Long> maxBytesPerFile,
       Optional<String> mode, Map<String, String> storageOptions);
 }

--- a/java/core/src/main/java/com/lancedb/lance/FragmentMetadata.java
+++ b/java/core/src/main/java/com/lancedb/lance/FragmentMetadata.java
@@ -15,7 +15,11 @@
 package com.lancedb.lance;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.arrow.util.Preconditions;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
@@ -74,5 +78,28 @@ public class FragmentMetadata implements Serializable {
     }
     return new FragmentMetadata(jsonMetadata, metadata.getInt(ID_KEY),
         metadata.getLong(PHYSICAL_ROWS_KEY));
+  }
+
+  /**
+   * Converts a JSON array string into a list of FragmentMetadata objects.
+   *
+   * @param jsonMetadata A JSON array string containing fragment metadata.
+   * @return A list of FragmentMetadata objects.
+   */
+  public static List<FragmentMetadata> fromJsonArray(String jsonMetadata) {
+    Preconditions.checkNotNull(jsonMetadata);
+    JSONArray metadatas = new JSONArray(jsonMetadata);
+    List<FragmentMetadata> fragmentMetadataList = new ArrayList<>();
+    for (Object object : metadatas) {
+      JSONObject metadata = (JSONObject) object;
+      if (!metadata.has(ID_KEY) || !metadata.has(PHYSICAL_ROWS_KEY)) {
+        throw new IllegalArgumentException(
+                String.format("Fragment metadata must have {} and {} but is {}",
+                        ID_KEY, PHYSICAL_ROWS_KEY, jsonMetadata));
+      }
+      fragmentMetadataList.add(new FragmentMetadata(metadata.toString(), metadata.getInt(ID_KEY),
+              metadata.getLong(PHYSICAL_ROWS_KEY)));
+    }
+    return fragmentMetadataList;
   }
 }

--- a/java/core/src/test/java/com/lancedb/lance/ScannerTest.java
+++ b/java/core/src/test/java/com/lancedb/lance/ScannerTest.java
@@ -225,17 +225,20 @@ public class ScannerTest {
     try (BufferAllocator allocator = new RootAllocator()) {
       TestUtils.SimpleTestDataset testDataset = new TestUtils.SimpleTestDataset(allocator, datasetPath);
       testDataset.createEmptyDataset().close();
-      int[] fragment0 = new int[]{0, 3};
-      int[] fragment1 = new int[]{1, 5};
-      int[] fragment2 = new int[]{2, 7};
-      FragmentMetadata metadata0 = testDataset.createNewFragment(fragment0[0], fragment0[1]);
-      FragmentMetadata metadata1 = testDataset.createNewFragment(fragment1[0], fragment1[1]);
-      FragmentMetadata metadata2 = testDataset.createNewFragment(fragment2[0], fragment2[1]);
+      int rowCount0 = 3;
+      int rowCount1 = 5;
+      int rowCount2 = 7;
+      FragmentMetadata metadata0 = testDataset.createNewFragment(rowCount0);
+      FragmentMetadata metadata1 = testDataset.createNewFragment(rowCount1);
+      FragmentMetadata metadata2 = testDataset.createNewFragment(rowCount2);
+      int fragmentId0 = metadata0.getId();
+      int fragmentId1 = metadata1.getId();
+      int fragmentId2 = metadata2.getId();
       FragmentOperation.Append appendOp = new FragmentOperation.Append(Arrays.asList(metadata0, metadata1, metadata2));
       try (Dataset dataset = Dataset.commit(allocator, datasetPath, appendOp, Optional.of(1L))) {
-        validScanResult(dataset, fragment0[0], fragment0[1]);
-        validScanResult(dataset, fragment1[0], fragment1[1]);
-        validScanResult(dataset, fragment2[0], fragment2[1]);
+        validScanResult(dataset, fragmentId0, rowCount0);
+        validScanResult(dataset, fragmentId1, rowCount1);
+        validScanResult(dataset, fragmentId2, rowCount2);
       }
     }
   }
@@ -249,12 +252,14 @@ public class ScannerTest {
       int[] fragment0 = new int[]{0, 3};
       int[] fragment1 = new int[]{1, 5};
       int[] fragment2 = new int[]{2, 7};
-      FragmentMetadata metadata0 = testDataset.createNewFragment(fragment0[0], fragment0[1]);
-      FragmentMetadata metadata1 = testDataset.createNewFragment(fragment1[0], fragment1[1]);
-      FragmentMetadata metadata2 = testDataset.createNewFragment(fragment2[0], fragment2[1]);
+      FragmentMetadata metadata0 = testDataset.createNewFragment(fragment0[1]);
+      FragmentMetadata metadata1 = testDataset.createNewFragment(fragment1[1]);
+      FragmentMetadata metadata2 = testDataset.createNewFragment(fragment2[1]);
+      int fragmentId1 = metadata1.getId();
+      int fragmentId2 = metadata2.getId();
       FragmentOperation.Append appendOp = new FragmentOperation.Append(Arrays.asList(metadata0, metadata1, metadata2));
       try (Dataset dataset = Dataset.commit(allocator, datasetPath, appendOp, Optional.of(1L))) {
-        try (Scanner scanner = dataset.newScan(new ScanOptions.Builder().batchSize(1024).fragmentIds(Arrays.asList(1, 2)).build())) {
+        try (Scanner scanner = dataset.newScan(new ScanOptions.Builder().batchSize(1024).fragmentIds(Arrays.asList(fragmentId1, fragmentId2)).build())) {
           try (ArrowReader reader = scanner.scanBatches()) {
             assertEquals(dataset.getSchema().getFields(), reader.getVectorSchemaRoot().getSchema().getFields());
             int rowcount = 0;

--- a/java/core/src/test/java/com/lancedb/lance/TestVectorDataset.java
+++ b/java/core/src/test/java/com/lancedb/lance/TestVectorDataset.java
@@ -102,7 +102,7 @@ public class TestVectorDataset implements AutoCloseable {
       root.setRowCount(80);
 
       WriteParams fragmentWriteParams = new WriteParams.Builder().build();
-      return Fragment.create(datasetPath.toString(), allocator, root, Optional.of(batchIndex), fragmentWriteParams);
+      return Fragment.create(datasetPath.toString(), allocator, root, fragmentWriteParams).get(0);
     }
   }
 
@@ -127,8 +127,8 @@ public class TestVectorDataset implements AutoCloseable {
       root.setRowCount(10);
 
       WriteParams writeParams = new WriteParams.Builder().build();
-      fragmentMetadata = Fragment.create(datasetPath.toString(), allocator, root, Optional.empty(),
-          writeParams);
+      fragmentMetadata = Fragment.create(datasetPath.toString(), allocator, root,
+          writeParams).get(0);
     }
     FragmentOperation.Append appendOp = new FragmentOperation.Append(Collections.singletonList(fragmentMetadata));
     return Dataset.commit(allocator, datasetPath.toString(), appendOp, Optional.of(2L));

--- a/java/spark/src/main/java/com/lancedb/lance/spark/internal/LanceDatasetAdapter.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/internal/LanceDatasetAdapter.java
@@ -33,9 +33,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class LanceDatasetAdapter {
-  private static final BufferAllocator allocator = new RootAllocator(
-      RootAllocator.configBuilder().from(RootAllocator.defaultConfig())
-          .maxAllocation(64 * 1024 * 1024).build());
+  private static final BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
 
   public static Optional<StructType> getSchema(LanceConfig config) {
     String uri = config.getDatasetUri();
@@ -88,12 +86,12 @@ public class LanceDatasetAdapter {
         ArrowUtils.toArrowSchema(sparkSchema, "UTC", false, false), batchSize);
   }
 
-  public static FragmentMetadata createFragment(String datasetUri, ArrowReader reader,
+  public static List<FragmentMetadata> createFragment(String datasetUri, ArrowReader reader,
                                                 WriteParams params) {
     try (ArrowArrayStream arrowStream = ArrowArrayStream.allocateNew(allocator)) {
       Data.exportArrayStream(allocator, reader, arrowStream);
       return Fragment.create(datasetUri, arrowStream,
-          java.util.Optional.empty(), params);
+          params);
     }
   }
 

--- a/java/spark/src/main/java/com/lancedb/lance/spark/write/LanceDataWriter.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/write/LanceDataWriter.java
@@ -26,18 +26,18 @@ import org.apache.spark.sql.connector.write.WriterCommitMessage;
 import org.apache.spark.sql.types.StructType;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 
 public class LanceDataWriter implements DataWriter<InternalRow> {
   private LanceArrowWriter arrowWriter;
-  private FutureTask<FragmentMetadata> fragmentCreationTask;
+  private FutureTask<List<FragmentMetadata>> fragmentCreationTask;
   private Thread fragmentCreationThread;
 
   private LanceDataWriter(LanceArrowWriter arrowWriter,
-      FutureTask<FragmentMetadata> fragmentCreationTask, Thread fragmentCreationThread) {
+      FutureTask<List<FragmentMetadata>> fragmentCreationTask, Thread fragmentCreationThread) {
     // TODO support write to multiple fragments
     this.arrowWriter = arrowWriter;
     this.fragmentCreationThread = fragmentCreationThread;
@@ -53,8 +53,8 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
   public WriterCommitMessage commit() throws IOException {
     arrowWriter.setFinished();
     try {
-      FragmentMetadata fragmentMetadata = fragmentCreationTask.get();
-      return new BatchAppend.TaskCommit(Arrays.asList(fragmentMetadata));
+      List<FragmentMetadata> fragmentMetadata = fragmentCreationTask.get();
+      return new BatchAppend.TaskCommit(fragmentMetadata);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IOException("Interrupted while waiting for reader thread to finish", e);
@@ -93,9 +93,9 @@ public class LanceDataWriter implements DataWriter<InternalRow> {
     public DataWriter<InternalRow> createWriter(int partitionId, long taskId) {
       LanceArrowWriter arrowWriter = LanceDatasetAdapter.getArrowWriter(schema, 1024);
       WriteParams params = SparkOptions.genWriteParamsFromConfig(config);
-      Callable<FragmentMetadata> fragmentCreator
+      Callable<List<FragmentMetadata>> fragmentCreator
           = () -> LanceDatasetAdapter.createFragment(config.getDatasetUri(), arrowWriter, params);
-      FutureTask<FragmentMetadata> fragmentCreationTask = new FutureTask<>(fragmentCreator);
+      FutureTask<List<FragmentMetadata>> fragmentCreationTask = new FutureTask<>(fragmentCreator);
       Thread fragmentCreationThread = new Thread(fragmentCreationTask);
       fragmentCreationThread.start();
 

--- a/java/spark/src/test/java/com/lancedb/lance/spark/write/SparkWriteTest.java
+++ b/java/spark/src/test/java/com/lancedb/lance/spark/write/SparkWriteTest.java
@@ -32,7 +32,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -52,6 +54,7 @@ public class SparkWriteTest {
         .appName("spark-lance-connector-test")
         .master("local")
         .config("spark.sql.catalog.lance", "com.lancedb.lance.spark.LanceCatalog")
+        .config("spark.sql.catalog.lance.max_row_per_file", "1")
         .getOrCreate();
     StructType schema = new StructType(new StructField[]{
         DataTypes.createStructField("id", DataTypes.IntegerType, false),
@@ -142,6 +145,31 @@ public class SparkWriteTest {
         .save();
 
     validateData(datasetName, 1);
+  }
+
+  @Test
+  public void writeMultiFiles(TestInfo testInfo) {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String filePath = LanceConfig.getDatasetUri(dbPath.toString(), datasetName);
+    testData.write().format(LanceDataSource.name)
+            .option(LanceConfig.CONFIG_DATASET_URI, filePath)
+            .save();
+
+    validateData(datasetName, 1);
+    File directory = new File(filePath + "/data");
+    assertEquals(2, directory.listFiles().length);
+  }
+
+  @Test
+  public void writeEmptyTaskFiles(TestInfo testInfo) {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String filePath = LanceConfig.getDatasetUri(dbPath.toString(), datasetName);
+    testData.repartition(4).write().format(LanceDataSource.name)
+            .option(LanceConfig.CONFIG_DATASET_URI, filePath)
+            .save();
+
+    File directory = new File(filePath + "/data");
+    assertEquals(2, directory.listFiles().length);
   }
 
   private void validateData(String datasetName, int iteration) {

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -531,6 +531,21 @@ impl FileFragment {
         builder.write(source, Some(id as u64)).await
     }
 
+    /// Create a list of [`FileFragment`] from a [`StreamingWriteSource`].
+    pub async fn create_fragments(
+        dataset_uri: &str,
+        source: impl StreamingWriteSource,
+        params: Option<WriteParams>,
+    ) -> Result<Vec<Fragment>> {
+        let mut builder = FragmentCreateBuilder::new(dataset_uri);
+
+        if let Some(params) = params.as_ref() {
+            builder = builder.write_params(params);
+        }
+
+        builder.write_fragments(source).await
+    }
+
     pub async fn create_from_file(
         filename: &str,
         dataset: &Dataset,

--- a/rust/lance/src/dataset/fragment/write.rs
+++ b/rust/lance/src/dataset/fragment/write.rs
@@ -456,8 +456,7 @@ mod tests {
         // Uses provided schema. Field ids are correct in fragment metadata.
         let data = test_data();
         let tmp_dir = tempfile::tempdir().unwrap();
-        let mut writer_params = WriteParams::default();
-        writer_params.max_rows_per_file = 1;
+        let writer_params = WriteParams { max_rows_per_file: 1, ..Default::default() };
         let fragments = FragmentCreateBuilder::new(tmp_dir.path().to_str().unwrap())
             .write_params(&writer_params)
             .write_fragments(data)

--- a/rust/lance/src/dataset/fragment/write.rs
+++ b/rust/lance/src/dataset/fragment/write.rs
@@ -456,7 +456,10 @@ mod tests {
         // Uses provided schema. Field ids are correct in fragment metadata.
         let data = test_data();
         let tmp_dir = tempfile::tempdir().unwrap();
-        let writer_params = WriteParams { max_rows_per_file: 1, ..Default::default() };
+        let writer_params = WriteParams {
+            max_rows_per_file: 1,
+            ..Default::default()
+        };
         let fragments = FragmentCreateBuilder::new(tmp_dir.path().to_str().unwrap())
             .write_params(&writer_params)
             .write_fragments(data)

--- a/rust/lance/src/dataset/fragment/write.rs
+++ b/rust/lance/src/dataset/fragment/write.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::borrow::Cow;
-use std::sync::Arc;
 use arrow_schema::Schema as ArrowSchema;
 use datafusion::execution::SendableRecordBatchStream;
 use futures::{StreamExt, TryStreamExt};
@@ -17,6 +15,8 @@ use lance_io::object_store::ObjectStore;
 use lance_table::format::{DataFile, Fragment};
 use lance_table::io::manifest::ManifestDescribing;
 use snafu::{location, Location};
+use std::borrow::Cow;
+use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::dataset::builder::DatasetBuilder;
@@ -160,9 +160,16 @@ impl<'a> FragmentCreateBuilder<'a> {
             self.dataset_uri,
             &params.store_params.clone().unwrap_or_default(),
         )
-            .await?;
-        do_write_fragments(Arc::new(object_store), &base_path, &schema, stream,
-                           params.into_owned(), LanceFileVersion::Stable).await
+        .await?;
+        do_write_fragments(
+            Arc::new(object_store),
+            &base_path,
+            &schema,
+            stream,
+            params.into_owned(),
+            LanceFileVersion::Stable,
+        )
+        .await
     }
 
     async fn write_impl(
@@ -443,7 +450,6 @@ mod tests {
         assert_eq!(fragments[0].files.len(), 1);
         assert_eq!(fragments[0].files[0].fields, vec![0, 1]);
     }
-
 
     #[tokio::test]
     async fn test_write_fragments_with_options() {


### PR DESCRIPTION
Now `FileFragment::create` only support create one file fragment and in spark connector will cause these two issues:
1. if the spark task is empty, this api will have exception since there is no data to create the fragment.
2. if the task data stream is very large, it will generate a huge file in lance format. It is not friendly for spark parallism.

So I remove the assigned fragment id and add a new method named `FileFragment::create_fragments` to generate empty or multi fragments.

![image](https://github.com/user-attachments/assets/54fb2497-8163-4652-9e0b-d50a88fade53)
