### PR TITLE
ci(java): timeout test jobs after an hour

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -47,6 +47,7 @@ jobs:
 
   build-and-test-java:
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     strategy:
       matrix:
         java-version: [8, 11, 17]


### PR DESCRIPTION
We have some java builds timing out after 6 hours. We should look into the hang, but for now let's limit them to an hour.