### PR TITLE
feat(java): support set options for spark datasource api

### DIFF
--- a/java/spark/src/main/java/com/lancedb/lance/spark/LanceCatalog.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/LanceCatalog.java
@@ -58,7 +58,7 @@ public class LanceCatalog implements TableCatalog {
       LanceIdentifier lanceIdentifier = LanceIdentifier.of(ident);
       LanceConfig config = lanceIdentifier.genLanceConfig(options);
       WriteParams params = SparkOptions.genWriteParamsFromConfig(config);
-      LanceDatasetAdapter.createDataset(ident.name(), schema, params);
+      LanceDatasetAdapter.createDataset(lanceIdentifier.shortName(), schema, params);
     } catch (IllegalArgumentException e) {
       throw new TableAlreadyExistsException(ident.name(), new Some<>(e));
     }

--- a/java/spark/src/main/java/com/lancedb/lance/spark/LanceCatalog.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/LanceCatalog.java
@@ -41,7 +41,8 @@ public class LanceCatalog implements TableCatalog {
 
   @Override
   public Table loadTable(Identifier ident) throws NoSuchTableException {
-    LanceConfig config = LanceConfig.from(options, ident.name());
+    LanceIdentifier lanceIdentifier = LanceIdentifier.of(ident);
+    LanceConfig config = lanceIdentifier.genLanceConfig(options);
     Optional<StructType> schema = LanceDatasetAdapter.getSchema(config);
     if (schema.isEmpty()) {
       throw new NoSuchTableException(config.getDbPath(), config.getDatasetName());
@@ -54,7 +55,8 @@ public class LanceCatalog implements TableCatalog {
       Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties)
       throws TableAlreadyExistsException, NoSuchNamespaceException {
     try {
-      LanceConfig config = LanceConfig.from(options, ident.name());
+      LanceIdentifier lanceIdentifier = LanceIdentifier.of(ident);
+      LanceConfig config = lanceIdentifier.genLanceConfig(options);
       WriteParams params = SparkOptions.genWriteParamsFromConfig(config);
       LanceDatasetAdapter.createDataset(ident.name(), schema, params);
     } catch (IllegalArgumentException e) {
@@ -70,7 +72,8 @@ public class LanceCatalog implements TableCatalog {
 
   @Override
   public boolean dropTable(Identifier ident) {
-    LanceConfig config = LanceConfig.from(options, ident.name());
+    LanceIdentifier lanceIdentifier = LanceIdentifier.of(ident);
+    LanceConfig config = lanceIdentifier.genLanceConfig(options);
     LanceDatasetAdapter.dropDataset(config);
     return true;
   }

--- a/java/spark/src/main/java/com/lancedb/lance/spark/LanceDataSource.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/LanceDataSource.java
@@ -48,7 +48,8 @@ public class LanceDataSource implements SupportsCatalogOptions, DataSourceRegist
 
   @Override
   public Identifier extractIdentifier(CaseInsensitiveStringMap options) {
-    return new LanceIdentifier(LanceConfig.from(options).getDatasetUri());
+    LanceConfig config = LanceConfig.from(options);
+    return new LanceIdentifier(config.getDatasetUri(), config.getOptions());
   }
 
   @Override

--- a/java/spark/src/main/java/com/lancedb/lance/spark/LanceIdentifier.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/LanceIdentifier.java
@@ -14,13 +14,85 @@
 package com.lancedb.lance.spark;
 
 import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * LanceIdentifier is a custom implementation of {@link Identifier} for Lance. It contains the
+ * dataset URI and the namespace. The namespace is an array of strings, which contains the namespace
+ * of the dataset and the options. The options are key-value pairs, which are separated by "#####".
+ */
 public class LanceIdentifier implements Identifier {
-  private final String[] namespace = new String[] {"default"};
+  public static final String SEPARATOR = "#####";
+  private final String[] namespace;
   private final String datasetUri;
+  private final Map<String, String> options;
 
   public LanceIdentifier(String datasetUri) {
+    this(datasetUri, "default");
+  }
+
+  public LanceIdentifier(String datasetUri, String... namespace) {
+    this(datasetUri, namespace, null);
+  }
+
+  public LanceIdentifier(String datasetUri, Map<String, String> options) {
+    this(datasetUri, new String[] {"default"}, options);
+  }
+
+  public LanceIdentifier(String datasetUri, String[] namespace, Map<String, String> options) {
     this.datasetUri = datasetUri;
+    if (null != options && !options.isEmpty()) {
+      this.namespace = new String[namespace.length + 1 + options.size()];
+      System.arraycopy(namespace, 0, this.namespace, 0, namespace.length);
+      this.namespace[namespace.length] = SEPARATOR;
+      int i = namespace.length + 1;
+      for (Map.Entry<String, String> entry : options.entrySet()) {
+        this.namespace[i] = entry.getKey() + "=" + entry.getValue();
+        i++;
+      }
+      this.options = options;
+    } else {
+      this.namespace = namespace;
+      this.options = new HashMap<>();
+    }
+  }
+
+  /**
+   * Convert any identifier into LanceIdentifier.
+   *
+   * @param identifier may be LanceIdentifier or IdentifierImpl
+   * @return LanceIdentifier
+   */
+  public static LanceIdentifier of(Identifier identifier) {
+    if (identifier instanceof LanceIdentifier) {
+      return (LanceIdentifier) identifier;
+    } else {
+      int index = -1;
+      for (int i = 0; i < identifier.namespace().length; i++) {
+        if (identifier.namespace()[i].contains(SEPARATOR)) {
+          index = i;
+          break;
+        }
+      }
+      if (index > 0) {
+        // when saving datasource, the IdentifierImpl will contain options in namespaces
+        String[] namespace = new String[index];
+        System.arraycopy(namespace, 0, identifier.namespace(), 0, index);
+        Map<String, String> options = new HashMap<>();
+        for (int i = index + 1; i < identifier.namespace().length; i++) {
+          String keyValue = identifier.namespace()[i];
+          String[] kv = keyValue.split("=");
+          options.put(kv[0], kv[1]);
+        }
+        return new LanceIdentifier(identifier.name(), namespace, options);
+      } else {
+        // catalog identifier only have namespaces
+        return new LanceIdentifier(identifier.name(), identifier.namespace());
+      }
+    }
   }
 
   @Override
@@ -31,5 +103,12 @@ public class LanceIdentifier implements Identifier {
   @Override
   public String name() {
     return datasetUri;
+  }
+
+  // lance datasource options will overwrite the catalog options.
+  public LanceConfig genLanceConfig(CaseInsensitiveStringMap catalogOptions) {
+    Map<String, String> mergedOptions = new HashMap<>(catalogOptions);
+    mergedOptions.putAll(this.options);
+    return LanceConfig.from(mergedOptions, datasetUri);
   }
 }

--- a/java/spark/src/main/java/com/lancedb/lance/spark/LanceIdentifier.java
+++ b/java/spark/src/main/java/com/lancedb/lance/spark/LanceIdentifier.java
@@ -80,7 +80,7 @@ public class LanceIdentifier implements Identifier {
       if (index > 0) {
         // when saving datasource, the IdentifierImpl will contain options in namespaces
         String[] namespace = new String[index];
-        System.arraycopy(namespace, 0, identifier.namespace(), 0, index);
+        System.arraycopy(identifier.namespace(), 0, namespace, 0, index);
         Map<String, String> options = new HashMap<>();
         for (int i = index + 1; i < identifier.namespace().length; i++) {
           String keyValue = identifier.namespace()[i];

--- a/java/spark/src/test/java/com/lancedb/lance/spark/LanceIdentifierTest.java
+++ b/java/spark/src/test/java/com/lancedb/lance/spark/LanceIdentifierTest.java
@@ -40,21 +40,18 @@ public class LanceIdentifierTest {
     options.put("key1", "value1");
     options.put("key2", "value2");
     identifier = new LanceIdentifier(url, options);
-    assertEquals(4, identifier.namespace().length);
+    assertEquals(1, identifier.namespace().length);
     assertEquals("default", identifier.namespace()[0]);
-    assertEquals(LanceIdentifier.SEPARATOR, identifier.namespace()[1]);
-    assertEquals("key1=value1", identifier.namespace()[2]);
-    assertEquals("key2=value2", identifier.namespace()[3]);
+    assertEquals("/tmp/data.lance#key1=value1&key2=value2", identifier.name());
+    assertEquals("/tmp/data.lance", identifier.shortName());
 
     String[] namespace = new String[] {"spark_catalog", "default"};
     identifier = new LanceIdentifier(url, namespace, options);
-    assertEquals(url, identifier.name());
-    assertEquals(5, identifier.namespace().length);
+    assertEquals("/tmp/data.lance#key1=value1&key2=value2", identifier.name());
+    assertEquals("/tmp/data.lance", identifier.shortName());
+    assertEquals(2, identifier.namespace().length);
     assertEquals("spark_catalog", identifier.namespace()[0]);
     assertEquals("default", identifier.namespace()[1]);
-    assertEquals(LanceIdentifier.SEPARATOR, identifier.namespace()[2]);
-    assertEquals("key1=value1", identifier.namespace()[3]);
-    assertEquals("key2=value2", identifier.namespace()[4]);
   }
 
   @Test
@@ -98,7 +95,7 @@ public class LanceIdentifierTest {
 
     identifierImpl = Identifier.of(namespace, identifier.name());
     lanceIdentifier = LanceIdentifier.of(identifierImpl);
-    assertEquals(0, lanceIdentifier.genLanceConfig(emptyOptions).getOptions().size());
+    assertEquals(2, lanceIdentifier.genLanceConfig(emptyOptions).getOptions().size());
     assertEquals(namespace, lanceIdentifier.namespace());
   }
 }

--- a/java/spark/src/test/java/com/lancedb/lance/spark/LanceIdentifierTest.java
+++ b/java/spark/src/test/java/com/lancedb/lance/spark/LanceIdentifierTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lancedb.lance.spark;
+
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LanceIdentifierTest {
+  @Test
+  public void testLanceIdentifierFullyConstruct() {
+    String url = "/tmp/data.lance";
+    LanceIdentifier identifier = new LanceIdentifier(url);
+    assertEquals(url, identifier.name());
+    assertEquals(1, identifier.namespace().length);
+    assertEquals("default", identifier.namespace()[0]);
+
+    identifier = new LanceIdentifier(url, "catalog", "ods");
+    assertEquals(2, identifier.namespace().length);
+    assertEquals("catalog", identifier.namespace()[0]);
+    assertEquals("ods", identifier.namespace()[1]);
+
+    Map<String, String> options = new HashMap<>();
+    options.put("key1", "value1");
+    options.put("key2", "value2");
+    identifier = new LanceIdentifier(url, options);
+    assertEquals(4, identifier.namespace().length);
+    assertEquals("default", identifier.namespace()[0]);
+    assertEquals(LanceIdentifier.SEPARATOR, identifier.namespace()[1]);
+    assertEquals("key1=value1", identifier.namespace()[2]);
+    assertEquals("key2=value2", identifier.namespace()[3]);
+
+    String[] namespace = new String[] {"spark_catalog", "default"};
+    identifier = new LanceIdentifier(url, namespace, options);
+    assertEquals(url, identifier.name());
+    assertEquals(5, identifier.namespace().length);
+    assertEquals("spark_catalog", identifier.namespace()[0]);
+    assertEquals("default", identifier.namespace()[1]);
+    assertEquals(LanceIdentifier.SEPARATOR, identifier.namespace()[2]);
+    assertEquals("key1=value1", identifier.namespace()[3]);
+    assertEquals("key2=value2", identifier.namespace()[4]);
+  }
+
+  @Test
+  public void testGenLanceConfig() {
+    Map<String, String> pros = new HashMap<>();
+    pros.put("key1", "value11");
+    pros.put("key3", "value3");
+    CaseInsensitiveStringMap map = new CaseInsensitiveStringMap(pros);
+
+    Map<String, String> options = new HashMap<>();
+    options.put("key1", "value1");
+    options.put("key2", "value2");
+    LanceIdentifier identifier = new LanceIdentifier("/tmp/data.lance", options);
+
+    LanceConfig config = identifier.genLanceConfig(map);
+    assertEquals("data", config.getDatasetName());
+    assertEquals("/tmp/data.lance", config.getDatasetUri());
+    assertEquals("/tmp/", config.getDbPath());
+    assertEquals(3, config.getOptions().size());
+    assertEquals("value1", config.getOptions().get("key1"));
+    assertEquals("value2", config.getOptions().get("key2"));
+    assertEquals("value3", config.getOptions().get("key3"));
+  }
+
+  @Test
+  public void testLanceIdentifierOf() {
+    String url = "/tmp/data.lance";
+    Map<String, String> options = new HashMap<>();
+    options.put("key1", "value1");
+    options.put("key2", "value2");
+    String[] namespace = new String[] {"spark_catalog", "default"};
+    LanceIdentifier identifier = new LanceIdentifier(url, namespace, options);
+
+    CaseInsensitiveStringMap emptyOptions = new CaseInsensitiveStringMap(new HashMap<>());
+    LanceIdentifier lanceIdentifier = LanceIdentifier.of(identifier);
+    assertEquals(options, lanceIdentifier.genLanceConfig(emptyOptions).getOptions());
+
+    Identifier identifierImpl = Identifier.of(identifier.namespace(), identifier.name());
+    lanceIdentifier = LanceIdentifier.of(identifierImpl);
+    assertEquals(options, lanceIdentifier.genLanceConfig(emptyOptions).getOptions());
+
+    identifierImpl = Identifier.of(namespace, identifier.name());
+    lanceIdentifier = LanceIdentifier.of(identifierImpl);
+    assertEquals(0, lanceIdentifier.genLanceConfig(emptyOptions).getOptions().size());
+    assertEquals(namespace, lanceIdentifier.namespace());
+  }
+}

--- a/java/spark/src/test/java/com/lancedb/lance/spark/read/SparkConnectorReadTest.java
+++ b/java/spark/src/test/java/com/lancedb/lance/spark/read/SparkConnectorReadTest.java
@@ -194,6 +194,7 @@ public class SparkConnectorReadTest {
             .format("lance")
             .option("version", "1")
             .load(LanceConfig.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName));
+    // first version has 2 rows
     assertEquals(2, df.count());
 
     df =
@@ -202,6 +203,17 @@ public class SparkConnectorReadTest {
             .format("lance")
             .option("version", "6")
             .load(LanceConfig.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName));
+    // 6 is the last version
     validateData(df, TestUtils.TestTable1Config.expectedValues);
+  }
+
+  @Test
+  void versionInSQL() {
+    String uri = LanceConfig.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName);
+    uri += "#version=1";
+    String sql = "SELECT * FROM lance.`" + uri + "`";
+    Dataset<Row> df = spark.sql(sql);
+    // first version has 2 rows
+    assertEquals(2, df.count());
   }
 }

--- a/java/spark/src/test/java/com/lancedb/lance/spark/read/SparkConnectorReadTest.java
+++ b/java/spark/src/test/java/com/lancedb/lance/spark/read/SparkConnectorReadTest.java
@@ -185,4 +185,23 @@ public class SparkConnectorReadTest {
     assertEquals(1, desc.size());
     assertTrue(desc.get(0).getString(0).contains("BroadcastHashJoin"));
   }
+
+  @Test
+  void supportReadOptions() {
+    Dataset<Row> df =
+        spark
+            .read()
+            .format("lance")
+            .option("version", "1")
+            .load(LanceConfig.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName));
+    assertEquals(2, df.count());
+
+    df =
+        spark
+            .read()
+            .format("lance")
+            .option("version", "6")
+            .load(LanceConfig.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName));
+    validateData(df, TestUtils.TestTable1Config.expectedValues);
+  }
 }

--- a/java/spark/src/test/java/com/lancedb/lance/spark/write/SparkWriteTest.java
+++ b/java/spark/src/test/java/com/lancedb/lance/spark/write/SparkWriteTest.java
@@ -278,4 +278,20 @@ public class SparkWriteTest {
     spark.sql("CREATE OR REPLACE TABLE lance.`" + path + "` AS SELECT * FROM tmp_view");
     spark.sql("DROP TABLE lance.`" + path + "`");
   }
+
+  @Test
+  public void writeWithOptions(TestInfo testInfo) {
+    String datasetName = testInfo.getTestMethod().get().getName();
+    String filePath = LanceConfig.getDatasetUri(dbPath.toString(), datasetName);
+    testData
+        .repartition(1)
+        .write()
+        .format(LanceDataSource.name)
+        .option(LanceConfig.CONFIG_DATASET_URI, filePath)
+        .option("max_row_per_file", "2")
+        .save();
+
+    File directory = new File(filePath + "/data");
+    assertEquals(1, directory.listFiles().length);
+  }
 }


### PR DESCRIPTION
use `option` to set options for lance spark datasource like read `version`:
```scala
spark
.read()
.format("lance")
.option("version", "1")
.load(LanceConfig.getDatasetUri(dbPath, TestUtils.TestTable1Config.datasetName));
```

- Why do it in this way
  The spark data source API will change the `LanceIdentifier` into `IdentifierImpl` and `IdentifierImpl` only have namespaces and name without the options in the data source.

- How to do that
  Inspired by Iceberg putting the options in the name. I designed the name `LanceIdentifier` with the format `name#key1=value1&key2=value2`. These options will only set the read and write options. The storage options should be set in spark configuration and not in option since the AK/SK format is complex.
