### PR TITLE
chore(api)!: remove unused param in take call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "fsst"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow-array",
  "lance-datagen",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "all_asserts",
  "approx",
@@ -3467,7 +3467,7 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3484,7 +3484,7 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3551,7 +3551,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrayref",
  "arrow",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding-datafusion"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "approx",
  "arrow",
@@ -3755,7 +3755,7 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "lance-jni"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -3822,7 +3822,7 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "approx",
  "arrow-arith",
@@ -3851,7 +3851,7 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "lance-test-macros"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "lance-testing"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.23.3"
+version = "0.24.0"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 license = "Apache-2.0"
@@ -44,21 +44,21 @@ categories = [
 rust-version = "1.80.1"
 
 [workspace.dependencies]
-lance = { version = "=0.23.3", path = "./rust/lance" }
-lance-arrow = { version = "=0.23.3", path = "./rust/lance-arrow" }
-lance-core = { version = "=0.23.3", path = "./rust/lance-core" }
-lance-datafusion = { version = "=0.23.3", path = "./rust/lance-datafusion" }
-lance-datagen = { version = "=0.23.3", path = "./rust/lance-datagen" }
-lance-encoding = { version = "=0.23.3", path = "./rust/lance-encoding" }
-lance-encoding-datafusion = { version = "=0.23.3", path = "./rust/lance-encoding-datafusion" }
-lance-file = { version = "=0.23.3", path = "./rust/lance-file" }
-lance-index = { version = "=0.23.3", path = "./rust/lance-index" }
-lance-io = { version = "=0.23.3", path = "./rust/lance-io" }
-lance-jni = { version = "=0.23.3", path = "./java/core/lance-jni" }
-lance-linalg = { version = "=0.23.3", path = "./rust/lance-linalg" }
-lance-table = { version = "=0.23.3", path = "./rust/lance-table" }
-lance-test-macros = { version = "=0.23.3", path = "./rust/lance-test-macros" }
-lance-testing = { version = "=0.23.3", path = "./rust/lance-testing" }
+lance = { version = "=0.24.0", path = "./rust/lance" }
+lance-arrow = { version = "=0.24.0", path = "./rust/lance-arrow" }
+lance-core = { version = "=0.24.0", path = "./rust/lance-core" }
+lance-datafusion = { version = "=0.24.0", path = "./rust/lance-datafusion" }
+lance-datagen = { version = "=0.24.0", path = "./rust/lance-datagen" }
+lance-encoding = { version = "=0.24.0", path = "./rust/lance-encoding" }
+lance-encoding-datafusion = { version = "=0.24.0", path = "./rust/lance-encoding-datafusion" }
+lance-file = { version = "=0.24.0", path = "./rust/lance-file" }
+lance-index = { version = "=0.24.0", path = "./rust/lance-index" }
+lance-io = { version = "=0.24.0", path = "./rust/lance-io" }
+lance-jni = { version = "=0.24.0", path = "./java/core/lance-jni" }
+lance-linalg = { version = "=0.24.0", path = "./rust/lance-linalg" }
+lance-table = { version = "=0.24.0", path = "./rust/lance-table" }
+lance-test-macros = { version = "=0.24.0", path = "./rust/lance-test-macros" }
+lance-testing = { version = "=0.24.0", path = "./rust/lance-testing" }
 approx = "0.5.1"
 # Note that this one does not include pyarrow
 arrow = { version = "53.2", optional = false, features = ["prettyprint"] }
@@ -114,7 +114,7 @@ datafusion-physical-expr = { version = "44.0" }
 deepsize = "0.2.0"
 dirs = "5.0.0"
 either = "1.0"
-fsst = { version = "=0.23.3", path = "./rust/lance-encoding/src/compression_algo/fsst" }
+fsst = { version = "=0.24.0", path = "./rust/lance-encoding/src/compression_algo/fsst" }
 futures = "0.3"
 http = "1.1.0"
 hyperloglogplus = { version = "0.4.1", features = ["const-loop"] }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -2147,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "fsst"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "rand",
 ]
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3140,7 +3140,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrayref",
  "arrow",
@@ -3193,7 +3193,7 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3282,7 +3282,7 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow-array",
  "arrow-ord",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "pylance"
-version = "0.23.3"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pylance"
-version = "0.23.3"
+version = "0.24.0"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 rust-version = "1.65"

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -792,7 +792,6 @@ class LanceDataset(pa.dataset.Dataset):
         self,
         indices: Union[List[int], pa.Array],
         columns: Optional[Union[List[str], Dict[str, str]]] = None,
-        **kwargs,
     ) -> pa.Table:
         """Select rows of data by index.
 
@@ -804,8 +803,6 @@ class LanceDataset(pa.dataset.Dataset):
             List of column names to be fetched.
             Or a dictionary of column names to SQL expressions.
             All columns are fetched if None or unspecified.
-        **kwargs : dict, optional
-            See :py:method::scanner method for full parameter description.
 
         Returns
         -------


### PR DESCRIPTION
Related to https://github.com/lancedb/lance/issues/3444

Removed unused kwargs parameter in [LanceDataset.take](https://github.com/lancedb/lance/blob/main/python/python/lance/dataset.py#L791)