### PR TITLE
fix: coerce scalar for between

### DIFF
--- a/python/python/tests/test_filter.py
+++ b/python/python/tests/test_filter.py
@@ -108,6 +108,13 @@ def test_sql_predicates(dataset):
         assert dataset.to_table(filter=expr).num_rows == expected_num_rows
 
 
+def test_illegal_predicates(dataset):
+    predicates_nrows = ["str BETWEEN 10 AND 20", "str > 10"]
+    for expr in predicates_nrows:
+        with pytest.raises(ValueError, match="Invalid user input: *"):
+            dataset.to_table(filter=expr)
+
+
 def test_compound(dataset):
     predicates = [
         pc.field("int") >= 50,

--- a/rust/lance-datafusion/src/logical_expr.rs
+++ b/rust/lance-datafusion/src/logical_expr.rs
@@ -98,20 +98,10 @@ pub fn resolve_expr(expr: &Expr, schema: &Schema) -> Result<Expr> {
             negated,
         }) => {
             if let Some(inner_expr_type) = resolve_column_type(inner_expr.as_ref(), schema) {
-                let low = if matches!(low.as_ref(), Expr::Literal(_)) {
-                    Box::new(resolve_value(low.as_ref(), &inner_expr_type)?)
-                } else {
-                    low.clone()
-                };
-                let high = if matches!(high.as_ref(), Expr::Literal(_)) {
-                    Box::new(resolve_value(high.as_ref(), &inner_expr_type)?)
-                } else {
-                    high.clone()
-                };
                 Ok(Expr::Between(Between {
                     expr: inner_expr.clone(),
-                    low,
-                    high,
+                    low: Box::new(coerce_expr(low.as_ref(), &inner_expr_type)?),
+                    high: Box::new(coerce_expr(high.as_ref(), &inner_expr_type)?),
                     negated: *negated,
                 }))
             } else {

--- a/rust/lance-datafusion/src/logical_expr.rs
+++ b/rust/lance-datafusion/src/logical_expr.rs
@@ -91,7 +91,12 @@ pub fn resolve_column_type(expr: &Expr, schema: &Schema) -> Option<DataType> {
 /// - *schema*: lance schema.
 pub fn resolve_expr(expr: &Expr, schema: &Schema) -> Result<Expr> {
     match expr {
-        Expr::Between(Between{expr: inner_expr, low, high, negated}) => {
+        Expr::Between(Between {
+            expr: inner_expr,
+            low,
+            high,
+            negated,
+        }) => {
             if let Some(inner_expr_type) = resolve_column_type(inner_expr.as_ref(), schema) {
                 let low = if matches!(low.as_ref(), Expr::Literal(_)) {
                     Box::new(resolve_value(low.as_ref(), &inner_expr_type)?)
@@ -107,12 +112,12 @@ pub fn resolve_expr(expr: &Expr, schema: &Schema) -> Result<Expr> {
                     expr: inner_expr.clone(),
                     low,
                     high,
-                    negated: *negated
+                    negated: *negated,
                 }))
             } else {
                 Ok(expr.clone())
             }
-        },
+        }
         Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
             if matches!(op, Operator::And | Operator::Or) {
                 Ok(Expr::BinaryExpr(BinaryExpr {

--- a/rust/lance-datafusion/src/logical_expr.rs
+++ b/rust/lance-datafusion/src/logical_expr.rs
@@ -9,7 +9,7 @@ use arrow_schema::DataType;
 
 use crate::expr::safe_coerce_scalar;
 use datafusion::logical_expr::{expr::ScalarFunction, BinaryExpr, Operator};
-use datafusion::logical_expr::{ScalarUDF, ScalarUDFImpl};
+use datafusion::logical_expr::{Between, ScalarUDF, ScalarUDFImpl};
 use datafusion::prelude::*;
 use datafusion::scalar::ScalarValue;
 use datafusion_functions::core::getfield::GetFieldFunc;
@@ -91,6 +91,28 @@ pub fn resolve_column_type(expr: &Expr, schema: &Schema) -> Option<DataType> {
 /// - *schema*: lance schema.
 pub fn resolve_expr(expr: &Expr, schema: &Schema) -> Result<Expr> {
     match expr {
+        Expr::Between(Between{expr: inner_expr, low, high, negated}) => {
+            if let Some(inner_expr_type) = resolve_column_type(inner_expr.as_ref(), schema) {
+                let low = if matches!(low.as_ref(), Expr::Literal(_)) {
+                    Box::new(resolve_value(low.as_ref(), &inner_expr_type)?)
+                } else {
+                    low.clone()
+                };
+                let high = if matches!(high.as_ref(), Expr::Literal(_)) {
+                    Box::new(resolve_value(high.as_ref(), &inner_expr_type)?)
+                } else {
+                    high.clone()
+                };
+                Ok(Expr::Between(Between {
+                    expr: inner_expr.clone(),
+                    low,
+                    high,
+                    negated: *negated
+                }))
+            } else {
+                Ok(expr.clone())
+            }
+        },
         Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
             if matches!(op, Operator::And | Operator::Or) {
                 Ok(Expr::BinaryExpr(BinaryExpr {


### PR DESCRIPTION
for example, current `str > 10` will throw exception. but `str BETWEEN 10 AND 20` will not throw exception.
with this PR check type coerce for between clause.