### PR TITLE
docs: fix typo in read_and_write.rst

### DIFF
--- a/docs/read_and_write.rst
+++ b/docs/read_and_write.rst
@@ -300,7 +300,7 @@ at the cost of lower precision:
     })
     dataset = lance.write_dataset(table, "embeddings")
     dataset.alter_columns({"path": "embedding",
-                           "type": pa.list_(pa.float16(), 128)})
+                           "data_type": pa.list_(pa.float16(), 128)})
     dataset.schema()
 
 .. testoutput::


### PR DESCRIPTION
Correct minor typo in docs around using `alter_columns` to type cast. According to https://github.com/lancedb/lance/commit/45c158dd56888501458a6dd7783f85a3367ad1b5 `type` should be `data_type`.