### PR TITLE
ci: allow bencher benchmarks to be executed with workflow_dispatch

### DIFF
--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -1,6 +1,7 @@
 name: Run Regression Benchmarks
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
This will make it possible to test new benchmarks added by PRs before we merge them into main