### PR TITLE
chore: add .java-version to .gitignore for java module

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -1,2 +1,3 @@
 *.iml
 spark/dependency-reduced-pom.xml
+.java-version


### PR DESCRIPTION
`.java-version` is generated automatically by [jenv](https://www.jenv.be/). Jenv is a very popular tool that is used to manage java environment.