### PR TITLE
fix: allow LANCE_LOG to be set to trace

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -326,7 +326,9 @@ class LanceDataset(pa.dataset.Dataset):
                     "refine_factor": 1
                 }
         batch_size: int, default None
-            The max size of batches returned.
+            The target size of batches returned.  In some cases batches can be up to
+            twice this size (but never larger than this).  In some cases batches can
+            be smaller than this size.
         io_buffer_size: int, default None
             The size of the IO buffer.  See ``ScannerBuilder.io_buffer_size``
             for more information.

--- a/python/python/lance/log.py
+++ b/python/python/lance/log.py
@@ -8,6 +8,13 @@ from typing import Optional
 ENV_NAME_PYLANCE_LOGGING_LEVEL = "LANCE_LOG"
 
 
+# Rust has 'trace' and Python does not so we map it to 'debug'
+def get_python_log_level(rust_log_level: str) -> str:
+    if rust_log_level.lower() == "trace":
+        return "DEBUG"
+    return rust_log_level
+
+
 def get_log_level():
     lance_log_level = os.environ.get(ENV_NAME_PYLANCE_LOGGING_LEVEL, "INFO").upper()
     if lance_log_level == "":
@@ -17,7 +24,7 @@ def get_log_level():
         entry for entry in lance_log_level.split(",") if "=" not in entry
     ]
     if len(lance_log_level) > 0:
-        return lance_log_level[0]
+        return get_python_log_level(lance_log_level[0])
     else:
         return "INFO"
 


### PR DESCRIPTION
Since we are now sharing `LANCE_LOG` with python logging and rust logging it was erroring out when the log level was set to `trace` since `trace` is not a valid python logging level.

In addition, I fix up the wording for the batch size, recognizing the fact that `CoalesceBatchesExec` (which we use in some filtering situations) could lead to batches larger than `batch_size`.