### PR TITLE
fix: work around deranged breaking change not labeled as such

### DIFF
--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -532,7 +532,7 @@ fn read_null_array(
                 0
             } else {
                 let idx_max = *indices.values().iter().max().unwrap() as u64;
-                if idx_max >= page_info.length.try_into().unwrap() {
+                if idx_max >= page_info.length as u64 {
                     return Err(Error::io(
                         format!(
                             "NullArray Reader: request([{}]) out of range: [0..{}]",


### PR DESCRIPTION
A breaking change was introduced in https://github.com/jhpratt/deranged/issues/18 which was not given a semver bump.  As a result we pick it up and it fails the "no lock file" test.

This PR just avoids the try_into entirely since it doesn't seem to be necessary (we only work on 64-bit machines so usize->u64 should be safe).