### PR TITLE
feat: add gcp token-based auth support

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -22,7 +22,7 @@ use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use object_store::aws::{
     AmazonS3ConfigKey, AwsCredential as ObjectStoreAwsCredential, AwsCredentialProvider,
 };
-use object_store::gcp::{GoogleCloudStorageBuilder, GcpCredential};
+use object_store::gcp::{GcpCredential, GoogleCloudStorageBuilder};
 use object_store::{
     aws::AmazonS3Builder, azure::AzureConfigKey, gcp::GoogleConfigKey, local::LocalFileSystem,
     memory::InMemory, CredentialProvider, Error as ObjectStoreError, Result as ObjectStoreResult,
@@ -938,9 +938,10 @@ async fn configure_store(
             }
             let token_key = "google_storage_token";
             if let Some(storage_token) = storage_options.get(token_key) {
-                let credential = GcpCredential { bearer: storage_token.to_string() };
-                let credential_provider =
-                    Arc::new(StaticCredentialProvider::new(credential)) as _;
+                let credential = GcpCredential {
+                    bearer: storage_token.to_string(),
+                };
+                let credential_provider = Arc::new(StaticCredentialProvider::new(credential)) as _;
                 builder = builder.with_credentials(credential_provider);
             }
             let store = builder.build()?;

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -22,7 +22,7 @@ use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use object_store::aws::{
     AmazonS3ConfigKey, AwsCredential as ObjectStoreAwsCredential, AwsCredentialProvider,
 };
-use object_store::gcp::GoogleCloudStorageBuilder;
+use object_store::gcp::{GoogleCloudStorageBuilder, GcpCredential};
 use object_store::{
     aws::AmazonS3Builder, azure::AzureConfigKey, gcp::GoogleConfigKey, local::LocalFileSystem,
     memory::InMemory, CredentialProvider, Error as ObjectStoreError, Result as ObjectStoreResult,
@@ -840,6 +840,10 @@ impl StorageOptions {
             })
             .collect()
     }
+
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.0.get(key)
+    }
 }
 
 impl From<HashMap<String, String>> for StorageOptions {
@@ -931,6 +935,13 @@ async fn configure_store(
             let mut builder = GoogleCloudStorageBuilder::new().with_url(url.as_ref());
             for (key, value) in storage_options.as_gcs_options() {
                 builder = builder.with_config(key, value);
+            }
+            let token_key = "google_storage_token";
+            if let Some(storage_token) = storage_options.get(token_key) {
+                let credential = GcpCredential { bearer: storage_token.to_string() };
+                let credential_provider =
+                    Arc::new(StaticCredentialProvider::new(credential)) as _;
+                builder = builder.with_credentials(credential_provider);
             }
             let store = builder.build()?;
             let store = Arc::new(store).traced();


### PR DESCRIPTION
Allow support of connecting to GCP with storage tokens instead of service key JSON or serialized key using object_store's [with_credentials](https://docs.rs/object_store/latest/object_store/gcp/struct.GoogleCloudStorageBuilder.html#method.with_credentials).

Tested and created dataset in GCP:
<img width="1466" alt="Screenshot 2025-03-05 at 6 24 40 PM" src="https://github.com/user-attachments/assets/6721d749-fd21-4b72-bd64-db014d04c82c" />
through notebook:
<img width="283" alt="Screenshot 2025-03-05 at 6 42 39 PM" src="https://github.com/user-attachments/assets/5bce3cc2-949b-471a-bf30-2d1ddc268458" />