### PR TITLE
ci: use ARM runner for Python ARM release builds

### DIFF
--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -67,9 +67,11 @@ runs:
         target: aarch64-unknown-linux-gnu
         manylinux: ${{ inputs.manylinux }}
         args: ${{ inputs.args }}
+        # This uses an image based on Ubuntu 22.04 that does cross compilation
+        # https://github.com/rust-cross/manylinux-cross?tab=readme-ov-file#manylinux_2_28
         before-script-linux: |
           set -e
-          yum install -y openssl-devel clang \
+          apt-get install -y pkg-config libssl-dev unzip \
             && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-aarch_64.zip > /tmp/protoc.zip \
             && unzip /tmp/protoc.zip -d /usr/local \
             && rm /tmp/protoc.zip

--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -67,13 +67,9 @@ runs:
         target: aarch64-unknown-linux-gnu
         manylinux: ${{ inputs.manylinux }}
         args: ${{ inputs.args }}
-        # This uses an image based on Ubuntu 22.04 that does cross compilation
-        # https://github.com/rust-cross/manylinux-cross?tab=readme-ov-file#manylinux_2_28
         before-script-linux: |
           set -e
-          # apt-get install -y pkg-config libssl-dev unzip \
           yum install -y openssl-devel clang \
             && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-aarch_64.zip > /tmp/protoc.zip \
             && unzip /tmp/protoc.zip -d /usr/local \
             && rm /tmp/protoc.zip
-

--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -71,7 +71,9 @@ runs:
         # https://github.com/rust-cross/manylinux-cross?tab=readme-ov-file#manylinux_2_28
         before-script-linux: |
           set -e
-          apt-get install -y pkg-config libssl-dev unzip \
+          # apt-get install -y pkg-config libssl-dev unzip \
+          yum install -y openssl-devel clang \
             && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-aarch_64.zip > /tmp/protoc.zip \
             && unzip /tmp/protoc.zip -d /usr/local \
             && rm /tmp/protoc.zip
+

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,11 +1,8 @@
 name: Build and upload python wheels
 
 on:
-  # release:
-  #   types: [published]
-  pull_request:
-    paths:
-      - .github/workflows/pypi-publish.yml
+  release:
+    types: [published]
 
 jobs:
   linux:
@@ -23,9 +20,6 @@ jobs:
             manylinux: "2_28"
             extra_args: "--features fp16kernels"
             runner: ubuntu-22.04
-          # TODO: maybe this is irrelevant?
-          # ring doesn't compile on aarch64 under manylinux2.17
-          # https://github.com/briansmith/ring/issues/1789
           - platform: aarch64
             manylinux: "2_17"
             extra_args: ""
@@ -63,11 +57,11 @@ jobs:
         args: "--release --strip ${{ matrix.config.extra_args }}"
         arm-build: ${{ matrix.config.platform == 'aarch64' }}
         manylinux: ${{ matrix.config.manylinux }}
-    # - uses: ./.github/workflows/upload_wheel
-    #   with:
-    #     pypi_token: ${{ secrets.PYPI_TOKEN }}
-    #     fury_token: ${{ secrets.FURY_TOKEN }}
-    #     repo: ${{ steps.handle_tag.outputs.repo }}
+    - uses: ./.github/workflows/upload_wheel
+      with:
+        pypi_token: ${{ secrets.PYPI_TOKEN }}
+        fury_token: ${{ secrets.FURY_TOKEN }}
+        repo: ${{ steps.handle_tag.outputs.repo }}
   mac:
     timeout-minutes: 60
     runs-on: ${{ matrix.config.runner }}
@@ -108,11 +102,11 @@ jobs:
       with:
         python-minor-version: ${{ matrix.python-minor-version }}
         args: "--release --strip --target ${{ matrix.config.target }} --features fp16kernels"
-    # - uses: ./.github/workflows/upload_wheel
-    #   with:
-    #     pypi_token: ${{ secrets.PYPI_TOKEN }}
-    #     fury_token: ${{ secrets.FURY_TOKEN }}
-    #     repo: ${{ steps.handle_tag.outputs.repo }}
+    - uses: ./.github/workflows/upload_wheel
+      with:
+        pypi_token: ${{ secrets.PYPI_TOKEN }}
+        fury_token: ${{ secrets.FURY_TOKEN }}
+        repo: ${{ steps.handle_tag.outputs.repo }}
   windows:
     timeout-minutes: 60
     runs-on: windows-latest
@@ -148,8 +142,8 @@ jobs:
           python-minor-version: ${{ matrix.python-minor-version }}
           args: "--release --strip"
           vcpkg_token: ${{ secrets.VCPKG_GITHUB_PACKAGES }}
-      # - uses: ./.github/workflows/upload_wheel
-      #   with:
-      #     pypi_token: ${{ secrets.PYPI_TOKEN }}
-      #     fury_token: ${{ secrets.FURY_TOKEN }}
-      #     repo: ${{ steps.handle_tag.outputs.repo }}
+      - uses: ./.github/workflows/upload_wheel
+        with:
+          pypi_token: ${{ secrets.PYPI_TOKEN }}
+          fury_token: ${{ secrets.FURY_TOKEN }}
+          repo: ${{ steps.handle_tag.outputs.repo }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,15 +18,23 @@ jobs:
           - platform: x86_64
             manylinux: "2_17"
             extra_args: ""
+            runner: ubuntu-22.04
           - platform: x86_64
             manylinux: "2_28"
             extra_args: "--features fp16kernels"
+            runner: ubuntu-22.04
+          # TODO: maybe this is irrelevant?
           # ring doesn't compile on aarch64 under manylinux2.17
           # https://github.com/briansmith/ring/issues/1789
           - platform: aarch64
+            manylinux: "2_17"
+            extra_args: ""
+            runner: ubuntu-2404-4x-arm64
+          - platform: aarch64
             manylinux: "2_28"
             extra_args: "--features fp16kernels"
-    runs-on: "ubuntu-22.04"
+            runner: ubuntu-2404-4x-arm64
+    runs-on: ${{ matrix.config.runner }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -26,8 +26,6 @@ jobs:
           - platform: aarch64
             manylinux: "2_28"
             extra_args: "--features fp16kernels"
-          # We don't build fp16 kernels for aarch64, because it uses
-          # cross compilation image, which doesn't have a new enough compiler.
     runs-on: "ubuntu-22.04"
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,8 +1,11 @@
 name: Build and upload python wheels
 
 on:
-  release:
-    types: [published]
+  # release:
+  #   types: [published]
+  pull_request:
+    paths:
+      - .github/workflows/pypi-publish.yml
 
 jobs:
   linux:
@@ -18,9 +21,8 @@ jobs:
           - platform: x86_64
             manylinux: "2_28"
             extra_args: "--features fp16kernels"
-          - platform: aarch64
-            manylinux: "2_17"
-            extra_args: ""
+          # ring doesn't compile on aarch64 under manylinux2.17
+          # https://github.com/briansmith/ring/issues/1789
           - platform: aarch64
             manylinux: "2_28"
             extra_args: "--features fp16kernels"
@@ -55,11 +57,11 @@ jobs:
         args: "--release --strip ${{ matrix.config.extra_args }}"
         arm-build: ${{ matrix.config.platform == 'aarch64' }}
         manylinux: ${{ matrix.config.manylinux }}
-    - uses: ./.github/workflows/upload_wheel
-      with:
-        pypi_token: ${{ secrets.PYPI_TOKEN }}
-        fury_token: ${{ secrets.FURY_TOKEN }}
-        repo: ${{ steps.handle_tag.outputs.repo }}
+    # - uses: ./.github/workflows/upload_wheel
+    #   with:
+    #     pypi_token: ${{ secrets.PYPI_TOKEN }}
+    #     fury_token: ${{ secrets.FURY_TOKEN }}
+    #     repo: ${{ steps.handle_tag.outputs.repo }}
   mac:
     timeout-minutes: 60
     runs-on: ${{ matrix.config.runner }}
@@ -100,11 +102,11 @@ jobs:
       with:
         python-minor-version: ${{ matrix.python-minor-version }}
         args: "--release --strip --target ${{ matrix.config.target }} --features fp16kernels"
-    - uses: ./.github/workflows/upload_wheel
-      with:
-        pypi_token: ${{ secrets.PYPI_TOKEN }}
-        fury_token: ${{ secrets.FURY_TOKEN }}
-        repo: ${{ steps.handle_tag.outputs.repo }}
+    # - uses: ./.github/workflows/upload_wheel
+    #   with:
+    #     pypi_token: ${{ secrets.PYPI_TOKEN }}
+    #     fury_token: ${{ secrets.FURY_TOKEN }}
+    #     repo: ${{ steps.handle_tag.outputs.repo }}
   windows:
     timeout-minutes: 60
     runs-on: windows-latest
@@ -140,8 +142,8 @@ jobs:
           python-minor-version: ${{ matrix.python-minor-version }}
           args: "--release --strip"
           vcpkg_token: ${{ secrets.VCPKG_GITHUB_PACKAGES }}
-      - uses: ./.github/workflows/upload_wheel
-        with:
-          pypi_token: ${{ secrets.PYPI_TOKEN }}
-          fury_token: ${{ secrets.FURY_TOKEN }}
-          repo: ${{ steps.handle_tag.outputs.repo }}
+      # - uses: ./.github/workflows/upload_wheel
+      #   with:
+      #     pypi_token: ${{ secrets.PYPI_TOKEN }}
+      #     fury_token: ${{ secrets.FURY_TOKEN }}
+      #     repo: ${{ steps.handle_tag.outputs.repo }}


### PR DESCRIPTION
We can get both 2_17 and 2_28 working if we use an ARM runner.