### PR TITLE
feat: simple auto cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3852,6 +3852,7 @@ dependencies = [
  "env_logger",
  "futures",
  "half",
+ "humantime",
  "itertools 0.13.0",
  "lance-arrow",
  "lance-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ fst = { version = "0.4.7", features = ["levenshtein"] }
 fsst = { version = "=0.25.3", path = "./rust/lance-encoding/src/compression_algo/fsst" }
 futures = "0.3"
 http = "1.1.0"
+humantime = "2.2.0"
 hyperloglogplus = { version = "0.4.1", features = ["const-loop"] }
 itertools = "0.13"
 jieba-rs = { version = "0.7", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -83,7 +83,6 @@ ignore = [
     { id = "RUSTSEC-2021-0153", reason = "`encoding` is used by lindera" },
     { id = "RUSTSEC-2024-0384", reason = "`instant` is used by tantivy" },
     { id = "RUSTSEC-2024-0436", reason = "`paste` is used by datafusion" },
-    { id = "RUSTSEC-2025-0014", reason = "`humantime` is used by object_store" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -2659,9 +2659,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -3192,6 +3192,7 @@ dependencies = [
  "deepsize",
  "futures",
  "half",
+ "humantime",
  "itertools 0.13.0",
  "lance-arrow",
  "lance-core",

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -793,8 +793,8 @@ mod tests {
             /*blob_dataset_version= */ None,
         );
 
-        let mut config = HashMap::new();
-        config.insert("lance:test".to_string(), "value".to_string());
+        let mut config = manifest.config.clone();
+        config.insert("lance.test".to_string(), "value".to_string());
         config.insert("other-key".to_string(), "other-value".to_string());
 
         manifest.update_config(config.clone());

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -75,6 +75,7 @@ aws-sdk-dynamodb = { workspace = true, optional = true }
 tempfile.workspace = true
 tracing.workspace = true
 lazy_static = { workspace = true }
+humantime = { workspace = true }
 async_cell = "0.2.2"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2147,6 +2147,7 @@ mod tests {
             test_uri,
             Some(WriteParams {
                 data_storage_version: Some(data_storage_version),
+                auto_cleanup: None,
                 ..Default::default()
             }),
         );
@@ -3736,8 +3737,8 @@ mod tests {
         let reader = RecordBatchIterator::new(vec![data.unwrap()].into_iter().map(Ok), schema);
         let mut dataset = Dataset::write(reader, test_uri, None).await.unwrap();
 
-        let mut desired_config = HashMap::new();
-        desired_config.insert("lance:test".to_string(), "value".to_string());
+        let mut desired_config = dataset.manifest.config.clone();
+        desired_config.insert("lance.test".to_string(), "value".to_string());
         desired_config.insert("other-key".to_string(), "other-value".to_string());
 
         dataset.update_config(desired_config.clone()).await.unwrap();

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -1015,7 +1015,7 @@ mod tests {
 
         fixture.create_some_data().await.unwrap();
 
-        let dataset_config = &(*fixture.open().await.unwrap()).manifest.config;
+        let dataset_config = &fixture.open().await.unwrap().manifest.config;
         let cleanup_interval: usize = dataset_config
             .get("lance.auto_cleanup.interval")
             .unwrap()

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -468,7 +468,7 @@ pub async fn cleanup_old_versions(
     cleanup.run().await
 }
 
-pub async fn auto_clean_hook(
+pub async fn auto_cleanup_hook(
     dataset: &Dataset,
     manifest: &Manifest,
 ) -> Result<Option<Result<RemovalStats>>> {

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -492,7 +492,7 @@ pub async fn auto_cleanup_hook(
                     })
                 }
             };
-            let older_than = TimeDelta::from_std(std_older_than).ok_or(TimeDelta::MAX);
+            let older_than = TimeDelta::from_std(std_older_than).unwrap_or(TimeDelta::MAX);
             let interval: u64 = match interval.parse() {
                 Ok(i) => i,
                 Err(e) => {

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -983,39 +983,60 @@ mod tests {
 
     #[tokio::test]
     async fn auto_cleanup_old_versions() {
-        // Every n commits, all versions older than T should be deleted This
-        // test assumes the default case of n = 20, T = 2 weeks.
+        // Every n commits, all versions older than T should be deleted.
         //
-        // This test first makes 15 commits and check that all of the versions are
-        // present. It then wait 20 days and make 5 more commits. We check that,
-        // without explicitly calling `fixture.run_cleanup`, the 15 old versions
-        // are automatically cleaned up and only 5 remain.
+        // We first make many commits and check that all of the versions are
+        // present. We then wait until the "older_than" period has elapsed and
+        // make many more commits. We check that, without explicitly calling
+        // `fixture.run_cleanup`, the old versions are automatically cleaned
+        // up and only the new ones remain. File counts are made after every
+        // commit.
         let fixture = MockDatasetFixture::try_new().unwrap();
+
         fixture.create_some_data().await.unwrap();
 
-        for _ in 0..14 {
-            fixture.overwrite_some_data().await.unwrap();
+        let dataset_config = &(*fixture.open().await.unwrap()).manifest.config;
+        let cleanup_interval: usize = dataset_config
+            .get("lance.auto_cleanup.interval")
+            .unwrap()
+            .parse()
+            .unwrap();
+        let cleanup_older_than: i64 = dataset_config
+            .get("lance.auto_cleanup.older_than")
+            .unwrap()
+            .parse()
+            .unwrap();
+
+        // Helper function to check that the number of files is correct.
+        async fn check_num_files<'a>(
+            fixture: &'a MockDatasetFixture<'a>,
+            num_expected_files: usize,
+        ) {
+            let file_count = fixture.count_files().await.unwrap();
+
+            assert_eq!(file_count.num_data_files, num_expected_files);
+            assert_eq!(file_count.num_manifest_files, num_expected_files);
+            assert_eq!(file_count.num_tx_files, num_expected_files);
         }
 
+        // First, write many files within the "older_than" window. Check that
+        // no files are automatically cleaned up.
+        for num_expected_files in 2..2 * cleanup_interval {
+            fixture.overwrite_some_data().await.unwrap();
+            check_num_files(&fixture, num_expected_files).await;
+        }
+
+        // Fast forward so we are outside of the "older_than" window.
         fixture
             .clock
-            .set_system_time(TimeDelta::try_days(20).unwrap());
+            .set_system_time(TimeDelta::try_days(cleanup_older_than + 1).unwrap());
 
-        let before_auto_clean_count = fixture.count_files().await.unwrap();
-
-        assert_eq!(before_auto_clean_count.num_data_files, 15);
-        assert_eq!(before_auto_clean_count.num_manifest_files, 15);
-        assert_eq!(before_auto_clean_count.num_tx_files, 15);
-
-        for _ in 0..5 {
+        // Write more files and check that those outside of the "older_than" window
+        // are cleaned up.
+        for num_expected_files in 2..cleanup_interval {
             fixture.overwrite_some_data().await.unwrap();
+            check_num_files(&fixture, num_expected_files).await;
         }
-
-        let after_auto_clean_count = fixture.count_files().await.unwrap();
-
-        assert_eq!(after_auto_clean_count.num_data_files, 5);
-        assert_eq!(after_auto_clean_count.num_manifest_files, 5);
-        assert_eq!(after_auto_clean_count.num_tx_files, 5);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -1011,11 +1011,6 @@ mod tests {
             fixture.overwrite_some_data().await.unwrap();
         }
 
-        // let _ = fixture
-        //     .run_cleanup(utc_now() - TimeDelta::try_days(8).unwrap())
-        //     .await
-        //     .unwrap();
-
         let after_auto_clean_count = fixture.count_files().await.unwrap();
 
         assert_eq!(after_auto_clean_count.num_data_files, 5);

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -492,17 +492,7 @@ pub async fn auto_cleanup_hook(
                     })
                 }
             };
-            let older_than = match TimeDelta::from_std(std_older_than) {
-                Ok(t) => t,
-                Err(e) => {
-                    return Err(Error::Cleanup {
-                        message: format!(
-                        "Error encountered while converting lance.auto_cleanup.older_than to chrono::TimeDelta: {}",
-                        e
-                    ),
-                    })
-                }
-            };
+            let older_than = TimeDelta::from_std(std_older_than).ok_or(TimeDelta::MAX);
             let interval: u64 = match interval.parse() {
                 Ok(i) => i,
                 Err(e) => {

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -471,7 +471,7 @@ pub async fn cleanup_old_versions(
 pub async fn auto_cleanup_hook(
     dataset: &Dataset,
     manifest: &Manifest,
-) -> Result<Option<Result<RemovalStats>>> {
+) -> Result<Option<RemovalStats>> {
     if let Some(older_than) = manifest.config.get("lance.auto_cleanup.older_than") {
         if let Some(interval) = manifest.config.get("lance.auto_cleanup.interval") {
             let older_than: i64 = match older_than.parse() {
@@ -500,7 +500,7 @@ pub async fn auto_cleanup_hook(
                 return Ok(Some(
                     dataset
                         .cleanup_old_versions(TimeDelta::days(older_than), Some(false), Some(false))
-                        .await,
+                        .await?,
                 ));
             }
         }

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -468,6 +468,12 @@ pub async fn cleanup_old_versions(
     cleanup.run().await
 }
 
+/// If the dataset config has `lance.auto_cleanup` parameters set,
+/// this function automatically calls `dataset.cleanup_old_versions`
+/// every `lance.auto_cleanup.interval` versions. This function calls
+/// `dataset.cleanup_old_versions` with `lance.auto_cleanup.older_than`
+/// for `older_than` and `Some(false)` for both `delete_unverified` and
+/// `error_if_tagged_old_versions`.
 pub async fn auto_cleanup_hook(
     dataset: &Dataset,
     manifest: &Manifest,

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -111,6 +111,22 @@ impl TryFrom<&str> for WriteMode {
     }
 }
 
+/// Autoclean Parameters
+#[derive(Debug, Clone)]
+pub struct AutoCleanupParams {
+    pub interval: usize,
+    pub older_than: usize,
+}
+
+impl Default for AutoCleanupParams {
+    fn default() -> Self {
+        Self {
+            interval: 20,
+            older_than: 14,
+        }
+    }
+}
+
 /// Dataset Write Parameters
 #[derive(Debug, Clone)]
 pub struct WriteParams {
@@ -173,6 +189,14 @@ pub struct WriteParams {
     pub object_store_registry: Arc<ObjectStoreRegistry>,
 
     pub session: Option<Arc<Session>>,
+
+    /// If Some, and this is a new dataset, set auto cleanup parameters.
+    /// This allows for old dataset versions to be automatically cleaned up, as
+    /// according to the parameters set out in `AutoCleanupParams`.
+    /// This parameter has no effect on existing datasets. To add autocleanup to
+    /// an existing /// dataset, use XXXXXXX method.
+    /// Default is Some({"interval": 20, "older_than": 14}).
+    pub auto_cleanup: Option<AutoCleanupParams>,
 }
 
 impl Default for WriteParams {
@@ -192,6 +216,7 @@ impl Default for WriteParams {
             enable_v2_manifest_paths: false,
             object_store_registry: Arc::new(ObjectStoreRegistry::default()),
             session: None,
+            auto_cleanup: Some(AutoCleanupParams::default()),
         }
     }
 }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
+use chrono::TimeDelta;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{StreamExt, TryStreamExt};
 use lance_core::datatypes::{
@@ -115,14 +116,14 @@ impl TryFrom<&str> for WriteMode {
 #[derive(Debug, Clone)]
 pub struct AutoCleanupParams {
     pub interval: usize,
-    pub older_than: usize,
+    pub older_than: TimeDelta,
 }
 
 impl Default for AutoCleanupParams {
     fn default() -> Self {
         Self {
             interval: 20,
-            older_than: 14,
+            older_than: TimeDelta::days(14),
         }
     }
 }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -190,12 +190,12 @@ pub struct WriteParams {
 
     pub session: Option<Arc<Session>>,
 
-    /// If Some, and this is a new dataset, set auto cleanup parameters.
-    /// This allows for old dataset versions to be automatically cleaned up, as
-    /// according to the parameters set out in `AutoCleanupParams`.
-    /// This parameter has no effect on existing datasets. To add autocleanup to
-    /// an existing /// dataset, use XXXXXXX method.
-    /// Default is Some({"interval": 20, "older_than": 14}).
+    /// If Some, and this is a new dataset, old dataset versions will be
+    /// automatically cleaned up as according to the parameters set out in
+    /// `AutoCleanupParams`. This parameter has no effect on existing datasets.
+    /// To add autocleaning to an existing dataset, use Dataset::update_config
+    /// to set lance.auto_cleanup.interval and lance.auto_cleanup.older_than.
+    /// Both parameters must be set to invoke autocleaning.
     pub auto_cleanup: Option<AutoCleanupParams>,
 }
 

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -111,7 +111,7 @@ impl TryFrom<&str> for WriteMode {
     }
 }
 
-/// Autoclean Parameters
+/// Auto cleanup parameters
 #[derive(Debug, Clone)]
 pub struct AutoCleanupParams {
     pub interval: usize,
@@ -190,8 +190,8 @@ pub struct WriteParams {
 
     pub session: Option<Arc<Session>>,
 
-    /// If Some, and this is a new dataset, old dataset versions will be
-    /// automatically cleaned up as according to the parameters set out in
+    /// If Some and this is a new dataset, old dataset versions will be
+    /// automatically cleaned up according to the parameters set out in
     /// `AutoCleanupParams`. This parameter has no effect on existing datasets.
     /// To add autocleaning to an existing dataset, use Dataset::update_config
     /// to set lance.auto_cleanup.interval and lance.auto_cleanup.older_than.

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -205,18 +205,25 @@ impl<'a> InsertBuilder<'a> {
         let operation = match context.params.mode {
             WriteMode::Create => {
                 // Fetch auto_cleanup params from context
-                let config_upsert_values = context.params.auto_cleanup.as_ref().map(|auto_cleanup_params| [
-                            (
-                                String::from("lance.auto_cleanup.interval"),
-                                auto_cleanup_params.interval.to_string(),
-                            ),
-                            (
-                                String::from("lance.auto_cleanup.older_than"),
-                                auto_cleanup_params.older_than.to_string(),
-                            ),
-                        ]
-                        .into_iter()
-                        .collect());
+                let config_upsert_values =
+                    context
+                        .params
+                        .auto_cleanup
+                        .as_ref()
+                        .map(|auto_cleanup_params| {
+                            [
+                                (
+                                    String::from("lance.auto_cleanup.interval"),
+                                    auto_cleanup_params.interval.to_string(),
+                                ),
+                                (
+                                    String::from("lance.auto_cleanup.older_than"),
+                                    auto_cleanup_params.older_than.to_string(),
+                                ),
+                            ]
+                            .into_iter()
+                            .collect()
+                        });
                 Operation::Overwrite {
                     // Use the full schema, not the written schema
                     schema,

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
 use arrow_array::RecordBatchIterator;
 use datafusion::execution::SendableRecordBatchStream;
+use humantime::format_duration;
 use lance_core::datatypes::NullabilityComparison;
 use lance_core::datatypes::Schema;
 use lance_core::datatypes::SchemaCompareOptions;
@@ -205,25 +207,34 @@ impl<'a> InsertBuilder<'a> {
         let operation = match context.params.mode {
             WriteMode::Create => {
                 // Fetch auto_cleanup params from context
-                let config_upsert_values =
-                    context
-                        .params
-                        .auto_cleanup
-                        .as_ref()
-                        .map(|auto_cleanup_params| {
-                            [
-                                (
-                                    String::from("lance.auto_cleanup.interval"),
-                                    auto_cleanup_params.interval.to_string(),
-                                ),
-                                (
+                let config_upsert_values = match context.params.auto_cleanup.as_ref() {
+                    Some(auto_cleanup_params) => {
+                        let mut upsert_values = HashMap::new();
+
+                        upsert_values.insert(
+                            String::from("lance.auto_cleanup.interval"),
+                            auto_cleanup_params.interval.to_string(),
+                        );
+
+                        match auto_cleanup_params.older_than.to_std() {
+                            Ok(d) => {
+                                upsert_values.insert(
                                     String::from("lance.auto_cleanup.older_than"),
-                                    auto_cleanup_params.older_than.to_string(),
-                                ),
-                            ]
-                            .into_iter()
-                            .collect()
-                        });
+                                    format_duration(d).to_string(),
+                                );
+                            }
+                            Err(e) => {
+                                return Err(Error::InvalidInput {
+                                    source: e.into(),
+                                    location: location!(),
+                                })
+                            }
+                        };
+
+                        Some(upsert_values)
+                    }
+                    None => None,
+                };
                 Operation::Overwrite {
                     // Use the full schema, not the written schema
                     schema,

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -203,7 +203,26 @@ impl<'a> InsertBuilder<'a> {
         context: &WriteContext<'_>,
     ) -> Result<Transaction> {
         let operation = match context.params.mode {
-            WriteMode::Create | WriteMode::Overwrite => Operation::Overwrite {
+            WriteMode::Create => Operation::Overwrite {
+                // Use the full schema, not the written schema
+                schema,
+                fragments: written_frags.default.0,
+                config_upsert_values: Some(
+                    [
+                        (
+                            String::from("lance.auto_cleanup.interval"),
+                            String::from("20"), // TODO: make configurable?
+                        ),
+                        (
+                            String::from("lance.auto_cleanup.older_than"),
+                            String::from("14"),
+                        ),
+                    ]
+                    .into_iter()
+                    .collect(),
+                ),
+            },
+            WriteMode::Overwrite => Operation::Overwrite {
                 // Use the full schema, not the written schema
                 schema,
                 fragments: written_frags.default.0,

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -205,9 +205,7 @@ impl<'a> InsertBuilder<'a> {
         let operation = match context.params.mode {
             WriteMode::Create => {
                 // Fetch auto_cleanup params from context
-                let config_upsert_values = match &context.params.auto_cleanup {
-                    Some(auto_cleanup_params) => Some(
-                        [
+                let config_upsert_values = context.params.auto_cleanup.as_ref().map(|auto_cleanup_params| [
                             (
                                 String::from("lance.auto_cleanup.interval"),
                                 auto_cleanup_params.interval.to_string(),
@@ -218,10 +216,7 @@ impl<'a> InsertBuilder<'a> {
                             ),
                         ]
                         .into_iter()
-                        .collect(),
-                    ),
-                    None => None,
-                };
+                        .collect());
                 Operation::Overwrite {
                     // Use the full schema, not the written schema
                     schema,

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -41,7 +41,7 @@ use object_store::path::Path;
 use prost::Message;
 
 use super::ObjectStore;
-use crate::dataset::cleanup::auto_clean_hook;
+use crate::dataset::cleanup::auto_cleanup_hook;
 use crate::dataset::fragment::FileFragment;
 use crate::dataset::transaction::{Operation, Transaction};
 use crate::dataset::{write_manifest_file, ManifestWriteConfig, BLOB_DIR};
@@ -631,8 +631,10 @@ pub(crate) async fn do_commit_detached_transaction(
 
         match result {
             Ok(location) => {
-                if let Some(auto_clean_carried_out) = auto_clean_hook(&dataset, &manifest).await? {
-                    auto_clean_carried_out?;
+                if let Some(auto_cleanup_carried_out) =
+                    auto_cleanup_hook(&dataset, &manifest).await?
+                {
+                    auto_cleanup_carried_out?;
                 }
 
                 return Ok((manifest, location.path, location.e_tag));
@@ -838,8 +840,10 @@ pub(crate) async fn commit_transaction(
                     .file_metadata_cache
                     .insert(cache_path, Arc::new(transaction.clone()));
 
-                if let Some(auto_clean_carried_out) = auto_clean_hook(&dataset, &manifest).await? {
-                    auto_clean_carried_out?;
+                if let Some(auto_cleanup_carried_out) =
+                    auto_cleanup_hook(&dataset, &manifest).await?
+                {
+                    auto_cleanup_carried_out?;
                 }
 
                 return Ok((manifest, manifest_location.path, manifest_location.e_tag));

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -41,6 +41,7 @@ use object_store::path::Path;
 use prost::Message;
 
 use super::ObjectStore;
+use crate::dataset::cleanup::auto_clean_hook;
 use crate::dataset::fragment::FileFragment;
 use crate::dataset::transaction::{Operation, Transaction};
 use crate::dataset::{write_manifest_file, ManifestWriteConfig, BLOB_DIR};
@@ -630,6 +631,10 @@ pub(crate) async fn do_commit_detached_transaction(
 
         match result {
             Ok(location) => {
+                if let Some(auto_clean_carried_out) = auto_clean_hook(&dataset, &manifest).await {
+                    auto_clean_carried_out?;
+                }
+
                 return Ok((manifest, location.path, location.e_tag));
             }
             Err(CommitError::CommitConflict) => {
@@ -832,6 +837,10 @@ pub(crate) async fn commit_transaction(
                     .session()
                     .file_metadata_cache
                     .insert(cache_path, Arc::new(transaction.clone()));
+
+                if let Some(auto_clean_carried_out) = auto_clean_hook(&dataset, &manifest).await {
+                    auto_clean_carried_out?;
+                }
 
                 return Ok((manifest, manifest_location.path, manifest_location.e_tag));
             }

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -631,12 +631,7 @@ pub(crate) async fn do_commit_detached_transaction(
 
         match result {
             Ok(location) => {
-                if let Some(auto_cleanup_carried_out) =
-                    auto_cleanup_hook(dataset, &manifest).await?
-                {
-                    auto_cleanup_carried_out?;
-                }
-
+                auto_cleanup_hook(dataset, &manifest).await?;
                 return Ok((manifest, location.path, location.e_tag));
             }
             Err(CommitError::CommitConflict) => {
@@ -840,12 +835,7 @@ pub(crate) async fn commit_transaction(
                     .file_metadata_cache
                     .insert(cache_path, Arc::new(transaction.clone()));
 
-                if let Some(auto_cleanup_carried_out) =
-                    auto_cleanup_hook(&dataset, &manifest).await?
-                {
-                    auto_cleanup_carried_out?;
-                }
-
+                auto_cleanup_hook(&dataset, &manifest).await?;
                 return Ok((manifest, manifest_location.path, manifest_location.e_tag));
             }
             Err(CommitError::CommitConflict) => {

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -1265,6 +1265,7 @@ mod tests {
     #[tokio::test]
     async fn test_good_concurrent_config_writes() {
         let (_tmpdir, dataset) = get_empty_dataset().await;
+        let original_num_config_keys = dataset.manifest.config.len();
 
         // Test successful concurrent insert config operations
         let futures: Vec<_> = ["key1", "key2", "key3", "key4", "key5"]
@@ -1286,7 +1287,7 @@ mod tests {
         }
 
         let dataset = dataset.checkout_version(6).await.unwrap();
-        assert_eq!(dataset.manifest.config.len(), 5);
+        assert_eq!(dataset.manifest.config.len(), 5 + original_num_config_keys);
 
         dataset.validate().await.unwrap();
 
@@ -1309,7 +1310,7 @@ mod tests {
         let dataset = dataset.checkout_version(11).await.unwrap();
 
         // There are now two fewer keys
-        assert_eq!(dataset.manifest.config.len(), 3);
+        assert_eq!(dataset.manifest.config.len(), 3 + original_num_config_keys);
 
         dataset.validate().await.unwrap()
     }

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -631,7 +631,6 @@ pub(crate) async fn do_commit_detached_transaction(
 
         match result {
             Ok(location) => {
-                auto_cleanup_hook(dataset, &manifest).await?;
                 return Ok((manifest, location.path, location.e_tag));
             }
             Err(CommitError::CommitConflict) => {

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -632,7 +632,7 @@ pub(crate) async fn do_commit_detached_transaction(
         match result {
             Ok(location) => {
                 if let Some(auto_cleanup_carried_out) =
-                    auto_cleanup_hook(&dataset, &manifest).await?
+                    auto_cleanup_hook(dataset, &manifest).await?
                 {
                     auto_cleanup_carried_out?;
                 }

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -631,7 +631,7 @@ pub(crate) async fn do_commit_detached_transaction(
 
         match result {
             Ok(location) => {
-                if let Some(auto_clean_carried_out) = auto_clean_hook(&dataset, &manifest).await {
+                if let Some(auto_clean_carried_out) = auto_clean_hook(&dataset, &manifest).await? {
                     auto_clean_carried_out?;
                 }
 
@@ -838,7 +838,7 @@ pub(crate) async fn commit_transaction(
                     .file_metadata_cache
                     .insert(cache_path, Arc::new(transaction.clone()));
 
-                if let Some(auto_clean_carried_out) = auto_clean_hook(&dataset, &manifest).await {
+                if let Some(auto_clean_carried_out) = auto_clean_hook(&dataset, &manifest).await? {
                     auto_clean_carried_out?;
                 }
 


### PR DESCRIPTION
Closes #2100.

This PR introduces:
-  A hook called `auto_cleanup_hook`. If config keys `lance.auto_cleanup.interval` and `lance.auto_cleanup.older_than` are both set, then, every `n_versions % lance.auto_cleanup.interval`, `cleanup_old_versions` will automatically be called.
- A new write param `auto_cleanup: Option<AutoCleanupParams>`.  If `Some`, new datasets are configured with the necessary `lance.auto_cleanup` config keys. By default this sets the `interval=20` and `older_than=14`.
- A test to ensure hook is automatically invoked. Some older tests have been fixed as they either do not assume autoclaving will take place, or assume the initial default config is empty.

This PR is Rust-only. I can add Python bindings in a future PR if desired.

From #2100:

- [x] Add configuration key for "auto_cleanup.interval", which is number of versions to have between running.
- [x] Add a configuration key for "auto_cleanup.older_than", which is the older_than parameter for cleanup_old_versions.
- [x] Double check documented default value of two weeks. Maybe it should be seven days. *(two weeks seems reasonable to me?)*
- [x] Add hook to do this in the commit path.
- [ ] Document how to manually call cleanup_old_versions *(not done yet - where would you like this documenting?)*
- [x] Document how to configure auto cleanup and how to disable it. *(done in the doc comment for `AutoCleanupParams` - let me know if you want this documented elsewhere)*
