### PR TITLE
fix: add len to torch dataset

### DIFF
--- a/python/python/lance/torch/data.py
+++ b/python/python/lance/torch/data.py
@@ -278,6 +278,9 @@ class LanceDataset(torch.utils.data.IterableDataset):
     def __repr__(self) -> str:
         return f"LanceTorchDataset({self.dataset.uri}, size={self.samples})"
 
+    def __len__(self) -> int:
+        return len(self.dataset)
+
     @property
     def schema(self) -> pa.Schema:
         if not self.columns:

--- a/python/python/tests/torch_tests/test_data.py
+++ b/python/python/tests/torch_tests/test_data.py
@@ -211,6 +211,22 @@ def test_filtered_sampling_odd_batch_size(tmp_path: Path):
     assert x.shape[1] == 3
 
 
+def test_len(tmp_path: Path):
+    tbl = pa.Table.from_pydict({"ints": pa.array(range(1000))})
+
+    lance.write_dataset(tbl, tmp_path, max_rows_per_file=200)
+
+    ds = LanceDataset(
+        tmp_path,
+        batch_size=38,
+        columns=["ints"],
+        samples=38 * 256,
+        filter="ints is not null",
+    )
+
+    assert len(ds) == 1000
+
+
 def test_sample_batches_with_filter(tmp_path: Path):
     NUM_ROWS = 10000
     tbl = pa.Table.from_pydict(


### PR DESCRIPTION
in  [pytorch dataloder](https://github.com/pytorch/pytorch/blob/5e4cf3e6ad6f1f06436f409b394ae02e5ed5583d/torch/utils/data/dataloader.py#L528 ) __len__ of dataset will be called, but lance torch dataset hasn't defined it. is this method expensive?

