### PR TITLE
feat: make it possible to build lance without protoc (except on Windows)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,6 +1314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
+name = "cmake"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3462,7 +3471,6 @@ dependencies = [
  "pretty_assertions",
  "prost 0.12.6",
  "prost 0.13.3",
- "prost-build 0.13.3",
  "prost-types 0.13.3",
  "rand",
  "random_word",
@@ -3617,6 +3625,7 @@ dependencies = [
  "prost 0.13.3",
  "prost-build 0.13.3",
  "prost-types 0.13.3",
+ "protobuf-src",
  "rand",
  "rand_xoshiro",
  "rstest",
@@ -3655,6 +3664,7 @@ dependencies = [
  "prost 0.13.3",
  "prost-build 0.13.3",
  "prost-types 0.13.3",
+ "protobuf-src",
  "rand",
  "snafu 0.7.5",
  "test-log",
@@ -3694,6 +3704,7 @@ dependencies = [
  "prost 0.13.3",
  "prost-build 0.13.3",
  "prost-types 0.13.3",
+ "protobuf-src",
  "rand",
  "roaring",
  "snafu 0.7.5",
@@ -3751,6 +3762,7 @@ dependencies = [
  "pprof",
  "prost 0.13.3",
  "prost-build 0.13.3",
+ "protobuf-src",
  "rand",
  "random_word",
  "rayon",
@@ -3800,7 +3812,6 @@ dependencies = [
  "pin-project",
  "pprof",
  "prost 0.13.3",
- "prost-build 0.13.3",
  "rand",
  "shellexpand",
  "snafu 0.7.5",
@@ -3894,6 +3905,7 @@ dependencies = [
  "prost 0.13.3",
  "prost-build 0.13.3",
  "prost-types 0.13.3",
+ "protobuf-src",
  "rand",
  "rangemap",
  "roaring",
@@ -5166,6 +5178,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
  "prost 0.13.3",
+]
+
+[[package]]
+name = "protobuf-src"
+version = "2.1.0+27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7edafa3bcc668fa93efafcbdf58d7821bbda0f4b458ac7fae3d57ec0fec8167"
+dependencies = [
+ "cmake",
 ]
 
 [[package]]

--- a/rust/lance-encoding-datafusion/Cargo.toml
+++ b/rust/lance-encoding-datafusion/Cargo.toml
@@ -42,9 +42,17 @@ lance-datagen.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true
+protobuf-src = { version = "2.1", optional = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof = { workspace = true }
+
+[features]
+protoc = ["dep:protobuf-src"]
+
+[package.metadata.docs.rs]
+# docs.rs uses an older version of Ubuntu that does not have the necessary protoc version
+features = ["protoc"]
 
 [lints]
 workspace = true

--- a/rust/lance-encoding-datafusion/build.rs
+++ b/rust/lance-encoding-datafusion/build.rs
@@ -6,6 +6,10 @@ use std::io::Result;
 fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=protos");
 
+    #[cfg(feature = "protoc")]
+    // Use vendored protobuf compiler if requested.
+    std::env::set_var("PROTOC", protobuf_src::protoc());
+
     let mut prost_build = prost_build::Config::new();
     prost_build.extern_path(".lance.encodings", "::lance_encoding::format::pb");
     prost_build.protoc_arg("--experimental_allow_proto3_optional");

--- a/rust/lance-encoding/Cargo.toml
+++ b/rust/lance-encoding/Cargo.toml
@@ -56,9 +56,17 @@ rand_xoshiro = "0.6.0"
 
 [build-dependencies]
 prost-build.workspace = true
+protobuf-src = { version = "2.1", optional = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof = { workspace = true }
+
+[features]
+protoc = ["dep:protobuf-src"]
+
+[package.metadata.docs.rs]
+# docs.rs uses an older version of Ubuntu that does not have the necessary protoc version
+features = ["protoc"]
 
 [[bench]]
 name = "decoder"

--- a/rust/lance-encoding/build.rs
+++ b/rust/lance-encoding/build.rs
@@ -6,6 +6,10 @@ use std::io::Result;
 fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=protos");
 
+    #[cfg(feature = "protoc")]
+    // Use vendored protobuf compiler if requested.
+    std::env::set_var("PROTOC", protobuf_src::protoc());
+
     let mut prost_build = prost_build::Config::new();
     prost_build.protoc_arg("--experimental_allow_proto3_optional");
     prost_build.enable_type_names();

--- a/rust/lance-file/Cargo.toml
+++ b/rust/lance-file/Cargo.toml
@@ -51,9 +51,17 @@ test-log.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true
+protobuf-src = { version = "2.1", optional = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof = { workspace = true }
+
+[features]
+protoc = ["dep:protobuf-src"]
+
+[package.metadata.docs.rs]
+# docs.rs uses an older version of Ubuntu that does not have the necessary protoc version
+features = ["protoc"]
 
 [[bench]]
 name = "reader"

--- a/rust/lance-file/build.rs
+++ b/rust/lance-file/build.rs
@@ -6,6 +6,10 @@ use std::io::Result;
 fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=protos");
 
+    #[cfg(feature = "protoc")]
+    // Use vendored protobuf compiler if requested.
+    std::env::set_var("PROTOC", protobuf_src::protoc());
+
     let mut prost_build = prost_build::Config::new();
     prost_build.protoc_arg("--experimental_allow_proto3_optional");
     prost_build.extern_path(".lance.encodings", "::lance_encoding::format::pb");

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -73,15 +73,21 @@ datafusion-sql.workspace = true
 random_word = { version = "0.4.3", features = ["en"] }
 
 [features]
+protoc = ["dep:protobuf-src"]
 tokenizer-lindera = ["lindera", "lindera-tantivy", "tokenizer-common"]
 tokenizer-jieba = ["jieba-rs", "tokenizer-common"]
 tokenizer-common = []
 
 [build-dependencies]
 prost-build.workspace = true
+protobuf-src = { version = "2.1", optional = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof.workspace = true
+
+[package.metadata.docs.rs]
+# docs.rs uses an older version of Ubuntu that does not have the necessary protoc version
+features = ["protoc"]
 
 [[bench]]
 name = "find_partitions"

--- a/rust/lance-index/build.rs
+++ b/rust/lance-index/build.rs
@@ -7,6 +7,10 @@ use std::io::Result;
 fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=protos");
 
+    #[cfg(feature = "protoc")]
+    // Use vendored protobuf compiler if requested.
+    std::env::set_var("PROTOC", protobuf_src::protoc());
+
     let mut prost_build = prost_build::Config::new();
     prost_build.protoc_arg("--experimental_allow_proto3_optional");
     prost_build.compile_protos(&["./protos/index.proto"], &["./protos"])?;

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -53,9 +53,6 @@ tempfile.workspace = true
 test-log.workspace = true
 mockall.workspace = true
 
-[build-dependencies]
-prost-build.workspace = true
-
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof.workspace = true
 

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -57,10 +57,16 @@ pprof = { workspace = true }
 
 [build-dependencies]
 prost-build.workspace = true
+protobuf-src = { version = "2.1", optional = true }
 
 [features]
 dynamodb = ["aws-sdk-dynamodb", "lazy_static"]
 dynamodb_tests = ["dynamodb"]
+protoc = ["dep:protobuf-src"]
+
+[package.metadata.docs.rs]
+# docs.rs uses an older version of Ubuntu that does not have the necessary protoc version
+features = ["protoc"]
 
 [[bench]]
 name = "row_id_index"

--- a/rust/lance-table/build.rs
+++ b/rust/lance-table/build.rs
@@ -6,6 +6,10 @@ use std::io::Result;
 fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=protos");
 
+    #[cfg(feature = "protoc")]
+    // Use vendored protobuf compiler if requested.
+    std::env::set_var("PROTOC", protobuf_src::protoc());
+
     let mut prost_build = prost_build::Config::new();
     prost_build.extern_path(".lance.file", "::lance_file::format::pb");
     prost_build.protoc_arg("--experimental_allow_proto3_optional");

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -82,9 +82,6 @@ pprof.workspace = true
 # Need this so we can prevent dynamic linking in binaries (see cli feature)
 lzma-sys = { version = "0.1" }
 
-[build-dependencies]
-prost-build.workspace = true
-
 [dev-dependencies]
 lance-test-macros = { workspace = true }
 lance-datagen = { workspace = true }
@@ -111,6 +108,12 @@ tensorflow = ["tfrecord", "prost_old"]
 dynamodb = ["lance-table/dynamodb", "aws-sdk-dynamodb"]
 dynamodb_tests = ["dynamodb"]
 substrait = ["lance-datafusion/substrait"]
+protoc = [
+    "lance-encoding/protoc",
+    "lance-file/protoc",
+    "lance-index/protoc",
+    "lance-table/protoc",
+]
 
 [[bin]]
 name = "lq"


### PR DESCRIPTION
Inspired by https://github.com/substrait-io/substrait-validator/pull/356 this PR adds a `protoc` feature to `lance`.  If the feature is specified then we will use [`protobuf-src`](https://github.com/MaterializeInc/rust-protobuf-native) to build a vendored copy of `protoc`.

This increases build times slightly (need to compile `protoc` as part of the build) but removes the need for an external copy of `protoc`.

At the moment it is not possible to build both the `protoc` and `substrait` features because `datafusion-substrait` does not yet have its own `protoc` feature (but it will hopefully have one added soon).