### PR TITLE
fix: full text search with limit may return an incorrect results

### DIFF
--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -165,7 +165,7 @@ impl Wand {
             let score = self.score(doc, &scorer);
             if self.candidates.len() < limit {
                 self.candidates.push(Reverse(OrderedDoc::new(doc, score)));
-            } else if score > self.threshold {
+            } else if score > self.candidates.peek().unwrap().0.score.0 {
                 self.candidates.pop();
                 self.candidates.push(Reverse(OrderedDoc::new(doc, score)));
                 self.threshold = self.candidates.peek().unwrap().0.score.0 * factor;


### PR DESCRIPTION
fix #3264 
this happens when limit is set and there are some docs the their estimated score is greater than threshold