### PR TITLE
fix: various improvements for 2.1 take, put FSL back into the compressors

### DIFF
--- a/protos/encodings.proto
+++ b/protos/encodings.proto
@@ -152,6 +152,8 @@ message List {
 message FixedSizeList {
   /// The number of items in each list
   uint32 dimension = 1;
+  /// True if the list is nullable
+  bool has_validity = 3;
   /// The items in the list
   ArrayEncoding items = 2;
 }
@@ -180,8 +182,6 @@ message Flat {
 message Constant {
   // The value (TODO: define encoding for literals?)
   bytes value = 1;
-  // The number of values
-  uint64 num_values = 2;
 }
 
 // Items are bitpacked in a buffer
@@ -211,9 +211,18 @@ message BitpackedForNonNeg {
   Buffer buffer = 3;
 }
 
-message Bitpack2 {
+// Opaque bitpacking variant where the bits per value are stored inline in the chunks themselves
+message InlineBitpacking {
   // the number of bits of the uncompressed value. e.g. for a u32, this will be 32
   uint64 uncompressed_bits_per_value = 2;
+}
+
+// Transparent bitpacking variant where the number of bits per value is fixed through the whole buffer
+message OutOfLineBitpacking {
+  // the number of bits of the uncompressed value. e.g. for a u32, this will be 32
+  uint64 uncompressed_bits_per_value = 2;
+  // The number of compressed bits per value, fixed across the entire buffer
+  uint64 compressed_bits_per_value = 3;
 }
 
 // An array encoding for shredded structs that will never be null
@@ -277,9 +286,10 @@ message ArrayEncoding {
         FixedSizeBinary fixed_size_binary = 11;
         BitpackedForNonNeg bitpacked_for_non_neg = 12;
         Constant constant = 13;
-        Bitpack2 bitpack2 = 14;
-        Variable variable = 15;
-        PackedStructFixedWidthMiniBlock packed_struct_fixed_width_mini_block = 16;
+        InlineBitpacking inline_bitpacking = 14;
+        OutOfLineBitpacking out_of_line_bitpacking = 15;
+        Variable variable = 16;
+        PackedStructFixedWidthMiniBlock packed_struct_fixed_width_mini_block = 17;
     }
 }
 
@@ -359,15 +369,25 @@ enum RepDefLayer {
 /// chunks (called mini blocks) which are roughly the size of a disk sector.
 message MiniBlockLayout {
   // Description of the compression of repetition levels (e.g. how many bits per rep)
+  //
+  // Optional, if there is no repetition then this field is not present
   ArrayEncoding rep_compression = 1;
   // Description of the compression of definition levels (e.g. how many bits per def)
+  //
+  // Optional, if there is no definition then this field is not present
   ArrayEncoding def_compression = 2;
   // Description of the compression of values
   ArrayEncoding value_compression = 3;
   // Dictionary data
   ArrayEncoding dictionary = 4;
+  // Number of items in the dictionary
+  uint64 num_dictionary_items = 5;
   // The meaning of each repdef layer, used to interpret repdef buffers correctly
-  repeated RepDefLayer layers = 5;
+  repeated RepDefLayer layers = 6;
+  // The number of buffers in each mini-block, this is determined by the compression and does
+  // NOT include the repetition or definition buffers (the presence of these buffers can be determined
+  // by looking at the rep_compression and def_compression fields)
+  uint64 num_buffers = 7;
   // The depth of the repetition index.
   //
   // If there is repetition then the depth must be at least 1.  If there are many layers
@@ -379,10 +399,10 @@ message MiniBlockLayout {
   // index if the `repetition_index_depth` is greater than 0.  The +1 is because we need to store
   // the number of "leftover items" at the end of the chunk.  Otherwise, we wouldn't have any way
   // to know if the final item in a chunk is valid or not.
-  uint32 repetition_index_depth = 6;
+  uint32 repetition_index_depth = 8;
   // The page already records how many rows are in the page.  For mini-block we also need to know how
   // many "items" are in the page.  A row and an item are the same thing unless the page has lists.
-  uint64 num_items = 7;
+  uint64 num_items = 9;
 }
 
 /// A layout used for pages where the data is large

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -414,14 +414,7 @@ impl FixedSizeListBlock {
         })
     }
 
-    fn remove_validity(self) -> Self {
-        Self {
-            child: Box::new(self.child.remove_validity()),
-            dimension: self.dimension,
-        }
-    }
-
-    fn num_values(&self) -> u64 {
+    pub fn num_values(&self) -> u64 {
         self.child.num_values() / self.dimension
     }
 
@@ -530,6 +523,43 @@ impl DataBlockBuilderImpl for FixedSizeListBlockBuilder {
         DataBlock::FixedSizeList(FixedSizeListBlock {
             child: Box::new(inner_block),
             dimension: self.dimension,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct NullableDataBlockBuilder {
+    inner: Box<dyn DataBlockBuilderImpl>,
+    validity: BooleanBufferBuilder,
+}
+
+impl NullableDataBlockBuilder {
+    fn new(inner: Box<dyn DataBlockBuilderImpl>, estimated_size_bytes: usize) -> Self {
+        Self {
+            inner,
+            validity: BooleanBufferBuilder::new(estimated_size_bytes * 8),
+        }
+    }
+}
+
+impl DataBlockBuilderImpl for NullableDataBlockBuilder {
+    fn append(&mut self, data_block: &DataBlock, selection: Range<u64>) {
+        let nullable = data_block.as_nullable_ref().unwrap();
+        let bool_buf = BooleanBuffer::new(
+            nullable.nulls.try_clone().unwrap().into_buffer(),
+            selection.start as usize,
+            (selection.end - selection.start) as usize,
+        );
+        self.validity.append_buffer(&bool_buf);
+        self.inner.append(nullable.data.as_ref(), selection);
+    }
+
+    fn finish(mut self: Box<Self>) -> DataBlock {
+        let inner_block = self.inner.finish();
+        DataBlock::Nullable(NullableDataBlock {
+            data: Box::new(inner_block),
+            nulls: LanceBuffer::Borrowed(self.validity.finish().into_inner()),
+            block_info: BlockInfo::new(),
         })
     }
 }
@@ -678,12 +708,12 @@ impl StructDataBlock {
         }
     }
 
-    fn remove_validity(self) -> Self {
+    fn remove_outer_validity(self) -> Self {
         Self {
             children: self
                 .children
                 .into_iter()
-                .map(|c| c.remove_validity())
+                .map(|c| c.remove_outer_validity())
                 .collect(),
             block_info: self.block_info,
         }
@@ -919,6 +949,20 @@ impl DataBlock {
         }
     }
 
+    pub fn is_nullable(&self) -> bool {
+        match self {
+            Self::AllNull(_) => true,
+            Self::Nullable(_) => true,
+            Self::FixedSizeList(fsl) => fsl.child.is_nullable(),
+            Self::Struct(strct) => strct.children.iter().any(|c| c.is_nullable()),
+            Self::Dictionary(_) => {
+                todo!("is_nullable for DictionaryDataBlock is not implemented yet")
+            }
+            Self::Opaque(_) => panic!("Does not make sense to ask if an Opaque block is nullable"),
+            _ => false,
+        }
+    }
+
     /// The number of values in the block
     ///
     /// This function does not recurse into child blocks.  If this is a FSL then it will
@@ -981,26 +1025,14 @@ impl DataBlock {
     /// This does not filter the block (e.g. remove rows).  It only removes
     /// the validity bitmaps (if present).  Any garbage masked by null bits
     /// will now appear as proper values.
-    pub fn remove_validity(self) -> Self {
+    ///
+    /// If `recurse` is true, then this will also remove validity from any child blocks.
+    pub fn remove_outer_validity(self) -> Self {
         match self {
-            Self::Empty() => Self::Empty(),
-            Self::Constant(inner) => Self::Constant(inner),
             Self::AllNull(_) => panic!("Cannot remove validity on all-null data"),
-            Self::Nullable(inner) => inner.data.remove_validity(),
-            Self::FixedWidth(inner) => Self::FixedWidth(inner),
-            Self::FixedSizeList(inner) => Self::FixedSizeList(inner.remove_validity()),
-            Self::VariableWidth(inner) => Self::VariableWidth(inner),
-            Self::Struct(inner) => Self::Struct(inner.remove_validity()),
-            Self::Dictionary(inner) => Self::FixedWidth(inner.indices),
-            Self::Opaque(inner) => Self::Opaque(inner),
-        }
-    }
-
-    pub fn flatten(self) -> Self {
-        if let Self::FixedSizeList(fsl) = self {
-            fsl.child.flatten()
-        } else {
-            self
+            Self::Nullable(inner) => *inner.data,
+            Self::Struct(inner) => Self::Struct(inner.remove_outer_validity()),
+            other => other,
         }
     }
 
@@ -1024,6 +1056,18 @@ impl DataBlock {
                     inner.dimension,
                 ))
             }
+            Self::Nullable(nullable) => {
+                // There's no easy way to know what percentage of the data is in the valiidty buffer
+                // but 1/16th seems like a reasonable guess.
+                let estimated_validity_size_bytes = estimated_size_bytes / 16;
+                let inner_builder = nullable
+                    .data
+                    .make_builder(estimated_size_bytes - estimated_validity_size_bytes);
+                Box::new(NullableDataBlockBuilder::new(
+                    inner_builder,
+                    estimated_validity_size_bytes as usize,
+                ))
+            }
             Self::Struct(struct_data_block) => {
                 let mut bits_per_values = vec![];
                 for child in struct_data_block.children.iter() {
@@ -1036,7 +1080,7 @@ impl DataBlock {
                     estimated_size_bytes,
                 ))
             }
-            _ => todo!(),
+            _ => todo!("make_builder for {:?}", self),
         }
     }
 }

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -27,7 +27,7 @@ use crate::encodings::logical::r#struct::StructStructuralEncoder;
 use crate::encodings::physical::binary::{BinaryMiniBlockEncoder, VariableEncoder};
 use crate::encodings::physical::bitpack_fastlanes::BitpackedForNonNegArrayEncoder;
 use crate::encodings::physical::bitpack_fastlanes::{
-    compute_compressed_bit_width_for_non_neg, BitpackMiniBlockEncoder,
+    compute_compressed_bit_width_for_non_neg, InlineBitpacking,
 };
 use crate::encodings::physical::block_compress::{CompressionConfig, CompressionScheme};
 use crate::encodings::physical::dictionary::AlreadyDictionaryEncoder;
@@ -148,9 +148,10 @@ pub const MAX_MINIBLOCK_VALUES: u64 = 4096;
 
 /// Page data that has been compressed into a series of chunks put into
 /// a single buffer.
+#[derive(Debug)]
 pub struct MiniBlockCompressed {
-    /// The buffer of compressed data
-    pub data: LanceBuffer,
+    /// The buffers of compressed data
+    pub data: Vec<LanceBuffer>,
     /// Describes the size of each chunk
     pub chunks: Vec<MiniBlockChunk>,
     /// The number of values in the entire page
@@ -168,10 +169,10 @@ pub struct MiniBlockCompressed {
 /// data (values, repetition, and definition) per mini-block.
 #[derive(Debug)]
 pub struct MiniBlockChunk {
-    // The number of bytes that make up the chunk
+    // The size in bytes of each buffer in the chunk.
     //
-    // This value must be less than or equal to 8Ki - 6 (8188)
-    pub num_bytes: u16,
+    // The total size must be less than or equal to 8Ki - 6 (8188)
+    pub buffer_sizes: Vec<u16>,
     // The log (base 2) of the number of values in the chunk.  If this is the final chunk
     // then this should be 0 (the number of values will be calculated by subtracting the
     // size of all other chunks from the total size of the page)
@@ -806,20 +807,24 @@ impl CompressionStrategy for CoreArrayEncodingStrategy {
         match data {
             DataBlock::FixedWidth(fixed_width_data) => {
                 let bit_widths = data.expect_stat(Stat::BitWidth);
+                let bit_widths = bit_widths.as_primitive::<UInt64Type>();
                 // Temporary hack to work around https://github.com/lancedb/lance/issues/3102
                 // Ideally we should still be able to bit-pack here (either to 0 or 1 bit per value)
-                let has_all_zeros = bit_widths
-                    .as_primitive::<UInt64Type>()
-                    .values()
-                    .iter()
-                    .any(|v| *v == 0);
+                let has_all_zeros = bit_widths.values().iter().any(|v| *v == 0);
+                // The minimum bit packing size is a block of 1024 values.  For very small pages the uncompressed
+                // size might be smaller than the compressed size.
+                let too_small = bit_widths.len() == 1
+                    && InlineBitpacking::min_size_bytes(bit_widths.value(0)) >= data.data_size();
                 if !has_all_zeros
+                    && !too_small
                     && (fixed_width_data.bits_per_value == 8
                         || fixed_width_data.bits_per_value == 16
                         || fixed_width_data.bits_per_value == 32
                         || fixed_width_data.bits_per_value == 64)
                 {
-                    Ok(Box::new(BitpackMiniBlockEncoder::default()))
+                    Ok(Box::new(InlineBitpacking::new(
+                        fixed_width_data.bits_per_value,
+                    )))
                 } else {
                     Ok(Box::new(ValueEncoder::default()))
                 }
@@ -855,16 +860,14 @@ impl CompressionStrategy for CoreArrayEncodingStrategy {
                 Ok(Box::new(PackedStructFixedWidthMiniBlockEncoder::default()))
             }
             DataBlock::FixedSizeList(_) => {
-                // In theory we could use something like bitpacking here but it's not clear it would
-                // be very effective.  At most we would shave a few bytes off the first item in the
-                // list.  It might be more sophisticated to treat the FSL as a table and bitpack each
-                // column but that would be expensive as well so it's not clear that would be a win.  For
-                // now we just don't compress FSL
-                if data.is_variable() {
-                    todo!("Implement MiniBlockCompression for variable width FSL")
-                } else {
-                    Ok(Box::new(ValueEncoder::default()))
-                }
+                // Ideally we would compress the list items but this creates something of a challenge.
+                // We don't want to break lists across chunks and we need to worry about inner validity
+                // layers.  If we try and use a compression scheme then it is unlikely to respect these
+                // constraints.
+                //
+                // For now, we just don't compress.  In the future, we might want to consider a more
+                // sophisticated approach.
+                Ok(Box::new(ValueEncoder::default()))
             }
             _ => Err(Error::NotSupported {
                 source: format!(
@@ -883,10 +886,8 @@ impl CompressionStrategy for CoreArrayEncodingStrategy {
         data: &DataBlock,
     ) -> Result<Box<dyn PerValueCompressor>> {
         match data {
-            DataBlock::FixedWidth(_) => {
-                let encoder = Box::new(ValueEncoder::default());
-                Ok(encoder)
-            }
+            DataBlock::FixedWidth(_) => Ok(Box::new(ValueEncoder::default())),
+            DataBlock::FixedSizeList(_) => Ok(Box::new(ValueEncoder::default())),
             DataBlock::VariableWidth(variable_width) => {
                 if variable_width.bits_per_offset == 32 {
                     let data_size = variable_width.expect_single_stat::<UInt64Type>(Stat::DataSize);
@@ -905,7 +906,10 @@ impl CompressionStrategy for CoreArrayEncodingStrategy {
                     todo!("Implement MiniBlockCompression for VariableWidth DataBlock with 64 bits offsets.")
                 }
             }
-            _ => unreachable!(),
+            _ => unreachable!(
+                "Per-value compression not yet supported for block type: {}",
+                data.name()
+            ),
         }
     }
 

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -12,12 +12,10 @@ use std::{
 };
 
 use arrow::array::AsArray;
-use arrow_array::{
-    make_array, types::UInt64Type, Array, ArrayRef, FixedSizeListArray, PrimitiveArray,
-};
+use arrow_array::{make_array, types::UInt64Type, Array, ArrayRef, PrimitiveArray};
 use arrow_buffer::{bit_util, BooleanBuffer, NullBuffer, ScalarBuffer};
 use arrow_schema::{DataType, Field as ArrowField};
-use futures::{future::BoxFuture, stream::FuturesUnordered, FutureExt, TryStreamExt};
+use futures::{future::BoxFuture, stream::FuturesOrdered, FutureExt, TryStreamExt};
 use itertools::Itertools;
 use lance_arrow::deepcopy::deep_copy_array;
 use lance_core::{
@@ -68,6 +66,8 @@ use crate::{
     repdef::{LevelBuffer, RepDefBuilder, RepDefUnraveler},
     EncodingsIo,
 };
+
+const FILL_BYTE: u8 = 0xFE;
 
 #[derive(Debug)]
 struct PrimitivePage {
@@ -323,12 +323,12 @@ struct DecodedMiniBlockChunk {
 /// the decoding of the block. (TODO: test this theory)
 #[derive(Debug)]
 struct DecodeMiniBlockTask {
-    // The decompressors for the rep, def, and value buffers
-    rep_decompressor: Arc<dyn BlockDecompressor>,
-    def_decompressor: Arc<dyn BlockDecompressor>,
+    rep_decompressor: Option<Arc<dyn BlockDecompressor>>,
+    def_decompressor: Option<Arc<dyn BlockDecompressor>>,
     value_decompressor: Arc<dyn MiniBlockDecompressor>,
     dictionary_data: Option<Arc<DataBlock>>,
     def_meaning: Arc<[DefinitionInterpretation]>,
+    num_buffers: u64,
     max_visible_level: u16,
     instructions: Vec<(ChunkDrainInstructions, LoadedChunk)>,
 }
@@ -337,23 +337,13 @@ impl DecodeMiniBlockTask {
     fn decode_levels(
         rep_decompressor: &dyn BlockDecompressor,
         levels: LanceBuffer,
-    ) -> Result<Option<ScalarBuffer<u16>>> {
-        let rep = rep_decompressor.decompress(levels)?;
-        match rep {
-            DataBlock::FixedWidth(mut rep) => Ok(Some(rep.data.borrow_to_typed_slice::<u16>())),
-            DataBlock::Constant(constant) => {
-                assert_eq!(constant.data.len(), 2);
-                if constant.data[0] == 0 && constant.data[1] == 0 {
-                    Ok(None)
-                } else {
-                    // Maybe in the future we will encode all-null def or
-                    // constant rep (all 1-item lists?) in a constant encoding
-                    // but that doesn't happen today so we don't need to worry.
-                    todo!()
-                }
-            }
-            _ => unreachable!(),
-        }
+        num_levels: u16,
+    ) -> Result<ScalarBuffer<u16>> {
+        let rep = rep_decompressor.decompress(levels, num_levels as u64)?;
+        let mut rep = rep.as_fixed_width().unwrap();
+        debug_assert_eq!(rep.num_values, num_levels as u64);
+        debug_assert_eq!(rep.bits_per_value, 16);
+        Ok(rep.data.borrow_to_typed_slice::<u16>())
     }
 
     // We are building a LevelBuffer (levels) and want to copy into it `total_len`
@@ -611,37 +601,86 @@ impl DecodeMiniBlockTask {
         }
     }
 
-    // Unwraps a miniblock chunk's "envelope" into the rep, def, and data buffers
+    // Unserialize a miniblock into a collection of vectors
     fn decode_miniblock_chunk(
         &self,
         buf: &LanceBuffer,
         items_in_chunk: u64,
     ) -> Result<DecodedMiniBlockChunk> {
-        // The first 6 bytes describe the size of the remaining buffers
-        let bytes_rep = u16::from_le_bytes([buf[0], buf[1]]) as usize;
-        let bytes_def = u16::from_le_bytes([buf[2], buf[3]]) as usize;
-        let bytes_val = u16::from_le_bytes([buf[4], buf[5]]) as usize;
+        let mut offset = 0;
+        let num_levels = u16::from_le_bytes([buf[offset], buf[offset + 1]]);
+        offset += 2;
 
-        debug_assert!(buf.len() >= bytes_rep + bytes_def + bytes_val + 6);
-        debug_assert!(
-            buf.len()
-                <= bytes_rep
-                                + bytes_def
-                                + bytes_val
-                                + 6
-                                + 1 // P1
-                                + (2 * MINIBLOCK_MAX_PADDING) // P2/P3
-        );
-        let p1 = bytes_rep % 2;
-        let rep = buf.slice_with_length(6, bytes_rep);
-        let def = buf.slice_with_length(6 + bytes_rep + p1, bytes_def);
-        let p2 = pad_bytes::<MINIBLOCK_ALIGNMENT>(6 + bytes_rep + p1 + bytes_def);
-        let values = buf.slice_with_length(6 + bytes_rep + bytes_def + p2, bytes_val);
+        let rep_size = if self.rep_decompressor.is_some() {
+            let rep_size = u16::from_le_bytes([buf[offset], buf[offset + 1]]);
+            offset += 2;
+            Some(rep_size)
+        } else {
+            None
+        };
+        let def_size = if self.def_decompressor.is_some() {
+            let def_size = u16::from_le_bytes([buf[offset], buf[offset + 1]]);
+            offset += 2;
+            Some(def_size)
+        } else {
+            None
+        };
+        let buffer_sizes = (0..self.num_buffers)
+            .map(|_| {
+                let size = u16::from_le_bytes([buf[offset], buf[offset + 1]]);
+                offset += 2;
+                size
+            })
+            .collect::<Vec<_>>();
 
-        let values = self.value_decompressor.decompress(values, items_in_chunk)?;
+        offset += pad_bytes::<MINIBLOCK_ALIGNMENT>(offset);
 
-        let rep = Self::decode_levels(self.rep_decompressor.as_ref(), rep)?;
-        let def = Self::decode_levels(self.def_decompressor.as_ref(), def)?;
+        let rep = rep_size.map(|rep_size| {
+            let rep = buf.slice_with_length(offset, rep_size as usize);
+            offset += rep_size as usize;
+            offset += pad_bytes::<MINIBLOCK_ALIGNMENT>(offset);
+            rep
+        });
+
+        let def = def_size.map(|def_size| {
+            let def = buf.slice_with_length(offset, def_size as usize);
+            offset += def_size as usize;
+            offset += pad_bytes::<MINIBLOCK_ALIGNMENT>(offset);
+            def
+        });
+
+        let buffers = buffer_sizes
+            .into_iter()
+            .map(|buf_size| {
+                let buf = buf.slice_with_length(offset, buf_size as usize);
+                offset += buf_size as usize;
+                offset += pad_bytes::<MINIBLOCK_ALIGNMENT>(offset);
+                buf
+            })
+            .collect::<Vec<_>>();
+
+        let values = self
+            .value_decompressor
+            .decompress(buffers, items_in_chunk)?;
+
+        let rep = rep
+            .map(|rep| {
+                Self::decode_levels(
+                    self.rep_decompressor.as_ref().unwrap().as_ref(),
+                    rep,
+                    num_levels,
+                )
+            })
+            .transpose()?;
+        let def = def
+            .map(|def| {
+                Self::decode_levels(
+                    self.def_decompressor.as_ref().unwrap().as_ref(),
+                    def,
+                    num_levels,
+                )
+            })
+            .transpose()?;
 
         Ok(DecodedMiniBlockChunk { rep, def, values })
     }
@@ -760,15 +799,15 @@ impl Clone for LoadedChunk {
 /// details on the different layouts.
 #[derive(Debug)]
 struct MiniBlockDecoder {
-    rep_decompressor: Arc<dyn BlockDecompressor>,
-    def_decompressor: Arc<dyn BlockDecompressor>,
+    rep_decompressor: Option<Arc<dyn BlockDecompressor>>,
+    def_decompressor: Option<Arc<dyn BlockDecompressor>>,
     value_decompressor: Arc<dyn MiniBlockDecompressor>,
     def_meaning: Arc<[DefinitionInterpretation]>,
     loaded_chunks: VecDeque<LoadedChunk>,
     instructions: VecDeque<ChunkInstructions>,
     offset_in_current_chunk: u64,
     num_rows: u64,
-    items_per_row: u64,
+    num_buffers: u64,
     dictionary: Option<Arc<DataBlock>>,
 }
 
@@ -776,7 +815,7 @@ struct MiniBlockDecoder {
 /// process for miniblock encoded data.
 impl StructuralPageDecoder for MiniBlockDecoder {
     fn drain(&mut self, num_rows: u64) -> Result<Box<dyn DecodePageTask>> {
-        let mut items_desired = num_rows * self.items_per_row;
+        let mut items_desired = num_rows;
         let mut need_preamble = false;
         let mut skip_in_chunk = self.offset_in_current_chunk;
         let mut drain_instructions = Vec::new();
@@ -815,6 +854,7 @@ impl StructuralPageDecoder for MiniBlockDecoder {
             value_decompressor: self.value_decompressor.clone(),
             dictionary_data: self.dictionary.clone(),
             def_meaning: self.def_meaning.clone(),
+            num_buffers: self.num_buffers,
             max_visible_level,
         }))
     }
@@ -856,7 +896,6 @@ pub struct ComplexAllNullScheduler {
     // Set from protobuf
     buffer_offsets_and_sizes: Arc<[(u64, u64)]>,
     def_meaning: Arc<[DefinitionInterpretation]>,
-    items_per_row: u64,
     repdef: Option<Arc<CachedComplexAllNullState>>,
 }
 
@@ -864,12 +903,10 @@ impl ComplexAllNullScheduler {
     pub fn new(
         buffer_offsets_and_sizes: Arc<[(u64, u64)]>,
         def_meaning: Arc<[DefinitionInterpretation]>,
-        items_per_row: u64,
     ) -> Self {
         Self {
             buffer_offsets_and_sizes,
             def_meaning,
-            items_per_row,
             repdef: None,
         }
     }
@@ -943,15 +980,10 @@ impl StructuralPageScheduler for ComplexAllNullScheduler {
     ) -> Result<BoxFuture<'static, Result<Box<dyn StructuralPageDecoder>>>> {
         let ranges = VecDeque::from_iter(ranges.iter().cloned());
         let num_rows = ranges.iter().map(|r| r.end - r.start).sum::<u64>();
-        let item_ranges = ranges
-            .iter()
-            .map(|r| r.start * self.items_per_row..r.end * self.items_per_row)
-            .collect();
         Ok(std::future::ready(Ok(Box::new(ComplexAllNullPageDecoder {
-            ranges: item_ranges,
+            ranges,
             rep: self.repdef.as_ref().unwrap().rep.clone(),
             def: self.repdef.as_ref().unwrap().def.clone(),
-            items_per_row: self.items_per_row,
             num_rows,
             def_meaning: self.def_meaning.clone(),
         }) as Box<dyn StructuralPageDecoder>))
@@ -965,7 +997,6 @@ pub struct ComplexAllNullPageDecoder {
     rep: Option<ScalarBuffer<u16>>,
     def: Option<ScalarBuffer<u16>>,
     num_rows: u64,
-    items_per_row: u64,
     def_meaning: Arc<[DefinitionInterpretation]>,
 }
 
@@ -991,12 +1022,7 @@ impl ComplexAllNullPageDecoder {
 
 impl StructuralPageDecoder for ComplexAllNullPageDecoder {
     fn drain(&mut self, num_rows: u64) -> Result<Box<dyn DecodePageTask>> {
-        // TODO: This is going to need to be more complicated to deal with nested lists of nulls
-        // because the row ranges might not map directly to item ranges
-        //
-        // We should add test cases and handle this later
-        let num_items = num_rows * self.items_per_row;
-        let drained_ranges = self.drain_ranges(num_items);
+        let drained_ranges = self.drain_ranges(num_rows);
         Ok(Box::new(DecodeComplexAllNullTask {
             ranges: drained_ranges,
             rep: self.rep.clone(),
@@ -1129,6 +1155,7 @@ struct MiniBlockSchedulerDictionary {
     dictionary_decompressor: Arc<dyn BlockDecompressor>,
     dictionary_buf_position_and_size: (u64, u64),
     dictionary_data_alignment: u64,
+    num_dictionary_items: u64,
 }
 
 #[derive(Debug)]
@@ -1256,10 +1283,10 @@ pub struct MiniBlockScheduler {
     buffer_offsets_and_sizes: Vec<(u64, u64)>,
     priority: u64,
     items_in_page: u64,
-    items_per_row: u64,
     repetition_index_depth: u16,
-    rep_decompressor: Arc<dyn BlockDecompressor>,
-    def_decompressor: Arc<dyn BlockDecompressor>,
+    num_buffers: u64,
+    rep_decompressor: Option<Arc<dyn BlockDecompressor>>,
+    def_decompressor: Option<Arc<dyn BlockDecompressor>>,
     value_decompressor: Arc<dyn MiniBlockDecompressor>,
     def_meaning: Arc<[DefinitionInterpretation]>,
     dictionary: Option<MiniBlockSchedulerDictionary>,
@@ -1272,14 +1299,27 @@ impl MiniBlockScheduler {
         buffer_offsets_and_sizes: &[(u64, u64)],
         priority: u64,
         items_in_page: u64,
-        items_per_row: u64,
         layout: &pb::MiniBlockLayout,
         decompressors: &dyn DecompressorStrategy,
     ) -> Result<Self> {
-        let rep_decompressor =
-            decompressors.create_block_decompressor(layout.rep_compression.as_ref().unwrap())?;
-        let def_decompressor =
-            decompressors.create_block_decompressor(layout.def_compression.as_ref().unwrap())?;
+        let rep_decompressor = layout
+            .rep_compression
+            .as_ref()
+            .map(|rep_compression| {
+                decompressors
+                    .create_block_decompressor(rep_compression)
+                    .map(Arc::from)
+            })
+            .transpose()?;
+        let def_decompressor = layout
+            .def_compression
+            .as_ref()
+            .map(|def_compression| {
+                decompressors
+                    .create_block_decompressor(def_compression)
+                    .map(Arc::from)
+            })
+            .transpose()?;
         let def_meaning = layout
             .layers
             .iter()
@@ -1288,6 +1328,7 @@ impl MiniBlockScheduler {
         let value_decompressor = decompressors
             .create_miniblock_decompressor(layout.value_compression.as_ref().unwrap())?;
         let dictionary = if let Some(dictionary_encoding) = layout.dictionary.as_ref() {
+            let num_dictionary_items = layout.num_dictionary_items;
             match dictionary_encoding.array_encoding.as_ref().unwrap() {
                 pb::array_encoding::ArrayEncoding::Variable(_) => {
                     Some(MiniBlockSchedulerDictionary {
@@ -1296,6 +1337,7 @@ impl MiniBlockScheduler {
                             .into(),
                         dictionary_buf_position_and_size: buffer_offsets_and_sizes[2],
                         dictionary_data_alignment: 4,
+                        num_dictionary_items,
                     })
                 }
                 pb::array_encoding::ArrayEncoding::Flat(_) => Some(MiniBlockSchedulerDictionary {
@@ -1304,6 +1346,7 @@ impl MiniBlockScheduler {
                         .into(),
                     dictionary_buf_position_and_size: buffer_offsets_and_sizes[2],
                     dictionary_data_alignment: 16,
+                    num_dictionary_items,
                 }),
                 _ => {
                     unreachable!("Currently only encodings `BinaryBlock` and `Flat` used for encoding MiniBlock dictionary.")
@@ -1315,13 +1358,13 @@ impl MiniBlockScheduler {
 
         Ok(Self {
             buffer_offsets_and_sizes: buffer_offsets_and_sizes.to_vec(),
-            rep_decompressor: rep_decompressor.into(),
-            def_decompressor: def_decompressor.into(),
+            rep_decompressor,
+            def_decompressor,
             value_decompressor: value_decompressor.into(),
             repetition_index_depth: layout.repetition_index_depth as u16,
+            num_buffers: layout.num_buffers,
             priority,
             items_in_page,
-            items_per_row,
             dictionary,
             def_meaning: def_meaning.into(),
             page_meta: None,
@@ -1631,7 +1674,10 @@ impl StructuralPageScheduler for MiniBlockScheduler {
                     debug_assert!(log_num_values > 0);
                     1 << log_num_values
                 } else {
-                    debug_assert_eq!(log_num_values, 0);
+                    debug_assert!(
+                        log_num_values == 0
+                            || (1 << log_num_values) == (self.items_in_page - rows_counter)
+                    );
                     self.items_in_page - rows_counter
                 };
                 rows_counter += num_values;
@@ -1681,6 +1727,7 @@ impl StructuralPageScheduler for MiniBlockScheduler {
                             dictionary_data,
                             dictionary.dictionary_data_alignment,
                         ),
+                        dictionary.num_dictionary_items,
                     )?));
             };
             let page_meta = Arc::new(page_meta);
@@ -1705,10 +1752,6 @@ impl StructuralPageScheduler for MiniBlockScheduler {
         io: &Arc<dyn EncodingsIo>,
     ) -> Result<BoxFuture<'static, Result<Box<dyn StructuralPageDecoder>>>> {
         let num_rows = ranges.iter().map(|r| r.end - r.start).sum();
-        let ranges = ranges
-            .iter()
-            .map(|r| r.start * self.items_per_row..r.end * self.items_per_row)
-            .collect::<Vec<_>>();
 
         let page_meta = self.page_meta.as_ref().unwrap();
 
@@ -1716,7 +1759,7 @@ impl StructuralPageScheduler for MiniBlockScheduler {
             ChunkInstructions::schedule_instructions(&page_meta.rep_index, &ranges);
 
         debug_assert_eq!(
-            num_rows * self.items_per_row,
+            num_rows,
             chunk_instructions
                 .iter()
                 .map(|ci| {
@@ -1745,12 +1788,12 @@ impl StructuralPageScheduler for MiniBlockScheduler {
         let rep_decompressor = self.rep_decompressor.clone();
         let def_decompressor = self.def_decompressor.clone();
         let value_decompressor = self.value_decompressor.clone();
+        let num_buffers = self.num_buffers;
         let dictionary = page_meta
             .dictionary
             .as_ref()
             .map(|dictionary| dictionary.clone());
         let def_meaning = self.def_meaning.clone();
-        let items_per_row = self.items_per_row;
 
         let res = async move {
             let loaded_chunk_data = loaded_chunk_data.await?;
@@ -1768,7 +1811,7 @@ impl StructuralPageScheduler for MiniBlockScheduler {
                 offset_in_current_chunk: 0,
                 dictionary,
                 num_rows,
-                items_per_row,
+                num_buffers,
             }) as Box<dyn StructuralPageDecoder>)
         }
         .boxed();
@@ -1795,7 +1838,6 @@ struct FullZipDecodeDetails {
     ctrl_word_parser: ControlWordParser,
     max_rep: u16,
     max_visible_def: u16,
-    items_per_row: u64,
 }
 
 /// A scheduler for full-zip encoded data
@@ -1820,7 +1862,6 @@ impl FullZipScheduler {
         buffer_offsets_and_sizes: &[(u64, u64)],
         priority: u64,
         rows_in_page: u64,
-        items_per_row: u64,
         layout: &pb::FullZipLayout,
         decompressors: &dyn DecompressorStrategy,
         bits_per_offset: u8,
@@ -1830,7 +1871,7 @@ impl FullZipScheduler {
         // and we have a repetition index.
         let (data_buf_position, _) = buffer_offsets_and_sizes[0];
         let rep_index = buffer_offsets_and_sizes.get(1).map(|(pos, len)| {
-            let num_reps = (items_per_row * rows_in_page) + 1;
+            let num_reps = rows_in_page + 1;
             let bytes_per_rep = len / num_reps;
             debug_assert_eq!(len % num_reps, 0);
             debug_assert!(
@@ -1883,7 +1924,6 @@ impl FullZipScheduler {
             value_decompressor,
             def_meaning: def_meaning.into(),
             ctrl_word_parser,
-            items_per_row,
             max_rep,
             max_visible_def,
         });
@@ -1905,7 +1945,7 @@ impl FullZipScheduler {
     #[allow(clippy::too_many_arguments)]
     async fn indirect_schedule_ranges(
         data_buffer_pos: u64,
-        item_ranges: Vec<Range<u64>>,
+        row_ranges: Vec<Range<u64>>,
         rep_index_ranges: Vec<Range<u64>>,
         bytes_per_rep: u64,
         io: Arc<dyn EncodingsIo>,
@@ -1937,7 +1977,7 @@ impl FullZipScheduler {
             .into_iter()
             .map(|d| LanceBuffer::from_bytes(d, 1))
             .collect();
-        let num_rows = item_ranges.into_iter().map(|r| r.end - r.start).sum();
+        let num_rows = row_ranges.into_iter().map(|r| r.end - r.start).sum();
 
         match &details.value_decompressor {
             PerValueDecompressor::Fixed(decompressor) => {
@@ -1981,13 +2021,7 @@ impl FullZipScheduler {
         io: &Arc<dyn EncodingsIo>,
         rep_index: &FullZipRepIndexDetails,
     ) -> Result<BoxFuture<'static, Result<Box<dyn StructuralPageDecoder>>>> {
-        // Convert row ranges to item ranges (i.e. multiply by items per row)
-        let item_ranges = ranges
-            .iter()
-            .map(|r| r.start * self.details.items_per_row..r.end * self.details.items_per_row)
-            .collect::<Vec<_>>();
-
-        let rep_index_ranges = item_ranges
+        let rep_index_ranges = ranges
             .iter()
             .flat_map(|r| {
                 let first_val_start =
@@ -2003,7 +2037,7 @@ impl FullZipScheduler {
 
         Ok(Self::indirect_schedule_ranges(
             self.data_buf_position,
-            item_ranges,
+            ranges.to_vec(),
             rep_index_ranges,
             rep_index.bytes_per_value,
             io.clone(),
@@ -2024,10 +2058,6 @@ impl FullZipScheduler {
     ) -> Result<BoxFuture<'static, Result<Box<dyn StructuralPageDecoder>>>> {
         // Convert row ranges to item ranges (i.e. multiply by items per row)
         let num_rows = ranges.iter().map(|r| r.end - r.start).sum();
-        let item_ranges = ranges
-            .iter()
-            .map(|r| r.start * self.details.items_per_row..r.end * self.details.items_per_row)
-            .collect::<Vec<_>>();
 
         let PerValueDecompressor::Fixed(decompressor) = &self.details.value_decompressor else {
             unreachable!()
@@ -2039,8 +2069,8 @@ impl FullZipScheduler {
         let bytes_per_value = bits_per_value / 8;
         let bytes_per_cw = self.details.ctrl_word_parser.bytes_per_word();
         let total_bytes_per_value = bytes_per_value + bytes_per_cw as u64;
-        let byte_ranges = item_ranges.iter().map(|r| {
-            debug_assert!(r.end <= self.rows_in_page * self.details.items_per_row);
+        let byte_ranges = ranges.iter().map(|r| {
+            debug_assert!(r.end <= self.rows_in_page);
             let start = self.data_buf_position + r.start * total_bytes_per_value;
             let end = self.data_buf_position + r.end * total_bytes_per_value;
             start..end
@@ -2157,7 +2187,6 @@ impl FixedFullZipDecoder {
                     block_info: BlockInfo::new(),
                 }),
                 rows_in_buf: rows_started,
-                items_in_buf: num_items,
             }
         } else {
             // If there's no repetition we can calculate the slicing point by just multiplying
@@ -2187,7 +2216,6 @@ impl FixedFullZipDecoder {
                     block_info: BlockInfo::new(),
                 }),
                 rows_in_buf: rows_taken,
-                items_in_buf: rows_taken,
             }
         }
     }
@@ -2196,18 +2224,17 @@ impl FixedFullZipDecoder {
 impl StructuralPageDecoder for FixedFullZipDecoder {
     fn drain(&mut self, num_rows: u64) -> Result<Box<dyn DecodePageTask>> {
         let mut task_data = Vec::with_capacity(self.data.len());
-        let mut remaining = num_rows * self.details.items_per_row;
+        let mut remaining = num_rows;
         while remaining > 0 {
             let task_item = self.slice_next_task(remaining);
             remaining -= task_item.rows_in_buf;
             task_data.push(task_item);
         }
-        let num_items = task_data.iter().map(|td| td.items_in_buf).sum::<u64>() as usize;
         Ok(Box::new(FixedFullZipDecodeTask {
             details: self.details.clone(),
             data: task_data,
             bytes_per_value: self.bytes_per_value,
-            num_items,
+            num_rows: num_rows as usize,
         }))
     }
 
@@ -2509,7 +2536,6 @@ impl DecodePageTask for VariableFullZipDecodeTask {
 struct FullZipDecodeTaskItem {
     data: PerValueDataBlock,
     rows_in_buf: u64,
-    items_in_buf: u64,
 }
 
 /// A task to unzip and decompress full-zip encoded data when that data
@@ -2518,7 +2544,7 @@ struct FullZipDecodeTaskItem {
 struct FixedFullZipDecodeTask {
     details: Arc<FullZipDecodeDetails>,
     data: Vec<FullZipDecodeTaskItem>,
-    num_items: usize,
+    num_rows: usize,
     bytes_per_value: usize,
 }
 
@@ -2546,9 +2572,9 @@ impl DecodePageTask for FixedFullZipDecodeTask {
                 else {
                     unreachable!()
                 };
-                debug_assert_eq!(fixed_data.num_values, task_item.items_in_buf);
-                let decompressed = decompressor.decompress(fixed_data)?;
-                data_builder.append(&decompressed, 0..task_item.items_in_buf);
+                debug_assert_eq!(fixed_data.num_values, task_item.rows_in_buf);
+                let decompressed = decompressor.decompress(fixed_data, task_item.rows_in_buf)?;
+                data_builder.append(&decompressed, 0..task_item.rows_in_buf);
             }
 
             let unraveler = RepDefUnraveler::new(None, None, self.details.def_meaning.clone());
@@ -2559,23 +2585,23 @@ impl DecodePageTask for FixedFullZipDecodeTask {
             })
         } else {
             // Slow path, unzipping needed
-            let mut rep = Vec::with_capacity(self.num_items);
-            let mut def = Vec::with_capacity(self.num_items);
+            let mut rep = Vec::with_capacity(self.num_rows);
+            let mut def = Vec::with_capacity(self.num_rows);
 
             for task_item in self.data.into_iter() {
                 let PerValueDataBlock::Fixed(fixed_data) = task_item.data else {
                     unreachable!()
                 };
                 let mut buf_slice = fixed_data.data.as_ref();
+                let num_values = fixed_data.num_values as usize;
                 // We will be unzipping repdef in to `rep` and `def` and the
                 // values into `values` (which contains the compressed values)
                 let mut values = Vec::with_capacity(
                     fixed_data.data.len()
-                        - (self.details.ctrl_word_parser.bytes_per_word()
-                            * task_item.items_in_buf as usize),
+                        - (self.details.ctrl_word_parser.bytes_per_word() * num_values as usize),
                 );
                 let mut visible_items = 0;
-                for _ in 0..task_item.items_in_buf {
+                for _ in 0..num_values {
                     // Extract rep/def
                     self.details
                         .ctrl_word_parser
@@ -2606,7 +2632,7 @@ impl DecodePageTask for FixedFullZipDecodeTask {
                 else {
                     unreachable!()
                 };
-                let decompressed = decompressor.decompress(fixed_data)?;
+                let decompressed = decompressor.decompress(fixed_data, visible_items)?;
                 data_builder.append(&decompressed, 0..visible_items);
             }
 
@@ -2755,7 +2781,6 @@ pub struct StructuralPrimitiveFieldScheduler {
 impl StructuralPrimitiveFieldScheduler {
     pub fn try_new(
         column_info: &ColumnInfo,
-        items_per_row: u64,
         decompressors: &dyn DecompressorStrategy,
     ) -> Result<Self> {
         let page_schedulers = column_info
@@ -2768,7 +2793,6 @@ impl StructuralPrimitiveFieldScheduler {
                     page_index,
                     column_info.index as usize,
                     decompressors,
-                    items_per_row,
                 )
             })
             .collect::<Result<Vec<_>>>()?;
@@ -2783,7 +2807,6 @@ impl StructuralPrimitiveFieldScheduler {
         page_index: usize,
         _column_index: usize,
         decompressors: &dyn DecompressorStrategy,
-        items_per_row: u64,
     ) -> Result<PageInfoAndScheduler> {
         let scheduler: Box<dyn StructuralPageScheduler> =
             match page_info.encoding.as_structural().layout.as_ref() {
@@ -2792,7 +2815,6 @@ impl StructuralPrimitiveFieldScheduler {
                         &page_info.buffer_offsets_and_sizes,
                         page_info.priority,
                         mini_block.num_items,
-                        items_per_row,
                         mini_block,
                         decompressors,
                     )?)
@@ -2802,7 +2824,6 @@ impl StructuralPrimitiveFieldScheduler {
                         &page_info.buffer_offsets_and_sizes,
                         page_info.priority,
                         page_info.num_rows,
-                        items_per_row,
                         full_zip,
                         decompressors,
                         /*bits_per_offset=*/ 32,
@@ -2823,7 +2844,6 @@ impl StructuralPrimitiveFieldScheduler {
                         Box::new(ComplexAllNullScheduler::new(
                             page_info.buffer_offsets_and_sizes.clone(),
                             def_meaning.into(),
-                            items_per_row,
                         )) as Box<dyn StructuralPageScheduler>
                     }
                 }
@@ -2886,7 +2906,7 @@ impl StructuralFieldScheduler for StructuralPrimitiveFieldScheduler {
             .page_schedulers
             .iter_mut()
             .map(|s| s.scheduler.initialize(context.io()))
-            .collect::<FuturesUnordered<_>>();
+            .collect::<FuturesOrdered<_>>();
 
         async move {
             let page_data = page_data.try_collect::<Vec<_>>().await?;
@@ -3067,9 +3087,8 @@ impl LogicalPageDecoder for PrimitiveFieldDecoder {
 #[derive(Debug)]
 pub struct StructuralCompositeDecodeArrayTask {
     tasks: Vec<Box<dyn DecodePageTask>>,
-    items_type: DataType,
-    fsl_fields: Arc<[Arc<ArrowField>]>,
     should_validate: bool,
+    data_type: DataType,
 }
 
 impl StructuralCompositeDecodeArrayTask {
@@ -3096,28 +3115,6 @@ impl StructuralCompositeDecodeArrayTask {
                 .build_unchecked()
         })
     }
-
-    fn restore_fsl(
-        array: Arc<dyn Array>,
-        unraveler: &mut CompositeRepDefUnraveler,
-        fsl_fields: Arc<[Arc<ArrowField>]>,
-    ) -> Arc<dyn Array> {
-        let mut array = array;
-        for fsl_field in fsl_fields.iter().rev() {
-            let DataType::FixedSizeList(child_field, dimension) = fsl_field.data_type() else {
-                unreachable!()
-            };
-            let fsl_num_values = array.len() / *dimension as usize;
-            let fsl_validity = unraveler.unravel_fsl_validity(fsl_num_values, *dimension as usize);
-            array = Arc::new(FixedSizeListArray::new(
-                child_field.clone(),
-                *dimension,
-                array,
-                fsl_validity,
-            ));
-        }
-        array
-    }
 }
 
 impl StructuralDecodeArrayTask for StructuralCompositeDecodeArrayTask {
@@ -3131,7 +3128,7 @@ impl StructuralDecodeArrayTask for StructuralCompositeDecodeArrayTask {
             let array = make_array(
                 decoded
                     .data
-                    .into_arrow(self.items_type.clone(), self.should_validate)?,
+                    .into_arrow(self.data_type.clone(), self.should_validate)?,
             );
 
             arrays.push(array);
@@ -3141,7 +3138,6 @@ impl StructuralDecodeArrayTask for StructuralCompositeDecodeArrayTask {
         let mut repdef = CompositeRepDefUnraveler::new(unravelers);
 
         let array = Self::restore_validity(array, &mut repdef);
-        let array = Self::restore_fsl(array, &mut repdef, self.fsl_fields);
 
         Ok(DecodedArray { array, repdef })
     }
@@ -3150,40 +3146,15 @@ impl StructuralDecodeArrayTask for StructuralCompositeDecodeArrayTask {
 #[derive(Debug)]
 pub struct StructuralPrimitiveFieldDecoder {
     field: Arc<ArrowField>,
-    items_type: DataType,
-    fsl_fields: Arc<[Arc<ArrowField>]>,
     page_decoders: VecDeque<Box<dyn StructuralPageDecoder>>,
     should_validate: bool,
     rows_drained_in_current: u64,
 }
 
 impl StructuralPrimitiveFieldDecoder {
-    fn flatten_field_helper(
-        field: &Arc<ArrowField>,
-        mut fields: Vec<Arc<ArrowField>>,
-    ) -> (Arc<[Arc<ArrowField>]>, &DataType) {
-        match field.data_type() {
-            DataType::FixedSizeList(inner, _) => {
-                fields.push(field.clone());
-                Self::flatten_field_helper(inner, fields)
-            }
-            _ => {
-                let fields = fields.into();
-                (fields, field.data_type())
-            }
-        }
-    }
-
-    fn flatten_field(field: &Arc<ArrowField>) -> (Arc<[Arc<ArrowField>]>, &DataType) {
-        Self::flatten_field_helper(field, Vec::default())
-    }
-
     pub fn new(field: &Arc<ArrowField>, should_validate: bool) -> Self {
-        let (fsl_fields, items_type) = Self::flatten_field(field);
         Self {
             field: field.clone(),
-            items_type: items_type.clone(),
-            fsl_fields,
             page_decoders: VecDeque::new(),
             should_validate,
             rows_drained_in_current: 0,
@@ -3220,9 +3191,8 @@ impl StructuralFieldDecoder for StructuralPrimitiveFieldDecoder {
         }
         Ok(Box::new(StructuralCompositeDecodeArrayTask {
             tasks,
-            items_type: self.items_type.clone(),
             should_validate: self.should_validate,
-            fsl_fields: self.fsl_fields.clone(),
+            data_type: self.field.data_type().clone(),
         }))
     }
 
@@ -3487,7 +3457,6 @@ struct SerializedFullZip {
 // Note: by "aligned to 8 bytes" we mean BOTH "aligned to 8 bytes from the start of
 // the page" and "aligned to 8 bytes from the start of the file."
 const MINIBLOCK_ALIGNMENT: usize = 8;
-const MINIBLOCK_MAX_PADDING: usize = MINIBLOCK_ALIGNMENT - 1;
 
 /// An encoder for primitive (leaf) arrays
 ///
@@ -3524,6 +3493,23 @@ pub struct PrimitiveStructuralEncoder {
     column_index: u32,
     field: Field,
     encoding_metadata: Arc<HashMap<String, String>>,
+}
+
+struct CompressedLevelsChunk {
+    data: LanceBuffer,
+    num_levels: u16,
+}
+
+struct CompressedLevels {
+    data: Vec<CompressedLevelsChunk>,
+    compression: pb::ArrayEncoding,
+    rep_index: Option<LanceBuffer>,
+}
+
+struct SerializedMiniBlockPage {
+    num_buffers: u64,
+    data: LanceBuffer,
+    metadata: LanceBuffer,
 }
 
 impl PrimitiveStructuralEncoder {
@@ -3598,17 +3584,10 @@ impl PrimitiveStructuralEncoder {
     // we also create a buffer for the repetition index.
     //
     // Each chunk is serialized as:
-    // | rep_len (2 bytes) | def_len (2 bytes) | values_len (2 bytes) | rep | P1 | def | P2 | values | P3 |
+    // | num_bufs (1 byte) | buf_lens (2 bytes per buffer) | P | buf0 | P | buf1 | ... | bufN | P |
     //
-    // P1 - Up to 1 padding byte to ensure `def` is 2-byte aligned
-    // P2 - Up to 7 padding bytes to ensure `values` is 8-byte aligned
-    // P3 - Up to 7 padding bytes to ensure the chunk is a multiple of 8 bytes (this also ensures
-    //      that the next `chunk` is 8-byte aligned)
-    //
-    // rep is guaranteed to be 2-byte aligned
-    // def is guaranteed to be 2-byte aligned
-    // values is guaranteed to be 8-byte aligned
-    // rep_len, def_len, and values_len are guaranteed to be 2-byte aligned but this shouldn't matter.
+    // P - Padding inserted to ensure each buffer is 8-byte aligned and the buffer size is a multiple
+    //     of 8 bytes (so that the next chunk is 8-byte aligned).
     //
     // Each block has a u16 word of metadata.  The upper 12 bits contain 1/6 the
     // # of bytes in the block (if the block does not have an even number of bytes
@@ -3647,61 +3626,93 @@ impl PrimitiveStructuralEncoder {
     // cached in memory.
     fn serialize_miniblocks(
         miniblocks: MiniBlockCompressed,
-        rep: Vec<LanceBuffer>,
-        def: Vec<LanceBuffer>,
-    ) -> (LanceBuffer, LanceBuffer) {
-        let bytes_rep = rep.iter().map(|r| r.len()).sum::<usize>();
-        let bytes_def = def.iter().map(|d| d.len()).sum::<usize>();
-        let max_bytes_repdef_len = rep.len() * 4;
-        let max_padding = miniblocks.chunks.len() * (1 + (2 * MINIBLOCK_MAX_PADDING));
-        let mut data_buffer = Vec::with_capacity(
-            miniblocks.data.len()      // `values`
-                + bytes_rep            // `rep_len * num_blocks`
-                + bytes_def            // `def_len * num_blocks`
-                + max_bytes_repdef_len // `rep` and `def`
-                + max_padding, // `P1`, `P2`, and `P3` for each block
-        );
-        let mut meta_buffer = Vec::with_capacity(miniblocks.data.len() * 2);
+        rep: Option<Vec<CompressedLevelsChunk>>,
+        def: Option<Vec<CompressedLevelsChunk>>,
+    ) -> SerializedMiniBlockPage {
+        let bytes_rep = rep
+            .as_ref()
+            .map(|rep| rep.iter().map(|r| r.data.len()).sum::<usize>())
+            .unwrap_or(0);
+        let bytes_def = def
+            .as_ref()
+            .map(|def| def.iter().map(|d| d.data.len()).sum::<usize>())
+            .unwrap_or(0);
+        let bytes_data = miniblocks.data.iter().map(|d| d.len()).sum::<usize>();
+        let mut num_buffers = miniblocks.data.len();
+        if rep.is_some() {
+            num_buffers += 1;
+        }
+        if def.is_some() {
+            num_buffers += 1;
+        }
+        // 2 bytes for the length of each buffer and up to 7 bytes of padding per buffer
+        let max_extra = 9 * num_buffers;
+        let mut data_buffer = Vec::with_capacity(bytes_rep + bytes_def + bytes_data + max_extra);
+        let mut meta_buffer = Vec::with_capacity(miniblocks.chunks.len() * 2);
 
-        let mut value_offset = 0;
-        for ((chunk, rep), def) in miniblocks.chunks.into_iter().zip(rep).zip(def) {
-            let start_len = data_buffer.len();
+        let mut rep_iter = rep.map(|r| r.into_iter());
+        let mut def_iter = def.map(|d| d.into_iter());
+
+        let mut buffer_offsets = vec![0; miniblocks.data.len()];
+        for chunk in miniblocks.chunks {
+            let start_pos = data_buffer.len();
             // Start of chunk should be aligned
-            debug_assert_eq!(start_len % MINIBLOCK_ALIGNMENT, 0);
+            debug_assert_eq!(start_pos % MINIBLOCK_ALIGNMENT, 0);
 
-            assert!(rep.len() < u16::MAX as usize);
-            assert!(def.len() < u16::MAX as usize);
-            let bytes_rep = rep.len() as u16;
-            let bytes_def = def.len() as u16;
-            let bytes_val = chunk.num_bytes;
+            let rep = rep_iter.as_mut().map(|r| r.next().unwrap());
+            let def = def_iter.as_mut().map(|d| d.next().unwrap());
 
-            // Each chunk starts with the size of the rep buffer (2 bytes) the size of
-            // the def buffer (2 bytes) and the size of the values buffer (2 bytes)
-            data_buffer.extend_from_slice(&bytes_rep.to_le_bytes());
-            data_buffer.extend_from_slice(&bytes_def.to_le_bytes());
-            data_buffer.extend_from_slice(&bytes_val.to_le_bytes());
+            // Write the number of levels, or 0 if there is no rep/def
+            let num_levels = rep
+                .as_ref()
+                .map(|r| r.num_levels)
+                .unwrap_or(def.as_ref().map(|d| d.num_levels).unwrap_or(0));
+            data_buffer.extend_from_slice(&num_levels.to_le_bytes());
 
-            data_buffer.extend_from_slice(&rep);
-            // In theory we should insert P1 here.  However, since we do not have bit-packing of rep
-            // def levels yet we can skip this step.
-            debug_assert_eq!(data_buffer.len() % 2, 0);
-            data_buffer.extend_from_slice(&def);
+            // Write the buffer lengths
+            if let Some(rep) = rep.as_ref() {
+                let bytes_rep = u16::try_from(rep.data.len()).unwrap();
+                data_buffer.extend_from_slice(&bytes_rep.to_le_bytes());
+            }
+            if let Some(def) = def.as_ref() {
+                let bytes_def = u16::try_from(def.data.len()).unwrap();
+                data_buffer.extend_from_slice(&bytes_def.to_le_bytes());
+            }
 
-            let p2 = pad_bytes::<MINIBLOCK_ALIGNMENT>(data_buffer.len());
-            // SAFETY: We ensured the data buffer would be large enough when we allocated
-            data_buffer.extend(iter::repeat(0).take(p2));
+            for buffer_size in &chunk.buffer_sizes {
+                let bytes = u16::try_from(*buffer_size).unwrap();
+                data_buffer.extend_from_slice(&bytes.to_le_bytes());
+            }
 
-            let num_value_bytes = chunk.num_bytes as usize;
-            let values =
-                &miniblocks.data[value_offset as usize..value_offset as usize + num_value_bytes];
-            debug_assert_eq!(data_buffer.len() % MINIBLOCK_ALIGNMENT, 0);
-            data_buffer.extend_from_slice(values);
+            // Pad
+            let add_padding = |data_buffer: &mut Vec<u8>| {
+                let pad = pad_bytes::<MINIBLOCK_ALIGNMENT>(data_buffer.len());
+                data_buffer.extend(iter::repeat(FILL_BYTE).take(pad));
+            };
+            add_padding(&mut data_buffer);
 
-            let p3 = pad_bytes::<MINIBLOCK_ALIGNMENT>(data_buffer.len());
-            data_buffer.extend(iter::repeat(0).take(p3));
-            value_offset += num_value_bytes as u64;
+            // Write the buffers themselves
+            if let Some(rep) = rep.as_ref() {
+                data_buffer.extend_from_slice(&rep.data);
+                add_padding(&mut data_buffer);
+            }
+            if let Some(def) = def.as_ref() {
+                data_buffer.extend_from_slice(&def.data);
+                add_padding(&mut data_buffer);
+            }
+            for (buffer_size, (buffer, buffer_offset)) in chunk
+                .buffer_sizes
+                .iter()
+                .zip(miniblocks.data.iter().zip(buffer_offsets.iter_mut()))
+            {
+                let start = *buffer_offset;
+                let end = start + *buffer_size as usize;
+                *buffer_offset += *buffer_size as usize;
+                data_buffer.extend_from_slice(&buffer[start..end]);
+                add_padding(&mut data_buffer);
+            }
 
-            let chunk_bytes = data_buffer.len() - start_len;
+            let chunk_bytes = data_buffer.len() - start_pos;
             assert!(chunk_bytes <= 16 * 1024);
             assert!(chunk_bytes > 0);
             assert_eq!(chunk_bytes % 8, 0);
@@ -3715,125 +3726,129 @@ impl PrimitiveStructuralEncoder {
             meta_buffer.extend_from_slice(&metadata.to_le_bytes());
         }
 
-        (
-            LanceBuffer::Owned(data_buffer),
-            LanceBuffer::Owned(meta_buffer),
-        )
+        let data_buffer = LanceBuffer::Owned(data_buffer);
+        let metadata_buffer = LanceBuffer::Owned(meta_buffer);
+
+        SerializedMiniBlockPage {
+            num_buffers: miniblocks.data.len() as u64,
+            data: data_buffer,
+            metadata: metadata_buffer,
+        }
     }
 
     /// Compresses a buffer of levels into chunks
     ///
-    /// TODO: Use bit-packing here
-    ///
     /// If these are repetition levels then we also calculate the repetition index here (that
     /// is the third return value)
     fn compress_levels(
-        levels: Option<RepDefSlicer<'_>>,
-        num_values: u64,
+        mut levels: RepDefSlicer<'_>,
+        num_elements: u64,
         compression_strategy: &dyn CompressionStrategy,
         chunks: &[MiniBlockChunk],
         // This will be 0 if we are compressing def levels
         max_rep: u16,
-    ) -> Result<(Vec<LanceBuffer>, pb::ArrayEncoding, LanceBuffer)> {
-        if let Some(mut levels) = levels {
-            let mut rep_index = if max_rep > 0 {
-                Vec::with_capacity(chunks.len())
+    ) -> Result<CompressedLevels> {
+        let mut rep_index = if max_rep > 0 {
+            Vec::with_capacity(chunks.len())
+        } else {
+            vec![]
+        };
+        // Make the levels into a FixedWidth data block
+        let num_levels = levels.num_levels() as u64;
+        let mut levels_buf = levels.all_levels().try_clone().unwrap();
+        let levels_block = DataBlock::FixedWidth(FixedWidthDataBlock {
+            data: levels_buf.borrow_and_clone(),
+            bits_per_value: 16,
+            num_values: num_levels,
+            block_info: BlockInfo::new(),
+        });
+        let levels_field = Field::new_arrow("", DataType::UInt16, false)?;
+        // Pick a block compressor
+        let (compressor, compressor_desc) =
+            compression_strategy.create_block_compressor(&levels_field, &levels_block)?;
+        // Compress blocks of levels (sized according to the chunks)
+        let mut level_chunks = Vec::with_capacity(chunks.len());
+        let mut values_counter = 0;
+        for (chunk_idx, chunk) in chunks.iter().enumerate() {
+            let chunk_num_values = chunk.num_values(values_counter, num_elements);
+            values_counter += chunk_num_values;
+            let mut chunk_levels = if chunk_idx < chunks.len() - 1 {
+                levels.slice_next(chunk_num_values as usize)
             } else {
-                vec![]
+                levels.slice_rest()
             };
-            // Make the levels into a FixedWidth data block
-            let num_levels = levels.num_levels() as u64;
-            let mut levels_buf = levels.all_levels().try_clone().unwrap();
-            let levels_block = DataBlock::FixedWidth(FixedWidthDataBlock {
-                data: levels_buf.borrow_and_clone(),
+            let num_chunk_levels = (chunk_levels.len() / 2) as u64;
+            if max_rep > 0 {
+                // If max_rep > 0 then we are working with rep levels and we need
+                // to calculate the repetition index.  The repetition index for a
+                // chunk is currently 2 values (in the future it may be more).
+                //
+                // The first value is the number of rows that _finish_ in the
+                // chunk.
+                //
+                // The second value is the number of "leftovers" after the last
+                // finished row in the chunk.
+                let rep_values = chunk_levels.borrow_to_typed_slice::<u16>();
+                let rep_values = rep_values.as_ref();
+
+                // We skip 1 here because a max_rep at spot 0 doesn't count as a finished list (we
+                // will count it in the previous chunk)
+                let mut num_rows = rep_values.iter().skip(1).filter(|v| **v == max_rep).count();
+                let num_leftovers = if chunk_idx < chunks.len() - 1 {
+                    rep_values
+                        .iter()
+                        .rev()
+                        .position(|v| *v == max_rep)
+                        // # of leftovers includes the max_rep spot
+                        .map(|pos| pos + 1)
+                        .unwrap_or(rep_values.len())
+                } else {
+                    // Last chunk can't have leftovers
+                    0
+                };
+
+                if chunk_idx != 0 && rep_values[0] == max_rep {
+                    // This chunk starts with a new row and so, if we thought we had leftovers
+                    // in the previous chunk, we were mistaken
+                    // TODO: Can use unchecked here
+                    let rep_len = rep_index.len();
+                    if rep_index[rep_len - 1] != 0 {
+                        // We thought we had leftovers but that was actually a full row
+                        rep_index[rep_len - 2] += 1;
+                        rep_index[rep_len - 1] = 0;
+                    }
+                }
+
+                if chunk_idx == chunks.len() - 1 {
+                    // The final list
+                    num_rows += 1;
+                }
+                rep_index.push(num_rows as u64);
+                rep_index.push(num_leftovers as u64);
+            }
+            let chunk_levels_block = DataBlock::FixedWidth(FixedWidthDataBlock {
+                data: chunk_levels,
                 bits_per_value: 16,
-                num_values: num_levels,
+                num_values: num_chunk_levels,
                 block_info: BlockInfo::new(),
             });
-            let levels_field = Field::new_arrow("", DataType::UInt16, false)?;
-            // Pick a block compressor
-            let (compressor, compressor_desc) =
-                compression_strategy.create_block_compressor(&levels_field, &levels_block)?;
-            // Compress blocks of levels (sized according to the chunks)
-            let mut buffers = Vec::with_capacity(chunks.len());
-            let mut values_counter = 0;
-            for (chunk_idx, chunk) in chunks.iter().enumerate() {
-                let chunk_num_values = chunk.num_values(values_counter, num_values);
-                values_counter += chunk_num_values;
-                let mut chunk_levels = if chunk_idx < chunks.len() - 1 {
-                    levels.slice_next(chunk_num_values as usize)
-                } else {
-                    levels.slice_rest()
-                };
-                let num_chunk_levels = (chunk_levels.len() / 2) as u64;
-                if max_rep > 0 {
-                    // If max_rep > 0 then we are working with rep levels and we need
-                    // to calculate the repetition index.  The repetition index for a
-                    // chunk is currently 2 values (in the future it may be more).
-                    //
-                    // The first value is the number of rows that _finish_ in the
-                    // chunk.
-                    //
-                    // The second value is the number of "leftovers" after the last
-                    // finished row in the chunk.
-                    let rep_values = chunk_levels.borrow_to_typed_slice::<u16>();
-                    let rep_values = rep_values.as_ref();
-
-                    // We skip 1 here because a max_rep at spot 0 doesn't count as a finished list (we
-                    // will count it in the previous chunk)
-                    let mut num_rows = rep_values.iter().skip(1).filter(|v| **v == max_rep).count();
-                    let num_leftovers = if chunk_idx < chunks.len() - 1 {
-                        rep_values
-                            .iter()
-                            .rev()
-                            .position(|v| *v == max_rep)
-                            // # of leftovers includes the max_rep spot
-                            .map(|pos| pos + 1)
-                            .unwrap_or(rep_values.len())
-                    } else {
-                        // Last chunk can't have leftovers
-                        0
-                    };
-
-                    if chunk_idx != 0 && rep_values[0] == max_rep {
-                        // This chunk starts with a new row and so, if we thought we had leftovers
-                        // in the previous chunk, we were mistaken
-                        // TODO: Can use unchecked here
-                        let rep_len = rep_index.len();
-                        if rep_index[rep_len - 1] != 0 {
-                            // We thought we had leftovers but that was actually a full row
-                            rep_index[rep_len - 2] += 1;
-                            rep_index[rep_len - 1] = 0;
-                        }
-                    }
-
-                    if chunk_idx == chunks.len() - 1 {
-                        // The final list
-                        num_rows += 1;
-                    }
-                    rep_index.push(num_rows as u64);
-                    rep_index.push(num_leftovers as u64);
-                }
-                let chunk_levels_block = DataBlock::FixedWidth(FixedWidthDataBlock {
-                    data: chunk_levels,
-                    bits_per_value: 16,
-                    num_values: num_chunk_levels,
-                    block_info: BlockInfo::new(),
-                });
-                let compressed_levels = compressor.compress(chunk_levels_block)?;
-                buffers.push(compressed_levels);
-            }
-            debug_assert_eq!(levels.num_levels_remaining(), 0);
-            let rep_index = LanceBuffer::reinterpret_vec(rep_index);
-            Ok((buffers, compressor_desc, rep_index))
-        } else {
-            // Everything is valid or we have no repetition so we encode as a constant
-            // array of 0
-            let data = chunks.iter().map(|_| LanceBuffer::empty()).collect();
-            let scalar = 0_u16.to_le_bytes().to_vec();
-            let encoding = ProtobufUtils::constant(scalar, num_values);
-            Ok((data, encoding, LanceBuffer::empty()))
+            let compressed_levels = compressor.compress(chunk_levels_block)?;
+            level_chunks.push(CompressedLevelsChunk {
+                data: compressed_levels,
+                num_levels: num_chunk_levels as u16,
+            });
         }
+        debug_assert_eq!(levels.num_levels_remaining(), 0);
+        let rep_index = if rep_index.is_empty() {
+            None
+        } else {
+            Some(LanceBuffer::reinterpret_vec(rep_index))
+        };
+        Ok(CompressedLevels {
+            data: level_chunks,
+            compression: compressor_desc,
+            rep_index,
+        })
     }
 
     fn encode_simple_all_null(
@@ -3904,12 +3919,10 @@ impl PrimitiveStructuralEncoder {
             todo!()
         }
 
-        // The validity is encoded in repdef so we can remove it
-        let data = data.remove_validity();
-
-        // We encode FSL by flattening the data and then compressing it.  This means the mini-block will have
-        // more items than rows if any FSL layers are present.
-        let data = data.flatten();
+        // The top-level validity is encoded in repdef so we can remove it.  There may be inner
+        // validities if we have FSL fields but those are not included in the repdef and need to
+        // be encoded.
+        let data = data.remove_outer_validity();
 
         let num_items = data.num_values();
 
@@ -3918,43 +3931,59 @@ impl PrimitiveStructuralEncoder {
 
         let max_rep = repdef.def_meaning.iter().filter(|l| l.is_list()).count() as u16;
 
-        let (compressed_rep, rep_encoding, rep_index) = Self::compress_levels(
-            repdef.rep_slicer(),
-            num_items,
-            compression_strategy,
-            &compressed_data.chunks,
-            max_rep,
-        )?;
+        let mut compressed_rep = repdef
+            .rep_slicer()
+            .map(|rep_slicer| {
+                Self::compress_levels(
+                    rep_slicer,
+                    num_items,
+                    compression_strategy,
+                    &compressed_data.chunks,
+                    max_rep,
+                )
+            })
+            .transpose()?;
 
-        let (rep_index, rep_index_depth) = if rep_index.is_empty() {
-            (None, 0)
-        } else {
-            // TODO: Support repetition index depth > 1
-            (Some(rep_index), 1)
-        };
+        let (rep_index, rep_index_depth) =
+            match compressed_rep.as_mut().and_then(|cr| cr.rep_index.as_mut()) {
+                Some(rep_index) => (Some(rep_index.borrow_and_clone()), 1),
+                None => (None, 0),
+            };
 
-        let (compressed_def, def_encoding, _) = Self::compress_levels(
-            repdef.def_slicer(),
-            num_items,
-            compression_strategy,
-            &compressed_data.chunks,
-            /*max_rep=*/ 0,
-        )?;
+        let mut compressed_def = repdef
+            .def_slicer()
+            .map(|def_slicer| {
+                Self::compress_levels(
+                    def_slicer,
+                    num_items,
+                    compression_strategy,
+                    &compressed_data.chunks,
+                    /*max_rep=*/ 0,
+                )
+            })
+            .transpose()?;
 
         // TODO: Parquet sparsely encodes values here.  We could do the same but
         // then we won't have log2 values per chunk.  This means more metadata
         // and potentially more decoder asymmetry.  However, it may be worth
         // investigating at some point
 
-        let (block_value_buffer, block_meta_buffer) =
-            Self::serialize_miniblocks(compressed_data, compressed_rep, compressed_def);
+        let rep_data = compressed_rep
+            .as_mut()
+            .map(|cr| std::mem::take(&mut cr.data));
+        let def_data = compressed_def
+            .as_mut()
+            .map(|cd| std::mem::take(&mut cd.data));
+
+        let serialized = Self::serialize_miniblocks(compressed_data, rep_data, def_data);
 
         // Metadata, Data, Dictionary, (maybe) Repetition Index
         let mut data = Vec::with_capacity(4);
-        data.push(block_meta_buffer);
-        data.push(block_value_buffer);
+        data.push(serialized.metadata);
+        data.push(serialized.data);
 
         if let Some(dictionary_data) = dictionary_data {
+            let num_dictionary_items = dictionary_data.num_values();
             // field in `create_block_compressor` is not used currently.
             let dummy_dictionary_field = Field::new_arrow("", DataType::UInt16, false)?;
 
@@ -3968,11 +3997,12 @@ impl PrimitiveStructuralEncoder {
             }
 
             let description = ProtobufUtils::miniblock_layout(
-                rep_encoding,
-                def_encoding,
+                compressed_rep.map(|cr| cr.compression),
+                compressed_def.map(|cd| cd.compression),
                 value_encoding,
                 rep_index_depth,
-                Some(dictionary_encoding),
+                serialized.num_buffers,
+                Some((dictionary_encoding, num_dictionary_items)),
                 &repdef.def_meaning,
                 num_items,
             );
@@ -3985,10 +4015,11 @@ impl PrimitiveStructuralEncoder {
             })
         } else {
             let description = ProtobufUtils::miniblock_layout(
-                rep_encoding,
-                def_encoding,
+                compressed_rep.map(|cr| cr.compression),
+                compressed_def.map(|cd| cd.compression),
                 value_encoding,
                 rep_index_depth,
+                serialized.num_buffers,
                 None,
                 &repdef.def_meaning,
                 num_items,
@@ -4016,9 +4047,9 @@ impl PrimitiveStructuralEncoder {
     fn serialize_full_zip_fixed(
         fixed: FixedWidthDataBlock,
         mut repdef: ControlWordIterator,
-        num_items: u64,
+        num_values: u64,
     ) -> SerializedFullZip {
-        let len = fixed.data.len() + repdef.bytes_per_word() * num_items as usize;
+        let len = fixed.data.len() + repdef.bytes_per_word() * num_values as usize;
         let mut zipped_data = Vec::with_capacity(len);
 
         let max_rep_index_val = if repdef.has_repetition() {
@@ -4028,7 +4059,7 @@ impl PrimitiveStructuralEncoder {
             0
         };
         let mut rep_index_builder =
-            BytepackedIntegerEncoder::with_capacity(num_items as usize + 1, max_rep_index_val);
+            BytepackedIntegerEncoder::with_capacity(num_values as usize + 1, max_rep_index_val);
 
         // I suppose we can just pad to the nearest byte but I'm not sure we need to worry about this anytime soon
         // because it is unlikely compression of large values is going to yield a result that is not byte aligned
@@ -4205,11 +4236,12 @@ impl PrimitiveStructuralEncoder {
             .as_ref()
             .map_or(0, |d| d.iter().max().copied().unwrap_or(0));
 
-        // The validity is encoded in repdef so we can remove it
-        let data = data.remove_validity();
+        // The top-level validity is encoded in repdef so we can remove it
+        let data = data.remove_outer_validity();
 
         // To handle FSL we just flatten
-        let data = data.flatten();
+        // let data = data.flatten();
+
         let (num_items, num_visible_items) =
             if let Some(rep_levels) = repdef.repetition_levels.as_ref() {
                 // If there are rep levels there may be "invisible" items and we need to encode
@@ -4515,12 +4547,14 @@ impl PrimitiveStructuralEncoder {
             DataType::Dictionary(_, _) => {
                 unreachable!()
             }
-            DataType::FixedSizeList(_, dimension) => {
-                // Extract our validity buf and then any child validity bufs
-                repdef.add_fsl(array.nulls().cloned(), *dimension as usize, array.len());
-                let array = array.as_fixed_size_list();
-                Self::extract_validity(array.values(), repdef);
-            }
+            // Extract our validity buf but NOT any child validity bufs. (they will be encoded in
+            // as part of the values).  Note: for FSL we do not use repdef.add_fsl because we do
+            // NOT want to increase the repdef depth.
+            //
+            // This would be quite catasrophic for something like vector embeddings.  Imagine we
+            // had thousands of vectors and some were null but no vector contained null items.  If
+            // we treated the vectors (primitive FSL) like we treat structural FSL we would end up
+            // with a rep/def value for every single item in the vector.
             _ => Self::extract_validity_buf(array, repdef),
         }
     }

--- a/rust/lance-encoding/src/encodings/physical.rs
+++ b/rust/lance-encoding/src/encodings/physical.rs
@@ -287,10 +287,7 @@ pub fn decoder_from_array_encoding(
         // This will change in the future when we add support for struct nullability.
         pb::array_encoding::ArrayEncoding::Struct(_) => unreachable!(),
         // 2.1 only
-        pb::array_encoding::ArrayEncoding::Constant(_) => unreachable!(),
-        pb::array_encoding::ArrayEncoding::Bitpack2(_) => unreachable!(),
-        pb::array_encoding::ArrayEncoding::Variable(_) => unreachable!(),
-        pb::array_encoding::ArrayEncoding::PackedStructFixedWidthMiniBlock(_) => unreachable!(),
+        _ => unreachable!("Unsupported array encoding: {:?}", encoding),
     }
 }
 

--- a/rust/lance-encoding/src/encodings/physical/bitpack_fastlanes.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpack_fastlanes.rs
@@ -7,6 +7,7 @@ use arrow::datatypes::{
     Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type, UInt64Type, UInt8Type,
 };
 use arrow_array::{Array, PrimitiveArray};
+use arrow_buffer::ArrowNativeType;
 use arrow_schema::DataType;
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::Bytes;
@@ -21,14 +22,19 @@ use crate::buffer::LanceBuffer;
 use crate::compression_algo::fastlanes::BitPacking;
 use crate::data::BlockInfo;
 use crate::data::{DataBlock, FixedWidthDataBlock, NullableDataBlock};
-use crate::decoder::{MiniBlockDecompressor, PageScheduler, PrimitivePageDecoder};
+use crate::decoder::{
+    BlockDecompressor, FixedPerValueDecompressor, MiniBlockDecompressor, PageScheduler,
+    PrimitivePageDecoder,
+};
 use crate::encoder::{
-    ArrayEncoder, EncodedArray, MiniBlockChunk, MiniBlockCompressed, MiniBlockCompressor,
+    ArrayEncoder, BlockCompressor, EncodedArray, MiniBlockChunk, MiniBlockCompressed,
+    MiniBlockCompressor, PerValueCompressor, PerValueDataBlock,
 };
 use crate::format::{pb, ProtobufUtils};
 use crate::statistics::{GetStat, Stat};
 use arrow::array::ArrayRef;
-use bytemuck::cast_slice;
+use bytemuck::{cast_slice, AnyBitPattern};
+
 const LOG_ELEMS_PER_CHUNK: u8 = 10;
 const ELEMS_PER_CHUNK: u64 = 1 << LOG_ELEMS_PER_CHUNK;
 
@@ -597,983 +603,40 @@ fn bitpacked_for_non_neg_decode(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    // use super::*;
-    // use arrow::array::{
-    //     Int16Array, Int32Array, Int64Array, Int8Array, UInt16Array, UInt32Array, UInt64Array,
-    //     UInt8Array,
-    // };
-    // use arrow::datatypes::DataType;
-
-    // #[test_log::test(tokio::test)]
-    // async fn test_compute_compressed_bit_width_for_non_neg() {}
-
-    // use std::collections::HashMap;
-
-    // use lance_datagen::RowCount;
-
-    // use crate::testing::{check_round_trip_encoding_of_data, TestCases};
-    // use crate::version::LanceFileVersion;
-
-    // async fn check_round_trip_bitpacked(array: Arc<dyn Array>) {
-    //     let test_cases = TestCases::default().with_file_version(LanceFileVersion::V2_1);
-    //     check_round_trip_encoding_of_data(vec![array], &test_cases, HashMap::new()).await;
-    // }
-
-    // #[test_log::test(tokio::test)]
-    // async fn test_bitpack_fastlanes_u8() {
-    //     let values: Vec<u8> = vec![5; 1024];
-    //     let array = UInt8Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u8> = vec![66; 1000];
-    //     let array = UInt8Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u8> = vec![77; 2000];
-    //     let array = UInt8Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u8> = vec![0; 10000];
-    //     let array = UInt8Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u8> = vec![88; 10000];
-    //     let array = UInt8Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt8))
-    //         .into_batch_rows(RowCount::from(1))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt8))
-    //         .into_batch_rows(RowCount::from(20))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt8))
-    //         .into_batch_rows(RowCount::from(50))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt8))
-    //         .into_batch_rows(RowCount::from(100))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt8))
-    //         .into_batch_rows(RowCount::from(1000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt8))
-    //         .into_batch_rows(RowCount::from(1024))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt8))
-    //         .into_batch_rows(RowCount::from(2000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt8))
-    //         .into_batch_rows(RowCount::from(3000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-    // }
-
-    // #[test_log::test(tokio::test)]
-    // async fn test_bitpack_fastlanes_u16() {
-    //     let values: Vec<u16> = vec![5; 1024];
-    //     let array = UInt16Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u16> = vec![66; 1000];
-    //     let array = UInt16Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u16> = vec![77; 2000];
-    //     let array = UInt16Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u16> = vec![0; 10000];
-    //     let array = UInt16Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u16> = vec![88; 10000];
-    //     let array = UInt16Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u16> = vec![300; 100];
-    //     let array = UInt16Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u16> = vec![800; 100];
-    //     let array = UInt16Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt16))
-    //         .into_batch_rows(RowCount::from(1))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt16))
-    //         .into_batch_rows(RowCount::from(20))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt16))
-    //         .into_batch_rows(RowCount::from(100))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt16))
-    //         .into_batch_rows(RowCount::from(1000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt16))
-    //         .into_batch_rows(RowCount::from(1024))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt16))
-    //         .into_batch_rows(RowCount::from(2000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt16))
-    //         .into_batch_rows(RowCount::from(3000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-    // }
-
-    // #[test_log::test(tokio::test)]
-    // async fn test_bitpack_fastlanes_u32() {
-    //     let values: Vec<u32> = vec![5; 1024];
-    //     let array = UInt32Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u32> = vec![7; 2000];
-    //     let array = UInt32Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u32> = vec![66; 1000];
-    //     let array = UInt32Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u32> = vec![666; 1000];
-    //     let array = UInt32Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u32> = vec![77; 2000];
-    //     let array = UInt32Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u32> = vec![0; 10000];
-    //     let array = UInt32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u32> = vec![1; 10000];
-    //     let array = UInt32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u32> = vec![88; 10000];
-    //     let array = UInt32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u32> = vec![300; 100];
-    //     let array = UInt32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u32> = vec![3000; 100];
-    //     let array = UInt32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u32> = vec![800; 100];
-    //     let array = UInt32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u32> = vec![8000; 100];
-    //     let array = UInt32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u32> = vec![65536; 100];
-    //     let array = UInt32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u32> = vec![655360; 100];
-    //     let array = UInt32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt32))
-    //         .into_batch_rows(RowCount::from(1))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt32))
-    //         .into_batch_rows(RowCount::from(20))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt32))
-    //         .into_batch_rows(RowCount::from(50))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt32))
-    //         .into_batch_rows(RowCount::from(100))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt32))
-    //         .into_batch_rows(RowCount::from(1000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt32))
-    //         .into_batch_rows(RowCount::from(1024))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt32))
-    //         .into_batch_rows(RowCount::from(2000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt32))
-    //         .into_batch_rows(RowCount::from(3000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-    // }
-
-    // #[test_log::test(tokio::test)]
-    // async fn test_bitpack_fastlanes_u64() {
-    //     let values: Vec<u64> = vec![5; 1024];
-    //     let array = UInt64Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u64> = vec![7; 2000];
-    //     let array = UInt64Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u64> = vec![66; 1000];
-    //     let array = UInt64Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u64> = vec![666; 1000];
-    //     let array = UInt64Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u64> = vec![77; 2000];
-    //     let array = UInt64Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<u64> = vec![0; 10000];
-    //     let array = UInt64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u64> = vec![1; 10000];
-    //     let array = UInt64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u64> = vec![88; 10000];
-    //     let array = UInt64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u64> = vec![300; 100];
-    //     let array = UInt64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u64> = vec![3000; 100];
-    //     let array = UInt64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u64> = vec![800; 100];
-    //     let array = UInt64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u64> = vec![8000; 100];
-    //     let array = UInt64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u64> = vec![65536; 100];
-    //     let array = UInt64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<u64> = vec![655360; 100];
-    //     let array = UInt64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt64))
-    //         .into_batch_rows(RowCount::from(1))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt64))
-    //         .into_batch_rows(RowCount::from(20))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt64))
-    //         .into_batch_rows(RowCount::from(50))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt64))
-    //         .into_batch_rows(RowCount::from(100))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt64))
-    //         .into_batch_rows(RowCount::from(1000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt64))
-    //         .into_batch_rows(RowCount::from(1024))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt64))
-    //         .into_batch_rows(RowCount::from(2000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::UInt64))
-    //         .into_batch_rows(RowCount::from(3000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-    // }
-
-    // #[test_log::test(tokio::test)]
-    // async fn test_bitpack_fastlanes_i8() {
-    //     let values: Vec<i8> = vec![-5; 1024];
-    //     let array = Int8Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i8> = vec![66; 1000];
-    //     let array = Int8Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i8> = vec![77; 2000];
-    //     let array = Int8Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i8> = vec![0; 10000];
-    //     let array = Int8Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i8> = vec![88; 10000];
-    //     let array = Int8Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i8> = vec![-88; 10000];
-    //     let array = Int8Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int8))
-    //         .into_batch_rows(RowCount::from(1))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int8))
-    //         .into_batch_rows(RowCount::from(20))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int8))
-    //         .into_batch_rows(RowCount::from(50))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int8))
-    //         .into_batch_rows(RowCount::from(100))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int8))
-    //         .into_batch_rows(RowCount::from(1000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int8))
-    //         .into_batch_rows(RowCount::from(1024))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int8))
-    //         .into_batch_rows(RowCount::from(2000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int8))
-    //         .into_batch_rows(RowCount::from(3000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-    // }
-
-    // #[test_log::test(tokio::test)]
-    // async fn test_bitpack_fastlanes_i16() {
-    //     let values: Vec<i16> = vec![-5; 1024];
-    //     let array = Int16Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i16> = vec![66; 1000];
-    //     let array = Int16Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i16> = vec![77; 2000];
-    //     let array = Int16Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i16> = vec![0; 10000];
-    //     let array = Int16Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i16> = vec![88; 10000];
-    //     let array = Int16Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i16> = vec![300; 100];
-    //     let array = Int16Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i16> = vec![800; 100];
-    //     let array = Int16Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int16))
-    //         .into_batch_rows(RowCount::from(1))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int16))
-    //         .into_batch_rows(RowCount::from(20))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int16))
-    //         .into_batch_rows(RowCount::from(50))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int16))
-    //         .into_batch_rows(RowCount::from(100))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int16))
-    //         .into_batch_rows(RowCount::from(1000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int16))
-    //         .into_batch_rows(RowCount::from(1024))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int16))
-    //         .into_batch_rows(RowCount::from(2000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int16))
-    //         .into_batch_rows(RowCount::from(3000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-    // }
-
-    // #[test_log::test(tokio::test)]
-    // async fn test_bitpack_fastlanes_i32() {
-    //     let values: Vec<i32> = vec![-5; 1024];
-    //     let array = Int32Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i32> = vec![66; 1000];
-    //     let array = Int32Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i32> = vec![-66; 1000];
-    //     let array = Int32Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i32> = vec![77; 2000];
-    //     let array = Int32Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i32> = vec![-77; 2000];
-    //     let array = Int32Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i32> = vec![0; 10000];
-    //     let array = Int32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i32> = vec![88; 10000];
-    //     let array = Int32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i32> = vec![-88; 10000];
-    //     let array = Int32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i32> = vec![300; 100];
-    //     let array = Int32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i32> = vec![-300; 100];
-    //     let array = Int32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i32> = vec![800; 100];
-    //     let array = Int32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i32> = vec![-800; 100];
-    //     let array = Int32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i32> = vec![65536; 100];
-    //     let array = Int32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i32> = vec![-65536; 100];
-    //     let array = Int32Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int32))
-    //         .into_batch_rows(RowCount::from(1))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int32))
-    //         .into_batch_rows(RowCount::from(20))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int32))
-    //         .into_batch_rows(RowCount::from(50))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int32))
-    //         .into_batch_rows(RowCount::from(100))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int32))
-    //         .into_batch_rows(RowCount::from(1000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int32))
-    //         .into_batch_rows(RowCount::from(1024))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int32))
-    //         .into_batch_rows(RowCount::from(2000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int32))
-    //         .into_batch_rows(RowCount::from(3000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-    // }
-
-    // #[test_log::test(tokio::test)]
-    // async fn test_bitpack_fastlanes_i64() {
-    //     let values: Vec<i64> = vec![-5; 1024];
-    //     let array = Int64Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i64> = vec![66; 1000];
-    //     let array = Int64Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i64> = vec![-66; 1000];
-    //     let array = Int64Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i64> = vec![77; 2000];
-    //     let array = Int64Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i64> = vec![-77; 2000];
-    //     let array = Int64Array::from(values);
-    //     let array: Arc<dyn arrow_array::Array> = Arc::new(array);
-    //     check_round_trip_bitpacked(array).await;
-
-    //     let values: Vec<i64> = vec![0; 10000];
-    //     let array = Int64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i64> = vec![88; 10000];
-    //     let array = Int64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i64> = vec![-88; 10000];
-    //     let array = Int64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i64> = vec![300; 100];
-    //     let array = Int64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i64> = vec![-300; 100];
-    //     let array = Int64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i64> = vec![800; 100];
-    //     let array = Int64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i64> = vec![-800; 100];
-    //     let array = Int64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i64> = vec![65536; 100];
-    //     let array = Int64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let values: Vec<i64> = vec![-65536; 100];
-    //     let array = Int64Array::from(values);
-    //     let arr = Arc::new(array) as ArrayRef;
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int64))
-    //         .into_batch_rows(RowCount::from(1))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int64))
-    //         .into_batch_rows(RowCount::from(20))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int64))
-    //         .into_batch_rows(RowCount::from(50))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int64))
-    //         .into_batch_rows(RowCount::from(100))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int64))
-    //         .into_batch_rows(RowCount::from(1000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int64))
-    //         .into_batch_rows(RowCount::from(1024))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int64))
-    //         .into_batch_rows(RowCount::from(2000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-
-    //     let arr = lance_datagen::gen()
-    //         .anon_col(lance_datagen::array::rand_type(&DataType::Int64))
-    //         .into_batch_rows(RowCount::from(3000))
-    //         .unwrap()
-    //         .column(0)
-    //         .clone();
-    //     check_round_trip_bitpacked(arr).await;
-    // }
+#[derive(Debug, Default)]
+pub struct InlineBitpacking {
+    uncompressed_bit_width: u64,
 }
 
-// This macro chunks the FixedWidth DataBlock, bitpacks them with 1024 values per chunk,
-// it puts the bit-width parameter in front of each chunk,
-// and the bit-width parameter has the same bit-width as the uncompressed DataBlock
-// for example, if the input DataBlock has `bits_per_value` of `16`, there will be 2 bytes(16 bits)
-// in front of each chunk storing the `bit-width` parameter.
-macro_rules! chunk_data_impl {
-    ($data:expr, $data_type:ty) => {{
-        let data_buffer = $data.data.borrow_to_typed_slice::<$data_type>();
+impl InlineBitpacking {
+    pub fn new(uncompressed_bit_width: u64) -> Self {
+        Self {
+            uncompressed_bit_width,
+        }
+    }
+
+    pub fn from_description(description: &pb::InlineBitpacking) -> Self {
+        Self {
+            uncompressed_bit_width: description.uncompressed_bits_per_value,
+        }
+    }
+
+    pub fn min_size_bytes(bit_width: u64) -> u64 {
+        (ELEMS_PER_CHUNK * bit_width).div_ceil(8)
+    }
+
+    /// Bitpacks a FixedWidthDataBlock into compressed chunks of 1024 values
+    ///
+    /// Each chunk can have a different bit width
+    ///
+    /// Each chunk has the compressed bit width stored inline in the chunk itself.
+    fn bitpack_chunked<T: ArrowNativeType + BitPacking>(
+        mut data: FixedWidthDataBlock,
+    ) -> MiniBlockCompressed {
+        let data_buffer = data.data.borrow_to_typed_slice::<T>();
         let data_buffer = data_buffer.as_ref();
 
-        let bit_widths = $data.expect_stat(Stat::BitWidth);
+        let bit_widths = data.expect_stat(Stat::BitWidth);
         let bit_widths_array = bit_widths
             .as_any()
             .downcast_ref::<PrimitiveArray<UInt64Type>>()
@@ -1583,7 +646,7 @@ macro_rules! chunk_data_impl {
             .values()
             .iter()
             .map(|&bit_width| {
-                let chunk_size = ((1024 * bit_width) / $data.bits_per_value) as usize;
+                let chunk_size = ((1024 * bit_width) / data.bits_per_value) as usize;
                 (chunk_size, chunk_size + 1)
             })
             .fold(
@@ -1594,86 +657,119 @@ macro_rules! chunk_data_impl {
                 },
             );
 
-        let mut output: Vec<$data_type> = Vec::with_capacity(total_size);
+        let mut output: Vec<T> = Vec::with_capacity(total_size);
         let mut chunks = Vec::with_capacity(bit_widths_array.len());
 
         for i in 0..bit_widths_array.len() - 1 {
             let start_elem = i * ELEMS_PER_CHUNK as usize;
-            let bit_width = bit_widths_array.value(i) as $data_type;
-            output.push(bit_width);
+            let bit_width = bit_widths_array.value(i) as usize;
+            output.push(T::from_usize(bit_width).unwrap());
             let output_len = output.len();
             unsafe {
                 output.set_len(output_len + packed_chunk_sizes[i]);
                 BitPacking::unchecked_pack(
-                    bit_width as usize,
+                    bit_width,
                     &data_buffer[start_elem..][..ELEMS_PER_CHUNK as usize],
                     &mut output[output_len..][..packed_chunk_sizes[i]],
                 );
             }
             chunks.push(MiniBlockChunk {
-                num_bytes: ((1 + packed_chunk_sizes[i]) * std::mem::size_of::<$data_type>()) as u16,
+                buffer_sizes: vec![((1 + packed_chunk_sizes[i]) * std::mem::size_of::<T>()) as u16],
                 log_num_values: LOG_ELEMS_PER_CHUNK,
             });
         }
 
         // Handle the last chunk
-        let last_chunk_elem_num = if $data.num_values % ELEMS_PER_CHUNK == 0 {
+        let last_chunk_elem_num = if data.num_values % ELEMS_PER_CHUNK == 0 {
             1024
         } else {
-            $data.num_values % ELEMS_PER_CHUNK
+            data.num_values % ELEMS_PER_CHUNK
         };
-        let mut last_chunk = vec![0; ELEMS_PER_CHUNK as usize];
+        let mut last_chunk: Vec<T> = vec![T::from_usize(0).unwrap(); ELEMS_PER_CHUNK as usize];
         last_chunk[..last_chunk_elem_num as usize].clone_from_slice(
-            &data_buffer[$data.num_values as usize - last_chunk_elem_num as usize..],
+            &data_buffer[data.num_values as usize - last_chunk_elem_num as usize..],
         );
-        let bit_width = bit_widths_array.value(bit_widths_array.len() - 1) as $data_type;
-        output.push(bit_width);
+        let bit_width = bit_widths_array.value(bit_widths_array.len() - 1) as usize;
+        output.push(T::from_usize(bit_width).unwrap());
         let output_len = output.len();
         unsafe {
             output.set_len(output_len + packed_chunk_sizes[bit_widths_array.len() - 1]);
             BitPacking::unchecked_pack(
-                bit_width as usize,
+                bit_width,
                 &last_chunk,
                 &mut output[output_len..][..packed_chunk_sizes[bit_widths_array.len() - 1]],
             );
         }
         chunks.push(MiniBlockChunk {
-            num_bytes: ((1 + packed_chunk_sizes[bit_widths_array.len() - 1])
-                * std::mem::size_of::<$data_type>()) as u16,
+            buffer_sizes: vec![
+                ((1 + packed_chunk_sizes[bit_widths_array.len() - 1]) * std::mem::size_of::<T>())
+                    as u16,
+            ],
             log_num_values: 0,
         });
 
-        (
-            MiniBlockCompressed {
-                data: LanceBuffer::reinterpret_vec(output),
-                chunks,
-                num_values: $data.num_values,
-            },
-            ProtobufUtils::bitpack2($data.bits_per_value),
-        )
-    }};
-}
+        MiniBlockCompressed {
+            data: vec![LanceBuffer::reinterpret_vec(output)],
+            chunks,
+            num_values: data.num_values,
+        }
+    }
 
-#[derive(Debug, Default)]
-pub struct BitpackMiniBlockEncoder {}
-
-impl BitpackMiniBlockEncoder {
     fn chunk_data(
         &self,
-        mut data: FixedWidthDataBlock,
+        data: FixedWidthDataBlock,
     ) -> (MiniBlockCompressed, crate::format::pb::ArrayEncoding) {
         assert!(data.bits_per_value % 8 == 0);
-        match data.bits_per_value {
-            8 => chunk_data_impl!(data, u8),
-            16 => chunk_data_impl!(data, u16),
-            32 => chunk_data_impl!(data, u32),
-            64 => chunk_data_impl!(data, u64),
+        assert_eq!(data.bits_per_value, self.uncompressed_bit_width);
+        let bits_per_value = data.bits_per_value;
+        let compressed = match bits_per_value {
+            8 => Self::bitpack_chunked::<u8>(data),
+            16 => Self::bitpack_chunked::<u16>(data),
+            32 => Self::bitpack_chunked::<u32>(data),
+            64 => Self::bitpack_chunked::<u64>(data),
             _ => unreachable!(),
+        };
+        (compressed, ProtobufUtils::inline_bitpacking(bits_per_value))
+    }
+
+    fn unchunk<T: ArrowNativeType + BitPacking + AnyBitPattern>(
+        data: LanceBuffer,
+        num_values: u64,
+    ) -> Result<DataBlock> {
+        assert!(data.len() >= 8);
+        assert!(num_values <= ELEMS_PER_CHUNK);
+
+        // This macro decompresses a chunk(1024 values) of bitpacked values.
+        let uncompressed_bit_width = std::mem::size_of::<T>() * 8;
+        let mut decompressed = vec![T::from_usize(0).unwrap(); ELEMS_PER_CHUNK as usize];
+
+        // Copy for memory alignment
+        let chunk_in_u8: Vec<u8> = data.to_vec();
+        let bit_width_bytes = &chunk_in_u8[..std::mem::size_of::<T>()];
+        let bit_width_value = LittleEndian::read_uint(bit_width_bytes, std::mem::size_of::<T>());
+        let chunk = cast_slice(&chunk_in_u8[std::mem::size_of::<T>()..]);
+
+        // The bit-packed chunk should have number of bytes (bit_width_value * ELEMS_PER_CHUNK / 8)
+        assert!(
+            chunk.len() * std::mem::size_of::<T>()
+                == (bit_width_value * ELEMS_PER_CHUNK as u64) as usize / 8
+        );
+
+        unsafe {
+            BitPacking::unchecked_unpack(bit_width_value as usize, chunk, &mut decompressed);
         }
+
+        decompressed.truncate(num_values as usize);
+        Ok(DataBlock::FixedWidth(FixedWidthDataBlock {
+            data: LanceBuffer::reinterpret_vec(decompressed),
+            bits_per_value: uncompressed_bit_width as u64,
+            num_values,
+            block_info: BlockInfo::new(),
+        }))
     }
 }
 
-impl MiniBlockCompressor for BitpackMiniBlockEncoder {
+impl MiniBlockCompressor for InlineBitpacking {
     fn compress(
         &self,
         chunk: DataBlock,
@@ -1692,66 +788,218 @@ impl MiniBlockCompressor for BitpackMiniBlockEncoder {
     }
 }
 
-/// A decompressor for fixed-width data that has
-/// been written, as-is, to disk in single contiguous array
-#[derive(Debug)]
-pub struct BitpackMiniBlockDecompressor {
-    uncompressed_bit_width: u64,
+impl BlockCompressor for InlineBitpacking {
+    fn compress(&self, data: DataBlock) -> Result<LanceBuffer> {
+        println!("Compressing rep-def levels with inline bitpacking");
+        let fixed_width = data.as_fixed_width().unwrap();
+        let (chunked, _) = self.chunk_data(fixed_width);
+        Ok(chunked.data.into_iter().next().unwrap())
+    }
 }
 
-impl BitpackMiniBlockDecompressor {
-    pub fn new(description: &pb::Bitpack2) -> Self {
-        Self {
-            uncompressed_bit_width: description.uncompressed_bits_per_value,
+impl MiniBlockDecompressor for InlineBitpacking {
+    fn decompress(&self, data: Vec<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        assert_eq!(data.len(), 1);
+        let data = data.into_iter().next().unwrap();
+        match self.uncompressed_bit_width {
+            8 => Self::unchunk::<u8>(data, num_values),
+            16 => Self::unchunk::<u16>(data, num_values),
+            32 => Self::unchunk::<u32>(data, num_values),
+            64 => Self::unchunk::<u64>(data, num_values),
+            _ => unimplemented!("Bitpacking word size must be 8, 16, 32, or 64"),
         }
     }
 }
 
-impl MiniBlockDecompressor for BitpackMiniBlockDecompressor {
+impl BlockDecompressor for InlineBitpacking {
     fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
-        assert!(data.len() >= 8);
-        assert!(num_values <= ELEMS_PER_CHUNK);
-
-        // This macro decompresses a chunk(1024 values) of bitpacked values.
-        macro_rules! decompress_impl {
-            ($type:ty) => {{
-                let uncompressed_bit_width = std::mem::size_of::<$type>() * 8;
-                let mut decompressed = vec![0 as $type; ELEMS_PER_CHUNK as usize];
-
-                // Copy for memory alignment
-                let chunk_in_u8: Vec<u8> = data.to_vec();
-                let bit_width_bytes = &chunk_in_u8[..std::mem::size_of::<$type>()];
-                let bit_width_value = LittleEndian::read_uint(bit_width_bytes, std::mem::size_of::<$type>());
-                let chunk = cast_slice(&chunk_in_u8[std::mem::size_of::<$type>()..]);
-
-                // The bit-packed chunk should have number of bytes (bit_width_value * ELEMS_PER_CHUNK / 8)
-                assert!(chunk.len() * std::mem::size_of::<$type>() == (bit_width_value * ELEMS_PER_CHUNK as u64) as usize / 8);
-
-                unsafe {
-                    BitPacking::unchecked_unpack(
-                        bit_width_value as usize,
-                        chunk,
-                        &mut decompressed,
-                    );
-                }
-
-                decompressed.shrink_to(num_values as usize);
-                Ok(DataBlock::FixedWidth(FixedWidthDataBlock {
-                    data: LanceBuffer::reinterpret_vec(decompressed),
-                    bits_per_value: uncompressed_bit_width as u64,
-                    num_values,
-                    block_info: BlockInfo::new(),
-                }))
-            }};
-        }
-
         match self.uncompressed_bit_width {
-            8 => decompress_impl!(u8),
-            16 => decompress_impl!(u16),
-            32 => decompress_impl!(u32),
-            64 => decompress_impl!(u64),
-            _ => todo!(),
+            8 => Self::unchunk::<u8>(data, num_values),
+            16 => Self::unchunk::<u16>(data, num_values),
+            32 => Self::unchunk::<u32>(data, num_values),
+            64 => Self::unchunk::<u64>(data, num_values),
+            _ => unimplemented!("Bitpacking word size must be 8, 16, 32, or 64"),
         }
+    }
+}
+
+/// Bitpacks a FixedWidthDataBlock with a given bit width
+///
+/// This function is simpler as it does not do any chunking, but slightly less efficient.
+/// The compressed bits per value is constant across the entire buffer.
+///
+/// Note: even though we are not strictly "chunking" we are still operating on chunks of
+/// 1024 values because that's what the bitpacking primitives expect.  They just don't
+/// have a unique bit width for each chunk.
+fn bitpack_out_of_line<T: ArrowNativeType + BitPacking>(
+    mut data: FixedWidthDataBlock,
+    bit_width: usize,
+) -> LanceBuffer {
+    let data_buffer = data.data.borrow_to_typed_slice::<T>();
+    let data_buffer = data_buffer.as_ref();
+
+    let num_chunks = data_buffer.len().div_ceil(ELEMS_PER_CHUNK as usize);
+    let last_chunk_is_runt = data_buffer.len() % ELEMS_PER_CHUNK as usize != 0;
+    let words_per_chunk =
+        (ELEMS_PER_CHUNK as usize * bit_width).div_ceil(data.bits_per_value as usize);
+    let mut output: Vec<T> = Vec::with_capacity(num_chunks * words_per_chunk);
+    unsafe {
+        output.set_len(num_chunks * words_per_chunk);
+    }
+
+    let num_whole_chunks = if last_chunk_is_runt {
+        num_chunks - 1
+    } else {
+        num_chunks
+    };
+
+    // Simple case for complete chunks
+    for i in 0..num_whole_chunks {
+        let input_start = i * ELEMS_PER_CHUNK as usize;
+        let input_end = input_start + ELEMS_PER_CHUNK as usize;
+        let output_start = i * words_per_chunk;
+        let output_end = output_start + words_per_chunk;
+        unsafe {
+            BitPacking::unchecked_pack(
+                bit_width,
+                &data_buffer[input_start..input_end],
+                &mut output[output_start..output_end],
+            );
+        }
+    }
+
+    if !last_chunk_is_runt {
+        return LanceBuffer::reinterpret_vec(output);
+    }
+
+    // If we get here then the last chunk needs to be padded with zeros
+    let remaining_items = data_buffer.len() % ELEMS_PER_CHUNK as usize;
+    let last_chunk_start = num_whole_chunks * ELEMS_PER_CHUNK as usize;
+
+    let mut last_chunk: Vec<T> = vec![T::from_usize(0).unwrap(); ELEMS_PER_CHUNK as usize];
+    last_chunk[..remaining_items as usize].clone_from_slice(&data_buffer[last_chunk_start..]);
+    let output_start = num_whole_chunks * words_per_chunk;
+    unsafe {
+        BitPacking::unchecked_pack(bit_width, &last_chunk, &mut output[output_start..]);
+    }
+
+    LanceBuffer::reinterpret_vec(output)
+}
+
+/// Unpacks a FixedWidthDataBlock that has been bitpacked with a constant bit width
+fn unpack_out_of_line<T: ArrowNativeType + BitPacking>(
+    mut data: FixedWidthDataBlock,
+    num_values: usize,
+    bits_per_value: usize,
+) -> FixedWidthDataBlock {
+    let words_per_chunk =
+        (ELEMS_PER_CHUNK as usize * bits_per_value).div_ceil(data.bits_per_value as usize);
+    let compressed_words = data.data.borrow_to_typed_slice::<T>();
+
+    let num_chunks = data.num_values as usize / words_per_chunk;
+    debug_assert_eq!(data.num_values as usize % words_per_chunk, 0);
+
+    // This is slightly larger than num_values because the last chunk has some padding, we will truncate at the end
+    let mut decompressed = Vec::with_capacity(num_chunks * ELEMS_PER_CHUNK as usize);
+    unsafe {
+        decompressed.set_len(num_chunks * ELEMS_PER_CHUNK as usize);
+    }
+
+    for chunk_idx in 0..num_chunks {
+        let input_start = chunk_idx * words_per_chunk;
+        let input_end = input_start + words_per_chunk;
+        let output_start = chunk_idx * ELEMS_PER_CHUNK as usize;
+        let output_end = output_start + ELEMS_PER_CHUNK as usize;
+        unsafe {
+            BitPacking::unchecked_unpack(
+                bits_per_value,
+                &compressed_words[input_start..input_end],
+                &mut decompressed[output_start..output_end],
+            );
+        }
+    }
+
+    decompressed.truncate(num_values);
+
+    FixedWidthDataBlock {
+        data: LanceBuffer::reinterpret_vec(decompressed),
+        bits_per_value: data.bits_per_value,
+        num_values: num_values as u64,
+        block_info: BlockInfo::new(),
+    }
+}
+
+/// A transparent compressor that bit packs data
+///
+/// In order for the encoding to be transparent we must have a fixed bit width
+/// across the entire array.  Chunking within the buffer is not supported.  This
+/// means that we will be slightly less efficient than something like the mini-block
+/// approach.
+///
+/// WARNING: DO NOT USE YET.
+///
+/// This was an interesting experiment but it can't be used as a per-value compressor
+/// at the moment.  The resulting data IS transparent but it's not quite so simple.  We
+/// compress in blocks of 1024 and each block has a fixed size but also has some padding.
+///
+/// In other words, if we try the simple math to access the item at index `i` we will be
+/// out of luck because `bits_per_value * i` is not the location.  What we need is something
+/// like:
+///
+/// ```ignore
+/// let chunk_idx = i / 1024;
+/// let chunk_offset = i % 1024;
+/// bits_per_chunk * chunk_idx + bits_per_value * chunk_offset
+/// ```
+///
+/// However, this logic isn't expressible with the per-value traits we have today.  We can
+/// enhance these traits should we need to support it at some point in the future.
+#[derive(Debug)]
+pub struct OutOfLineBitpacking {
+    compressed_bit_width: usize,
+}
+
+impl PerValueCompressor for OutOfLineBitpacking {
+    fn compress(
+        &self,
+        data: DataBlock,
+    ) -> Result<(crate::encoder::PerValueDataBlock, pb::ArrayEncoding)> {
+        let fixed_width = data.as_fixed_width().unwrap();
+        let num_values = fixed_width.num_values;
+        let word_size = fixed_width.bits_per_value;
+        let compressed = match word_size {
+            8 => bitpack_out_of_line::<u8>(fixed_width, self.compressed_bit_width),
+            16 => bitpack_out_of_line::<u16>(fixed_width, self.compressed_bit_width),
+            32 => bitpack_out_of_line::<u32>(fixed_width, self.compressed_bit_width),
+            64 => bitpack_out_of_line::<u64>(fixed_width, self.compressed_bit_width),
+            _ => panic!("Bitpacking word size must be 8,16,32,64"),
+        };
+        let compressed = FixedWidthDataBlock {
+            data: compressed,
+            bits_per_value: self.compressed_bit_width as u64,
+            num_values,
+            block_info: BlockInfo::new(),
+        };
+        let encoding =
+            ProtobufUtils::out_of_line_bitpacking(word_size, self.compressed_bit_width as u64);
+        Ok((PerValueDataBlock::Fixed(compressed), encoding))
+    }
+}
+
+impl FixedPerValueDecompressor for OutOfLineBitpacking {
+    fn decompress(&self, data: FixedWidthDataBlock, num_values: u64) -> Result<DataBlock> {
+        let unpacked = match data.bits_per_value {
+            8 => unpack_out_of_line::<u8>(data, num_values as usize, self.compressed_bit_width),
+            16 => unpack_out_of_line::<u16>(data, num_values as usize, self.compressed_bit_width),
+            32 => unpack_out_of_line::<u32>(data, num_values as usize, self.compressed_bit_width),
+            64 => unpack_out_of_line::<u64>(data, num_values as usize, self.compressed_bit_width),
+            _ => panic!("Bitpacking word size must be 8,16,32,64"),
+        };
+        Ok(DataBlock::FixedWidth(unpacked))
+    }
+
+    fn bits_per_value(&self) -> u64 {
+        self.compressed_bit_width as u64
     }
 }
 

--- a/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/physical/fixed_size_list.rs
@@ -123,7 +123,8 @@ impl ArrayEncoder for FslEncoder {
             dimension: self.dimension as u64,
         });
 
-        let encoding = ProtobufUtils::fixed_size_list(encoded_data.encoding, self.dimension as u64);
+        let encoding =
+            ProtobufUtils::fsl_encoding(self.dimension as u64, encoded_data.encoding, false);
         Ok(EncodedArray { data, encoding })
     }
 }
@@ -161,6 +162,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_simple_fsl() {
+        // [0, NULL], NULL, [4, 5]
         let items = Arc::new(Int32Array::from(vec![
             Some(0),
             None,

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -385,7 +385,7 @@ impl FsstMiniBlockDecompressor {
 }
 
 impl MiniBlockDecompressor for FsstMiniBlockDecompressor {
-    fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
+    fn decompress(&self, data: Vec<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
         // Step 1. decompress data use `BinaryMiniBlockDecompressor`
         let binary_decompressor =
             Box::new(BinaryMiniBlockDecompressor::default()) as Box<dyn MiniBlockDecompressor>;

--- a/rust/lance-encoding/src/encodings/physical/struct_encoding.rs
+++ b/rust/lance-encoding/src/encodings/physical/struct_encoding.rs
@@ -107,7 +107,7 @@ impl PackedStructFixedWidthMiniBlockDecompressor {
             .as_ref()
             .unwrap()
         {
-            pb::array_encoding::ArrayEncoding::Flat(flat) => Box::new(ValueDecompressor::new(flat)),
+            pb::array_encoding::ArrayEncoding::Flat(flat) => Box::new(ValueDecompressor::from_flat(flat)),
             _ => panic!("Currently only `ArrayEncoding::Flat` is supported in packed struct encoding in Lance 2.1."),
         };
         Self {
@@ -118,7 +118,8 @@ impl PackedStructFixedWidthMiniBlockDecompressor {
 }
 
 impl MiniBlockDecompressor for PackedStructFixedWidthMiniBlockDecompressor {
-    fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
+    fn decompress(&self, data: Vec<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        assert_eq!(data.len(), 1);
         let encoded_data_block = self.array_encoding.decompress(data, num_values)?;
         let DataBlock::FixedWidth(encoded_data_block) = encoded_data_block else {
             panic!("ValueDecompressor should output FixedWidth DataBlock")

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use arrow_buffer::bit_util;
+use arrow_buffer::{bit_util, BooleanBufferBuilder};
 use arrow_schema::DataType;
 use bytes::Bytes;
 use futures::{future::BoxFuture, FutureExt};
@@ -13,6 +13,7 @@ use std::sync::{Arc, Mutex};
 use crate::buffer::LanceBuffer;
 use crate::data::{
     BlockInfo, ConstantDataBlock, DataBlock, FixedSizeListBlock, FixedWidthDataBlock,
+    NullableDataBlock,
 };
 use crate::decoder::{BlockDecompressor, FixedPerValueDecompressor, MiniBlockDecompressor};
 use crate::encoder::{
@@ -266,7 +267,7 @@ impl ValueEncoder {
             if row_offset + vals_per_chunk <= data.num_values {
                 chunks.push(MiniBlockChunk {
                     log_num_values: log_vals_per_chunk as u8,
-                    num_bytes: bytes_per_chunk,
+                    buffer_sizes: vec![bytes_per_chunk],
                 });
                 row_offset += vals_per_chunk;
                 bytes_counter += bytes_per_chunk as u64;
@@ -276,7 +277,7 @@ impl ValueEncoder {
                 let num_bytes = u16::try_from(num_bytes).unwrap();
                 chunks.push(MiniBlockChunk {
                     log_num_values: 0,
-                    num_bytes,
+                    buffer_sizes: vec![num_bytes],
                 });
                 break;
             }
@@ -284,20 +285,337 @@ impl ValueEncoder {
 
         MiniBlockCompressed {
             chunks,
-            data: data_buffer,
+            data: vec![data_buffer],
             num_values: data.num_values,
         }
     }
+}
 
-    fn make_fsl_encoding(data: &FixedSizeListBlock) -> ArrayEncoding {
-        let inner_encoding = match data.child.as_ref() {
+#[derive(Debug)]
+struct MiniblockFslLayer {
+    validity: Option<LanceBuffer>,
+    dimension: u64,
+}
+
+/// This impl deals with encoding FSL<FSL<...<FSL<FixedWidth>>>> data as a mini-block compressor.
+/// The tricky part of FSL data is that we want to include inner validity buffers (we don't want these
+/// to be part of the rep-def because that usually ends up being more expensive).
+///
+/// The resulting mini-block will, instead of having a single buffer, have X + 1 buffers where X is
+/// the number of FSL layers that contain validity.
+///
+/// In the simple case where there is no validity inside the FSL layers, all we are doing here is flattening
+/// the FSL layers into a single buffer.
+///
+/// Also: We don't allow a row to be broken across chunks.  This typically isn't too big of a deal since we
+/// are usually dealing with relatively small vectors if we are using mini-block.
+///
+/// Note: when we do have validity we have to make copies of the validity buffers because they are bit buffers
+/// and we need to bit slice them which requires copies or offsets.  Paying the price at write time to make
+/// the copies is better than paying the price at read time to do the bit slicing.
+impl ValueEncoder {
+    fn make_fsl_encoding(layers: &[MiniblockFslLayer], bits_per_value: u64) -> ArrayEncoding {
+        let mut encoding = ProtobufUtils::flat_encoding(bits_per_value, 0, None);
+        for layer in layers.iter().rev() {
+            let has_validity = layer.validity.is_some();
+            let dimension = layer.dimension as u64;
+            encoding = ProtobufUtils::fsl_encoding(dimension, encoding, has_validity);
+        }
+        encoding
+    }
+
+    fn extract_fsl_chunk(
+        data: &FixedWidthDataBlock,
+        layers: &[MiniblockFslLayer],
+        row_offset: usize,
+        num_rows: usize,
+        validity_buffers: &mut Vec<Vec<u8>>,
+    ) -> Vec<u16> {
+        let mut row_offset = row_offset;
+        let mut num_values = num_rows;
+        let mut buffer_counter = 0;
+        let mut buffer_sizes = Vec::with_capacity(validity_buffers.len() + 1);
+        for layer in layers {
+            row_offset *= layer.dimension as usize;
+            num_values *= layer.dimension as usize;
+            if let Some(validity) = &layer.validity {
+                let validity_slice = validity
+                    .try_clone()
+                    .unwrap()
+                    .bit_slice_le_with_length(row_offset, num_values);
+                validity_buffers[buffer_counter].extend_from_slice(&validity_slice);
+                buffer_sizes.push(validity_slice.len() as u16);
+                buffer_counter += 1;
+            }
+        }
+
+        let bytes_per_value = data.bits_per_value as usize / 8;
+        buffer_sizes.push((bytes_per_value * num_values) as u16);
+
+        buffer_sizes
+    }
+
+    fn chunk_fsl(
+        data: FixedWidthDataBlock,
+        layers: Vec<MiniblockFslLayer>,
+        num_rows: u64,
+    ) -> (MiniBlockCompressed, ArrayEncoding) {
+        // Count size to calculate rows per chunk
+        let mut ceil_bytes_validity = 0;
+        let mut cum_dim = 1;
+        let mut num_validity_buffers = 0;
+        for layer in &layers {
+            cum_dim *= layer.dimension;
+            if layer.validity.is_some() {
+                ceil_bytes_validity += cum_dim.div_ceil(8);
+                num_validity_buffers += 1;
+            }
+        }
+        // It's an estimate because validity buffers may have some padding bits
+        let est_bytes_per_value = ceil_bytes_validity + (data.bits_per_value * cum_dim).div_ceil(8);
+        let (log_rows_per_chunk, rows_per_chunk) =
+            Self::find_log_vals_per_chunk(est_bytes_per_value);
+
+        let num_chunks = num_rows.div_ceil(rows_per_chunk) as usize;
+
+        // Allocate buffers for validity, these will be slightly bigger than the input validity buffers
+        let mut chunks = Vec::with_capacity(num_chunks);
+        let mut validity_buffers: Vec<Vec<u8>> = Vec::with_capacity(num_validity_buffers);
+        cum_dim = 1;
+        for layer in &layers {
+            cum_dim *= layer.dimension;
+            if let Some(validity) = &layer.validity {
+                let layer_bytes_validity = cum_dim.div_ceil(8);
+                let validity_with_padding =
+                    layer_bytes_validity as usize * num_chunks * rows_per_chunk as usize;
+                debug_assert!(validity_with_padding >= validity.len());
+                validity_buffers.push(Vec::with_capacity(
+                    layer_bytes_validity as usize * num_chunks,
+                ));
+            }
+        }
+
+        // Now go through and extract validity buffers
+        let mut row_offset = 0;
+        while row_offset + rows_per_chunk <= num_rows {
+            let buffer_sizes = Self::extract_fsl_chunk(
+                &data,
+                &layers,
+                row_offset as usize,
+                rows_per_chunk as usize,
+                &mut validity_buffers,
+            );
+            row_offset += rows_per_chunk;
+            chunks.push(MiniBlockChunk {
+                log_num_values: log_rows_per_chunk as u8,
+                buffer_sizes,
+            })
+        }
+        let rows_in_chunk = num_rows - row_offset;
+        if rows_in_chunk > 0 {
+            let buffer_sizes = Self::extract_fsl_chunk(
+                &data,
+                &layers,
+                row_offset as usize,
+                rows_in_chunk as usize,
+                &mut validity_buffers,
+            );
+            chunks.push(MiniBlockChunk {
+                log_num_values: 0,
+                buffer_sizes,
+            });
+        }
+
+        let encoding = Self::make_fsl_encoding(&layers, data.bits_per_value);
+        // Finally, add the data buffer
+        let buffers = validity_buffers
+            .into_iter()
+            .map(|buf| LanceBuffer::Owned(buf))
+            .chain(std::iter::once(data.data))
+            .collect::<Vec<_>>();
+
+        (
+            MiniBlockCompressed {
+                chunks,
+                data: buffers,
+                num_values: num_rows,
+            },
+            encoding,
+        )
+    }
+
+    fn miniblock_fsl(data: DataBlock) -> (MiniBlockCompressed, ArrayEncoding) {
+        let num_rows = data.num_values();
+        let fsl = data.as_fixed_size_list().unwrap();
+        let mut layers = Vec::new();
+        let mut child = *fsl.child;
+        let mut cur_layer = MiniblockFslLayer {
+            validity: None,
+            dimension: fsl.dimension,
+        };
+        loop {
+            if let DataBlock::Nullable(nullable) = child {
+                cur_layer.validity = Some(nullable.nulls);
+                child = *nullable.data;
+            }
+            match child {
+                DataBlock::FixedSizeList(inner) => {
+                    layers.push(cur_layer);
+                    cur_layer = MiniblockFslLayer {
+                        validity: None,
+                        dimension: inner.dimension,
+                    };
+                    child = *inner.child;
+                }
+                DataBlock::FixedWidth(inner) => {
+                    layers.push(cur_layer);
+                    return Self::chunk_fsl(inner, layers, num_rows);
+                }
+                _ => unreachable!("Unexpected data block type in value encoder's miniblock_fsl"),
+            }
+        }
+    }
+}
+
+struct PerValueFslValidityIter {
+    buffer: LanceBuffer,
+    bits_per_row: usize,
+    offset: usize,
+}
+
+/// In this section we deal with per-value encoding of FSL<FSL<...<FSL<FixedWidth>>>> data.
+///
+/// It's easier than mini-block.  All we need to do is flatten the FSL layers into a single buffer.
+/// This includes any validity buffers we encounter on the way.
+impl ValueEncoder {
+    fn fsl_to_encoding(fsl: &FixedSizeListBlock) -> ArrayEncoding {
+        let mut inner = fsl.child.as_ref();
+        let mut has_validity = false;
+        inner = match inner {
+            DataBlock::Nullable(nullable) => {
+                has_validity = true;
+                nullable.data.as_ref()
+            }
+            _ => inner,
+        };
+        let inner_encoding = match inner {
             DataBlock::FixedWidth(fixed_width) => {
                 ProtobufUtils::flat_encoding(fixed_width.bits_per_value, 0, None)
             }
-            DataBlock::FixedSizeList(fsl) => Self::make_fsl_encoding(fsl),
-            _ => unreachable!(),
+            DataBlock::FixedSizeList(inner) => Self::fsl_to_encoding(inner),
+            _ => unreachable!("Unexpected data block type in value encoder's fsl_to_encoding"),
         };
-        ProtobufUtils::fixed_size_list(inner_encoding, data.dimension)
+        ProtobufUtils::fsl_encoding(fsl.dimension, inner_encoding, has_validity)
+    }
+
+    fn simple_per_value_fsl(fsl: FixedSizeListBlock) -> (PerValueDataBlock, ArrayEncoding) {
+        // The simple case is zero-copy, we just return the flattened inner buffer
+        let encoding = Self::fsl_to_encoding(&fsl);
+        let num_values = fsl.num_values();
+        let mut child = *fsl.child;
+        let mut cum_dim = 1;
+        loop {
+            cum_dim *= fsl.dimension;
+            match child {
+                DataBlock::Nullable(nullable) => {
+                    child = *nullable.data;
+                }
+                DataBlock::FixedSizeList(inner) => {
+                    child = *inner.child;
+                }
+                DataBlock::FixedWidth(inner) => {
+                    let data = FixedWidthDataBlock {
+                        bits_per_value: inner.bits_per_value * cum_dim,
+                        num_values: num_values,
+                        data: inner.data,
+                        block_info: BlockInfo::new(),
+                    };
+                    return (PerValueDataBlock::Fixed(data), encoding);
+                }
+                _ => unreachable!(
+                    "Unexpected data block type in value encoder's simple_per_value_fsl"
+                ),
+            }
+        }
+    }
+
+    fn nullable_per_value_fsl(fsl: FixedSizeListBlock) -> (PerValueDataBlock, ArrayEncoding) {
+        // If there are nullable inner values then we need to zip the validity with the values
+        let encoding = Self::fsl_to_encoding(&fsl);
+        let num_values = fsl.num_values();
+        let mut bytes_per_row = 0;
+        let mut cum_dim = 1;
+        let mut current = fsl;
+        let mut validity_iters: Vec<PerValueFslValidityIter> = Vec::new();
+        let data_bytes_per_row: usize;
+        let data_buffer: LanceBuffer;
+        loop {
+            cum_dim *= current.dimension;
+            let mut child = *current.child;
+            match child {
+                DataBlock::Nullable(nullable) => {
+                    // Each item will need this many bytes of validity prepended to it
+                    bytes_per_row += cum_dim.div_ceil(8) as usize;
+                    validity_iters.push(PerValueFslValidityIter {
+                        buffer: nullable.nulls,
+                        bits_per_row: cum_dim as usize,
+                        offset: 0,
+                    });
+                    child = *nullable.data;
+                }
+                _ => {}
+            };
+            match child {
+                DataBlock::FixedSizeList(inner) => {
+                    current = inner;
+                }
+                DataBlock::FixedWidth(fixed_width) => {
+                    data_bytes_per_row =
+                        (fixed_width.bits_per_value.div_ceil(8) * cum_dim) as usize;
+                    bytes_per_row += data_bytes_per_row;
+                    data_buffer = fixed_width.data;
+                    break;
+                }
+                _ => unreachable!(
+                    "Unexpected data block type in value encoder's nullable_per_value_fsl: {:?}",
+                    child
+                ),
+            }
+        }
+
+        let bytes_needed = bytes_per_row * num_values as usize;
+        let mut zipped = Vec::with_capacity(bytes_needed);
+        let data_slice = &data_buffer;
+        // Hopefully values are pretty large so we don't iterate this loop _too_ many times
+        for i in 0..num_values as usize {
+            for validity in validity_iters.iter_mut() {
+                let validity_slice = validity
+                    .buffer
+                    .bit_slice_le_with_length(validity.offset, validity.bits_per_row);
+                zipped.extend_from_slice(&validity_slice);
+                validity.offset += validity.bits_per_row;
+            }
+            let start = i * data_bytes_per_row;
+            let end = start + data_bytes_per_row;
+            zipped.extend_from_slice(&data_slice[start..end]);
+        }
+
+        let zipped = LanceBuffer::Owned(zipped);
+        let data = PerValueDataBlock::Fixed(FixedWidthDataBlock {
+            bits_per_value: bytes_per_row as u64 * 8,
+            num_values,
+            data: zipped,
+            block_info: BlockInfo::new(),
+        });
+        (data, encoding)
+    }
+
+    fn per_value_fsl(fsl: FixedSizeListBlock) -> (PerValueDataBlock, ArrayEncoding) {
+        if !fsl.child.is_nullable() {
+            Self::simple_per_value_fsl(fsl)
+        } else {
+            Self::nullable_per_value_fsl(fsl)
+        }
     }
 }
 
@@ -356,11 +674,7 @@ impl MiniBlockCompressor for ValueEncoder {
                 let encoding = ProtobufUtils::flat_encoding(fixed_width.bits_per_value, 0, None);
                 Ok((Self::chunk_data(fixed_width), encoding))
             }
-            DataBlock::FixedSizeList(mut fixed_size_list) => {
-                let flattened = fixed_size_list.flatten_as_fixed();
-                let encoding = Self::make_fsl_encoding(&fixed_size_list);
-                Ok((Self::chunk_data(flattened), encoding))
-            }
+            DataBlock::FixedSizeList(_) => Ok(Self::miniblock_fsl(chunk)),
             _ => Err(Error::InvalidInput {
                 source: format!(
                     "Cannot compress a data block of type {} with ValueEncoder",
@@ -377,46 +691,100 @@ impl MiniBlockCompressor for ValueEncoder {
 #[derive(Debug)]
 pub struct ConstantDecompressor {
     scalar: LanceBuffer,
-    num_values: u64,
 }
 
 impl ConstantDecompressor {
-    pub fn new(scalar: LanceBuffer, num_values: u64) -> Self {
+    pub fn new(scalar: LanceBuffer) -> Self {
         Self {
             scalar: scalar.into_borrowed(),
-            num_values,
         }
     }
 }
 
 impl BlockDecompressor for ConstantDecompressor {
-    fn decompress(&self, _data: LanceBuffer) -> Result<DataBlock> {
+    fn decompress(&self, _data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
         Ok(DataBlock::Constant(ConstantDataBlock {
             data: self.scalar.try_clone().unwrap(),
-            num_values: self.num_values,
+            num_values,
         }))
     }
+}
+
+#[derive(Debug)]
+struct ValueFslDesc {
+    dimension: u64,
+    has_validity: bool,
 }
 
 /// A decompressor for fixed-width data that has
 /// been written, as-is, to disk in single contiguous array
 #[derive(Debug)]
 pub struct ValueDecompressor {
+    /// How many bytes are in each inner-most item (e.g. FSL<Int32, 100> would be 4)
+    bytes_per_item: u64,
+    /// How many bytes are in each value (e.g. FSL<Int32, 100> would be 400)
+    ///
+    /// This number is a little trickier to compute because we also have to include bytes
+    /// of any inner validity
     bytes_per_value: u64,
+    layers: Vec<ValueFslDesc>,
 }
 
 impl ValueDecompressor {
-    pub fn new(description: &pb::Flat) -> Self {
+    pub fn from_flat(description: &pb::Flat) -> Self {
         assert!(description.bits_per_value % 8 == 0);
+        let bytes_per_item = description.bits_per_value / 8;
         Self {
-            bytes_per_value: description.bits_per_value / 8,
+            bytes_per_item,
+            bytes_per_value: bytes_per_item,
+            layers: Vec::default(),
+        }
+    }
+
+    pub fn from_fsl(mut description: &pb::FixedSizeList) -> Self {
+        let mut layers = Vec::new();
+        let mut cum_dim = 1;
+        let mut bytes_per_value = 0;
+        loop {
+            layers.push(ValueFslDesc {
+                has_validity: description.has_validity,
+                dimension: description.dimension as u64,
+            });
+            cum_dim *= description.dimension as u64;
+            if description.has_validity {
+                bytes_per_value += cum_dim.div_ceil(8);
+            }
+            match description
+                .items
+                .as_ref()
+                .unwrap()
+                .array_encoding
+                .as_ref()
+                .unwrap()
+            {
+                pb::array_encoding::ArrayEncoding::FixedSizeList(inner) => {
+                    description = inner;
+                }
+                pb::array_encoding::ArrayEncoding::Flat(flat) => {
+                    let bytes_per_item = flat.bits_per_value / 8;
+                    bytes_per_value += bytes_per_item * cum_dim;
+                    assert_eq!(flat.bits_per_value % 8, 0);
+                    return Self {
+                        bytes_per_item,
+                        bytes_per_value,
+                        layers,
+                    };
+                }
+                _ => unreachable!(),
+            }
         }
     }
 
     fn buffer_to_block(&self, data: LanceBuffer) -> DataBlock {
+        let num_values = data.len() as u64 / self.bytes_per_item;
         DataBlock::FixedWidth(FixedWidthDataBlock {
-            bits_per_value: self.bytes_per_value * 8,
-            num_values: data.len() as u64 / self.bytes_per_value,
+            bits_per_value: self.bytes_per_item * 8,
+            num_values,
             data,
             block_info: BlockInfo::new(),
         })
@@ -424,21 +792,159 @@ impl ValueDecompressor {
 }
 
 impl BlockDecompressor for ValueDecompressor {
-    fn decompress(&self, data: LanceBuffer) -> Result<DataBlock> {
-        Ok(self.buffer_to_block(data))
+    fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
+        let block = self.buffer_to_block(data);
+        assert_eq!(block.num_values(), num_values);
+        Ok(block)
     }
 }
 
 impl MiniBlockDecompressor for ValueDecompressor {
-    fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
-        assert_eq!(data.len() as u64, num_values * self.bytes_per_value);
-        Ok(self.buffer_to_block(data))
+    fn decompress(&self, data: Vec<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
+        let mut buffer_iter = data.into_iter().rev();
+
+        // Always at least 1 buffer
+        let data_buf = buffer_iter.next().unwrap();
+        let mut items = self.buffer_to_block(data_buf);
+
+        for layer in self.layers.iter().rev() {
+            if layer.has_validity {
+                let validity_buf = buffer_iter.next().unwrap();
+                items = DataBlock::Nullable(NullableDataBlock {
+                    data: Box::new(items),
+                    nulls: validity_buf,
+                    block_info: BlockInfo::default(),
+                });
+            }
+            items = DataBlock::FixedSizeList(FixedSizeListBlock {
+                child: Box::new(items),
+                dimension: layer.dimension,
+            })
+        }
+
+        assert_eq!(items.num_values(), num_values);
+        Ok(items)
+    }
+}
+
+struct FslDecompressorValidityBuilder {
+    buffer: BooleanBufferBuilder,
+    bits_per_row: usize,
+    bytes_per_row: usize,
+}
+
+// Helper methods for per-value decompression
+impl ValueDecompressor {
+    fn has_validity(&self) -> bool {
+        self.layers.iter().any(|layer| layer.has_validity)
+    }
+
+    // If there is no validity then decompression is zero-copy, we just need to restore any FSL layers
+    fn simple_decompress(&self, data: FixedWidthDataBlock, num_rows: u64) -> DataBlock {
+        let mut cum_dim = 1;
+        for layer in &self.layers {
+            cum_dim *= layer.dimension;
+        }
+        debug_assert_eq!(self.bytes_per_item, data.bits_per_value / 8 / cum_dim);
+        let mut block = DataBlock::FixedWidth(FixedWidthDataBlock {
+            bits_per_value: self.bytes_per_item * 8,
+            num_values: num_rows * cum_dim,
+            data: data.data,
+            block_info: BlockInfo::new(),
+        });
+        for layer in self.layers.iter().rev() {
+            block = DataBlock::FixedSizeList(FixedSizeListBlock {
+                child: Box::new(block),
+                dimension: layer.dimension,
+            });
+        }
+        debug_assert_eq!(num_rows, block.num_values());
+        block
+    }
+
+    // If there is validity then it has been zipped in with the values and we must unzip it
+    fn unzip_decompress(&self, data: FixedWidthDataBlock, num_rows: usize) -> DataBlock {
+        let mut buffer_builders = Vec::with_capacity(self.layers.len());
+        let mut cum_dim = 1;
+        let mut total_size_bytes = 0;
+        // First, go through the layers, setup our builders, allocate space
+        for layer in &self.layers {
+            cum_dim *= layer.dimension as usize;
+            if layer.has_validity {
+                let validity_size_bits = cum_dim;
+                let validity_size_bytes = validity_size_bits.div_ceil(8);
+                total_size_bytes += num_rows * validity_size_bytes;
+                buffer_builders.push(FslDecompressorValidityBuilder {
+                    buffer: BooleanBufferBuilder::new(validity_size_bits * num_rows),
+                    bits_per_row: cum_dim,
+                    bytes_per_row: validity_size_bytes,
+                })
+            }
+        }
+        let num_items = num_rows * cum_dim;
+        let data_size = num_items * self.bytes_per_item as usize;
+        total_size_bytes += data_size;
+        let mut data_buffer = Vec::with_capacity(data_size);
+
+        assert_eq!(data.data.len(), total_size_bytes);
+
+        let bytes_per_value = self.bytes_per_item as usize;
+        let data_bytes_per_row = bytes_per_value * cum_dim;
+
+        // Next, unzip
+        let mut data_offset = 0;
+        while data_offset < total_size_bytes {
+            for builder in buffer_builders.iter_mut() {
+                let start = data_offset * 8;
+                let end = start + builder.bits_per_row;
+                builder.buffer.append_packed_range(start..end, &data.data);
+                data_offset += builder.bytes_per_row;
+            }
+            let end = data_offset + data_bytes_per_row;
+            data_buffer.extend_from_slice(&data.data[data_offset..end]);
+            data_offset += data_bytes_per_row;
+        }
+
+        // Finally, restore the structure
+        let mut block = DataBlock::FixedWidth(FixedWidthDataBlock {
+            bits_per_value: self.bytes_per_item * 8,
+            num_values: num_items as u64,
+            data: LanceBuffer::Owned(data_buffer),
+            block_info: BlockInfo::new(),
+        });
+
+        let mut validity_bufs = buffer_builders
+            .into_iter()
+            .rev()
+            .map(|mut b| LanceBuffer::Borrowed(b.buffer.finish().into_inner()));
+        for layer in self.layers.iter().rev() {
+            if layer.has_validity {
+                let nullable = NullableDataBlock {
+                    data: Box::new(block),
+                    nulls: validity_bufs.next().unwrap(),
+                    block_info: BlockInfo::new(),
+                };
+                block = DataBlock::Nullable(nullable);
+            }
+            block = DataBlock::FixedSizeList(FixedSizeListBlock {
+                child: Box::new(block),
+                dimension: layer.dimension,
+            });
+        }
+
+        assert_eq!(num_rows, block.num_values() as usize);
+
+        block
     }
 }
 
 impl FixedPerValueDecompressor for ValueDecompressor {
-    fn decompress(&self, data: FixedWidthDataBlock) -> Result<DataBlock> {
-        Ok(DataBlock::FixedWidth(data))
+    fn decompress(&self, data: FixedWidthDataBlock, num_rows: u64) -> Result<DataBlock> {
+        if self.has_validity() {
+            Ok(self.unzip_decompress(data, num_rows as usize))
+        } else {
+            Ok(self.simple_decompress(data, num_rows))
+        }
     }
 
     fn bits_per_value(&self) -> u64 {
@@ -453,6 +959,7 @@ impl PerValueCompressor for ValueEncoder {
                 let encoding = ProtobufUtils::flat_encoding(fixed_width.bits_per_value, 0, None);
                 (PerValueDataBlock::Fixed(fixed_width), encoding)
             }
+            DataBlock::FixedSizeList(fixed_size_list) => Self::per_value_fsl(fixed_size_list),
             _ => unimplemented!(
                 "Cannot compress block of type {} with ValueEncoder",
                 data.name()
@@ -467,14 +974,25 @@ impl PerValueCompressor for ValueEncoder {
 pub(crate) mod tests {
     use std::{collections::HashMap, sync::Arc};
 
-    use arrow_array::{Array, ArrayRef, Decimal128Array, Int32Array};
+    use arrow_array::{
+        make_array, Array, ArrayRef, Decimal128Array, FixedSizeListArray, Int32Array,
+    };
+    use arrow_buffer::{BooleanBuffer, NullBuffer};
     use arrow_schema::{DataType, Field, TimeUnit};
+    use lance_datagen::{array, gen, ArrayGeneratorExt, Dimension, RowCount};
     use rstest::rstest;
 
     use crate::{
+        data::DataBlock,
+        decoder::{FixedPerValueDecompressor, MiniBlockDecompressor},
+        encoder::{MiniBlockCompressor, PerValueCompressor, PerValueDataBlock},
+        encodings::physical::value::ValueDecompressor,
+        format::pb,
         testing::{check_round_trip_encoding_of_data, check_round_trip_encoding_random, TestCases},
         version::LanceFileVersion,
     };
+
+    use super::ValueEncoder;
 
     const PRIMITIVE_TYPES: &[DataType] = &[
         DataType::Null,
@@ -502,6 +1020,29 @@ pub(crate) mod tests {
         // at the moment and Lance schema can't parse interval
         // DataType::Interval(IntervalUnit::DayTime),
     ];
+
+    #[test_log::test(tokio::test)]
+    async fn test_simple_value() {
+        let items = Arc::new(Int32Array::from(vec![
+            Some(0),
+            None,
+            Some(2),
+            Some(3),
+            Some(4),
+            Some(5),
+        ]));
+
+        let test_cases = TestCases::default()
+            .with_range(0..3)
+            .with_range(0..2)
+            .with_range(1..3)
+            .with_indices(vec![0, 1, 2])
+            .with_indices(vec![1])
+            .with_indices(vec![2])
+            .with_file_version(LanceFileVersion::V2_1);
+
+        check_round_trip_encoding_of_data(vec![items], &test_cases, HashMap::default()).await;
+    }
 
     #[rstest]
     #[test_log::test(tokio::test)]
@@ -595,5 +1136,186 @@ pub(crate) mod tests {
                 check_round_trip_encoding_of_data(data.clone(), &test_cases, HashMap::new()).await;
             }
         }
+    }
+
+    fn create_simple_fsl() -> FixedSizeListArray {
+        // [[0, 1], NULL], [NULL, NULL], [[8, 9], [NULL, 11]]
+        let items = Arc::new(Int32Array::from(vec![
+            Some(0),
+            Some(1),
+            Some(2),
+            Some(3),
+            None,
+            None,
+            None,
+            None,
+            Some(8),
+            Some(9),
+            None,
+            Some(11),
+        ]));
+        let items_field = Arc::new(Field::new("item", DataType::Int32, true));
+        let inner_list_nulls = BooleanBuffer::from(vec![true, false, false, false, true, true]);
+        let inner_list = Arc::new(FixedSizeListArray::new(
+            items_field.clone(),
+            2,
+            items,
+            Some(NullBuffer::new(inner_list_nulls)),
+        ));
+        let inner_list_field = Arc::new(Field::new(
+            "item",
+            DataType::FixedSizeList(items_field, 2),
+            true,
+        ));
+        FixedSizeListArray::new(inner_list_field, 2, inner_list, None)
+    }
+
+    #[test]
+    fn test_fsl_value_compression_miniblock() {
+        let sample_list = create_simple_fsl();
+
+        let starting_data = DataBlock::from_array(sample_list.clone());
+
+        let encoder = ValueEncoder::default();
+        let (data, compression) = MiniBlockCompressor::compress(&encoder, starting_data).unwrap();
+
+        assert_eq!(data.num_values, 3);
+        assert_eq!(data.data.len(), 3);
+        assert_eq!(data.chunks.len(), 1);
+        assert_eq!(data.chunks[0].buffer_sizes, vec![1, 2, 48]);
+        assert_eq!(data.chunks[0].log_num_values, 0);
+
+        let fsl = match compression.array_encoding.unwrap() {
+            pb::array_encoding::ArrayEncoding::FixedSizeList(fsl) => fsl,
+            _ => panic!(),
+        };
+
+        let decompressor = ValueDecompressor::from_fsl(fsl.as_ref());
+
+        let decompressed =
+            MiniBlockDecompressor::decompress(&decompressor, data.data, data.num_values).unwrap();
+
+        let decompressed = make_array(
+            decompressed
+                .into_arrow(sample_list.data_type().clone(), true)
+                .unwrap(),
+        );
+
+        assert_eq!(decompressed.as_ref(), &sample_list);
+    }
+
+    #[test]
+    fn test_fsl_value_compression_per_value() {
+        let sample_list = create_simple_fsl();
+
+        let starting_data = DataBlock::from_array(sample_list.clone());
+
+        let encoder = ValueEncoder::default();
+        let (data, compression) = PerValueCompressor::compress(&encoder, starting_data).unwrap();
+
+        let PerValueDataBlock::Fixed(data) = data else {
+            panic!()
+        };
+
+        assert_eq!(data.bits_per_value, 144);
+        assert_eq!(data.num_values, 3);
+        assert_eq!(data.data.len(), 18 * 3);
+
+        let fsl = match compression.array_encoding.unwrap() {
+            pb::array_encoding::ArrayEncoding::FixedSizeList(fsl) => fsl,
+            _ => panic!(),
+        };
+
+        let decompressor = ValueDecompressor::from_fsl(fsl.as_ref());
+
+        let num_values = data.num_values;
+        let decompressed =
+            FixedPerValueDecompressor::decompress(&decompressor, data, num_values).unwrap();
+
+        let decompressed = make_array(
+            decompressed
+                .into_arrow(sample_list.data_type().clone(), true)
+                .unwrap(),
+        );
+
+        assert_eq!(decompressed.as_ref(), &sample_list);
+    }
+
+    fn create_random_fsl() -> Arc<dyn Array> {
+        // Several levels of def and multiple pages
+        let inner = array::rand_type(&DataType::Int32).with_random_nulls(0.1);
+        let list_one = array::cycle_vec(inner, Dimension::from(4)).with_random_nulls(0.1);
+        let list_two = array::cycle_vec(list_one, Dimension::from(4)).with_random_nulls(0.1);
+        let list_three = array::cycle_vec(list_two, Dimension::from(2));
+
+        // Should be 256Ki rows ~ 1MiB of data
+        let batch = gen()
+            .anon_col(list_three)
+            .into_batch_rows(RowCount::from(8 * 1024))
+            .unwrap();
+        batch.column(0).clone()
+    }
+
+    #[test]
+    fn fsl_value_miniblock_stress() {
+        let sample_array = create_random_fsl();
+
+        let starting_data =
+            DataBlock::from_arrays(&[sample_array.clone()], sample_array.len() as u64);
+
+        let encoder = ValueEncoder::default();
+        let (data, compression) = MiniBlockCompressor::compress(&encoder, starting_data).unwrap();
+
+        let fsl = match compression.array_encoding.unwrap() {
+            pb::array_encoding::ArrayEncoding::FixedSizeList(fsl) => fsl,
+            _ => panic!(),
+        };
+
+        let decompressor = ValueDecompressor::from_fsl(fsl.as_ref());
+
+        let decompressed =
+            MiniBlockDecompressor::decompress(&decompressor, data.data, data.num_values).unwrap();
+
+        let decompressed = make_array(
+            decompressed
+                .into_arrow(sample_array.data_type().clone(), true)
+                .unwrap(),
+        );
+
+        assert_eq!(decompressed.as_ref(), sample_array.as_ref());
+    }
+
+    #[test]
+    fn fsl_value_per_value_stress() {
+        let sample_array = create_random_fsl();
+
+        let starting_data =
+            DataBlock::from_arrays(&[sample_array.clone()], sample_array.len() as u64);
+
+        let encoder = ValueEncoder::default();
+        let (data, compression) = PerValueCompressor::compress(&encoder, starting_data).unwrap();
+
+        let fsl = match compression.array_encoding.unwrap() {
+            pb::array_encoding::ArrayEncoding::FixedSizeList(fsl) => fsl,
+            _ => panic!(),
+        };
+
+        let decompressor = ValueDecompressor::from_fsl(fsl.as_ref());
+
+        let PerValueDataBlock::Fixed(data) = data else {
+            panic!()
+        };
+
+        let num_values = data.num_values;
+        let decompressed =
+            FixedPerValueDecompressor::decompress(&decompressor, data, num_values).unwrap();
+
+        let decompressed = make_array(
+            decompressed
+                .into_arrow(sample_array.data_type().clone(), true)
+                .unwrap(),
+        );
+
+        assert_eq!(decompressed.as_ref(), sample_array.as_ref());
     }
 }

--- a/rust/lance-encoding/src/format.rs
+++ b/rust/lance-encoding/src/format.rs
@@ -20,9 +20,10 @@ use pb::{
     full_zip_layout,
     nullable::{AllNull, NoNull, Nullability, SomeNull},
     page_layout::Layout,
-    AllNullLayout, ArrayEncoding, Binary, Bitpack2, Bitpacked, BitpackedForNonNeg, Dictionary,
-    FixedSizeBinary, FixedSizeList, Flat, Fsst, MiniBlockLayout, Nullable, PackedStruct,
-    PackedStructFixedWidthMiniBlock, PageLayout, RepDefLayer, Variable,
+    AllNullLayout, ArrayEncoding, Binary, Bitpacked, BitpackedForNonNeg, Dictionary,
+    FixedSizeBinary, FixedSizeList, Flat, Fsst, InlineBitpacking, MiniBlockLayout, Nullable,
+    OutOfLineBitpacking, PackedStruct, PackedStructFixedWidthMiniBlock, PageLayout, RepDefLayer,
+    Variable,
 };
 
 use crate::{
@@ -35,11 +36,10 @@ use self::pb::Constant;
 pub struct ProtobufUtils {}
 
 impl ProtobufUtils {
-    pub fn constant(value: Vec<u8>, num_values: u64) -> ArrayEncoding {
+    pub fn constant(value: Vec<u8>) -> ArrayEncoding {
         ArrayEncoding {
             array_encoding: Some(ArrayEncodingEnum::Constant(Constant {
                 value: value.into(),
-                num_values,
             })),
         }
     }
@@ -96,11 +96,12 @@ impl ProtobufUtils {
         }
     }
 
-    pub fn fsl_encoding(dimension: u64, items: ArrayEncoding) -> ArrayEncoding {
+    pub fn fsl_encoding(dimension: u64, items: ArrayEncoding, has_validity: bool) -> ArrayEncoding {
         ArrayEncoding {
             array_encoding: Some(ArrayEncodingEnum::FixedSizeList(Box::new(FixedSizeList {
                 dimension: dimension.try_into().unwrap(),
                 items: Some(Box::new(items)),
+                has_validity,
             }))),
         }
     }
@@ -140,11 +141,24 @@ impl ProtobufUtils {
             })),
         }
     }
-    pub fn bitpack2(uncompressed_bits_per_value: u64) -> ArrayEncoding {
+    pub fn inline_bitpacking(uncompressed_bits_per_value: u64) -> ArrayEncoding {
         ArrayEncoding {
-            array_encoding: Some(ArrayEncodingEnum::Bitpack2(Bitpack2 {
+            array_encoding: Some(ArrayEncodingEnum::InlineBitpacking(InlineBitpacking {
                 uncompressed_bits_per_value,
             })),
+        }
+    }
+    pub fn out_of_line_bitpacking(
+        uncompressed_bits_per_value: u64,
+        compressed_bits_per_value: u64,
+    ) -> ArrayEncoding {
+        ArrayEncoding {
+            array_encoding: Some(ArrayEncodingEnum::OutOfLineBitpacking(
+                OutOfLineBitpacking {
+                    uncompressed_bits_per_value,
+                    compressed_bits_per_value,
+                },
+            )),
         }
     }
 
@@ -236,15 +250,6 @@ impl ProtobufUtils {
         }
     }
 
-    pub fn fixed_size_list(data: ArrayEncoding, dimension: u64) -> ArrayEncoding {
-        ArrayEncoding {
-            array_encoding: Some(ArrayEncodingEnum::FixedSizeList(Box::new(FixedSizeList {
-                dimension: dimension.try_into().unwrap(),
-                items: Some(Box::new(data)),
-            }))),
-        }
-    }
-
     fn def_inter_to_repdef_layer(def: DefinitionInterpretation) -> i32 {
         match def {
             DefinitionInterpretation::AllValidItem => RepDefLayer::RepdefAllValidItem as i32,
@@ -274,22 +279,28 @@ impl ProtobufUtils {
     }
 
     pub fn miniblock_layout(
-        rep_encoding: ArrayEncoding,
-        def_encoding: ArrayEncoding,
+        rep_encoding: Option<ArrayEncoding>,
+        def_encoding: Option<ArrayEncoding>,
         value_encoding: ArrayEncoding,
         repetition_index_depth: u32,
-        dictionary_encoding: Option<ArrayEncoding>,
+        num_buffers: u64,
+        dictionary_encoding: Option<(ArrayEncoding, u64)>,
         def_meaning: &[DefinitionInterpretation],
         num_items: u64,
     ) -> PageLayout {
         assert!(!def_meaning.is_empty());
+        let (dictionary, num_dictionary_items) = dictionary_encoding
+            .map(|(d, i)| (Some(d), i))
+            .unwrap_or((None, 0));
         PageLayout {
             layout: Some(Layout::MiniBlockLayout(MiniBlockLayout {
-                def_compression: Some(def_encoding),
-                rep_compression: Some(rep_encoding),
+                def_compression: def_encoding,
+                rep_compression: rep_encoding,
                 value_compression: Some(value_encoding),
                 repetition_index_depth,
-                dictionary: dictionary_encoding,
+                num_buffers,
+                dictionary,
+                num_dictionary_items,
                 layers: def_meaning
                     .iter()
                     .map(|&def| Self::def_inter_to_repdef_layer(def))


### PR DESCRIPTION
Previously we moved all FSL handling out into the rep/def levels.  Now we're back at it again, but this time we've put the FSL handling back into the compressors.  It turns out we really _don't_ want to store rep/def levels for every element in a vector.

There are also some minor perf. improvements to bitpacking and we disable bitpacking if the input is really small (mainly for testing purposes).

Another significant change is that the miniblock encoding now allows for a variable number of buffers instead of requiring things to be zipped into one.