### PR TITLE
fix: ensure that 'block_size' parameter is properly propagated in the ObjectStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3813,6 +3813,7 @@ dependencies = [
  "pprof",
  "prost 0.13.4",
  "rand",
+ "rstest",
  "shellexpand",
  "snafu 0.7.5",
  "tempfile",

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -52,6 +52,7 @@ parquet.workspace = true
 tempfile.workspace = true
 test-log.workspace = true
 mockall.workspace = true
+rstest = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof.workspace = true

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -52,7 +52,7 @@ parquet.workspace = true
 tempfile.workspace = true
 test-log.workspace = true
 mockall.workspace = true
-rstest = { workspace = true }
+rstest.workspace = true
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof.workspace = true


### PR DESCRIPTION

Previously, setting a block_size parameter did not change the range coalescing being done in FileScheduler's [submit_request ](https://github.com/lancedb/lance/blob/main/rust/lance-io/src/scheduler.rs#L717) function. This was because the FileScheduler was using the block_size parameter in the underlying ObjectStore, but that parameter was not being properly propagated in the configure_store method. 

This change keeps the same defaults but always uses the parameter value if it is set. 

Verified via unit tests and profiling to determine increasing block size now does actually decrease the number of get_range queries.