### PR TITLE
fix: remove overzealous warning

### DIFF
--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -567,7 +567,6 @@ fn visit_comparison(
     } else {
         // Datafusion's query simplifier will canonicalize expressions and so we shouldn't reach this case.  If, for some reason, we
         // do reach this case we can handle it in the future by inverting expr.op and swapping the left and right sides
-        warn!("Unexpected comparison encountered (DF simplifier should have removed this case).  Scalar indices will not be applied");
         None
     }
 }


### PR DESCRIPTION
In the code parsing scalar expressions I am expecting binary expressions to follow a certain pattern (`column op scalar` and not `scalar op column`) and so I added a warning when I didn't see the pattern since that would mean my assumption was wrong and then I returned None.

However, the pattern I was expecting was a bit stricter than that (`indexed column op scalar`) and there are lots of cases where we might see `not indexed column op scalar` and yet returning `None` is exactly the right thing to do here so we're ok and don't need the warning.