### PR TITLE
fix: cast null arrays to the appropriate type when coercing to a table

### DIFF
--- a/python/python/lance/ray/sink.py
+++ b/python/python/lance/ray/sink.py
@@ -46,8 +46,9 @@ def _pd_to_arrow(
         tbl.schema = tbl.schema.remove_metadata()
         return tbl
     elif isinstance(df, pa.Table):
-        new_table = df.to_pydict()
-        new_table = pa.Table.from_pydict(new_table, schema=schema)
+        if schema is None:
+            return df
+        return df.cast(schema)
         return new_table
     return df
 

--- a/python/python/lance/ray/sink.py
+++ b/python/python/lance/ray/sink.py
@@ -440,7 +440,9 @@ def write_lance(
         ),
         batch_size=max_rows_per_file,
     ).write_datasink(
-        LanceCommitter(output_uri, schema=schema, mode=mode, storage_options=storage_options)
+        LanceCommitter(
+            output_uri, schema=schema, mode=mode, storage_options=storage_options
+        )
     )
 
 

--- a/python/python/lance/ray/sink.py
+++ b/python/python/lance/ray/sink.py
@@ -46,9 +46,8 @@ def _pd_to_arrow(
         tbl.schema = tbl.schema.remove_metadata()
         return tbl
     elif isinstance(df, pa.Table):
-        if schema is None:
-            return df
-        return df.cast(schema)
+        if schema is not None:
+            return df.cast(schema)
     return df
 
 

--- a/python/python/lance/ray/sink.py
+++ b/python/python/lance/ray/sink.py
@@ -49,7 +49,6 @@ def _pd_to_arrow(
         if schema is None:
             return df
         return df.cast(schema)
-        return new_table
     return df
 
 

--- a/python/python/tests/test_ray.py
+++ b/python/python/tests/test_ray.py
@@ -140,7 +140,6 @@ def test_ray_write_lance_none_str(tmp_path: Path):
         assert item is None
 
 
-
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_ray_write_lance_none_str_datasink(tmp_path: Path):
     def f(row):


### PR DESCRIPTION
@eddyxu @westonpace @Jay-ju Don't ask me why :) just try testing `None` with `LanceDatasink`.

See this comment: https://github.com/lancedb/lance/issues/3308#issuecomment-2579940079
Ref issue: https://github.com/lancedb/lance/issues/3308