### PR TITLE
fix: remove extraneous padding in plain encoder

### DIFF
--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -822,7 +822,7 @@ impl BufferExt for arrow_buffer::Buffer {
         let mut buf = MutableBuffer::with_capacity(size_bytes);
         let to_fill = size_bytes - bytes.len();
         buf.extend(bytes);
-        buf.extend(std::iter::repeat(0).take(to_fill));
+        buf.extend(std::iter::repeat(0_u8).take(to_fill));
         Self::from(buf)
     }
 }


### PR DESCRIPTION
This fixes two bugs with the padding added by the bytes_to_array function in the plain encoder. This function is used for reading indexes in LanceDB cloud.

Problem 1:
Prior to this commit, space was reserved based on an incorrect multiplication of the user-supplied buffer's byte length and the bytewidth of the item type. Instead, we should multiply the bytewidth by the element count. The effect of this was previously to pad too much space at the end of parsed arrays.

Problem 2:
We previously had some logic that was padding a buffer by extending it with 0-valued uint32s, instead of 0-valued uint8. This resulted in a multiplication of the padding added by four.