### PR TITLE
fix: correctly copy null buffer when making deep copy

### DIFF
--- a/rust/lance-arrow/src/deepcopy.rs
+++ b/rust/lance-arrow/src/deepcopy.rs
@@ -4,22 +4,28 @@
 use std::sync::Arc;
 
 use arrow_array::{make_array, Array, RecordBatch};
-use arrow_buffer::{Buffer, NullBuffer};
-use arrow_data::ArrayData;
+use arrow_buffer::{BooleanBuffer, Buffer, NullBuffer};
+use arrow_data::{ArrayData, ArrayDataBuilder};
 
 pub fn deep_copy_buffer(buffer: &Buffer) -> Buffer {
     Buffer::from(buffer.as_slice())
 }
 
-fn deep_copy_nulls(nulls: &NullBuffer) -> Buffer {
-    deep_copy_buffer(nulls.inner().inner())
+fn deep_copy_nulls(nulls: Option<&NullBuffer>) -> Option<NullBuffer> {
+    let nulls = nulls?;
+    let bit_buffer = deep_copy_buffer(nulls.inner().inner());
+    Some(unsafe {
+        NullBuffer::new_unchecked(
+            BooleanBuffer::new(bit_buffer, nulls.offset(), nulls.len()),
+            nulls.null_count(),
+        )
+    })
 }
 
 pub fn deep_copy_array_data(data: &ArrayData) -> ArrayData {
     let data_type = data.data_type().clone();
     let len = data.len();
-    let null_count = data.null_count();
-    let null_bit_buffer = data.nulls().map(deep_copy_nulls);
+    let nulls = deep_copy_nulls(data.nulls());
     let offset = data.offset();
     let buffers = data
         .buffers()
@@ -32,15 +38,13 @@ pub fn deep_copy_array_data(data: &ArrayData) -> ArrayData {
         .map(deep_copy_array_data)
         .collect::<Vec<_>>();
     unsafe {
-        ArrayData::new_unchecked(
-            data_type,
-            len,
-            Some(null_count),
-            null_bit_buffer,
-            offset,
-            buffers,
-            child_data,
-        )
+        ArrayDataBuilder::new(data_type)
+            .len(len)
+            .nulls(nulls)
+            .offset(offset)
+            .buffers(buffers)
+            .child_data(child_data)
+            .build_unchecked()
     }
 }
 
@@ -57,4 +61,26 @@ pub fn deep_copy_batch(batch: &RecordBatch) -> crate::Result<RecordBatch> {
         .map(|array| deep_copy_array(array))
         .collect::<Vec<_>>();
     RecordBatch::try_new(batch.schema(), arrays)
+}
+
+#[cfg(test)]
+pub mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{Array, Int32Array};
+
+    #[test]
+    fn test_deep_copy_sliced_array_with_nulls() {
+        let array = Arc::new(Int32Array::from(vec![
+            Some(1),
+            None,
+            Some(3),
+            None,
+            Some(5),
+        ]));
+        let sliced_array = array.slice(1, 3);
+        let copied_array = super::deep_copy_array(&sliced_array);
+        assert_eq!(sliced_array.len(), copied_array.len());
+        assert_eq!(sliced_array.nulls(), copied_array.nulls());
+    }
 }

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -1469,7 +1469,7 @@ mod tests {
     use lance_datagen::{array, ArrayGeneratorExt, RowCount, DEFAULT_SEED};
     use rand::SeedableRng;
 
-    use crate::{buffer::LanceBuffer, data};
+    use crate::buffer::LanceBuffer;
 
     use super::{AllNullDataBlock, DataBlock};
 

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -1461,7 +1461,7 @@ mod tests {
     use arrow::datatypes::{Int32Type, Int8Type};
     use arrow_array::{
         make_array, new_null_array, ArrayRef, DictionaryArray, Int8Array, LargeBinaryArray,
-        StringArray, UInt8Array,
+        StringArray, UInt16Array, UInt8Array,
     };
     use arrow_buffer::{BooleanBuffer, NullBuffer};
 
@@ -1469,12 +1469,32 @@ mod tests {
     use lance_datagen::{array, ArrayGeneratorExt, RowCount, DEFAULT_SEED};
     use rand::SeedableRng;
 
-    use crate::buffer::LanceBuffer;
+    use crate::{buffer::LanceBuffer, data};
 
     use super::{AllNullDataBlock, DataBlock};
 
     use arrow::compute::concat;
     use arrow_array::Array;
+
+    #[test]
+    fn test_sliced_to_data_block() {
+        let ints = UInt16Array::from(vec![0, 1, 2, 3, 4, 5, 6, 7, 8]);
+        let ints = ints.slice(2, 4);
+        let data = DataBlock::from_array(ints);
+
+        let fixed_data = data.as_fixed_width().unwrap();
+        assert_eq!(fixed_data.num_values, 4);
+        assert_eq!(fixed_data.data.len(), 8);
+
+        let nullable_ints =
+            UInt16Array::from(vec![Some(0), None, Some(2), None, Some(4), None, Some(6)]);
+        let nullable_ints = nullable_ints.slice(1, 3);
+        let data = DataBlock::from_array(nullable_ints);
+
+        let nullable = data.as_nullable().unwrap();
+        assert_eq!(nullable.nulls, LanceBuffer::Owned(vec![0b00000010]));
+    }
+
     #[test]
     fn test_string_to_data_block() {
         // Converting string arrays that contain nulls to DataBlock


### PR DESCRIPTION
In some situations an array could be sliced in such a way that the array had no offset, but the array's null buffer did have an offset.  In these cases we were not deep copying the array correctly and the offset of the null buffer was lost.  This does mean, in some cases, the 2.0 writer could write incorrect nulls.  However, the input conditions would mean that the user's data would have to originate from rust in such a way that it was sliced like this.  It would be impossible for batches from the C data interface or from python to look like this.