### PR TITLE
chore: add RUSTSEC-2024-0436 to ignore list for cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -82,6 +82,7 @@ ignore = [
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2021-0153", reason = "`encoding` is used by lindera" },
     { id = "RUSTSEC-2024-0384", reason = "`instant` is used by tantivy" },
+    { id = "RUSTSEC-2024-0436", reason = "`paste` is used by datafusion" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -136,8 +137,8 @@ expression = "MIT AND ISC AND OpenSSL"
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
 license-files = [
-# Each entry is a crate relative path, and the (opaque) hash of its contents
-{ path = "LICENSE", hash = 0xbd0eed23 }
+    # Each entry is a crate relative path, and the (opaque) hash of its contents
+    { path = "LICENSE", hash = 0xbd0eed23 },
 ]
 
 [licenses.private]


### PR DESCRIPTION
`paste` is a library that helps combine strings when building proc macros.  It is used in several datafusion crates as well as in our own creates (we brought it over when we vendored bitpacking).

RUSTSEC-2024-0436 reports that paste is unmaintained

However, it appears the main reason is simply that `paste` is more or less a "finished" library.  It is one of the 200 most downloaded rust libraries (it is somewhat ubiquitous when building proc macros) and it seems likely that someone will step up and fix any security issues that are detected.

This seems an acceptable risk to ignore this advisory.