### PR TITLE
feat: don't log span info

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -6149,7 +6149,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -56,7 +56,7 @@ serde_yaml = "0.9.34"
 snafu = "0.8"
 tracing-chrome = "0.7.1"
 tracing-subscriber = "0.3.17"
-tracing = { version = "0.1", features = ["log"] }
+tracing = { version = "0.1" }
 url = "2.5.0"
 bytes = "1.4"
 


### PR DESCRIPTION
Previously we connected tracing into the logs when running in python.  This behavior was too verbose.  This PR changes it so only events are logged and the resulting logs are a bit easier to parse should someone want to.