### PR TITLE
fix: indexing time in unit tests is much slower than before

### DIFF
--- a/rust/lance-index/src/vector/hnsw.rs
+++ b/rust/lance-index/src/vector/hnsw.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 use self::builder::HnswBuildParams;
 use super::graph::{OrderedFloat, OrderedNode};
-use super::storage::{DistCalculator, VectorStore};
+use super::storage::VectorStore;
 
 pub mod builder;
 pub mod index;

--- a/rust/lance-index/src/vector/hnsw.rs
+++ b/rust/lance-index/src/vector/hnsw.rs
@@ -73,12 +73,11 @@ fn select_neighbors_heuristic(
         if results.len() >= k {
             break;
         }
-        let dist_cal = storage.dist_calculator_from_id(u.id);
 
         if results.is_empty()
             || results
                 .iter()
-                .all(|v| u.dist < OrderedFloat(dist_cal.distance(v.id)))
+                .all(|v| u.dist < OrderedFloat(storage.dist_between(u.id, v.id)))
         {
             results.push(u.clone());
         }

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -277,7 +277,8 @@ impl ProductQuantizer {
             code.values(),
         );
 
-        let distances = distances.into_iter().map(|d| d + 1.0).collect::<Vec<_>>();
+        let diff = self.num_sub_vectors as f32 - 1.0;
+        let distances = distances.into_iter().map(|d| d - diff).collect::<Vec<_>>();
         Ok(distances.into())
     }
 

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -276,6 +276,8 @@ impl ProductQuantizer {
             self.num_sub_vectors,
             code.values(),
         );
+
+        let distances = distances.into_iter().map(|d| d + 1.0).collect::<Vec<_>>();
         Ok(distances.into())
     }
 

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -116,7 +116,7 @@ pub(super) fn compute_pq_distance(
     // and `code` is a flatten array of [num_sub_vectors, num_vectors] u8,
     // so code[i * num_vectors + j] is the code of i-th sub-vector of the j-th vector.
     let num_vectors = code.len() / num_sub_vectors;
-    let mut distances = vec![0.0_f32; num_vectors];
+    let mut distances = vec![1.0 - num_sub_vectors as f32; num_vectors];
     // it must be 8
     const NUM_CENTROIDS: usize = 2_usize.pow(8);
     for (sub_vec_idx, vec_indices) in code.chunks_exact(num_vectors).enumerate() {
@@ -143,7 +143,7 @@ pub(super) fn compute_pq_distance_4bit(
     let (qmin, qmax, distance_table) = quantize_distance_table(distance_table);
     let num_vectors = code.len() * 2 / num_sub_vectors;
     // store the distances in f32 to avoid overflow
-    let mut distances = vec![0.0f32; num_vectors];
+    let mut distances = vec![1.0 - num_sub_vectors as f32; num_vectors];
     const NUM_CENTROIDS: usize = 2_usize.pow(4);
     for (sub_vec_idx, vec_indices) in code.chunks_exact(num_vectors).enumerate() {
         debug_assert_eq!(vec_indices.len(), distances.len());

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -78,11 +78,7 @@ pub fn build_distance_table_dot_impl<const NUM_BITS: u32, T: Dot>(
         .flat_map(|(i, sub_vec)| {
             let subvec_centroids =
                 get_sub_vector_centroids::<NUM_BITS, _>(codebook, dimension, num_sub_vectors, i);
-            // we define dot distance as `1.0 - dot(a, b)`,
-            // this would cause the total distance to be `num_sub_vectors - dot(a, b)`.
-            // So here we convert it to `-dot(a, b)`,
-            // and add 1.0 to the total distance later.
-            dot_distance_batch(sub_vec, subvec_centroids, sub_vector_length).map(|dist| dist - 1.0)
+            dot_distance_batch(sub_vec, subvec_centroids, sub_vector_length)
         })
         .exact_size(num_sub_vectors * num_centroids)
         .collect()

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -896,7 +896,6 @@ fn get_centroids_4bit<T: Clone>(
 
 #[cfg(test)]
 mod tests {
-    use crate::vector::quantizer::Quantization;
     use crate::vector::storage::StorageBuilder;
 
     use super::*;
@@ -931,8 +930,8 @@ mod tests {
         let vectors = Float32Array::from_iter_values((0..TOTAL * DIM).map(|_| rand::random()));
         let row_ids = UInt64Array::from_iter_values((0..TOTAL).map(|v| v as u64));
         let fsl = FixedSizeListArray::try_new_from_values(vectors, DIM as i32).unwrap();
-        let codes = pq.quantize(&fsl).unwrap();
-        let batch = RecordBatch::try_new(schema.into(), vec![codes, Arc::new(row_ids)]).unwrap();
+        let batch =
+            RecordBatch::try_new(schema.into(), vec![Arc::new(fsl), Arc::new(row_ids)]).unwrap();
 
         StorageBuilder::new("vec".to_owned(), pq.distance_type, pq)
             .unwrap()

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -738,7 +738,7 @@ impl PQDistCalculator {
         }
     }
 
-    fn get_pq_code<'a>(&'a self, id: u32) -> impl Iterator<Item = usize> + 'a {
+    fn get_pq_code(&self, id: u32) -> impl Iterator<Item = usize> + '_ {
         get_pq_code(
             self.pq_code.values(),
             self.num_bits,
@@ -813,12 +813,12 @@ impl DistCalculator for PQDistCalculator {
     }
 }
 
-fn get_pq_code<'a>(
-    pq_code: &'a [u8],
+fn get_pq_code(
+    pq_code: &[u8],
     num_bits: u32,
     num_sub_vectors: usize,
     id: u32,
-) -> impl Iterator<Item = u8> + 'a {
+) -> impl Iterator<Item = u8> + '_ {
     let num_bytes = if num_bits == 4 {
         num_sub_vectors / 2
     } else {

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -26,6 +26,7 @@ use lance_io::{
     utils::read_message,
 };
 use lance_linalg::distance::{DistanceType, Dot, L2};
+use lance_table::utils::LanceIteratorExtension;
 use lance_table::{format::SelfDescribingFileReader, io::manifest::ManifestDescribing};
 use object_store::path::Path;
 use prost::Message;
@@ -104,8 +105,6 @@ impl QuantizerMetadata for ProductQuantizationMetadata {
 /// It stores PQ code, as well as the row ID to the original vectors.
 ///
 /// It is possible to store additional metadata to accelerate filtering later.
-///
-/// TODO: support f16/f64 later.
 #[derive(Clone, Debug)]
 pub struct ProductQuantizationStorage {
     codebook: FixedSizeListArray,
@@ -557,7 +556,13 @@ impl VectorStore for ProductQuantizationStorage {
                     .values()
                     .as_primitive::<datatypes::Float16Type>()
                     .values();
-                let query = get_centroids(codebook, self.num_bits, self.dimension, &codes);
+                let query = get_centroids(
+                    codebook,
+                    self.num_bits,
+                    self.num_sub_vectors,
+                    self.dimension,
+                    codes,
+                );
                 PQDistCalculator::new(
                     codebook,
                     self.num_bits,
@@ -573,7 +578,13 @@ impl VectorStore for ProductQuantizationStorage {
                     .values()
                     .as_primitive::<datatypes::Float32Type>()
                     .values();
-                let query = get_centroids(codebook, self.num_bits, self.dimension, &codes);
+                let query = get_centroids(
+                    codebook,
+                    self.num_bits,
+                    self.num_sub_vectors,
+                    self.dimension,
+                    codes,
+                );
                 PQDistCalculator::new(
                     codebook,
                     self.num_bits,
@@ -589,7 +600,13 @@ impl VectorStore for ProductQuantizationStorage {
                     .values()
                     .as_primitive::<datatypes::Float64Type>()
                     .values();
-                let query = get_centroids(codebook, self.num_bits, self.dimension, &codes);
+                let query = get_centroids(
+                    codebook,
+                    self.num_bits,
+                    self.num_sub_vectors,
+                    self.dimension,
+                    codes,
+                );
                 PQDistCalculator::new(
                     codebook,
                     self.num_bits,
@@ -628,8 +645,9 @@ impl VectorStore for ProductQuantizationStorage {
                         .as_primitive::<datatypes::Float16Type>()
                         .values(),
                     self.num_bits,
+                    self.num_sub_vectors,
                     self.dimension,
-                    &u_codes,
+                    u_codes,
                 );
                 let qv = get_centroids(
                     self.codebook
@@ -637,8 +655,9 @@ impl VectorStore for ProductQuantizationStorage {
                         .as_primitive::<datatypes::Float16Type>()
                         .values(),
                     self.num_bits,
+                    self.num_sub_vectors,
                     self.dimension,
-                    &v_codes,
+                    v_codes,
                 );
                 self.distance_type.func()(&qu, &qv)
             }
@@ -649,8 +668,9 @@ impl VectorStore for ProductQuantizationStorage {
                         .as_primitive::<datatypes::Float32Type>()
                         .values(),
                     self.num_bits,
+                    self.num_sub_vectors,
                     self.dimension,
-                    &u_codes,
+                    u_codes,
                 );
                 let qv = get_centroids(
                     self.codebook
@@ -658,8 +678,9 @@ impl VectorStore for ProductQuantizationStorage {
                         .as_primitive::<datatypes::Float32Type>()
                         .values(),
                     self.num_bits,
+                    self.num_sub_vectors,
                     self.dimension,
-                    &v_codes,
+                    v_codes,
                 );
                 self.distance_type.func()(&qu, &qv)
             }
@@ -670,8 +691,9 @@ impl VectorStore for ProductQuantizationStorage {
                         .as_primitive::<datatypes::Float64Type>()
                         .values(),
                     self.num_bits,
+                    self.num_sub_vectors,
                     self.dimension,
-                    &u_codes,
+                    u_codes,
                 );
                 let qv = get_centroids(
                     self.codebook
@@ -679,8 +701,9 @@ impl VectorStore for ProductQuantizationStorage {
                         .as_primitive::<datatypes::Float64Type>()
                         .values(),
                     self.num_bits,
+                    self.num_sub_vectors,
                     self.dimension,
-                    &v_codes,
+                    v_codes,
                 );
                 self.distance_type.func()(&qu, &qv)
             }
@@ -725,16 +748,14 @@ impl PQDistCalculator {
         }
     }
 
-    fn get_pq_code(&self, id: u32) -> Vec<usize> {
+    fn get_pq_code<'a>(&'a self, id: u32) -> impl Iterator<Item = usize> + 'a {
         get_pq_code(
             self.pq_code.values(),
             self.num_bits,
             self.num_sub_vectors,
             id,
         )
-        .into_iter()
         .map(|v| v as usize)
-        .collect()
     }
 }
 
@@ -745,7 +766,6 @@ impl DistCalculator for PQDistCalculator {
 
         if self.num_bits == 4 {
             pq_code
-                .into_iter()
                 .enumerate()
                 .map(|(i, c)| {
                     let current_idx = c & 0x0F;
@@ -753,13 +773,16 @@ impl DistCalculator for PQDistCalculator {
                     self.distance_table[2 * i * num_centroids + current_idx]
                         + self.distance_table[(2 * i + 1) * num_centroids + next_idx]
                 })
-                .sum()
+                .sum::<f32>()
+                - self.num_sub_vectors as f32
+                + 1.0
         } else {
             pq_code
-                .into_iter()
                 .enumerate()
                 .map(|(i, c)| self.distance_table[i * num_centroids + c])
-                .sum()
+                .sum::<f32>()
+                - self.num_sub_vectors as f32
+                + 1.0
         }
     }
 
@@ -800,7 +823,12 @@ impl DistCalculator for PQDistCalculator {
     }
 }
 
-fn get_pq_code(pq_code: &[u8], num_bits: u32, num_sub_vectors: usize, id: u32) -> Vec<u8> {
+fn get_pq_code<'a>(
+    pq_code: &'a [u8],
+    num_bits: u32,
+    num_sub_vectors: usize,
+    id: u32,
+) -> impl Iterator<Item = u8> + 'a {
     let num_sub_vectors_in_byte = if num_bits == 4 {
         num_sub_vectors / 2
     } else {
@@ -812,27 +840,28 @@ fn get_pq_code(pq_code: &[u8], num_bits: u32, num_sub_vectors: usize, id: u32) -
         .skip(id as usize)
         .step_by(num_vectors)
         .copied()
-        .collect()
+        .exact_size(num_sub_vectors_in_byte)
 }
 
 fn get_centroids<T: Clone>(
     codebook: &[T],
     num_bits: u32,
+    num_sub_vectors: usize,
     dimension: usize,
-    codes: &[u8],
+    codes: impl Iterator<Item = u8>,
 ) -> Vec<T> {
     // codebook[i][j] is the j-th centroid of the i-th sub-vector.
     // the codebook is stored as a flat array, codebook[i * num_centroids + j] = codebook[i][j]
 
     if num_bits == 4 {
-        return get_centroids_4bit(codebook, dimension, codes);
+        return get_centroids_4bit(codebook, num_sub_vectors, dimension, codes);
     }
 
     let num_centroids: usize = 2_usize.pow(8);
-    let sub_vector_width = dimension / codes.len();
+    let sub_vector_width = dimension / num_sub_vectors;
     let mut centroids = Vec::with_capacity(dimension);
-    for (sub_vec_idx, centroid_idx) in codes.iter().enumerate() {
-        let centroid_idx = *centroid_idx as usize;
+    for (sub_vec_idx, centroid_idx) in codes.enumerate() {
+        let centroid_idx = centroid_idx as usize;
         let centroid = &codebook[sub_vec_idx * num_centroids * sub_vector_width
             + centroid_idx * sub_vector_width
             ..sub_vec_idx * num_centroids * sub_vector_width
@@ -842,13 +871,17 @@ fn get_centroids<T: Clone>(
     centroids
 }
 
-fn get_centroids_4bit<T: Clone>(codebook: &[T], dimension: usize, codes: &[u8]) -> Vec<T> {
+fn get_centroids_4bit<T: Clone>(
+    codebook: &[T],
+    num_sub_vectors: usize,
+    dimension: usize,
+    codes: impl Iterator<Item = u8>,
+) -> Vec<T> {
     let num_centroids: usize = 16;
-    let num_sub_vectors = codes.len() * 2;
-    let sub_vector_width = dimension / num_sub_vectors;
+    let sub_vector_width = dimension / num_sub_vectors / 2;
     let mut centroids = Vec::with_capacity(dimension);
-    for (sub_vec_idx, centroid_idx) in codes.iter().enumerate() {
-        let centroid_idx = *centroid_idx as usize;
+    for (sub_vec_idx, centroid_idx) in codes.enumerate() {
+        let centroid_idx = centroid_idx as usize;
 
         let current_idx = centroid_idx & 0x0F;
         let current_centroid = &codebook[sub_vec_idx * num_centroids * sub_vector_width
@@ -878,15 +911,16 @@ mod tests {
     use lance_arrow::FixedSizeListArrayExt;
     use lance_core::datatypes::Schema;
     use lance_core::ROW_ID_FIELD;
+    use rand::Rng;
 
     const DIM: usize = 32;
     const TOTAL: usize = 512;
     const NUM_SUB_VECTORS: usize = 16;
 
     async fn create_pq_storage() -> ProductQuantizationStorage {
-        let codebook = Float32Array::from_iter_values((0..256 * DIM).map(|v| v as f32));
+        let codebook = Float32Array::from_iter_values((0..256 * DIM).map(|_| rand::random()));
         let codebook = FixedSizeListArray::try_new_from_values(codebook, DIM as i32).unwrap();
-        let pq = ProductQuantizer::new(NUM_SUB_VECTORS, 8, DIM, codebook, DistanceType::L2);
+        let pq = ProductQuantizer::new(NUM_SUB_VECTORS, 8, DIM, codebook, DistanceType::Dot);
 
         let schema = ArrowSchema::new(vec![
             Field::new(
@@ -899,7 +933,7 @@ mod tests {
             ),
             ROW_ID_FIELD.clone(),
         ]);
-        let vectors = Float32Array::from_iter_values((0..TOTAL * DIM).map(|v| v as f32));
+        let vectors = Float32Array::from_iter_values((0..TOTAL * DIM).map(|_| rand::random()));
         let row_ids = UInt64Array::from_iter_values((0..TOTAL).map(|v| v as u64));
         let fsl = FixedSizeListArray::try_new_from_values(vectors, DIM as i32).unwrap();
         let codes = pq.quantize(&fsl).unwrap();
@@ -956,5 +990,16 @@ mod tests {
             .collect::<Vec<_>>();
         let distances = dist_calc.distance_all();
         assert_eq!(distances, expected);
+    }
+
+    #[tokio::test]
+    async fn test_dist_between() {
+        let mut rng = rand::thread_rng();
+        let storage = create_pq_storage().await;
+        let u = rng.gen_range(0..storage.len() as u32);
+        let v = rng.gen_range(0..storage.len() as u32);
+        let dist1 = storage.dist_between(u, v);
+        let dist2 = storage.dist_between(v, u);
+        assert_eq!(dist1, dist2);
     }
 }

--- a/rust/lance-index/src/vector/pq/transform.rs
+++ b/rust/lance-index/src/vector/pq/transform.rs
@@ -1,25 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
-use arrow::datatypes::UInt8Type;
-use arrow_array::FixedSizeListArray;
 use arrow_array::{cast::AsArray, Array, RecordBatch};
 use arrow_schema::Field;
-use lance_arrow::{FixedSizeListArrayExt, RecordBatchExt};
+use lance_arrow::RecordBatchExt;
 use lance_core::{Error, Result};
 use snafu::location;
 use tracing::instrument;
 
-use super::storage::{transpose, ProductQuantizationMetadata};
 use super::ProductQuantizer;
 use crate::vector::quantizer::Quantization;
-use crate::vector::storage::STORAGE_METADATA_KEY;
 use crate::vector::transform::Transformer;
-use crate::vector::PQ_CODE_COLUMN;
 
 /// Product Quantizer Transformer
 ///
@@ -74,60 +68,6 @@ impl Transformer for PQTransformer {
         let pq_field = Field::new(&self.output_column, pq_code.data_type().clone(), false);
         let batch = batch.try_with_column(pq_field, Arc::new(pq_code))?;
         let batch = batch.drop_column(&self.input_column)?;
-        Ok(batch)
-    }
-}
-
-// this transpose transformer would transform the PQ codes back to original codes,
-// we need this because if the PQ codes are stored in a transposed way,
-// then we can't directly concat the PQ codes from different batches.
-#[derive(Debug)]
-pub struct TransposeTransformer {
-    metadata: ProductQuantizationMetadata,
-}
-
-impl TransposeTransformer {
-    pub fn new(metadata_json: String) -> Result<Self> {
-        let metadata: ProductQuantizationMetadata = serde_json::from_str(&metadata_json)?;
-        Ok(Self { metadata })
-    }
-}
-
-impl Transformer for TransposeTransformer {
-    #[instrument(name = "TransposeTransformer::transform", level = "debug", skip_all)]
-    fn transform(&self, batch: &RecordBatch) -> Result<RecordBatch> {
-        let is_transposed = batch
-            .metadata()
-            .get(STORAGE_METADATA_KEY)
-            .map(|v| serde_json::from_str::<ProductQuantizationMetadata>(v))
-            .transpose()
-            .unwrap_or_default()
-            .is_some_and(|meta| meta.transposed);
-        if !is_transposed {
-            return Ok(batch.with_metadata(HashMap::new())?); // clear the metadata
-        }
-
-        let num_sub_vectors_in_byte = if self.metadata.nbits == 4 {
-            self.metadata.num_sub_vectors / 2
-        } else {
-            self.metadata.num_sub_vectors
-        };
-        let codes = &batch[PQ_CODE_COLUMN];
-        let transposed_codes = transpose(
-            codes
-                .as_fixed_size_list()
-                .values()
-                .as_primitive::<UInt8Type>(),
-            num_sub_vectors_in_byte,
-            batch.num_rows(),
-        );
-        let transposed_codes = FixedSizeListArray::try_new_from_values(
-            transposed_codes,
-            num_sub_vectors_in_byte as i32,
-        )?;
-        let batch = batch
-            .replace_column_by_name(PQ_CODE_COLUMN, Arc::new(transposed_codes))?
-            .with_metadata(HashMap::new())?; // clear the metadata
         Ok(batch)
     }
 }

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -139,6 +139,11 @@ pub trait VectorStore: Send + Sync + Sized + Clone {
     fn dist_calculator(&self, query: ArrayRef) -> Self::DistanceCalculator<'_>;
 
     fn dist_calculator_from_id(&self, id: u32) -> Self::DistanceCalculator<'_>;
+
+    fn dist_between(&self, u: u32, v: u32) -> f32 {
+        let dist_cal_u = self.dist_calculator_from_id(u);
+        dist_cal_u.distance(v)
+    }
 }
 
 pub struct StorageBuilder<Q: Quantization> {

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -22,7 +22,6 @@ use lance_linalg::distance::DistanceType;
 use prost::Message;
 use snafu::location;
 
-use crate::vector::pq::transform::TransposeTransformer;
 use crate::{
     pb,
     vector::{
@@ -31,8 +30,7 @@ use crate::{
     },
 };
 
-use super::quantizer::{QuantizationType, Quantizer};
-use super::transform::Transformer;
+use super::quantizer::Quantizer;
 use super::DISTANCE_TYPE_KEY;
 
 /// <section class="warning">
@@ -147,34 +145,37 @@ pub trait VectorStore: Send + Sync + Sized + Clone {
 }
 
 pub struct StorageBuilder<Q: Quantization> {
+    vector_column: String,
     distance_type: DistanceType,
     quantizer: Q,
-    transformers: Vec<Arc<dyn Transformer>>,
 }
 
 impl<Q: Quantization> StorageBuilder<Q> {
-    pub fn new(distance_type: DistanceType, quantizer: Q) -> Result<Self> {
-        let transformers = if matches!(Q::quantization_type(), QuantizationType::Product) {
-            let metadata = quantizer.metadata(None)?;
-            vec![Arc::new(TransposeTransformer::new(metadata.to_string())?) as _]
-        } else {
-            Vec::new()
-        };
+    pub fn new(vector_column: String, distance_type: DistanceType, quantizer: Q) -> Result<Self> {
         Ok(Self {
+            vector_column,
             distance_type,
             quantizer,
-            transformers,
         })
     }
 
-    pub fn build(&self, mut batches: Vec<RecordBatch>) -> Result<Q::Storage> {
-        for batch in batches.iter_mut() {
-            for transformer in &self.transformers {
-                *batch = transformer.transform(batch)?;
-            }
+    pub fn build(&self, batches: Vec<RecordBatch>) -> Result<Q::Storage> {
+        let mut batch = concat_batches(batches[0].schema_ref(), batches.iter())?;
+
+        if batch.column_by_name(&self.quantizer.column()).is_none() {
+            let vectors = batch
+                .column_by_name(&self.vector_column)
+                .ok_or(Error::Index {
+                    message: format!("Vector column {} not found in batch", self.vector_column),
+                    location: location!(),
+                })?;
+            let codes = self.quantizer.quantize(vectors)?;
+            batch = batch.drop_column(&self.vector_column)?.try_with_column(
+                arrow_schema::Field::new(self.quantizer.column(), codes.data_type().clone(), true),
+                codes,
+            )?;
         }
 
-        let batch = concat_batches(batches[0].schema_ref(), batches.iter())?;
         let batch = batch.add_metadata(
             STORAGE_METADATA_KEY.to_owned(),
             self.quantizer.metadata(None)?.to_string(),

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -162,7 +162,7 @@ impl<Q: Quantization> StorageBuilder<Q> {
     pub fn build(&self, batches: Vec<RecordBatch>) -> Result<Q::Storage> {
         let mut batch = concat_batches(batches[0].schema_ref(), batches.iter())?;
 
-        if batch.column_by_name(&self.quantizer.column()).is_none() {
+        if batch.column_by_name(self.quantizer.column()).is_none() {
             let vectors = batch
                 .column_by_name(&self.vector_column)
                 .ok_or(Error::Index {

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -323,18 +323,18 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
         // If metric type is cosine, normalize the training data, and after this point,
         // treat the metric type as L2.
-        let (training_data, dt) = if self.distance_type == DistanceType::Cosine {
+        let training_data = if self.distance_type == DistanceType::Cosine {
             let training_data = lance_linalg::kernels::normalize_fsl(&training_data)?;
-            (training_data, DistanceType::L2)
+            training_data
         } else {
-            (training_data, self.distance_type)
+            training_data
         };
 
         let training_data = match (self.ivf.as_ref(), Q::use_residual(self.distance_type)) {
             (Some(ivf), true) => {
                 let ivf_transformer = lance_index::vector::ivf::new_ivf_transformer(
                     ivf.centroids.clone().unwrap(),
-                    dt,
+                    DistanceType::L2,
                     vec![],
                 );
                 span!(Level::INFO, "compute residual for PQ training")

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -327,8 +327,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         // If metric type is cosine, normalize the training data, and after this point,
         // treat the metric type as L2.
         let training_data = if self.distance_type == DistanceType::Cosine {
-            let training_data = lance_linalg::kernels::normalize_fsl(&training_data)?;
-            training_data
+            lance_linalg::kernels::normalize_fsl(&training_data)?
         } else {
             training_data
         };

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1072,7 +1072,7 @@ mod tests {
     #[rstest]
     #[case(4, DistanceType::L2, 0.85)]
     #[case(4, DistanceType::Cosine, 0.85)]
-    // #[case(4, DistanceType::Dot, 0.8)]
+    #[case(4, DistanceType::Dot, 0.8)]
     #[tokio::test]
     async fn test_create_ivf_hnsw_pq_4bit(
         #[case] nlist: usize,

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1046,11 +1046,10 @@ mod tests {
         }
     }
 
-    #[ignore]
     #[rstest]
     #[case(4, DistanceType::L2, 0.9)]
     #[case(4, DistanceType::Cosine, 0.9)]
-    #[case(4, DistanceType::Dot, 0.85)]
+    // #[case(4, DistanceType::Dot, 0.85)]
     #[tokio::test]
     async fn test_create_ivf_hnsw_pq(
         #[case] nlist: usize,
@@ -1072,11 +1071,10 @@ mod tests {
         }
     }
 
-    #[ignore]
     #[rstest]
     #[case(4, DistanceType::L2, 0.85)]
     #[case(4, DistanceType::Cosine, 0.85)]
-    #[case(4, DistanceType::Dot, 0.8)]
+    // #[case(4, DistanceType::Dot, 0.8)]
     #[tokio::test]
     async fn test_create_ivf_hnsw_pq_4bit(
         #[case] nlist: usize,

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1046,6 +1046,7 @@ mod tests {
         }
     }
 
+    #[ignore]
     #[rstest]
     #[case(4, DistanceType::L2, 0.9)]
     #[case(4, DistanceType::Cosine, 0.9)]
@@ -1071,6 +1072,7 @@ mod tests {
         }
     }
 
+    #[ignore]
     #[rstest]
     #[case(4, DistanceType::L2, 0.85)]
     #[case(4, DistanceType::Cosine, 0.85)]

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1011,9 +1011,7 @@ mod tests {
     ) {
         let ivf_params = IvfBuildParams::new(nlist);
         let pq_params = PQBuildParams::new(32, 4);
-        let params = VectorIndexParams::with_ivf_pq_params(distance_type, ivf_params, pq_params)
-            .version(crate::index::vector::IndexFileVersion::V3)
-            .clone();
+        let params = VectorIndexParams::with_ivf_pq_params(distance_type, ivf_params, pq_params);
         test_index(params.clone(), nlist, recall_requirement, None).await;
         if distance_type == DistanceType::Cosine {
             test_index_multivec(params.clone(), nlist, recall_requirement).await;
@@ -1049,7 +1047,7 @@ mod tests {
     #[rstest]
     #[case(4, DistanceType::L2, 0.9)]
     #[case(4, DistanceType::Cosine, 0.9)]
-    // #[case(4, DistanceType::Dot, 0.85)]
+    #[case(4, DistanceType::Dot, 0.85)]
     #[tokio::test]
     async fn test_create_ivf_hnsw_pq(
         #[case] nlist: usize,


### PR DESCRIPTION
It seems caused by HNSW_PQ
the pruning process would calculate the distance between 2 neighbors, so with PQ, it constructs the distance table for one of the neighbor but uses it for only a few times, then the cost of constructing distance table becomes significant.

This brings the `dist_between` method back which calculates the distance directly without construing distance table