### PR TITLE
ci: relax recall thresholds for CI

### DIFF
--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -750,7 +750,7 @@ mod tests {
     #[case(4, DistanceType::L2, 1.0)]
     #[case(4, DistanceType::Cosine, 1.0)]
     #[case(4, DistanceType::Dot, 1.0)]
-    #[case(4, DistanceType::Hamming, 0.7)]
+    #[case(4, DistanceType::Hamming, 0.9)]
     #[tokio::test]
     async fn test_build_ivf_flat(
         #[case] nlist: usize,
@@ -763,9 +763,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(4, DistanceType::L2, 0.7)]
-    #[case(4, DistanceType::Cosine, 0.7)]
-    #[case(4, DistanceType::Dot, 0.7)]
+    #[case(4, DistanceType::L2, 0.9)]
+    #[case(4, DistanceType::Cosine, 0.9)]
+    #[case(4, DistanceType::Dot, 0.9)]
     #[tokio::test]
     async fn test_build_ivf_pq(
         #[case] nlist: usize,
@@ -780,9 +780,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(4, DistanceType::L2, 0.7)]
-    #[case(4, DistanceType::Cosine, 0.7)]
-    #[case(4, DistanceType::Dot, 0.7)]
+    #[case(4, DistanceType::L2, 0.9)]
+    #[case(4, DistanceType::Cosine, 0.9)]
+    #[case(4, DistanceType::Dot, 0.9)]
     #[tokio::test]
     async fn test_build_ivf_pq_v3(
         #[case] nlist: usize,
@@ -799,9 +799,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(4, DistanceType::L2, 0.7)]
-    #[case(4, DistanceType::Cosine, 0.7)]
-    #[case(4, DistanceType::Dot, 0.7)]
+    #[case(4, DistanceType::L2, 0.85)]
+    #[case(4, DistanceType::Cosine, 0.85)]
+    #[case(4, DistanceType::Dot, 0.75)]
     #[tokio::test]
     async fn test_build_ivf_pq_4bit(
         #[case] nlist: usize,
@@ -818,9 +818,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(4, DistanceType::L2, 0.7)]
-    #[case(4, DistanceType::Cosine, 0.7)]
-    #[case(4, DistanceType::Dot, 0.7)]
+    #[case(4, DistanceType::L2, 0.9)]
+    #[case(4, DistanceType::Cosine, 0.9)]
+    #[case(4, DistanceType::Dot, 0.9)]
     #[tokio::test]
     async fn test_create_ivf_hnsw_sq(
         #[case] nlist: usize,
@@ -840,9 +840,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(4, DistanceType::L2, 0.7)]
-    #[case(4, DistanceType::Cosine, 0.7)]
-    #[case(4, DistanceType::Dot, 0.7)]
+    #[case(4, DistanceType::L2, 0.9)]
+    #[case(4, DistanceType::Cosine, 0.9)]
+    #[case(4, DistanceType::Dot, 0.9)]
     #[tokio::test]
     async fn test_create_ivf_hnsw_pq(
         #[case] nlist: usize,
@@ -862,9 +862,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(4, DistanceType::L2, 0.7)]
-    #[case(4, DistanceType::Cosine, 0.7)]
-    #[case(4, DistanceType::Dot, 0.7)]
+    #[case(4, DistanceType::L2, 0.9)]
+    #[case(4, DistanceType::Cosine, 0.9)]
+    #[case(4, DistanceType::Dot, 0.8)]
     #[tokio::test]
     async fn test_create_ivf_hnsw_pq_4bit(
         #[case] nlist: usize,

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -765,7 +765,7 @@ mod tests {
     #[rstest]
     #[case(4, DistanceType::L2, 0.9)]
     #[case(4, DistanceType::Cosine, 0.9)]
-    #[case(4, DistanceType::Dot, 0.9)]
+    #[case(4, DistanceType::Dot, 0.85)]
     #[tokio::test]
     async fn test_build_ivf_pq(
         #[case] nlist: usize,
@@ -782,7 +782,7 @@ mod tests {
     #[rstest]
     #[case(4, DistanceType::L2, 0.9)]
     #[case(4, DistanceType::Cosine, 0.9)]
-    #[case(4, DistanceType::Dot, 0.9)]
+    #[case(4, DistanceType::Dot, 0.85)]
     #[tokio::test]
     async fn test_build_ivf_pq_v3(
         #[case] nlist: usize,
@@ -820,7 +820,7 @@ mod tests {
     #[rstest]
     #[case(4, DistanceType::L2, 0.9)]
     #[case(4, DistanceType::Cosine, 0.9)]
-    #[case(4, DistanceType::Dot, 0.9)]
+    #[case(4, DistanceType::Dot, 0.85)]
     #[tokio::test]
     async fn test_create_ivf_hnsw_sq(
         #[case] nlist: usize,
@@ -842,7 +842,7 @@ mod tests {
     #[rstest]
     #[case(4, DistanceType::L2, 0.9)]
     #[case(4, DistanceType::Cosine, 0.9)]
-    #[case(4, DistanceType::Dot, 0.9)]
+    #[case(4, DistanceType::Dot, 0.85)]
     #[tokio::test]
     async fn test_create_ivf_hnsw_pq(
         #[case] nlist: usize,

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -750,7 +750,7 @@ mod tests {
     #[case(4, DistanceType::L2, 1.0)]
     #[case(4, DistanceType::Cosine, 1.0)]
     #[case(4, DistanceType::Dot, 1.0)]
-    #[case(4, DistanceType::Hamming, 0.9)]
+    #[case(4, DistanceType::Hamming, 0.7)]
     #[tokio::test]
     async fn test_build_ivf_flat(
         #[case] nlist: usize,
@@ -763,9 +763,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(4, DistanceType::L2, 0.9)]
-    #[case(4, DistanceType::Cosine, 0.9)]
-    #[case(4, DistanceType::Dot, 0.9)]
+    #[case(4, DistanceType::L2, 0.7)]
+    #[case(4, DistanceType::Cosine, 0.7)]
+    #[case(4, DistanceType::Dot, 0.7)]
     #[tokio::test]
     async fn test_build_ivf_pq(
         #[case] nlist: usize,
@@ -780,9 +780,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(4, DistanceType::L2, 0.9)]
-    #[case(4, DistanceType::Cosine, 0.9)]
-    #[case(4, DistanceType::Dot, 0.9)]
+    #[case(4, DistanceType::L2, 0.7)]
+    #[case(4, DistanceType::Cosine, 0.7)]
+    #[case(4, DistanceType::Dot, 0.7)]
     #[tokio::test]
     async fn test_build_ivf_pq_v3(
         #[case] nlist: usize,
@@ -799,9 +799,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(4, DistanceType::L2, 0.9)]
-    #[case(4, DistanceType::Cosine, 0.9)]
-    #[case(4, DistanceType::Dot, 0.8)]
+    #[case(4, DistanceType::L2, 0.7)]
+    #[case(4, DistanceType::Cosine, 0.7)]
+    #[case(4, DistanceType::Dot, 0.7)]
     #[tokio::test]
     async fn test_build_ivf_pq_4bit(
         #[case] nlist: usize,
@@ -818,9 +818,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(4, DistanceType::L2, 0.9)]
-    #[case(4, DistanceType::Cosine, 0.9)]
-    #[case(4, DistanceType::Dot, 0.9)]
+    #[case(4, DistanceType::L2, 0.7)]
+    #[case(4, DistanceType::Cosine, 0.7)]
+    #[case(4, DistanceType::Dot, 0.7)]
     #[tokio::test]
     async fn test_create_ivf_hnsw_sq(
         #[case] nlist: usize,
@@ -840,9 +840,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(4, DistanceType::L2, 0.9)]
-    #[case(4, DistanceType::Cosine, 0.9)]
-    #[case(4, DistanceType::Dot, 0.9)]
+    #[case(4, DistanceType::L2, 0.7)]
+    #[case(4, DistanceType::Cosine, 0.7)]
+    #[case(4, DistanceType::Dot, 0.7)]
     #[tokio::test]
     async fn test_create_ivf_hnsw_pq(
         #[case] nlist: usize,
@@ -862,9 +862,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case(4, DistanceType::L2, 0.9)]
-    #[case(4, DistanceType::Cosine, 0.9)]
-    #[case(4, DistanceType::Dot, 0.8)]
+    #[case(4, DistanceType::L2, 0.7)]
+    #[case(4, DistanceType::Cosine, 0.7)]
+    #[case(4, DistanceType::Dot, 0.7)]
     #[tokio::test]
     async fn test_create_ivf_hnsw_pq_4bit(
         #[case] nlist: usize,


### PR DESCRIPTION
I am concerned that a number of our tests test with random data and have quite strict recall thresholds.  These tests seem to fail on a regular basis.

On the one hand, this may be a concern that we have broken recall but on the other hand I believe these are just in the category of "it's possible to get bad results sometime with the wrong random data".

In other words, if our CI thresholds are set at P=0.05 then that is too strict because if we have a dozen tests and they fail 5% of the time we will have too many CI failures.

I have proposed some very relaxed suggestions here but feel free to propose alternative suggestions.  I'd like these tests to be designed so that if the test fails it is a sign that we broke something and we need to fix it, not just something we ignore.

We could potentially add recall benchmarks to our benchmarking suites if we are concerned about the slow degradation of recall or our recall performance.  These should probably be designed with real (not random data) and could hopefully be made more reliable in that way.