### PR TITLE
refactor: rework how take handles parallelism

### DIFF
--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -326,7 +326,7 @@ struct Footer {
 const FOOTER_LEN: usize = 40;
 
 impl FileReader {
-    pub fn with_scheduler(&self, scheduler: Arc<dyn EncodingsIo>) -> FileReader {
+    pub fn with_scheduler(&self, scheduler: Arc<dyn EncodingsIo>) -> Self {
         Self {
             scheduler,
             base_projection: self.base_projection.clone(),

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -292,7 +292,7 @@ impl ReaderProjection {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct FileReaderOptions {
     validate_on_decode: bool,
 }
@@ -326,6 +326,18 @@ struct Footer {
 const FOOTER_LEN: usize = 40;
 
 impl FileReader {
+    pub fn with_scheduler(&self, scheduler: Arc<dyn EncodingsIo>) -> FileReader {
+        Self {
+            scheduler,
+            base_projection: self.base_projection.clone(),
+            cache: self.cache.clone(),
+            decoder_plugins: self.decoder_plugins.clone(),
+            metadata: self.metadata.clone(),
+            options: self.options.clone(),
+            num_rows: self.num_rows,
+        }
+    }
+
     pub fn num_rows(&self) -> u64 {
         self.num_rows
     }

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -759,6 +759,15 @@ impl FileScheduler {
         }
     }
 
+    pub fn with_priority(&self, priority: u64) -> FileScheduler {
+        FileScheduler {
+            reader: self.reader.clone(),
+            root: self.root.clone(),
+            block_size: self.block_size,
+            base_priority: priority,
+        }
+    }
+
     /// Submit a single IOP to the reader
     ///
     /// If you have multiple IOPS to perform then [`Self::submit_request`] is going

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -759,8 +759,8 @@ impl FileScheduler {
         }
     }
 
-    pub fn with_priority(&self, priority: u64) -> FileScheduler {
-        FileScheduler {
+    pub fn with_priority(&self, priority: u64) -> Self {
+        Self {
             reader: self.reader.clone(),
             root: self.root.clone(),
             block_size: self.block_size,

--- a/rust/lance/src/datafusion.rs
+++ b/rust/lance/src/datafusion.rs
@@ -15,18 +15,16 @@ pub trait MetricsExt {
 
 impl MetricsExt for MetricsSet {
     fn find_count(&self, metric_name: &str) -> Option<Count> {
-        self.iter()
-            .filter_map(|m| match m.value() {
-                MetricValue::Count { name, count } => {
-                    if name == metric_name {
-                        Some(count.clone())
-                    } else {
-                        None
-                    }
+        self.iter().find_map(|m| match m.value() {
+            MetricValue::Count { name, count } => {
+                if name == metric_name {
+                    Some(count.clone())
+                } else {
+                    None
                 }
-                _ => None,
-            })
-            .next()
+            }
+            _ => None,
+        })
     }
 }
 

--- a/rust/lance/src/datafusion.rs
+++ b/rust/lance/src/datafusion.rs
@@ -4,7 +4,30 @@
 //! Extends DataFusion
 //!
 
+use datafusion::physical_plan::metrics::{Count, MetricValue, MetricsSet};
+
 pub(crate) mod dataframe;
 pub(crate) mod logical_plan;
+
+pub trait MetricsExt {
+    fn find_count(&self, name: &str) -> Option<Count>;
+}
+
+impl MetricsExt for MetricsSet {
+    fn find_count(&self, metric_name: &str) -> Option<Count> {
+        self.iter()
+            .filter_map(|m| match m.value() {
+                MetricValue::Count { name, count } => {
+                    if name == metric_name {
+                        Some(count.clone())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            })
+            .next()
+    }
+}
 
 pub use dataframe::LanceTableProvider;

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2088,7 +2088,7 @@ mod tests {
         for fragment in &fragments {
             assert_eq!(fragment.count_rows(None).await.unwrap(), 100);
             let reader = fragment
-                .open(dataset.schema(), FragReadConfig::default(), None)
+                .open(dataset.schema(), FragReadConfig::default())
                 .await
                 .unwrap();
             // No group / batch concept in v2

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -369,7 +369,7 @@ mod v2_adapter {
             )?;
 
             let reader = if let Some(take_priority) = take_priority {
-                let op_priority = (take_priority as u64) << 32 | self.default_priority as u64;
+                let op_priority = ((take_priority as u64) << 32) | self.default_priority as u64;
                 let scheduler = self.file_scheduler.with_priority(op_priority);
                 Arc::new(
                     self.reader

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -91,6 +91,7 @@ pub trait GenericFileReader: std::fmt::Debug + Send + Sync {
         indices: &[u32],
         batch_size: u32,
         projection: Arc<lance_core::datatypes::Schema>,
+        take_priority: Option<u32>,
     ) -> Result<ReadBatchTaskStream>;
 
     /// Return the number of rows in the file
@@ -223,6 +224,7 @@ impl GenericFileReader for V1Reader {
         indices: &[u32],
         _batch_size: u32,
         projection: Arc<Schema>,
+        _take_priority: Option<u32>,
     ) -> Result<ReadBatchTaskStream> {
         let indices_vec = indices.to_vec();
         let reader = self.reader.clone();
@@ -276,6 +278,8 @@ mod v2_adapter {
         reader: Arc<v2::reader::FileReader>,
         projection: Arc<Schema>,
         field_id_to_column_idx: Arc<BTreeMap<u32, u32>>,
+        default_priority: u32,
+        file_scheduler: FileScheduler,
     }
 
     impl Reader {
@@ -283,11 +287,15 @@ mod v2_adapter {
             reader: Arc<v2::reader::FileReader>,
             projection: Arc<Schema>,
             field_id_to_column_idx: Arc<BTreeMap<u32, u32>>,
+            default_priority: u32,
+            file_scheduler: FileScheduler,
         ) -> Self {
             Self {
                 reader,
                 projection,
                 field_id_to_column_idx,
+                default_priority,
+                file_scheduler,
             }
         }
     }
@@ -351,6 +359,7 @@ mod v2_adapter {
             indices: &[u32],
             batch_size: u32,
             projection: Arc<Schema>,
+            take_priority: Option<u32>,
         ) -> Result<ReadBatchTaskStream> {
             let indices = UInt32Array::from(indices.to_vec());
             let projection = ReaderProjection::from_field_ids(
@@ -358,8 +367,19 @@ mod v2_adapter {
                 projection.as_ref(),
                 self.field_id_to_column_idx.as_ref(),
             )?;
-            Ok(self
-                .reader
+
+            let reader = if let Some(take_priority) = take_priority {
+                let op_priority = (take_priority as u64) << 32 | self.default_priority as u64;
+                let scheduler = self.file_scheduler.with_priority(op_priority);
+                Arc::new(
+                    self.reader
+                        .with_scheduler(Arc::new(LanceEncodingsIo(scheduler))),
+                )
+            } else {
+                self.reader.clone()
+            };
+
+            Ok(reader
                 .read_tasks(
                     ReadBatchParams::Indices(indices),
                     batch_size,
@@ -488,6 +508,7 @@ impl GenericFileReader for NullReader {
         indices: &[u32],
         batch_size: u32,
         projection: Arc<Schema>,
+        _take_priority: Option<u32>,
     ) -> Result<ReadBatchTaskStream> {
         let num_rows = indices.len() as u64;
         self.read_range_tasks(0..num_rows, batch_size, projection)
@@ -528,6 +549,19 @@ pub struct FragReadConfig {
     pub with_row_id: bool,
     // Add the row address column
     pub with_row_address: bool,
+    /// The scan scheduler to use for reading data files.
+    ///
+    /// This should be specified if multiple readers are being used in
+    /// an operation
+    pub scan_scheduler: Option<Arc<ScanScheduler>>,
+    /// The default scan priority to use for reading data files
+    ///
+    /// Only used if `scan_scheduler` is provided
+    ///
+    /// The overall priority for reads will be
+    ///
+    /// operation_priority: u32 | reader_priority: u32 | file_position: u64
+    pub reader_priority: Option<u32>,
 }
 
 impl FragReadConfig {
@@ -538,6 +572,16 @@ impl FragReadConfig {
 
     pub fn with_row_address(mut self, value: bool) -> Self {
         self.with_row_address = value;
+        self
+    }
+
+    pub fn with_scan_scheduler(mut self, value: Arc<ScanScheduler>) -> Self {
+        self.scan_scheduler = Some(value);
+        self
+    }
+
+    pub fn with_reader_priority(mut self, value: u32) -> Self {
+        self.reader_priority = Some(value);
         self
     }
 }
@@ -665,7 +709,10 @@ impl FileFragment {
         scan_scheduler: Arc<ScanScheduler>,
     ) -> Result<()> {
         for reader in self
-            .open_readers(dataset_schema, Some((scan_scheduler, 0)))
+            .open_readers(
+                dataset_schema,
+                &FragReadConfig::default().with_scan_scheduler(scan_scheduler),
+            )
             .await?
         {
             reader.update_storage_stats(field_stats);
@@ -722,9 +769,8 @@ impl FileFragment {
         &self,
         projection: &Schema,
         read_config: FragReadConfig,
-        scan_scheduler: Option<(Arc<ScanScheduler>, u64)>,
     ) -> Result<FragmentReader> {
-        let open_files = self.open_readers(projection, scan_scheduler);
+        let open_files = self.open_readers(projection, &read_config);
         let deletion_vec_load =
             self.load_deletion_vector(&self.dataset.object_store, &self.metadata);
 
@@ -783,7 +829,7 @@ impl FileFragment {
         &self,
         data_file: &DataFile,
         projection: Option<&Schema>,
-        scan_scheduler: Option<(Arc<ScanScheduler>, u64)>,
+        read_config: &FragReadConfig,
     ) -> Result<Option<Box<dyn GenericFileReader>>> {
         let full_schema = self.dataset.schema();
         // The data file may contain fields that are not part of the dataset any longer, remove those
@@ -821,23 +867,29 @@ impl FileFragment {
             Ok(None)
         } else {
             let path = self.dataset.data_dir().child(data_file.path.as_str());
-            let (store_scheduler, priority_offset) = scan_scheduler.unwrap_or_else(|| {
-                (
-                    ScanScheduler::new(
-                        self.dataset.object_store.clone(),
-                        SchedulerConfig::max_bandwidth(&self.dataset.object_store),
-                    ),
-                    0,
-                )
-            });
+            let (store_scheduler, reader_priority) =
+                if let Some(scan_scheduler) = read_config.scan_scheduler.as_ref() {
+                    (
+                        scan_scheduler.clone(),
+                        read_config.reader_priority.unwrap_or(0),
+                    )
+                } else {
+                    (
+                        ScanScheduler::new(
+                            self.dataset.object_store.clone(),
+                            SchedulerConfig::max_bandwidth(&self.dataset.object_store),
+                        ),
+                        0,
+                    )
+                };
             let file_scheduler = store_scheduler
-                .open_file_with_priority(&path, priority_offset)
+                .open_file_with_priority(&path, reader_priority as u64)
                 .await?;
             let file_metadata = self.get_file_metadata(&file_scheduler).await?;
             let path = file_scheduler.reader().path().clone();
             let reader = Arc::new(
                 v2::reader::FileReader::try_open_with_file_metadata(
-                    Arc::new(LanceEncodingsIo(file_scheduler)),
+                    Arc::new(LanceEncodingsIo(file_scheduler.clone())),
                     path,
                     None,
                     Arc::<DecoderPlugins>::default(),
@@ -861,7 +913,13 @@ impl FileFragment {
                         }
                     }),
             ));
-            let reader = v2_adapter::Reader::new(reader, schema_per_file, field_id_to_column_idx);
+            let reader = v2_adapter::Reader::new(
+                reader,
+                schema_per_file,
+                field_id_to_column_idx,
+                reader_priority,
+                file_scheduler,
+            );
             Ok(Some(Box::new(reader)))
         }
     }
@@ -869,12 +927,12 @@ impl FileFragment {
     async fn open_readers(
         &self,
         projection: &Schema,
-        scan_scheduler: Option<(Arc<ScanScheduler>, u64)>,
+        read_config: &FragReadConfig,
     ) -> Result<Vec<Box<dyn GenericFileReader>>> {
         let mut opened_files = vec![];
         for data_file in &self.metadata.files {
             if let Some(reader) = self
-                .open_reader(data_file, Some(projection), scan_scheduler.clone())
+                .open_reader(data_file, Some(projection), read_config)
                 .await?
             {
                 opened_files.push(reader);
@@ -998,7 +1056,7 @@ impl FileFragment {
         // Just open any file. All of them should have same size.
         let some_file = &self.metadata.files[0];
         let reader = self
-            .open_reader(some_file, None, None)
+            .open_reader(some_file, None, &FragReadConfig::default())
             .await?
             .ok_or_else(|| Error::Internal {
                 message: format!(
@@ -1074,7 +1132,7 @@ impl FileFragment {
 
         let get_lengths = self.metadata.files.iter().map(|data_file| async move {
             let reader = self
-                .open_reader(data_file, None, None)
+                .open_reader(data_file, None, &FragReadConfig::default())
                 .await?
                 .ok_or_else(|| {
                     Error::corrupt_file(
@@ -1292,7 +1350,6 @@ impl FileFragment {
             .open(
                 projection,
                 FragReadConfig::default().with_row_address(with_row_address),
-                None,
             )
             .await?;
 
@@ -1302,7 +1359,7 @@ impl FileFragment {
             reader.legacy_read_range_as_batch(range).await
         } else {
             // FIXME, change this method to streams
-            reader.take_as_batch(row_offsets).await
+            reader.take_as_batch(row_offsets, None).await
         }
     }
 
@@ -1384,7 +1441,6 @@ impl FileFragment {
             FragReadConfig::default()
                 .with_row_address(with_row_addr)
                 .with_row_id(with_row_id),
-            None,
         );
         let deletion_vector = read_deletion_file(
             &self.dataset.base,
@@ -2130,20 +2186,36 @@ impl FragmentReader {
     }
 
     /// Take rows from this fragment.
-    pub async fn take(&self, indices: &[u32], batch_size: u32) -> Result<ReadBatchFutStream> {
+    pub async fn take(
+        &self,
+        indices: &[u32],
+        batch_size: u32,
+        take_priority: Option<u32>,
+    ) -> Result<ReadBatchFutStream> {
         let indices_arr = UInt32Array::from(indices.to_vec());
         self.new_read_impl(
             ReadBatchParams::Indices(indices_arr),
             batch_size,
-            move |reader| reader.take_all_tasks(indices, batch_size, reader.projection().clone()),
+            move |reader| {
+                reader.take_all_tasks(
+                    indices,
+                    batch_size,
+                    reader.projection().clone(),
+                    take_priority,
+                )
+            },
         )
     }
 
     /// Take rows from this fragment, will perform a copy if the underlying reader returns multiple
     /// batches.  May return an error if the taken rows do not fit into a single batch.
-    pub async fn take_as_batch(&self, indices: &[u32]) -> Result<RecordBatch> {
+    pub async fn take_as_batch(
+        &self,
+        indices: &[u32],
+        take_priority: Option<u32>,
+    ) -> Result<RecordBatch> {
         let batches = self
-            .take(indices, u32::MAX)
+            .take(indices, u32::MAX, take_priority)
             .await?
             .buffered(get_num_compute_intensive_cpus())
             .try_collect::<Vec<_>>()
@@ -2347,7 +2419,6 @@ mod tests {
                 .open(
                     fragment.schema(),
                     FragReadConfig::default().with_row_id(with_row_id),
-                    None,
                 )
                 .await
                 .unwrap();
@@ -2371,7 +2442,6 @@ mod tests {
                 .open(
                     fragment.schema(),
                     FragReadConfig::default().with_row_id(with_row_id),
-                    None,
                 )
                 .await
                 .unwrap();
@@ -2410,7 +2480,6 @@ mod tests {
                     FragReadConfig::default()
                         .with_row_id(with_row_id)
                         .with_row_address(with_row_address),
-                    None,
                 )
                 .await
                 .unwrap();
@@ -2436,7 +2505,6 @@ mod tests {
                     FragReadConfig::default()
                         .with_row_id(with_row_id)
                         .with_row_address(with_row_address),
-                    None,
                 )
                 .await
                 .unwrap();
@@ -2471,7 +2539,6 @@ mod tests {
             .open(
                 dataset.schema(),
                 FragReadConfig::default().with_row_id(true),
-                None,
             )
             .await
             .unwrap();
@@ -2563,7 +2630,6 @@ mod tests {
                 .open(
                     dataset.schema(),
                     FragReadConfig::default().with_row_id(true),
-                    None,
                 )
                 .await
                 .unwrap();
@@ -3111,9 +3177,9 @@ mod tests {
             .get_fragments()
             .first()
             .unwrap()
-            .open(dataset.schema(), FragReadConfig::default(), None)
+            .open(dataset.schema(), FragReadConfig::default())
             .await?;
-        let actual_data = reader.take_as_batch(&[0, 1, 2]).await?;
+        let actual_data = reader.take_as_batch(&[0, 1, 2], None).await?;
         assert_eq!(expected_data.slice(0, 3), actual_data);
 
         let actual_data = reader
@@ -3165,7 +3231,6 @@ mod tests {
             .open(
                 &dataset.schema().project::<&str>(&[])?,
                 FragReadConfig::default().with_row_id(true),
-                None,
             )
             .await?;
         let batch = reader.legacy_read_range_as_batch(0..20).await?;
@@ -3181,7 +3246,6 @@ mod tests {
             .open(
                 &dataset.schema().project::<&str>(&[])?,
                 FragReadConfig::default(),
-                None,
             )
             .await;
         assert!(matches!(res, Err(Error::IO { .. })));

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1031,7 +1031,7 @@ impl Scanner {
             Ok(DatasetRecordBatchStream::new(execute_plan(
                 plan,
                 LanceExecutionOptions {
-                    batch_size: self.batch_size.clone(),
+                    batch_size: self.batch_size,
                     ..Default::default()
                 },
             )?))
@@ -2401,7 +2401,7 @@ impl Scanner {
         analyze_plan(
             plan,
             LanceExecutionOptions {
-                batch_size: self.batch_size.clone(),
+                batch_size: self.batch_size,
                 ..Default::default()
             },
         )

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -13,12 +13,10 @@ use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema, SchemaR
 use arrow_select::concat::concat_batches;
 use async_recursion::async_recursion;
 use datafusion::common::SchemaExt;
-use datafusion::execution::TaskContext;
 use datafusion::functions_aggregate;
 use datafusion::functions_aggregate::count::count_udaf;
 use datafusion::logical_expr::Expr;
 use datafusion::physical_expr::PhysicalSortExpr;
-use datafusion::physical_plan::analyze::AnalyzeExec;
 use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
 use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::expressions;
@@ -46,7 +44,7 @@ use lance_arrow::DataTypeExt;
 use lance_core::datatypes::{Field, OnMissing, Projection};
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use lance_core::{ROW_ADDR, ROW_ADDR_FIELD, ROW_ID, ROW_ID_FIELD};
-use lance_datafusion::exec::{execute_plan, LanceExecutionOptions};
+use lance_datafusion::exec::{analyze_plan, execute_plan, LanceExecutionOptions};
 use lance_datafusion::projection::ProjectionPlan;
 use lance_index::scalar::expression::PlannerIndexExt;
 use lance_index::scalar::inverted::{FTS_SCHEMA, SCORE_COL};
@@ -1032,7 +1030,10 @@ impl Scanner {
 
             Ok(DatasetRecordBatchStream::new(execute_plan(
                 plan,
-                LanceExecutionOptions::default(),
+                LanceExecutionOptions {
+                    batch_size: self.batch_size.clone(),
+                    ..Default::default()
+                },
             )?))
         }
         .boxed()
@@ -1493,7 +1494,7 @@ impl Scanner {
             )?;
         }
 
-        plan = self.take(plan, pre_filter_projection, self.batch_readahead)?;
+        plan = self.take(plan, pre_filter_projection)?;
 
         // Stage 2: filter
         if let Some(refine_expr) = filter_plan.refine_expr {
@@ -1513,7 +1514,7 @@ impl Scanner {
                 .empty_projection()
                 .union_columns(ordering_columns, OnMissing::Error)?;
             // We haven't loaded the sort column yet so take it now
-            plan = self.take(plan, projection_with_ordering, self.batch_readahead)?;
+            plan = self.take(plan, projection_with_ordering)?;
             let col_exprs = ordering
                 .iter()
                 .map(|col| {
@@ -1541,7 +1542,7 @@ impl Scanner {
             .dataset
             .empty_projection()
             .union_schema(&physical_schema);
-        plan = self.take(plan, physical_projection, self.batch_readahead)?;
+        plan = self.take(plan, physical_projection)?;
         // Stage 6: physical projection -- reorder physical columns needed before final projection
         let output_arrow_schema = physical_schema.as_ref().into();
 
@@ -1757,8 +1758,7 @@ impl Scanner {
                     .empty_projection()
                     .union_column(&q.column, OnMissing::Error)
                     .unwrap();
-                let knn_node_with_vector =
-                    self.take(ann_node, vector_projection, self.batch_readahead)?;
+                let knn_node_with_vector = self.take(ann_node, vector_projection)?;
                 // TODO: now we just open an index to get its metric type.
                 let idx = self
                     .dataset
@@ -1836,7 +1836,7 @@ impl Scanner {
                     .empty_projection()
                     .union_column(&q.column, OnMissing::Error)
                     .unwrap();
-                knn_node = self.take(knn_node, vector_projection, self.batch_readahead)?;
+                knn_node = self.take(knn_node, vector_projection)?;
             }
 
             let mut columns = vec![q.column.clone()];
@@ -1975,7 +1975,7 @@ impl Scanner {
                 let refine_cols = Planner::column_names_in_expr(refine_expr);
                 take_projection = take_projection.union_columns(refine_cols, OnMissing::Error)?;
             }
-            plan = self.take(plan, take_projection, self.batch_readahead)?;
+            plan = self.take(plan, take_projection)?;
         }
 
         let post_take_filter = match (needs_recheck, refine_expr) {
@@ -2370,18 +2370,14 @@ impl Scanner {
         &self,
         input: Arc<dyn ExecutionPlan>,
         output_projection: Projection,
-        batch_readahead: usize,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let coalesced = Arc::new(CoalesceBatchesExec::new(
             input.clone(),
             self.get_batch_size(),
         ));
-        if let Some(take_plan) = TakeExec::try_new(
-            self.dataset.clone(),
-            coalesced,
-            output_projection,
-            batch_readahead,
-        )? {
+        if let Some(take_plan) =
+            TakeExec::try_new(self.dataset.clone(), coalesced, output_projection)?
+        {
             Ok(Arc::new(take_plan))
         } else {
             // No new columns needed
@@ -2401,21 +2397,15 @@ impl Scanner {
     #[instrument(level = "info", skip(self))]
     pub async fn analyze_plan(&self) -> Result<String> {
         let plan = self.create_plan().await?;
-        let schema = plan.schema();
-        let analyze = Arc::new(AnalyzeExec::new(true, true, plan, schema));
-        let ctx = Arc::new(TaskContext::default());
-        let mut stream = analyze.execute(0, ctx).map_err(|err| {
-            Error::io(
-                format!("Failed to execute analyze plan: {}", err),
-                location!(),
-            )
-        })?;
 
-        // fully execute the plan
-        while (stream.next().await).is_some() {}
-
-        let display = DisplayableExecutionPlan::with_metrics(analyze.as_ref());
-        Ok(format!("{}", display.indent(true)))
+        analyze_plan(
+            plan,
+            LanceExecutionOptions {
+                batch_size: self.batch_size.clone(),
+                ..Default::default()
+            },
+        )
+        .await
     }
 
     #[instrument(level = "info", skip(self))]
@@ -4636,6 +4626,23 @@ mod test {
                 }
             }
         }
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_index_take_batch_size() {
+        let fixture = ScalarIndexTestFixture::new(LanceFileVersion::Stable, false).await;
+        let stream = fixture
+            .dataset
+            .scan()
+            .filter("indexed > 0")
+            .unwrap()
+            .batch_size(16)
+            .try_into_stream()
+            .await
+            .unwrap();
+        let batches = stream.collect::<Vec<_>>().await;
+        assert_eq!(batches.len(), 1000_usize.div_ceil(16));
     }
 
     async fn assert_plan_node_equals(

--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -150,7 +150,7 @@ async fn do_take_rows(
         })?;
 
         let reader = fragment
-            .open(&projection.physical_schema, FragReadConfig::default(), None)
+            .open(&projection.physical_schema, FragReadConfig::default())
             .await?;
         reader.legacy_read_range_as_batch(range).await
     } else if row_addr_stats.sorted {

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -58,7 +58,7 @@ use futures::{
 use lance_core::{
     datatypes::{OnMissing, OnTypeMismatch, SchemaCompareOptions},
     error::{box_error, InvalidInputSnafu},
-    utils::{futures::Capacity, tokio::get_num_compute_intensive_cpus},
+    utils::futures::Capacity,
     Error, Result, ROW_ADDR, ROW_ADDR_FIELD, ROW_ID, ROW_ID_FIELD,
 };
 use lance_datafusion::{
@@ -461,15 +461,9 @@ impl MergeInsertJob {
             .dataset
             .empty_projection()
             .union_arrow_schema(schema.as_ref(), OnMissing::Error)?;
-        let mut target = Arc::new(
-            TakeExec::try_new(
-                self.dataset.clone(),
-                index_mapper,
-                projection,
-                get_num_compute_intensive_cpus(),
-            )?
-            .unwrap(),
-        ) as Arc<dyn ExecutionPlan>;
+        let mut target =
+            Arc::new(TakeExec::try_new(self.dataset.clone(), index_mapper, projection)?.unwrap())
+                as Arc<dyn ExecutionPlan>;
 
         // 5 - Take puts the row id and row addr at the beginning.  A full scan (used when there is
         //     no scalar index) puts the row id and addr at the end.  We need to match these up so
@@ -669,7 +663,7 @@ impl MergeInsertJob {
     ) -> Result<(Vec<Fragment>, Vec<Fragment>)> {
         // Expected source schema: _rowaddr, updated_cols*
         use datafusion::logical_expr::{col, lit};
-        let session_ctx = get_session_context(LanceExecutionOptions {
+        let session_ctx = get_session_context(&LanceExecutionOptions {
             use_spilling: true,
             ..Default::default()
         });
@@ -742,7 +736,6 @@ impl MergeInsertJob {
                             .open(
                                 dataset.schema(),
                                 FragReadConfig::default().with_row_address(true),
-                                None,
                             )
                             .await?;
                         let batch_size = reader.legacy_num_rows_in_batch(0).unwrap();

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -1,207 +1,286 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::collections::HashSet;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 
-use arrow_array::{cast::as_primitive_array, RecordBatch, UInt64Array};
+use arrow::array::AsArray;
+use arrow::compute::{concat_batches, TakeOptions};
+use arrow::datatypes::UInt64Type;
+use arrow_array::{Array, UInt32Array};
+use arrow_array::{RecordBatch, UInt64Array};
 use arrow_schema::{Schema as ArrowSchema, SchemaRef};
 use datafusion::common::Statistics;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricValue, MetricsSet,
+};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, RecordBatchStream,
-    SendableRecordBatchStream,
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, SendableRecordBatchStream,
 };
 use datafusion_physical_expr::EquivalenceProperties;
-use futures::stream::{self, Stream, StreamExt, TryStreamExt};
+use futures::stream::{FuturesOrdered, Stream, StreamExt, TryStreamExt};
 use futures::{Future, FutureExt};
+use lance_arrow::RecordBatchExt;
 use lance_core::datatypes::{Field, OnMissing, Projection};
-use tokio::sync::mpsc::{self, Receiver};
-use tokio::task::JoinHandle;
-use tracing::{instrument, Instrument};
+use lance_core::error::{DataFusionResult, LanceOptionExt};
+use lance_core::utils::address::RowAddress;
+use lance_core::utils::tokio::get_num_compute_intensive_cpus;
+use lance_core::{ROW_ADDR, ROW_ID};
+use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 
-use crate::dataset::{Dataset, ProjectionRequest, ROW_ID};
+use crate::dataset::fragment::{FragReadConfig, FragmentReader};
+use crate::dataset::rowids::get_row_id_index;
+use crate::dataset::Dataset;
 use crate::datatypes::Schema;
-use crate::{arrow::*, Error};
 
-/// Dataset Take Node.
-///
-/// [Take] node takes the filtered batch from the child node.
-///
-/// It uses the `_rowid` to random access on [Dataset] to gather the final results.
-pub struct Take {
-    rx: Receiver<Result<RecordBatch>>,
-    bg_thread: Option<JoinHandle<()>>,
-    output_schema: SchemaRef,
+struct TakeStreamMetrics {
     baseline_metrics: BaselineMetrics,
+    batches_processed: Count,
 }
 
-impl Take {
-    /// Create a Take node with
+impl TakeStreamMetrics {
+    fn new(metrics: &ExecutionPlanMetricsSet, partition: usize) -> Self {
+        let batches_processed = Count::new();
+        MetricBuilder::new(metrics)
+            .with_partition(partition)
+            .build(MetricValue::Count {
+                name: Cow::Borrowed("batches_processed"),
+                count: batches_processed.clone(),
+            });
+        Self {
+            baseline_metrics: BaselineMetrics::new(metrics, partition),
+            batches_processed,
+        }
+    }
+}
+
+struct TakeStream {
+    /// The dataset to take from
+    dataset: Arc<Dataset>,
+    /// The fields to take from the input stream
+    fields_to_take: Arc<Schema>,
+    /// The output schema, needed for us to merge the new columns
+    /// into the input data in the correct order
+    output_schema: SchemaRef,
+    /// A cache of opened file readers
     ///
-    ///  - Dataset: the dataset to read from
-    ///  - projection: extra columns to take from the dataset.
-    ///  - output_schema: the output schema of the take node.
-    ///  - child: the upstream stream to feed data in.
-    ///  - batch_readahead: max number of batches to readahead, potentially concurrently
-    #[instrument(level = "debug", skip_all, name = "Take::new")]
+    /// This is a map from fragment id to a reader.
+    readers_cache: Arc<Mutex<HashMap<u32, Arc<FragmentReader>>>>,
+    /// The scan scheduler to use for reading fragments
+    scan_scheduler: Arc<ScanScheduler>,
+    /// The metrics for the stream
+    metrics: TakeStreamMetrics,
+}
+
+impl TakeStream {
     fn new(
         dataset: Arc<Dataset>,
-        projection: Arc<Schema>,
+        fields_to_take: Arc<Schema>,
         output_schema: SchemaRef,
-        child: SendableRecordBatchStream,
-        batch_readahead: usize,
-        baseline_metrics: BaselineMetrics,
+        scan_scheduler: Arc<ScanScheduler>,
+        metrics: &ExecutionPlanMetricsSet,
+        partition: usize,
     ) -> Self {
-        let (tx, rx) = mpsc::channel(4);
+        Self {
+            dataset,
+            fields_to_take,
+            output_schema,
+            readers_cache: Arc::new(Mutex::new(HashMap::new())),
+            scan_scheduler,
+            metrics: TakeStreamMetrics::new(metrics, partition),
+        }
+    }
 
-        let output_schema_copy = output_schema.clone();
-        let bg_thread = tokio::spawn(
-            async move {
-                if let Err(e) = child
-                    .zip(stream::repeat_with(|| {
-                        (dataset.clone(), projection.clone())
-                    }))
-                    .map(|(batch, (dataset, extra))| {
-                        let output_schema_copy = output_schema_copy.clone();
-                        async move {
-                            Self::take_batch(batch?, dataset, extra, output_schema_copy).await
-                        }})
-                    .buffered(batch_readahead)
-                    .map(|r| r.map_err(|e| DataFusionError::Execution(e.to_string())))
-                    .try_for_each(|b| async {
-                        if tx.send(Ok(b)).await.is_err() {
-                        // If channel is closed, make sure we return an error to end the stream. 
-                        return Err(DataFusionError::Internal(
-                            "ExecNode(Take): channel closed".to_string(),
-                        ));
-                        }
-                        Ok(())
-                    })
-                    .await
-                {
-                    if let Err(e) = tx.send(Err(e)).await {
-                        if let Err(e) = e.0 {
-                            // if channel was closed, it was cancelled by the receiver.
-                            // But if there was a different error we should send it
-                            // or log it.
-                            if !e.to_string().contains("channel closed") {
-                                log::error!("channel was closed by receiver, but error occurred in background thread: {:?}", e);
-                            }
-                        }
-                    }
-                }
-                drop(tx)
-            }
-            .in_current_span(),
+    async fn do_open_reader(&self, fragment_id: u32) -> DataFusionResult<Arc<FragmentReader>> {
+        let fragment = self
+        .dataset
+        .get_fragment(fragment_id as usize)
+        .ok_or_else(|| {
+            DataFusionError::Execution(format!("The input to a take operation specified fragment id {} but this fragment does not exist in the dataset", fragment_id))
+        })?;
+
+        let reader = Arc::new(
+            fragment
+                .open(
+                    &self.fields_to_take,
+                    FragReadConfig::default().with_scan_scheduler(self.scan_scheduler.clone()),
+                )
+                .await?,
         );
 
-        Self {
-            rx,
-            bg_thread: Some(bg_thread),
-            output_schema,
-            baseline_metrics,
-        }
+        let mut readers = self.readers_cache.lock().unwrap();
+        readers.insert(fragment_id, reader.clone());
+        Ok(reader)
     }
 
-    /// Given a batch with a _rowid column, retrieve extra columns from dataset.
-    // This method mostly exists to annotate the Send bound so the compiler
-    // doesn't produce a higher-order lifetime error.
-    // manually implemented async for Send bound
-    #[allow(clippy::manual_async_fn)]
-    #[instrument(level = "debug", skip_all)]
-    fn take_batch(
-        batch: RecordBatch,
-        dataset: Arc<Dataset>,
-        extra: Arc<Schema>,
-        output_schema: SchemaRef,
-    ) -> impl Future<Output = Result<RecordBatch, Error>> + Send {
-        async move {
-            let row_id_arr = batch.column_by_name(ROW_ID).unwrap();
-            let row_ids: &UInt64Array = as_primitive_array(row_id_arr);
-            let rows = if extra.fields.is_empty() {
-                batch
-            } else {
-                let new_columns = dataset
-                    .take_rows(row_ids.values(), ProjectionRequest::Schema(extra))
-                    .await?;
-                debug_assert_eq!(batch.num_rows(), new_columns.num_rows());
-                batch.merge_with_schema(&new_columns, &output_schema)?
-            };
-            Ok::<RecordBatch, Error>(rows)
+    async fn open_reader(&self, fragment_id: u32) -> DataFusionResult<Arc<FragmentReader>> {
+        if let Some(reader) = self
+            .readers_cache
+            .lock()
+            .unwrap()
+            .get(&fragment_id)
+            .cloned()
+        {
+            return Ok(reader);
         }
-        .in_current_span()
+
+        self.do_open_reader(fragment_id).await
     }
-}
 
-impl Stream for Take {
-    type Item = Result<RecordBatch>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = Pin::into_inner(self);
-        let timer = this.baseline_metrics.elapsed_compute().timer();
-        // We need to check the JoinHandle to make sure the thread hasn't panicked.
-        let bg_thread_completed = if let Some(bg_thread) = &mut this.bg_thread {
-            match bg_thread.poll_unpin(cx) {
-                Poll::Ready(Ok(())) => true,
-                Poll::Ready(Err(join_error)) => {
-                    return Poll::Ready(Some(Err(DataFusionError::Execution(format!(
-                        "ExecNode(Take): thread panicked: {}",
-                        join_error
-                    )))));
-                }
-                Poll::Pending => false,
-            }
+    async fn get_row_addrs(&self, batch: &RecordBatch) -> Result<Arc<dyn Array>> {
+        if let Some(row_addr_array) = batch.column_by_name(ROW_ADDR) {
+            Ok(row_addr_array.clone())
         } else {
-            false
-        };
-        if bg_thread_completed {
-            // Need to take it, since we aren't allowed to poll if again after.
-            this.bg_thread.take();
+            let row_id_array = batch.column_by_name(ROW_ID).expect_ok()?;
+
+            if let Some(row_id_index) = get_row_id_index(&self.dataset).await? {
+                let row_id_array = row_id_array.as_primitive::<UInt64Type>();
+                let addresses = row_id_array
+                    .values()
+                    .iter()
+                    .filter_map(|id| row_id_index.get(*id).map(|address| address.into()))
+                    .collect::<Vec<u64>>();
+                Ok(Arc::new(UInt64Array::from(addresses)))
+            } else {
+                Ok(row_id_array.clone())
+            }
         }
-        // this.rx.
-        timer.done();
-        this.baseline_metrics.record_poll(this.rx.poll_recv(cx))
+    }
+
+    fn map_batch(
+        self: Arc<Self>,
+        batch: RecordBatch,
+        batch_number: u32,
+    ) -> impl Future<Output = DataFusionResult<RecordBatch>> + Send {
+        async move {
+            let compute_timer = self.metrics.baseline_metrics.elapsed_compute().timer();
+            let row_addrs_arr = self.get_row_addrs(&batch).await?;
+            let row_addrs = row_addrs_arr.as_primitive::<UInt64Type>();
+
+            // Check if the row addresses are already sorted to avoid unnecessary reorders
+            let is_sorted = row_addrs.values().windows(2).all(|w| w[0] <= w[1]);
+
+            let sorted_addrs: Arc<dyn Array>;
+            let (sorted_addrs, permutation) = if is_sorted {
+                (row_addrs, None)
+            } else {
+                let permutation =
+                    arrow::compute::sort_to_indices(&row_addrs_arr, None, None).unwrap();
+                sorted_addrs = arrow::compute::take(
+                    &row_addrs_arr,
+                    &permutation,
+                    Some(TakeOptions {
+                        check_bounds: false,
+                    }),
+                )
+                .unwrap();
+                // Calculate the inverse permutation to restore the original order
+                let mut inverse_permutation = vec![0; permutation.len()];
+                for (i, p) in permutation.values().iter().enumerate() {
+                    inverse_permutation[*p as usize] = i as u32;
+                }
+                (
+                    sorted_addrs.as_primitive::<UInt64Type>(),
+                    Some(UInt32Array::from(inverse_permutation)),
+                )
+            };
+
+            let mut futures = FuturesOrdered::new();
+            let mut current_offsets = Vec::new();
+            let mut current_fragment_id = None;
+
+            for row_addr in sorted_addrs.values() {
+                let addr = RowAddress::new_from_u64(*row_addr);
+
+                if Some(addr.fragment_id()) != current_fragment_id {
+                    // Start a new group
+                    if let Some(fragment_id) = current_fragment_id {
+                        let reader = self.open_reader(fragment_id).await?;
+                        let offsets = std::mem::take(&mut current_offsets);
+                        futures.push_back(
+                            async move { reader.take_as_batch(&offsets, Some(batch_number)).await }
+                                .boxed(),
+                        );
+                    }
+                    current_fragment_id = Some(addr.fragment_id());
+                }
+
+                current_offsets.push(addr.row_offset());
+            }
+
+            // Handle the last group
+            if let Some(fragment_id) = current_fragment_id {
+                let reader = self.open_reader(fragment_id).await?;
+                futures.push_back(
+                    async move {
+                        reader
+                            .take_as_batch(&current_offsets, Some(batch_number))
+                            .await
+                    }
+                    .boxed(),
+                );
+            }
+
+            // Stop the compute timer, don't count I/O time
+            drop(compute_timer);
+
+            let batches = futures.try_collect::<Vec<_>>().await?;
+
+            let _compute_timer = self.metrics.baseline_metrics.elapsed_compute().timer();
+            let schema = batches.first().expect_ok()?.schema();
+            let mut new_data = concat_batches(&schema, batches.iter())?;
+
+            // Restore previous order (if addresses were out of order originally)
+            if let Some(permutation) = permutation {
+                new_data = arrow_select::take::take_record_batch(&new_data, &permutation).unwrap();
+            }
+
+            self.metrics
+                .baseline_metrics
+                .record_output(new_data.num_rows());
+            self.metrics.batches_processed.add(1);
+            Ok(batch.merge_with_schema(&new_data, self.output_schema.as_ref())?)
+        }
+    }
+
+    fn apply<S: Stream<Item = Result<RecordBatch>> + Send + 'static>(
+        self: Arc<Self>,
+        input: S,
+    ) -> impl Stream<Item = Result<RecordBatch>> {
+        let batches = input
+            .enumerate()
+            .map(move |(batch_index, batch)| {
+                let batch = batch?;
+                let this = self.clone();
+                Ok(
+                    tokio::task::spawn(this.map_batch(batch, batch_index as u32))
+                        .map(|res| res.unwrap()),
+                )
+            })
+            .boxed();
+        batches.try_buffered(get_num_compute_intensive_cpus())
     }
 }
 
-impl RecordBatchStream for Take {
-    fn schema(&self) -> SchemaRef {
-        self.output_schema.clone()
-    }
-}
-
-/// [`TakeExec`] is a [`ExecutionPlan`] that enriches the input [`RecordBatch`]
-/// with extra columns from [`Dataset`].
-///
-/// The rows are identified by the inexplicit row IDs from `input` plan.
-///
-/// The output schema will be the input schema, merged with extra schemas from the dataset.
 #[derive(Debug)]
 pub struct TakeExec {
-    /// Dataset to read from.
-    pub(crate) dataset: Arc<Dataset>,
-
-    /// The original projection is kept to recalculate `with_new_children`.
-    pub(crate) original_projection: Arc<Schema>,
-
-    /// The schema to pass to dataset.take, this should be the original projection
-    /// minus any fields in the input schema.
+    // The dataset to take from
+    dataset: Arc<Dataset>,
+    // The desired output projection of the relation (input schema + take schema)
+    //
+    // This is used to re-calculate output_projection and extra_schema when
+    // with_new_children is called.
+    output_projection: Projection,
+    // The schema of the extra columns to take from the dataset
     schema_to_take: Arc<Schema>,
-
+    // The schema of the output
+    output_schema: SchemaRef,
+    scan_scheduler: Arc<ScanScheduler>,
     input: Arc<dyn ExecutionPlan>,
-
-    /// Output schema is the merged schema between input schema and extra schema and
-    /// tells us how to merge the input and extra columns.
-    output_schema: Arc<Schema>,
-
-    batch_readahead: usize,
-
     properties: PlanProperties,
-
     metrics: ExecutionPlanMetricsSet,
 }
 
@@ -220,10 +299,11 @@ impl DisplayAs for TakeExec {
                     .fields
                     .iter()
                     .map(|f| {
-                        if extra_fields.contains(&f.name) {
-                            format!("({})", f.name.as_str())
+                        let name = f.name();
+                        if extra_fields.contains(name) {
+                            format!("({})", name)
                         } else {
-                            f.name.clone()
+                            name.to_string()
                         }
                     })
                     .collect::<Vec<_>>()
@@ -246,9 +326,8 @@ impl TakeExec {
         dataset: Arc<Dataset>,
         input: Arc<dyn ExecutionPlan>,
         projection: Projection,
-        batch_readahead: usize,
     ) -> Result<Option<Self>> {
-        let original_projection = projection.clone().into_schema_ref();
+        let original_projection = projection.clone();
         let projection =
             projection.subtract_arrow_schema(input.schema().as_ref(), OnMissing::Ignore)?;
         if projection.is_empty() {
@@ -256,16 +335,19 @@ impl TakeExec {
         }
 
         // We actually need a take so lets make sure we have a row id
-        if input.schema().column_with_name(ROW_ID).is_none() {
-            return Err(DataFusionError::Plan(
-                "TakeExec requires the input plan to have a column named '_rowid'".to_string(),
-            ));
+        if input.schema().column_with_name(ROW_ADDR).is_none()
+            && input.schema().column_with_name(ROW_ID).is_none()
+        {
+            return Err(DataFusionError::Plan(format!(
+                "TakeExec requires the input plan to have a column named '{}' or '{}'",
+                ROW_ADDR, ROW_ID
+            )));
         }
 
         // Can't use take if we don't want any fields and we can't use take to add row_id or row_addr
         assert!(
             !projection.with_row_id && !projection.with_row_addr,
-            "Take cannot insert row_id / row_addr: {:#?}",
+            "Take should not be used to insert row_id / row_addr: {:#?}",
             projection
         );
 
@@ -278,17 +360,21 @@ impl TakeExec {
         let properties = input
             .properties()
             .clone()
-            .with_eq_properties(EquivalenceProperties::new(output_arrow));
+            .with_eq_properties(EquivalenceProperties::new(output_arrow.clone()));
+
+        let obj_store = dataset.object_store.clone();
+        let scheduler_config = SchedulerConfig::max_bandwidth(&obj_store);
+        let scan_scheduler = ScanScheduler::new(obj_store, scheduler_config);
 
         Ok(Some(Self {
             dataset,
-            original_projection,
+            output_projection: original_projection,
             schema_to_take: projection.into_schema_ref(),
             input,
-            output_schema,
-            batch_readahead,
+            output_schema: output_arrow,
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
+            scan_scheduler,
         }))
     }
 
@@ -344,13 +430,6 @@ impl TakeExec {
             metadata: dataset_schema.metadata.clone(),
         }
     }
-
-    /// Get the dataset.
-    ///
-    /// WARNING: Internal API with no stability guarantees.
-    pub fn dataset(&self) -> &Arc<Dataset> {
-        &self.dataset
-    }
 }
 
 impl ExecutionPlan for TakeExec {
@@ -363,7 +442,7 @@ impl ExecutionPlan for TakeExec {
     }
 
     fn schema(&self) -> SchemaRef {
-        Arc::new(self.output_schema.as_ref().into())
+        self.output_schema.clone()
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
@@ -381,17 +460,9 @@ impl ExecutionPlan for TakeExec {
             ));
         }
 
-        let projection = self
-            .dataset
-            .empty_projection()
-            .union_schema(&self.original_projection);
+        let projection = self.output_projection.clone();
 
-        let plan = Self::try_new(
-            self.dataset.clone(),
-            children[0].clone(),
-            projection,
-            self.batch_readahead,
-        )?;
+        let plan = Self::try_new(self.dataset.clone(), children[0].clone(), projection)?;
 
         if let Some(plan) = plan {
             Ok(Arc::new(plan))
@@ -406,16 +477,20 @@ impl ExecutionPlan for TakeExec {
         partition: usize,
         context: Arc<datafusion::execution::context::TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
         let input_stream = self.input.execute(partition, context)?;
-        let output_schema_arrow = Arc::new(ArrowSchema::from(self.output_schema.as_ref()));
-        Ok(Box::pin(Take::new(
+        let take_stream = Arc::new(TakeStream::new(
             self.dataset.clone(),
             self.schema_to_take.clone(),
-            output_schema_arrow,
-            input_stream,
-            self.batch_readahead,
-            baseline_metrics,
+            self.output_schema.clone(),
+            self.scan_scheduler.clone(),
+            &self.metrics,
+            partition,
+        ));
+        let output_stream = take_stream.apply(input_stream);
+        let output_schema = self.output_schema.clone();
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            output_schema,
+            output_stream,
         )))
     }
 
@@ -444,10 +519,14 @@ mod tests {
     };
     use arrow_schema::{DataType, Field, Fields};
     use datafusion::execution::TaskContext;
-    use lance_core::datatypes::OnMissing;
+    use lance_arrow::SchemaExt;
+    use lance_core::{datatypes::OnMissing, ROW_ID};
+    use lance_datafusion::exec::OneShotExec;
+    use rstest::rstest;
     use tempfile::{tempdir, TempDir};
 
     use crate::{
+        datafusion::MetricsExt,
         dataset::WriteParams,
         io::exec::{LanceScanConfig, LanceScanExec},
     };
@@ -498,7 +577,7 @@ mod tests {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
         let params = WriteParams {
-            max_rows_per_group: 10,
+            max_rows_per_file: 10,
             ..Default::default()
         };
         let reader =
@@ -537,7 +616,7 @@ mod tests {
             .empty_projection()
             .union_column("s", OnMissing::Error)
             .unwrap();
-        let take_exec = TakeExec::try_new(dataset, input, projection, 10)
+        let take_exec = TakeExec::try_new(dataset, input, projection)
             .unwrap()
             .unwrap();
         let schema = take_exec.schema();
@@ -545,6 +624,132 @@ mod tests {
             schema.fields.iter().map(|f| f.name()).collect::<Vec<_>>(),
             vec!["i", ROW_ID, "s"]
         );
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum TakeInput {
+        RowIds,
+        RowAddrs,
+        RowIdsAndAddrs,
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_simple_take(
+        #[values(TakeInput::RowIds, TakeInput::RowAddrs, TakeInput::RowIdsAndAddrs)]
+        take_input: TakeInput,
+    ) {
+        let TestFixture {
+            dataset,
+            _tmp_dir_guard,
+        } = test_fixture().await;
+
+        let scan_schema = Arc::new(dataset.schema().project(&["i"]).unwrap());
+        let config = LanceScanConfig {
+            with_row_address: take_input != TakeInput::RowIds,
+            with_row_id: take_input != TakeInput::RowAddrs,
+            ..Default::default()
+        };
+        let input = Arc::new(LanceScanExec::new(
+            dataset.clone(),
+            dataset.fragments().clone(),
+            None,
+            scan_schema,
+            config,
+        ));
+
+        let projection = dataset
+            .empty_projection()
+            .union_column("s", OnMissing::Error)
+            .unwrap();
+        let take_exec = TakeExec::try_new(dataset, input, projection)
+            .unwrap()
+            .unwrap();
+        let schema = take_exec.schema();
+
+        let mut expected_fields = vec!["i"];
+        if take_input != TakeInput::RowAddrs {
+            expected_fields.push(ROW_ID);
+        }
+        if take_input != TakeInput::RowIds {
+            expected_fields.push(ROW_ADDR);
+        }
+        expected_fields.push("s");
+        assert_eq!(&schema.field_names(), &expected_fields);
+
+        let mut stream = take_exec
+            .execute(0, Arc::new(TaskContext::default()))
+            .unwrap();
+
+        while let Some(batch) = stream.try_next().await.unwrap() {
+            assert_eq!(&batch.schema().field_names(), &expected_fields);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_take_order() {
+        let TestFixture {
+            dataset,
+            _tmp_dir_guard,
+        } = test_fixture().await;
+
+        // Grab all row addresses, shuffle them, and select the first 15 (half of the rows)
+        let data = dataset
+            .scan()
+            .project(&["s"])
+            .unwrap()
+            .with_row_address()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let indices = UInt64Array::from(vec![8, 13, 1, 7, 4, 5, 12, 9, 10, 2, 11, 6, 3, 0, 28]);
+        let data = arrow_select::take::take_record_batch(&data, &indices).unwrap();
+
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            ROW_ADDR,
+            DataType::UInt64,
+            true,
+        )]));
+        let row_addrs = data.project_by_schema(&schema).unwrap();
+
+        // Split into 3 batches of 5
+        let batches = (0..3)
+            .map(|i| {
+                let start = i * 5;
+                row_addrs.slice(start, 5)
+            })
+            .collect::<Vec<_>>();
+
+        let row_addr_stream = futures::stream::iter(batches.clone().into_iter().map(Ok));
+        let row_addr_stream = Box::pin(RecordBatchStreamAdapter::new(schema, row_addr_stream));
+
+        let input = Arc::new(OneShotExec::new(row_addr_stream));
+
+        let projection = dataset
+            .empty_projection()
+            .union_column("s", OnMissing::Error)
+            .unwrap();
+        let take_exec = TakeExec::try_new(dataset, input, projection)
+            .unwrap()
+            .unwrap();
+
+        let stream = take_exec
+            .execute(0, Arc::new(TaskContext::default()))
+            .unwrap();
+
+        let expected = vec![data.slice(0, 5), data.slice(5, 5), data.slice(10, 5)];
+
+        let batches = stream.try_collect::<Vec<_>>().await.unwrap();
+        assert_eq!(batches.len(), 3);
+        for (batch, expected) in batches.into_iter().zip(expected) {
+            assert_eq!(batch.schema().field_names(), vec![ROW_ADDR, "s"]);
+            let expected = expected.project_by_schema(&batch.schema()).unwrap();
+            assert_eq!(batch, expected);
+        }
+
+        let metrics = take_exec.metrics().unwrap();
+        assert_eq!(metrics.output_rows(), Some(15));
+        assert_eq!(metrics.find_count("batches_processed").unwrap().value(), 3);
     }
 
     #[tokio::test]
@@ -559,7 +764,7 @@ mod tests {
         let scan_schema = Arc::new(dataset.schema().project(&["struct.y"]).unwrap());
 
         let config = LanceScanConfig {
-            with_row_id: true,
+            with_row_address: true,
             ..Default::default()
         };
         let input = Arc::new(LanceScanExec::new(
@@ -575,7 +780,7 @@ mod tests {
             .union_column("struct.x", OnMissing::Error)
             .unwrap();
 
-        let take_exec = TakeExec::try_new(dataset, input, projection, 10)
+        let take_exec = TakeExec::try_new(dataset, input, projection)
             .unwrap()
             .unwrap();
 
@@ -588,7 +793,7 @@ mod tests {
                 ])),
                 false,
             ),
-            Field::new(ROW_ID, DataType::UInt64, true),
+            Field::new(ROW_ADDR, DataType::UInt64, true),
         ]);
         let schema = take_exec.schema();
         assert_eq!(schema.as_ref(), &expected_schema);
@@ -603,7 +808,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_take_no_row_id() {
+    async fn test_take_no_row_addr() {
         let TestFixture { dataset, .. } = test_fixture().await;
 
         let scan_arrow_schema = ArrowSchema::new(vec![Field::new("i", DataType::Int32, false)]);
@@ -614,7 +819,7 @@ mod tests {
             .union_column("s", OnMissing::Error)
             .unwrap();
 
-        // No row ID
+        // No row address
         let input = Arc::new(LanceScanExec::new(
             dataset.clone(),
             dataset.fragments().clone(),
@@ -622,7 +827,7 @@ mod tests {
             scan_schema,
             LanceScanConfig::default(),
         ));
-        assert!(TakeExec::try_new(dataset, input, projection, 10).is_err());
+        assert!(TakeExec::try_new(dataset, input, projection).is_err());
     }
 
     #[tokio::test]
@@ -649,7 +854,7 @@ mod tests {
         ));
 
         assert_eq!(input.schema().field_names(), vec!["i", ROW_ID],);
-        let take_exec = TakeExec::try_new(dataset.clone(), input.clone(), projection, 10)?.unwrap();
+        let take_exec = TakeExec::try_new(dataset.clone(), input.clone(), projection)?.unwrap();
         assert_eq!(take_exec.schema().field_names(), vec!["i", ROW_ID, "s"],);
 
         let projection = dataset
@@ -658,7 +863,7 @@ mod tests {
             .unwrap();
 
         let outer_take =
-            Arc::new(TakeExec::try_new(dataset, Arc::new(take_exec), projection, 10)?.unwrap());
+            Arc::new(TakeExec::try_new(dataset, Arc::new(take_exec), projection)?.unwrap());
         assert_eq!(
             outer_take.schema().field_names(),
             vec!["i", ROW_ID, "s", "f"],


### PR DESCRIPTION
Previously, when handling a large take, the `TakeExec` would issue `batch_readahead`  calls to `LanceDataset::take_rows`.  Each call would then have its own scan scheduler and the result would be that we would overload the I/O parallelism.  On a take of 1M rows against S3 I got 400K request retries.

Now, there is one scan scheduler that is shared across the entire take operation, applying the same concurrency limits as before.

In addition, this PR adds the `batch_count` metric to our standard metrics.

In addition, this PR changes `MaterializeIndexExec` to emit batches based on the plan's batch size instead of a fixed constant.

In addition, this PR passes the `batch_size` parameter from the scanner into datafusion