### PR TITLE
feat: set object store retry via environment variables

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,7 +113,7 @@ jobs:
           fail_ci_if_error: false
   linux-arm:
     runs-on: ubuntu-2404-4x-arm64
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -28,10 +28,8 @@ use object_store::{
     aws::AmazonS3Builder, azure::AzureConfigKey, gcp::GoogleConfigKey, local::LocalFileSystem,
     memory::InMemory, CredentialProvider, Error as ObjectStoreError, Result as ObjectStoreResult,
 };
-use object_store::{
-    parse_url_opts, ClientOptions, DynObjectStore, RetryConfig, StaticCredentialProvider,
-};
 use object_store::{path::Path, ObjectMeta, ObjectStore as OSObjectStore};
+use object_store::{ClientOptions, DynObjectStore, RetryConfig, StaticCredentialProvider};
 use shellexpand::tilde;
 use snafu::location;
 use tokio::io::AsyncWriteExt;


### PR DESCRIPTION
Expose the object store retry config to set via Env variable. 
During Azure network instability, the original retry config will only retry for around 20 seconds.
Expose these values to be configurable by users to survive flaky azure network.