### PR TITLE
feat: add support for ngram indices

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,3 +1,6 @@
+[default]
+extend-ignore-re = ["(?Rm)^.*(#|//)\\s*spellchecker:disable-line$"]
+
 [default.extend-words]
 DNE = "DNE"
 arange = "arange"
@@ -8,3 +11,4 @@ afe = "afe"
 
 [files]
 extend-exclude = ["notebooks/*.ipynb"]
+# If a line ends with # or // and has spellchecker:disable-line, ignore it

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -361,4 +361,5 @@ message BTreeIndexDetails {}
 message BitmapIndexDetails {}
 message LabelListIndexDetails {}
 message InvertedIndexDetails {}
+message NGramIndexDetails {}
 message VectorIndexDetails {}

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1494,6 +1494,7 @@ class LanceDataset(pa.dataset.Dataset):
             Literal["LABEL_LIST"],
             Literal["INVERTED"],
             Literal["FTS"],
+            Literal["NGRAM"],
         ],
         name: Optional[str] = None,
         *,
@@ -1547,6 +1548,10 @@ class LanceDataset(pa.dataset.Dataset):
           contains lists of tags (e.g. ``["tag1", "tag2", "tag3"]``) can be indexed
           with a ``LABEL_LIST`` index.  This index can only speedup queries with
           ``array_has_any`` or ``array_has_all`` filters.
+        * ``NGRAM``. A special index that is used to index string columns.  This index
+          creates a bitmap for each ngram in the string.  By default we use trigrams.
+          This index can currently speed up queries using the ``contains`` function
+          in filters.
         * ``FTS/INVERTED``. It is used to index document columns. This index
           can conduct full-text searches. For example, a column that contains any word
           of query string "hello world". The results will be ranked by BM25.
@@ -1564,7 +1569,7 @@ class LanceDataset(pa.dataset.Dataset):
             or string column.
         index_type : str
             The type of the index.  One of ``"BTREE"``, ``"BITMAP"``,
-            ``"LABEL_LIST"``, "FTS" or ``"INVERTED"``.
+            ``"LABEL_LIST"``, ``"NGRAM"``, ``"FTS"`` or ``"INVERTED"``.
         name : str, optional
             The index name. If not provided, it will be generated from the
             column name.
@@ -1651,10 +1656,10 @@ class LanceDataset(pa.dataset.Dataset):
             raise KeyError(f"{column} not found in schema")
 
         index_type = index_type.upper()
-        if index_type not in ["BTREE", "BITMAP", "LABEL_LIST", "INVERTED"]:
+        if index_type not in ["BTREE", "BITMAP", "NGRAM", "LABEL_LIST", "INVERTED"]:
             raise NotImplementedError(
                 (
-                    'Only "BTREE", "LABEL_LIST", "INVERTED", '
+                    'Only "BTREE", "LABEL_LIST", "INVERTED", "NGRAM", '
                     'or "BITMAP" are supported for '
                     f"scalar columns.  Received {index_type}",
                 )
@@ -1676,6 +1681,9 @@ class LanceDataset(pa.dataset.Dataset):
         elif index_type == "LABEL_LIST":
             if not pa.types.is_list(field.type):
                 raise TypeError(f"LABEL_LIST index column {column} must be a list")
+        elif index_type == "NGRAM":
+            if not pa.types.is_string(field.type):
+                raise TypeError(f"NGRAM index column {column} must be a string")
         elif index_type in ["INVERTED", "FTS"]:
             if not pa.types.is_string(field.type) and not pa.types.is_large_string(
                 field.type

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -614,6 +614,7 @@ def test_scalar_index_with_nulls(tmp_path):
             "numeric_float": [0.1, None] * (test_table_size // 2),
             "boolean_col": [True, None] * (test_table_size // 2),
             "timestamp_col": [datetime(2023, 1, 1), None] * (test_table_size // 2),
+            "ngram_col": ["apple", None] * (test_table_size // 2),
         }
     )
     ds = lance.write_dataset(test_table, tmp_path)
@@ -621,6 +622,7 @@ def test_scalar_index_with_nulls(tmp_path):
     ds.create_scalar_index("category", index_type="BTREE")
     ds.create_scalar_index("boolean_col", index_type="BTREE")
     ds.create_scalar_index("timestamp_col", index_type="BTREE")
+    ds.create_scalar_index("ngram_col", index_type="NGRAM")
     # Test querying with filters on columns with nulls.
     k = test_table_size // 2
     result = ds.to_table(filter="category = 'a'", limit=k)
@@ -629,6 +631,14 @@ def test_scalar_index_with_nulls(tmp_path):
     result = ds.to_table(filter="boolean_col IS TRUE", limit=k)
     assert len(result) == k
     result = ds.to_table(filter="timestamp_col IS NOT NULL", limit=k)
+    assert len(result) == k
+
+    # Ensure ngram index works with nulls
+    result = ds.to_table(filter="ngram_col = 'apple'")
+    assert len(result) == k
+    result = ds.to_table(filter="ngram_col IS NULL")
+    assert len(result) == k
+    result = ds.to_table(filter="contains(ngram_col, 'appl')")
     assert len(result) == k
 
 
@@ -652,11 +662,12 @@ def test_create_index_empty_dataset(tmp_path: Path):
             pa.field("bitmap", pa.int32()),
             pa.field("label_list", pa.list_(pa.string())),
             pa.field("inverted", pa.string()),
+            pa.field("ngram", pa.string()),
         ]
     )
     ds = lance.write_dataset([], tmp_path, schema=schema)
 
-    for index_type in ["BTREE", "BITMAP", "LABEL_LIST", "INVERTED"]:
+    for index_type in ["BTREE", "BITMAP", "LABEL_LIST", "INVERTED", "NGRAM"]:
         ds.create_scalar_index(index_type.lower(), index_type=index_type)
 
     # Make sure the empty index doesn't cause searches to fail
@@ -667,6 +678,7 @@ def test_create_index_empty_dataset(tmp_path: Path):
                 "bitmap": pa.array([1], pa.int32()),
                 "label_list": [["foo", "bar"]],
                 "inverted": ["blah"],
+                "ngram": ["apple"],
             }
         )
     )
@@ -680,6 +692,9 @@ def test_create_index_empty_dataset(tmp_path: Path):
         assert ds.to_table(filter="array_has_any(label_list, ['oof'])").num_rows == 0
         assert ds.to_table(filter="inverted = 'blah'").num_rows == 1
         assert ds.to_table(filter="inverted = 'halb'").num_rows == 0
+        assert ds.to_table(filter="contains(ngram, 'apple')").num_rows == 1
+        assert ds.to_table(filter="contains(ngram, 'banana')").num_rows == 0
+        assert ds.to_table(filter="ngram = 'apple'").num_rows == 1
 
     test_searches()
 
@@ -696,32 +711,47 @@ def test_create_index_empty_dataset(tmp_path: Path):
 
 def test_optimize_no_new_data(tmp_path: Path):
     tbl = pa.table(
-        {"btree": pa.array([None], pa.int64()), "bitmap": pa.array([None], pa.int64())}
+        {
+            "btree": pa.array([None], pa.int64()),
+            "bitmap": pa.array([None], pa.int64()),
+            "ngram": pa.array([None], pa.string()),
+        }
     )
     dataset = lance.write_dataset(tbl, tmp_path)
     dataset.create_scalar_index("btree", index_type="BTREE")
     dataset.create_scalar_index("bitmap", index_type="BITMAP")
+    dataset.create_scalar_index("ngram", index_type="NGRAM")
 
     assert dataset.to_table(filter="btree IS NULL").num_rows == 1
     assert dataset.to_table(filter="bitmap IS NULL").num_rows == 1
+    assert dataset.to_table(filter="ngram IS NULL").num_rows == 1
 
     dataset.insert([], schema=tbl.schema)
     dataset.optimize.optimize_indices()
 
     assert dataset.to_table(filter="btree IS NULL").num_rows == 1
     assert dataset.to_table(filter="bitmap IS NULL").num_rows == 1
+    assert dataset.to_table(filter="ngram IS NULL").num_rows == 1
 
     dataset.insert(pa.table({"btree": [2]}))
     dataset.optimize.optimize_indices()
 
     assert dataset.to_table(filter="btree IS NULL").num_rows == 1
     assert dataset.to_table(filter="bitmap IS NULL").num_rows == 2
+    assert dataset.to_table(filter="ngram IS NULL").num_rows == 2
 
     dataset.insert(pa.table({"bitmap": [2]}))
     dataset.optimize.optimize_indices()
 
     assert dataset.to_table(filter="btree IS NULL").num_rows == 2
     assert dataset.to_table(filter="bitmap IS NULL").num_rows == 2
+    assert dataset.to_table(filter="ngram IS NULL").num_rows == 3
+
+    dataset.insert(pa.table({"ngram": ["apple"]}))
+
+    assert dataset.to_table(filter="btree IS NULL").num_rows == 3
+    assert dataset.to_table(filter="bitmap IS NULL").num_rows == 3
+    assert dataset.to_table(filter="ngram IS NULL").num_rows == 3
 
 
 def test_drop_index(tmp_path):
@@ -731,14 +761,16 @@ def test_drop_index(tmp_path):
             "btree": list(range(test_table_size)),
             "bitmap": list(range(test_table_size)),
             "fts": ["a" for _ in range(test_table_size)],
+            "ngram": ["a" for _ in range(test_table_size)],
         }
     )
     ds = lance.write_dataset(test_table, tmp_path)
     ds.create_scalar_index("btree", index_type="BTREE")
     ds.create_scalar_index("bitmap", index_type="BITMAP")
     ds.create_scalar_index("fts", index_type="INVERTED")
+    ds.create_scalar_index("ngram", index_type="NGRAM")
 
-    assert len(ds.list_indices()) == 3
+    assert len(ds.list_indices()) == 4
 
     # Attempt to drop index (name does not exist)
     with pytest.raises(RuntimeError, match="index not found"):
@@ -754,3 +786,4 @@ def test_drop_index(tmp_path):
     assert ds.to_table(filter="btree = 1").num_rows == 1
     assert ds.to_table(filter="bitmap = 1").num_rows == 1
     assert ds.to_table(filter="fts = 'a'").num_rows == test_table_size
+    assert ds.to_table(filter="contains(ngram, 'a')").num_rows == test_table_size

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -535,6 +535,43 @@ def test_bitmap_index(tmp_path: Path):
     assert indices[0]["type"] == "Bitmap"
 
 
+def test_ngram_index(tmp_path: Path):
+    """Test create ngram index"""
+    tbl = pa.Table.from_arrays(
+        [
+            pa.array(
+                [["apple", "apples", "banana", "coconut"][i % 4] for i in range(100)]
+            )
+        ],
+        names=["words"],
+    )
+    dataset = lance.write_dataset(tbl, tmp_path / "dataset")
+    dataset.create_scalar_index("words", index_type="NGRAM")
+    indices = dataset.list_indices()
+    assert len(indices) == 1
+    assert indices[0]["type"] == "NGram"
+
+    scan_plan = dataset.scanner(filter="contains(words, 'apple')").explain_plan(True)
+    assert "MaterializeIndex" in scan_plan
+
+    assert dataset.to_table(filter="contains(words, 'apple')").num_rows == 50
+    assert dataset.to_table(filter="contains(words, 'banana')").num_rows == 25
+    assert dataset.to_table(filter="contains(words, 'coconut')").num_rows == 25
+    assert dataset.to_table(filter="contains(words, 'apples')").num_rows == 25
+    assert (
+        dataset.to_table(
+            filter="contains(words, 'apple') AND contains(words, 'banana')"
+        ).num_rows
+        == 0
+    )
+    assert (
+        dataset.to_table(
+            filter="contains(words, 'apple') OR contains(words, 'banana')"
+        ).num_rows
+        == 75
+    )
+
+
 def test_null_handling(tmp_path: Path):
     tbl = pa.table(
         {

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1176,6 +1176,7 @@ impl Dataset {
         let idx_type = match index_type.as_str() {
             "BTREE" => IndexType::Scalar,
             "BITMAP" => IndexType::Bitmap,
+            "NGRAM" => IndexType::NGram,
             "LABEL_LIST" => IndexType::LabelList,
             "INVERTED" | "FTS" => IndexType::Inverted,
             "IVF_FLAT" | "IVF_PQ" | "IVF_HNSW_PQ" | "IVF_HNSW_SQ" => IndexType::Vector,
@@ -1192,6 +1193,9 @@ impl Dataset {
             "BITMAP" => Box::new(ScalarIndexParams {
                 // Temporary workaround until we add support for auto-detection of scalar index type
                 force_index_type: Some(ScalarIndexType::Bitmap),
+            }),
+            "NGRAM" => Box::new(ScalarIndexParams {
+                force_index_type: Some(ScalarIndexType::NGram),
             }),
             "LABEL_LIST" => Box::new(ScalarIndexParams {
                 force_index_type: Some(ScalarIndexType::LabelList),

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -828,6 +828,16 @@ impl Projection {
         }
     }
 
+    pub fn with_row_id(mut self) -> Self {
+        self.with_row_id = true;
+        self
+    }
+
+    pub fn with_row_addr(mut self) -> Self {
+        self.with_row_addr = true;
+        self
+    }
+
     /// Add a column (and any of its parents) to the projection from a string reference
     pub fn union_column(mut self, column: impl AsRef<str>, on_missing: OnMissing) -> Result<Self> {
         let column = column.as_ref();
@@ -853,6 +863,11 @@ impl Projection {
     /// True if the projection selects the given field id
     pub fn contains_field_id(&self, id: i32) -> bool {
         self.field_ids.contains(&id)
+    }
+
+    /// True if the projection selects fields other than the row id / addr
+    pub fn has_data_fields(&self) -> bool {
+        !self.field_ids.is_empty()
     }
 
     /// Add multiple columns (and their parents) to the projection

--- a/rust/lance-core/src/utils/mask.rs
+++ b/rust/lance-core/src/utils/mask.rs
@@ -10,7 +10,7 @@ use arrow_array::{Array, BinaryArray, GenericBinaryArray};
 use arrow_buffer::{Buffer, NullBuffer, OffsetBuffer};
 use byteorder::{ReadBytesExt, WriteBytesExt};
 use deepsize::DeepSizeOf;
-use roaring::{MultiOps, RoaringBitmap};
+use roaring::{MultiOps, RoaringBitmap, RoaringTreemap};
 
 use crate::Result;
 
@@ -703,6 +703,16 @@ impl FromIterator<u64> for RowIdTreeMap {
 impl<'a> FromIterator<&'a u64> for RowIdTreeMap {
     fn from_iter<T: IntoIterator<Item = &'a u64>>(iter: T) -> Self {
         Self::from_iter(iter.into_iter().copied())
+    }
+}
+
+impl From<RoaringTreemap> for RowIdTreeMap {
+    fn from(roaring: RoaringTreemap) -> Self {
+        let mut inner = BTreeMap::new();
+        for (fragment, set) in roaring.bitmaps() {
+            inner.insert(fragment, RowIdSelection::Partial(set.clone()));
+        }
+        Self { inner }
     }
 }
 

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -114,6 +114,10 @@ name = "sq"
 harness = false
 
 [[bench]]
+name = "ngram"
+harness = false
+
+[[bench]]
 name = "inverted"
 harness = false
 

--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-
 use std::{sync::Arc, time::Duration};
 
 use arrow::array::AsArray;

--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Benchmark of HNSW graph.
+//!
+//!
+
+use std::{sync::Arc, time::Duration};
+
+use arrow::array::AsArray;
+use arrow_array::{RecordBatch, StringArray, UInt64Array};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use futures::stream;
+use itertools::Itertools;
+use lance_core::cache::FileMetadataCache;
+use lance_core::ROW_ID;
+use lance_index::scalar::lance_format::LanceIndexStore;
+use lance_index::scalar::ngram::{NGramIndex, NGramIndexBuilder};
+use lance_index::scalar::{ScalarIndex, TextQuery};
+use lance_io::object_store::ObjectStore;
+use object_store::path::Path;
+#[cfg(target_os = "linux")]
+use pprof::criterion::{Output, PProfProfiler};
+
+fn bench_ngram(c: &mut Criterion) {
+    const TOTAL: usize = 1_000_000;
+
+    let rt = tokio::runtime::Builder::new_multi_thread().build().unwrap();
+
+    let tempdir = tempfile::tempdir().unwrap();
+    let index_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
+    let store = rt.block_on(async {
+        Arc::new(LanceIndexStore::new(
+            ObjectStore::local(),
+            index_dir,
+            FileMetadataCache::no_cache(),
+        ))
+    });
+
+    // generate 2000 different tokens
+    let tokens = random_word::all(random_word::Lang::En);
+    let row_id_col = Arc::new(UInt64Array::from(
+        (0..TOTAL).map(|i| i as u64).collect_vec(),
+    ));
+    let docs = (0..TOTAL)
+        .map(|_| {
+            let num_words = rand::random::<usize>() % 30 + 1;
+            let doc = (0..num_words)
+                .map(|_| tokens[rand::random::<usize>() % tokens.len()])
+                .collect::<Vec<_>>();
+            doc.join(" ")
+        })
+        .collect_vec();
+    let doc_col = Arc::new(StringArray::from(docs));
+    let batch = RecordBatch::try_new(
+        arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("doc", arrow_schema::DataType::Utf8, false),
+            arrow_schema::Field::new(ROW_ID, arrow_schema::DataType::UInt64, false),
+        ])
+        .into(),
+        vec![doc_col, row_id_col],
+    )
+    .unwrap();
+    let stream =
+        RecordBatchStreamAdapter::new(batch.schema(), stream::iter(vec![Ok(batch.clone())]));
+    let stream = Box::pin(stream);
+
+    rt.block_on(async {
+        let mut builder = NGramIndexBuilder::default();
+        builder.train(stream).await.unwrap();
+        builder.write(store.as_ref()).await.unwrap();
+    });
+    let index = rt.block_on(NGramIndex::load(store)).unwrap();
+
+    c.bench_function(format!("invert({TOTAL})").as_str(), |b| {
+        b.to_async(&rt).iter(|| async {
+            let sample_idx = rand::random::<usize>() % batch.num_rows();
+            let sample = batch
+                .column(0)
+                .as_string::<i32>()
+                .value(sample_idx)
+                .to_string();
+            black_box(
+                index
+                    .search(&TextQuery::StringContains(sample))
+                    .await
+                    .unwrap(),
+            );
+        })
+    });
+}
+
+#[cfg(target_os = "linux")]
+criterion_group!(
+    name=benches;
+    config = Criterion::default()
+        .measurement_time(Duration::from_secs(10))
+        .sample_size(10)
+        .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench_ngram);
+
+// Non-linux version does not support pprof.
+#[cfg(not(target_os = "linux"))]
+criterion_group!(
+    name=benches;
+    config = Criterion::default()
+        .measurement_time(Duration::from_secs(10))
+        .sample_size(10);
+    targets = bench_inverted);
+
+criterion_main!(benches);

--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-//! Benchmark of HNSW graph.
-//!
-//!
 
 use std::{sync::Arc, time::Duration};
 

--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -79,6 +79,8 @@ pub enum IndexType {
 
     Inverted = 4, // Inverted
 
+    NGram = 5, // NGram
+
     // 100+ and up for vector index.
     /// Flat vector index.
     Vector = 100, // Legacy vector index, alias to IvfPq
@@ -96,6 +98,7 @@ impl std::fmt::Display for IndexType {
             Self::Bitmap => write!(f, "Bitmap"),
             Self::LabelList => write!(f, "LabelList"),
             Self::Inverted => write!(f, "Inverted"),
+            Self::NGram => write!(f, "NGram"),
             Self::Vector | Self::IvfPq => write!(f, "IVF_PQ"),
             Self::IvfFlat => write!(f, "IVF_FLAT"),
             Self::IvfSq => write!(f, "IVF_SQ"),
@@ -114,6 +117,7 @@ impl TryFrom<i32> for IndexType {
             v if v == Self::BTree as i32 => Ok(Self::BTree),
             v if v == Self::Bitmap as i32 => Ok(Self::Bitmap),
             v if v == Self::LabelList as i32 => Ok(Self::LabelList),
+            v if v == Self::NGram as i32 => Ok(Self::NGram),
             v if v == Self::Inverted as i32 => Ok(Self::Inverted),
             v if v == Self::Vector as i32 => Ok(Self::Vector),
             v if v == Self::IvfFlat as i32 => Ok(Self::IvfFlat),
@@ -133,7 +137,12 @@ impl IndexType {
     pub fn is_scalar(&self) -> bool {
         matches!(
             self,
-            Self::Scalar | Self::BTree | Self::Bitmap | Self::LabelList | Self::Inverted
+            Self::Scalar
+                | Self::BTree
+                | Self::Bitmap
+                | Self::LabelList
+                | Self::Inverted
+                | Self::NGram
         )
     }
 

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -47,7 +47,7 @@ use crate::{Index, IndexType};
 
 use super::{
     flat::FlatIndexMetadata, AnyQuery, IndexReader, IndexStore, IndexWriter, SargableQuery,
-    ScalarIndex,
+    ScalarIndex, SearchResult,
 };
 
 const BTREE_LOOKUP_NAME: &str = "page_lookup.lance";
@@ -781,7 +781,13 @@ impl BTreeIndex {
         // values that might be in the page.  E.g. if we are searching for X IN [5, 3, 7] and five is in pages
         // 1 and 2 and three is in page 2 and seven is in pages 8 and 9 then when we search page 2 we only need
         // to search for X IN [5, 3]
-        subindex.search(query).await
+        match subindex.search(query).await? {
+            SearchResult::Exact(map) => Ok(map),
+            _ => Err(Error::Internal {
+                message: "BTree sub-indices need to return exact results".to_string(),
+                location: location!(),
+            }),
+        }
     }
 
     fn try_from_serialized(
@@ -943,7 +949,7 @@ impl Index for BTreeIndex {
 
 #[async_trait]
 impl ScalarIndex for BTreeIndex {
-    async fn search(&self, query: &dyn AnyQuery) -> Result<RowIdTreeMap> {
+    async fn search(&self, query: &dyn AnyQuery) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<SargableQuery>().unwrap();
         let pages = match query {
             SargableQuery::Equals(val) => self
@@ -970,12 +976,17 @@ impl ScalarIndex for BTreeIndex {
             })
             .collect::<Vec<_>>();
         debug!("Searching {} btree pages", page_tasks.len());
-        stream::iter(page_tasks)
+        let row_ids = stream::iter(page_tasks)
             // I/O and compute mixed here but important case is index in cache so
             // use compute intensive thread count
             .buffered(get_num_compute_intensive_cpus())
             .try_collect::<RowIdTreeMap>()
-            .await
+            .await?;
+        Ok(SearchResult::Exact(row_ids))
+    }
+
+    fn can_answer_exact(&self, _: &dyn AnyQuery) -> bool {
+        true
     }
 
     async fn load(store: Arc<dyn IndexStore>) -> Result<Arc<Self>> {

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -531,7 +531,7 @@ mod tests {
         let tokens = collect_tokens(&tokenizer, "café");
         assert_eq!(
             tokens,
-            vec!["c", "ca", "calf", "a", "af", "afe", "f", "fe", "e"]
+            vec!["c", "ca", "caf", "a", "af", "afe", "f", "fe", "e"] // spellchecker:disable-line
         );
 
         // Allow numbers

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -1,0 +1,453 @@
+use std::any::Any;
+use std::{collections::HashMap, sync::Arc};
+
+use arrow::array::AsArray;
+use arrow::datatypes::UInt64Type;
+use arrow_array::{BinaryArray, RecordBatch, StringArray};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use async_trait::async_trait;
+use datafusion::execution::SendableRecordBatchStream;
+use deepsize::DeepSizeOf;
+use futures::{StreamExt, TryStreamExt};
+use lance_core::utils::address::RowAddress;
+use lance_core::Result;
+use lance_core::{utils::mask::RowIdTreeMap, Error};
+use moka::future::Cache;
+use roaring::{RoaringBitmap, RoaringTreemap};
+use serde::Serialize;
+use snafu::location;
+use tantivy::tokenizer::TextAnalyzer;
+use tracing::instrument;
+
+use crate::scalar::inverted::CACHE_SIZE;
+use crate::vector::VectorIndex;
+use crate::{Index, IndexType};
+
+use super::btree::TrainingSource;
+use super::inverted::TokenSet;
+use super::{AnyQuery, IndexReader, IndexStore, ScalarIndex, SearchResult, TextQuery};
+
+const TOKENS_COL: &str = "tokens";
+const POSTING_LIST_COL: &str = "posting_list";
+const POSTINGS_FILENAME: &str = "ngram_postings.lance";
+
+lazy_static::lazy_static! {
+    pub static ref TOKENS_FIELD: Field = Field::new(TOKENS_COL, DataType::Utf8, false);
+    pub static ref POSTINGS_FIELD: Field = Field::new(POSTING_LIST_COL, DataType::Binary, false);
+    pub static ref POSTINGS_SCHEMA: SchemaRef = Arc::new(Schema::new(vec![TOKENS_FIELD.clone(), POSTINGS_FIELD.clone()]));
+    /// Currently we ALWAYS use trigrams with ascii folding and lower casing.  We may want to make this configurable in the future.
+    pub static ref NGRAM_TOKENIZER: TextAnalyzer = TextAnalyzer::builder(tantivy::tokenizer::NgramTokenizer::all_ngrams(1, 3).unwrap())
+    .filter(tantivy::tokenizer::LowerCaser)
+    .filter(tantivy::tokenizer::AlphaNumOnlyFilter)
+    .filter(tantivy::tokenizer::AsciiFoldingFilter)
+    .build();
+}
+trait TextAnalyzerExt {
+    fn tokenize(self, text: &str) -> Vec<String>;
+}
+
+impl TextAnalyzerExt for TextAnalyzer {
+    fn tokenize(mut self, text: &str) -> Vec<String> {
+        let mut stream = self.token_stream(text);
+        let mut tokens = Vec::new();
+        while stream.advance() {
+            let token = stream.token();
+            tokens.push(token.text.clone());
+        }
+        tokens
+    }
+}
+
+/// Basic stats about an ngram index
+#[derive(Serialize)]
+struct NGramStatistics {
+    num_ngrams: usize,
+}
+
+/// The row ids that contain a given ngram
+#[derive(Debug)]
+struct NGramPostingList {
+    bitmap: RoaringTreemap,
+}
+
+impl DeepSizeOf for NGramPostingList {
+    fn deep_size_of_children(&self, _: &mut deepsize::Context) -> usize {
+        self.bitmap.serialized_size() as usize
+    }
+}
+
+impl NGramPostingList {
+    fn try_from_batch(batch: RecordBatch) -> Result<Self> {
+        let bitmap_bytes = batch.column(0).as_binary::<i32>().value(0);
+        let bitmap =
+            RoaringTreemap::deserialize_from(bitmap_bytes).map_err(|e| Error::Internal {
+                message: format!("Error deserializing ngram list: {}", e),
+                location: location!(),
+            })?;
+        Ok(Self { bitmap })
+    }
+
+    fn intersect<'a>(lists: impl IntoIterator<Item = &'a Self>) -> RoaringTreemap {
+        let mut iter = lists.into_iter();
+        let mut result = iter
+            .next()
+            .map(|list| list.bitmap.clone())
+            .unwrap_or_default();
+        for list in iter {
+            result &= &list.bitmap;
+        }
+        result
+    }
+}
+
+/// Reads on-demand ngram posting lists from storage (and stores them in a cache)
+struct NGramPostingListReader {
+    reader: Arc<dyn IndexReader>,
+    cache: Cache<u32, Arc<NGramPostingList>>,
+}
+
+impl DeepSizeOf for NGramPostingListReader {
+    fn deep_size_of_children(&self, _: &mut deepsize::Context) -> usize {
+        self.cache.weighted_size() as usize
+    }
+}
+
+impl std::fmt::Debug for NGramPostingListReader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NGramListReader")
+            .field("cache_entry_count", &self.cache.entry_count())
+            .finish()
+    }
+}
+
+impl NGramPostingListReader {
+    #[instrument(level = "debug", skip(self))]
+    pub async fn ngram_list(&self, token_id: u32) -> Result<Arc<NGramPostingList>> {
+        Ok(self
+            .cache
+            .try_get_with(token_id, async move {
+                let batch = self
+                    .reader
+                    .read_range(
+                        token_id as usize..token_id as usize + 1,
+                        Some(&[POSTING_LIST_COL]),
+                    )
+                    .await?;
+                Result::Ok(Arc::new(NGramPostingList::try_from_batch(batch)?))
+            })
+            .await
+            .map_err(|e| Error::io(e.to_string(), location!()))?)
+    }
+}
+
+/// An ngram index
+///
+/// This index stores a mapping from ngrams to the row ids that contain them.
+///
+/// As a simple example consider a 1-gram index.  It would basically be a mapping from
+/// each letter to the row ids that contain that letter.  Then, if the user searches for
+/// "cat", the index would look up the row ids for "c", "a", and "t", and return the intersection
+/// of those row ids because only rows have at least one c, a, and t could possible contain "cat".
+///
+/// This is an in-exact index, similar to a bloom filter.  It can return false positives and a
+/// recheck step is needed to confirm the results.
+///
+/// Note that it cannot return false negatives.
+pub struct NGramIndex {
+    /// The mapping from ngrams to token ids
+    tokens: TokenSet,
+    /// The reader for the posting lists
+    list_reader: Arc<NGramPostingListReader>,
+    /// The tokenizer used to tokenize text.  Note: not all tokenizers can be used with this index.  For
+    /// example, a stemming tokenizer would not work well because "dozing" would stem to "doze" and if the
+    /// search term is "zing" it would not match.  As a result, this tokenizer is not as configurable as the
+    /// tokenizers used in an inverted index.
+    tokenizer: TextAnalyzer,
+    io_parallelism: usize,
+}
+
+impl std::fmt::Debug for NGramIndex {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NGramIndex")
+            .field("tokens", &self.tokens)
+            .field("list_reader", &self.list_reader)
+            .finish()
+    }
+}
+
+impl DeepSizeOf for NGramIndex {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.tokens.deep_size_of_children(context) + self.list_reader.deep_size_of_children(context)
+    }
+}
+
+impl NGramIndex {
+    async fn from_store(store: &dyn IndexStore) -> Result<Self> {
+        let tokens = store.open_index_file(POSTINGS_FILENAME).await?;
+        let tokens = tokens
+            .read_range(0..tokens.num_rows(), Some(&[TOKENS_COL]))
+            .await?;
+
+        let mut tokens_map = HashMap::with_capacity(tokens.num_rows());
+        tokens_map.extend(
+            tokens
+                .column(0)
+                .as_string::<i32>()
+                .iter()
+                .enumerate()
+                .map(|(i, token)| (token.unwrap().to_owned(), i as u32)),
+        );
+        let tokens = TokenSet::new(tokens_map);
+
+        let posting_reader = Arc::new(NGramPostingListReader {
+            reader: store.open_index_file(POSTINGS_FILENAME).await?,
+            cache: Cache::builder()
+                .max_capacity(*CACHE_SIZE as u64)
+                .weigher(|_, posting: &Arc<NGramPostingList>| posting.deep_size_of() as u32)
+                .build(),
+        });
+
+        Ok(Self {
+            io_parallelism: store.io_parallelism(),
+            tokens,
+            list_reader: posting_reader,
+            tokenizer: NGRAM_TOKENIZER.clone(),
+        })
+    }
+
+    fn tokenize(&self, text: &str) -> Vec<String> {
+        let mut tokenizer = self.tokenizer.clone();
+        let mut stream = tokenizer.token_stream(text);
+        let mut tokens = Vec::new();
+        while stream.advance() {
+            let token = stream.token();
+            tokens.push(token.text.clone());
+        }
+        tokens
+    }
+}
+
+#[async_trait]
+impl Index for NGramIndex {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+        self
+    }
+
+    fn as_vector_index(self: Arc<Self>) -> Result<Arc<dyn VectorIndex>> {
+        Err(Error::InvalidInput {
+            source: "NGramIndex is not a vector index".into(),
+            location: location!(),
+        })
+    }
+
+    fn statistics(&self) -> Result<serde_json::Value> {
+        let ngram_stats = NGramStatistics {
+            num_ngrams: self.tokens.num_tokens(),
+        };
+        serde_json::to_value(ngram_stats).map_err(|e| Error::Internal {
+            message: format!("Error serializing statistics: {}", e),
+            location: location!(),
+        })
+    }
+
+    fn index_type(&self) -> IndexType {
+        IndexType::NGram
+    }
+
+    async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {
+        let mut frag_ids = RoaringBitmap::new();
+        for token in self.tokens.all_tokens() {
+            let list = self.list_reader.ngram_list(token).await?;
+            frag_ids.extend(
+                list.bitmap
+                    .iter()
+                    .map(|row_addr| RowAddress::from(row_addr).fragment_id()),
+            );
+        }
+        Ok(frag_ids)
+    }
+}
+
+#[async_trait]
+impl ScalarIndex for NGramIndex {
+    async fn search(&self, query: &dyn AnyQuery) -> Result<SearchResult> {
+        let query =
+            query
+                .as_any()
+                .downcast_ref::<TextQuery>()
+                .ok_or_else(|| Error::InvalidInput {
+                    source: "Query is not a TextQuery".into(),
+                    location: location!(),
+                })?;
+        match query {
+            TextQuery::StringContains(substr) => {
+                let tokens = self.tokenize(substr);
+                let token_ids = tokens
+                    .into_iter()
+                    .map(|t| self.tokens.get(&t))
+                    .collect::<Option<Vec<_>>>();
+                let Some(token_ids) = token_ids else {
+                    return Ok(SearchResult::Exact(RowIdTreeMap::new()));
+                };
+                let posting_lists = futures::stream::iter(
+                    token_ids
+                        .into_iter()
+                        .map(|token_id| self.list_reader.ngram_list(token_id)),
+                )
+                .buffer_unordered(self.io_parallelism)
+                .try_collect::<Vec<_>>()
+                .await?;
+                let list_refs = posting_lists.iter().map(|list| list.as_ref());
+                let row_ids = NGramPostingList::intersect(list_refs);
+                Ok(SearchResult::AtMost(RowIdTreeMap::from(row_ids)))
+            }
+        }
+    }
+
+    fn can_answer_exact(&self, _: &dyn AnyQuery) -> bool {
+        false
+    }
+
+    /// Load the scalar index from storage
+    async fn load(store: Arc<dyn IndexStore>) -> Result<Arc<Self>>
+    where
+        Self: Sized,
+    {
+        Ok(Arc::new(Self::from_store(store.as_ref()).await?))
+    }
+
+    /// Remap the row ids, creating a new remapped version of this index in `dest_store`
+    async fn remap(
+        &self,
+        _mapping: &HashMap<u64, Option<u64>>,
+        _dest_store: &dyn IndexStore,
+    ) -> Result<()> {
+        todo!()
+    }
+
+    /// Add the new data into the index, creating an updated version of the index in `dest_store`
+    async fn update(
+        &self,
+        _new_data: SendableRecordBatchStream,
+        _dest_store: &dyn IndexStore,
+    ) -> Result<()> {
+        todo!()
+    }
+}
+
+pub struct NGramIndexBuilder {
+    tokenizer: TextAnalyzer,
+    tokens_map: HashMap<String, u32>,
+    tokens_counter: u32,
+    bitmaps: Vec<RoaringTreemap>,
+}
+
+impl Default for NGramIndexBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl NGramIndexBuilder {
+    pub fn new() -> Self {
+        let tokenizer = NGRAM_TOKENIZER.clone();
+        Self {
+            tokenizer,
+            // Default capacity loosely based on case insensitive ascii ngrams with punctuation stripped
+            tokens_map: HashMap::with_capacity(4 * 26 * 26 * 26),
+            bitmaps: Vec::with_capacity(4 * 26 * 26 * 26),
+            tokens_counter: 0,
+        }
+    }
+
+    fn validate_schema(schema: &Schema) -> Result<()> {
+        if schema.fields().len() != 2 {
+            return Err(Error::InvalidInput {
+                source: "Ngram index schema must have exactly two fields".into(),
+                location: location!(),
+            });
+        }
+        if *schema.field(0).data_type() != DataType::Utf8 {
+            return Err(Error::InvalidInput {
+                source: "First field in ngram index schema must be of type Utf8".into(),
+                location: location!(),
+            });
+        }
+        if *schema.field(1).data_type() != DataType::UInt64 {
+            return Err(Error::InvalidInput {
+                source: "Second field in ngram index schema must be of type UInt64".into(),
+                location: location!(),
+            });
+        }
+        Ok(())
+    }
+
+    fn process_batch(&mut self, batch: &RecordBatch) {
+        let text_col = batch.column(0).as_string::<i32>();
+        let row_id_col = batch.column(1).as_primitive::<UInt64Type>();
+        for (text, row_id) in text_col.iter().zip(row_id_col.values()) {
+            let text = text.unwrap();
+            let tokens = self.tokenizer.clone().tokenize(text);
+            for token in tokens {
+                let token_id = *self.tokens_map.entry(token).or_insert_with(|| {
+                    let token_id = self.tokens_counter;
+                    self.tokens_counter += 1;
+                    self.bitmaps.push(RoaringTreemap::new());
+                    token_id
+                });
+                self.bitmaps[token_id as usize].insert(*row_id);
+            }
+        }
+    }
+
+    pub async fn train(&mut self, mut data: SendableRecordBatchStream) -> Result<()> {
+        let schema = data.schema();
+        Self::validate_schema(schema.as_ref())?;
+
+        while let Some(batch) = data.try_next().await? {
+            self.process_batch(&batch);
+        }
+        Ok(())
+    }
+
+    pub async fn write(self, store: &dyn IndexStore) -> Result<()> {
+        let mut ordered_tokens = self.tokens_map.into_iter().collect::<Vec<_>>();
+        ordered_tokens.sort_by_key(|(_, id)| *id);
+        let tokens_array =
+            StringArray::from_iter_values(ordered_tokens.into_iter().map(|(t, _)| t));
+
+        let bitmap_array = BinaryArray::from_iter_values(self.bitmaps.into_iter().map(|bitmap| {
+            let mut buf = Vec::with_capacity(bitmap.serialized_size());
+            bitmap.serialize_into(&mut buf).unwrap();
+            buf
+        }));
+        let postings_batch = RecordBatch::try_new(
+            POSTINGS_SCHEMA.clone(),
+            vec![Arc::new(tokens_array), Arc::new(bitmap_array)],
+        )?;
+
+        let mut postings_writer = store
+            .new_index_file(POSTINGS_FILENAME, POSTINGS_SCHEMA.clone())
+            .await?;
+        postings_writer.write_record_batch(postings_batch).await?;
+        postings_writer.finish().await?;
+
+        Ok(())
+    }
+}
+
+pub async fn train_ngram_index(
+    data_source: Box<dyn TrainingSource + Send>,
+    index_store: &dyn IndexStore,
+) -> Result<()> {
+    let batches_source = data_source.scan_unordered_chunks(4096).await?;
+    let mut builder = NGramIndexBuilder::new();
+
+    builder.train(batches_source).await?;
+
+    builder.write(index_store).await
+}

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -47,7 +47,7 @@ lazy_static::lazy_static! {
 }
 
 // Helper function to apply a function to each token in a text
-fn tokenize_visitor(analyzer: &TextAnalyzer, text: &str, mut visitor: impl FnMut(&String) -> ()) {
+fn tokenize_visitor(analyzer: &TextAnalyzer, text: &str, mut visitor: impl FnMut(&String)) {
     // The token_stream method is mutable.  As far as I can tell this is to enforce exclusivity and not
     // true mutability.  For example, the object returned by `token_stream` has thread-local state but
     // it is reset each time `token_stream` is called.
@@ -76,7 +76,7 @@ struct NGramPostingList {
 
 impl DeepSizeOf for NGramPostingList {
     fn deep_size_of_children(&self, _: &mut deepsize::Context) -> usize {
-        self.bitmap.serialized_size() as usize
+        self.bitmap.serialized_size()
     }
 }
 
@@ -127,8 +127,7 @@ impl std::fmt::Debug for NGramPostingListReader {
 impl NGramPostingListReader {
     #[instrument(level = "debug", skip(self))]
     pub async fn ngram_list(&self, token_id: u32) -> Result<Arc<NGramPostingList>> {
-        Ok(self
-            .cache
+        self.cache
             .try_get_with(token_id, async move {
                 let batch = self
                     .reader
@@ -140,7 +139,7 @@ impl NGramPostingListReader {
                 Result::Ok(Arc::new(NGramPostingList::try_from_batch(batch)?))
             })
             .await
-            .map_err(|e| Error::io(e.to_string(), location!()))?)
+            .map_err(|e| Error::io(e.to_string(), location!()))
     }
 
     pub async fn load_all_lists(&self) -> Result<Vec<RoaringTreemap>> {

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
 use std::any::Any;
 use std::{collections::HashMap, sync::Arc};
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1732,7 +1732,7 @@ impl Scanner {
                 .empty_projection()
                 .union_columns(&columns, OnMissing::Error)?;
             let mut plan = if filter_plan.index_query.is_some() {
-                self.scalar_indexed_scan(vector_scan_projection, &filter_plan)
+                self.scalar_indexed_scan(vector_scan_projection, filter_plan)
                     .await?
             } else {
                 self.scan(
@@ -1917,7 +1917,7 @@ impl Scanner {
                 take_projection = take_projection.union_columns(filter_cols, OnMissing::Error)?;
             }
             if let Some(refine_expr) = refine_expr {
-                let refine_cols = Planner::column_names_in_expr(&refine_expr);
+                let refine_cols = Planner::column_names_in_expr(refine_expr);
                 take_projection = take_projection.union_columns(refine_cols, OnMissing::Error)?;
             }
             plan = self.take(plan, take_projection, self.batch_readahead)?;
@@ -2285,10 +2285,7 @@ impl Scanner {
                 // is a refine expression that needs to be applied to the results so we need to do a full
                 // filtered scan
                 let filtered_row_ids = self
-                    .scalar_indexed_scan(
-                        self.dataset.empty_projection().with_row_id(),
-                        &filter_plan,
-                    )
+                    .scalar_indexed_scan(self.dataset.empty_projection().with_row_id(), filter_plan)
                     .await?;
                 PreFilterSource::FilteredRowIds(filtered_row_ids)
             } // Should be index_scan -> filter

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1100,21 +1100,6 @@ impl Scanner {
         .boxed()
     }
 
-    /// Given a base schema and a list of desired fields figure out which fields, if any, still need loaded
-    fn calc_new_fields<S: AsRef<str>>(
-        &self,
-        base_schema: &Schema,
-        columns: &[S],
-    ) -> Result<Option<Schema>> {
-        let new_schema = self.dataset.schema().project(columns)?;
-        let new_schema = new_schema.exclude(base_schema)?;
-        if new_schema.fields.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(new_schema))
-        }
-    }
-
     // A "narrow" field is a field that is so small that we are better off reading the
     // entire column and filtering in memory rather than "take"ing the column.
     //
@@ -1156,31 +1141,20 @@ impl Scanner {
     // cheaper to read the entire column and filter in memory.
     //
     // Note: only add columns that we actually need to read
-    fn calc_eager_columns(
+    fn calc_eager_projection(
         &self,
         filter_plan: &FilterPlan,
         desired_schema: &Schema,
-    ) -> Result<Arc<Schema>> {
+    ) -> Result<Projection> {
         let filter_columns = filter_plan.refine_columns();
-        let early_schema = self
-            .dataset
+        self.dataset
             .empty_projection()
             // Start with the desired schema
             .union_schema(desired_schema)
             // Subtract columns that are expensive
             .subtract_predicate(|f| !self.is_early_field(f))
             // Add back columns that we need for filtering
-            .union_columns(filter_columns, OnMissing::Error)?
-            .into_schema_ref();
-
-        if early_schema.fields.iter().any(|f| !f.is_default_storage()) {
-            return Err(Error::NotSupported {
-                source: "non-default storage columns cannot be used as filters".into(),
-                location: location!(),
-            });
-        }
-
-        Ok(early_schema)
+            .union_columns(filter_columns, OnMissing::Error)
     }
 
     /// Create [`ExecutionPlan`] for Scan.
@@ -1363,40 +1337,46 @@ impl Scanner {
                 } else {
                     self.use_stats
                 };
-                match (&filter_plan.index_query, &mut filter_plan.refine_expr) {
-                    (Some(index_query), None) => {
-                        self.scalar_indexed_scan(
-                            self.projection_plan.physical_schema.as_ref(),
-                            index_query,
-                        )
-                        .await?
+                match (
+                    filter_plan.index_query.is_some(),
+                    filter_plan.refine_expr.is_some(),
+                ) {
+                    (true, false) => {
+                        let projection = self
+                            .dataset
+                            .empty_projection()
+                            .union_schema(&self.projection_plan.physical_schema);
+                        self.scalar_indexed_scan(projection, &filter_plan).await?
                     }
                     // TODO: support combined pushdown and scalar index scan
-                    (Some(index_query), Some(_)) => {
+                    (true, true) => {
                         // If there is a filter then just load the eager columns and
                         // "take" the other columns later.
-                        let eager_schema = self.calc_eager_columns(
+                        let eager_projection = self.calc_eager_projection(
                             &filter_plan,
                             self.projection_plan.physical_schema.as_ref(),
                         )?;
-                        self.scalar_indexed_scan(&eager_schema, index_query).await?
+                        self.scalar_indexed_scan(eager_projection, &filter_plan)
+                            .await?
                     }
-                    (None, Some(_)) if use_stats && self.batch_size.is_none() => {
+                    (false, true) if use_stats && self.batch_size.is_none() => {
                         self.pushdown_scan(false, filter_plan.refine_expr.take().unwrap())?
                     }
-                    (None, _) => {
+                    (false, _) => {
                         // The source is a full scan of the table
                         let with_row_id = filter_plan.has_refine() || self.with_row_id;
-                        let eager_schema = if filter_plan.has_refine() {
+                        let eager_projection = if filter_plan.has_refine() {
                             // If there is a filter then only load the filter columns in the
                             // initial scan.  We will `take` the remaining columns later
-                            self.calc_eager_columns(
+                            self.calc_eager_projection(
                                 &filter_plan,
                                 self.projection_plan.physical_schema.as_ref(),
                             )?
                         } else {
                             // If there is no filter we eagerly load everything
-                            self.projection_plan.physical_schema.clone()
+                            self.dataset
+                                .empty_projection()
+                                .union_schema(&self.projection_plan.physical_schema)
                         };
                         if scan_range.is_some() && !self.dataset.is_legacy_storage() {
                             // If this is a v2 dataset with no filter then we can pushdown
@@ -1409,7 +1389,7 @@ impl Scanner {
                             self.with_row_address,
                             false,
                             scan_range,
-                            eager_schema,
+                            eager_projection.into_schema_ref(),
                         )
                     }
                 }
@@ -1734,12 +1714,21 @@ impl Scanner {
             if let Some(refine_expr) = filter_plan.refine_expr.as_ref() {
                 columns.extend(Planner::column_names_in_expr(refine_expr));
             }
-            let vector_scan_projection = Arc::new(self.dataset.schema().project(&columns).unwrap());
-            let mut plan = if let Some(index_query) = &filter_plan.index_query {
-                self.scalar_indexed_scan(&vector_scan_projection, index_query)
+            let vector_scan_projection = self
+                .dataset
+                .empty_projection()
+                .union_columns(&columns, OnMissing::Error)?;
+            let mut plan = if filter_plan.index_query.is_some() {
+                self.scalar_indexed_scan(vector_scan_projection, &filter_plan)
                     .await?
             } else {
-                self.scan(true, false, true, None, vector_scan_projection)
+                self.scan(
+                    true,
+                    false,
+                    true,
+                    None,
+                    vector_scan_projection.into_schema_ref(),
+                )
             };
             if let Some(refine_expr) = &filter_plan.refine_expr {
                 let planner = Planner::new(plan.schema());
@@ -1864,8 +1853,8 @@ impl Scanner {
     // target fragments with those ids
     async fn scalar_indexed_scan(
         &self,
-        projection: &Schema,
-        index_expr: &ScalarIndexExpr,
+        projection: Projection,
+        filter_plan: &FilterPlan,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         // One or more scalar indices cover this data and there is a filter which is
         // compatible with the indices.  Use that filter to perform a take instead of
@@ -1875,6 +1864,12 @@ impl Scanner {
         } else {
             (**self.dataset.fragments()).clone()
         };
+
+        // If this unwrap fails we have a bug because we shouldn't be using this function unless we've already
+        // checked that there is an index query
+        let index_expr = filter_plan.index_query.as_ref().unwrap();
+
+        let needs_recheck = index_expr.needs_recheck();
 
         // Figure out which fragments are covered by ALL of the indices we are using
         let covered_frags = self.fragments_covered_by_index_query(index_expr).await?;
@@ -1894,15 +1889,43 @@ impl Scanner {
             Arc::new(relevant_frags),
         ));
 
-        // If there is more than just _rowid in projection
-        let needs_take = match projection.fields.len() {
-            0 => false,
-            1 => projection.fields[0].name != ROW_ID,
-            _ => true,
-        };
+        let refine_expr = filter_plan.refine_expr.as_ref();
+
+        // If all we want is the row ids then we can skip the take.  However, if there is a refine
+        // or a recheck then we still need to do a take because we need filter columns.
+        let needs_take =
+            needs_recheck || projection.has_data_fields() || filter_plan.refine_expr.is_some();
         if needs_take {
-            let take_projection = self.dataset.empty_projection().union_schema(projection);
+            let mut take_projection = projection.clone();
+            if needs_recheck {
+                // If we need to recheck then we need to also take the columns used for the filter
+                let filter_expr = index_expr.to_expr();
+                let filter_cols = Planner::column_names_in_expr(&filter_expr);
+                take_projection = take_projection.union_columns(filter_cols, OnMissing::Error)?;
+            }
+            if let Some(refine_expr) = refine_expr {
+                let refine_cols = Planner::column_names_in_expr(&refine_expr);
+                take_projection = take_projection.union_columns(refine_cols, OnMissing::Error)?;
+            }
             plan = self.take(plan, take_projection, self.batch_readahead)?;
+        }
+
+        let post_take_filter = match (needs_recheck, refine_expr) {
+            (false, None) => None,
+            (true, None) => {
+                // If we need to recheck then we need to apply the filter to the results
+                Some(index_expr.to_expr())
+            }
+            (true, Some(_)) => Some(filter_plan.full_expr.as_ref().unwrap().clone()),
+            (false, Some(refine_expr)) => Some(refine_expr.clone()),
+        };
+
+        if let Some(post_take_filter) = post_take_filter {
+            let planner = Planner::new(plan.schema());
+            let optimized_filter = planner.optimize_expr(post_take_filter)?;
+            let physical_refine_expr = planner.create_physical_expr(&optimized_filter)?;
+
+            plan = Arc::new(FilterExec::try_new(physical_refine_expr, plan)?);
         }
 
         if self.with_row_address {
@@ -1922,23 +1945,21 @@ impl Scanner {
             // If there were no extra columns then we still need the project
             // because Materialize -> Take puts the row id at the left and
             // Scan puts the row id at the right
-            let filter_expr = index_expr.to_expr();
-            let filter_cols = Planner::column_names_in_expr(&filter_expr);
-            let full_schema = self
-                .calc_new_fields(projection, &filter_cols)?
-                .map(|filter_only_schema| projection.merge(&filter_only_schema))
-                .transpose()?;
-            let schema = full_schema.as_ref().unwrap_or(projection);
+            let filter = filter_plan.full_expr.as_ref().unwrap();
+            let filter_cols = Planner::column_names_in_expr(filter);
+            let scan_projection = projection.union_columns(filter_cols, OnMissing::Error)?;
 
-            let planner = Planner::new(Arc::new(schema.into()));
-            let optimized_filter = planner.optimize_expr(filter_expr)?;
+            let scan_schema = scan_projection.into_schema_ref();
+            let scan_arrow_schema = Arc::new(scan_schema.as_ref().into());
+            let planner = Planner::new(scan_arrow_schema);
+            let optimized_filter = planner.optimize_expr(filter.clone())?;
             let physical_refine_expr = planner.create_physical_expr(&optimized_filter)?;
 
             let new_data_scan = self.scan_fragments(
                 true,
                 self.with_row_address,
                 false,
-                Arc::new(schema.clone()),
+                scan_schema,
                 missing_frags.into(),
                 // No pushdown of limit/offset when doing scalar indexed scan
                 None,
@@ -2244,23 +2265,21 @@ impl Scanner {
             &filter_plan.index_query,
             &filter_plan.refine_expr,
             self.prefilter,
+            filter_plan.skip_recheck,
         ) {
-            (Some(index_query), Some(refine_expr), _) => {
-                // The filter is only partially satisfied by the index.  We need
-                // to do an indexed scan and then refine the results to determine
-                // the row ids.
-                let columns_in_filter = Planner::column_names_in_expr(refine_expr);
-                let filter_schema = Arc::new(self.dataset.schema().project(&columns_in_filter)?);
-                let filter_input = self
-                    .scalar_indexed_scan(&filter_schema, index_query)
+            (Some(_), Some(_), _, _) | (Some(_), None, true, false) => {
+                // Prefilter source is covered by an index but either that index needs a recheck or there
+                // is a refine expression that needs to be applied to the results so we need to do a full
+                // filtered scan
+                let filtered_row_ids = self
+                    .scalar_indexed_scan(
+                        self.dataset.empty_projection().with_row_id(),
+                        &filter_plan,
+                    )
                     .await?;
-                let planner = Planner::new(filter_input.schema());
-                let physical_refine_expr = planner.create_physical_expr(refine_expr)?;
-                let filtered_row_ids =
-                    Arc::new(FilterExec::try_new(physical_refine_expr, filter_input)?);
                 PreFilterSource::FilteredRowIds(filtered_row_ids)
             } // Should be index_scan -> filter
-            (Some(index_query), None, true) => {
+            (Some(index_query), None, true, true) => {
                 // Index scan doesn't honor the fragment allowlist today.
                 // TODO: we could filter the index scan results to only include the allowed fragments.
                 self.ensure_not_fragment_scan()?;
@@ -2274,7 +2293,7 @@ impl Scanner {
                 ));
                 PreFilterSource::ScalarIndexQuery(index_query)
             }
-            (None, Some(refine_expr), true) => {
+            (None, Some(refine_expr), true, _) => {
                 // No indices match the filter.  We need to do a full scan
                 // of the filter columns to determine the valid row ids.
                 let columns_in_filter = Planner::column_names_in_expr(refine_expr);
@@ -2287,8 +2306,8 @@ impl Scanner {
                 PreFilterSource::FilteredRowIds(filtered_row_ids)
             }
             // No prefilter
-            (None, None, true) => PreFilterSource::None,
-            (_, _, false) => PreFilterSource::None,
+            (None, None, true, _) => PreFilterSource::None,
+            (_, _, false, _) => PreFilterSource::None,
         };
 
         Ok(prefilter_source)
@@ -4655,6 +4674,83 @@ mod test {
         .unwrap();
     }
 
+    #[tokio::test]
+    async fn test_inexact_scalar_index_plans() {
+        let data = gen()
+            .col("ngram", array::rand_utf8(ByteCount::from(5), false))
+            .col("exact", array::rand_type(&DataType::UInt32))
+            .col("no_index", array::rand_type(&DataType::UInt32))
+            .into_reader_rows(RowCount::from(1000), BatchCount::from(5));
+
+        let mut dataset = Dataset::write(data, "memory://test", None).await.unwrap();
+        dataset
+            .create_index(
+                &["ngram"],
+                IndexType::NGram,
+                None,
+                &ScalarIndexParams::default(),
+                true,
+            )
+            .await
+            .unwrap();
+        dataset
+            .create_index(
+                &["exact"],
+                IndexType::BTree,
+                None,
+                &ScalarIndexParams::default(),
+                true,
+            )
+            .await
+            .unwrap();
+
+        // Simple in-exact filter
+        assert_plan_equals(
+            &dataset,
+            |scanner| scanner.filter("contains(ngram, 'test string')"),
+            "ProjectionExec: expr=[ngram@1 as ngram, exact@2 as exact, no_index@3 as no_index]
+  FilterExec: contains(ngram@1, test string)
+    Take: columns=\"_rowid, (ngram), (exact), (no_index)\"
+      CoalesceBatchesExec: target_batch_size=8192
+        MaterializeIndex: query=contains(ngram, Utf8(\"test string\"))",
+        )
+        .await
+        .unwrap();
+
+        // Combined with exact filter
+        //
+        // TODO: The FilterExec _should_ be just contains(ngram, 'test string')
+        assert_plan_equals(
+            &dataset,
+            |scanner| scanner.filter("contains(ngram, 'test string') and exact < 50"),
+            "ProjectionExec: expr=[ngram@1 as ngram, exact@2 as exact, no_index@3 as no_index]
+  FilterExec: contains(ngram@1, test string) AND exact@2 < 50
+    Take: columns=\"_rowid, (ngram), (exact), (no_index)\"
+      CoalesceBatchesExec: target_batch_size=8192
+        MaterializeIndex: query=AND(contains(ngram, Utf8(\"test string\")),exact < 50)",
+        )
+        .await
+        .unwrap();
+
+        // All three filters
+        //
+        // TODO: Maybe an optimizer rule to combine the filters?  Not a big deal
+        assert_plan_equals(
+            &dataset,
+            |scanner| {
+                scanner.filter("contains(ngram, 'test string') and exact < 50 AND no_index > 100")
+            },
+            "ProjectionExec: expr=[ngram@1 as ngram, exact@2 as exact, no_index@3 as no_index]
+  FilterExec: no_index@3 > 100
+    FilterExec: contains(ngram@1, test string) AND exact@2 < 50 AND no_index@3 > 100
+      Take: columns=\"_rowid, (ngram), (exact), (no_index)\"
+        CoalesceBatchesExec: target_batch_size=8192
+          MaterializeIndex: query=AND(contains(ngram, Utf8(\"test string\")),exact < 50)",
+        )
+        .await
+        .unwrap();
+    }
+
     #[rstest]
     #[tokio::test]
     async fn test_late_materialization(
@@ -5312,9 +5408,9 @@ mod test {
       Take: columns=\"_rowid, (s)\"
         CoalesceBatchesExec: target_batch_size=8192
           MaterializeIndex: query=i > 10
-      ProjectionExec: expr=[_rowid@2 as _rowid, s@0 as s]
-        FilterExec: i@1 > 10
-          LanceScan: uri=..., projection=[s, i], row_id=true, row_addr=false, ordered=false",
+      ProjectionExec: expr=[_rowid@2 as _rowid, s@1 as s]
+        FilterExec: i@0 > 10
+          LanceScan: uri=..., projection=[i, s], row_id=true, row_addr=false, ordered=false",
         )
         .await?;
 
@@ -5372,9 +5468,9 @@ mod test {
         Take: columns=\"_rowid, (s)\"
           CoalesceBatchesExec: target_batch_size=8192
             MaterializeIndex: query=i > 10
-        ProjectionExec: expr=[_rowid@2 as _rowid, s@0 as s]
-          FilterExec: i@1 > 10
-            LanceScan: uri=..., projection=[s, i], row_id=true, row_addr=false, ordered=false",
+        ProjectionExec: expr=[_rowid@2 as _rowid, s@1 as s]
+          FilterExec: i@0 > 10
+            LanceScan: uri=..., projection=[i, s], row_id=true, row_addr=false, ordered=false",
         )
         .await?;
 

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -21,6 +21,7 @@ use lance_index::optimize::OptimizeOptions;
 use lance_index::pb::index::Implementation;
 use lance_index::scalar::expression::{
     IndexInformationProvider, LabelListQueryParser, SargableQueryParser, ScalarQueryParser,
+    TextQueryParser,
 };
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::{InvertedIndexParams, ScalarIndex, ScalarIndexType};
@@ -239,7 +240,11 @@ impl DatasetIndexExt for Dataset {
         let index_id = Uuid::new_v4();
         let index_details: prost_types::Any = match (index_type, params.index_name()) {
             (
-                IndexType::Bitmap | IndexType::BTree | IndexType::Inverted | IndexType::LabelList,
+                IndexType::Bitmap
+                | IndexType::BTree
+                | IndexType::Inverted
+                | IndexType::NGram
+                | IndexType::LabelList,
                 LANCE_SCALAR_INDEX,
             ) => {
                 let params = ScalarIndexParams::new(index_type.try_into()?);
@@ -989,7 +994,15 @@ impl DatasetIndexInternalExt for Dataset {
                     if matches!(index_type, ScalarIndexType::Inverted) {
                         continue;
                     }
-                    Box::<SargableQueryParser>::default() as Box<dyn ScalarQueryParser>
+                    match index_type {
+                        ScalarIndexType::BTree | ScalarIndexType::Bitmap => {
+                            Box::<SargableQueryParser>::default() as Box<dyn ScalarQueryParser>
+                        }
+                        ScalarIndexType::NGram => {
+                            Box::<TextQueryParser>::default() as Box<dyn ScalarQueryParser>
+                        }
+                        _ => continue,
+                    }
                 }
                 _ => Box::<SargableQueryParser>::default() as Box<dyn ScalarQueryParser>,
             };

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -12,6 +12,7 @@ use datafusion::physical_plan::SendableRecordBatchStream;
 use lance_core::{Error, Result};
 use lance_datafusion::{chunker::chunk_concat_stream, exec::LanceExecutionOptions};
 use lance_index::scalar::btree::DEFAULT_BTREE_BATCH_SIZE;
+use lance_index::scalar::ngram::{train_ngram_index, NGramIndex};
 use lance_index::scalar::InvertedIndexParams;
 use lance_index::scalar::{
     bitmap::{train_bitmap_index, BitmapIndex, BITMAP_LOOKUP_NAME},
@@ -125,6 +126,11 @@ fn label_list_index_details() -> prost_types::Any {
     prost_types::Any::from_msg(&details).unwrap()
 }
 
+fn ngram_index_details() -> prost_types::Any {
+    let details = lance_table::format::pb::NGramIndexDetails {};
+    prost_types::Any::from_msg(&details).unwrap()
+}
+
 pub(super) fn inverted_index_details() -> prost_types::Any {
     let details = lance_table::format::pb::InvertedIndexDetails::default();
     prost_types::Any::from_msg(&details).unwrap()
@@ -154,6 +160,12 @@ impl ScalarIndexDetails for lance_table::format::pb::InvertedIndexDetails {
     }
 }
 
+impl ScalarIndexDetails for lance_table::format::pb::NGramIndexDetails {
+    fn get_type(&self) -> ScalarIndexType {
+        ScalarIndexType::NGram
+    }
+}
+
 fn get_scalar_index_details(
     details: &prost_types::Any,
 ) -> Result<Option<Box<dyn ScalarIndexDetails>>> {
@@ -172,6 +184,10 @@ fn get_scalar_index_details(
     } else if details.type_url.ends_with("InvertedIndexDetails") {
         Ok(Some(Box::new(
             details.to_msg::<lance_table::format::pb::InvertedIndexDetails>()?,
+        )))
+    } else if details.type_url.ends_with("NGramIndexDetails") {
+        Ok(Some(Box::new(
+            details.to_msg::<lance_table::format::pb::NGramIndexDetails>()?,
         )))
     } else {
         Ok(None)
@@ -242,6 +258,16 @@ pub(super) async fn build_scalar_index(
             .await?;
             Ok(inverted_index_details())
         }
+        Some(ScalarIndexType::NGram) => {
+            if field.data_type() != DataType::Utf8 {
+                return Err(Error::InvalidInput {
+                    source: "NGram index can only be created on Utf8 type columns".into(),
+                    location: location!(),
+                });
+            }
+            train_ngram_index(training_request, &index_store).await?;
+            Ok(ngram_index_details())
+        }
         _ => {
             let flat_index_trainer = FlatIndexMetadata::new(field.data_type());
             train_btree_index(
@@ -292,6 +318,10 @@ pub async fn open_scalar_index(
         ScalarIndexType::Inverted => {
             let inverted_index = InvertedIndex::load(index_store).await?;
             Ok(inverted_index as Arc<dyn ScalarIndex>)
+        }
+        ScalarIndexType::NGram => {
+            let ngram_index = NGramIndex::load(index_store).await?;
+            Ok(ngram_index as Arc<dyn ScalarIndex>)
         }
         ScalarIndexType::BTree => {
             let btree_index = BTreeIndex::load(index_store).await?;


### PR DESCRIPTION
Ngram indices are indices that can speed up various string filters.  To start with they will be able to speed up `contains(col, 'substr')` filters.  They work by creating a bitmap for each ngram (short sequence of characters) in a value.  For example, consider an index of 1-grams.  This would create a bitmap for each letter of the alphabet.  Then, at query time, we can use this to narrow down which strings could potentially satisfy the query.

This is the first scalar index that requires a "recheck" step.  It doesn't tell us exactly which rows satisfy the query.  It only narrows down the list.  Other indices that might behave like this are bloom filters and zone maps.  This means that we need to still apply the filter on the results of the index search.  A good portion of this PR is adding support for this concept into the scanner.