### PR TITLE
feat: change MSRV from 1.78 to 1.80.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -199,7 +199,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        msrv: ["1.78.0"] # This should match up with rust-version in Cargo.toml
+        msrv: ["1.80.1"] # This should match up with rust-version in Cargo.toml
     env:
       # Need up-to-date compilers for kernels
       CC: clang

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ categories = [
     "development-tools",
     "science",
 ]
-rust-version = "1.78"
+rust-version = "1.80.1"
 
 [workspace.dependencies]
 lance = { version = "=0.21.0", path = "./rust/lance" }


### PR DESCRIPTION
I'm going to leave this as a non-breaking change since that seems to be the consensus in the community from what I can gather.  That being said, this being a non-breaking change in downstream libraries is what caused this in the first place :confounded: 