### PR TITLE
chore: emit warning if unstable version is used

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1240,6 +1240,18 @@ def test_load_scanner_from_fragments(tmp_path: Path):
     assert scanner.to_table().num_rows == 2 * 100
 
 
+def test_write_unstable_data_version(tmp_path: Path, capfd):
+    # Note: this test will only work if no earlier test attempts
+    # to use an unstable version.  If we need that later we can find a way to
+    # run this test in a separate process (pytest-xdist?)
+    tab = pa.table({"a": range(100), "b": range(100)})
+    ds = lance.write_dataset(
+        tab, tmp_path / "dataset", mode="append", data_storage_version="next"
+    )
+    assert ds.to_table() == tab
+    assert "You have requested an unstable format version" in capfd.readouterr().err
+
+
 def test_merge_data(tmp_path: Path):
     tab = pa.table({"a": range(100), "b": range(100)})
     lance.write_dataset(tab, tmp_path / "dataset", mode="append")

--- a/rust/lance-encoding/src/version.rs
+++ b/rust/lance-encoding/src/version.rs
@@ -88,6 +88,7 @@ impl FromStr for LanceFileVersion {
             V2_FORMAT_2_1 => Ok(Self::V2_1),
             "stable" => Ok(Self::Stable),
             "legacy" => Ok(Self::Legacy),
+            "next" => Ok(Self::Next),
             // Version 0.3 is an alias of 2.0
             "0.3" => Ok(Self::V2_0),
             _ => Err(Error::InvalidInput {

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -3,6 +3,7 @@
 
 use core::panic;
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
@@ -24,7 +25,7 @@ use lance_encoding::version::LanceFileVersion;
 use lance_io::object_store::ObjectStore;
 use lance_io::object_writer::ObjectWriter;
 use lance_io::traits::Writer;
-use log::debug;
+use log::{debug, warn};
 use object_store::path::Path;
 use prost::Message;
 use prost_types::Any;
@@ -114,6 +115,8 @@ fn initial_column_metadata() -> pbfile::ColumnMetadata {
     }
 }
 
+const WARNED_ON_UNSTABLE_API: AtomicBool = AtomicBool::new(false);
+
 impl FileWriter {
     /// Create a new FileWriter with a desired output schema
     pub fn try_new(
@@ -131,6 +134,20 @@ impl FileWriter {
     /// The output schema will be set based on the first batch of data to arrive.
     /// If no data arrives and the writer is finished then the write will fail.
     pub fn new_lazy(object_writer: ObjectWriter, options: FileWriterOptions) -> Self {
+        if let Some(format_version) = options.format_version {
+            if format_version > LanceFileVersion::Stable
+                && WARNED_ON_UNSTABLE_API
+                    .compare_exchange(
+                        false,
+                        true,
+                        std::sync::atomic::Ordering::Relaxed,
+                        std::sync::atomic::Ordering::Relaxed,
+                    )
+                    .is_ok()
+            {
+                warn!("You have requested an unstable format version.  Files written with this format version may not be readable in the future!  This is a development feature and should only be used for experimentation and never for production data.");
+            }
+        }
         Self {
             writer: object_writer,
             schema: None,


### PR DESCRIPTION
Precursor to releasing 2.1 as unstable beta