### PR TITLE
WIP: support for distance calculation Int8 vectors

### DIFF
--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -8,6 +8,7 @@
 use std::sync::Arc;
 use std::{collections::HashMap, ptr::NonNull};
 
+use arrow_array::{Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array};
 use arrow_array::{
     cast::AsArray, Array, ArrayRef, ArrowNumericType, FixedSizeBinaryArray, FixedSizeListArray,
     GenericListArray, OffsetSizeTrait, PrimitiveArray, RecordBatch, StructArray, UInt32Array,
@@ -235,6 +236,9 @@ pub trait FixedSizeListArrayExt {
     /// assert_eq!(sampled.values().len(), 160);
     /// ```
     fn sample(&self, n: usize) -> Result<FixedSizeListArray>;
+
+    /// Convert the [FixedSizeListArray] to floating point type.
+    fn convert_to_floating_point (&self) -> Result<FixedSizeListArray>;
 }
 
 impl FixedSizeListArrayExt for FixedSizeListArray {
@@ -252,6 +256,132 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
         let mut rng = SmallRng::from_entropy();
         let chosen = (0..self.len() as u32).choose_multiple(&mut rng, n);
         take(self, &UInt32Array::from(chosen), None).map(|arr| arr.as_fixed_size_list().clone())
+    }
+
+    fn convert_to_floating_point (&self) -> Result<FixedSizeListArray> {
+        match self.data_type() {
+            DataType::FixedSizeList(field, size) => {
+                match field.data_type() {
+                    DataType::Float16 | DataType::Float32 | DataType::Float64 => Ok(self.clone()),
+                    DataType::Int8 => Ok(
+                        FixedSizeListArray::new(
+                            Arc::new(arrow_schema::Field::new(
+                                field.name(), 
+                                DataType::Float32, 
+                                field.is_nullable())),
+                            *size, 
+                            Arc::new(Float32Array::from_iter_values(
+                                self
+                                .values()
+                                .as_any()
+                                .downcast_ref::<Int8Array>()
+                                .ok_or(ArrowError::ParseError(format!("Fail to cast primitive array to Int8Type")))?
+                                .into_iter()
+                                .filter_map(|x| x.map(|y| y as f32)))), 
+                            self
+                            .nulls()
+                            .map(|x| x.clone()))
+                    ),
+                    DataType::Int16 => Ok(
+                        FixedSizeListArray::new(
+                            Arc::new(arrow_schema::Field::new(
+                                field.name(), 
+                                DataType::Float32, 
+                                field.is_nullable())),
+                            *size, 
+                            Arc::new(Float32Array::from_iter_values(
+                                self
+                                .values()
+                                .as_any()
+                                .downcast_ref::<Int16Array>()
+                                .ok_or(ArrowError::ParseError(format!("Fail to cast primitive array to Int8Type")))?
+                                .into_iter()
+                                .filter_map(|x| x.map(|y| y as f32)))), 
+                            self
+                            .nulls()
+                            .map(|x| x.clone()))
+                    ),
+                    DataType::Int32 => Ok(
+                        FixedSizeListArray::new(
+                            Arc::new(arrow_schema::Field::new(
+                                field.name(), 
+                                DataType::Float32, 
+                                field.is_nullable())),
+                            *size, 
+                            Arc::new(Float32Array::from_iter_values(
+                                self
+                                .values()
+                                .as_any()
+                                .downcast_ref::<Int32Array>()
+                                .ok_or(ArrowError::ParseError(format!("Fail to cast primitive array to Int8Type")))?
+                                .into_iter()
+                                .filter_map(|x| x.map(|y| y as f32)))), 
+                            self
+                            .nulls()
+                            .map(|x| x.clone()))
+                    ),
+                    DataType::Int64 => Ok(
+                        FixedSizeListArray::new(
+                            Arc::new(arrow_schema::Field::new(
+                                field.name(), 
+                                DataType::Float64, 
+                                field.is_nullable())),
+                            *size, 
+                            Arc::new(Float64Array::from_iter_values(
+                                self
+                                .values()
+                                .as_any()
+                                .downcast_ref::<Int64Array>()
+                                .ok_or(ArrowError::ParseError(format!("Fail to cast primitive array to Int8Type")))?
+                                .into_iter()
+                                .filter_map(|x| x.map(|y| y as f64)))), 
+                            self
+                            .nulls()
+                            .map(|x| x.clone()))
+                    ),
+                    DataType::UInt8 => Ok(
+                        FixedSizeListArray::new(
+                            Arc::new(arrow_schema::Field::new(
+                                field.name(), 
+                                DataType::Float64, 
+                                field.is_nullable())),
+                            *size, 
+                            Arc::new(Float64Array::from_iter_values(
+                                self
+                                .values()
+                                .as_any()
+                                .downcast_ref::<UInt8Array>()
+                                .ok_or(ArrowError::ParseError(format!("Fail to cast primitive array to Int8Type")))?
+                                .into_iter()
+                                .filter_map(|x| x.map(|y| y as f64)))), 
+                            self
+                            .nulls()
+                            .map(|x| x.clone()))
+                    ),
+                    DataType::UInt32 => Ok(
+                        FixedSizeListArray::new(
+                            Arc::new(arrow_schema::Field::new(
+                                field.name(), 
+                                DataType::Float64, 
+                                field.is_nullable())),
+                            *size, 
+                            Arc::new(Float64Array::from_iter_values(
+                                self
+                                .values()
+                                .as_any()
+                                .downcast_ref::<UInt32Array>()
+                                .ok_or(ArrowError::ParseError(format!("Fail to cast primitive array to Int8Type")))?
+                                .into_iter()
+                                .filter_map(|x| x.map(|y| y as f64)))), 
+                            self
+                            .nulls()
+                            .map(|x| x.clone()))
+                    ),
+                    data_type => Err(ArrowError::ParseError(format!("Expect either floating type or integer got {:?}", data_type)))
+                }
+            }
+            data_type => Err(ArrowError::ParseError(format!("Expect either FixedSizeList got {:?}", data_type)))
+        }
     }
 }
 

--- a/rust/lance-index/src/vector/transform.rs
+++ b/rust/lance-index/src/vector/transform.rs
@@ -139,6 +139,7 @@ impl Transformer for KeepFiniteVectors {
                     DataType::Float16 => is_all_finite::<Float16Type>(&data),
                     DataType::Float32 => is_all_finite::<Float32Type>(&data),
                     DataType::Float64 => is_all_finite::<Float64Type>(&data),
+                    DataType::Int8 => true,
                     _ => false,
                 };
                 if is_valid {

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -11,12 +11,12 @@ use std::sync::Arc;
 
 use arrow_array::{
     cast::AsArray,
-    types::{Float16Type, Float32Type, Float64Type},
+    types::{Float16Type, Float32Type, Float64Type, Int8Type},
     Array, FixedSizeListArray, Float32Array,
 };
 use arrow_schema::DataType;
 use half::{bf16, f16};
-use lance_arrow::{ArrowFloatType, FloatArray};
+use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray};
 #[cfg(feature = "fp16kernels")]
 use lance_core::utils::cpu::SimdSupport;
 use lance_core::utils::cpu::FP16_SIMD_SUPPORT;
@@ -320,6 +320,13 @@ pub fn cosine_distance_arrow_batch(
         DataType::Float16 => do_cosine_distance_arrow_batch::<Float16Type>(from.as_primitive(), to),
         DataType::Float32 => do_cosine_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),
         DataType::Float64 => do_cosine_distance_arrow_batch::<Float64Type>(from.as_primitive(), to),
+        DataType::Int8 => do_cosine_distance_arrow_batch::<Float32Type>(
+            &from.as_primitive::<Int8Type>()
+                .into_iter()
+                .map(|x| x.unwrap() as f32)
+                .collect(), 
+            &to.convert_to_floating_point()?
+        ),
         _ => Err(Error::InvalidArgumentError(format!(
             "Unsupported data type {:?}",
             from.data_type()

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -278,6 +278,7 @@ pub fn dot_distance_arrow_batch(
         DataType::Float16 => do_dot_distance_arrow_batch::<Float16Type>(from.as_primitive(), to),
         DataType::Float32 => do_dot_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),
         DataType::Float64 => do_dot_distance_arrow_batch::<Float64Type>(from.as_primitive(), to),
+        DataType::Int8 => do_dot_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),
         _ => Err(Error::InvalidArgumentError(format!(
             "Unsupported data type: {:?}",
             from.data_type()

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -10,12 +10,12 @@ use std::sync::Arc;
 
 use arrow_array::{
     cast::AsArray,
-    types::{Float16Type, Float32Type, Float64Type},
+    types::{Float16Type, Float32Type, Float64Type, Int8Type},
     Array, FixedSizeListArray, Float32Array,
 };
 use arrow_schema::DataType;
 use half::{bf16, f16};
-use lance_arrow::{ArrowFloatType, FloatArray};
+use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray};
 #[cfg(feature = "fp16kernels")]
 use lance_core::utils::cpu::SimdSupport;
 use lance_core::utils::cpu::FP16_SIMD_SUPPORT;
@@ -293,6 +293,13 @@ pub fn l2_distance_arrow_batch(
         DataType::Float16 => do_l2_distance_arrow_batch::<Float16Type>(from.as_primitive(), to),
         DataType::Float32 => do_l2_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),
         DataType::Float64 => do_l2_distance_arrow_batch::<Float64Type>(from.as_primitive(), to),
+        DataType::Int8 => do_l2_distance_arrow_batch::<Float32Type>(
+            &from.as_primitive::<Int8Type>()
+                .into_iter()
+                .map(|x| x.unwrap() as f32)
+                .collect(), 
+            &to.convert_to_floating_point()?
+        ),
         _ => Err(Error::ComputeError(format!(
             "Unsupported data type: {}",
             from.data_type()

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -730,10 +730,6 @@ impl Scanner {
 
         let key = match element_type {
             dt if dt == *q.data_type() => q,
-            dt if dt.is_integer() => coerce_float_vector(
-                q.as_any().downcast_ref::<Float32Array>().unwrap(),
-                FloatType::try_from(&dt)?,
-            )?,
             dt if dt.is_floating() => coerce_float_vector(
                 q.as_any().downcast_ref::<Float32Array>().unwrap(),
                 FloatType::try_from(&dt)?,

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use arrow::array::AsArray;
-use arrow_array::{Array, Float32Array, Int64Array, RecordBatch};
+use arrow_array::{Array, Float32Array, Int64Array, Int8Array, RecordBatch};
 use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef, SortOptions};
 use arrow_select::concat::concat_batches;
 use async_recursion::async_recursion;
@@ -730,6 +730,10 @@ impl Scanner {
 
         let key = match element_type {
             dt if dt == *q.data_type() => q,
+            dt if dt.is_integer() => coerce_float_vector(
+                q.as_any().downcast_ref::<Float32Array>().unwrap(),
+                FloatType::try_from(&dt)?,
+            )?,
             dt if dt.is_floating() => coerce_float_vector(
                 q.as_any().downcast_ref::<Float32Array>().unwrap(),
                 FloatType::try_from(&dt)?,

--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -79,7 +79,8 @@ fn infer_vector_element_type_impl(
                 arrow::datatypes::DataType::Float16
                 | arrow::datatypes::DataType::Float32
                 | arrow::datatypes::DataType::Float64
-                | arrow::datatypes::DataType::UInt8 => Ok(element_field.data_type().clone()),
+                | arrow::datatypes::DataType::UInt8
+                | arrow::datatypes::DataType::Int8 => Ok(element_field.data_type().clone()),
                 _ => Err(Error::Index {
                     message: format!(
                         "vector element is not expected type (Float16/Float32/Float64 or UInt8): {:?}",


### PR DESCRIPTION
Using [AllMiniLM12V2](https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2) to generate embeddings, I found that with a tiny bit of transformation, I can store the embedding as int8 to massively reduce its storage requirement and turn it into f32 during distance calculation (using cosine and dot) with marginal change to the outcome.

I would like to add support for int8 by converting FixedSizeList type of Int8Array to Float32Array during calculation. The conversion is done with a ``convert_to_floating_point`` on the ``FixedSizeListArrayExt`` trait. In theory, this can also work with other types like uint8, int32, int64. This would make a big difference in storage requirement on the compatible models.

I've made this change as a patch on the tag v.0.24.1 to test with my internal work. If you think this approach make sense, please let me know your thoughts and I can try to finish this work and make a pull request on main or wherever appropriate.

Much appreciate! 🙏