### PR TITLE
feat: emit a trace event when a significant user file is created or deleted

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -6070,6 +6070,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -56,7 +56,7 @@ serde_yaml = "0.9.34"
 snafu = "0.8"
 tracing-chrome = "0.7.1"
 tracing-subscriber = "0.3.17"
-tracing = "0.1.37"
+tracing = { version = "0.1", features = ["log"] }
 url = "2.5.0"
 bytes = "1.4"
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -46,6 +46,7 @@ use file::{
 };
 use futures::StreamExt;
 use lance_index::DatasetIndexExt;
+use log::LevelFilter;
 use pyo3::exceptions::{PyIOError, PyValueError};
 use pyo3::prelude::*;
 use session::Session;
@@ -110,7 +111,9 @@ fn lance(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     let env = Env::new()
         .filter_or("LANCE_LOG", "warn")
         .write_style("LANCE_LOG_STYLE");
-    env_logger::init_from_env(env);
+    let mut log_builder = env_logger::Builder::from_env(env);
+    log_builder.filter_module("tracing::span", LevelFilter::Off);
+    log_builder.try_init().unwrap();
 
     m.add_class::<Scanner>()?;
     m.add_class::<Dataset>()?;

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -43,7 +43,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ops::Range;
 use std::pin::Pin;
 use std::sync::Arc;
-use tracing::instrument;
+use tracing::{info, instrument};
 
 mod blob;
 pub mod builder;
@@ -1703,6 +1703,7 @@ fn write_manifest_file_to_path<'a>(
             .await?;
         let size = object_writer.tell().await? as u64;
         object_writer.shutdown().await?;
+        info!(target: "file_audit", mode="create", type="manifest", path = path.to_string());
         Ok(size)
     })
 }


### PR DESCRIPTION
Data files, deletion files, and manifest files are significant user files that cannot easily be recovered or recreated (unlike indices or transactions)

We should log when these are created and deleted to help provide some minimum debugging and audit tracking.  This isn't a complete audit system, we aren't capturing the user responsible, etc. (at this level we don't know these things) but it can be integrated into a larger monitoring system to detect user events.  Also, it can help debug bugs like https://github.com/lancedb/lancedb/issues/2193 where files aren't there and we need to distinguish between "file was never created" and "file was removed".