### PR TITLE
fix: when taking struct fields they should be merged into the output in the correct order

### DIFF
--- a/python/python/tests/test_filter.py
+++ b/python/python/tests/test_filter.py
@@ -257,3 +257,12 @@ def test_duckdb(tmp_path):
     expected = duckdb.query("SELECT id, meta, price FROM ds").to_df()
     expected = expected[expected.meta == "aa"].reset_index(drop=True)
     tm.assert_frame_equal(actual, expected)
+
+
+def test_struct_field_order(tmp_path):
+    data = pa.table({"struct": [{"x": i, "y": i} for i in range(10)]})
+    dataset = lance.write_dataset(data, tmp_path)
+    result = dataset.to_table(filter="struct.y > 5")
+
+    expected = pa.table({"struct": [{"x": i, "y": i} for i in range(6, 10)]})
+    assert result == expected

--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -349,6 +349,17 @@ pub trait RecordBatchExt {
 
     /// Merge with another [`RecordBatch`] and returns a new one.
     ///
+    /// Fields are merged based on name.  First we iterate the left columns.  If a matching
+    /// name is found in the right then we merge the two columns.  If there is no match then
+    /// we add the left column to the output.
+    ///
+    /// To merge two columns we consider the type.  If both arrays are struct arrays we recurse.
+    /// Otherwise we use the left array.
+    ///
+    /// Afterwards we add all non-matching right columns to the output.
+    ///
+    /// Note: This method likely does not handle nested fields correctly and you may want to consider
+    /// using [`merge_with_schema`] instead.
     /// ```
     /// use std::sync::Arc;
     /// use arrow_array::*;
@@ -381,6 +392,17 @@ pub trait RecordBatchExt {
     ///
     /// TODO: add merge nested fields support.
     fn merge(&self, other: &RecordBatch) -> Result<RecordBatch>;
+
+    /// Create a batch by merging columns between two batches with a given schema.
+    ///
+    /// A reference schema is used to determine the proper ordering of nested fields.
+    ///
+    /// For each field in the reference schema we look for corresponding fields in
+    /// the left and right batches.  If a field is found in both batches we recursively merge
+    /// it.
+    ///
+    /// If a field is only in the left or right batch we take it as it is.
+    fn merge_with_schema(&self, other: &RecordBatch, schema: &Schema) -> Result<RecordBatch>;
 
     /// Drop one column specified with the name and return the new [`RecordBatch`].
     ///
@@ -448,6 +470,23 @@ impl RecordBatchExt for RecordBatch {
         let left_struct_array: StructArray = self.clone().into();
         let right_struct_array: StructArray = other.clone().into();
         self.try_new_from_struct_array(merge(&left_struct_array, &right_struct_array))
+    }
+
+    fn merge_with_schema(&self, other: &RecordBatch, schema: &Schema) -> Result<RecordBatch> {
+        if self.num_rows() != other.num_rows() {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "Attempt to merge two RecordBatch with different sizes: {} != {}",
+                self.num_rows(),
+                other.num_rows()
+            )));
+        }
+        let left_struct_array: StructArray = self.clone().into();
+        let right_struct_array: StructArray = other.clone().into();
+        self.try_new_from_struct_array(merge_with_schema(
+            &left_struct_array,
+            &right_struct_array,
+            schema.fields(),
+        ))
     }
 
     fn drop_column(&self, name: &str) -> Result<Self> {
@@ -542,7 +581,6 @@ fn project(struct_array: &StructArray, fields: &Fields) -> Result<StructArray> {
     StructArray::try_new(fields.clone(), columns, None)
 }
 
-/// Merge the fields and columns of two RecordBatch's recursively
 fn merge(left_struct_array: &StructArray, right_struct_array: &StructArray) -> StructArray {
     let mut fields: Vec<Field> = vec![];
     let mut columns: Vec<ArrayRef> = vec![];
@@ -612,6 +650,77 @@ fn merge(left_struct_array: &StructArray, right_struct_array: &StructArray) -> S
         .cloned()
         .map(Arc::new)
         .zip(columns.iter().cloned())
+        .collect::<Vec<_>>();
+    StructArray::from(zipped)
+}
+
+fn merge_with_schema(
+    left_struct_array: &StructArray,
+    right_struct_array: &StructArray,
+    fields: &Fields,
+) -> StructArray {
+    // Helper function that returns true if both types are struct or both are non-struct
+    fn same_type_kind(left: &DataType, right: &DataType) -> bool {
+        match (left, right) {
+            (DataType::Struct(_), DataType::Struct(_)) => true,
+            (DataType::Struct(_), _) => false,
+            (_, DataType::Struct(_)) => false,
+            _ => true,
+        }
+    }
+
+    let mut output_fields: Vec<Field> = Vec::with_capacity(fields.len());
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(fields.len());
+
+    let left_fields = left_struct_array.fields();
+    let left_columns = left_struct_array.columns();
+    let right_fields = right_struct_array.fields();
+    let right_columns = right_struct_array.columns();
+
+    for field in fields {
+        let left_match_idx = left_fields.iter().position(|f| {
+            f.name() == field.name() && same_type_kind(f.data_type(), field.data_type())
+        });
+        let right_match_idx = right_fields.iter().position(|f| {
+            f.name() == field.name() && same_type_kind(f.data_type(), field.data_type())
+        });
+
+        match (left_match_idx, right_match_idx) {
+            (None, Some(right_idx)) => {
+                output_fields.push(right_fields[right_idx].as_ref().clone());
+                columns.push(right_columns[right_idx].clone());
+            }
+            (Some(left_idx), None) => {
+                output_fields.push(left_fields[left_idx].as_ref().clone());
+                columns.push(left_columns[left_idx].clone());
+            }
+            (Some(left_idx), Some(right_idx)) => {
+                if let DataType::Struct(child_fields) = field.data_type() {
+                    let left_sub_array = left_columns[left_idx].as_struct();
+                    let right_sub_array = right_columns[right_idx].as_struct();
+                    let merged_sub_array =
+                        merge_with_schema(left_sub_array, right_sub_array, child_fields);
+                    output_fields.push(Field::new(
+                        field.name(),
+                        merged_sub_array.data_type().clone(),
+                        field.is_nullable(),
+                    ));
+                    columns.push(Arc::new(merged_sub_array) as ArrayRef);
+                } else {
+                    output_fields.push(left_fields[left_idx].as_ref().clone());
+                    columns.push(left_columns[left_idx].clone());
+                }
+            }
+            (None, None) => {
+                // The field will not be included in the output
+            }
+        }
+    }
+
+    let zipped: Vec<(FieldRef, ArrayRef)> = output_fields
+        .into_iter()
+        .map(Arc::new)
+        .zip(columns)
         .collect::<Vec<_>>();
     StructArray::from(zipped)
 }
@@ -721,7 +830,7 @@ impl BufferExt for arrow_buffer::Buffer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{Int32Array, StringArray};
+    use arrow_array::{new_empty_array, Int32Array, StringArray};
 
     #[test]
     fn test_merge_recursive() {
@@ -806,6 +915,52 @@ mod tests {
 
         let result = left_batch.merge(&right_batch).unwrap();
         assert_eq!(result, merged_batch);
+    }
+
+    #[test]
+    fn test_merge_with_schema() {
+        fn test_batch(names: &[&str], types: &[DataType]) -> (Schema, RecordBatch) {
+            let fields: Fields = names
+                .iter()
+                .zip(types)
+                .map(|(name, ty)| Field::new(name.to_string(), ty.clone(), false))
+                .collect();
+            let schema = Schema::new(vec![Field::new(
+                "struct",
+                DataType::Struct(fields.clone()),
+                false,
+            )]);
+            let children = types
+                .iter()
+                .map(|ty| new_empty_array(ty))
+                .collect::<Vec<_>>();
+            let batch = RecordBatch::try_new(
+                Arc::new(schema.clone()),
+                vec![Arc::new(StructArray::new(fields, children, None)) as ArrayRef],
+            );
+            (schema, batch.unwrap())
+        }
+
+        let (_, left_batch) = test_batch(&["a", "b"], &[DataType::Int32, DataType::Int64]);
+        let (_, right_batch) = test_batch(&["c", "b"], &[DataType::Int32, DataType::Int64]);
+        let (output_schema, _) = test_batch(
+            &["b", "a", "c"],
+            &[DataType::Int64, DataType::Int32, DataType::Int32],
+        );
+
+        // If we use merge_with_schema the schema is respected
+        let merged = left_batch
+            .merge_with_schema(&right_batch, &output_schema)
+            .unwrap();
+        assert_eq!(merged.schema().as_ref(), &output_schema);
+
+        // If we use merge we get first-come first-serve based on the left batch
+        let (naive_schema, _) = test_batch(
+            &["a", "b", "c"],
+            &[DataType::Int32, DataType::Int64, DataType::Int32],
+        );
+        let merged = left_batch.merge(&right_batch).unwrap();
+        assert_eq!(merged.schema().as_ref(), &naive_schema);
     }
 
     #[test]

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -19,10 +19,10 @@ mod schema;
 
 use crate::{Error, Result};
 pub use field::{
-    Encoding, Field, NullabilityComparison, SchemaCompareOptions, StorageClass,
+    Encoding, Field, NullabilityComparison, OnTypeMismatch, SchemaCompareOptions, StorageClass,
     LANCE_STORAGE_CLASS_SCHEMA_META_KEY,
 };
-pub use schema::Schema;
+pub use schema::{OnMissing, Projectable, Projection, Schema};
 
 pub const COMPRESSION_META_KEY: &str = "lance-encoding:compression";
 pub const COMPRESSION_LEVEL_META_KEY: &str = "lance-encoding:compression-level";

--- a/rust/lance/src/datafusion/logical_plan.rs
+++ b/rust/lance/src/datafusion/logical_plan.rs
@@ -13,6 +13,7 @@ use datafusion::{
     physical_plan::ExecutionPlan,
     prelude::Expr,
 };
+use lance_core::datatypes::{OnMissing, OnTypeMismatch};
 
 use crate::Dataset;
 
@@ -52,7 +53,11 @@ impl TableProvider for Dataset {
             if projection.len() != schema_ref.fields.len() {
                 let arrow_schema: ArrowSchema = schema_ref.into();
                 let arrow_schema = arrow_schema.project(projection)?;
-                schema_ref.project_by_schema(&arrow_schema)?
+                schema_ref.project_by_schema(
+                    &arrow_schema,
+                    OnMissing::Error,
+                    OnTypeMismatch::Error,
+                )?
             } else {
                 schema_ref.clone()
             }

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -18,7 +18,7 @@ use datafusion::logical_expr::Expr;
 use datafusion::scalar::ScalarValue;
 use futures::future::try_join_all;
 use futures::{join, stream, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
-use lance_core::datatypes::SchemaCompareOptions;
+use lance_core::datatypes::{OnMissing, OnTypeMismatch, SchemaCompareOptions};
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use lance_core::{datatypes::Schema, Error, Result};
@@ -754,9 +754,11 @@ impl FileFragment {
                     Some(&self.dataset.session.file_metadata_cache),
                 )
                 .await?;
-                let initialized_schema = reader
-                    .schema()
-                    .project_by_schema(schema_per_file.as_ref())?;
+                let initialized_schema = reader.schema().project_by_schema(
+                    schema_per_file.as_ref(),
+                    OnMissing::Error,
+                    OnTypeMismatch::Error,
+                )?;
                 let reader = V1Reader::new(reader, Arc::new(initialized_schema));
                 Ok(Some(Box::new(reader)))
             } else {

--- a/rust/lance/src/dataset/updater.rs
+++ b/rust/lance/src/dataset/updater.rs
@@ -3,6 +3,7 @@
 
 use arrow_array::{RecordBatch, UInt32Array};
 use futures::StreamExt;
+use lance_core::datatypes::{OnMissing, OnTypeMismatch};
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::{datatypes::Schema, Error, Result};
 use lance_table::format::Fragment;
@@ -182,12 +183,11 @@ impl Updater {
                 final_schema.set_field_id(Some(self.fragment.dataset().manifest.max_field_id()));
                 self.final_schema = Some(final_schema);
                 self.final_schema.as_ref().unwrap().validate()?;
-                self.write_schema = Some(
-                    self.final_schema
-                        .as_ref()
-                        .unwrap()
-                        .project_by_schema(output_schema.as_ref())?,
-                );
+                self.write_schema = Some(self.final_schema.as_ref().unwrap().project_by_schema(
+                    output_schema.as_ref(),
+                    OnMissing::Error,
+                    OnTypeMismatch::Error,
+                )?);
             }
 
             self.writer = Some(

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -458,12 +458,15 @@ impl MergeInsertJob {
             .dataset
             .empty_projection()
             .union_arrow_schema(schema.as_ref(), OnMissing::Error)?;
-        let mut target = Arc::new(TakeExec::try_new(
-            self.dataset.clone(),
-            index_mapper,
-            projection,
-            get_num_compute_intensive_cpus(),
-        )?) as Arc<dyn ExecutionPlan>;
+        let mut target = Arc::new(
+            TakeExec::try_new(
+                self.dataset.clone(),
+                index_mapper,
+                projection,
+                get_num_compute_intensive_cpus(),
+            )?
+            .unwrap(),
+        ) as Arc<dyn ExecutionPlan>;
 
         // 5 - Take puts the row id and row addr at the beginning.  A full scan (used when there is
         //     no scalar index) puts the row id and addr at the end.  We need to match these up so

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -54,7 +54,7 @@ use futures::{
     Stream, StreamExt, TryStreamExt,
 };
 use lance_core::{
-    datatypes::SchemaCompareOptions,
+    datatypes::{OnMissing, OnTypeMismatch, SchemaCompareOptions},
     error::{box_error, InvalidInputSnafu},
     utils::{
         futures::Capacity,
@@ -454,10 +454,14 @@ impl MergeInsertJob {
         }
 
         // 4 - Take the mapped row ids
+        let projection = self
+            .dataset
+            .empty_projection()
+            .union_arrow_schema(schema.as_ref(), OnMissing::Error)?;
         let mut target = Arc::new(TakeExec::try_new(
             self.dataset.clone(),
             index_mapper,
-            Arc::new(self.dataset.schema().project_by_schema(schema.as_ref())?),
+            projection,
             get_num_compute_intensive_cpus(),
         )?) as Arc<dyn ExecutionPlan>;
 
@@ -632,7 +636,11 @@ impl MergeInsertJob {
             ) -> Result<usize> {
                 // batches still have _rowaddr
                 let write_schema = batches[0].schema().as_ref().without_column(ROW_ADDR);
-                let write_schema = dataset.local_schema().project_by_schema(&write_schema)?;
+                let write_schema = dataset.local_schema().project_by_schema(
+                    &write_schema,
+                    OnMissing::Error,
+                    OnTypeMismatch::Error,
+                )?;
 
                 let updated_rows: usize = batches.iter().map(|batch| batch.num_rows()).sum();
                 if Some(updated_rows) == metadata.physical_rows {
@@ -804,7 +812,11 @@ impl MergeInsertJob {
                 let reader = RecordBatchIterator::new(batches, write_schema.clone());
                 let stream = reader_to_stream(Box::new(reader));
 
-                let write_schema = dataset.schema().project_by_schema(write_schema.as_ref())?;
+                let write_schema = dataset.schema().project_by_schema(
+                    write_schema.as_ref(),
+                    OnMissing::Error,
+                    OnTypeMismatch::Error,
+                )?;
 
                 let fragments = write_fragments_internal(
                     Some(dataset.as_ref()),

--- a/rust/lance/src/io/exec/optimizer.rs
+++ b/rust/lance/src/io/exec/optimizer.rs
@@ -6,20 +6,67 @@
 use std::sync::Arc;
 
 use super::TakeExec;
+use arrow_schema::Schema as ArrowSchema;
 use datafusion::{
     common::tree_node::{Transformed, TreeNode},
     config::ConfigOptions,
     error::Result as DFResult,
     physical_optimizer::{optimizer::PhysicalOptimizer, PhysicalOptimizerRule},
     physical_plan::{
-        coalesce_batches::CoalesceBatchesExec, projection::ProjectionExec as DFProjectionExec,
-        ExecutionPlan,
+        coalesce_batches::CoalesceBatchesExec, projection::ProjectionExec, ExecutionPlan,
     },
 };
-use datafusion_physical_expr::expressions::Column;
+use datafusion_physical_expr::{expressions::Column, PhysicalExpr};
 
 /// Rule that eliminates [TakeExec] nodes that are immediately followed by another [TakeExec].
 pub struct CoalesceTake;
+
+impl CoalesceTake {
+    fn field_order_differs(old_schema: &ArrowSchema, new_schema: &ArrowSchema) -> bool {
+        old_schema
+            .fields
+            .iter()
+            .zip(&new_schema.fields)
+            .any(|(old, new)| old.name() != new.name())
+    }
+
+    fn remap_collapsed_output(
+        old_schema: &ArrowSchema,
+        new_schema: &ArrowSchema,
+        plan: Arc<dyn ExecutionPlan>,
+    ) -> Arc<dyn ExecutionPlan> {
+        let mut project_exprs = Vec::with_capacity(old_schema.fields.len());
+        for field in &old_schema.fields {
+            project_exprs.push((
+                Arc::new(Column::new_with_schema(field.name(), new_schema).unwrap())
+                    as Arc<dyn PhysicalExpr>,
+                field.name().clone(),
+            ));
+        }
+        Arc::new(ProjectionExec::try_new(project_exprs, plan).unwrap())
+    }
+
+    fn collapse_takes(
+        inner_take: &TakeExec,
+        outer_take: &TakeExec,
+        outer_exec: Arc<dyn ExecutionPlan>,
+    ) -> Arc<dyn ExecutionPlan> {
+        let inner_take_input = inner_take.children()[0].clone();
+        let old_output_schema = outer_take.schema();
+        let collapsed = outer_exec
+            .with_new_children(vec![inner_take_input])
+            .unwrap();
+        let new_output_schema = collapsed.schema();
+
+        // It's possible that collapsing the take can change the field order.  This disturbs DF's planner and
+        // so we must restore it.
+        if Self::field_order_differs(&old_output_schema, &new_output_schema) {
+            Self::remap_collapsed_output(&old_output_schema, &new_output_schema, collapsed)
+        } else {
+            collapsed
+        }
+    }
+}
 
 impl PhysicalOptimizerRule for CoalesceTake {
     fn optimize(
@@ -29,20 +76,26 @@ impl PhysicalOptimizerRule for CoalesceTake {
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         Ok(plan
             .transform_down(|plan| {
-                if let Some(take) = plan.as_any().downcast_ref::<TakeExec>() {
-                    let child = take.children()[0];
-                    if let Some(exec_child) = child.as_any().downcast_ref::<TakeExec>() {
-                        let inner_child = exec_child.children()[0].clone();
-                        return Ok(Transformed::yes(plan.with_new_children(vec![inner_child])?));
+                if let Some(outer_take) = plan.as_any().downcast_ref::<TakeExec>() {
+                    let child = outer_take.children()[0];
+                    // Case 1: TakeExec -> TakeExec
+                    if let Some(inner_take) = child.as_any().downcast_ref::<TakeExec>() {
+                        return Ok(Transformed::yes(Self::collapse_takes(
+                            inner_take,
+                            outer_take,
+                            plan.clone(),
+                        )));
+                    // Case 2: TakeExec -> CoalesceBatchesExec -> TakeExec
                     } else if let Some(exec_child) =
                         child.as_any().downcast_ref::<CoalesceBatchesExec>()
                     {
                         let inner_child = exec_child.children()[0].clone();
-                        if let Some(exec_child) = inner_child.as_any().downcast_ref::<TakeExec>() {
-                            let inner_inner_child = exec_child.children()[0].clone();
-                            return Ok(Transformed::yes(
-                                plan.with_new_children(vec![inner_inner_child])?,
-                            ));
+                        if let Some(inner_take) = inner_child.as_any().downcast_ref::<TakeExec>() {
+                            return Ok(Transformed::yes(Self::collapse_takes(
+                                inner_take,
+                                outer_take,
+                                plan.clone(),
+                            )));
                         }
                     }
                 }
@@ -72,7 +125,7 @@ impl PhysicalOptimizerRule for SimplifyProjection {
     ) -> DFResult<Arc<dyn ExecutionPlan>> {
         Ok(plan
             .transform_down(|plan| {
-                if let Some(proj) = plan.as_any().downcast_ref::<DFProjectionExec>() {
+                if let Some(proj) = plan.as_any().downcast_ref::<ProjectionExec>() {
                     let children = proj.children();
                     if children.len() != 1 {
                         return Ok(Transformed::no(plan));

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -17,6 +17,7 @@ use datafusion::physical_plan::{
 use datafusion_physical_expr::EquivalenceProperties;
 use futures::stream::{self, Stream, StreamExt, TryStreamExt};
 use futures::{Future, FutureExt};
+use lance_core::datatypes::{Field, OnMissing, OnTypeMismatch, Projection};
 use tokio::sync::mpsc::{self, Receiver};
 use tokio::task::JoinHandle;
 use tracing::{instrument, Instrument};
@@ -33,7 +34,6 @@ use crate::{arrow::*, Error};
 pub struct Take {
     rx: Receiver<Result<RecordBatch>>,
     bg_thread: Option<JoinHandle<()>>,
-
     output_schema: SchemaRef,
 }
 
@@ -55,15 +55,18 @@ impl Take {
     ) -> Self {
         let (tx, rx) = mpsc::channel(4);
 
+        let output_schema_copy = output_schema.clone();
         let bg_thread = tokio::spawn(
             async move {
                 if let Err(e) = child
                     .zip(stream::repeat_with(|| {
                         (dataset.clone(), projection.clone())
                     }))
-                    .map(|(batch, (dataset, extra))| async move {
-                        Self::take_batch(batch?, dataset, extra).await
-                    })
+                    .map(|(batch, (dataset, extra))| {
+                        let output_schema_copy = output_schema_copy.clone();
+                        async move {
+                            Self::take_batch(batch?, dataset, extra, output_schema_copy).await
+                        }})
                     .buffered(batch_readahead)
                     .map(|r| r.map_err(|e| DataFusionError::Execution(e.to_string())))
                     .try_for_each(|b| async {
@@ -110,6 +113,7 @@ impl Take {
         batch: RecordBatch,
         dataset: Arc<Dataset>,
         extra: Arc<Schema>,
+        output_schema: SchemaRef,
     ) -> impl Future<Output = Result<RecordBatch, Error>> + Send {
         async move {
             let row_id_arr = batch.column_by_name(ROW_ID).unwrap();
@@ -121,7 +125,7 @@ impl Take {
                     .take_rows(row_ids.values(), ProjectionRequest::Schema(extra))
                     .await?;
                 debug_assert_eq!(batch.num_rows(), new_columns.num_rows());
-                batch.merge(&new_columns)?
+                batch.merge_with_schema(&new_columns, &output_schema)?
             };
             Ok::<RecordBatch, Error>(rows)
         }
@@ -175,12 +179,18 @@ pub struct TakeExec {
     /// Dataset to read from.
     dataset: Arc<Dataset>,
 
-    pub(crate) extra_schema: Arc<Schema>,
+    /// The original projection is kept to recalculate `with_new_children`.
+    original_projection: Arc<Schema>,
+
+    /// The schema to pass to dataset.take, this should be the original projection
+    /// minus any fields in the input schema.
+    schema_to_take: Arc<Schema>,
 
     input: Arc<dyn ExecutionPlan>,
 
-    /// Output schema is the merged schema between input schema and extra schema.
-    output_schema: Schema,
+    /// Output schema is the merged schema between input schema and extra schema and
+    /// tells us how to merge the input and extra columns.
+    output_schema: Arc<Schema>,
 
     batch_readahead: usize,
 
@@ -190,7 +200,7 @@ pub struct TakeExec {
 impl DisplayAs for TakeExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let extra_fields = self
-            .extra_schema
+            .original_projection
             .fields
             .iter()
             .map(|f| f.name.clone())
@@ -221,11 +231,11 @@ impl TakeExec {
     ///
     /// - dataset: the dataset to read from
     /// - input: the upstream [`ExecutionPlan`] to feed data in.
-    /// - extra_schema: the extra schema to take / read from the dataset.
+    /// - projection: the desired output projection, can overlap with the input schema if desired
     pub fn try_new(
         dataset: Arc<Dataset>,
         input: Arc<dyn ExecutionPlan>,
-        extra_schema: Arc<Schema>,
+        projection: Projection,
         batch_readahead: usize,
     ) -> Result<Self> {
         if input.schema().column_with_name(ROW_ID).is_none() {
@@ -233,13 +243,28 @@ impl TakeExec {
                 "TakeExec requires the input plan to have a column named '_rowid'".to_string(),
             ));
         }
+        let original_projection = projection.clone().into_schema_ref();
+        let input_projection = dataset.schema().project_by_schema(
+            input.schema().as_ref(),
+            OnMissing::Ignore,
+            OnTypeMismatch::Error,
+        )?;
 
-        let input_schema = Schema::try_from(input.schema().as_ref())?;
-        let output_schema = input_schema.merge(extra_schema.as_ref())?;
+        let projection = projection.subtract_schema(&input_projection);
 
-        let remaining_schema = extra_schema.exclude(&input_schema)?;
+        // Can't use take if we don't want any fields and we can't use take to add row_id or row_addr
+        assert!(
+            !projection.is_empty() && !projection.with_row_id && !projection.with_row_addr,
+            "invalid take projection: {:#?}",
+            projection
+        );
 
-        let output_arrow = Arc::new(ArrowSchema::from(&output_schema));
+        let output_schema = Arc::new(Self::calculate_output_schema(
+            dataset.schema(),
+            &input.schema(),
+            &projection,
+        ));
+        let output_arrow = Arc::new(ArrowSchema::from(output_schema.as_ref()));
         let properties = input
             .properties()
             .clone()
@@ -247,12 +272,65 @@ impl TakeExec {
 
         Ok(Self {
             dataset,
-            extra_schema: Arc::new(remaining_schema),
+            original_projection,
+            schema_to_take: projection.into_schema_ref(),
             input,
             output_schema,
             batch_readahead,
             properties,
         })
+    }
+
+    /// The output of a take operation will be all columns from the input schema followed
+    /// by any new columns from the dataset.
+    ///
+    /// There is no meaningful order to the new columns that one can expect
+    ///
+    /// Nested columns in the input schema may have new fields inserted into them.
+    ///
+    /// If this happens the order of the new nested fields will match the order defined in
+    /// the dataset schema.
+    fn calculate_output_schema(
+        dataset_schema: &Schema,
+        input_schema: &ArrowSchema,
+        projection: &Projection,
+    ) -> Schema {
+        // TakeExec doesn't reorder top-level fields and so the first thing we need to do is determine the
+        // top-level field order.
+        let mut top_level_fields_added = HashSet::with_capacity(input_schema.fields.len());
+        let projected_schema = projection.to_schema();
+
+        let mut output_fields =
+            Vec::with_capacity(input_schema.fields.len() + projected_schema.fields.len());
+        // TakeExec always moves the _rowid to the start of the output schema
+        output_fields.extend(input_schema.fields.iter().map(|f| {
+            let f = Field::try_from(f.as_ref()).unwrap();
+            if let Some(ds_field) = dataset_schema.field(&f.name) {
+                top_level_fields_added.insert(ds_field.id);
+                // Field is in the dataset, it might have new fields added to it
+                if let Some(projected_field) = ds_field.apply_projection(projection) {
+                    f.merge_with_reference(&projected_field, ds_field)
+                } else {
+                    // No new fields added, keep as-is
+                    f
+                }
+            } else {
+                // Field not in dataset, not possible to add extra fields, use as-is
+                f
+            }
+        }));
+
+        // Now we add to the end any brand new top-level fields
+        output_fields.extend(
+            projected_schema
+                .fields
+                .into_iter()
+                .filter(|f| !top_level_fields_added.contains(&f.id)),
+        );
+        Schema {
+            fields: output_fields,
+            metadata: dataset_schema.metadata.clone(),
+        }
     }
 
     /// Get the dataset.
@@ -273,7 +351,7 @@ impl ExecutionPlan for TakeExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        ArrowSchema::from(&self.output_schema).into()
+        Arc::new(self.output_schema.as_ref().into())
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
@@ -291,14 +369,15 @@ impl ExecutionPlan for TakeExec {
             ));
         }
 
-        let child = &children[0];
-
-        let extra_schema = self.output_schema.exclude(child.schema().as_ref())?;
+        let projection = self
+            .dataset
+            .empty_projection()
+            .union_schema(&self.original_projection);
 
         let plan = Self::try_new(
             self.dataset.clone(),
             children[0].clone(),
-            Arc::new(extra_schema),
+            projection,
             self.batch_readahead,
         )?;
 
@@ -311,10 +390,11 @@ impl ExecutionPlan for TakeExec {
         context: Arc<datafusion::execution::context::TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let input_stream = self.input.execute(partition, context)?;
+        let output_schema_arrow = Arc::new(ArrowSchema::from(self.output_schema.as_ref()));
         Ok(Box::pin(Take::new(
             self.dataset.clone(),
-            self.extra_schema.clone(),
-            self.schema(),
+            self.schema_to_take.clone(),
+            output_schema_arrow,
             input_stream,
             self.batch_readahead,
         )))
@@ -336,20 +416,35 @@ impl ExecutionPlan for TakeExec {
 mod tests {
     use super::*;
 
-    use arrow_array::{ArrayRef, Float32Array, Int32Array, RecordBatchIterator, StringArray};
-    use arrow_schema::{DataType, Field};
-    use tempfile::tempdir;
+    use arrow_array::{
+        ArrayRef, Float32Array, Int32Array, RecordBatchIterator, StringArray, StructArray,
+    };
+    use arrow_schema::{DataType, Field, Fields};
+    use datafusion::execution::TaskContext;
+    use lance_core::datatypes::OnMissing;
+    use tempfile::{tempdir, TempDir};
 
     use crate::{
         dataset::WriteParams,
         io::exec::{LanceScanConfig, LanceScanExec},
     };
 
-    async fn create_dataset() -> Arc<Dataset> {
+    struct TestFixture {
+        dataset: Arc<Dataset>,
+        _tmp_dir_guard: TempDir,
+    }
+
+    async fn test_fixture() -> TestFixture {
+        let struct_fields = Fields::from(vec![
+            Arc::new(Field::new("x", DataType::Int32, false)),
+            Arc::new(Field::new("y", DataType::Int32, false)),
+        ]);
+
         let schema = Arc::new(ArrowSchema::new(vec![
             Field::new("i", DataType::Int32, false),
             Field::new("f", DataType::Float32, false),
             Field::new("s", DataType::Utf8, false),
+            Field::new("struct", DataType::Struct(struct_fields.clone()), false),
         ]));
 
         // Write 3 batches.
@@ -362,7 +457,15 @@ mod tests {
                         value_range.clone().map(|v| v as f32),
                     )),
                     Arc::new(StringArray::from_iter_values(
-                        value_range.map(|v| format!("str-{v}")),
+                        value_range.clone().map(|v| format!("str-{v}")),
+                    )),
+                    Arc::new(StructArray::new(
+                        struct_fields.clone(),
+                        vec![
+                            Arc::new(Int32Array::from_iter(value_range.clone())),
+                            Arc::new(Int32Array::from_iter(value_range)),
+                        ],
+                        None,
                     )),
                 ];
                 RecordBatch::try_new(schema.clone(), columns).unwrap()
@@ -381,18 +484,18 @@ mod tests {
             .await
             .unwrap();
 
-        Arc::new(Dataset::open(test_uri).await.unwrap())
+        TestFixture {
+            dataset: Arc::new(Dataset::open(test_uri).await.unwrap()),
+            _tmp_dir_guard: test_dir,
+        }
     }
 
     #[tokio::test]
     async fn test_take_schema() {
-        let dataset = create_dataset().await;
+        let TestFixture { dataset, .. } = test_fixture().await;
 
         let scan_arrow_schema = ArrowSchema::new(vec![Field::new("i", DataType::Int32, false)]);
         let scan_schema = Arc::new(Schema::try_from(&scan_arrow_schema).unwrap());
-
-        let extra_arrow_schema = ArrowSchema::new(vec![Field::new("s", DataType::Int32, false)]);
-        let extra_schema = Arc::new(Schema::try_from(&extra_arrow_schema).unwrap());
 
         // With row id
         let config = LanceScanConfig {
@@ -406,7 +509,12 @@ mod tests {
             scan_schema,
             config,
         ));
-        let take_exec = TakeExec::try_new(dataset, input, extra_schema, 10).unwrap();
+
+        let projection = dataset
+            .empty_projection()
+            .union_column("s", OnMissing::Error)
+            .unwrap();
+        let take_exec = TakeExec::try_new(dataset, input, projection, 10).unwrap();
         let schema = take_exec.schema();
         assert_eq!(
             schema.fields.iter().map(|f| f.name()).collect::<Vec<_>>(),
@@ -415,18 +523,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_take_no_extra_columns() {
-        let dataset = create_dataset().await;
+    async fn test_take_struct() {
+        // When taking fields into an existing struct, the field order should be maintained
+        // according the the schema of the struct.
+        let TestFixture {
+            dataset,
+            _tmp_dir_guard,
+        } = test_fixture().await;
 
-        let scan_arrow_schema = ArrowSchema::new(vec![
-            Field::new("i", DataType::Int32, false),
-            Field::new("s", DataType::Int32, false),
-        ]);
-        let scan_schema = Arc::new(Schema::try_from(&scan_arrow_schema).unwrap());
-
-        // Extra column is already read.
-        let extra_arrow_schema = ArrowSchema::new(vec![Field::new("s", DataType::Int32, false)]);
-        let extra_schema = Arc::new(Schema::try_from(&extra_arrow_schema).unwrap());
+        let scan_schema = Arc::new(dataset.schema().project(&["struct.y"]).unwrap());
 
         let config = LanceScanConfig {
             with_row_id: true,
@@ -439,17 +544,40 @@ mod tests {
             scan_schema,
             config,
         ));
-        let take_exec = TakeExec::try_new(dataset, input, extra_schema, 10).unwrap();
+
+        let projection = dataset
+            .empty_projection()
+            .union_column("struct.x", OnMissing::Error)
+            .unwrap();
+
+        let take_exec = TakeExec::try_new(dataset, input, projection, 10).unwrap();
+
+        let expected_schema = ArrowSchema::new(vec![
+            Field::new(
+                "struct",
+                DataType::Struct(Fields::from(vec![
+                    Arc::new(Field::new("x", DataType::Int32, false)),
+                    Arc::new(Field::new("y", DataType::Int32, false)),
+                ])),
+                false,
+            ),
+            Field::new(ROW_ID, DataType::UInt64, true),
+        ]);
         let schema = take_exec.schema();
-        assert_eq!(
-            schema.fields.iter().map(|f| f.name()).collect::<Vec<_>>(),
-            vec!["i", "s", ROW_ID]
-        );
+        assert_eq!(schema.as_ref(), &expected_schema);
+
+        let mut stream = take_exec
+            .execute(0, Arc::new(TaskContext::default()))
+            .unwrap();
+
+        while let Some(batch) = stream.try_next().await.unwrap() {
+            assert_eq!(batch.schema().as_ref(), &expected_schema);
+        }
     }
 
     #[tokio::test]
     async fn test_take_no_row_id() {
-        let dataset = create_dataset().await;
+        let TestFixture { dataset, .. } = test_fixture().await;
 
         let scan_arrow_schema = ArrowSchema::new(vec![
             Field::new("i", DataType::Int32, false),
@@ -457,8 +585,10 @@ mod tests {
         ]);
         let scan_schema = Arc::new(Schema::try_from(&scan_arrow_schema).unwrap());
 
-        let extra_arrow_schema = ArrowSchema::new(vec![Field::new("s", DataType::Int32, false)]);
-        let extra_schema = Arc::new(Schema::try_from(&extra_arrow_schema).unwrap());
+        let projection = dataset
+            .empty_projection()
+            .union_column("s", OnMissing::Error)
+            .unwrap();
 
         // No row ID
         let input = Arc::new(LanceScanExec::new(
@@ -468,36 +598,45 @@ mod tests {
             scan_schema,
             LanceScanConfig::default(),
         ));
-        assert!(TakeExec::try_new(dataset, input, extra_schema, 10).is_err());
+        assert!(TakeExec::try_new(dataset, input, projection, 10).is_err());
     }
 
     #[tokio::test]
     async fn test_with_new_children() -> Result<()> {
-        let dataset = create_dataset().await;
+        let TestFixture { dataset, .. } = test_fixture().await;
 
         let config = LanceScanConfig {
             with_row_id: true,
             ..Default::default()
         };
+
+        let input_schema = Arc::new(dataset.schema().project(&["i"])?);
+        let projection = dataset
+            .empty_projection()
+            .union_column("s", OnMissing::Error)
+            .unwrap();
+
         let input = Arc::new(LanceScanExec::new(
             dataset.clone(),
             dataset.fragments().clone(),
             None,
-            Arc::new(dataset.schema().project(&["i"])?),
+            input_schema,
             config,
         ));
+
         assert_eq!(input.schema().field_names(), vec!["i", ROW_ID],);
-        let take_exec = TakeExec::try_new(
-            dataset.clone(),
-            input.clone(),
-            Arc::new(dataset.schema().project(&["s"])?),
-            10,
-        )?;
+        let take_exec = TakeExec::try_new(dataset.clone(), input.clone(), projection, 10)?;
         assert_eq!(take_exec.schema().field_names(), vec!["i", ROW_ID, "s"],);
+
+        let projection = dataset
+            .empty_projection()
+            .union_columns(["s", "f"], OnMissing::Error)
+            .unwrap();
+
         let outer_take = Arc::new(TakeExec::try_new(
-            dataset.clone(),
+            dataset,
             Arc::new(take_exec),
-            Arc::new(dataset.schema().project(&["f"])?),
+            projection,
             10,
         )?);
         assert_eq!(
@@ -507,7 +646,7 @@ mod tests {
 
         // with_new_children should preserve the output schema.
         let edited = outer_take.with_new_children(vec![input])?;
-        assert_eq!(edited.schema().field_names(), vec!["i", ROW_ID, "s", "f"],);
+        assert_eq!(edited.schema().field_names(), vec!["i", ROW_ID, "f", "s"],);
         Ok(())
     }
 }

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -286,7 +286,7 @@ impl TakeExec {
     /// The output of a take operation will be all columns from the input schema followed
     /// by any new columns from the dataset.
     ///
-    /// There is no meaningful order to the new columns that one can expect
+    /// The output fields will always be added in dataset schema order
     ///
     /// Nested columns in the input schema may have new fields inserted into them.
     ///
@@ -322,7 +322,8 @@ impl TakeExec {
             }
         }));
 
-        // Now we add to the end any brand new top-level fields
+        // Now we add to the end any brand new top-level fields.  These will be added
+        // dataset schema order.
         output_fields.extend(
             projected_schema
                 .fields
@@ -590,10 +591,7 @@ mod tests {
     async fn test_take_no_row_id() {
         let TestFixture { dataset, .. } = test_fixture().await;
 
-        let scan_arrow_schema = ArrowSchema::new(vec![
-            Field::new("i", DataType::Int32, false),
-            Field::new("s", DataType::Int32, false),
-        ]);
+        let scan_arrow_schema = ArrowSchema::new(vec![Field::new("i", DataType::Int32, false)]);
         let scan_schema = Arc::new(Schema::try_from(&scan_arrow_schema).unwrap());
 
         let projection = dataset


### PR DESCRIPTION
In various situations we need to fetch some fields from a struct and then later add more fields for the struct.  For example, maybe we have a `struct<big_string: string, filter: i32>`.  We might query with a filter on `filter` and then use late materialization to take `big_string`.  When we do this we were previously creating `struct<filter: i32, big_string: string>` which would cause issues since that isn't the correct data type.

In creating this fix I added a new `Projection` concept and I would like to slowly replace a lot of the places where we use schemas as projections to use `Projection` instead.  Not necessarily for performance but more for convenience.