### PR TITLE
fix(python): correct type hint for `write_fragments()`

### DIFF
--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -790,7 +790,9 @@ def write_fragments(
             will be assigned when the fragments are committed to a dataset.
 
         If return_transaction is True:
-            the write transaction
+            The write transaction. The type of transaction will correspond to
+            the mode parameter specified. This transaction can be passed to
+            :meth:`LanceDataset.commit`.
 
     """
     from .dataset import LanceDataset

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -783,10 +783,15 @@ def write_fragments(
         secondary indices need to be updated to point to new row ids.
     Returns
     -------
-    List[FragmentMetadata]
-        A list of :class:`FragmentMetadata` for the fragments written. The
-        fragment ids are left as zero meaning they are not yet specified. They
-        will be assigned when the fragments are committed to a dataset.
+    List[FragmentMetadata] | Transaction
+        If return_transaction is False:
+            a list of :class:`FragmentMetadata` for the fragments written. The
+            fragment ids are left as zero meaning they are not yet specified. They
+            will be assigned when the fragments are committed to a dataset.
+
+        If return_transaction is True:
+            the write transaction
+
     """
     from .dataset import LanceDataset
 

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -680,9 +680,9 @@ if TYPE_CHECKING:
     def write_fragments(
         data: ReaderLike,
         dataset_uri: Union[str, Path, LanceDataset],
-        return_transaction: Literal[True],
         schema: Optional[pa.Schema] = None,
         *,
+        return_transaction: Literal[True],
         mode: str = "append",
         max_rows_per_file: int = 1024 * 1024,
         max_rows_per_group: int = 1024,
@@ -698,9 +698,9 @@ if TYPE_CHECKING:
     def write_fragments(
         data: ReaderLike,
         dataset_uri: Union[str, Path, LanceDataset],
-        return_transaction: Literal[False] = False,
         schema: Optional[pa.Schema] = None,
         *,
+        return_transaction: Literal[False] = False,
         mode: str = "append",
         max_rows_per_file: int = 1024 * 1024,
         max_rows_per_group: int = 1024,
@@ -716,9 +716,9 @@ if TYPE_CHECKING:
 def write_fragments(
     data: ReaderLike,
     dataset_uri: Union[str, Path, LanceDataset],
-    return_transaction: bool = False,
     schema: Optional[pa.Schema] = None,
     *,
+    return_transaction: bool = False,
     mode: str = "append",
     max_rows_per_file: int = 1024 * 1024,
     max_rows_per_group: int = 1024,
@@ -743,11 +743,11 @@ def write_fragments(
         The data to be written to the fragment.
     dataset_uri : str, Path, or LanceDataset
         The URI of the dataset or the dataset object.
-    return_transaction: bool, default False
-        If it's true, the transaction will be returned.
     schema : pa.Schema, optional
         The schema of the data. If not specified, the schema will be inferred
         from the data.
+    return_transaction: bool, default False
+        If it's true, the transaction will be returned.
     mode : str, default "append"
         The write mode. If "append" is specified, the data will be checked
         against the existing dataset's schema. Otherwise, pass "create" or

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -391,8 +391,9 @@ def _write_fragments(
     max_rows_per_group: int,
     max_bytes_per_file: int,
     progress: Optional[FragmentWriteProgress],
-    data_storage_version=Optional[str],
-    storage_options=Optional[Dict[str, str]],
+    data_storage_version: Optional[str],
+    storage_options: Optional[Dict[str, str]],
+    enable_move_stable_row_ids: bool,
 ): ...
 def _write_fragments_transaction(
     dataset_uri: str | Path | _Dataset,
@@ -402,8 +403,9 @@ def _write_fragments_transaction(
     max_rows_per_group: int,
     max_bytes_per_file: int,
     progress: Optional[FragmentWriteProgress],
-    data_storage_version=Optional[str],
-    storage_options=Optional[Dict[str, str]],
+    data_storage_version: Optional[str],
+    storage_options: Optional[Dict[str, str]],
+    enable_move_stable_row_ids: bool,
 ) -> Transaction: ...
 def _json_to_schema(schema_json: str) -> pa.Schema: ...
 def _schema_to_json(schema: pa.Schema) -> str: ...


### PR DESCRIPTION
documents for new arguments of write_fragments method are missing.  and write_fragments is dependent typing now. I added two override signatures to make the type checker happy.

