### PR TITLE
feat(python): add files lance/schema.py, lance/file.py, lance/util.py for pyright typecheck

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -77,6 +77,9 @@ include = [
     "python/lance/debug.py",
     "python/lance/tracing.py",
     "python/lance/dependencies.py",
+    "python/lance/schema.py",
+    "python/lance/file.py",
+    "python/lance/util.py",
 ]
 # Dependencies like pyarrow make this difficult to enforce strictly.
 reportMissingTypeStubs = "warning"


### PR DESCRIPTION
This just adds the lance/schema.py, lance/file.py, lance/util.py files such that they can be checked with pyright. Fixes [#329](https://github.com/lancedb/lance/issues/3294)