### PR TITLE
feat(java): support topn pushdown in spark connector

### DIFF
--- a/java/core/lance-jni/src/blocking_scanner.rs
+++ b/java/core/lance-jni/src/blocking_scanner.rs
@@ -116,7 +116,7 @@ fn inner_create_scanner<'local>(
     query_obj: JObject,
     with_row_id: jboolean,
     batch_readahead: jint,
-    column_orderings: JObject
+    column_orderings: JObject,
 ) -> Result<JObject<'local>> {
     let fragment_ids_opt = env.get_ints_opt(&fragment_ids_obj)?;
     let dataset_guard =
@@ -209,7 +209,9 @@ fn inner_create_scanner<'local>(
     }
     scanner.batch_readahead(batch_readahead as usize);
 
-    let column_orders_is_present = env.call_method(&column_orderings, "isPresent", "()Z", &[])?.z()?;
+    let column_orders_is_present = env
+        .call_method(&column_orderings, "isPresent", "()Z", &[])?
+        .z()?;
     if column_orders_is_present {
         let java_obj = env
             .call_method(&column_orderings, "get", "()Ljava/lang/Object;", &[])?
@@ -226,7 +228,7 @@ fn inner_create_scanner<'local>(
             let col_order = ColumnOrdering {
                 ascending,
                 nulls_first,
-                column_name
+                column_name,
             };
             results.push(col_order)
         }

--- a/java/core/lance-jni/src/blocking_scanner.rs
+++ b/java/core/lance-jni/src/blocking_scanner.rs
@@ -221,7 +221,6 @@ fn inner_create_scanner<'local>(
         let mut iter = list.iter(env)?;
         let mut results = Vec::with_capacity(list.size(env)? as usize);
         while let Some(elem) = iter.next(env)? {
-            // Set column and key for nearest search
             let column_name = env.get_string_from_method(&elem, "getColumnName")?;
             let nulls_first = env.get_boolean_from_method(&elem, "isNullFirst")?;
             let ascending = env.get_boolean_from_method(&elem, "isAscending")?;

--- a/java/core/src/main/java/com/lancedb/lance/ipc/ColumnOrdering.java
+++ b/java/core/src/main/java/com/lancedb/lance/ipc/ColumnOrdering.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.lancedb.lance.ipc;
+
+import org.apache.arrow.util.Preconditions;
+
+import java.io.Serializable;
+
+public class ColumnOrdering implements Serializable {
+  private static final long serialVersionUID = 1L;
+  private final String columnName;
+  private final boolean nullFirst;
+  private final boolean ascending;
+
+  private ColumnOrdering(Builder builder) {
+    this.columnName = Preconditions.checkNotNull(builder.columnName, "Columns must be set");
+    Preconditions.checkArgument(!builder.columnName.isEmpty(), "Column must not be empty");
+    this.nullFirst = builder.nullFirst;
+    this.ascending = builder.ascending;
+  }
+
+  public String getColumnName() {
+    return columnName;
+  }
+
+  public boolean isNullFirst() {
+    return nullFirst;
+  }
+
+  public boolean isAscending() {
+    return ascending;
+  }
+
+  @Override
+  public String toString() {
+    return "ColumnOrdering{"
+        + "columnName='"
+        + columnName
+        + '\''
+        + ", nullFirst="
+        + nullFirst
+        + ", ascending="
+        + ascending
+        + '}';
+  }
+
+  public static class Builder {
+    private String columnName;
+    private boolean nullFirst = true;
+    private boolean ascending = true;
+
+    public void setColumnName(String columnName) {
+      this.columnName = columnName;
+    }
+
+    public void setNullFirst(boolean nullFirst) {
+      this.nullFirst = nullFirst;
+    }
+
+    public void setAscending(boolean ascending) {
+      this.ascending = ascending;
+    }
+
+    public ColumnOrdering build() {
+      return new ColumnOrdering(this);
+    }
+  }
+}

--- a/java/core/src/main/java/com/lancedb/lance/ipc/LanceScanner.java
+++ b/java/core/src/main/java/com/lancedb/lance/ipc/LanceScanner.java
@@ -70,7 +70,8 @@ public class LanceScanner implements org.apache.arrow.dataset.scanner.Scanner {
             options.getOffset(),
             options.getNearest(),
             options.isWithRowId(),
-            options.getBatchReadahead());
+            options.getBatchReadahead(),
+            options.getColumnOrderings());
     scanner.allocator = allocator;
     scanner.dataset = dataset;
     scanner.options = options;
@@ -88,7 +89,8 @@ public class LanceScanner implements org.apache.arrow.dataset.scanner.Scanner {
       Optional<Long> offset,
       Optional<Query> query,
       boolean withRowId,
-      int batchReadahead);
+      int batchReadahead,
+      Optional<List<ColumnOrdering>> columnOrderings);
 
   /**
    * Closes this scanner and releases any system resources associated with it. If the scanner is

--- a/java/core/src/main/java/com/lancedb/lance/ipc/ScanOptions.java
+++ b/java/core/src/main/java/com/lancedb/lance/ipc/ScanOptions.java
@@ -33,6 +33,7 @@ public class ScanOptions {
   private final Optional<Query> nearest;
   private final boolean withRowId;
   private final int batchReadahead;
+  private final Optional<List<ColumnOrdering>> columnOrderings;
 
   /**
    * Constructor for LanceScanOptions.
@@ -60,7 +61,8 @@ public class ScanOptions {
       Optional<Long> offset,
       Optional<Query> nearest,
       boolean withRowId,
-      int batchReadahead) {
+      int batchReadahead,
+      Optional<List<ColumnOrdering>> columnOrderings) {
     Preconditions.checkArgument(
         !(filter.isPresent() && substraitFilter.isPresent()),
         "cannot set both substrait filter and string filter");
@@ -74,6 +76,7 @@ public class ScanOptions {
     this.nearest = nearest;
     this.withRowId = withRowId;
     this.batchReadahead = batchReadahead;
+    this.columnOrderings = columnOrderings;
   }
 
   /**
@@ -166,6 +169,10 @@ public class ScanOptions {
     return batchReadahead;
   }
 
+  public Optional<List<ColumnOrdering>> getColumnOrderings() {
+    return columnOrderings;
+  }
+
   @Override
   public String toString() {
     return new ToStringBuilder(this)
@@ -181,6 +188,7 @@ public class ScanOptions {
         .append("nearest", nearest.orElse(null))
         .append("withRowId", withRowId)
         .append("batchReadahead", batchReadahead)
+        .append("columnOrdering", columnOrderings)
         .toString();
   }
 
@@ -196,6 +204,7 @@ public class ScanOptions {
     private Optional<Query> nearest = Optional.empty();
     private boolean withRowId = false;
     private int batchReadahead = 16;
+    private Optional<List<ColumnOrdering>> columnOrderings = Optional.empty();
 
     public Builder() {}
 
@@ -215,6 +224,7 @@ public class ScanOptions {
       this.nearest = options.getNearest();
       this.withRowId = options.isWithRowId();
       this.batchReadahead = options.getBatchReadahead();
+      this.columnOrderings = options.getColumnOrderings();
     }
 
     /**
@@ -327,6 +337,11 @@ public class ScanOptions {
       return this;
     }
 
+    public Builder setColumnOrderings(List<ColumnOrdering> columnOrderings) {
+      this.columnOrderings = Optional.of(columnOrderings);
+      return this;
+    }
+
     /**
      * Build the LanceScanOptions instance.
      *
@@ -343,7 +358,8 @@ public class ScanOptions {
           offset,
           nearest,
           withRowId,
-          batchReadahead);
+          batchReadahead,
+          columnOrderings);
     }
   }
 }

--- a/java/spark/src/main/java/com/lancedb/lance/spark/SparkOptions.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/SparkOptions.java
@@ -35,6 +35,7 @@ public class SparkOptions {
   private static final String max_rows_per_group = "max_rows_per_group";
   private static final String max_bytes_per_file = "max_bytes_per_file";
   private static final String batch_size = "batch_size";
+  private static final String topN_push_down = "topN_push_down";
 
   public static ReadOptions genReadOptionFromConfig(LanceConfig config) {
     ReadOptions.Builder builder = new ReadOptions.Builder();
@@ -93,5 +94,9 @@ public class SparkOptions {
       return Integer.parseInt(options.get(batch_size));
     }
     return 512;
+  }
+
+  public static boolean enableTopNPushDown(LanceConfig config) {
+    return Boolean.parseBoolean(config.getOptions().getOrDefault(topN_push_down, "true"));
   }
 }

--- a/java/spark/src/main/java/com/lancedb/lance/spark/internal/LanceFragmentScanner.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/internal/LanceFragmentScanner.java
@@ -68,6 +68,9 @@ public class LanceFragmentScanner implements AutoCloseable {
       if (inputPartition.getOffset().isPresent()) {
         scanOptions.offset(inputPartition.getOffset().get());
       }
+      if (inputPartition.getTopNSortOrders().isPresent()) {
+        scanOptions.setColumnOrderings(inputPartition.getTopNSortOrders().get());
+      }
       scanner = fragment.newScan(scanOptions.build());
     } catch (Throwable t) {
       if (scanner != null) {

--- a/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceInputPartition.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceInputPartition.java
@@ -14,11 +14,14 @@
 
 package com.lancedb.lance.spark.read;
 
+import com.lancedb.lance.ipc.ColumnOrdering;
 import com.lancedb.lance.spark.LanceConfig;
 import com.lancedb.lance.spark.utils.Optional;
 
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.types.StructType;
+
+import java.util.List;
 
 public class LanceInputPartition implements InputPartition {
   private static final long serialVersionUID = 4723894723984723984L;
@@ -30,6 +33,7 @@ public class LanceInputPartition implements InputPartition {
   private final Optional<String> whereCondition;
   private final Optional<Integer> limit;
   private final Optional<Integer> offset;
+  private final Optional<List<ColumnOrdering>> topNSortOrders;
 
   public LanceInputPartition(
       StructType schema,
@@ -44,6 +48,7 @@ public class LanceInputPartition implements InputPartition {
     this.whereCondition = whereCondition;
     this.limit = Optional.empty();
     this.offset = Optional.empty();
+    this.topNSortOrders = Optional.empty();
   }
 
   public LanceInputPartition(
@@ -61,6 +66,26 @@ public class LanceInputPartition implements InputPartition {
     this.whereCondition = whereCondition;
     this.limit = limit;
     this.offset = offset;
+    this.topNSortOrders = Optional.empty();
+  }
+
+  public LanceInputPartition(
+      StructType schema,
+      int partitionId,
+      LanceSplit lanceSplit,
+      LanceConfig config,
+      Optional<String> whereCondition,
+      Optional<Integer> limit,
+      Optional<Integer> offset,
+      Optional<List<ColumnOrdering>> topNSortOrders) {
+    this.schema = schema;
+    this.partitionId = partitionId;
+    this.lanceSplit = lanceSplit;
+    this.config = config;
+    this.whereCondition = whereCondition;
+    this.limit = limit;
+    this.offset = offset;
+    this.topNSortOrders = topNSortOrders;
   }
 
   public StructType getSchema() {
@@ -89,5 +114,9 @@ public class LanceInputPartition implements InputPartition {
 
   public Optional<Integer> getOffset() {
     return offset;
+  }
+
+  public Optional<List<ColumnOrdering>> getTopNSortOrders() {
+    return topNSortOrders;
   }
 }

--- a/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScan.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScan.java
@@ -14,6 +14,7 @@
 
 package com.lancedb.lance.spark.read;
 
+import com.lancedb.lance.ipc.ColumnOrdering;
 import com.lancedb.lance.spark.LanceConfig;
 import com.lancedb.lance.spark.utils.Optional;
 
@@ -24,14 +25,17 @@ import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReader;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
 import org.apache.spark.sql.connector.read.Scan;
+import org.apache.spark.sql.internal.connector.SupportsMetadata;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
+import scala.collection.immutable.Map;
+import scala.collection.mutable.HashMap;
 
 import java.io.Serializable;
 import java.util.List;
 import java.util.stream.IntStream;
 
-public class LanceScan implements Batch, Scan, Serializable {
+public class LanceScan implements Batch, Scan, SupportsMetadata, Serializable {
   private static final long serialVersionUID = 947284762748623947L;
 
   private final StructType schema;
@@ -39,18 +43,21 @@ public class LanceScan implements Batch, Scan, Serializable {
   private final Optional<String> whereConditions;
   private final Optional<Integer> limit;
   private final Optional<Integer> offset;
+  private final Optional<List<ColumnOrdering>> topNSortOrders;
 
   public LanceScan(
       StructType schema,
       LanceConfig config,
       Optional<String> whereConditions,
       Optional<Integer> limit,
-      Optional<Integer> offset) {
+      Optional<Integer> offset,
+      Optional<List<ColumnOrdering>> topNSortOrders) {
     this.schema = schema;
     this.config = config;
     this.whereConditions = whereConditions;
     this.limit = limit;
     this.offset = offset;
+    this.topNSortOrders = topNSortOrders;
   }
 
   @Override
@@ -65,7 +72,14 @@ public class LanceScan implements Batch, Scan, Serializable {
         .mapToObj(
             i ->
                 new LanceInputPartition(
-                    schema, i, splits.get(i), config, whereConditions, limit, offset))
+                    schema,
+                    i,
+                    splits.get(i),
+                    config,
+                    whereConditions,
+                    limit,
+                    offset,
+                    topNSortOrders))
         .toArray(InputPartition[]::new);
   }
 
@@ -77,6 +91,16 @@ public class LanceScan implements Batch, Scan, Serializable {
   @Override
   public StructType readSchema() {
     return schema;
+  }
+
+  @Override
+  public Map<String, String> getMetaData() {
+    HashMap<String, String> hashMap = new HashMap<>();
+    hashMap.put("whereConditions", whereConditions.toString());
+    hashMap.put("limit", limit.toString());
+    hashMap.put("offset", offset.toString());
+    hashMap.put("topNSortOrders", topNSortOrders.toString());
+    return hashMap.toMap(scala.Predef.conforms());
   }
 
   private class LanceReaderFactory implements PartitionReaderFactory {

--- a/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScanBuilder.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScanBuilder.java
@@ -108,7 +108,8 @@ public class LanceScanBuilder
 
   @Override
   public boolean pushTopN(SortOrder[] orders, int limit) {
-    // Oder by will use compute thread in lance. It's better to have an option to enable it.
+    // The Order by operator will use compute thread in lance.
+    // So it's better to have an option to enable it.
     if (!SparkOptions.enableTopNPushDown(this.config)) {
       return false;
     }

--- a/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScanBuilder.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/read/LanceScanBuilder.java
@@ -14,29 +14,41 @@
 
 package com.lancedb.lance.spark.read;
 
+import com.lancedb.lance.ipc.ColumnOrdering;
 import com.lancedb.lance.spark.LanceConfig;
+import com.lancedb.lance.spark.SparkOptions;
 import com.lancedb.lance.spark.internal.LanceDatasetAdapter;
 import com.lancedb.lance.spark.utils.Optional;
 
+import org.apache.spark.sql.connector.expressions.FieldReference;
+import org.apache.spark.sql.connector.expressions.NullOrdering;
+import org.apache.spark.sql.connector.expressions.SortDirection;
+import org.apache.spark.sql.connector.expressions.SortOrder;
 import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.SupportsPushDownFilters;
 import org.apache.spark.sql.connector.read.SupportsPushDownLimit;
 import org.apache.spark.sql.connector.read.SupportsPushDownOffset;
 import org.apache.spark.sql.connector.read.SupportsPushDownRequiredColumns;
+import org.apache.spark.sql.connector.read.SupportsPushDownTopN;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.types.StructType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class LanceScanBuilder
     implements SupportsPushDownRequiredColumns,
         SupportsPushDownFilters,
         SupportsPushDownLimit,
-        SupportsPushDownOffset {
+        SupportsPushDownOffset,
+        SupportsPushDownTopN {
   private final LanceConfig config;
   private StructType schema;
 
   private Filter[] pushedFilters = new Filter[0];
   private Optional<Integer> limit = Optional.empty();
   private Optional<Integer> offset = Optional.empty();
+  private Optional<List<ColumnOrdering>> topNSortOrders = Optional.empty();
 
   public LanceScanBuilder(StructType schema, LanceConfig config) {
     this.schema = schema;
@@ -46,7 +58,7 @@ public class LanceScanBuilder
   @Override
   public Scan build() {
     Optional<String> whereCondition = FilterPushDown.compileFiltersToSqlWhereClause(pushedFilters);
-    return new LanceScan(schema, config, whereCondition, limit, offset);
+    return new LanceScan(schema, config, whereCondition, limit, offset, topNSortOrders);
   }
 
   @Override
@@ -87,5 +99,33 @@ public class LanceScanBuilder
     } else {
       return false;
     }
+  }
+
+  @Override
+  public boolean isPartiallyPushed() {
+    return true;
+  }
+
+  @Override
+  public boolean pushTopN(SortOrder[] orders, int limit) {
+    // Oder by will use compute thread in lance. It's better to have an option to enable it.
+    if (!SparkOptions.enableTopNPushDown(this.config)) {
+      return false;
+    }
+    this.limit = Optional.of(limit);
+    List<ColumnOrdering> topNSortOrders = new ArrayList<>();
+    for (SortOrder sortOrder : orders) {
+      ColumnOrdering.Builder builder = new ColumnOrdering.Builder();
+      builder.setNullFirst(sortOrder.nullOrdering() == NullOrdering.NULLS_FIRST);
+      builder.setAscending(sortOrder.direction() == SortDirection.ASCENDING);
+      if (!(sortOrder.expression() instanceof FieldReference)) {
+        return false;
+      }
+      FieldReference reference = (FieldReference) sortOrder.expression();
+      builder.setColumnName(reference.fieldNames()[0]);
+      topNSortOrders.add(builder.build());
+    }
+    this.topNSortOrders = Optional.of(topNSortOrders);
+    return true;
   }
 }


### PR DESCRIPTION
In my test for 10M rows of ssb test suite for this sql

```sql
select * from lance_table order by lo_orderkey limit 10
```

| PushDown | NonPushDown |
| ---- | ---- |
| 3s    | 26s |

