### PR TITLE
fix(rust): adjust scan range to avoid unnecessary warnings

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -486,9 +486,11 @@ def test_limit_offset(tmp_path: Path, data_storage_version: str):
 
     # test just limit
     assert dataset.to_table(limit=10) == table.slice(0, 10)
+    assert dataset.to_table(limit=100) == table.slice(0, 100)
 
     # test just offset
-    assert dataset.to_table(offset=10) == table.slice(10, 100)
+    assert dataset.to_table(offset=0) == table.slice(0, 100)
+    assert dataset.to_table(offset=10) == table.slice(10, 90)
 
     # test both
     assert dataset.to_table(offset=10, limit=10) == table.slice(10, 10)
@@ -503,7 +505,18 @@ def test_limit_offset(tmp_path: Path, data_storage_version: str):
     assert dataset.to_table(offset=50, limit=25) == table.slice(50, 25)
 
     # Limit past the end
-    assert dataset.to_table(offset=50, limit=100) == table.slice(50, 50)
+    assert dataset.to_table(limit=101) == table.slice(0, 100)
+
+    # Limit with offset past the end
+    assert dataset.to_table(offset=50, limit=51) == table.slice(50, 50)
+
+    # Offset past the end
+    assert dataset.to_table(offset=100) == table.slice(100, 0)  # Empty table
+    assert dataset.to_table(offset=101) == table.slice(100, 0)  # Empty table
+
+    # Offset with limit past the end
+    assert dataset.to_table(offset=100, limit=1) == table.slice(100, 0)  # Empty table
+    assert dataset.to_table(offset=101, limit=1) == table.slice(100, 0)  # Empty table
 
     # Invalid limit / offset
     with pytest.raises(ValueError, match="Offset must be non-negative"):


### PR DESCRIPTION
Fixes https://github.com/lancedb/lance/issues/3086

While adding test cases, I noticed that the following error would occur in the original code. But with this update, this is fixed too.

<details>

<summary>Error detail</summary>

#### Test case:
When the offset is specified as larger than the number of rows without a limit. (This test case is added in this change)
`test_limit_offset` in `python/tests/test_dataset.py`
```python
assert dataset.to_table(offset=101) == table.slice(100, 0)
```

#### Error message: 

The error occurs here when attempting to execute `100 - 101` as a `u64`.
https://github.com/lancedb/lance/blob/537d4e1fa83a899e0a1d5601cd1db6c508f5a046/rust/lance/src/io/exec/scan.rs#L154-L154



```
attempt to subtract with overflow
thread 'dataset::scanner::test::test_limit::data_storage_version_1_LanceFileVersion__Stable' panicked at rust/lance/src/io/exec/scan.rs:154:36:
attempt to subtract with overflow
stack backtrace:
   0: rust_begin_unwind
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_fmt
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panicking.rs:72:14
   2: core::panicking::panic
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/panicking.rs:145:5
   3: lance::io::exec::scan::LanceStream::try_new_v2
             at ./src/io/exec/scan.rs:154:36
   4: lance::io::exec::scan::LanceStream::try_new
             at ./src/io/exec/scan.rs:104:13
   5: <lance::io::exec::scan::LanceScanExec as datafusion_physical_plan::execution_plan::ExecutionPlan>::execute
             at ./src/io/exec/scan.rs:529:21
   6: lance_datafusion::exec::execute_plan
             at /Users/taka/Documents/GitHub/lance/rust/lance-datafusion/src/exec.rs:255:8
   7: lance::dataset::scanner::Scanner::try_into_stream::{{closure}}::{{closure}}
             at ./src/dataset/scanner.rs:948:42
   8: lance::dataset::scanner::Scanner::try_into_stream::{{closure}}
             at ./src/dataset/scanner.rs:945:5
   9: lance::dataset::scanner::Scanner::try_into_batch::{{closure}}
             at ./src/dataset/scanner.rs:963:45
  10: lance::dataset::scanner::test::test_limit::{{closure}}
             at ./src/dataset/scanner.rs:2524:14
  11: lance::dataset::scanner::test::test_limit::data_storage_version_1_LanceFileVersion__Stable::{{closure}}
             at ./src/dataset/scanner.rs:2509:5
  12: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/future/future.rs:123:9
  13: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/future/future.rs:123:9
  14: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}::{{closure}}
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/scheduler/current_thread/mod.rs:673:57
  15: tokio::runtime::coop::with_budget
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/coop.rs:107:5
  16: tokio::runtime::coop::budget
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/coop.rs:73:5
  17: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/scheduler/current_thread/mod.rs:673:25
  18: tokio::runtime::scheduler::current_thread::Context::enter
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/scheduler/current_thread/mod.rs:412:19
  19: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/scheduler/current_thread/mod.rs:672:36
  20: tokio::runtime::scheduler::current_thread::CoreGuard::enter::{{closure}}
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/scheduler/current_thread/mod.rs:751:68
  21: tokio::runtime::context::scoped::Scoped<T>::set
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/context/scoped.rs:40:9
  22: tokio::runtime::context::set_scheduler::{{closure}}
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/context.rs:180:26
  23: std::thread::local::LocalKey<T>::try_with
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/thread/local.rs:284:16
  24: std::thread::local::LocalKey<T>::with
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/std/src/thread/local.rs:260:9
  25: tokio::runtime::context::set_scheduler
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/context.rs:180:9
  26: tokio::runtime::scheduler::current_thread::CoreGuard::enter
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/scheduler/current_thread/mod.rs:751:27
  27: tokio::runtime::scheduler::current_thread::CoreGuard::block_on
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/scheduler/current_thread/mod.rs:660:19
  28: tokio::runtime::scheduler::current_thread::CurrentThread::block_on::{{closure}}
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/scheduler/current_thread/mod.rs:180:28
  29: tokio::runtime::context::runtime::enter_runtime
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/context/runtime.rs:65:16
  30: tokio::runtime::scheduler::current_thread::CurrentThread::block_on
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/scheduler/current_thread/mod.rs:168:9
  31: tokio::runtime::runtime::Runtime::block_on_inner
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/runtime.rs:361:47
  32: tokio::runtime::runtime::Runtime::block_on
             at /Users/taka/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/runtime.rs:335:13
  33: lance::dataset::scanner::test::test_limit::data_storage_version_1_LanceFileVersion__Stable
             at ./src/dataset/scanner.rs:2509:5
  34: lance::dataset::scanner::test::test_limit::data_storage_version_1_LanceFileVersion__Stable::{{closure}}
             at ./src/dataset/scanner.rs:2514:10
  35: core::ops::function::FnOnce::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ops/function.rs:250:5
  36: core::ops::function::FnOnce::call_once
             at /rustc/9b00956e56009bab2aa15d7bff10916599e3d6d6/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


Process finished with exit code 101
```

</details>