### PR TITLE
perf: improve ngram indexing performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4490,7 +4490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7344,9 +7344,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/rust/lance-core/src/utils/tracing.rs
+++ b/rust/lance-core/src/utils/tracing.rs
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use futures::Stream;
-use lazy_static::lazy_static;
 use pin_project::pin_project;
 use tracing::Span;
 
@@ -47,23 +46,6 @@ impl<S: Stream> StreamTracingExt for S {
             span: Span::current(),
         }
     }
-}
-
-lazy_static! {
-    pub static ref OUTPUT_TIMEIT_DURATION: bool =
-        std::env!("OUTPUT_TIMEIT_DURATION").parse().unwrap_or(false);
-}
-#[macro_export]
-macro_rules! timeit {
-    ($name:expr, $block:block) => {{
-        let start = std::time::Instant::now();
-        let result = { $block };
-        let duration = start.elapsed();
-        if *lance_core::utils::tracing::OUTPUT_TIMEIT_DURATION {
-            std::println!("execution time {}:\t{} ms", $name, duration.as_millis());
-        }
-        result
-    }};
 }
 
 pub const TRACE_FILE_AUDIT: &str = "lance::file_audit";

--- a/rust/lance-core/src/utils/tracing.rs
+++ b/rust/lance-core/src/utils/tracing.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use futures::Stream;
+use lazy_static::lazy_static;
 use pin_project::pin_project;
 use tracing::Span;
 
@@ -46,6 +47,23 @@ impl<S: Stream> StreamTracingExt for S {
             span: Span::current(),
         }
     }
+}
+
+lazy_static! {
+    pub static ref OUTPUT_TIMEIT_DURATION: bool =
+        std::env!("OUTPUT_TIMEIT_DURATION").parse().unwrap_or(false);
+}
+#[macro_export]
+macro_rules! timeit {
+    ($name:expr, $block:block) => {{
+        let start = std::time::Instant::now();
+        let result = { $block };
+        let duration = start.elapsed();
+        if *lance_core::utils::tracing::OUTPUT_TIMEIT_DURATION {
+            std::println!("execution time {}:\t{} ms", $name, duration.as_millis());
+        }
+        result
+    }};
 }
 
 pub const TRACE_FILE_AUDIT: &str = "lance::file_audit";

--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -10,7 +10,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::stream;
 use itertools::Itertools;
 use lance_core::cache::FileMetadataCache;
-use lance_core::{timeit, ROW_ID};
+use lance_core::ROW_ID;
 use lance_index::metrics::NoOpMetricsCollector;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::ngram::{NGramIndex, NGramIndexBuilder, NGramIndexBuilderOptions};
@@ -77,12 +77,11 @@ fn bench_ngram(c: &mut Criterion) {
             let mut builder =
                 NGramIndexBuilder::try_new(NGramIndexBuilderOptions::default()).unwrap();
             let num_spill_files = builder.train(stream).await.unwrap();
-            timeit!("ngram_bench::write_index", {
-                builder
-                    .write_index(store.as_ref(), num_spill_files, None)
-                    .await
-                    .unwrap();
-            });
+
+            builder
+                .write_index(store.as_ref(), num_spill_files, None)
+                .await
+                .unwrap();
         })
     });
 

--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -10,7 +10,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::stream;
 use itertools::Itertools;
 use lance_core::cache::FileMetadataCache;
-use lance_core::ROW_ID;
+use lance_core::{timeit, ROW_ID};
 use lance_index::metrics::NoOpMetricsCollector;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::ngram::{NGramIndex, NGramIndexBuilder, NGramIndexBuilderOptions};
@@ -77,10 +77,12 @@ fn bench_ngram(c: &mut Criterion) {
             let mut builder =
                 NGramIndexBuilder::try_new(NGramIndexBuilderOptions::default()).unwrap();
             let num_spill_files = builder.train(stream).await.unwrap();
-            builder
-                .write_index(store.as_ref(), num_spill_files, None)
-                .await
-                .unwrap();
+            timeit!("ngram_bench::write_index", {
+                builder
+                    .write_index(store.as_ref(), num_spill_files, None)
+                    .await
+                    .unwrap();
+            });
         })
     });
 


### PR DESCRIPTION
- the slowest step is `merge_spills`, ~ 70%+ of total indexing time
- then the `tokneize_and_partition`, ~20% of total indexing time

this PR parallelizes `merge_spills`, gains 40%+ faster