### PR TITLE
ci: update python/Cargo.log on version bump

### DIFF
--- a/.github/workflows/bump-version/action.yml
+++ b/.github/workflows/bump-version/action.yml
@@ -24,6 +24,11 @@ runs:
       run: |
         cargo install cargo-workspaces --version 0.2.44
         cargo ws version --no-git-commit -y --exact --force 'lance*' ${{ inputs.part }}
+    - name: Update python lockfile
+      working-directory: python
+      shell: bash
+      run: |
+        cargo update -p lance
     - name: Bump java version
       working-directory: java
       shell: bash


### PR DESCRIPTION
When we create the version bump commit it currently updates the lock file `Cargo.lock` to point to the new versions.  I suspect it is the `cargo ws version --no-git-commit -y --exact --force 'lance*' ${{ inputs.part }}` command that does this.  However, we have two lock files, and `python/Cargo.lock` is not updated.  This PR adds a step to the version bump to also update `python/Cargo.lock`.