### PR TITLE
feat: enhance repdef utilities to handle empty / null lists

### DIFF
--- a/protos/encodings.proto
+++ b/protos/encodings.proto
@@ -310,6 +310,23 @@ message ColumnEncoding {
   }
 }
 
+enum RepDefLayer {
+  // Should never be used, included for debugging purporses and general protobuf best practice
+  REPDEF_UNSPECIFIED = 0;
+  // All values are valid (can be primitive or struct)
+  REPDEF_ALL_VALID_ITEM = 1;
+  // All list values are valid
+  REPDEF_ALL_VALID_LIST = 2;
+  // There are one or more null items (can be primitive or struct)
+  REPDEF_NULLABLE_ITEM = 3;
+  // A list layer with null lists but no empty lists
+  REPDEF_NULLABLE_LIST = 4;
+  // A list layer with empty lists but no null lists
+  REPDEF_EMPTYABLE_LIST = 5;
+  // A list layer with both empty lists and null lists
+  REPDEF_NULL_AND_EMPTY_LIST = 6;
+}
+
 /// A layout used for pages where the data is small
 ///
 /// In this case we can fit many values into a single disk sector and transposing buffers is
@@ -322,7 +339,10 @@ message MiniBlockLayout {
   ArrayEncoding def_compression = 2;
   // Description of the compression of values
   ArrayEncoding value_compression = 3;
+  // Dictionary data
   ArrayEncoding dictionary = 4;
+  // The meaning of each repdef layer, used to interpret repdef buffers correctly
+  repeated RepDefLayer layers = 5;
 }
 
 /// A layout used for pages where the data is large
@@ -336,6 +356,8 @@ message FullZipLayout {
   uint32 bits_def = 2;
   // Description of the compression of values
   ArrayEncoding value_compression = 3;
+  // The meaning of each repdef layer, used to interpret repdef buffers correctly
+  repeated RepDefLayer layers = 4;
 }
 
 /// A layout used for pages where all values are null

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "fsst"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "rand",
 ]
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -2772,7 +2772,7 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2851,7 +2851,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrayref",
  "arrow",
@@ -2904,7 +2904,7 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2989,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrow-array",
  "arrow-ord",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3368,12 +3368,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "multimap"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "murmurhash32"
@@ -3959,7 +3953,7 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "log",
- "multimap 0.8.3",
+ "multimap",
  "petgraph",
  "prettyplease 0.1.25",
  "prost 0.11.9",
@@ -3978,9 +3972,9 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "log",
- "multimap 0.10.0",
+ "multimap",
  "once_cell",
  "petgraph",
  "prettyplease 0.2.25",
@@ -3999,9 +3993,9 @@ checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
- "multimap 0.10.0",
+ "multimap",
  "once_cell",
  "petgraph",
  "prettyplease 0.2.25",
@@ -4032,7 +4026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -4045,7 +4039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -4080,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "pylance"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/rust/lance-encoding/src/buffer.rs
+++ b/rust/lance-encoding/src/buffer.rs
@@ -227,7 +227,7 @@ impl LanceBuffer {
     pub fn reinterpret_slice<T: ArrowNativeType + RefUnwindSafe>(arc: Arc<[T]>) -> Self {
         let slice = arc.as_ref();
         let data = NonNull::new(slice.as_ptr() as _).unwrap_or(NonNull::dangling());
-        let len = slice.len() * std::mem::size_of::<T>();
+        let len = std::mem::size_of_val(slice);
         // SAFETY: the ptr will be valid for len items if the Arc<[T]> is valid
         let buffer = unsafe { Buffer::from_custom_allocation(data, len, Arc::new(arc)) };
         Self::Borrowed(buffer)

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -251,6 +251,7 @@ impl FixedWidthDataBlock {
     }
 }
 
+#[derive(Debug)]
 pub struct VariableWidthDataBlockBuilder {
     offsets: Vec<u32>,
     bytes: Vec<u8>,
@@ -304,6 +305,7 @@ impl DataBlockBuilderImpl for VariableWidthDataBlockBuilder {
     }
 }
 
+#[derive(Debug)]
 struct FixedWidthDataBlockBuilder {
     bits_per_value: u64,
     bytes_per_value: u64,
@@ -449,6 +451,7 @@ impl FixedSizeListBlock {
     }
 }
 
+#[derive(Debug)]
 struct FixedSizeListBlockBuilder {
     inner: Box<dyn DataBlockBuilderImpl>,
     dimension: u64,
@@ -1415,11 +1418,12 @@ impl From<ArrayRef> for DataBlock {
     }
 }
 
-pub trait DataBlockBuilderImpl {
+pub trait DataBlockBuilderImpl: std::fmt::Debug {
     fn append(&mut self, data_block: &DataBlock, selection: Range<u64>);
     fn finish(self: Box<Self>) -> DataBlock;
 }
 
+#[derive(Debug)]
 pub struct DataBlockBuilder {
     estimated_size_bytes: u64,
     builder: Option<Box<dyn DataBlockBuilderImpl>>,

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -253,7 +253,7 @@ use crate::encodings::physical::fsst::FsstMiniBlockDecompressor;
 use crate::encodings::physical::value::{ConstantDecompressor, ValueDecompressor};
 use crate::encodings::physical::{ColumnBuffers, FileBuffers};
 use crate::format::pb::{self, column_encoding};
-use crate::repdef::{LevelBuffer, RepDefUnraveler};
+use crate::repdef::{CompositeRepDefUnraveler, RepDefUnraveler};
 use crate::version::LanceFileVersion;
 use crate::{BufferScheduler, EncodingsIo};
 
@@ -489,7 +489,7 @@ pub trait DecompressorStrategy: std::fmt::Debug + Send + Sync {
     ) -> Result<Box<dyn BlockDecompressor>>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct CoreDecompressorStrategy {}
 
 impl DecompressorStrategy for CoreDecompressorStrategy {
@@ -1685,7 +1685,11 @@ pub fn create_decode_stream(
 ) -> BoxStream<'static, ReadBatchTask> {
     if is_structural {
         let arrow_schema = ArrowSchema::from(schema);
-        let structural_decoder = StructuralStructDecoder::new(arrow_schema.fields, should_validate);
+        let structural_decoder = StructuralStructDecoder::new(
+            arrow_schema.fields,
+            should_validate,
+            /*is_root=*/ true,
+        );
         StructuralBatchDecodeStream::new(rx, batch_size, num_rows, structural_decoder).into_stream()
     } else {
         let arrow_schema = ArrowSchema::from(schema);
@@ -2305,8 +2309,7 @@ pub trait LogicalPageDecoder: std::fmt::Debug + Send {
 
 pub struct DecodedPage {
     pub data: DataBlock,
-    pub repetition: Option<LevelBuffer>,
-    pub definition: Option<LevelBuffer>,
+    pub repdef: RepDefUnraveler,
 }
 
 pub trait DecodePageTask: Send + std::fmt::Debug {
@@ -2347,7 +2350,7 @@ pub struct LoadedPage {
 
 pub struct DecodedArray {
     pub array: ArrayRef,
-    pub repdef: RepDefUnraveler,
+    pub repdef: CompositeRepDefUnraveler,
 }
 
 pub trait StructuralDecodeArrayTask: std::fmt::Debug + Send {

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -583,10 +583,12 @@ pub struct StructuralStructDecoder {
     children: Vec<Box<dyn StructuralFieldDecoder>>,
     data_type: DataType,
     child_fields: Fields,
+    // The root decoder is slightly different because it cannot have nulls
+    is_root: bool,
 }
 
 impl StructuralStructDecoder {
-    pub fn new(fields: Fields, should_validate: bool) -> Self {
+    pub fn new(fields: Fields, should_validate: bool, is_root: bool) -> Self {
         let children = fields
             .iter()
             .map(|field| Self::field_to_decoder(field, should_validate))
@@ -596,6 +598,7 @@ impl StructuralStructDecoder {
             data_type,
             children,
             child_fields: fields,
+            is_root,
         }
     }
 
@@ -604,7 +607,7 @@ impl StructuralStructDecoder {
         should_validate: bool,
     ) -> Box<dyn StructuralFieldDecoder> {
         match field.data_type() {
-            DataType::Struct(fields) => Box::new(Self::new(fields.clone(), should_validate)),
+            DataType::Struct(fields) => Box::new(Self::new(fields.clone(), should_validate, false)),
             DataType::List(_) | DataType::LargeList(_) => todo!(),
             DataType::RunEndEncoded(_, _) => todo!(),
             DataType::ListView(_) | DataType::LargeListView(_) => todo!(),
@@ -633,6 +636,7 @@ impl StructuralFieldDecoder for StructuralStructDecoder {
         Ok(Box::new(RepDefStructDecodeTask {
             children: child_tasks,
             child_fields: self.child_fields.clone(),
+            is_root: self.is_root,
         }))
     }
 
@@ -645,6 +649,7 @@ impl StructuralFieldDecoder for StructuralStructDecoder {
 struct RepDefStructDecodeTask {
     children: Vec<Box<dyn StructuralDecodeArrayTask>>,
     child_fields: Fields,
+    is_root: bool,
 }
 
 impl StructuralDecodeArrayTask for RepDefStructDecodeTask {
@@ -657,15 +662,22 @@ impl StructuralDecodeArrayTask for RepDefStructDecodeTask {
         let mut children = Vec::with_capacity(arrays.len());
         let mut arrays_iter = arrays.into_iter();
         let first_array = arrays_iter.next().unwrap();
+        let length = first_array.array.len();
 
         // The repdef should be identical across all children at this point
         let mut repdef = first_array.repdef;
         children.push(first_array.array);
+
         for array in arrays_iter {
+            debug_assert_eq!(length, array.array.len());
             children.push(array.array);
         }
 
-        let validity = repdef.unravel_validity();
+        let validity = if self.is_root {
+            None
+        } else {
+            repdef.unravel_validity(length)
+        };
         let array = StructArray::new(self.child_fields, children, validity);
         Ok(DecodedArray {
             array: Arc::new(array),

--- a/rust/lance-encoding/src/format.rs
+++ b/rust/lance-encoding/src/format.rs
@@ -21,10 +21,12 @@ use pb::{
     page_layout::Layout,
     AllNullLayout, ArrayEncoding, Binary, BinaryBlock, BinaryMiniBlock, Bitpack2, Bitpacked,
     BitpackedForNonNeg, Dictionary, FixedSizeBinary, FixedSizeList, Flat, Fsst, FsstMiniBlock,
-    MiniBlockLayout, Nullable, PackedStruct, PageLayout,
+    MiniBlockLayout, Nullable, PackedStruct, PageLayout, RepDefLayer,
 };
 
-use crate::encodings::physical::block_compress::CompressionConfig;
+use crate::{
+    encodings::physical::block_compress::CompressionConfig, repdef::DefinitionInterpretation,
+};
 
 use self::pb::Constant;
 
@@ -229,18 +231,52 @@ impl ProtobufUtils {
         }
     }
 
+    fn def_inter_to_repdef_layer(def: DefinitionInterpretation) -> i32 {
+        match def {
+            DefinitionInterpretation::AllValidItem => RepDefLayer::RepdefAllValidItem as i32,
+            DefinitionInterpretation::AllValidList => RepDefLayer::RepdefAllValidList as i32,
+            DefinitionInterpretation::NullableItem => RepDefLayer::RepdefNullableItem as i32,
+            DefinitionInterpretation::NullableList => RepDefLayer::RepdefNullableList as i32,
+            DefinitionInterpretation::EmptyableList => RepDefLayer::RepdefEmptyableList as i32,
+            DefinitionInterpretation::NullableAndEmptyableList => {
+                RepDefLayer::RepdefNullAndEmptyList as i32
+            }
+        }
+    }
+
+    pub fn repdef_layer_to_def_interp(layer: i32) -> DefinitionInterpretation {
+        let layer = RepDefLayer::try_from(layer).unwrap();
+        match layer {
+            RepDefLayer::RepdefAllValidItem => DefinitionInterpretation::AllValidItem,
+            RepDefLayer::RepdefAllValidList => DefinitionInterpretation::AllValidList,
+            RepDefLayer::RepdefNullableItem => DefinitionInterpretation::NullableItem,
+            RepDefLayer::RepdefNullableList => DefinitionInterpretation::NullableList,
+            RepDefLayer::RepdefEmptyableList => DefinitionInterpretation::EmptyableList,
+            RepDefLayer::RepdefNullAndEmptyList => {
+                DefinitionInterpretation::NullableAndEmptyableList
+            }
+            RepDefLayer::RepdefUnspecified => panic!("Unspecified repdef layer"),
+        }
+    }
+
     pub fn miniblock_layout(
         rep_encoding: ArrayEncoding,
         def_encoding: ArrayEncoding,
         value_encoding: ArrayEncoding,
         dictionary_encoding: Option<ArrayEncoding>,
+        def_meaning: &[DefinitionInterpretation],
     ) -> PageLayout {
+        assert!(!def_meaning.is_empty());
         PageLayout {
             layout: Some(Layout::MiniBlockLayout(MiniBlockLayout {
                 def_compression: Some(def_encoding),
                 rep_compression: Some(rep_encoding),
                 value_compression: Some(value_encoding),
                 dictionary: dictionary_encoding,
+                layers: def_meaning
+                    .iter()
+                    .map(|&def| Self::def_inter_to_repdef_layer(def))
+                    .collect(),
             })),
         }
     }
@@ -249,12 +285,17 @@ impl ProtobufUtils {
         bits_rep: u8,
         bits_def: u8,
         value_encoding: ArrayEncoding,
+        def_meaning: &[DefinitionInterpretation],
     ) -> PageLayout {
         PageLayout {
             layout: Some(Layout::FullZipLayout(pb::FullZipLayout {
                 bits_rep: bits_rep as u32,
                 bits_def: bits_def as u32,
                 value_compression: Some(value_encoding),
+                layers: def_meaning
+                    .iter()
+                    .map(|&def| Self::def_inter_to_repdef_layer(def))
+                    .collect(),
             })),
         }
     }

--- a/rust/lance-encoding/src/repdef.rs
+++ b/rust/lance-encoding/src/repdef.rs
@@ -92,7 +92,10 @@
 // This means we end up with 3 bits per level instead of 2.  We could instead record
 // the layers that are all null somewhere else and not require wider rep levels.
 
-use std::{iter::Zip, sync::Arc};
+use std::{
+    iter::{Copied, Zip},
+    sync::Arc,
+};
 
 use arrow_array::OffsetSizeTrait;
 use arrow_buffer::{
@@ -101,36 +104,348 @@ use arrow_buffer::{
 use lance_core::{utils::bit::log_2_ceil, Error, Result};
 use snafu::{location, Location};
 
+use crate::buffer::LanceBuffer;
+
 // We assume 16 bits is good enough for rep-def levels.  This gives us
 // 65536 levels of struct nesting and list nesting.
 pub type LevelBuffer = Vec<u16>;
+
+#[derive(Clone, Debug)]
+struct OffsetDesc {
+    offsets: Arc<[i64]>,
+    specials: Arc<[SpecialOffset]>,
+    validity: Option<BooleanBuffer>,
+    has_empty_lists: bool,
+    num_values: usize,
+}
+
+#[derive(Clone, Debug)]
+struct ValidityDesc {
+    validity: Option<BooleanBuffer>,
+    num_values: usize,
+}
 
 // As we build up rep/def from arrow arrays we record a
 // series of RawRepDef objects
 #[derive(Clone, Debug)]
 enum RawRepDef {
-    Offsets(Arc<[i64]>),
-    Validity(BooleanBuffer),
-    NoNull(usize),
+    Offsets(OffsetDesc),
+    Validity(ValidityDesc),
+}
+
+impl RawRepDef {
+    fn has_nulls(&self) -> bool {
+        match self {
+            Self::Offsets(OffsetDesc { validity, .. }) => validity.is_some(),
+            Self::Validity(ValidityDesc { validity, .. }) => validity.is_some(),
+        }
+    }
+
+    fn num_values(&self) -> usize {
+        match self {
+            Self::Offsets(OffsetDesc { num_values, .. }) => *num_values,
+            Self::Validity(ValidityDesc { num_values, .. }) => *num_values,
+        }
+    }
 }
 
 /// Represents repetition and definition levels that have been
 /// serialized into a pair of (optional) level buffers
 #[derive(Debug)]
 pub struct SerializedRepDefs {
-    // If None, there are no lists
-    pub repetition_levels: Option<LevelBuffer>,
-    // If None, there are no nulls
-    pub definition_levels: Option<LevelBuffer>,
+    /// The repetition levels, one per item
+    ///
+    /// If None, there are no lists
+    pub repetition_levels: Option<Arc<[u16]>>,
+    /// The definition levels, one per item
+    ///
+    /// If None, there are no nulls
+    pub definition_levels: Option<Arc<[u16]>>,
+    /// Special records indicate empty / null lists
+    ///
+    /// These do not have any mapping to items.  There may be empty or there may
+    /// be more special records than items or anywhere in between.
+    pub special_records: Vec<SpecialRecord>,
+    /// The meaning of each definition level
+    pub def_meaning: Vec<DefinitionInterpretation>,
+    /// The maximum level that is "visible" from the lowest level
+    ///
+    /// This is the last level before we encounter a list level of some kind.  Once we've
+    /// hit a list level then nulls in any level beyond do not map to actual items.
+    ///
+    /// This is None if there are no lists
+    pub max_visible_level: Option<u16>,
 }
 
 impl SerializedRepDefs {
+    pub fn new(
+        repetition_levels: Option<LevelBuffer>,
+        definition_levels: Option<LevelBuffer>,
+        special_records: Vec<SpecialRecord>,
+        def_meaning: Vec<DefinitionInterpretation>,
+    ) -> Self {
+        let first_list = def_meaning.iter().position(|level| level.is_list());
+        let max_visible_level = first_list.map(|first_list| {
+            def_meaning
+                .iter()
+                .map(|level| level.num_def_levels())
+                .take(first_list)
+                .sum::<u16>()
+        });
+        Self {
+            repetition_levels: repetition_levels.map(Arc::from),
+            definition_levels: definition_levels.map(Arc::from),
+            special_records,
+            def_meaning,
+            max_visible_level,
+        }
+    }
+
     /// Creates an empty SerializedRepDefs (no repetition, all valid)
-    pub fn empty() -> Self {
+    pub fn empty(def_meaning: Vec<DefinitionInterpretation>) -> Self {
         Self {
             repetition_levels: None,
             definition_levels: None,
+            special_records: Vec::new(),
+            def_meaning,
+            max_visible_level: None,
         }
+    }
+
+    pub fn rep_slicer(&self) -> Option<RepDefSlicer> {
+        self.repetition_levels
+            .as_ref()
+            .map(|rep| RepDefSlicer::new(self, rep.clone()))
+    }
+
+    pub fn def_slicer(&self) -> Option<RepDefSlicer> {
+        self.definition_levels
+            .as_ref()
+            .map(|def| RepDefSlicer::new(self, def.clone()))
+    }
+
+    /// Creates a version of the SerializedRepDefs with the specials collapsed into
+    /// the repetition and definition levels
+    pub fn collapse_specials(self) -> Self {
+        if self.special_records.is_empty() {
+            return self;
+        }
+
+        // If we have specials then we must have repetition
+        let rep = self.repetition_levels.unwrap();
+
+        let new_len = rep.len() + self.special_records.len();
+
+        let mut new_rep = Vec::with_capacity(new_len);
+        let mut new_def = Vec::with_capacity(new_len);
+
+        // Now we just merge the rep/def levels and the specials into one list.  There is just
+        // one tricky part.  If a non-special is added after a special item then it swaps its
+        // repetition level with the special item.
+        if let Some(def) = self.definition_levels {
+            let mut def_itr = def.into_iter();
+            let mut rep_itr = rep.into_iter();
+            let mut special_itr = self.special_records.into_iter().peekable();
+            let mut last_special = None;
+
+            for idx in 0..new_len {
+                if let Some(special) = special_itr.peek() {
+                    if special.pos == idx {
+                        new_rep.push(special.rep_level);
+                        new_def.push(special.def_level);
+                        special_itr.next();
+                        last_special = Some(new_rep.last_mut().unwrap());
+                    } else {
+                        let rep = if let Some(last_special) = last_special {
+                            let rep = *last_special;
+                            *last_special = *rep_itr.next().unwrap();
+                            rep
+                        } else {
+                            *rep_itr.next().unwrap()
+                        };
+                        new_rep.push(rep);
+                        new_def.push(*def_itr.next().unwrap());
+                        last_special = None;
+                    }
+                } else {
+                    let rep = if let Some(last_special) = last_special {
+                        let rep = *last_special;
+                        *last_special = *rep_itr.next().unwrap();
+                        rep
+                    } else {
+                        *rep_itr.next().unwrap()
+                    };
+                    new_rep.push(rep);
+                    new_def.push(*def_itr.next().unwrap());
+                    last_special = None;
+                }
+            }
+        } else {
+            let mut rep_itr = rep.into_iter();
+            let mut special_itr = self.special_records.into_iter().peekable();
+            let mut last_special = None;
+
+            for idx in 0..new_len {
+                if let Some(special) = special_itr.peek() {
+                    if special.pos == idx {
+                        new_rep.push(special.rep_level);
+                        new_def.push(special.def_level);
+                        special_itr.next();
+                        last_special = Some(new_rep.last_mut().unwrap());
+                    } else {
+                        let rep = if let Some(last_special) = last_special {
+                            let rep = *last_special;
+                            *last_special = *rep_itr.next().unwrap();
+                            rep
+                        } else {
+                            *rep_itr.next().unwrap()
+                        };
+                        new_rep.push(rep);
+                        new_def.push(0);
+                        last_special = None;
+                    }
+                } else {
+                    let rep = if let Some(last_special) = last_special {
+                        let rep = *last_special;
+                        *last_special = *rep_itr.next().unwrap();
+                        rep
+                    } else {
+                        *rep_itr.next().unwrap()
+                    };
+                    new_rep.push(rep);
+                    new_def.push(0);
+                    last_special = None;
+                }
+            }
+        }
+
+        Self {
+            repetition_levels: Some(new_rep.into()),
+            definition_levels: Some(new_def.into()),
+            special_records: Vec::new(),
+            def_meaning: self.def_meaning,
+            max_visible_level: self.max_visible_level,
+        }
+    }
+}
+
+pub struct RepDefSlicer<'a> {
+    repdef: &'a SerializedRepDefs,
+    to_slice: LanceBuffer,
+    current: usize,
+}
+
+impl<'a> RepDefSlicer<'a> {
+    fn new(repdef: &'a SerializedRepDefs, levels: Arc<[u16]>) -> Self {
+        Self {
+            repdef,
+            to_slice: LanceBuffer::reinterpret_slice(levels),
+            current: 0,
+        }
+    }
+
+    pub fn num_levels(&self) -> usize {
+        self.to_slice.len()
+    }
+
+    pub fn all_levels(&self) -> &LanceBuffer {
+        &self.to_slice
+    }
+
+    pub fn slice_next(&mut self, num_values: usize) -> LanceBuffer {
+        let start = self.current;
+        let Some(max_visible_level) = self.repdef.max_visible_level else {
+            // No lists, should be 1:1 mapping from levels to values
+            self.current = start + num_values;
+            return self.to_slice.slice_with_length(start * 2, num_values * 2);
+        };
+        if let Some(def) = self.repdef.definition_levels.as_ref() {
+            // There are lists and there are def levels.  That means there may be
+            // more rep/def levels than values.  We need to scan the def levels to figure
+            // out which items are "invisible" and skip over them
+            let mut def_itr = def[start..].iter();
+            let mut num_taken = 0;
+            let mut num_passed = 0;
+            while num_taken < num_values {
+                let def_level = *def_itr.next().unwrap();
+                if def_level <= max_visible_level {
+                    num_taken += 1;
+                }
+                num_passed += 1;
+            }
+            self.current = start + num_passed;
+            self.to_slice.slice_with_length(start * 2, num_passed * 2)
+        } else {
+            // No def levels, should be 1:1 mapping from levels to values
+            self.current = start + num_values;
+            self.to_slice.slice_with_length(start * 2, num_values * 2)
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct SpecialRecord {
+    /// The position of the special record in the items array
+    ///
+    /// Note that this is the position in the "expanded" items array (including the specials)
+    ///
+    /// For example, if we have five items [I0, I1, ..., I4] and two specials [S0(pos=3), S1(pos=6)] then
+    /// the combined array is [I0, I1, I2, S0, I3, I4, S1].
+    ///
+    /// Another tricky fact is that a special "swaps" the repetition level of the matching item when it is
+    /// being inserted into the combined list.  So, if items are [I0(rep=2), I1(rep=1), I2(rep=2), I3(rep=0)]
+    /// and a special is S0(pos=2, rep=1) then the combined list is
+    /// [I0(rep=2), I1(rep=1), S0(rep=2), I2(rep=1), I3(rep=0)].
+    ///
+    /// Or, to put it in practice we start with [[I0], [I1]], [[I2, I3]] and after inserting our special
+    /// we have [[I0], [I1]], [S0, [I2, I3]]
+    pos: usize,
+    /// The definition level of the special record.  This is never 0 and is used to distinguish between an
+    /// empty list and a null list.
+    def_level: u16,
+    /// The repetition level of the special record.  This is never 0 and is used to indicate which level of
+    /// nesting the special record is at.
+    rep_level: u16,
+}
+
+/// Indicates if a definition level represents a null value or an empty list
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum DefinitionInterpretation {
+    AllValidItem,
+    AllValidList,
+    NullableItem,
+    NullableList,
+    EmptyableList,
+    NullableAndEmptyableList,
+}
+
+impl DefinitionInterpretation {
+    pub fn num_def_levels(&self) -> u16 {
+        match self {
+            Self::AllValidItem => 0,
+            Self::AllValidList => 0,
+            Self::NullableItem => 1,
+            Self::NullableList => 1,
+            Self::EmptyableList => 1,
+            Self::NullableAndEmptyableList => 2,
+        }
+    }
+
+    pub fn is_all_valid(&self) -> bool {
+        matches!(
+            self,
+            Self::AllValidItem | Self::AllValidList | Self::EmptyableList
+        )
+    }
+
+    pub fn is_list(&self) -> bool {
+        matches!(
+            self,
+            Self::AllValidList
+                | Self::NullableList
+                | Self::EmptyableList
+                | Self::NullableAndEmptyableList
+        )
     }
 }
 
@@ -167,7 +482,10 @@ impl SerializedRepDefs {
 /// we would have 5 definition levels.  We can use our current offsets
 /// ([0, 3, 5]) to expand [T, F] into [T, T, T, F, F].
 struct SerializerContext {
-    last_offsets: Option<Arc<[i64]>>,
+    last_offsets: Option<Vec<usize>>,
+    last_offsets_full: Option<Vec<usize>>,
+    specials: Vec<SpecialRecord>,
+    def_meaning: Vec<DefinitionInterpretation>,
     rep_levels: LevelBuffer,
     def_levels: LevelBuffer,
     current_rep: u16,
@@ -176,62 +494,149 @@ struct SerializerContext {
 }
 
 impl SerializerContext {
-    fn new(len: usize, has_nulls: bool) -> Self {
+    fn new(len: usize, has_nulls: bool, has_offsets: bool, num_layers: usize) -> Self {
+        let def_meaning = Vec::with_capacity(num_layers);
         Self {
             last_offsets: None,
-            rep_levels: LevelBuffer::with_capacity(len),
-            def_levels: if has_nulls {
-                LevelBuffer::with_capacity(len)
+            last_offsets_full: None,
+            rep_levels: if has_offsets {
+                vec![0; len]
             } else {
                 LevelBuffer::default()
             },
+            def_levels: if has_nulls {
+                vec![0; len]
+            } else {
+                LevelBuffer::default()
+            },
+            def_meaning,
             current_rep: 1,
             current_def: 1,
             has_nulls: false,
+            specials: Vec::default(),
         }
     }
 
-    fn record_all_valid(&mut self, len: usize) {
-        self.current_def += 1;
-        if self.def_levels.is_empty() {
-            self.def_levels.resize(len, 0);
-        }
+    fn checkout_def(&mut self, meaning: DefinitionInterpretation) -> u16 {
+        let def = self.current_def;
+        self.current_def += meaning.num_def_levels();
+        self.def_meaning.push(meaning);
+        def
     }
 
-    fn record_offsets(&mut self, offsets: &Arc<[i64]>) {
+    fn record_offsets(&mut self, offset_desc: &OffsetDesc) {
         let rep_level = self.current_rep;
+        let (null_list_level, empty_list_level) =
+            match (offset_desc.validity.is_some(), offset_desc.has_empty_lists) {
+                (true, true) => {
+                    let level =
+                        self.checkout_def(DefinitionInterpretation::NullableAndEmptyableList);
+                    (level, level + 1)
+                }
+                (true, false) => (self.checkout_def(DefinitionInterpretation::NullableList), 0),
+                (false, true) => (
+                    0,
+                    self.checkout_def(DefinitionInterpretation::EmptyableList),
+                ),
+                (false, false) => {
+                    self.checkout_def(DefinitionInterpretation::AllValidList);
+                    (0, 0)
+                }
+            };
         self.current_rep += 1;
         if let Some(last_offsets) = &self.last_offsets {
-            let mut new_last_off = Vec::with_capacity(offsets.len());
-            for off in offsets[..offsets.len() - 1].iter() {
-                let offset_ctx = last_offsets[*off as usize];
+            let last_offsets_full = self.last_offsets_full.as_ref().unwrap();
+            let mut new_last_off = Vec::with_capacity(offset_desc.offsets.len());
+            let mut new_last_off_full = Vec::with_capacity(offset_desc.offsets.len());
+            let mut empties_seen = 0;
+            for off in offset_desc.offsets.windows(2) {
+                let offset_ctx = last_offsets[off[0] as usize];
                 new_last_off.push(offset_ctx);
-                self.rep_levels[offset_ctx as usize] = rep_level;
+                new_last_off_full.push(last_offsets_full[off[0] as usize] + empties_seen);
+                self.rep_levels[offset_ctx] = rep_level;
+                if off[0] == off[1] {
+                    empties_seen += 1;
+                }
             }
-            self.last_offsets = Some(new_last_off.into());
+            self.last_offsets = Some(new_last_off);
+            self.last_offsets_full = Some(new_last_off_full);
         } else {
-            self.rep_levels.resize(*offsets.last().unwrap() as usize, 0);
-            for off in offsets[..offsets.len() - 1].iter() {
-                self.rep_levels[*off as usize] = rep_level;
+            let mut new_last_off = Vec::with_capacity(offset_desc.offsets.len());
+            let mut new_last_off_full = Vec::with_capacity(offset_desc.offsets.len());
+            let mut empties_seen = 0;
+            for off in offset_desc.offsets.windows(2) {
+                self.rep_levels[off[0] as usize] = rep_level;
+                new_last_off.push(off[0] as usize);
+                new_last_off_full.push(off[0] as usize + empties_seen);
+                if off[0] == off[1] {
+                    empties_seen += 1;
+                }
             }
-            self.last_offsets = Some(offsets.clone());
+            self.last_offsets = Some(new_last_off);
+            self.last_offsets_full = Some(new_last_off_full);
         }
+
+        // Must update specials _after_ setting last_offsets_full
+        let last_offsets_full = self.last_offsets_full.as_ref().unwrap();
+        let num_combined_specials = self.specials.len() + offset_desc.specials.len();
+        let mut new_specials = Vec::with_capacity(num_combined_specials);
+        let mut new_inserted = 0;
+        let mut old_specials_itr = self.specials.iter().peekable();
+        let mut specials_itr = offset_desc.specials.iter().peekable();
+        for _ in 0..num_combined_specials {
+            if let Some(old_special) = old_specials_itr.peek() {
+                let old_special_pos = old_special.pos + new_inserted;
+                if let Some(new_special) = specials_itr.peek() {
+                    let new_special_pos = last_offsets_full[new_special.pos()];
+                    if old_special_pos < new_special_pos {
+                        let mut old_special = *old_specials_itr.next().unwrap();
+                        old_special.pos = old_special_pos;
+                        new_specials.push(old_special);
+                    } else {
+                        let new_special = specials_itr.next().unwrap();
+                        new_specials.push(SpecialRecord {
+                            pos: new_special_pos,
+                            def_level: if matches!(new_special, SpecialOffset::EmptyList(_)) {
+                                empty_list_level
+                            } else {
+                                null_list_level
+                            },
+                            rep_level,
+                        });
+                        new_inserted += 1;
+                    }
+                } else {
+                    let mut old_special = *old_specials_itr.next().unwrap();
+                    old_special.pos = old_special_pos;
+                    new_specials.push(old_special);
+                }
+            } else {
+                let new_special = specials_itr.next().unwrap();
+                new_specials.push(SpecialRecord {
+                    pos: last_offsets_full[new_special.pos()],
+                    def_level: if matches!(new_special, SpecialOffset::EmptyList(_)) {
+                        empty_list_level
+                    } else {
+                        null_list_level
+                    },
+                    rep_level,
+                });
+                new_inserted += 1;
+            }
+        }
+        self.specials = new_specials;
     }
 
-    fn record_validity(&mut self, validity: &BooleanBuffer) {
+    fn do_record_validity(&mut self, validity: &BooleanBuffer, null_level: u16) {
         self.has_nulls = true;
-        let def_level = self.current_def;
-        self.current_def += 1;
-        if self.def_levels.is_empty() {
-            self.def_levels.resize(validity.len(), 0);
-        }
+        assert!(!self.def_levels.is_empty());
         if let Some(last_offsets) = &self.last_offsets {
             last_offsets
                 .windows(2)
                 .zip(validity.iter())
                 .for_each(|(w, valid)| {
                     if !valid {
-                        self.def_levels[w[0] as usize..w[1] as usize].fill(def_level);
+                        self.def_levels[w[0]..w[1]].fill(null_level);
                     }
                 });
         } else {
@@ -240,24 +645,52 @@ impl SerializerContext {
                 .zip(validity.iter())
                 .for_each(|(def, valid)| {
                     if !valid {
-                        *def = def_level;
+                        *def = null_level;
                     }
                 });
         }
     }
 
+    fn record_validity(&mut self, validity_desc: &ValidityDesc) {
+        if let Some(validity) = validity_desc.validity.as_ref() {
+            let def_level = self.checkout_def(DefinitionInterpretation::NullableItem);
+            self.do_record_validity(validity, def_level);
+        } else {
+            self.checkout_def(DefinitionInterpretation::AllValidItem);
+        }
+    }
+
     fn build(self) -> SerializedRepDefs {
-        SerializedRepDefs {
-            definition_levels: if self.has_nulls {
-                Some(self.def_levels)
-            } else {
-                None
-            },
-            repetition_levels: if self.current_rep > 1 {
-                Some(self.rep_levels)
-            } else {
-                None
-            },
+        let definition_levels = if self.has_nulls {
+            Some(self.def_levels)
+        } else {
+            None
+        };
+        let repetition_levels = if self.current_rep > 1 {
+            Some(self.rep_levels)
+        } else {
+            None
+        };
+        SerializedRepDefs::new(
+            repetition_levels,
+            definition_levels,
+            self.specials,
+            self.def_meaning,
+        )
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+enum SpecialOffset {
+    NullList(usize),
+    EmptyList(usize),
+}
+
+impl SpecialOffset {
+    fn pos(&self) -> usize {
+        match self {
+            Self::NullList(pos) => *pos,
+            Self::EmptyList(pos) => *pos,
         }
     }
 }
@@ -268,7 +701,7 @@ impl SerializerContext {
 /// As we are encoding the structural encoders are given this struct and
 /// will record the arrow information into it.  Once we hit a leaf node we
 /// serialize the data into rep/def levels and write these into the page.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Debug)]
 pub struct RepDefBuilder {
     // The rep/def info we have collected so far
     repdefs: Vec<RawRepDef>,
@@ -291,10 +724,12 @@ impl RepDefBuilder {
         self.repdefs.len()
     }
 
+    /// The builder is "empty" if there is no repetition and no nulls.  In this case we don't need
+    /// to store anything to disk (except the description)
     fn is_empty(&self) -> bool {
         self.repdefs
             .iter()
-            .all(|r| matches!(r, RawRepDef::NoNull(_)))
+            .all(|r| matches!(r, RawRepDef::Validity(ValidityDesc { validity: None, .. })))
     }
 
     /// Returns true if there is only a single layer of definition
@@ -307,21 +742,38 @@ impl RepDefBuilder {
     /// Return False if all layers are non-null (the def levels can
     /// be skipped in this case)
     pub fn has_nulls(&self) -> bool {
+        self.repdefs.iter().any(|rd| {
+            matches!(
+                rd,
+                RawRepDef::Validity(ValidityDesc {
+                    validity: Some(_),
+                    ..
+                })
+            )
+        })
+    }
+
+    pub fn has_offsets(&self) -> bool {
         self.repdefs
             .iter()
-            .any(|rd| matches!(rd, RawRepDef::Validity(_)))
+            .any(|rd| matches!(rd, RawRepDef::Offsets(OffsetDesc { .. })))
     }
 
     /// Registers a nullable validity bitmap
     pub fn add_validity_bitmap(&mut self, validity: NullBuffer) {
         self.check_validity_len(&validity);
-        self.repdefs
-            .push(RawRepDef::Validity(validity.into_inner()));
+        self.repdefs.push(RawRepDef::Validity(ValidityDesc {
+            num_values: validity.len(),
+            validity: Some(validity.into_inner()),
+        }));
     }
 
     /// Registers an all-valid validity layer
     pub fn add_no_null(&mut self, len: usize) {
-        self.repdefs.push(RawRepDef::NoNull(len));
+        self.repdefs.push(RawRepDef::Validity(ValidityDesc {
+            validity: None,
+            num_values: len,
+        }));
     }
 
     fn check_offset_len(&mut self, offsets: &[i64]) {
@@ -335,91 +787,269 @@ impl RepDefBuilder {
     ///
     /// Note: a List/LargeList/etc. array has both offsets and validity.  The
     /// caller should register the validity before registering the offsets
-    pub fn add_offsets<O: OffsetSizeTrait>(&mut self, repetition: OffsetBuffer<O>) {
+    pub fn add_offsets<O: OffsetSizeTrait>(
+        &mut self,
+        repetition: OffsetBuffer<O>,
+        validity: Option<NullBuffer>,
+    ) {
         // We should be able to zero-copy
         if O::IS_LARGE {
             let inner = repetition.into_inner();
             let len = inner.len();
             let i64_buff = ScalarBuffer::new(inner.into_inner(), 0, len);
             let offsets = Vec::from(i64_buff);
+            let mut specials = Vec::new();
+            let mut has_empty_lists = false;
+            if let Some(validity) = validity.as_ref() {
+                for (idx, (_, valid)) in offsets
+                    .windows(2)
+                    .zip(validity.iter())
+                    .enumerate()
+                    .filter(|(_, (off, _))| off[0] == off[1])
+                {
+                    if valid {
+                        has_empty_lists = true;
+                        specials.push(SpecialOffset::EmptyList(idx));
+                    } else {
+                        specials.push(SpecialOffset::NullList(idx));
+                    }
+                }
+            } else {
+                for (idx, _) in offsets
+                    .windows(2)
+                    .enumerate()
+                    .filter(|(_, off)| off[0] == off[1])
+                {
+                    has_empty_lists = true;
+                    specials.push(SpecialOffset::EmptyList(idx));
+                }
+            };
             self.check_offset_len(&offsets);
-            self.repdefs.push(RawRepDef::Offsets(offsets.into()));
+            self.repdefs.push(RawRepDef::Offsets(OffsetDesc {
+                num_values: offsets.len() - 1,
+                offsets: offsets.into(),
+                validity: validity.map(|v| v.into_inner()),
+                has_empty_lists,
+                specials: specials.into(),
+            }));
         } else {
             let inner = repetition.into_inner();
             let len = inner.len();
-            let casted = ScalarBuffer::<i32>::new(inner.into_inner(), 0, len)
-                .iter()
-                .copied()
-                .map(|o| o as i64)
-                .collect::<Vec<_>>();
+            let mut casted = Vec::with_capacity(len);
+            let mut has_empty_lists = false;
+            let mut specials = Vec::new();
+            if let Some(validity) = validity.as_ref() {
+                let scalar_off = ScalarBuffer::<i32>::new(inner.into_inner(), 0, len);
+                for (idx, (off, valid)) in scalar_off.windows(2).zip(validity.iter()).enumerate() {
+                    if off[0] == off[1] {
+                        if valid {
+                            has_empty_lists = true;
+                            specials.push(SpecialOffset::EmptyList(idx));
+                        } else {
+                            specials.push(SpecialOffset::NullList(idx));
+                        }
+                    }
+                    casted.push(off[0] as i64);
+                }
+                casted.push(*scalar_off.last().unwrap() as i64);
+            } else {
+                let scalar_off = ScalarBuffer::<i32>::new(inner.into_inner(), 0, len);
+                for (idx, off) in scalar_off.windows(2).enumerate() {
+                    if off[0] == off[1] {
+                        has_empty_lists = true;
+                        specials.push(SpecialOffset::EmptyList(idx));
+                    }
+                    casted.push(off[0] as i64);
+                }
+                casted.push(*scalar_off.last().unwrap() as i64);
+            };
             self.check_offset_len(&casted);
-            self.repdefs.push(RawRepDef::Offsets(casted.into()));
+            self.repdefs.push(RawRepDef::Offsets(OffsetDesc {
+                num_values: casted.len() - 1,
+                offsets: casted.into(),
+                validity: validity.map(|v| v.into_inner()),
+                has_empty_lists,
+                specials: specials.into(),
+            }));
         }
     }
 
-    // TODO: This is lazy.  We shouldn't need this concatenation pass.  We should be able
-    // to concatenate as we build up the rep/def levels but I'm saving that for a
-    // future optimization.
-    fn concat_layers<'a>(mut layers: impl Iterator<Item = &'a RawRepDef>, len: usize) -> RawRepDef {
-        let first = layers.next().unwrap();
-        match &first {
-            RawRepDef::NoNull(_) | RawRepDef::Validity(_) => {
-                // Also lazy, building up a validity buffer just to throw it away
-                // if there are no nulls
-                let mut has_nulls = false;
-                let mut builder = BooleanBufferBuilder::new(len);
-                for layer in std::iter::once(first).chain(layers) {
-                    match layer {
-                        RawRepDef::NoNull(num_valid) => {
-                            builder.append_n(*num_valid, true);
-                        }
-                        RawRepDef::Validity(validity) => {
-                            has_nulls = true;
-                            builder.append_buffer(validity);
-                        }
-                        _ => unreachable!(),
-                    }
-                }
-                if has_nulls {
-                    RawRepDef::Validity(builder.finish())
-                } else {
-                    RawRepDef::NoNull(builder.len())
-                }
+    // When we are encoding data it arrives in batches.  For each batch we create a RepDefBuilder and collect the
+    // various validity buffers and offset buffers from that batch.  Once we have enough batches to write a page we
+    // need to take this collection of RepDefBuilders and concatenate them and then serialize them into rep/def levels.
+    //
+    // TODO: In the future, we may concatenate and serialize at the same time?
+    //
+    // This method takes care of the concatenation part.  First we collect all of layer 0 from each builder, then we
+    // call this method.  Then we collect all of layer 1 from each builder and call this method.  And so on.
+    //
+    // That means this method should get a collection of `RawRepDef` where each item is the same kind (all validity or
+    // all offsets) though the nullability / lengths may be different in each layer.
+    fn concat_layers<'a>(
+        layers: impl Iterator<Item = &'a RawRepDef>,
+        num_layers: usize,
+    ) -> RawRepDef {
+        // We make two passes through the layers.  The first determines if we need to pay the cost of allocating
+        // buffers.  The second pass actually adds the values.
+        let mut collected = Vec::with_capacity(num_layers);
+        let mut has_nulls = false;
+        let mut is_offsets = false;
+        let mut num_specials = 0;
+        let mut all_has_empty_lists = false;
+        let mut all_num_values = 0;
+        for layer in layers {
+            has_nulls |= layer.has_nulls();
+            if let RawRepDef::Offsets(OffsetDesc {
+                specials,
+                has_empty_lists,
+                ..
+            }) = layer
+            {
+                all_has_empty_lists |= *has_empty_lists;
+                is_offsets = true;
+                num_specials += specials.len();
             }
-            RawRepDef::Offsets(offsets) => {
-                let mut all_offsets = Vec::with_capacity(len);
-                all_offsets.extend(offsets.iter().copied());
-                for layer in layers {
+            collected.push(layer);
+            all_num_values += layer.num_values();
+        }
+
+        // Shortcut if there are no nulls
+        if !has_nulls && !is_offsets {
+            return RawRepDef::Validity(ValidityDesc {
+                validity: None,
+                num_values: all_num_values,
+            });
+        }
+
+        // Only allocate if needed
+        let mut validity_builder = if has_nulls {
+            BooleanBufferBuilder::new(all_num_values)
+        } else {
+            BooleanBufferBuilder::new(0)
+        };
+        let mut all_offsets = if is_offsets {
+            let mut all_offsets = Vec::with_capacity(all_num_values);
+            all_offsets.push(0);
+            all_offsets
+        } else {
+            Vec::new()
+        };
+        let mut all_specials = Vec::with_capacity(num_specials);
+
+        for layer in collected {
+            match layer {
+                RawRepDef::Validity(ValidityDesc {
+                    validity: Some(validity),
+                    ..
+                }) => {
+                    validity_builder.append_buffer(validity);
+                }
+                RawRepDef::Validity(ValidityDesc {
+                    validity: None,
+                    num_values,
+                }) => {
+                    validity_builder.append_n(*num_values, true);
+                }
+                RawRepDef::Offsets(OffsetDesc {
+                    offsets,
+                    validity: Some(validity),
+                    has_empty_lists,
+                    specials,
+                    ..
+                }) => {
+                    all_has_empty_lists |= has_empty_lists;
+                    validity_builder.append_buffer(validity);
+                    let existing_lists = all_offsets.len() - 1;
                     let last = *all_offsets.last().unwrap();
-                    let RawRepDef::Offsets(offsets) = layer else {
-                        unreachable!()
-                    };
                     all_offsets.extend(offsets.iter().skip(1).map(|off| *off + last));
+                    all_specials.extend(specials.iter().map(|s| match s {
+                        SpecialOffset::NullList(pos) => {
+                            SpecialOffset::NullList(*pos + existing_lists)
+                        }
+                        SpecialOffset::EmptyList(pos) => {
+                            SpecialOffset::EmptyList(*pos + existing_lists)
+                        }
+                    }));
                 }
-                RawRepDef::Offsets(all_offsets.into())
+                RawRepDef::Offsets(OffsetDesc {
+                    offsets,
+                    validity: None,
+                    has_empty_lists,
+                    num_values,
+                    specials,
+                }) => {
+                    all_has_empty_lists |= has_empty_lists;
+                    if has_nulls {
+                        validity_builder.append_n(*num_values, true);
+                    }
+                    let last = *all_offsets.last().unwrap();
+                    let existing_lists = all_offsets.len() - 1;
+                    all_offsets.extend(offsets.iter().skip(1).map(|off| *off + last));
+                    all_specials.extend(specials.iter().map(|s| match s {
+                        SpecialOffset::NullList(pos) => {
+                            SpecialOffset::NullList(*pos + existing_lists)
+                        }
+                        SpecialOffset::EmptyList(pos) => {
+                            SpecialOffset::EmptyList(*pos + existing_lists)
+                        }
+                    }));
+                }
             }
+        }
+        let validity = if has_nulls {
+            Some(validity_builder.finish())
+        } else {
+            None
+        };
+        if all_offsets.is_empty() {
+            RawRepDef::Validity(ValidityDesc {
+                validity,
+                num_values: all_num_values,
+            })
+        } else {
+            RawRepDef::Offsets(OffsetDesc {
+                offsets: all_offsets.into(),
+                validity,
+                has_empty_lists: all_has_empty_lists,
+                num_values: all_num_values,
+                specials: all_specials.into(),
+            })
         }
     }
 
     /// Converts the validity / offsets buffers that have been gathered so far
     /// into repetition and definition levels
     pub fn serialize(builders: Vec<Self>) -> SerializedRepDefs {
-        if builders.is_empty() {
-            return SerializedRepDefs::empty();
-        }
+        assert!(!builders.is_empty());
         if builders.iter().all(|b| b.is_empty()) {
             // No repetition, all-valid
-            return SerializedRepDefs::empty();
+            return SerializedRepDefs::empty(
+                builders
+                    .first()
+                    .unwrap()
+                    .repdefs
+                    .iter()
+                    .map(|_| DefinitionInterpretation::AllValidItem)
+                    .collect::<Vec<_>>(),
+            );
         }
         let has_nulls = builders.iter().any(|b| b.has_nulls());
+        let has_offsets = builders.iter().any(|b| b.has_offsets());
         let total_len = builders.iter().map(|b| b.len.unwrap()).sum();
-        let mut context = SerializerContext::new(total_len, has_nulls);
+        let num_layers = builders[0].num_layers();
+        let mut context = SerializerContext::new(total_len, has_nulls, has_offsets, num_layers);
+        let combined_layers = (0..num_layers)
+            .map(|layer_index| {
+                Self::concat_layers(
+                    builders.iter().map(|b| &b.repdefs[layer_index]),
+                    builders.len(),
+                )
+            })
+            .collect::<Vec<_>>();
         debug_assert!(builders
             .iter()
             .all(|b| b.num_layers() == builders[0].num_layers()));
-        for layer_index in (0..builders[0].num_layers()).rev() {
-            let layer =
-                Self::concat_layers(builders.iter().map(|b| &b.repdefs[layer_index]), total_len);
+        for layer in combined_layers.into_iter().rev() {
             match layer {
                 RawRepDef::Validity(def) => {
                     context.record_validity(&def);
@@ -427,12 +1057,9 @@ impl RepDefBuilder {
                 RawRepDef::Offsets(rep) => {
                     context.record_offsets(&rep);
                 }
-                RawRepDef::NoNull(len) => {
-                    context.record_all_valid(len);
-                }
             }
         }
-        context.build()
+        context.build().collapse_specials()
     }
 }
 
@@ -444,37 +1071,146 @@ impl RepDefBuilder {
 pub struct RepDefUnraveler {
     rep_levels: Option<LevelBuffer>,
     def_levels: Option<LevelBuffer>,
+    // Maps from definition level to the rep level at which that definition level is visible
+    levels_to_rep: Vec<u16>,
+    def_meaning: Arc<[DefinitionInterpretation]>,
     // Current definition level to compare to.
     current_def_cmp: u16,
+    // Current rep level, determines which specials we can see
+    current_rep_cmp: u16,
+    // Current layer index, 0 means inner-most layer and it counts up from there.  Used to index
+    // into special_defs
+    current_layer: usize,
 }
 
 impl RepDefUnraveler {
     /// Creates a new unraveler from serialized repetition and definition information
-    pub fn new(rep_levels: Option<LevelBuffer>, def_levels: Option<LevelBuffer>) -> Self {
+    pub fn new(
+        rep_levels: Option<LevelBuffer>,
+        def_levels: Option<LevelBuffer>,
+        def_meaning: Arc<[DefinitionInterpretation]>,
+    ) -> Self {
+        let mut levels_to_rep = Vec::with_capacity(def_meaning.len());
+        let mut rep_counter = 0;
+        // Level=0 is always visible and means valid item
+        levels_to_rep.push(0);
+        for meaning in def_meaning.as_ref() {
+            match meaning {
+                DefinitionInterpretation::AllValidItem | DefinitionInterpretation::AllValidList => {
+                    // There is no corresponding level, so nothing to put in levels_to_rep
+                }
+                DefinitionInterpretation::NullableItem => {
+                    // Some null structs are not visible at inner rep levels in cases like LIST<STRUCT<LIST<...>>>
+                    levels_to_rep.push(rep_counter);
+                }
+                DefinitionInterpretation::NullableList => {
+                    rep_counter += 1;
+                    levels_to_rep.push(rep_counter);
+                }
+                DefinitionInterpretation::EmptyableList => {
+                    rep_counter += 1;
+                    levels_to_rep.push(rep_counter);
+                }
+                DefinitionInterpretation::NullableAndEmptyableList => {
+                    rep_counter += 1;
+                    levels_to_rep.push(rep_counter);
+                    levels_to_rep.push(rep_counter);
+                }
+            }
+        }
         Self {
             rep_levels,
             def_levels,
             current_def_cmp: 0,
+            current_rep_cmp: 0,
+            levels_to_rep,
+            current_layer: 0,
+            def_meaning,
         }
+    }
+
+    pub fn is_all_valid(&self) -> bool {
+        self.def_meaning[self.current_layer].is_all_valid()
+    }
+
+    /// If the current level is a repetition layer then this returns the number of lists
+    /// at this level.
+    ///
+    /// This is not valid to call when the current level is a struct/primitive layer because
+    /// in some cases there may be no rep or def information to know this.
+    pub fn max_lists(&self) -> usize {
+        debug_assert!(
+            self.def_meaning[self.current_layer] != DefinitionInterpretation::NullableItem
+        );
+        self.rep_levels
+            .as_ref()
+            // Worst case every rep item is max_rep and a new list
+            .map(|levels| levels.len())
+            .unwrap_or(0)
     }
 
     /// Unravels a layer of offsets from the unraveler into the given offset width
     ///
     /// When decoding a list the caller should first unravel the offsets and then
     /// unravel the validity (this is the opposite order used during encoding)
-    pub fn unravel_offsets<T: ArrowNativeType>(&mut self) -> Result<OffsetBuffer<T>> {
+    pub fn unravel_offsets<T: ArrowNativeType>(
+        &mut self,
+        offsets: &mut Vec<T>,
+        validity: Option<&mut BooleanBufferBuilder>,
+    ) -> Result<()> {
         let rep_levels = self
             .rep_levels
             .as_mut()
             .expect("Expected repetition level but data didn't contain repetition");
-        let mut offsets: Vec<T> = Vec::with_capacity(rep_levels.len() + 1);
-        let mut curlen: usize = 0;
+        let valid_level = self.current_def_cmp;
+        let (null_level, empty_level) = match self.def_meaning[self.current_layer] {
+            DefinitionInterpretation::NullableList => {
+                self.current_def_cmp += 1;
+                (valid_level + 1, 0)
+            }
+            DefinitionInterpretation::EmptyableList => {
+                self.current_def_cmp += 1;
+                (0, valid_level + 1)
+            }
+            DefinitionInterpretation::NullableAndEmptyableList => {
+                self.current_def_cmp += 2;
+                (valid_level + 1, valid_level + 2)
+            }
+            DefinitionInterpretation::AllValidList => (0, 0),
+            _ => unreachable!(),
+        };
+        let max_level = null_level.max(empty_level);
+        self.current_layer += 1;
+
+        let mut curlen: usize = offsets.last().map(|o| o.as_usize()).unwrap_or(0);
+
+        // If offsets is empty this is a no-op.  If offsets is not empty that means we already
+        // added a set of offsets.  For example, we might have added [0, 3, 5] (2 lists).  Now
+        // say we want to add [0, 1, 4] (2 lists).  We should get [0, 3, 5, 6, 9] (4 lists).  If
+        // we don't pop here we get [0, 3, 5, 5, 6, 9] which is wrong.
+        //
+        // Or, to think about it another way, if every unraveler adds the starting 0 and the trailing
+        // length then we have N + unravelers.len() values instead of N + 1.
+        offsets.pop();
+
         let to_offset = |val: usize| {
             T::from_usize(val)
             .ok_or_else(|| Error::invalid_input("A single batch had more than i32::MAX values and so a large container type is required", location!()))
         };
+        self.current_rep_cmp += 1;
+        println!(
+            "Unraveling offsets (mut validity={:?}) with curlen: {} and rep: {}",
+            validity, curlen, self.current_rep_cmp
+        );
         if let Some(def_levels) = &mut self.def_levels {
             assert!(rep_levels.len() == def_levels.len());
+            // It's possible validity is None even if we have def levels.  For example, we might have
+            // empty lists (which require def levels) but no nulls.
+            let mut push_validity: Box<dyn FnMut(bool) -> ()> = if let Some(validity) = validity {
+                Box::new(|is_valid| validity.append(is_valid))
+            } else {
+                Box::new(|_| {})
+            };
             // This is a strange access pattern.  We are iterating over the rep/def levels and
             // at the same time writing the rep/def levels.  This means we need both a mutable
             // and immutable reference to the rep/def levels.
@@ -486,25 +1222,48 @@ impl RepDefUnraveler {
                 unsafe {
                     let rep_val = *rep_levels.get_unchecked(read_idx);
                     if rep_val != 0 {
-                        // Finish the current list
-                        offsets.push(to_offset(curlen)?);
+                        let def_val = *def_levels.get_unchecked(read_idx);
+                        // Copy over
                         *rep_levels.get_unchecked_mut(write_idx) = rep_val - 1;
-                        *def_levels.get_unchecked_mut(write_idx) =
-                            *def_levels.get_unchecked(read_idx);
+                        *def_levels.get_unchecked_mut(write_idx) = def_val;
                         write_idx += 1;
+
+                        if def_val == 0 {
+                            // This is a valid list
+                            offsets.push(to_offset(curlen)?);
+                            curlen += 1;
+                            push_validity(true);
+                        } else if def_val > max_level {
+                            // This is not visible at this rep level, do not add to offsets, but keep in repdef
+                        } else if def_val == null_level {
+                            // This is a null list
+                            offsets.push(to_offset(curlen)?);
+                            push_validity(false);
+                        } else if def_val == empty_level {
+                            // This is an empty list
+                            offsets.push(to_offset(curlen)?);
+                            push_validity(true);
+                        } else {
+                            // New valid list starting with null item
+                            offsets.push(to_offset(curlen)?);
+                            curlen += 1;
+                            push_validity(true);
+                        }
+                    } else {
+                        curlen += 1;
                     }
-                    curlen += 1;
                     read_idx += 1;
                 }
             }
             offsets.push(to_offset(curlen)?);
-            rep_levels.truncate(offsets.len() - 1);
-            def_levels.truncate(offsets.len() - 1);
-            Ok(OffsetBuffer::new(ScalarBuffer::from(offsets)))
+            rep_levels.truncate(write_idx);
+            def_levels.truncate(write_idx);
+            Ok(())
         } else {
             // SAFETY: See above loop
             let mut read_idx = 0;
             let mut write_idx = 0;
+            let old_offsets_len = offsets.len();
             while read_idx < rep_levels.len() {
                 // SAFETY: read_idx / write_idx cannot go past rep_levels.len()
                 unsafe {
@@ -519,25 +1278,111 @@ impl RepDefUnraveler {
                     read_idx += 1;
                 }
             }
+            let num_new_lists = offsets.len() - old_offsets_len;
             offsets.push(to_offset(curlen)?);
             rep_levels.truncate(offsets.len() - 1);
-            Ok(OffsetBuffer::new(ScalarBuffer::from(offsets)))
+            if let Some(validity) = validity {
+                // Even though we don't have validity it is possible another unraveler did and so we need
+                // to push all valids
+                println!("Pushing {} auto-valids", num_new_lists);
+                validity.append_n(num_new_lists, true);
+            }
+            Ok(())
         }
     }
 
+    pub fn skip_validity(&mut self) {
+        debug_assert!(
+            self.def_meaning[self.current_layer] == DefinitionInterpretation::AllValidItem
+        );
+        self.current_layer += 1;
+    }
+
     /// Unravels a layer of validity from the definition levels
-    pub fn unravel_validity(&mut self) -> Option<NullBuffer> {
-        let Some(def_levels) = &self.def_levels else {
-            return None;
-        };
+    pub fn unravel_validity(&mut self, validity: &mut BooleanBufferBuilder) {
+        debug_assert!(
+            self.def_meaning[self.current_layer] != DefinitionInterpretation::AllValidItem
+        );
+        self.current_layer += 1;
+
+        let def_levels = &self.def_levels.as_ref().unwrap();
+
         let current_def_cmp = self.current_def_cmp;
         self.current_def_cmp += 1;
-        let validity = BooleanBuffer::from_iter(def_levels.iter().map(|&r| r <= current_def_cmp));
-        if validity.count_set_bits() == validity.len() {
+
+        for is_valid in def_levels.iter().filter_map(|&level| {
+            if self.levels_to_rep[level as usize] <= self.current_rep_cmp {
+                Some(level <= current_def_cmp)
+            } else {
+                None
+            }
+        }) {
+            validity.append(is_valid);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct CompositeRepDefUnraveler {
+    unravelers: Vec<RepDefUnraveler>,
+}
+
+impl CompositeRepDefUnraveler {
+    pub fn new(unravelers: Vec<RepDefUnraveler>) -> Self {
+        Self { unravelers }
+    }
+
+    pub fn unravel_validity(&mut self, num_values: usize) -> Option<NullBuffer> {
+        let is_all_valid = self
+            .unravelers
+            .iter()
+            .all(|unraveler| unraveler.is_all_valid());
+
+        if is_all_valid {
+            for unraveler in self.unravelers.iter_mut() {
+                unraveler.skip_validity();
+            }
             None
         } else {
-            Some(NullBuffer::new(validity))
+            let mut validity = BooleanBufferBuilder::new(num_values);
+            for unraveler in self.unravelers.iter_mut() {
+                unraveler.unravel_validity(&mut validity);
+            }
+            Some(NullBuffer::new(validity.finish()))
         }
+    }
+
+    pub fn unravel_offsets<T: ArrowNativeType>(
+        &mut self,
+    ) -> Result<(OffsetBuffer<T>, Option<NullBuffer>)> {
+        let mut is_all_valid = true;
+        let mut max_num_lists = 0;
+        for unraveler in self.unravelers.iter() {
+            is_all_valid &= unraveler.is_all_valid();
+            max_num_lists += unraveler.max_lists();
+        }
+
+        println!("Is all valid: {}", is_all_valid);
+
+        let mut validity = if is_all_valid {
+            None
+        } else {
+            println!("Making validity with up to {} elements", max_num_lists);
+            // Note: This is probably an over-estimate and potentially even an under-estimate.  We only know
+            // right now how many items we have and not how many rows.  (TODO: Shouldn't we know the # of rows?)
+            Some(BooleanBufferBuilder::new(max_num_lists))
+        };
+
+        let mut offsets = Vec::with_capacity(max_num_lists + 1);
+
+        for unraveler in self.unravelers.iter_mut() {
+            unraveler.unravel_offsets(&mut offsets, validity.as_mut())?;
+        }
+
+        Ok((
+            OffsetBuffer::new(ScalarBuffer::from(offsets)),
+            validity.map(|mut v| NullBuffer::new(v.finish())),
+        ))
     }
 }
 
@@ -646,17 +1491,32 @@ fn get_mask(width: u16) -> u16 {
 /// need two bytes.  In the worst case we need 4 bytes though this suggests hundreds of
 /// levels of nesting which seems unlikely to encounter in practice.
 #[derive(Debug)]
-pub enum ControlWordIterator {
-    Binary8(BinaryControlWordIterator<Zip<std::vec::IntoIter<u16>, std::vec::IntoIter<u16>>, u8>),
-    Binary16(BinaryControlWordIterator<Zip<std::vec::IntoIter<u16>, std::vec::IntoIter<u16>>, u16>),
-    Binary32(BinaryControlWordIterator<Zip<std::vec::IntoIter<u16>, std::vec::IntoIter<u16>>, u32>),
-    Unary8(UnaryControlWordIterator<std::vec::IntoIter<u16>, u8>),
-    Unary16(UnaryControlWordIterator<std::vec::IntoIter<u16>, u16>),
-    Unary32(UnaryControlWordIterator<std::vec::IntoIter<u16>, u32>),
+pub enum ControlWordIterator<'a> {
+    Binary8(
+        BinaryControlWordIterator<
+            Zip<Copied<std::slice::Iter<'a, u16>>, Copied<std::slice::Iter<'a, u16>>>,
+            u8,
+        >,
+    ),
+    Binary16(
+        BinaryControlWordIterator<
+            Zip<Copied<std::slice::Iter<'a, u16>>, Copied<std::slice::Iter<'a, u16>>>,
+            u16,
+        >,
+    ),
+    Binary32(
+        BinaryControlWordIterator<
+            Zip<Copied<std::slice::Iter<'a, u16>>, Copied<std::slice::Iter<'a, u16>>>,
+            u32,
+        >,
+    ),
+    Unary8(UnaryControlWordIterator<Copied<std::slice::Iter<'a, u16>>, u8>),
+    Unary16(UnaryControlWordIterator<Copied<std::slice::Iter<'a, u16>>, u16>),
+    Unary32(UnaryControlWordIterator<Copied<std::slice::Iter<'a, u16>>, u32>),
     Nilary(NilaryControlWordIterator),
 }
 
-impl ControlWordIterator {
+impl<'a> ControlWordIterator<'a> {
     /// Appends the next control word to the buffer
     pub fn append_next(&mut self, buf: &mut Vec<u8>) {
         match self {
@@ -713,12 +1573,12 @@ impl ControlWordIterator {
 /// Builds a [`ControlWordIterator`] from repetition and definition levels
 /// by first calculating the width needed and then creating the iterator
 /// with the appropriate width
-pub fn build_control_word_iterator(
-    rep: Option<Vec<u16>>,
+pub fn build_control_word_iterator<'a>(
+    rep: Option<&'a [u16]>,
     max_rep: u16,
-    def: Option<Vec<u16>>,
+    def: Option<&'a [u16]>,
     max_def: u16,
-) -> ControlWordIterator {
+) -> ControlWordIterator<'a> {
     let rep_width = if max_rep == 0 {
         0
     } else {
@@ -734,7 +1594,7 @@ pub fn build_control_word_iterator(
     let total_width = rep_width + def_width;
     match (rep, def) {
         (Some(rep), Some(def)) => {
-            let iter = rep.into_iter().zip(def);
+            let iter = rep.iter().copied().zip(def.iter().copied());
             let def_width = def_width as usize;
             if total_width <= 8 {
                 ControlWordIterator::Binary8(BinaryControlWordIterator {
@@ -769,7 +1629,7 @@ pub fn build_control_word_iterator(
             }
         }
         (Some(lev), None) => {
-            let iter = lev.into_iter();
+            let iter = lev.iter().copied();
             if total_width <= 8 {
                 ControlWordIterator::Unary8(UnaryControlWordIterator {
                     repdef: iter,
@@ -797,7 +1657,7 @@ pub fn build_control_word_iterator(
             }
         }
         (None, Some(lev)) => {
-            let iter = lev.into_iter();
+            let iter = lev.iter().copied();
             if total_width <= 8 {
                 ControlWordIterator::Unary8(UnaryControlWordIterator {
                     repdef: iter,
@@ -981,7 +1841,9 @@ impl ControlWordParser {
 mod tests {
     use arrow_buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
 
-    use crate::repdef::RepDefUnraveler;
+    use crate::repdef::{
+        CompositeRepDefUnraveler, DefinitionInterpretation, RepDefUnraveler, SerializedRepDefs,
+    };
 
     use super::RepDefBuilder;
 
@@ -998,13 +1860,17 @@ mod tests {
     }
 
     #[test]
-    fn test_repdef() {
+    fn test_repdef_basic() {
         // Basic case, rep & def
         let mut builder = RepDefBuilder::default();
-        builder.add_validity_bitmap(validity(&[true, false, true]));
-        builder.add_offsets(offsets_64(&[0, 2, 3, 5]));
-        builder.add_validity_bitmap(validity(&[true, true, true, false, true]));
-        builder.add_offsets(offsets_64(&[0, 1, 3, 5, 7, 9]));
+        builder.add_offsets(
+            offsets_64(&[0, 2, 2, 5]),
+            Some(validity(&[true, false, true])),
+        );
+        builder.add_offsets(
+            offsets_64(&[0, 1, 3, 5, 5, 9]),
+            Some(validity(&[true, true, true, false, true])),
+        );
         builder.add_validity_bitmap(validity(&[
             true, true, true, false, false, false, true, true, false,
         ]));
@@ -1013,71 +1879,152 @@ mod tests {
         let rep = repdefs.repetition_levels.unwrap();
         let def = repdefs.definition_levels.unwrap();
 
-        assert_eq!(vec![0, 0, 0, 3, 3, 2, 2, 0, 1], def);
-        assert_eq!(vec![2, 1, 0, 2, 0, 2, 0, 1, 0], rep);
+        assert_eq!(vec![0, 0, 0, 3, 1, 1, 2, 1, 0, 0, 1], *def);
+        assert_eq!(vec![2, 1, 0, 2, 2, 0, 1, 1, 0, 0, 0], *rep);
 
-        let mut unraveler = RepDefUnraveler::new(Some(rep), Some(def));
+        let mut unraveler = CompositeRepDefUnraveler::new(vec![RepDefUnraveler::new(
+            Some(rep.as_ref().to_vec()),
+            Some(def.as_ref().to_vec()),
+            repdefs.def_meaning.into(),
+        )]);
 
         // Note: validity doesn't exactly round-trip because repdef normalizes some of the
         // redundant validity values
         assert_eq!(
-            unraveler.unravel_validity(),
+            unraveler.unravel_validity(9),
             Some(validity(&[
-                true, true, true, false, false, false, false, true, false
+                true, true, true, false, false, false, true, true, false
             ]))
         );
-        assert_eq!(
-            unraveler.unravel_offsets::<i32>().unwrap().inner(),
-            offsets_32(&[0, 1, 3, 5, 7, 9]).inner()
+        let (off, val) = unraveler.unravel_offsets::<i32>().unwrap();
+        assert_eq!(off.inner(), offsets_32(&[0, 1, 3, 5, 5, 9]).inner());
+        assert_eq!(val, Some(validity(&[true, true, true, false, true])));
+        let (off, val) = unraveler.unravel_offsets::<i32>().unwrap();
+        assert_eq!(off.inner(), offsets_32(&[0, 2, 2, 5]).inner());
+        assert_eq!(val, Some(validity(&[true, false, true])));
+    }
+
+    #[test]
+    fn test_repdef_simple_null_empty_list() {
+        let check = |repdefs: SerializedRepDefs, last_def: DefinitionInterpretation| {
+            let rep = repdefs.repetition_levels.unwrap();
+            let def = repdefs.definition_levels.unwrap();
+
+            assert_eq!([1, 0, 1, 1, 0, 0], *rep);
+            assert_eq!([0, 0, 2, 0, 1, 0], *def);
+            assert!(repdefs.special_records.is_empty());
+            assert_eq!(
+                vec![DefinitionInterpretation::NullableItem, last_def,],
+                repdefs.def_meaning
+            );
+        };
+
+        // Null list and empty list should be serialized mostly the same
+
+        // Null case
+        let mut builder = RepDefBuilder::default();
+        builder.add_offsets(
+            offsets_32(&[0, 2, 2, 5]),
+            Some(validity(&[true, false, true])),
         );
-        assert_eq!(
-            unraveler.unravel_validity(),
-            Some(validity(&[true, true, false, false, true]))
+        builder.add_validity_bitmap(validity(&[true, true, true, false, true]));
+
+        let repdefs = RepDefBuilder::serialize(vec![builder]);
+
+        check(repdefs, DefinitionInterpretation::NullableList);
+
+        // Empty case
+        let mut builder = RepDefBuilder::default();
+        builder.add_offsets(offsets_32(&[0, 2, 2, 5]), None);
+        builder.add_validity_bitmap(validity(&[true, true, true, false, true]));
+
+        let repdefs = RepDefBuilder::serialize(vec![builder]);
+
+        check(repdefs, DefinitionInterpretation::EmptyableList);
+    }
+
+    #[test]
+    fn test_repdef_complex_null_empty() {
+        let mut builder = RepDefBuilder::default();
+        builder.add_offsets(
+            offsets_32(&[0, 4, 4, 4, 6]),
+            Some(validity(&[true, false, true, true])),
         );
-        assert_eq!(
-            unraveler.unravel_offsets::<i32>().unwrap().inner(),
-            offsets_32(&[0, 2, 3, 5]).inner()
+        builder.add_offsets(
+            offsets_32(&[0, 1, 1, 2, 2, 2, 3]),
+            Some(validity(&[true, false, true, false, true, true])),
         );
-        assert_eq!(
-            unraveler.unravel_validity(),
-            Some(validity(&[true, false, true]))
-        );
+        builder.add_no_null(3);
+
+        let repdefs = RepDefBuilder::serialize(vec![builder]);
+
+        let rep = repdefs.repetition_levels.unwrap();
+        let def = repdefs.definition_levels.unwrap();
+
+        assert_eq!([2, 1, 1, 1, 2, 2, 2, 1], *rep);
+        assert_eq!([0, 1, 0, 1, 3, 4, 2, 0], *def);
+    }
+
+    #[test]
+    fn test_repdef_empty_list_no_null() {
+        // Tests when we have some empty lists but no null lists.  This case
+        // caused some bugs because we have definition but no nulls
+        let mut builder = RepDefBuilder::default();
+        builder.add_offsets(offsets_32(&[0, 4, 4, 4, 6]), None);
+        builder.add_no_null(6);
+
+        let repdefs = RepDefBuilder::serialize(vec![builder]);
+
+        let rep = repdefs.repetition_levels.unwrap();
+        let def = repdefs.definition_levels.unwrap();
+
+        assert_eq!([1, 0, 0, 0, 1, 1, 1, 0], *rep);
+        assert_eq!([0, 0, 0, 0, 1, 1, 0, 0], *def);
+
+        let mut unraveler = CompositeRepDefUnraveler::new(vec![RepDefUnraveler::new(
+            Some(rep.as_ref().to_vec()),
+            Some(def.as_ref().to_vec()),
+            repdefs.def_meaning.into(),
+        )]);
+
+        assert_eq!(unraveler.unravel_validity(6), None);
+        let (off, val) = unraveler.unravel_offsets::<i32>().unwrap();
+        assert_eq!(off.inner(), offsets_32(&[0, 4, 4, 4, 6]).inner());
+        assert_eq!(val, None);
     }
 
     #[test]
     fn test_repdef_all_valid() {
         let mut builder = RepDefBuilder::default();
-        builder.add_no_null(3);
-        builder.add_offsets(offsets_64(&[0, 2, 3, 5]));
-        builder.add_no_null(5);
-        builder.add_offsets(offsets_64(&[0, 1, 3, 5, 7, 9]));
+        builder.add_offsets(offsets_64(&[0, 2, 3, 5]), None);
+        builder.add_offsets(offsets_64(&[0, 1, 3, 5, 7, 9]), None);
         builder.add_no_null(9);
 
         let repdefs = RepDefBuilder::serialize(vec![builder]);
         let rep = repdefs.repetition_levels.unwrap();
         assert!(repdefs.definition_levels.is_none());
 
-        assert_eq!(vec![2, 1, 0, 2, 0, 2, 0, 1, 0], rep);
+        assert_eq!([2, 1, 0, 2, 0, 2, 0, 1, 0], *rep);
 
-        let mut unraveler = RepDefUnraveler::new(Some(rep), None);
+        let mut unraveler = CompositeRepDefUnraveler::new(vec![RepDefUnraveler::new(
+            Some(rep.as_ref().to_vec()),
+            None,
+            repdefs.def_meaning.into(),
+        )]);
 
-        assert_eq!(unraveler.unravel_validity(), None);
-        assert_eq!(
-            unraveler.unravel_offsets::<i32>().unwrap().inner(),
-            offsets_32(&[0, 1, 3, 5, 7, 9]).inner()
-        );
-        assert_eq!(unraveler.unravel_validity(), None);
-        assert_eq!(
-            unraveler.unravel_offsets::<i32>().unwrap().inner(),
-            offsets_32(&[0, 2, 3, 5]).inner()
-        );
-        assert_eq!(unraveler.unravel_validity(), None);
+        assert_eq!(unraveler.unravel_validity(9), None);
+        let (off, val) = unraveler.unravel_offsets::<i32>().unwrap();
+        assert_eq!(off.inner(), offsets_32(&[0, 1, 3, 5, 7, 9]).inner());
+        assert_eq!(val, None);
+        let (off, val) = unraveler.unravel_offsets::<i32>().unwrap();
+        assert_eq!(off.inner(), offsets_32(&[0, 2, 3, 5]).inner());
+        assert_eq!(val, None);
     }
 
     #[test]
     fn test_repdef_no_rep() {
         let mut builder = RepDefBuilder::default();
-        builder.add_no_null(3);
+        builder.add_no_null(5);
         builder.add_validity_bitmap(validity(&[false, false, true, true, true]));
         builder.add_validity_bitmap(validity(&[false, true, true, true, false]));
 
@@ -1085,52 +2032,93 @@ mod tests {
         assert!(repdefs.repetition_levels.is_none());
         let def = repdefs.definition_levels.unwrap();
 
-        assert_eq!(vec![2, 2, 0, 0, 1], def);
+        assert_eq!([2, 2, 0, 0, 1], *def);
 
-        let mut unraveler = RepDefUnraveler::new(None, Some(def));
+        let mut unraveler = CompositeRepDefUnraveler::new(vec![RepDefUnraveler::new(
+            None,
+            Some(def.as_ref().to_vec()),
+            repdefs.def_meaning.into(),
+        )]);
 
         assert_eq!(
-            unraveler.unravel_validity(),
+            unraveler.unravel_validity(5),
             Some(validity(&[false, false, true, true, false]))
         );
         assert_eq!(
-            unraveler.unravel_validity(),
+            unraveler.unravel_validity(5),
             Some(validity(&[false, false, true, true, true]))
         );
-        assert_eq!(unraveler.unravel_validity(), None);
+        assert_eq!(unraveler.unravel_validity(5), None);
+    }
+
+    #[test]
+    fn test_composite_unravel() {
+        let mut builder = RepDefBuilder::default();
+        builder.add_offsets(
+            offsets_64(&[0, 2, 2, 5]),
+            Some(validity(&[true, false, true])),
+        );
+        let repdef1 = RepDefBuilder::serialize(vec![builder]);
+
+        let mut builder = RepDefBuilder::default();
+        builder.add_offsets(offsets_64(&[0, 1, 3, 5, 7, 9]), None);
+        let repdef2 = RepDefBuilder::serialize(vec![builder]);
+
+        let unravel1 = RepDefUnraveler::new(
+            repdef1.repetition_levels.map(|l| l.to_vec()),
+            repdef1.definition_levels.map(|l| l.to_vec()),
+            repdef1.def_meaning.into(),
+        );
+        let unravel2 = RepDefUnraveler::new(
+            repdef2.repetition_levels.map(|l| l.to_vec()),
+            repdef2.definition_levels.map(|l| l.to_vec()),
+            repdef2.def_meaning.into(),
+        );
+
+        let mut unraveler = CompositeRepDefUnraveler::new(vec![unravel1, unravel2]);
+
+        let (off, val) = unraveler.unravel_offsets::<i32>().unwrap();
+        assert_eq!(
+            off.inner(),
+            offsets_32(&[0, 2, 2, 5, 6, 8, 10, 12, 14]).inner()
+        );
+        assert_eq!(
+            val,
+            Some(validity(&[true, false, true, true, true, true, true, true]))
+        );
     }
 
     #[test]
     fn test_repdef_multiple_builders() {
         // Basic case, rep & def
         let mut builder1 = RepDefBuilder::default();
-        builder1.add_validity_bitmap(validity(&[true]));
-        builder1.add_offsets(offsets_64(&[0, 2]));
-        builder1.add_validity_bitmap(validity(&[true, true]));
-        builder1.add_offsets(offsets_64(&[0, 1, 3]));
+        builder1.add_offsets(offsets_64(&[0, 2]), None);
+        builder1.add_offsets(offsets_64(&[0, 1, 3]), None);
         builder1.add_validity_bitmap(validity(&[true, true, true]));
 
         let mut builder2 = RepDefBuilder::default();
-        builder2.add_validity_bitmap(validity(&[false, true]));
-        builder2.add_offsets(offsets_64(&[0, 1, 3]));
-        builder2.add_validity_bitmap(validity(&[true, false, true]));
-        builder2.add_offsets(offsets_64(&[0, 2, 4, 6]));
+        builder2.add_offsets(offsets_64(&[0, 0, 3]), Some(validity(&[false, true])));
+        builder2.add_offsets(
+            offsets_64(&[0, 2, 2, 6]),
+            Some(validity(&[true, false, true])),
+        );
         builder2.add_validity_bitmap(validity(&[false, false, false, true, true, false]));
 
         let repdefs = RepDefBuilder::serialize(vec![builder1, builder2]);
+
         let rep = repdefs.repetition_levels.unwrap();
         let def = repdefs.definition_levels.unwrap();
 
-        assert_eq!(vec![2, 1, 0, 2, 0, 2, 0, 1, 0], rep);
-        assert_eq!(vec![0, 0, 0, 3, 3, 2, 2, 0, 1], def);
+        assert_eq!([2, 1, 0, 2, 2, 0, 1, 1, 0, 0, 0], *rep);
+        assert_eq!([0, 0, 0, 3, 1, 1, 2, 1, 0, 0, 1], *def);
     }
 
     #[test]
     fn test_control_words() {
         // Convert to control words, verify expected, convert back, verify same as original
         fn check(
-            rep: Vec<u16>,
-            def: Vec<u16>,
+            rep: &[u16],
+            def: &[u16],
             expected_values: Vec<u8>,
             expected_bytes_per_word: usize,
             expected_bits_rep: u8,
@@ -1140,16 +2128,8 @@ mod tests {
             let max_rep = rep.iter().max().copied().unwrap_or(0);
             let max_def = def.iter().max().copied().unwrap_or(0);
 
-            let in_rep = if rep.is_empty() {
-                None
-            } else {
-                Some(rep.clone())
-            };
-            let in_def = if def.is_empty() {
-                None
-            } else {
-                Some(def.clone())
-            };
+            let in_rep = if rep.is_empty() { None } else { Some(rep) };
+            let in_def = if def.is_empty() { None } else { Some(def) };
 
             let mut iter = super::build_control_word_iterator(in_rep, max_rep, in_def, max_def);
             assert_eq!(iter.bytes_per_word(), expected_bytes_per_word);
@@ -1174,13 +2154,13 @@ mod tests {
                 }
             }
 
-            assert_eq!(rep, rep_out);
-            assert_eq!(def, def_out);
+            assert_eq!(rep.as_ref(), rep_out.as_slice());
+            assert_eq!(def.as_ref(), def_out.as_slice());
         }
 
         // Each will need 4 bits and so we should get 1-byte control words
-        let rep = vec![0_u16, 7, 3, 2, 9, 8, 12, 5];
-        let def = vec![5_u16, 3, 1, 2, 12, 15, 0, 2];
+        let rep = &[0_u16, 7, 3, 2, 9, 8, 12, 5];
+        let def = &[5_u16, 3, 1, 2, 12, 15, 0, 2];
         let expected = vec![
             0b00000101, // 0, 5
             0b01110011, // 7, 3
@@ -1194,8 +2174,8 @@ mod tests {
         check(rep, def, expected, 1, 4, 4);
 
         // Now we need 5 bits for def so we get 2-byte control words
-        let rep = vec![0_u16, 7, 3, 2, 9, 8, 12, 5];
-        let def = vec![5_u16, 3, 1, 2, 12, 22, 0, 2];
+        let rep = &[0_u16, 7, 3, 2, 9, 8, 12, 5];
+        let def = &[5_u16, 3, 1, 2, 12, 22, 0, 2];
         let expected = vec![
             0b00000101, 0b00000000, // 0, 5
             0b11100011, 0b00000000, // 7, 3
@@ -1209,7 +2189,7 @@ mod tests {
         check(rep, def, expected, 2, 4, 5);
 
         // Just rep, 4 bits so 1 byte each
-        let levels = vec![0_u16, 7, 3, 2, 9, 8, 12, 5];
+        let levels = &[0_u16, 7, 3, 2, 9, 8, 12, 5];
         let expected = vec![
             0b00000000, // 0
             0b00000111, // 7
@@ -1220,12 +2200,12 @@ mod tests {
             0b00001100, // 12
             0b00000101, // 5
         ];
-        check(levels.clone(), Vec::default(), expected.clone(), 1, 4, 0);
+        check(levels, &[], expected.clone(), 1, 4, 0);
 
         // Just def
-        check(Vec::default(), levels, expected, 1, 0, 4);
+        check(&[], levels, expected, 1, 0, 4);
 
         // No rep, no def, no bytes
-        check(Vec::default(), Vec::default(), Vec::default(), 0, 0, 0);
+        check(&[], &[], Vec::default(), 0, 0, 0);
     }
 }

--- a/rust/lance-encoding/src/repdef.rs
+++ b/rust/lance-encoding/src/repdef.rs
@@ -1540,7 +1540,7 @@ pub enum ControlWordIterator<'a> {
     Nilary(NilaryControlWordIterator),
 }
 
-impl<'a> ControlWordIterator<'a> {
+impl ControlWordIterator<'_> {
     /// Appends the next control word to the buffer
     pub fn append_next(&mut self, buf: &mut Vec<u8>) {
         match self {

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -208,6 +208,13 @@ async fn test_decode(
             let expected_size = (batch_size as usize).min(expected.len() - offset);
             let expected = expected.slice(offset, expected_size);
             assert_eq!(expected.data_type(), actual.data_type());
+            if expected.len() != actual.len() {
+                panic!(
+                    "Mismatch in length expected {} but got {}",
+                    expected.len(),
+                    actual.len()
+                );
+            }
             if &expected != actual {
                 if let Ok(comparator) = make_comparator(&expected, &actual, SortOptions::default())
                 {


### PR DESCRIPTION
Empty & null lists are interesting.  If you have them then your final repetition & definition buffers will have more items than you have in your flattened array.  This fact required a considerably reworking in how we build and unravel rep/def buffers.

When building we record the position of the specials and then, when we serialize into rep/def buffers, we insert these special values.  When unraveling we need to deal with the fact that certain rep/def values are "invisible" to the current context in which we are unraveling.

In addition, we now need to start keeping track of the structure of each layer of repetition in the page metadata.  This helps us understand the meaning behind different definition levels later when we are unraveling.

This PR adds the changes to the rep/def utilities.  We still aren't actually using repetition levels at all yet.  That will come in future PRs.