### PR TITLE
ci: fix rust benchmark using warp arm to run

### DIFF
--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   Benchmark:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: warp-ubuntu-latest-arm64-8x
     timeout-minutes: 120
     steps:
       - name: Checkout


### PR DESCRIPTION
The self-hosted machine is not maintained, and rust is too old to run benchmark.

https://github.com/lancedb/lance/actions/runs/14329500137