### PR TITLE
feat(java): support limit and offset interface for spark connector

### DIFF
--- a/java/spark/src/main/java/com/lancedb/lance/spark/LanceDataset.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/LanceDataset.java
@@ -51,7 +51,7 @@ public class LanceDataset implements SupportsRead, SupportsWrite, SupportsMetada
         }
       };
 
-  LanceConfig options;
+  LanceConfig config;
   private final StructType sparkSchema;
 
   /**
@@ -61,18 +61,18 @@ public class LanceDataset implements SupportsRead, SupportsWrite, SupportsMetada
    * @param sparkSchema spark struct type
    */
   public LanceDataset(LanceConfig config, StructType sparkSchema) {
-    this.options = config;
+    this.config = config;
     this.sparkSchema = sparkSchema;
   }
 
   @Override
   public ScanBuilder newScanBuilder(CaseInsensitiveStringMap caseInsensitiveStringMap) {
-    return new LanceScanBuilder(sparkSchema, options);
+    return new LanceScanBuilder(sparkSchema, config);
   }
 
   @Override
   public String name() {
-    return this.options.getDatasetName();
+    return this.config.getDatasetName();
   }
 
   @Override
@@ -87,7 +87,7 @@ public class LanceDataset implements SupportsRead, SupportsWrite, SupportsMetada
 
   @Override
   public WriteBuilder newWriteBuilder(LogicalWriteInfo logicalWriteInfo) {
-    return new SparkWrite.SparkWriteBuilder(sparkSchema, options);
+    return new SparkWrite.SparkWriteBuilder(sparkSchema, config);
   }
 
   @Override

--- a/java/spark/src/main/java/com/lancedb/lance/spark/internal/LanceFragmentScanner.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/internal/LanceFragmentScanner.java
@@ -63,10 +63,10 @@ public class LanceFragmentScanner implements AutoCloseable {
       scanOptions.batchSize(SparkOptions.getBatchSize(config));
       scanOptions.withRowId(getWithRowId(inputPartition.getSchema()));
       if (inputPartition.getLimit().isPresent()) {
-        scanOptions.limit(inputPartition.getLimit().getAsInt());
+        scanOptions.limit(inputPartition.getLimit().get());
       }
       if (inputPartition.getOffset().isPresent()) {
-        scanOptions.offset(inputPartition.getOffset().getAsInt());
+        scanOptions.offset(inputPartition.getOffset().get());
       }
       scanner = fragment.newScan(scanOptions.build());
     } catch (Throwable t) {

--- a/java/spark/src/main/java/com/lancedb/lance/spark/internal/LanceFragmentScanner.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/internal/LanceFragmentScanner.java
@@ -62,6 +62,12 @@ public class LanceFragmentScanner implements AutoCloseable {
       }
       scanOptions.batchSize(SparkOptions.getBatchSize(config));
       scanOptions.withRowId(getWithRowId(inputPartition.getSchema()));
+      if (inputPartition.getLimit().isPresent()) {
+        scanOptions.limit(inputPartition.getLimit().getAsInt());
+      }
+      if (inputPartition.getOffset().isPresent()) {
+        scanOptions.offset(inputPartition.getOffset().getAsInt());
+      }
       scanner = fragment.newScan(scanOptions.build());
     } catch (Throwable t) {
       if (scanner != null) {

--- a/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceInputPartition.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceInputPartition.java
@@ -20,6 +20,8 @@ import com.lancedb.lance.spark.utils.Optional;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.types.StructType;
 
+import java.util.OptionalInt;
+
 public class LanceInputPartition implements InputPartition {
   private static final long serialVersionUID = 4723894723984723984L;
 
@@ -28,6 +30,8 @@ public class LanceInputPartition implements InputPartition {
   private final LanceSplit lanceSplit;
   private final LanceConfig config;
   private final Optional<String> whereCondition;
+  private final OptionalInt limit;
+  private final OptionalInt offset;
 
   public LanceInputPartition(
       StructType schema,
@@ -40,6 +44,25 @@ public class LanceInputPartition implements InputPartition {
     this.lanceSplit = lanceSplit;
     this.config = config;
     this.whereCondition = whereCondition;
+    this.limit = OptionalInt.empty();
+    this.offset = OptionalInt.empty();
+  }
+
+  public LanceInputPartition(
+      StructType schema,
+      int partitionId,
+      LanceSplit lanceSplit,
+      LanceConfig config,
+      Optional<String> whereCondition,
+      OptionalInt limit,
+      OptionalInt offset) {
+    this.schema = schema;
+    this.partitionId = partitionId;
+    this.lanceSplit = lanceSplit;
+    this.config = config;
+    this.whereCondition = whereCondition;
+    this.limit = limit;
+    this.offset = offset;
   }
 
   public StructType getSchema() {
@@ -60,5 +83,13 @@ public class LanceInputPartition implements InputPartition {
 
   public Optional<String> getWhereCondition() {
     return whereCondition;
+  }
+
+  public OptionalInt getLimit() {
+    return limit;
+  }
+
+  public OptionalInt getOffset() {
+    return offset;
   }
 }

--- a/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceInputPartition.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceInputPartition.java
@@ -20,8 +20,6 @@ import com.lancedb.lance.spark.utils.Optional;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.types.StructType;
 
-import java.util.OptionalInt;
-
 public class LanceInputPartition implements InputPartition {
   private static final long serialVersionUID = 4723894723984723984L;
 
@@ -30,8 +28,8 @@ public class LanceInputPartition implements InputPartition {
   private final LanceSplit lanceSplit;
   private final LanceConfig config;
   private final Optional<String> whereCondition;
-  private final OptionalInt limit;
-  private final OptionalInt offset;
+  private final Optional<Integer> limit;
+  private final Optional<Integer> offset;
 
   public LanceInputPartition(
       StructType schema,
@@ -44,8 +42,8 @@ public class LanceInputPartition implements InputPartition {
     this.lanceSplit = lanceSplit;
     this.config = config;
     this.whereCondition = whereCondition;
-    this.limit = OptionalInt.empty();
-    this.offset = OptionalInt.empty();
+    this.limit = Optional.empty();
+    this.offset = Optional.empty();
   }
 
   public LanceInputPartition(
@@ -54,8 +52,8 @@ public class LanceInputPartition implements InputPartition {
       LanceSplit lanceSplit,
       LanceConfig config,
       Optional<String> whereCondition,
-      OptionalInt limit,
-      OptionalInt offset) {
+      Optional<Integer> limit,
+      Optional<Integer> offset) {
     this.schema = schema;
     this.partitionId = partitionId;
     this.lanceSplit = lanceSplit;
@@ -85,11 +83,11 @@ public class LanceInputPartition implements InputPartition {
     return whereCondition;
   }
 
-  public OptionalInt getLimit() {
+  public Optional<Integer> getLimit() {
     return limit;
   }
 
-  public OptionalInt getOffset() {
+  public Optional<Integer> getOffset() {
     return offset;
   }
 }

--- a/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScan.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScan.java
@@ -29,6 +29,7 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.stream.IntStream;
 
 public class LanceScan implements Batch, Scan, Serializable {
@@ -37,11 +38,20 @@ public class LanceScan implements Batch, Scan, Serializable {
   private final StructType schema;
   private final LanceConfig options;
   private final Optional<String> whereConditions;
+  private final OptionalInt limit;
+  private final OptionalInt offset;
 
-  public LanceScan(StructType schema, LanceConfig options, Optional<String> whereConditions) {
+  public LanceScan(
+      StructType schema,
+      LanceConfig options,
+      Optional<String> whereConditions,
+      OptionalInt limit,
+      OptionalInt offset) {
     this.schema = schema;
     this.options = options;
     this.whereConditions = whereConditions;
+    this.limit = limit;
+    this.offset = offset;
   }
 
   @Override
@@ -53,7 +63,10 @@ public class LanceScan implements Batch, Scan, Serializable {
   public InputPartition[] planInputPartitions() {
     List<LanceSplit> splits = LanceSplit.generateLanceSplits(options);
     return IntStream.range(0, splits.size())
-        .mapToObj(i -> new LanceInputPartition(schema, i, splits.get(i), options, whereConditions))
+        .mapToObj(
+            i ->
+                new LanceInputPartition(
+                    schema, i, splits.get(i), options, whereConditions, limit, offset))
         .toArray(InputPartition[]::new);
   }
 

--- a/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScan.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScan.java
@@ -29,7 +29,6 @@ import org.apache.spark.sql.vectorized.ColumnarBatch;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.OptionalInt;
 import java.util.stream.IntStream;
 
 public class LanceScan implements Batch, Scan, Serializable {
@@ -38,15 +37,15 @@ public class LanceScan implements Batch, Scan, Serializable {
   private final StructType schema;
   private final LanceConfig options;
   private final Optional<String> whereConditions;
-  private final OptionalInt limit;
-  private final OptionalInt offset;
+  private final Optional<Integer> limit;
+  private final Optional<Integer> offset;
 
   public LanceScan(
       StructType schema,
       LanceConfig options,
       Optional<String> whereConditions,
-      OptionalInt limit,
-      OptionalInt offset) {
+      Optional<Integer> limit,
+      Optional<Integer> offset) {
     this.schema = schema;
     this.options = options;
     this.whereConditions = whereConditions;

--- a/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScan.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScan.java
@@ -35,19 +35,19 @@ public class LanceScan implements Batch, Scan, Serializable {
   private static final long serialVersionUID = 947284762748623947L;
 
   private final StructType schema;
-  private final LanceConfig options;
+  private final LanceConfig config;
   private final Optional<String> whereConditions;
   private final Optional<Integer> limit;
   private final Optional<Integer> offset;
 
   public LanceScan(
       StructType schema,
-      LanceConfig options,
+      LanceConfig config,
       Optional<String> whereConditions,
       Optional<Integer> limit,
       Optional<Integer> offset) {
     this.schema = schema;
-    this.options = options;
+    this.config = config;
     this.whereConditions = whereConditions;
     this.limit = limit;
     this.offset = offset;
@@ -60,12 +60,12 @@ public class LanceScan implements Batch, Scan, Serializable {
 
   @Override
   public InputPartition[] planInputPartitions() {
-    List<LanceSplit> splits = LanceSplit.generateLanceSplits(options);
+    List<LanceSplit> splits = LanceSplit.generateLanceSplits(config);
     return IntStream.range(0, splits.size())
         .mapToObj(
             i ->
                 new LanceInputPartition(
-                    schema, i, splits.get(i), options, whereConditions, limit, offset))
+                    schema, i, splits.get(i), config, whereConditions, limit, offset))
         .toArray(InputPartition[]::new);
   }
 

--- a/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScanBuilder.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScanBuilder.java
@@ -25,8 +25,6 @@ import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructType;
 
-import java.util.OptionalInt;
-
 public class LanceScanBuilder
     implements SupportsPushDownRequiredColumns,
         SupportsPushDownFilters,
@@ -36,8 +34,8 @@ public class LanceScanBuilder
   private StructType schema;
 
   private Filter[] pushedFilters = new Filter[0];
-  private OptionalInt limit = OptionalInt.empty();
-  private OptionalInt offset = OptionalInt.empty();
+  private Optional<Integer> limit = Optional.empty();
+  private Optional<Integer> offset = Optional.empty();
 
   public LanceScanBuilder(StructType schema, LanceConfig config) {
     this.schema = schema;
@@ -75,13 +73,13 @@ public class LanceScanBuilder
 
   @Override
   public boolean pushLimit(int limit) {
-    this.limit = OptionalInt.of(limit);
+    this.limit = Optional.of(limit);
     return true;
   }
 
   @Override
   public boolean pushOffset(int offset) {
-    this.offset = OptionalInt.of(offset);
+    this.offset = Optional.of(offset);
     return true;
   }
 }

--- a/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScanBuilder.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScanBuilder.java
@@ -15,6 +15,7 @@
 package com.lancedb.lance.spark.read;
 
 import com.lancedb.lance.spark.LanceConfig;
+import com.lancedb.lance.spark.internal.LanceDatasetAdapter;
 import com.lancedb.lance.spark.utils.Optional;
 
 import org.apache.spark.sql.connector.read.Scan;
@@ -79,7 +80,12 @@ public class LanceScanBuilder
 
   @Override
   public boolean pushOffset(int offset) {
-    this.offset = Optional.of(offset);
-    return true;
+    // Only one data file can be pushed down the offset.
+    if (LanceDatasetAdapter.getFragmentIds(config).size() == 1) {
+      this.offset = Optional.of(offset);
+      return true;
+    } else {
+      return false;
+    }
   }
 }

--- a/java/spark/src/main/java/com/lancedb/lance/spark/write/SparkWrite.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/write/SparkWrite.java
@@ -44,17 +44,17 @@ public class SparkWrite implements Write {
 
   /** Task commit. */
   public static class SparkWriteBuilder implements WriteBuilder {
-    private final LanceConfig options;
+    private final LanceConfig config;
     private final StructType schema;
 
-    public SparkWriteBuilder(StructType schema, LanceConfig options) {
+    public SparkWriteBuilder(StructType schema, LanceConfig config) {
       this.schema = schema;
-      this.options = options;
+      this.config = config;
     }
 
     @Override
     public Write build() {
-      return new SparkWrite(schema, options);
+      return new SparkWrite(schema, config);
     }
   }
 }


### PR DESCRIPTION
Add the `SupportsPushDownLimit` and `SupportsPushDownOffset` interface for `LanceScanBuilder`.

When set the limit, lance spark scan will push it down the lance dataset.

When set the offset, lance spark scan will check the fragments first, only single fragment can push the offset down to the lance datasets since multi fragments has no meaning of offsets.

And rename all the LanceConfig fields from options into config.