### PR TITLE
fix: divide by 0 error if remapping PQ storage to empty

### DIFF
--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -174,7 +174,7 @@ pub(super) fn compute_pq_distance_4bit(
     let mut quantized_dists = vec![0_u8; num_vectors];
 
     let remainder = num_vectors % NUM_CENTROIDS;
-    for i in (0..num_vectors - NUM_CENTROIDS + 1).step_by(NUM_CENTROIDS) {
+    for i in (0..num_vectors - remainder).step_by(NUM_CENTROIDS) {
         let mut block_distances = u8x16::zeros();
 
         for (sub_vec_idx, vec_indices) in code.chunks_exact(num_vectors).enumerate() {

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -509,18 +509,27 @@ impl VectorStore for ProductQuantizationStorage {
 
         let new_row_ids = Arc::new(UInt64Array::from(new_row_ids));
         let new_codes = UInt8Array::from(new_codes);
-        let num_bytes_in_code = new_codes.len() / new_row_ids.len();
-        let new_transposed_codes = transpose(&new_codes, new_row_ids.len(), num_bytes_in_code);
-        let codes_fsl = Arc::new(FixedSizeListArray::try_new_from_values(
-            new_transposed_codes.clone(),
-            num_bytes_in_code as i32,
-        )?);
-        let batch = RecordBatch::try_new(self.schema(), vec![new_row_ids.clone(), codes_fsl])?;
+        let batch = if new_row_ids.is_empty() {
+            RecordBatch::new_empty(self.schema())
+        } else {
+            let num_bytes_in_code = new_codes.len() / new_row_ids.len();
+            let new_transposed_codes = transpose(&new_codes, new_row_ids.len(), num_bytes_in_code);
+            let codes_fsl = Arc::new(FixedSizeListArray::try_new_from_values(
+                new_transposed_codes.clone(),
+                num_bytes_in_code as i32,
+            )?);
+            RecordBatch::try_new(self.schema(), vec![new_row_ids.clone(), codes_fsl])?
+        };
+        let transposed_codes = batch[PQ_CODE_COLUMN]
+            .as_fixed_size_list()
+            .values()
+            .as_primitive::<UInt8Type>()
+            .clone();
 
         Ok(Self {
             codebook: self.codebook.clone(),
             batch,
-            pq_code: Arc::new(new_transposed_codes),
+            pq_code: Arc::new(transposed_codes),
             row_ids: new_row_ids,
             num_sub_vectors: self.num_sub_vectors,
             num_bits: self.num_bits,

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -515,7 +515,7 @@ impl VectorStore for ProductQuantizationStorage {
             let num_bytes_in_code = new_codes.len() / new_row_ids.len();
             let new_transposed_codes = transpose(&new_codes, new_row_ids.len(), num_bytes_in_code);
             let codes_fsl = Arc::new(FixedSizeListArray::try_new_from_values(
-                new_transposed_codes.clone(),
+                new_transposed_codes,
                 num_bytes_in_code as i32,
             )?);
             RecordBatch::try_new(self.schema(), vec![new_row_ids.clone(), codes_fsl])?

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -668,7 +668,7 @@ mod tests {
     use tempfile::tempdir;
 
     use crate::dataset::optimize::{compact_files, CompactionOptions};
-    use crate::dataset::UpdateBuilder;
+    use crate::dataset::{UpdateBuilder, WriteParams};
     use crate::index::DatasetIndexInternalExt;
     use crate::{index::vector::VectorIndexParams, Dataset};
 
@@ -685,7 +685,16 @@ mod tests {
         let (batch, schema) = generate_batch::<T>(NUM_ROWS, None, range, false);
         let vectors = batch.column_by_name("vector").unwrap().clone();
         let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
-        let dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+        let dataset = Dataset::write(
+            batches,
+            test_uri,
+            Some(WriteParams {
+                mode: crate::dataset::WriteMode::Overwrite,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
         (dataset, Arc::new(vectors.as_fixed_size_list().clone()))
     }
 
@@ -969,11 +978,6 @@ mod tests {
         compact_files(&mut dataset, CompactionOptions::default(), None)
             .await
             .unwrap();
-        // index the updated data
-        dataset
-            .optimize_indices(&OptimizeOptions::new())
-            .await
-            .unwrap();
         // query again, the result should not include the deleted row
         let result = dataset.scan().try_into_batch().await.unwrap();
         let ids = result["id"].as_primitive::<UInt64Type>();
@@ -981,7 +985,6 @@ mod tests {
         ids.values().iter().for_each(|id| {
             assert!(*id >= half_rows as u64 + 50);
         });
-        let max_id = ids.values().iter().copied().max().unwrap();
 
         // make sure we can still hit the recall
         let gt = ground_truth(&dataset, vector_column, &query, 100, params.metric_type).await;
@@ -1004,8 +1007,13 @@ mod tests {
         assert_ge!(recall, 0.8, "{}", recall);
 
         // delete so that only one row left, to trigger remap and there must be some empty partitions
+        let (mut dataset, _) = generate_test_dataset::<T>(test_uri, range).await;
+        dataset
+            .create_index(&[vector_column], IndexType::Vector, None, &params, true)
+            .await
+            .unwrap();
         assert_eq!(dataset.load_indices().await.unwrap().len(), 1);
-        dataset.delete(&format!("id < {}", max_id)).await.unwrap();
+        dataset.delete("id > 0").await.unwrap();
         assert_eq!(dataset.count_rows(None).await.unwrap(), 1);
         assert_eq!(dataset.load_indices().await.unwrap().len(), 1);
         compact_files(&mut dataset, CompactionOptions::default(), None)


### PR DESCRIPTION
this fixes:
- divide by 0 error if remapping an empty PQ storage
- 4bit PQ panic if there are less than 16 rows