### PR TITLE
fix: handle deletions in take

### DIFF
--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -16,7 +16,7 @@ use futures::{Future, Stream, StreamExt, TryStreamExt};
 use lance_arrow::RecordBatchExt;
 use lance_core::datatypes::Schema;
 use lance_core::utils::address::RowAddress;
-use lance_core::utils::deletion::{self, OffsetMapper};
+use lance_core::utils::deletion::OffsetMapper;
 use lance_core::ROW_ADDR;
 use lance_datafusion::projection::ProjectionPlan;
 use snafu::{location, Location};


### PR DESCRIPTION
We were not properly handling deletions when mapping raw offsets to row addresses. This PR makes sure we use the deletion files to figure out the exact row addresses.

Fixes #3332