### PR TITLE
fix: pass down correct types when creating indices and items scheduler

### DIFF
--- a/rust/lance-encoding/src/encodings/physical.rs
+++ b/rust/lance-encoding/src/encodings/physical.rs
@@ -247,14 +247,22 @@ pub fn decoder_from_array_encoding(
             let items_encoding = dictionary.items.as_ref().unwrap();
             let num_dictionary_items = dictionary.num_dictionary_items;
 
-            let DataType::Dictionary(key_type, value_type) = data_type else {
-                panic!("Dictionary encoding must be applied to a dictionary type")
+            // We can get here in 2 ways.  The data is dictionary encoded and the user wants a dictionary or
+            // the data is dictionary encoded, as an optimization, and the user wants the value type.  Figure
+            // out the value type.
+            let value_type = if let DataType::Dictionary(_, value_type) = data_type {
+                value_type
+            } else {
+                data_type
             };
 
+            // Note: we don't actually know the indices type here, passing down `data_type` works ok because
+            // the dictionary indices are always integers and we don't need the data_type to figure out how
+            // to decode integers.
             let indices_scheduler =
-                decoder_from_array_encoding(indices_encoding, buffers, key_type.as_ref());
-            let items_scheduler =
-                decoder_from_array_encoding(items_encoding, buffers, value_type.as_ref());
+                decoder_from_array_encoding(indices_encoding, buffers, data_type);
+
+            let items_scheduler = decoder_from_array_encoding(items_encoding, buffers, value_type);
 
             let should_decode_dict = !data_type.is_dictionary();
 

--- a/rust/lance-encoding/src/encodings/physical.rs
+++ b/rust/lance-encoding/src/encodings/physical.rs
@@ -247,9 +247,14 @@ pub fn decoder_from_array_encoding(
             let items_encoding = dictionary.items.as_ref().unwrap();
             let num_dictionary_items = dictionary.num_dictionary_items;
 
+            let DataType::Dictionary(key_type, value_type) = data_type else {
+                panic!("Dictionary encoding must be applied to a dictionary type")
+            };
+
             let indices_scheduler =
-                decoder_from_array_encoding(indices_encoding, buffers, data_type);
-            let items_scheduler = decoder_from_array_encoding(items_encoding, buffers, data_type);
+                decoder_from_array_encoding(indices_encoding, buffers, key_type.as_ref());
+            let items_scheduler =
+                decoder_from_array_encoding(items_encoding, buffers, value_type.as_ref());
 
             let should_decode_dict = !data_type.is_dictionary();
 


### PR DESCRIPTION
When decoding something like `List<Dictionary<UInt8, LargeList>>` we were not correctly passing down the `LargeList` portion.  This caused decoding to fail later.

This will fix https://github.com/lancedb/lancedb/issues/2154