### PR TITLE
feat: allow replacement of entire datafile when the schema lines up correctly

### DIFF
--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -173,6 +173,16 @@ message Transaction {
     }
   }
 
+  message DataReplacementGroup {
+    uint64 fragment_id = 1;
+    DataFile new_file = 2;
+  }
+
+  // An operation that replaces the data in a region of the table with new data.
+  message DataReplacement {
+    repeated DataReplacementGroup replacements = 1;
+  }
+
   // The operation of this transaction.
   oneof operation {
     Append append = 100;
@@ -186,6 +196,7 @@ message Transaction {
     Update update = 108;
     Project project = 109;
     UpdateConfig update_config = 110;
+    DataReplacement data_replacement = 111;
   }
 
   // An operation to apply to the blob dataset

--- a/python/python/lance/file.py
+++ b/python/python/lance/file.py
@@ -134,7 +134,7 @@ class LanceFileReader:
             if indices[i] > indices[i + 1]:
                 raise ValueError(
                     f"Indices must be sorted in ascending order for \
-                                 file API, got {indices[i]} > {indices[i+1]}"
+                                 file API, got {indices[i]} > {indices[i + 1]}"
                 )
 
         return ReaderResults(

--- a/python/python/lance/ray/sink.py
+++ b/python/python/lance/ray/sink.py
@@ -161,7 +161,7 @@ class _BaseLanceDatasink(ray.data.Datasink):
 
         if len(write_results) == 0:
             warnings.warn(
-                "write results is empty. please check ray version " "or internal error",
+                "write results is empty. please check ray version or internal error",
                 DeprecationWarning,
             )
             return


### PR DESCRIPTION
For internal design doc see notion or ping me

What this PR implements
![image](https://github.com/user-attachments/assets/85219024-a4a4-4b9a-bfb7-2b2f4990e68d)

Plan of attack:
* This PR: basic functionality, i.e. when there is no conflict calling this tx should just work
* Next PR: implement more fine-grained conflict resolution
* Potential future PR (when time permits): Allow partial replacement of a datafile. This can be done by "dropping" column indice in a datafile, thereby dropping the column in favor of another


TODO:
- [x] proto definition of the new transaction
- [x] simple rust tests
- [x] test error handling
- [x] PR desc
- [x] python tests
- [x] implement conflict detection

