### PR TITLE
fix: reintroduce TakeExec.dataset method

### DIFF
--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -439,6 +439,13 @@ impl TakeExec {
             metadata: dataset_schema.metadata.clone(),
         }
     }
+
+    /// Get the dataset.
+    ///
+    /// WARNING: Internal API with no stability guarantees.
+    pub fn dataset(&self) -> &Arc<Dataset> {
+        &self.dataset
+    }
 }
 
 impl ExecutionPlan for TakeExec {


### PR DESCRIPTION
This internal API was removed in a recent commit.