### PR TITLE
feat: support AND query and improve phrase query performance

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3401,9 +3401,7 @@ class ScannerBuilder:
             The columns to search in. If None, search in all indexed columns.
         """
         if isinstance(query, FullTextQuery):
-            self._full_text_query = {
-                "query": query.to_dict(),
-            }
+            self._full_text_query = query.inner
         else:
             self._full_text_query = {
                 "query": query,

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -453,5 +453,34 @@ class BFloat16:
 
 def bfloat16_array(values: List[str | None]) -> BFloat16Array: ...
 
+class PyFullTextQuery:
+    @staticmethod
+    def match_query(
+        column: str,
+        query: str,
+        boost: float = 1.0,
+        fuzziness: Optional[int] = 0,
+        max_expansions: int = 50,
+        operator: str = "OR",
+    ) -> PyFullTextQuery: ...
+    @staticmethod
+    def phrase_query(
+        query: str,
+        column: str,
+    ) -> PyFullTextQuery: ...
+    @staticmethod
+    def boost_query(
+        positive: PyFullTextQuery,
+        negative: PyFullTextQuery,
+        negative_boost: Optional[float],
+    ) -> PyFullTextQuery: ...
+    @staticmethod
+    def multi_match_query(
+        query: str,
+        columns: List[str],
+        boosts: Optional[List[float]] = None,
+        operator: str = "OR",
+    ) -> PyFullTextQuery: ...
+
 __version__: str
 language_model_home: Callable[[], str]

--- a/python/python/lance/query.py
+++ b/python/python/lance/query.py
@@ -14,6 +14,11 @@ class FullTextQueryType(Enum):
     MULTI_MATCH = "multi_match"
 
 
+class FullTextOperator(Enum):
+    AND = "AND"
+    OR = "OR"
+
+
 class FullTextQuery(abc.ABC):
     @abc.abstractmethod
     def query_type(self) -> FullTextQueryType:
@@ -47,6 +52,7 @@ class MatchQuery(FullTextQuery):
         boost: float = 1.0,
         fuzziness: int = 0,
         max_expansions: int = 50,
+        operator: FullTextOperator = FullTextOperator.AND,
     ):
         """
         Match query for full-text search.
@@ -76,6 +82,7 @@ class MatchQuery(FullTextQuery):
         self.boost = boost
         self.fuzziness = fuzziness
         self.max_expansions = max_expansions
+        self.operator = operator
 
     def query_type(self) -> FullTextQueryType:
         return FullTextQueryType.MATCH
@@ -88,6 +95,7 @@ class MatchQuery(FullTextQuery):
                     "boost": self.boost,
                     "fuzziness": self.fuzziness,
                     "max_expansions": self.max_expansions,
+                    "operator": self.operator,
                 }
             }
         }

--- a/python/python/lance/query.py
+++ b/python/python/lance/query.py
@@ -6,6 +6,8 @@ import abc
 from enum import Enum
 from typing import Optional
 
+from .lance import PyFullTextQuery
+
 
 class FullTextQueryType(Enum):
     MATCH = "match"
@@ -20,6 +22,20 @@ class FullTextOperator(Enum):
 
 
 class FullTextQuery(abc.ABC):
+    _inner: PyFullTextQuery
+
+    @property
+    def inner(self) -> PyFullTextQuery:
+        """
+        Get the inner query object.
+
+        Returns
+        -------
+        PyFullTextQuery
+            The inner query object.
+        """
+        return self._inner
+
     @abc.abstractmethod
     def query_type(self) -> FullTextQueryType:
         """
@@ -29,17 +45,6 @@ class FullTextQuery(abc.ABC):
         -------
         str
             The type of the query.
-        """
-
-    @abc.abstractmethod
-    def to_dict(self) -> dict:
-        """
-        Convert the query to a dictionary.
-
-        Returns
-        -------
-        dict
-            The query as a dictionary.
         """
 
 
@@ -52,7 +57,7 @@ class MatchQuery(FullTextQuery):
         boost: float = 1.0,
         fuzziness: int = 0,
         max_expansions: int = 50,
-        operator: FullTextOperator = FullTextOperator.AND,
+        operator: FullTextOperator = FullTextOperator.OR,
     ):
         """
         Match query for full-text search.
@@ -77,28 +82,17 @@ class MatchQuery(FullTextQuery):
             The maximum number of terms to consider for fuzzy matching.
             Defaults to 50.
         """
-        self.column = column
-        self.query = query
-        self.boost = boost
-        self.fuzziness = fuzziness
-        self.max_expansions = max_expansions
-        self.operator = operator
+        self._inner = PyFullTextQuery.match_query(
+            query,
+            column,
+            boost=boost,
+            fuzziness=fuzziness,
+            max_expansions=max_expansions,
+            operator=operator.value,
+        )
 
     def query_type(self) -> FullTextQueryType:
         return FullTextQueryType.MATCH
-
-    def to_dict(self) -> dict:
-        return {
-            "match": {
-                self.column: {
-                    "query": self.query,
-                    "boost": self.boost,
-                    "fuzziness": self.fuzziness,
-                    "max_expansions": self.max_expansions,
-                    "operator": self.operator,
-                }
-            }
-        }
 
 
 class PhraseQuery(FullTextQuery):
@@ -113,18 +107,10 @@ class PhraseQuery(FullTextQuery):
         column : str
             The name of the column to match against.
         """
-        self.column = column
-        self.query = query
+        self._inner = PyFullTextQuery.phrase_query(query, column)
 
     def query_type(self) -> FullTextQueryType:
         return FullTextQueryType.MATCH_PHRASE
-
-    def to_dict(self) -> dict:
-        return {
-            "match_phrase": {
-                self.column: self.query,
-            }
-        }
 
 
 class BoostQuery(FullTextQuery):
@@ -132,7 +118,8 @@ class BoostQuery(FullTextQuery):
         self,
         positive: FullTextQuery,
         negative: FullTextQuery,
-        negative_boost: float,
+        *,
+        negative_boost: float = 0.5,
     ):
         """
         Boost query for full-text search.
@@ -143,24 +130,15 @@ class BoostQuery(FullTextQuery):
             The positive query object.
         negative : dict
             The negative query object.
-        negative_boost : float
+        negative_boost : float, default 0.5
             The boost factor for the negative query.
         """
-        self.positive = positive
-        self.negative = negative
-        self.negative_boost = negative_boost
+        self._inner = PyFullTextQuery.boost_query(
+            positive.inner, negative.inner, negative_boost
+        )
 
     def query_type(self) -> FullTextQueryType:
         return FullTextQueryType.BOOST
-
-    def to_dict(self) -> dict:
-        return {
-            "boost": {
-                "positive": self.positive.to_dict(),
-                "negative": self.negative.to_dict(),
-                "negative_boost": self.negative_boost,
-            }
-        }
 
 
 class MultiMatchQuery(FullTextQuery):
@@ -170,6 +148,7 @@ class MultiMatchQuery(FullTextQuery):
         columns: list[str],
         *,
         boosts: Optional[list[float]] = None,
+        operator: FullTextOperator = FullTextOperator.OR,
     ):
         """
         Multi-match query for full-text search.
@@ -185,21 +164,17 @@ class MultiMatchQuery(FullTextQuery):
         boosts : list[float], optional
             The list of boost factors for each column. If not provided,
             all columns will have the same boost factor.
+        operator : FullTextOperator, default OR
+            The operator to use for combining the query results.
+            Can be either `AND` or `OR`.
+            It would be applied to all columns individually.
+            For example, if the operator is `AND`,
+            then the query "hello world" is equal to
+            `match("hello AND world", column1) OR match("hello AND world", column2)`.
         """
-        self.query = query
-        self.columns = columns
-        if boosts is None:
-            boosts = [1.0] * len(columns)
-        self.boosts = boosts
+        self._inner = PyFullTextQuery.multi_match_query(
+            query, columns, boosts=boosts, operator=operator.value
+        )
 
     def query_type(self) -> FullTextQueryType:
         return FullTextQueryType.MULTI_MATCH
-
-    def to_dict(self) -> dict:
-        return {
-            "multi_match": {
-                "query": self.query,
-                "columns": self.columns,
-                "boost": self.boosts,
-            }
-        }

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -539,7 +539,6 @@ impl Dataset {
                 .map_err(|err| PyValueError::new_err(err.to_string()))?;
         }
         if let Some(full_text_query) = full_text_query {
-            println!("{:?}", full_text_query.get_type());
             let fts_query = if let Ok(full_text_query) = full_text_query.downcast::<PyDict>() {
                 let mut query = full_text_query
                     .get_item("query")?

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -40,7 +40,9 @@ use lance::index::vector::utils::get_vector_type;
 use lance::index::{vector::VectorIndexParams, DatasetIndexInternalExt};
 use lance_arrow::as_fixed_size_list_array;
 use lance_index::metrics::NoOpMetricsCollector;
-use lance_index::scalar::inverted::query::{FtsQuery, MatchQuery, PhraseQuery};
+use lance_index::scalar::inverted::query::{
+    BoostQuery, FtsQuery, MatchQuery, MultiMatchQuery, Operator, PhraseQuery,
+};
 use lance_index::scalar::InvertedIndexParams;
 use lance_index::{
     optimize::OptimizeOptions,
@@ -73,7 +75,7 @@ use crate::file::object_store_from_uri_or_path;
 use crate::fragment::FileFragment;
 use crate::schema::LanceSchema;
 use crate::session::Session;
-use crate::utils::{parse_fts_query, PyLance};
+use crate::utils::PyLance;
 use crate::RT;
 use crate::{LanceReader, Scanner};
 
@@ -502,7 +504,7 @@ impl Dataset {
         use_stats: Option<bool>,
         substrait_filter: Option<Vec<u8>>,
         fast_search: Option<bool>,
-        full_text_query: Option<&Bound<'_, PyDict>>,
+        full_text_query: Option<&Bound<'_, PyAny>>,
         late_materialization: Option<PyObject>,
         use_scalar_index: Option<bool>,
         include_deleted_rows: Option<bool>,
@@ -537,12 +539,12 @@ impl Dataset {
                 .map_err(|err| PyValueError::new_err(err.to_string()))?;
         }
         if let Some(full_text_query) = full_text_query {
-            let query = full_text_query
-                .get_item("query")?
-                .ok_or_else(|| PyKeyError::new_err("query must be specified"))?;
-
-            let fts_query = if let Ok(query) = query.downcast::<PyString>() {
-                let mut query = query.to_string();
+            println!("{:?}", full_text_query.get_type());
+            let fts_query = if let Ok(full_text_query) = full_text_query.downcast::<PyDict>() {
+                let mut query = full_text_query
+                    .get_item("query")?
+                    .ok_or_else(|| PyKeyError::new_err("query must be specified"))?
+                    .to_string();
                 let columns = if let Some(columns) = full_text_query.get_item("columns")? {
                     if columns.is_none() {
                         None
@@ -586,9 +588,9 @@ impl Dataset {
                     })?;
                 }
                 query
-            } else if let Ok(query) = query.downcast::<PyDict>() {
-                let query = parse_fts_query(query)?;
-                FullTextSearchQuery::new_query(query)
+            } else if let Ok(query) = full_text_query.downcast::<PyFullTextQuery>() {
+                let query = query.borrow();
+                FullTextSearchQuery::new_query(query.inner.clone())
             } else {
                 return Err(PyValueError::new_err(
                     "query must be a string or a Query object",
@@ -2113,6 +2115,84 @@ impl UDFCheckpointStore for PyBatchUDFCheckpointWrapper {
                 ),
                 location!(),
             )
+        })
+    }
+}
+
+#[pyclass(name = "PyFullTextQuery")]
+#[derive(Debug, Clone)]
+pub struct PyFullTextQuery {
+    pub(crate) inner: FtsQuery,
+}
+
+#[pymethods]
+impl PyFullTextQuery {
+    #[staticmethod]
+    #[pyo3(signature = (query, column, boost=1.0, fuzziness=Some(0), max_expansions=50, operator="OR"))]
+    fn match_query(
+        query: String,
+        column: String,
+        boost: f32,
+        fuzziness: Option<u32>,
+        max_expansions: usize,
+        operator: &str,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: MatchQuery::new(query)
+                .with_column(Some(column))
+                .with_boost(boost)
+                .with_fuzziness(fuzziness)
+                .with_max_expansions(max_expansions)
+                .with_operator(
+                    Operator::try_from(operator)
+                        .map_err(|e| PyValueError::new_err(format!("Invalid operator: {}", e)))?,
+                )
+                .into(),
+        })
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (query, column))]
+    fn phrase_query(query: String, column: String) -> PyResult<Self> {
+        Ok(Self {
+            inner: PhraseQuery::new(query).with_column(Some(column)).into(),
+        })
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (positive, negative,negative_boost=None))]
+    fn boost_query(
+        positive: PyFullTextQuery,
+        negative: PyFullTextQuery,
+        negative_boost: Option<f32>,
+    ) -> PyResult<Self> {
+        Ok(Self {
+            inner: BoostQuery::new(positive.inner, negative.inner, negative_boost).into(),
+        })
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (query, columns, boosts=None, operator="OR"))]
+    fn multi_match_query(
+        query: String,
+        columns: Vec<String>,
+        boosts: Option<Vec<f32>>,
+        operator: &str,
+    ) -> PyResult<Self> {
+        let q = MultiMatchQuery::try_new(query, columns)
+            .map_err(|e| PyValueError::new_err(format!("Invalid query: {}", e)))?;
+        let q = if let Some(boosts) = boosts {
+            q.try_with_boosts(boosts)
+                .map_err(|e| PyValueError::new_err(format!("Invalid boosts: {}", e)))?
+        } else {
+            q
+        };
+
+        let op = Operator::try_from(operator)
+            .map_err(|e| PyValueError::new_err(format!("Invalid operator: {}", e)))?;
+
+        Ok(Self {
+            inner: q.with_operator(op).into(),
         })
     }
 }

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -38,7 +38,7 @@ use dataset::cleanup::CleanupStats;
 use dataset::optimize::{
     PyCompaction, PyCompactionMetrics, PyCompactionPlan, PyCompactionTask, PyRewriteResult,
 };
-use dataset::MergeInsertBuilder;
+use dataset::{MergeInsertBuilder, PyFullTextQuery};
 use env_logger::{Builder, Env};
 use file::{
     LanceBufferDescriptor, LanceColumnMetadata, LanceFileMetadata, LanceFileReader,
@@ -152,6 +152,7 @@ fn lance(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Session>()?;
     m.add_class::<TraceGuard>()?;
     m.add_class::<schema::LanceSchema>()?;
+    m.add_class::<PyFullTextQuery>()?;
     m.add_wrapped(wrap_pyfunction!(bfloat16_array))?;
     m.add_wrapped(wrap_pyfunction!(write_dataset))?;
     m.add_wrapped(wrap_pyfunction!(write_fragments))?;

--- a/python/src/utils.rs
+++ b/python/src/utils.rs
@@ -335,7 +335,9 @@ pub fn parse_fts_query(query: &Bound<'_, PyDict>) -> PyResult<FtsQuery> {
                 .with_boost(boost)
                 .with_fuzziness(fuzziness)
                 .with_max_expansions(max_expansions)
-                .with_operator(Operator::from(&operator));
+                .with_operator(Operator::try_from(operator.as_str()).map_err(|e| {
+                    PyValueError::new_err(format!("expected operator to be AND or OR: {}", e))
+                })?);
             Ok(query.into())
         }
 

--- a/python/src/utils.rs
+++ b/python/src/utils.rs
@@ -24,9 +24,6 @@ use lance::Result;
 use lance::{datatypes::Schema, io::ObjectStore};
 use lance_arrow::FixedSizeListArrayExt;
 use lance_file::writer::FileWriter;
-use lance_index::scalar::inverted::query::{
-    BoostQuery, FtsQuery, MatchQuery, MultiMatchQuery, Operator, PhraseQuery,
-};
 use lance_index::scalar::IndexWriter;
 use lance_index::vector::hnsw::{builder::HnswBuildParams, HNSW};
 use lance_index::vector::v3::subindex::IvfSubIndex;
@@ -38,7 +35,6 @@ use lance_linalg::{
 use lance_table::io::manifest::ManifestDescribing;
 use object_store::path::Path;
 use pyo3::intern;
-use pyo3::types::PyDict;
 use pyo3::{
     exceptions::{PyIOError, PyRuntimeError, PyValueError},
     prelude::*,
@@ -285,125 +281,5 @@ pub fn class_name(ob: &Bound<'_, PyAny>) -> PyResult<String> {
     match full_name.rsplit_once('.') {
         Some((_, name)) => Ok(name.to_string()),
         None => Ok(full_name),
-    }
-}
-
-pub fn parse_fts_query(query: &Bound<'_, PyDict>) -> PyResult<FtsQuery> {
-    let query_type = query.keys().get_item(0)?.extract::<String>()?;
-    let query_value = query
-        .get_item(&query_type)?
-        .ok_or(PyValueError::new_err(format!(
-            "Query type {} not found",
-            query_type
-        )))?;
-    let query_value = query_value.downcast::<PyDict>()?;
-
-    match query_type.as_str() {
-        "match" => {
-            let column = query_value.keys().get_item(0)?.extract::<String>()?;
-            let params = query_value
-                .get_item(&column)?
-                .ok_or(PyValueError::new_err(format!(
-                    "column {} not found",
-                    column
-                )))?;
-            let params = params.downcast::<PyDict>()?;
-
-            let query = params
-                .get_item("query")?
-                .ok_or(PyValueError::new_err("query not found"))?
-                .extract::<String>()?;
-            let boost = params
-                .get_item("boost")?
-                .ok_or(PyValueError::new_err("boost not found"))?
-                .extract::<f32>()?;
-            let fuzziness = params
-                .get_item("fuzziness")?
-                .ok_or(PyValueError::new_err("fuzziness not found"))?
-                .extract::<Option<u32>>()?;
-            let max_expansions = params
-                .get_item("max_expansions")?
-                .ok_or(PyValueError::new_err("max_expansions not found"))?
-                .extract::<usize>()?;
-            let operator = params
-                .get_item("operator")?
-                .ok_or(PyValueError::new_err("operator not found"))?
-                .extract::<String>()?;
-
-            let query = MatchQuery::new(query)
-                .with_column(Some(column))
-                .with_boost(boost)
-                .with_fuzziness(fuzziness)
-                .with_max_expansions(max_expansions)
-                .with_operator(Operator::try_from(operator.as_str()).map_err(|e| {
-                    PyValueError::new_err(format!("expected operator to be AND or OR: {}", e))
-                })?);
-            Ok(query.into())
-        }
-
-        "match_phrase" => {
-            let column = query_value.keys().get_item(0)?.extract::<String>()?;
-            let query = query_value
-                .get_item(&column)?
-                .ok_or(PyValueError::new_err(format!(
-                    "column {} not found",
-                    column
-                )))?
-                .extract::<String>()?;
-
-            let query = PhraseQuery::new(query).with_column(Some(column));
-            Ok(query.into())
-        }
-
-        "boost" => {
-            let positive: Bound<'_, PyAny> = query_value
-                .get_item("positive")?
-                .ok_or(PyValueError::new_err("positive not found"))?;
-            let positive = positive.downcast::<PyDict>()?;
-
-            let negative = query_value
-                .get_item("negative")?
-                .ok_or(PyValueError::new_err("negative not found"))?;
-            let negative = negative.downcast::<PyDict>()?;
-
-            let negative_boost = query_value
-                .get_item("negative_boost")?
-                .ok_or(PyValueError::new_err("negative_boost not found"))?
-                .extract::<f32>()?;
-
-            let positive_query = parse_fts_query(positive)?;
-            let negative_query = parse_fts_query(negative)?;
-            let query = BoostQuery::new(positive_query, negative_query, Some(negative_boost));
-
-            Ok(query.into())
-        }
-
-        "multi_match" => {
-            let query = query_value
-                .get_item("query")?
-                .ok_or(PyValueError::new_err("query not found"))?
-                .extract::<String>()?;
-
-            let columns = query_value
-                .get_item("columns")?
-                .ok_or(PyValueError::new_err("columns not found"))?
-                .extract::<Vec<String>>()?;
-
-            let boost = query_value
-                .get_item("boost")?
-                .ok_or(PyValueError::new_err("boost not found"))?
-                .extract::<Vec<f32>>()?;
-
-            let query =
-                MultiMatchQuery::try_new_with_boosts(query, columns, boost).map_err(|e| {
-                    PyValueError::new_err(format!("Error creating MultiMatchQuery: {}", e))
-                })?;
-            Ok(query.into())
-        }
-
-        _ => Err(PyValueError::new_err(format!(
-            "Unsupported query type: {}",
-            query_type
-        ))),
     }
 }

--- a/python/src/utils.rs
+++ b/python/src/utils.rs
@@ -25,7 +25,7 @@ use lance::{datatypes::Schema, io::ObjectStore};
 use lance_arrow::FixedSizeListArrayExt;
 use lance_file::writer::FileWriter;
 use lance_index::scalar::inverted::query::{
-    BoostQuery, FtsQuery, MatchQuery, MultiMatchQuery, PhraseQuery,
+    BoostQuery, FtsQuery, MatchQuery, MultiMatchQuery, Operator, PhraseQuery,
 };
 use lance_index::scalar::IndexWriter;
 use lance_index::vector::hnsw::{builder::HnswBuildParams, HNSW};
@@ -325,12 +325,17 @@ pub fn parse_fts_query(query: &Bound<'_, PyDict>) -> PyResult<FtsQuery> {
                 .get_item("max_expansions")?
                 .ok_or(PyValueError::new_err("max_expansions not found"))?
                 .extract::<usize>()?;
+            let operator = params
+                .get_item("operator")?
+                .ok_or(PyValueError::new_err("operator not found"))?
+                .extract::<String>()?;
 
             let query = MatchQuery::new(query)
                 .with_column(Some(column))
                 .with_boost(boost)
                 .with_fuzziness(fuzziness)
-                .with_max_expansions(max_expansions);
+                .with_max_expansions(max_expansions)
+                .with_operator(Operator::from(&operator));
             Ok(query.into())
         }
 

--- a/rust/lance-index/benches/inverted.rs
+++ b/rust/lance-index/benches/inverted.rs
@@ -16,7 +16,7 @@ use lance_core::cache::FileMetadataCache;
 use lance_core::ROW_ID;
 use lance_index::metrics::NoOpMetricsCollector;
 use lance_index::prefilter::NoFilter;
-use lance_index::scalar::inverted::query::FtsSearchParams;
+use lance_index::scalar::inverted::query::{FtsSearchParams, Operator};
 use lance_index::scalar::inverted::{InvertedIndex, InvertedIndexBuilder};
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::ScalarIndex;
@@ -80,6 +80,7 @@ fn bench_inverted(c: &mut Criterion) {
                     .bm25_search(
                         &[tokens[rand::random::<usize>() % tokens.len()].to_owned()],
                         &params,
+                        Operator::Or,
                         false,
                         no_filter.clone(),
                         &NoOpMetricsCollector,

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -164,6 +164,7 @@ impl InvertedIndex {
         &self,
         tokens: &[String],
         params: &FtsSearchParams,
+        operator: Operator,
         is_phrase_query: bool,
         prefilter: Arc<dyn PreFilter>,
         metrics: &dyn MetricsCollector,
@@ -199,7 +200,7 @@ impl InvertedIndex {
             .try_collect::<Vec<_>>()
             .await?;
 
-        let mut wand = Wand::new(self.docs.len(), postings.into_iter());
+        let mut wand = Wand::new(self.docs.len(), operator, postings.into_iter());
         wand.search(
             is_phrase_query,
             params.limit.unwrap_or(usize::MAX),

--- a/rust/lance-index/src/scalar/inverted/query.rs
+++ b/rust/lance-index/src/scalar/inverted/query.rs
@@ -46,8 +46,8 @@ pub enum Operator {
 impl From<&str> for Operator {
     fn from(value: &str) -> Self {
         match value {
-            "AND" => Operator::And,
-            "OR" => Operator::Or,
+            "AND" => Self::And,
+            "OR" => Self::Or,
             _ => panic!("Invalid operator: {}", value),
         }
     }

--- a/rust/lance-index/src/scalar/inverted/query.rs
+++ b/rust/lance-index/src/scalar/inverted/query.rs
@@ -43,12 +43,16 @@ pub enum Operator {
     Or,
 }
 
-impl From<&str> for Operator {
-    fn from(value: &str) -> Self {
-        match value {
-            "AND" => Self::And,
-            "OR" => Self::Or,
-            _ => panic!("Invalid operator: {}", value),
+impl TryFrom<&str> for Operator {
+    type Error = Error;
+    fn try_from(value: &str) -> Result<Self> {
+        match value.to_ascii_uppercase().as_str() {
+            "AND" => Ok(Self::And),
+            "OR" => Ok(Self::Or),
+            _ => Err(Error::invalid_input(
+                format!("Invalid operator: {}", value),
+                location!(),
+            )),
         }
     }
 }

--- a/rust/lance-index/src/scalar/inverted/query.rs
+++ b/rust/lance-index/src/scalar/inverted/query.rs
@@ -37,6 +37,22 @@ impl Default for FtsSearchParams {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Operator {
+    And,
+    Or,
+}
+
+impl From<&str> for Operator {
+    fn from(value: &str) -> Self {
+        match value {
+            "AND" => Operator::And,
+            "OR" => Operator::Or,
+            _ => panic!("Invalid operator: {}", value),
+        }
+    }
+}
+
 pub trait FtsQueryNode {
     fn columns(&self) -> HashSet<String>;
 }
@@ -177,6 +193,12 @@ pub struct MatchQuery {
     /// The maximum number of terms to expand for fuzzy matching.
     /// Default to 50.
     pub max_expansions: usize,
+
+    /// The operator to use for combining terms.
+    /// This can be either `And` or `Or`, it's 'Or' by default.
+    /// - `And`: All terms must match.
+    /// - `Or`: At least one term must match.
+    pub operator: Operator,
 }
 
 impl MatchQuery {
@@ -187,6 +209,7 @@ impl MatchQuery {
             boost: 1.0,
             fuzziness: Some(0),
             max_expansions: 50,
+            operator: Operator::Or,
         }
     }
 
@@ -207,6 +230,11 @@ impl MatchQuery {
 
     pub fn with_max_expansions(mut self, max_expansions: usize) -> Self {
         self.max_expansions = max_expansions;
+        self
+    }
+
+    pub fn with_operator(mut self, operator: Operator) -> Self {
+        self.operator = operator;
         self
     }
 

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -141,7 +141,7 @@ impl Wand {
             num_docs,
             postings: posting_lists
                 .into_iter()
-                .filter(|posting| posting.list.len() > 0) // filter out empty postings
+                .filter(|posting| posting.doc().is_some())
                 .collect(),
         }
     }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -5065,8 +5065,8 @@ mod tests {
             .try_into_batch()
             .await
             .unwrap();
-        assert_eq!(result.num_rows(), 2);
         let ids = result["id"].as_primitive::<UInt64Type>().values();
+        assert_eq!(result.num_rows(), 2, "{:?}", ids);
         assert!(ids.contains(&0));
         assert!(ids.contains(&1));
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1765,7 +1765,7 @@ mod tests {
     use lance_datagen::{array, gen, BatchCount, Dimension, RowCount};
     use lance_file::v2::writer::FileWriter;
     use lance_file::version::LanceFileVersion;
-    use lance_index::scalar::inverted::query::PhraseQuery;
+    use lance_index::scalar::inverted::query::{MatchQuery, Operator, PhraseQuery};
     use lance_index::scalar::inverted::TokenizerConfig;
     use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
     use lance_index::{scalar::ScalarIndexParams, vector::DIST_COL, DatasetIndexExt, IndexType};
@@ -4994,12 +4994,29 @@ mod tests {
             .try_into_batch()
             .await
             .unwrap();
-
         assert_eq!(result.num_rows(), 3);
         let ids = result["id"].as_primitive::<UInt64Type>().values();
         assert!(ids.contains(&0));
         assert!(ids.contains(&1));
         assert!(ids.contains(&3));
+
+        let result = ds
+            .scan()
+            .project(&["id"])
+            .unwrap()
+            .full_text_search(
+                FullTextSearchQuery::new_query(
+                    MatchQuery::new("lance database".to_owned())
+                        .with_operator(Operator::And)
+                        .into(),
+                )
+                .limit(Some(3)),
+            )
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(result.num_rows(), 2);
 
         let result = ds
             .scan()


### PR DESCRIPTION
this also improves the phrase query performance by skipping documents that's impossible to be a candidate.
before we always set the WAND threshold to 0, and update the threshold when hit the limit. But for AND query, only documents that contain all terms can be a candidate, so the init threshold can be the sum of upper bounds

this also refines the pyo3 APIs so that we can get rid of that complicated `parse_fts_query` method