### PR TITLE
feat: auto-migrate old index metadata

### DIFF
--- a/rust/lance-core/src/utils.rs
+++ b/rust/lance-core/src/utils.rs
@@ -8,6 +8,7 @@ pub mod deletion;
 pub mod futures;
 pub mod hash;
 pub mod mask;
+pub mod parse;
 pub mod path;
 pub mod testing;
 pub mod tokio;

--- a/rust/lance-core/src/utils/parse.rs
+++ b/rust/lance-core/src/utils/parse.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+/// Parse a string into a boolean value.
+pub fn str_is_truthy(val: &str) -> bool {
+    val.eq_ignore_ascii_case("1")
+        | val.eq_ignore_ascii_case("true")
+        | val.eq_ignore_ascii_case("on")
+        | val.eq_ignore_ascii_case("yes")
+        | val.eq_ignore_ascii_case("y")
+}

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -17,6 +17,7 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use deepsize::DeepSizeOf;
 use futures::{future, stream::BoxStream, StreamExt, TryStreamExt};
+use lance_core::utils::parse::str_is_truthy;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use object_store::aws::{
     AmazonS3ConfigKey, AwsCredential as ObjectStoreAwsCredential, AwsCredentialProvider,
@@ -1037,14 +1038,6 @@ fn infer_block_size(scheme: &str) -> usize {
         "file" => 4 * 1024,
         _ => 64 * 1024,
     }
-}
-
-fn str_is_truthy(val: &str) -> bool {
-    val.eq_ignore_ascii_case("1")
-        | val.eq_ignore_ascii_case("true")
-        | val.eq_ignore_ascii_case("on")
-        | val.eq_ignore_ascii_case("yes")
-        | val.eq_ignore_ascii_case("y")
 }
 
 /// Attempt to create a Url from given table location.

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -11,6 +11,7 @@ use arrow_schema::DataType;
 use async_trait::async_trait;
 use futures::{stream, StreamExt, TryStreamExt};
 use itertools::Itertools;
+use lance_core::utils::parse::str_is_truthy;
 use lance_file::reader::FileReader;
 use lance_file::v2;
 use lance_file::v2::reader::FileReaderOptions;
@@ -70,15 +71,8 @@ use self::vector::{build_vector_index, VectorIndexParams, LANCE_VECTOR_INDEX};
 
 // Whether to auto-migrate a dataset when we encounter corruption.
 fn auto_migrate_corruption() -> bool {
-    static MAX_CONN_RESET_RETRIES: OnceLock<bool> = OnceLock::new();
-    fn str_is_truthy(val: &str) -> bool {
-        val.eq_ignore_ascii_case("1")
-            | val.eq_ignore_ascii_case("true")
-            | val.eq_ignore_ascii_case("on")
-            | val.eq_ignore_ascii_case("yes")
-            | val.eq_ignore_ascii_case("y")
-    }
-    *MAX_CONN_RESET_RETRIES.get_or_init(|| {
+    static LANCE_AUTO_MIGRATION: OnceLock<bool> = OnceLock::new();
+    *LANCE_AUTO_MIGRATION.get_or_init(|| {
         std::env::var("LANCE_AUTO_MIGRATION")
             .ok()
             .map(|s| str_is_truthy(&s))


### PR DESCRIPTION
Follow up to https://github.com/lancedb/lance/pull/3377. That PR made `index_statistics()` error by default. This ended up being a footgun for some users who rely heavily on that method. So instead of forcing the user to do the migration themself, we do it for them. It can be disabled using an environment variable.