### PR TITLE
fix: avoid creating empty encoding task and part for PrimitiveFieldEncoder

### DIFF
--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -3404,6 +3404,9 @@ impl PrimitiveFieldEncoder {
                 let part_size = bit_util::ceil(array.len(), num_parts);
                 for _ in 0..num_parts {
                     let avail = array.len() - offset;
+                    if avail == 0 {
+                        break;
+                    }
                     let chunk_size = avail.min(part_size);
                     let part = array.slice(offset, chunk_size);
                     let task = self.create_encode_task(vec![part])?;


### PR DESCRIPTION
`PrimitiveFieldEncoder` may generate empty `part`s and their corresponding encoding tasks, especially when `max_page_size` is small. This is unnecessary and can be confusing, as some empty part information gets recorded at the end, and redundant encoding tasks are processed needlessly. This PR fixes the issue by exiting the loop early when there is no data to process.