### PR TITLE
chore: update clippy suggestions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,15 +1188,15 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-link",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7277,12 +7277,6 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,15 +1188,15 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -7277,6 +7277,12 @@ checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "windows-link"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ byteorder = "1.5"
 clap = { version = "4", features = ["derive"] }
 # Version temporarily pinned to work around unlabeled breaking change
 # https://github.com/apache/arrow-rs/commit/2fddf85afcd20110ce783ed5b4cdeb82293da30b
-chrono = { version = "0.4.39", default-features = false, features = [
+chrono = { version = "=0.4.39", default-features = false, features = [
     "std",
     "now",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,9 @@ bitvec = "1"
 bytes = "1.4"
 byteorder = "1.5"
 clap = { version = "4", features = ["derive"] }
-chrono = { version = "0.4.25", default-features = false, features = [
+# Version temporarily pinned to work around unlabeled breaking change
+# https://github.com/apache/arrow-rs/commit/2fddf85afcd20110ce783ed5b4cdeb82293da30b
+chrono = { version = "0.4.39", default-features = false, features = [
     "std",
     "now",
 ] }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1062,9 +1062,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -4372,7 +4372,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -4392,7 +4392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -4425,7 +4425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -4438,7 +4438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -18,6 +18,10 @@
 //! automatic versioning, optimized for computer vision, bioinformatics, spatial and ML data.
 //! [Apache Arrow](https://arrow.apache.org/) and DuckDB compatible.
 
+// Workaround for https://github.com/rust-lang/rust-clippy/issues/12039
+// Remove after upgrading pyo3 to 0.23
+#![allow(clippy::useless_conversion)]
+
 use std::env;
 use std::sync::Arc;
 

--- a/python/src/scanner.rs
+++ b/python/src/scanner.rs
@@ -72,9 +72,10 @@ impl Scanner {
     fn analyze_plan(self_: PyRef<'_, Self>) -> PyResult<String> {
         let scanner = self_.scanner.clone();
         let res = RT
-            .spawn(Some(self_.py()), async move {
-                scanner.analyze_plan().await
-            })?
+            .spawn(
+                Some(self_.py()),
+                async move { scanner.analyze_plan().await },
+            )?
             .map_err(|err| PyValueError::new_err(err.to_string()))?;
 
         Ok(res)

--- a/rust/lance-core/src/utils/mask.rs
+++ b/rust/lance-core/src/utils/mask.rs
@@ -518,7 +518,8 @@ impl RowIdTreeMap {
     ///   * u32: fragment_id
     ///   * u32: bitmap size
     ///   * \[u8\]: bitmap
-    ///     If bitmap size is zero then the entire fragment is selected.
+    ///
+    /// If bitmap size is zero then the entire fragment is selected.
     pub fn serialize_into<W: Write>(&self, mut writer: W) -> Result<()> {
         writer.write_u32::<byteorder::LittleEndian>(self.inner.len() as u32)?;
         for (fragment, set) in &self.inner {

--- a/rust/lance-datafusion/src/planner.rs
+++ b/rust/lance-datafusion/src/planner.rs
@@ -816,7 +816,7 @@ impl Planner {
         for i in (start_idx..hex_bytes.len()).step_by(2) {
             let high = Self::try_decode_hex_char(hex_bytes[i])?;
             let low = Self::try_decode_hex_char(hex_bytes[i + 1])?;
-            decoded_bytes.push(high << 4 | low);
+            decoded_bytes.push((high << 4) | low);
         }
 
         Some(decoded_bytes)

--- a/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
+++ b/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
@@ -38,7 +38,7 @@ const FSST_HASH_PRIME: u64 = 2971215073;
 const FSST_SHIFT: usize = 15;
 #[inline]
 fn fsst_hash(w: u64) -> u64 {
-    w.wrapping_mul(FSST_HASH_PRIME) ^ (w.wrapping_mul(FSST_HASH_PRIME)) >> FSST_SHIFT
+    w.wrapping_mul(FSST_HASH_PRIME) ^ ((w.wrapping_mul(FSST_HASH_PRIME)) >> FSST_SHIFT)
 }
 
 const MAX_SYMBOL_LENGTH: usize = 8;
@@ -119,7 +119,7 @@ impl Symbol {
         Self {
             val: c as u64,
             // in a symbol which represents a single character, 56 bits(7 bytes) are ignored, code length is 1
-            icl: (1 << CODE_LEN_SHIFT_IN_ICL) | (code as u64) << CODE_SHIFT_IN_ICL | 56,
+            icl: (1 << CODE_LEN_SHIFT_IN_ICL) | ((code as u64) << CODE_SHIFT_IN_ICL) | 56,
         }
     }
 
@@ -368,7 +368,7 @@ impl SymbolTable {
             return self.byte_codes[input[0] as usize] & FSST_CODE_MASK;
         }
         if len == 2 {
-            let short_code = (input[1] as usize) << 8 | input[0] as usize;
+            let short_code = ((input[1] as usize) << 8) | input[0] as usize;
             if self.short_codes[short_code] >= FSST_CODE_BASE {
                 return self.short_codes[short_code] & FSST_CODE_MASK;
             } else {
@@ -1053,9 +1053,9 @@ impl FsstEncoder {
         let st = &self.symbol_table;
 
         let st_info: u64 = FSST_MAGIC
-            | (self.encoder_switch as u64) << 24
-            | ((st.suffix_lim & 255) as u64) << 16
-            | ((st.terminator & 255) as u64) << 8
+            | ((self.encoder_switch as u64) << 24)
+            | (((st.suffix_lim & 255) as u64) << 16)
+            | (((st.terminator & 255) as u64) << 8)
             | ((st.n_symbols & 255) as u64);
 
         let st_info_bytes = st_info.to_ne_bytes();


### PR DESCRIPTION
Some new suggestions were adding in 1.85 and they are tripping up CI builds

We need to temporarily ignore `useless_conversion` until we're able to upgrade arrow due to https://github.com/rust-lang/rust-clippy/issues/12039

We need to temporarily pin `chrono` until we're able to upgrade arrow due to https://github.com/chronotope/chrono/pull/1666