### PR TITLE
feat: allow blob in `write_fragments`

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2209,6 +2209,7 @@ class LanceDataset(pa.dataset.Dataset):
     def commit(
         base_uri: Union[str, Path, LanceDataset],
         operation: LanceOperation.BaseOperation,
+        blobs_op: Optional[LanceOperation.BaseOperation] = None,
         read_version: Optional[int] = None,
         commit_lock: Optional[CommitLock] = None,
         storage_options: Optional[Dict[str, str]] = None,
@@ -2320,10 +2321,10 @@ class LanceDataset(pa.dataset.Dataset):
                 "read_version is required for all operations except "
                 "Overwrite and Restore"
             )
-
         new_ds = _Dataset.commit(
             base_uri,
             operation,
+            blobs_op,
             read_version,
             commit_lock,
             storage_options=storage_options,
@@ -2591,10 +2592,8 @@ class LanceOperation:
         fragments: Iterable[FragmentMetadata]
 
         def __post_init__(self):
-            if not isinstance(self.new_schema, pa.Schema):
-                raise TypeError(
-                    f"schema must be pyarrow.Schema, got {type(self.new_schema)}"
-                )
+            if isinstance(self.new_schema, pa.Schema):
+                self.new_schema = LanceSchema.from_pyarrow(self.new_schema)
             LanceOperation._validate_fragments(self.fragments)
 
     @dataclass

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -277,6 +277,7 @@ class _Dataset:
     def commit(
         dest: str | _Dataset,
         operation: LanceOperation.BaseOperation,
+        blobs_op: Optional[LanceOperation.BaseOperation] = None,
         read_version: Optional[int] = None,
         commit_lock: Optional[CommitLock] = None,
         storage_options: Optional[Dict[str, str]] = None,
@@ -392,6 +393,17 @@ def _write_fragments(
     data_storage_version=Optional[str],
     storage_options=Optional[Dict[str, str]],
 ): ...
+def _write_fragments_transaction(
+    dataset_uri: str | Path | _Dataset,
+    reader: ReaderLike,
+    mode: str,
+    max_rows_per_file: int,
+    max_rows_per_group: int,
+    max_bytes_per_file: int,
+    progress: Optional[FragmentWriteProgress],
+    data_storage_version=Optional[str],
+    storage_options=Optional[Dict[str, str]],
+) -> Transaction: ...
 def _json_to_schema(schema_json: str) -> pa.Schema: ...
 def _schema_to_json(schema: pa.Schema) -> str: ...
 

--- a/python/python/tests/test_balanced.py
+++ b/python/python/tests/test_balanced.py
@@ -73,7 +73,7 @@ def test_write_fragments(balanced_dataset, tmp_path):
         transaction.blobs_op.new_schema, transaction.blobs_op.fragments
     )
 
-    ds = lance.LanceDataset.commit(
+    lance.LanceDataset.commit(
         tmp_path / "ds",
         operation,
         blobs_op=blob_operation,

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -357,7 +357,7 @@ def test_create_from_file(tmp_path):
         new_fragments=[frag],
     )
     op = LanceOperation.Rewrite(groups=[group], rewritten_indices=[])
-    dataset = lance.LanceDataset.commit(dataset.uri, op, dataset.version)
+    dataset = lance.LanceDataset.commit(dataset.uri, op, read_version=dataset.version)
 
     assert dataset.count_rows() == 1600
     assert len(dataset.get_fragments()) == 1

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -325,7 +325,7 @@ def test_create_from_file(tmp_path):
     frag = LanceFragment.create_from_file(fragment_name, dataset, 0)
     op = LanceOperation.Append([frag])
 
-    dataset = lance.LanceDataset.commit(dataset.uri, op, dataset.version)
+    dataset = lance.LanceDataset.commit(dataset.uri, op, read_version=dataset.version)
     frag = dataset.get_fragments()[0]
     assert frag.fragment_id == 0
 
@@ -339,7 +339,7 @@ def test_create_from_file(tmp_path):
     frag = LanceFragment.create_from_file(fragment_name, dataset, 0)
     op = LanceOperation.Append([frag])
 
-    dataset = lance.LanceDataset.commit(dataset.uri, op, dataset.version)
+    dataset = lance.LanceDataset.commit(dataset.uri, op, read_version=dataset.version)
     frag = dataset.get_fragments()[1]
     assert frag.fragment_id == 1
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1319,8 +1319,12 @@ impl Dataset {
             WriteDestination::Uri(dest.extract()?)
         };
 
-        let transaction =
-            Transaction::new(read_version.unwrap_or_default(), operation.0, blobs_op.map(|op| op.0), None);
+        let transaction = Transaction::new(
+            read_version.unwrap_or_default(),
+            operation.0,
+            blobs_op.map(|op| op.0),
+            None,
+        );
 
         let mut builder = CommitBuilder::new(dest)
             .enable_v2_manifest_paths(enable_v2_manifest_paths.unwrap_or(false))

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1287,10 +1287,11 @@ impl Dataset {
 
     #[allow(clippy::too_many_arguments)]
     #[staticmethod]
-    #[pyo3(signature = (dest, operation, read_version = None, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None))]
+    #[pyo3(signature = (dest, operation, blobs_op=None, read_version = None, commit_lock = None, storage_options = None, enable_v2_manifest_paths = None, detached = None, max_retries = None))]
     fn commit(
         dest: &Bound<PyAny>,
         operation: PyLance<Operation>,
+        blobs_op: Option<PyLance<Operation>>,
         read_version: Option<u64>,
         commit_lock: Option<&Bound<'_, PyAny>>,
         storage_options: Option<HashMap<String, String>>,
@@ -1319,7 +1320,7 @@ impl Dataset {
         };
 
         let transaction =
-            Transaction::new(read_version.unwrap_or_default(), operation.0, None, None);
+            Transaction::new(read_version.unwrap_or_default(), operation.0, blobs_op.map(|op| op.0), None);
 
         let mut builder = CommitBuilder::new(dest)
             .enable_v2_manifest_paths(enable_v2_manifest_paths.unwrap_or(false))

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -418,8 +418,6 @@ pub fn write_fragments_transaction(
         )?
         .map_err(|err| PyIOError::new_err(err.to_string()))?;
 
-    println!("written: {:?}", written);
-
     Ok(PyLance(written).to_object(reader.py()))
 }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -68,7 +68,7 @@ pub(crate) mod transaction;
 pub(crate) mod utils;
 
 pub use crate::arrow::{bfloat16_array, BFloat16};
-use crate::fragment::write_fragments;
+use crate::fragment::{write_fragments, write_fragments_transaction};
 pub use crate::tracing::{trace_to_chrome, TraceGuard};
 use crate::utils::Hnsw;
 use crate::utils::KMeans;
@@ -137,6 +137,7 @@ fn lance(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(bfloat16_array))?;
     m.add_wrapped(wrap_pyfunction!(write_dataset))?;
     m.add_wrapped(wrap_pyfunction!(write_fragments))?;
+    m.add_wrapped(wrap_pyfunction!(write_fragments_transaction))?;
     m.add_wrapped(wrap_pyfunction!(schema_to_json))?;
     m.add_wrapped(wrap_pyfunction!(json_to_schema))?;
     m.add_wrapped(wrap_pyfunction!(infer_tfrecord_schema))?;

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -126,6 +126,23 @@ impl ToPyObject for PyLance<&Operation> {
                     .expect("Failed to get Append class");
                 cls.call1((fragments,)).unwrap().to_object(py)
             }
+            Operation::Overwrite {
+                ref fragments,
+                ref schema,
+                ..
+            } => {
+                let fragments_py = export_vec(py, fragments.as_slice());
+
+                let schema_py = LanceSchema(schema.clone());
+
+                let cls = namespace
+                    .getattr("Overwrite")
+                    .expect("Failed to get Overwrite class");
+
+                cls.call1((schema_py, fragments_py))
+                    .expect("Failed to create Overwrite instance")
+                    .to_object(py)
+            }
             _ => todo!(),
         }
     }


### PR DESCRIPTION
Allow user use `write_fragments` for lance with blob storage class by returning a nullable list of blob ops