### PR TITLE
fix: remove some expensive debug impls

### DIFF
--- a/rust/lance-core/src/cache.rs
+++ b/rust/lance-core/src/cache.rs
@@ -122,6 +122,13 @@ impl FileMetadataCache {
         }
     }
 
+    pub fn approx_size(&self) -> usize {
+        if let Some(cache) = self.cache.as_ref() {
+            cache.entry_count() as usize
+        } else {
+            0
+        }
+    }
     /// Fetch an item from the cache, using a str as the key
     pub fn get_by_str<T: Send + Sync + 'static>(&self, path: &str) -> Option<Arc<T>> {
         self.get(&Path::parse(path).unwrap())

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -106,7 +106,7 @@ pub(crate) const DEFAULT_INDEX_CACHE_SIZE: usize = 256;
 pub(crate) const DEFAULT_METADATA_CACHE_SIZE: usize = 256;
 
 /// Lance Dataset
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Dataset {
     pub object_store: Arc<ObjectStore>,
     pub(crate) commit_handler: Arc<dyn CommitHandler>,
@@ -123,6 +123,17 @@ pub struct Dataset {
     pub(crate) session: Arc<Session>,
     pub tags: Tags,
     pub manifest_naming_scheme: ManifestNamingScheme,
+}
+
+impl std::fmt::Debug for Dataset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Dataset")
+            .field("uri", &self.uri)
+            .field("base", &self.base)
+            .field("version", &self.manifest.version)
+            .field("cache_num_items", &self.session.approx_num_items())
+            .finish()
+    }
 }
 
 /// Dataset Version

--- a/rust/lance/src/index/cache.rs
+++ b/rust/lance/src/index/cache.rs
@@ -105,6 +105,13 @@ impl IndexCache {
             + self.metadata_cache.entry_count()) as usize
     }
 
+    pub(crate) fn approx_size(&self) -> usize {
+        (self.scalar_cache.entry_count()
+            + self.vector_cache.entry_count()
+            + self.vector_partition_cache.entry_count()
+            + self.metadata_cache.entry_count()) as usize
+    }
+
     pub(crate) fn get_type(&self, key: &str) -> Option<ScalarIndexType> {
         if let Some(index) = self.type_cache.get(key) {
             self.cache_stats.record_hit();

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -34,18 +34,13 @@ impl std::fmt::Debug for Session {
         f.debug_struct("Session")
             .field(
                 "index_cache",
-                &format!(
-                    "IndexCache(items={}, size_bytes={})",
-                    self.index_cache.get_size(),
-                    self.index_cache.deep_size_of()
-                ),
+                &format!("IndexCache(items={})", self.index_cache.approx_size(),),
             )
             .field(
                 "file_metadata_cache",
                 &format!(
-                    "FileMetadataCache(items={}, size_bytes={})",
-                    self.file_metadata_cache.size(),
-                    self.file_metadata_cache.deep_size_of()
+                    "FileMetadataCache(items={})",
+                    self.file_metadata_cache.approx_size(),
                 ),
             )
             .field(
@@ -124,6 +119,12 @@ impl Session {
         // We re-expose deep_size_of here so that users don't
         // need the deepsize crate themselves (e.g. to use deep_size_of)
         self.deep_size_of() as u64
+    }
+
+    pub fn approx_num_items(&self) -> usize {
+        self.index_cache.approx_size()
+            + self.file_metadata_cache.approx_size()
+            + self.index_extensions.len()
     }
 }
 


### PR DESCRIPTION
`FileMetadataCache::deep_size_of` was the worst offender as it required iterating through all items.
`Dataset`'s debug can get quite large if there are several object store wrappers.  In addition, the debug for the manifest is quite large.