### PR TITLE
fix: scalar quantization can't work with NaNs

### DIFF
--- a/rust/lance-index/src/vector/sq.rs
+++ b/rust/lance-index/src/vector/sq.rs
@@ -233,19 +233,17 @@ impl Quantization for ScalarQuantizer {
 }
 
 pub(crate) fn scale_to_u8<T: ArrowFloatType>(values: &[T::Native], bounds: &Range<f64>) -> Vec<u8> {
+    if bounds.start == bounds.end {
+        return vec![0; values.len()];
+    }
+
     let range = bounds.end - bounds.start;
     values
         .iter()
         .map(|&v| {
             let v = v.to_f64().unwrap();
-            match v {
-                v if v < bounds.start => 0,
-                v if v > bounds.end => 255,
-                _ => ((v - bounds.start) * f64::from_u32(255).unwrap() / range)
-                    .round()
-                    .to_u8()
-                    .unwrap(),
-            }
+            let v = ((v - bounds.start) * 255.0 / range).round();
+            v as u8 // rust `as` performs saturating cast when casting float to int, so it's safe and expected here
         })
         .collect_vec()
 }

--- a/rust/lance-index/src/vector/sq.rs
+++ b/rust/lance-index/src/vector/sq.rs
@@ -88,7 +88,7 @@ impl ScalarQuantizer {
             .as_slice();
 
         self.bounds = data.iter().fold(self.bounds.clone(), |f, v| {
-            f.start.min(v.to_f64().unwrap())..f.end.max(v.to_f64().unwrap())
+            f.start.min(v.as_())..f.end.max(v.as_())
         });
 
         Ok(self.bounds.clone())
@@ -347,5 +347,16 @@ mod tests {
         sq_values.values().iter().enumerate().for_each(|(i, v)| {
             assert_eq!(*v, (i * 17) as u8,);
         });
+    }
+
+    #[tokio::test]
+    async fn test_scale_to_u8_with_nan() {
+        let values = vec![0.0, 1.0, 2.0, 3.0, f64::NAN];
+        let bounds = Range::<f64> {
+            start: 0.0,
+            end: 3.0,
+        };
+        let u8_values = scale_to_u8::<Float64Type>(&values, &bounds);
+        assert_eq!(u8_values, vec![0, 85, 170, 255, 0]);
     }
 }


### PR DESCRIPTION
Address potential out-of-range issues when scaling values to `u8` in the `ScalarQuantizer`. Introduce a test case to handle NaN values in the scaling function.