### PR TITLE
feat: expose specifying scanner filters via datafusion

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -534,7 +534,7 @@ impl Scanner {
         Ok(self)
     }
 
-    pub(crate) fn filter_expr(&mut self, filter: Expr) -> &mut Self {
+    pub fn filter_expr(&mut self, filter: Expr) -> &mut Self {
         self.filter = Some(LanceFilter::Datafusion(filter));
         self
     }


### PR DESCRIPTION
We are trying to build a Datafusion table provider in LanceDB and it receives expressions as DF logical exprs.  We can go DF expr -> substrait -> DF expr but it seems simpler to just expose the API to accept filters as DF exprs directly.