### PR TITLE
fix: don't change dictionary threshold

### DIFF
--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -684,8 +684,6 @@ fn check_dict_encoding(arrays: &[ArrayRef], threshold: u64) -> bool {
     }
     const PRECISION: u8 = 12;
 
-    let threshold = threshold.max(num_total_rows as u64 / 4);
-
     let mut hll: HyperLogLogPlus<String, RandomState> =
         HyperLogLogPlus::new(PRECISION, RandomState::new()).unwrap();
 


### PR DESCRIPTION
As part of 2.1 development we changed the threshold for dictionary encoding.  This threshold is shared by the 2.0 writer.  It can cause the 2.0 writer to fail and write corrupted data.