### PR TITLE
ci: support python310 tomli

### DIFF
--- a/ci/check_versions.py
+++ b/ci/check_versions.py
@@ -11,7 +11,12 @@ def get_versions():
     """
     Gets the current version in both python/Cargo.toml and Cargo.toml files.
     """
-    import tomllib
+    try:
+        # Python 3.11+ 
+        import tomllib
+    except ImportError:
+        # Python 3.6-3.10 use tomli
+        import tomli as tomllib
 
     with open("python/Cargo.toml", "rb") as file:
         pylance_version = tomllib.load(file)["package"]["version"]


### PR DESCRIPTION
Python 3.11 and later versions natively support tomllib, but lower versions require third-party libraries like tomli or toml. 
For example:

```
# Python 3.11+ (built-in)
import tomllib

# For Python <3.11:
# First install: pip install tomli
import tomli as tomllib
```