### PR TITLE
fix: disable enforcing zero copy only

### DIFF
--- a/python/python/lance/torch/data.py
+++ b/python/python/lance/torch/data.py
@@ -41,7 +41,7 @@ def _fsl_to_tensor(arr: pa.FixedSizeListArray, dimension: int) -> torch.Tensor:
     num_vals = len(arr) * dimension
     values = values.slice(start, num_vals)
     # Convert to numpy
-    nparr = values.to_numpy(zero_copy_only=True).reshape(-1, dimension)
+    nparr = values.to_numpy(zero_copy_only=False).reshape(-1, dimension)
     return torch.from_numpy(nparr)
 
 
@@ -89,7 +89,7 @@ def _to_tensor(
             or pa.types.is_floating(arr.type)
             or pa.types.is_boolean(arr.type)
         ):
-            tensor = torch.from_numpy(arr.to_numpy(zero_copy_only=True))
+            tensor = torch.from_numpy(arr.to_numpy(zero_copy_only=False))
 
             if uint64_as_int64 and tensor.dtype == torch.uint64:
                 tensor = tensor.to(torch.int64)

--- a/python/python/lance/torch/kmeans.py
+++ b/python/python/lance/torch/kmeans.py
@@ -92,7 +92,7 @@ class KMeans:
         self, data: Union[pa.FixedSizeListArray, np.ndarray, torch.Tensor]
     ) -> torch.Tensor:
         if isinstance(data, pa.FixedSizeListArray):
-            np_tensor = data.values.to_numpy(zero_copy_only=True).reshape(
+            np_tensor = data.values.to_numpy(zero_copy_only=False).reshape(
                 -1, data.type.list_size
             )
             data = torch.from_numpy(np_tensor)


### PR DESCRIPTION
we get non contigous arrays sometimes and requiring zero copy crashes indexing