### PR TITLE
feat: add testing of string/binary to 2.1 full-zip encoding and fix bugs

### DIFF
--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -473,7 +473,11 @@ impl SimulatedWriter {
         let page_encoding = encoded_page.description;
         let buffer_offsets_and_sizes = page_buffers
             .into_iter()
-            .map(|b| self.write_buffer(b))
+            .map(|b| {
+                let (offset, size) = self.write_buffer(b);
+                trace!("Encoded buffer offset={} size={}", offset, size);
+                (offset, size)
+            })
             .collect::<Vec<_>>();
 
         let page_info = PageInfo {


### PR DESCRIPTION
The bugs mostly originated from having `def` information but no `rep` information since the variable full zip path was originally built to support lists.