### PR TITLE
fix: filter out null values when sampling for index training

### DIFF
--- a/rust/lance-core/src/utils/tokio.rs
+++ b/rust/lance-core/src/utils/tokio.rs
@@ -37,6 +37,7 @@ lazy_static::lazy_static! {
         .thread_name("lance-cpu")
         .max_blocking_threads(get_num_compute_intensive_cpus())
         .worker_threads(1)
+        .enable_time()
         // keep the thread alive "forever"
         .thread_keep_alive(Duration::from_secs(u64::MAX))
         .build()

--- a/rust/lance-core/src/utils/tokio.rs
+++ b/rust/lance-core/src/utils/tokio.rs
@@ -37,7 +37,6 @@ lazy_static::lazy_static! {
         .thread_name("lance-cpu")
         .max_blocking_threads(get_num_compute_intensive_cpus())
         .worker_threads(1)
-        .enable_time()
         // keep the thread alive "forever"
         .thread_keep_alive(Duration::from_secs(u64::MAX))
         .build()

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -123,6 +123,9 @@ pub async fn merge_indices<'a>(
                     .with_fragments(unindexed)
                     .with_row_id()
                     .project(&[&column.name])?;
+                if column.nullable {
+                    scanner.filter_expr(datafusion_expr::col(&column.name).is_not_null());
+                }
                 Some(scanner.try_into_stream().await?)
             };
 

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -447,7 +447,7 @@ pub async fn build_pq_model(
         "Finished loading training data in {:02} seconds",
         start.elapsed().as_secs_f32()
     );
-    debug_assert_eq!(training_data.logical_null_count(), 0);
+    assert_eq!(training_data.logical_null_count(), 0);
 
     info!(
         "starting to compute partitions for PQ training, sample size: {}",

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -447,6 +447,7 @@ pub async fn build_pq_model(
         "Finished loading training data in {:02} seconds",
         start.elapsed().as_secs_f32()
     );
+    debug_assert_eq!(training_data.logical_null_count(), 0);
 
     info!(
         "starting to compute partitions for PQ training, sample size: {}",

--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -135,7 +135,7 @@ pub async fn maybe_sample_training_data(
             .scan()
             .filter_expr(datafusion_expr::col(column).is_not_null())
             .with_row_address()
-            .project(&["_rowaddr"])?
+            .project::<&str>(&[])?
             .try_into_batch()
             .await?;
         debug_assert_eq!(row_addrs.num_columns(), 1);


### PR DESCRIPTION
We were not filtering out null values when sampling. Because we often call `array.values()` on Arrow arrays, which ignores the null bitmap, we are often silently treating the nulls as zeros (or possibly undefined values). Only thing that caught these nulls is an assertion. However, residualization occurring with L2 and Cosine often meant that these values were transformed and null information was lost before the assertion, which is why it got past previous unit tests.

This PR adds more assertions validating there aren't nulls, and makes sure the sampling code handles null vectors.

Closes #3402
Closes #3400