### PR TITLE
ci: fix Python Arm build

### DIFF
--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -70,7 +70,7 @@ runs:
         before-script-linux: |
           set -e
           yum install -y openssl-devel clang \
-            && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-$(uname -m).zip > /tmp/protoc.zip \
+            && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-aarch_64.zip > /tmp/protoc.zip \
             && unzip /tmp/protoc.zip -d /usr/local \
             && rm /tmp/protoc.zip
           # set -e

--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -73,13 +73,3 @@ runs:
             && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-aarch_64.zip > /tmp/protoc.zip \
             && unzip /tmp/protoc.zip -d /usr/local \
             && rm /tmp/protoc.zip
-          # set -e
-          # apt-get install -y unzip
-          # if [ $(uname -m) = "x86_64" ]; then
-          #   PROTOC_ARCH="x86_64"
-          # else
-          #   PROTOC_ARCH="aarch_64"
-          # fi
-          # curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-$PROTOC_ARCH.zip > /tmp/protoc.zip \
-          #   && unzip /tmp/protoc.zip -d /usr/local \
-          #   && rm /tmp/protoc.zip

--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -69,12 +69,17 @@ runs:
         args: ${{ inputs.args }}
         before-script-linux: |
           set -e
-          sudo apt install -y unzip
-          if [ $(uname -m) = "x86_64" ]; then
-            PROTOC_ARCH="x86_64"
-          else
-            PROTOC_ARCH="aarch_64"
-          fi
-          curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-$PROTOC_ARCH.zip > /tmp/protoc.zip \
+          yum install -y openssl-devel clang \
+            && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-$(uname -m).zip > /tmp/protoc.zip \
             && unzip /tmp/protoc.zip -d /usr/local \
             && rm /tmp/protoc.zip
+          # set -e
+          # apt-get install -y unzip
+          # if [ $(uname -m) = "x86_64" ]; then
+          #   PROTOC_ARCH="x86_64"
+          # else
+          #   PROTOC_ARCH="aarch_64"
+          # fi
+          # curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-$PROTOC_ARCH.zip > /tmp/protoc.zip \
+          #   && unzip /tmp/protoc.zip -d /usr/local \
+          #   && rm /tmp/protoc.zip

--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -69,7 +69,7 @@ runs:
         args: ${{ inputs.args }}
         before-script-linux: |
           set -e
-          apt install -y unzip
+          sudo apt install -y unzip
           if [ $(uname -m) = "x86_64" ]; then
             PROTOC_ARCH="x86_64"
           else

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -21,6 +21,9 @@ jobs:
           - platform: aarch64
             manylinux: "2_17"
             extra_args: ""
+          - platform: aarch64
+            manylinux: "2_28"
+            extra_args: ""
           # We don't build fp16 kernels for aarch64, because it uses
           # cross compilation image, which doesn't have a new enough compiler.
     runs-on: "ubuntu-22.04"

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -23,7 +23,7 @@ jobs:
             extra_args: ""
           - platform: aarch64
             manylinux: "2_28"
-            extra_args: ""
+            extra_args: "--features fp16kernels"
           # We don't build fp16 kernels for aarch64, because it uses
           # cross compilation image, which doesn't have a new enough compiler.
     runs-on: "ubuntu-22.04"

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,7 +19,7 @@ jobs:
             manylinux: "2_28"
             extra_args: "--features fp16kernels"
           - platform: aarch64
-            manylinux: "2_24"
+            manylinux: "2_17"
             extra_args: ""
           # We don't build fp16 kernels for aarch64, because it uses
           # cross compilation image, which doesn't have a new enough compiler.

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -146,7 +146,6 @@ jobs:
         with:
           arm-build: "true"
           manylinux: "2_28"
-          extra_args: "--features fp16kernels"
       - name: Install dependencies
         run: |
           sudo apt update -y -qq

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -145,7 +145,7 @@ jobs:
       - uses: ./.github/workflows/build_linux_wheel
         with:
           arm-build: "true"
-          manylinux: "2_24"
+          manylinux: "2_17"
       - name: Install dependencies
         run: |
           sudo apt update -y -qq

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -145,7 +145,7 @@ jobs:
       - uses: ./.github/workflows/build_linux_wheel
         with:
           arm-build: "true"
-          manylinux: "2_17"
+          manylinux: "2_28"
       - name: Install dependencies
         run: |
           sudo apt update -y -qq

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -146,6 +146,7 @@ jobs:
         with:
           arm-build: "true"
           manylinux: "2_28"
+          extra_args: "--features fp16kernels"
       - name: Install dependencies
         run: |
           sudo apt update -y -qq


### PR DESCRIPTION
We were using deprecated 2_24 for ARM, but that seems to have some issues. Dropping down to 2_17 for now to keep wide support, as I believe some of the popular cloud linuxes don't have >=2.28 glibc.