### PR TITLE
chore: remove SNAPSHOT from version

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lancedb</groupId>
         <artifactId>lance-parent</artifactId>
-        <version>0.25.1-SNAPSHOT</version>
+        <version>0.25.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.lancedb</groupId>
     <artifactId>lance-parent</artifactId>
-    <version>0.25.1-SNAPSHOT</version>
+    <version>0.25.1</version>
     <packaging>pom</packaging>
 
     <name>Lance Parent</name>

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lancedb</groupId>
         <artifactId>lance-parent</artifactId>
-        <version>0.25.1-SNAPSHOT</version>
+        <version>0.25.1</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>com.lancedb</groupId>
             <artifactId>lance-core</artifactId>
-            <version>0.25.1-SNAPSHOT</version>
+            <version>0.25.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>


### PR DESCRIPTION
Reverts part of #3546 which added `-SNAPSHOT` to the versions.  Currently the CI build system does not publish Java artifacts on pre-releases.  There is also nothing in the build script to remove the `-SNAPSHOT` designation from the version.  As a result the publish failed.

Currently, CI requires the version specifier point to the next stable version that will be released.  This restores that so the next stable release can succeed.