### PR TITLE
perf: make miniblock decoding cheaper

### DIFF
--- a/rust/lance-encoding/build.rs
+++ b/rust/lance-encoding/build.rs
@@ -13,6 +13,7 @@ fn main() -> Result<()> {
     let mut prost_build = prost_build::Config::new();
     prost_build.protoc_arg("--experimental_allow_proto3_optional");
     prost_build.enable_type_names();
+    prost_build.bytes(&["."]); // Enable Bytes type for all messages to avoid Vec clones.
     prost_build.compile_protos(&["./protos/encodings.proto"], &["./protos"])?;
 
     Ok(())

--- a/rust/lance-encoding/build.rs
+++ b/rust/lance-encoding/build.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
     let mut prost_build = prost_build::Config::new();
     prost_build.protoc_arg("--experimental_allow_proto3_optional");
     prost_build.enable_type_names();
-    prost_build.bytes(&["."]); // Enable Bytes type for all messages to avoid Vec clones.
+    prost_build.bytes(["."]); // Enable Bytes type for all messages to avoid Vec clones.
     prost_build.compile_protos(&["./protos/encodings.proto"], &["./protos"])?;
 
     Ok(())

--- a/rust/lance-encoding/src/buffer.rs
+++ b/rust/lance-encoding/src/buffer.rs
@@ -164,6 +164,14 @@ impl LanceBuffer {
         }
     }
 
+    /// Convert a buffer into a bytes::Bytes object
+    pub fn into_bytes(self) -> bytes::Bytes {
+        match self {
+            Self::Owned(buf) => buf.into(),
+            Self::Borrowed(buf) => buf.into_vec::<u8>().unwrap().into(),
+        }
+    }
+
     /// Convert into a borrowed buffer, this is a zero-copy operation
     ///
     /// This is often called before cloning the buffer

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -554,7 +554,7 @@ impl DecompressorStrategy for CoreDecompressorStrategy {
             }
             pb::array_encoding::ArrayEncoding::Fsst(ref fsst) => {
                 Ok(Box::new(FsstPerValueDecompressor::new(
-                    fsst.symbol_table.clone(),
+                    LanceBuffer::from_bytes(fsst.symbol_table.clone(), 1),
                     Box::new(VariableDecoder::default()),
                 )))
             }
@@ -571,7 +571,7 @@ impl DecompressorStrategy for CoreDecompressorStrategy {
                 Ok(Box::new(ValueDecompressor::new(flat)))
             }
             pb::array_encoding::ArrayEncoding::Constant(constant) => {
-                let scalar = LanceBuffer::Owned(constant.value.clone());
+                let scalar = LanceBuffer::from_bytes(constant.value.clone(), 1);
                 Ok(Box::new(ConstantDecompressor::new(
                     scalar,
                     constant.num_values,

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -1542,7 +1542,7 @@ impl RootDecoderType for SimpleStructDecoder {
     }
 }
 
-/// A blocking back decoder that performs synchronous decoding
+/// A blocking batch decoder that performs synchronous decoding
 struct BatchDecodeIterator<T: RootDecoderType> {
     messages: VecDeque<Result<DecoderMessage>>,
     root_decoder: T,

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -217,10 +217,10 @@ use std::sync::Once;
 use std::{ops::Range, sync::Arc};
 
 use arrow_array::cast::AsArray;
-use arrow_array::{ArrayRef, RecordBatch};
-use arrow_schema::{DataType, Field as ArrowField, Fields, Schema as ArrowSchema};
+use arrow_array::{ArrayRef, RecordBatch, RecordBatchIterator, RecordBatchReader};
+use arrow_schema::{ArrowError, DataType, Field as ArrowField, Fields, Schema as ArrowSchema};
 use bytes::Bytes;
-use futures::future::BoxFuture;
+use futures::future::{maybe_done, BoxFuture, MaybeDone};
 use futures::stream::{self, BoxStream};
 use futures::{FutureExt, StreamExt};
 use lance_arrow::DataTypeExt;
@@ -231,7 +231,7 @@ use snafu::{location, Location};
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::{self, unbounded_channel};
 
-use lance_core::{Error, Result};
+use lance_core::{ArrowResult, Error, Result};
 use tracing::instrument;
 
 use crate::buffer::LanceBuffer;
@@ -252,7 +252,7 @@ use crate::encodings::physical::binary::{
     BinaryBlockDecompressor, BinaryMiniBlockDecompressor, VariableDecoder,
 };
 use crate::encodings::physical::bitpack_fastlanes::BitpackMiniBlockDecompressor;
-use crate::encodings::physical::fsst::FsstMiniBlockDecompressor;
+use crate::encodings::physical::fsst::{FsstMiniBlockDecompressor, FsstPerValueDecompressor};
 use crate::encodings::physical::struct_encoding::PackedStructFixedWidthMiniBlockDecompressor;
 use crate::encodings::physical::value::{ConstantDecompressor, ValueDecompressor};
 use crate::encodings::physical::{ColumnBuffers, FileBuffers};
@@ -547,10 +547,16 @@ impl DecompressorStrategy for CoreDecompressorStrategy {
         &self,
         description: &pb::ArrayEncoding,
     ) -> Result<Box<dyn VariablePerValueDecompressor>> {
-        match description.array_encoding.as_ref().unwrap() {
-            &pb::array_encoding::ArrayEncoding::Variable(variable) => {
+        match *description.array_encoding.as_ref().unwrap() {
+            pb::array_encoding::ArrayEncoding::Variable(variable) => {
                 assert!(variable.bits_per_offset < u8::MAX as u32);
                 Ok(Box::new(VariableDecoder::default()))
+            }
+            pb::array_encoding::ArrayEncoding::Fsst(ref fsst) => {
+                Ok(Box::new(FsstPerValueDecompressor::new(
+                    fsst.symbol_table.clone(),
+                    Box::new(VariableDecoder::default()),
+                )))
             }
             _ => todo!("variable-per-value decompressor for {:?}", description),
         }
@@ -1468,34 +1474,6 @@ impl BatchDecodeStream {
         Ok(Some(next_task))
     }
 
-    #[instrument(level = "debug", skip_all)]
-    fn task_to_batch(
-        task: NextDecodeTask,
-        emitted_batch_size_warning: Arc<Once>,
-    ) -> Result<RecordBatch> {
-        let struct_arr = task.task.decode();
-        match struct_arr {
-            Ok(struct_arr) => {
-                let batch = RecordBatch::from(struct_arr.as_struct());
-                let size_bytes = batch.get_array_memory_size() as u64;
-                if size_bytes > BATCH_SIZE_BYTES_WARNING {
-                    emitted_batch_size_warning.call_once(|| {
-                        let size_mb = size_bytes / 1024 / 1024;
-                        debug!("Lance read in a single batch that contained more than {}MiB of data.  You may want to consider reducing the batch size.", size_mb);
-                    });
-                }
-                Ok(batch)
-            }
-            Err(e) => {
-                let e = Error::Internal {
-                    message: format!("Error decoding batch: {}", e),
-                    location: location!(),
-                };
-                Err(e)
-            }
-        }
-    }
-
     pub fn into_stream(self) -> BoxStream<'static, ReadBatchTask> {
         let stream = futures::stream::unfold(self, |mut slf| async move {
             let next_task = slf.next_batch_task().await;
@@ -1504,7 +1482,7 @@ impl BatchDecodeStream {
                 let emitted_batch_size_warning = slf.emitted_batch_size_warning.clone();
                 let task = tokio::spawn(async move {
                     let next_task = next_task?;
-                    Self::task_to_batch(next_task, emitted_batch_size_warning)
+                    next_task.into_batch(emitted_batch_size_warning)
                 });
                 (task, num_rows)
             });
@@ -1520,6 +1498,195 @@ impl BatchDecodeStream {
             })
         });
         stream.boxed()
+    }
+}
+
+// Utility types to smooth out the differences between the 2.0 and 2.1 decoders so that
+// we can have a single implementation of the batch decode iterator
+enum RootDecoderMessage {
+    LoadedPage(LoadedPage),
+    LegacyPage(DecoderReady),
+}
+trait RootDecoderType {
+    fn accept_message(&mut self, message: RootDecoderMessage) -> Result<()>;
+    fn drain_batch(&mut self, num_rows: u64) -> Result<NextDecodeTask>;
+    fn wait(&mut self, loaded_need: u64, runtime: &tokio::runtime::Runtime) -> Result<()>;
+}
+impl RootDecoderType for StructuralStructDecoder {
+    fn accept_message(&mut self, message: RootDecoderMessage) -> Result<()> {
+        let RootDecoderMessage::LoadedPage(loaded_page) = message else {
+            unreachable!()
+        };
+        self.accept_page(loaded_page)
+    }
+    fn drain_batch(&mut self, num_rows: u64) -> Result<NextDecodeTask> {
+        self.drain_batch_task(num_rows)
+    }
+    fn wait(&mut self, _: u64, _: &tokio::runtime::Runtime) -> Result<()> {
+        // Waiting happens elsewhere (not as part of the decoder)
+        Ok(())
+    }
+}
+impl RootDecoderType for SimpleStructDecoder {
+    fn accept_message(&mut self, message: RootDecoderMessage) -> Result<()> {
+        let RootDecoderMessage::LegacyPage(legacy_page) = message else {
+            unreachable!()
+        };
+        self.accept_child(legacy_page)
+    }
+    fn drain_batch(&mut self, num_rows: u64) -> Result<NextDecodeTask> {
+        self.drain(num_rows)
+    }
+    fn wait(&mut self, loaded_need: u64, runtime: &tokio::runtime::Runtime) -> Result<()> {
+        runtime.block_on(self.wait_for_loaded(loaded_need))
+    }
+}
+
+/// A blocking back decoder that performs synchronous decoding
+struct BatchDecodeIterator<T: RootDecoderType> {
+    messages: VecDeque<Result<DecoderMessage>>,
+    root_decoder: T,
+    rows_remaining: u64,
+    rows_per_batch: u32,
+    rows_scheduled: u64,
+    rows_drained: u64,
+    emitted_batch_size_warning: Arc<Once>,
+    // Note: this is not the runtime on which I/O happens.
+    // That's always in the scheduler.  This is just a runtime we use to
+    // sleep the current thread if I/O is unready
+    wait_for_io_runtime: tokio::runtime::Runtime,
+    schema: Arc<ArrowSchema>,
+}
+
+impl<T: RootDecoderType> BatchDecodeIterator<T> {
+    /// Create a new instance of a batch decode iterator
+    pub fn new(
+        messages: VecDeque<Result<DecoderMessage>>,
+        rows_per_batch: u32,
+        num_rows: u64,
+        root_decoder: T,
+        schema: Arc<ArrowSchema>,
+    ) -> Self {
+        Self {
+            messages,
+            root_decoder,
+            rows_remaining: num_rows,
+            rows_per_batch,
+            rows_scheduled: 0,
+            rows_drained: 0,
+            wait_for_io_runtime: tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap(),
+            emitted_batch_size_warning: Arc::new(Once::new()),
+            schema,
+        }
+    }
+
+    /// Wait for a single page of data to finish loading
+    ///
+    /// If the data is not available this will perform a *blocking* wait (put
+    /// the current thread to sleep)
+    fn wait_for_page(&self, unloaded_page: UnloadedPage) -> Result<LoadedPage> {
+        match maybe_done(unloaded_page.0) {
+            // Fast path, avoid all runtime shenanigans if the data is ready
+            MaybeDone::Done(loaded_page) => loaded_page,
+            // Slow path, we need to wait on I/O, enter the runtime
+            MaybeDone::Future(fut) => self.wait_for_io_runtime.block_on(fut),
+            MaybeDone::Gone => unreachable!(),
+        }
+    }
+
+    /// Waits for I/O until `scheduled_need` rows have been loaded
+    ///
+    /// Note that `scheduled_need` is cumulative.  E.g. this method
+    /// should be called with 5, 10, 15 and not 5, 5, 5
+    #[instrument(skip_all)]
+    fn wait_for_io(&mut self, scheduled_need: u64) -> Result<u64> {
+        while self.rows_scheduled < scheduled_need && !self.messages.is_empty() {
+            let message = self.messages.pop_front().unwrap()?;
+            self.rows_scheduled = message.scheduled_so_far;
+            for decoder_message in message.decoders {
+                match decoder_message {
+                    MessageType::UnloadedPage(unloaded_page) => {
+                        let loaded_page = self.wait_for_page(unloaded_page)?;
+                        self.root_decoder
+                            .accept_message(RootDecoderMessage::LoadedPage(loaded_page))?;
+                    }
+                    MessageType::DecoderReady(decoder_ready) => {
+                        // The root decoder we can ignore
+                        if !decoder_ready.path.is_empty() {
+                            self.root_decoder
+                                .accept_message(RootDecoderMessage::LegacyPage(decoder_ready))?;
+                        }
+                    }
+                }
+            }
+        }
+
+        let loaded_need = self.rows_drained + self.rows_per_batch as u64 - 1;
+
+        self.root_decoder
+            .wait(loaded_need, &self.wait_for_io_runtime)?;
+        Ok(self.rows_scheduled)
+    }
+
+    #[instrument(level = "debug", skip_all)]
+    fn next_batch_task(&mut self) -> Result<Option<RecordBatch>> {
+        trace!(
+            "Draining batch task (rows_remaining={} rows_drained={} rows_scheduled={})",
+            self.rows_remaining,
+            self.rows_drained,
+            self.rows_scheduled,
+        );
+        if self.rows_remaining == 0 {
+            return Ok(None);
+        }
+
+        let mut to_take = self.rows_remaining.min(self.rows_per_batch as u64);
+        self.rows_remaining -= to_take;
+
+        let scheduled_need = (self.rows_drained + to_take).saturating_sub(self.rows_scheduled);
+        trace!("scheduled_need = {} because rows_drained = {} and to_take = {} and rows_scheduled = {}", scheduled_need, self.rows_drained, to_take, self.rows_scheduled);
+        if scheduled_need > 0 {
+            let desired_scheduled = scheduled_need + self.rows_scheduled;
+            trace!(
+                "Draining from scheduler (desire at least {} scheduled rows)",
+                desired_scheduled
+            );
+            let actually_scheduled = self.wait_for_io(desired_scheduled)?;
+            if actually_scheduled < desired_scheduled {
+                let under_scheduled = desired_scheduled - actually_scheduled;
+                to_take -= under_scheduled;
+            }
+        }
+
+        if to_take == 0 {
+            return Ok(None);
+        }
+
+        let next_task = self.root_decoder.drain_batch(to_take)?;
+
+        self.rows_drained += to_take;
+
+        let batch = next_task.into_batch(self.emitted_batch_size_warning.clone())?;
+
+        Ok(Some(batch))
+    }
+}
+
+impl<T: RootDecoderType> Iterator for BatchDecodeIterator<T> {
+    type Item = ArrowResult<RecordBatch>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_batch_task()
+            .transpose()
+            .map(|r| r.map_err(ArrowError::from))
+    }
+}
+
+impl<T: RootDecoderType> RecordBatchReader for BatchDecodeIterator<T> {
+    fn schema(&self) -> Arc<ArrowSchema> {
+        self.schema.clone()
     }
 }
 
@@ -1626,42 +1793,9 @@ impl StructuralBatchDecodeStream {
             return Ok(None);
         }
 
-        let next_task = self.root_decoder.drain(to_take)?;
-        let next_task = NextDecodeTask {
-            has_more: self.rows_remaining > 0,
-            num_rows: to_take,
-            task: Box::new(next_task),
-        };
+        let next_task = self.root_decoder.drain_batch_task(to_take)?;
         self.rows_drained += to_take;
         Ok(Some(next_task))
-    }
-
-    #[instrument(level = "debug", skip_all)]
-    fn task_to_batch(
-        task: NextDecodeTask,
-        emitted_batch_size_warning: Arc<Once>,
-    ) -> Result<RecordBatch> {
-        let struct_arr = task.task.decode();
-        match struct_arr {
-            Ok(struct_arr) => {
-                let batch = RecordBatch::from(struct_arr.as_struct());
-                let size_bytes = batch.get_array_memory_size() as u64;
-                if size_bytes > BATCH_SIZE_BYTES_WARNING {
-                    emitted_batch_size_warning.call_once(|| {
-                        let size_mb = size_bytes / 1024 / 1024;
-                        debug!("Lance read in a single batch that contained more than {}MiB of data.  You may want to consider reducing the batch size.", size_mb);
-                    });
-                }
-                Ok(batch)
-            }
-            Err(e) => {
-                let e = Error::Internal {
-                    message: format!("Error decoding batch: {}", e),
-                    location: location!(),
-                };
-                Err(e)
-            }
-        }
     }
 
     pub fn into_stream(self) -> BoxStream<'static, ReadBatchTask> {
@@ -1672,7 +1806,7 @@ impl StructuralBatchDecodeStream {
                 let emitted_batch_size_warning = slf.emitted_batch_size_warning.clone();
                 let task = tokio::spawn(async move {
                     let next_task = next_task?;
-                    Self::task_to_batch(next_task, emitted_batch_size_warning)
+                    next_task.into_batch(emitted_batch_size_warning)
                 });
                 (task, num_rows)
             });
@@ -1757,6 +1891,41 @@ pub fn create_decode_stream(
 
         let simple_struct_decoder = SimpleStructDecoder::new(root_fields, num_rows);
         BatchDecodeStream::new(rx, batch_size, num_rows, simple_struct_decoder).into_stream()
+    }
+}
+
+/// Creates a iterator that decodes a set of messages in a blocking fashion
+///
+/// See [`schedule_and_decode_blocking`] for more information.
+pub fn create_decode_iterator(
+    schema: &Schema,
+    num_rows: u64,
+    batch_size: u32,
+    should_validate: bool,
+    is_structural: bool,
+    messages: VecDeque<Result<DecoderMessage>>,
+) -> Box<dyn RecordBatchReader> {
+    let arrow_schema = Arc::new(ArrowSchema::from(schema));
+    let root_fields = arrow_schema.fields.clone();
+    if is_structural {
+        let simple_struct_decoder =
+            StructuralStructDecoder::new(root_fields, should_validate, /*is_root=*/ true);
+        Box::new(BatchDecodeIterator::new(
+            messages,
+            batch_size,
+            num_rows,
+            simple_struct_decoder,
+            arrow_schema,
+        ))
+    } else {
+        let root_decoder = SimpleStructDecoder::new(root_fields, num_rows);
+        Box::new(BatchDecodeIterator::new(
+            messages,
+            batch_size,
+            num_rows,
+            root_decoder,
+            arrow_schema,
+        ))
     }
 }
 
@@ -1852,6 +2021,90 @@ pub fn schedule_and_decode(
         }))
         .boxed(),
     }
+}
+
+lazy_static::lazy_static! {
+    pub static ref WAITER_RT: tokio::runtime::Runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+}
+
+/// Schedules and decodes the requested data in a blocking fashion
+///
+/// This function is a blocking version of [`schedule_and_decode`]. It schedules the requested data
+/// and decodes it in the current thread.
+///
+/// This can be useful when the disk is fast (or the data is in memory) and the amount
+/// of data is relatively small.  For example, when doing a take against NVMe or in-memory data.
+///
+/// This should NOT be used for full scans.  Even if the data is in memory this function will
+/// not parallelize the decode and will be slower than the async version.  Full scans typically
+/// make relatively few IOPs and so the asynchronous overhead is much smaller.
+///
+/// This method will first completely run the scheduling process.  Then it will run the
+/// decode process.
+pub fn schedule_and_decode_blocking(
+    column_infos: Vec<Arc<ColumnInfo>>,
+    requested_rows: RequestedRows,
+    filter: FilterExpression,
+    column_indices: Vec<u32>,
+    target_schema: Arc<Schema>,
+    config: SchedulerDecoderConfig,
+) -> Result<Box<dyn RecordBatchReader>> {
+    if requested_rows.num_rows() == 0 {
+        let arrow_schema = Arc::new(ArrowSchema::from(target_schema.as_ref()));
+        return Ok(Box::new(RecordBatchIterator::new(vec![], arrow_schema)));
+    }
+
+    let num_rows = requested_rows.num_rows();
+    let is_structural = column_infos[0].is_structural();
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    // Initialize the scheduler.  This is still "asynchronous" but we run it with a current-thread
+    // runtime.
+    let mut decode_scheduler = WAITER_RT.block_on(DecodeBatchScheduler::try_new(
+        target_schema.as_ref(),
+        &column_indices,
+        &column_infos,
+        &vec![],
+        num_rows,
+        config.decoder_plugins,
+        config.io.clone(),
+        config.cache,
+        &filter,
+    ))?;
+
+    // Schedule the requested rows
+    match requested_rows {
+        RequestedRows::Ranges(ranges) => {
+            decode_scheduler.schedule_ranges(&ranges, &filter, tx, config.io)
+        }
+        RequestedRows::Indices(indices) => {
+            decode_scheduler.schedule_take(&indices, &filter, tx, config.io)
+        }
+    }
+
+    // Drain the scheduler queue into a vec of decode messages
+    let mut messages = Vec::new();
+    while rx
+        .recv_many(&mut messages, usize::MAX)
+        .now_or_never()
+        .unwrap()
+        != 0
+    {}
+
+    // Create a decoder to decode the messages
+    let decode_iterator = create_decode_iterator(
+        &target_schema,
+        num_rows,
+        config.batch_size,
+        config.should_validate,
+        is_structural,
+        messages.into(),
+    );
+
+    Ok(decode_iterator)
 }
 
 /// A decoder for single-column encodings of primitive data (this includes fixed size
@@ -2237,14 +2490,46 @@ impl DecodeArrayTask for Box<dyn StructuralDecodeArrayTask> {
     }
 }
 
-/// A task to decode data into an Arrow array
+/// A task to decode data into an Arrow record batch
+///
+/// It has a child `task` which decodes a struct array with no nulls.
+/// This is then converted into a record batch.
 pub struct NextDecodeTask {
     /// The decode task itself
     pub task: Box<dyn DecodeArrayTask>,
     /// The number of rows that will be created
     pub num_rows: u64,
-    /// Whether or not the decoder that created this still has more rows to decode
-    pub has_more: bool,
+}
+
+impl NextDecodeTask {
+    // Run the task and produce a record batch
+    //
+    // If the batch is very large this function will log a warning message
+    // suggesting the user try a smaller batch size.
+    #[instrument(name = "task_to_batch", level = "debug", skip_all)]
+    fn into_batch(self, emitted_batch_size_warning: Arc<Once>) -> Result<RecordBatch> {
+        let struct_arr = self.task.decode();
+        match struct_arr {
+            Ok(struct_arr) => {
+                let batch = RecordBatch::from(struct_arr.as_struct());
+                let size_bytes = batch.get_array_memory_size() as u64;
+                if size_bytes > BATCH_SIZE_BYTES_WARNING {
+                    emitted_batch_size_warning.call_once(|| {
+                        let size_mb = size_bytes / 1024 / 1024;
+                        debug!("Lance read in a single batch that contained more than {}MiB of data.  You may want to consider reducing the batch size.", size_mb);
+                    });
+                }
+                Ok(batch)
+            }
+            Err(e) => {
+                let e = Error::Internal {
+                    message: format!("Error decoding batch: {}", e),
+                    location: location!(),
+                };
+                Err(e)
+            }
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -249,28 +249,6 @@ pub trait PerValueCompressor: std::fmt::Debug + Send + Sync {
     fn compress(&self, data: DataBlock) -> Result<(PerValueDataBlock, pb::ArrayEncoding)>;
 }
 
-/// Trait for compression algorithms that are suitable for use in the zipped structural encoding
-///
-/// This encoding is useful for non-short strings, binary, and variable length lists
-/// (i.e. when the average value is >= 128 bytes)
-///
-/// These compressors can be extremely generic.  They only need to produce one buffer of bytes
-/// and another buffer of offsets into the bytes, one offset for each value.  Both of these buffers
-/// will be stored.
-///
-/// Note: It is perfectly legal for a value to have 0 bytes.  However, we still need to store the
-/// offset itself.  This means that this compressor, when implemented by something like RLE will not
-/// be as efficient (space-wise) as a block version (which could skip the offsets for runs).
-///
-/// Accessing this data will require 2 IOPS and accessing in a random-access fashion will require
-/// a repetition index.
-pub trait VariablePerValueCompressor: std::fmt::Debug + Send + Sync {
-    /// Compress the data into a single buffer where each value is encoded with a different size
-    ///
-    /// Also returns a description of the compression that can be used to decompress when reading the data back
-    fn compress(&self, data: DataBlock) -> Result<(VariableWidthBlock, pb::ArrayEncoding)>;
-}
-
 /// Trait for compression algorithms that compress an entire block of data into one opaque
 /// and self-described chunk.
 ///
@@ -515,13 +493,26 @@ impl CoreArrayEncodingStrategy {
         let bin_indices_encoder =
             Self::choose_array_encoder(arrays, &DataType::UInt64, data_size, false, version, None)?;
 
-        let compression = field_meta.and_then(Self::get_field_compression);
-
-        let bin_encoder = Box::new(BinaryEncoder::new(bin_indices_encoder, compression));
-        if compression.is_none() && Self::can_use_fsst(data_type, data_size, version) {
-            Ok(Box::new(FsstArrayEncoder::new(bin_encoder)))
+        if let Some(compression) = field_meta.and_then(Self::get_field_compression) {
+            if compression.scheme == CompressionScheme::Fsst {
+                // User requested FSST
+                let raw_encoder = Box::new(BinaryEncoder::new(bin_indices_encoder, None));
+                Ok(Box::new(FsstArrayEncoder::new(raw_encoder)))
+            } else {
+                // Generic compression
+                Ok(Box::new(BinaryEncoder::new(
+                    bin_indices_encoder,
+                    Some(compression),
+                )))
+            }
         } else {
-            Ok(bin_encoder)
+            // No user-specified compression, use FSST if we can
+            let bin_encoder = Box::new(BinaryEncoder::new(bin_indices_encoder, None));
+            if Self::can_use_fsst(data_type, data_size, version) {
+                Ok(Box::new(FsstArrayEncoder::new(bin_encoder)))
+            } else {
+                Ok(bin_encoder)
+            }
         }
     }
 

--- a/rust/lance-encoding/src/encodings/logical/binary.rs
+++ b/rust/lance-encoding/src/encodings/logical/binary.rs
@@ -118,7 +118,6 @@ impl LogicalPageDecoder for BinaryPageDecoder {
     fn drain(&mut self, num_rows: u64) -> Result<NextDecodeTask> {
         let inner_task = self.inner.drain(num_rows)?;
         Ok(NextDecodeTask {
-            has_more: inner_task.has_more,
             num_rows: inner_task.num_rows,
             task: Box::new(BinaryArrayDecoder {
                 inner: inner_task.task,

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -231,7 +231,6 @@ impl LogicalPageDecoder for BlobFieldDecoder {
         let validity = self.drain_validity(num_rows as usize)?;
         self.rows_drained += num_rows;
         Ok(NextDecodeTask {
-            has_more: self.rows_drained < self.num_rows,
             num_rows,
             task: Box::new(BlobArrayDecodeTask::new(bytes, validity)),
         })

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -786,9 +786,7 @@ impl LogicalPageDecoder for ListPageDecoder {
         };
 
         self.rows_drained += num_rows;
-        let has_more = self.rows_left() > 0;
         Ok(NextDecodeTask {
-            has_more,
             num_rows,
             task: Box::new(ListDecodeTask {
                 offsets,

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -1670,7 +1670,7 @@ impl StructuralPageScheduler for MiniBlockScheduler {
         let def_meaning = self.def_meaning.clone();
         let items_per_row = self.items_per_row;
 
-        Ok(async move {
+        let res = async move {
             let loaded_chunk_data = loaded_chunk_data.await?;
             for (loaded_chunk, chunk_data) in loaded_chunks.iter_mut().zip(loaded_chunk_data) {
                 loaded_chunk.data = LanceBuffer::from_bytes(chunk_data, 1);
@@ -1689,7 +1689,8 @@ impl StructuralPageScheduler for MiniBlockScheduler {
                 items_per_row,
             }) as Box<dyn StructuralPageDecoder>)
         }
-        .boxed())
+        .boxed();
+        Ok(res)
     }
 }
 
@@ -2909,7 +2910,6 @@ impl LogicalPageDecoder for PrimitiveFieldDecoder {
         Ok(NextDecodeTask {
             task,
             num_rows: rows_to_take,
-            has_more: self.rows_drained != self.num_rows,
         })
     }
 
@@ -4253,7 +4253,7 @@ impl PrimitiveStructuralEncoder {
                 }
             }
             _ => {
-                unreachable!()
+                unreachable!("dictionary encode called with data block {:?}", data_block)
             }
         }
     }

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -1445,7 +1445,7 @@ impl ChunkInstructions {
                 Err(idx) => idx - 1,
             };
 
-            let mut to_skip = user_range.start - &rep_index.blocks[block_index].first_row;
+            let mut to_skip = user_range.start - rep_index.blocks[block_index].first_row;
 
             while rows_needed > 0 || need_preamble {
                 let chunk = &rep_index.blocks[block_index];
@@ -2876,7 +2876,7 @@ impl StructuralFieldScheduler for StructuralPrimitiveFieldScheduler {
                 .iter_mut()
                 .zip(cached_data.pages.iter())
                 .for_each(|(page_scheduler, cached_data)| {
-                    page_scheduler.scheduler.load(&cached_data);
+                    page_scheduler.scheduler.load(cached_data);
                 });
             return std::future::ready(Ok(())).boxed();
         };
@@ -2891,7 +2891,7 @@ impl StructuralFieldScheduler for StructuralPrimitiveFieldScheduler {
         async move {
             let page_data = page_data.try_collect::<Vec<_>>().await?;
             let cached_data = Arc::new(CachedFieldData { pages: page_data });
-            cache.insert_by_str::<CachedFieldData>(&cache_key, cached_data.clone());
+            cache.insert_by_str::<CachedFieldData>(&cache_key, cached_data);
             Ok(())
         }
         .boxed()

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -1133,9 +1133,9 @@ struct MiniBlockSchedulerDictionary {
 
 #[derive(Debug)]
 struct RepIndexBlock {
-    // The first row in the block, if there is a preamble then this is the offset
-    // of the row after the preamble (that row may not exist if the block is entirely)
-    // preamble
+    // The index of the first row that starts after the beginning of this block.  If the block
+    // has a preamble this will be the row after the preamble.  If the block is entirely preamble
+    // then this will be a row that starts in some future block.
     first_row: u64,
     // The number of rows in the block, including the trailer but not the preamble.
     // Can be 0 if the block is entirely preamble

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -631,6 +631,14 @@ impl StructuralStructDecoder {
             _ => Box::new(StructuralPrimitiveFieldDecoder::new(field, should_validate)),
         }
     }
+
+    pub fn drain_batch_task(&mut self, num_rows: u64) -> Result<NextDecodeTask> {
+        let array_drain = self.drain(num_rows)?;
+        Ok(NextDecodeTask {
+            num_rows,
+            task: Box::new(array_drain),
+        })
+    }
 }
 
 impl StructuralFieldDecoder for StructuralStructDecoder {
@@ -787,16 +795,13 @@ impl LogicalPageDecoder for SimpleStructDecoder {
             .map(|child| child.drain(num_rows))
             .collect::<Result<Vec<_>>>()?;
         let num_rows = child_tasks[0].num_rows;
-        let has_more = child_tasks[0].has_more;
         debug_assert!(child_tasks.iter().all(|task| task.num_rows == num_rows));
-        debug_assert!(child_tasks.iter().all(|task| task.has_more == has_more));
         Ok(NextDecodeTask {
             task: Box::new(SimpleStructDecodeTask {
                 children: child_tasks,
                 child_fields: self.child_fields.clone(),
             }),
             num_rows,
-            has_more,
         })
     }
 

--- a/rust/lance-encoding/src/encodings/physical.rs
+++ b/rust/lance-encoding/src/encodings/physical.rs
@@ -12,6 +12,7 @@ use self::{
     dictionary::DictionaryPageScheduler, fixed_size_list::FixedListScheduler,
     value::ValuePageScheduler,
 };
+use crate::buffer::LanceBuffer;
 use crate::encodings::physical::block_compress::CompressionScheme;
 use crate::{
     decoder::PageScheduler,
@@ -236,7 +237,10 @@ pub fn decoder_from_array_encoding(
             let inner =
                 decoder_from_array_encoding(fsst.binary.as_ref().unwrap(), buffers, data_type);
 
-            Box::new(FsstPageScheduler::new(inner, fsst.symbol_table.clone()))
+            Box::new(FsstPageScheduler::new(
+                inner,
+                LanceBuffer::from_bytes(fsst.symbol_table.clone(), 1),
+            ))
         }
         pb::array_encoding::ArrayEncoding::Dictionary(dictionary) => {
             let indices_encoding = dictionary.indices.as_ref().unwrap();

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -847,7 +847,10 @@ pub mod tests {
     };
     use arrow_schema::{DataType, Field};
 
-    use lance_core::datatypes::{STRUCTURAL_ENCODING_FULLZIP, STRUCTURAL_ENCODING_MINIBLOCK};
+    use lance_core::datatypes::{
+        COMPRESSION_META_KEY, STRUCTURAL_ENCODING_FULLZIP, STRUCTURAL_ENCODING_META_KEY,
+        STRUCTURAL_ENCODING_MINIBLOCK,
+    };
     use rstest::rstest;
     use std::{collections::HashMap, sync::Arc, vec};
 
@@ -917,6 +920,23 @@ pub mod tests {
 
         let field = Field::new("", data_type, false).with_metadata(field_metadata);
         check_round_trip_encoding_random(field, version).await;
+    }
+
+    #[rstest]
+    #[test_log::test(tokio::test)]
+    async fn test_binary_fsst(
+        #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
+        structural_encoding: &str,
+    ) {
+        let mut field_metadata = HashMap::new();
+        field_metadata.insert(
+            STRUCTURAL_ENCODING_META_KEY.to_string(),
+            structural_encoding.into(),
+        );
+        field_metadata.insert(COMPRESSION_META_KEY.to_string(), "fsst".into());
+
+        let field = Field::new("", DataType::Utf8, true).with_metadata(field_metadata);
+        check_round_trip_encoding_random(field, LanceFileVersion::V2_1).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/encodings/physical/block_compress.rs
+++ b/rust/lance-encoding/src/encodings/physical/block_compress.rs
@@ -40,12 +40,14 @@ impl Default for CompressionConfig {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CompressionScheme {
     None,
+    Fsst,
     Zstd,
 }
 
 impl std::fmt::Display for CompressionScheme {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let scheme_str = match self {
+            Self::Fsst => "fsst",
             Self::Zstd => "zstd",
             Self::None => "none",
         };
@@ -121,6 +123,8 @@ pub struct GeneralBufferCompressor {}
 impl GeneralBufferCompressor {
     pub fn get_compressor(compression_config: CompressionConfig) -> Box<dyn BufferCompressor> {
         match compression_config.scheme {
+            // FSST has its own compression path and isn't implemented as a generic buffer compressor
+            CompressionScheme::Fsst => unimplemented!(),
             CompressionScheme::Zstd => Box::new(ZstdBufferCompressor::new(
                 compression_config.level.unwrap_or(0),
             )),

--- a/rust/lance-encoding/src/format.rs
+++ b/rust/lance-encoding/src/format.rs
@@ -37,7 +37,10 @@ pub struct ProtobufUtils {}
 impl ProtobufUtils {
     pub fn constant(value: Vec<u8>, num_values: u64) -> ArrayEncoding {
         ArrayEncoding {
-            array_encoding: Some(ArrayEncodingEnum::Constant(Constant { value, num_values })),
+            array_encoding: Some(ArrayEncodingEnum::Constant(Constant {
+                value: value.into(),
+                num_values,
+            })),
         }
     }
 
@@ -160,7 +163,7 @@ impl ProtobufUtils {
         ArrayEncoding {
             array_encoding: Some(ArrayEncodingEnum::Fsst(Box::new(Fsst {
                 binary: Some(Box::new(data)),
-                symbol_table,
+                symbol_table: symbol_table.into(),
             }))),
         }
     }

--- a/rust/lance-file/src/v2.rs
+++ b/rust/lance-file/src/v2.rs
@@ -5,3 +5,5 @@ pub(crate) mod io;
 pub mod reader;
 pub mod testing;
 pub mod writer;
+
+pub use io::LanceEncodingsIo;

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -29,6 +29,7 @@ use lance_datafusion::utils::StreamingWriteSource;
 use lance_encoding::decoder::DecoderPlugins;
 use lance_file::reader::{read_batch, FileReader};
 use lance_file::v2::reader::{CachedFileMetadata, FileReaderOptions, ReaderProjection};
+use lance_file::v2::LanceEncodingsIo;
 use lance_file::version::LanceFileVersion;
 use lance_file::{determine_file_version, v2};
 use lance_io::object_store::ObjectStore;
@@ -833,9 +834,11 @@ impl FileFragment {
                 .open_file_with_priority(&path, priority_offset)
                 .await?;
             let file_metadata = self.get_file_metadata(&file_scheduler).await?;
+            let path = file_scheduler.reader().path().clone();
             let reader = Arc::new(
                 v2::reader::FileReader::try_open_with_file_metadata(
-                    file_scheduler,
+                    Arc::new(LanceEncodingsIo(file_scheduler)),
+                    path,
                     None,
                     Arc::<DecoderPlugins>::default(),
                     file_metadata,


### PR DESCRIPTION
This fixes a few performance bottlenecks on 2.1 take operations

* Change the protobuf config to generate `bytes::Bytes` instead of `Vec`.  This helps avoid some expensive FSST symbol table clones.
* Moka cache lookups during initialization are expensive.  Instead of one cache lookup per page we now do one cache lookup per column
* Our current scheduling approach for mini block was slow.  There were many switches to calculate info about the repetition index.  We now precompute that during initialization.  In addition, we now search the repetition index with a binary search instead of a full scan.