### PR TITLE
perf: parallelize ngram indexing

### DIFF
--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -58,18 +58,24 @@ fn bench_ngram(c: &mut Criterion) {
         vec![doc_col, row_id_col],
     )
     .unwrap();
-    let stream =
-        RecordBatchStreamAdapter::new(batch.schema(), stream::iter(vec![Ok(batch.clone())]));
-    let stream = Box::pin(stream);
 
-    rt.block_on(async {
-        let mut builder = NGramIndexBuilder::default();
-        builder.train(stream).await.unwrap();
-        builder.write(store.as_ref()).await.unwrap();
+    let batches = (0..1000).map(|i| batch.slice(i * 1000, 1000)).collect_vec();
+
+    c.bench_function(format!("ngram_index({TOTAL})").as_str(), |b| {
+        b.to_async(&rt).iter(|| async {
+            let stream = RecordBatchStreamAdapter::new(
+                batch.schema(),
+                stream::iter(batches.clone().into_iter().map(|b| Ok(b))),
+            );
+            let stream = Box::pin(stream);
+            let mut builder = NGramIndexBuilder::default();
+            builder.train(stream).await.unwrap();
+            builder.write(store.as_ref()).await.unwrap();
+        })
     });
-    let index = rt.block_on(NGramIndex::load(store)).unwrap();
 
-    c.bench_function(format!("invert({TOTAL})").as_str(), |b| {
+    let index = rt.block_on(NGramIndex::load(store)).unwrap();
+    c.bench_function(format!("ngram_search({TOTAL})").as_str(), |b| {
         b.to_async(&rt).iter(|| async {
             let sample_idx = rand::random::<usize>() % batch.num_rows();
             let sample = batch

--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -65,7 +65,7 @@ fn bench_ngram(c: &mut Criterion) {
         b.to_async(&rt).iter(|| async {
             let stream = RecordBatchStreamAdapter::new(
                 batch.schema(),
-                stream::iter(batches.clone().into_iter().map(|b| Ok(b))),
+                stream::iter(batches.clone().into_iter().map(Ok)),
             );
             let stream = Box::pin(stream);
             let mut builder = NGramIndexBuilder::default();

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-mod builder;
+pub mod builder;
 mod index;
 mod tokenizer;
 mod wand;

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -53,7 +53,7 @@ lazy_static! {
     // it doesn't mean higher value will result in better performance,
     // because the bottleneck can be the IO once the number of shards is large enough,
     // it's 8 by default
-    static ref LANCE_FTS_NUM_SHARDS: usize = std::env::var("LANCE_FTS_NUM_SHARDS")
+    pub static ref LANCE_FTS_NUM_SHARDS: usize = std::env::var("LANCE_FTS_NUM_SHARDS")
         .unwrap_or_else(|_| "8".to_string())
         .parse()
         .expect("failed to parse LANCE_FTS_NUM_SHARDS");

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -13,7 +13,6 @@ use datafusion::execution::SendableRecordBatchStream;
 use deepsize::DeepSizeOf;
 use futures::{StreamExt, TryStreamExt};
 use lance_core::utils::address::RowAddress;
-use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use lance_core::Result;
 use lance_core::{utils::mask::RowIdTreeMap, Error};
 use moka::future::Cache;

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -468,14 +468,10 @@ impl NGramIndexBuilder {
         Self::validate_schema(schema.as_ref())?;
 
         let num_shards = *LANCE_FTS_NUM_SHARDS;
-        let buffer_size = get_num_compute_intensive_cpus()
-            .saturating_sub(num_shards)
-            .max(1)
-            .min(num_shards);
         let mut senders = Vec::with_capacity(num_shards);
         let mut builders = Vec::with_capacity(num_shards);
         for _ in 0..*LANCE_FTS_NUM_SHARDS {
-            let (send, mut recv) = tokio::sync::mpsc::channel(buffer_size);
+            let (send, mut recv) = tokio::sync::mpsc::channel(2);
             senders.push(send);
 
             let mut builder = Self::new();


### PR DESCRIPTION
total indexing time reduced from 23s to 5s
```
ngram_index(1000000)    time:   [5.1192 s 5.1756 s 5.2319 s]
                        change: [-78.163% -77.791% -77.410%] (p = 0.00 < 0.05)
                        Performance has improved.
```