### PR TITLE
perf: pass session down when checking existing table

### DIFF
--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -344,7 +344,7 @@ impl<'a> InsertBuilder<'a> {
                     store_options: params.store_params.clone(),
                     commit_handler: params.commit_handler.clone(),
                     object_store_registry: params.object_store_registry.clone(),
-                    // session: params.session.clone(),
+                    session: params.session.clone(),
                     ..Default::default()
                 });
 
@@ -395,31 +395,4 @@ struct WriteContext<'a> {
     base_path: Path,
     commit_handler: Arc<dyn CommitHandler>,
     storage_version: LanceFileVersion,
-}
-
-#[cfg(test)]
-mod test {
-    use arrow_schema::{DataType, Field, Schema};
-
-    use crate::session::Session;
-
-    use super::*;
-
-    #[tokio::test]
-    async fn test_pass_session() {
-        let session = Arc::new(Session::new(0, 0));
-        let dataset = InsertBuilder::new("memory://")
-            .with_params(&WriteParams {
-                session: Some(session.clone()),
-                ..Default::default()
-            })
-            .execute_stream(RecordBatchIterator::new(
-                vec![],
-                Arc::new(Schema::new(vec![Field::new("col", DataType::Int32, false)])),
-            ))
-            .await
-            .unwrap();
-
-        assert_eq!(Arc::as_ptr(&dataset.session()), Arc::as_ptr(&session));
-    }
 }

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -344,6 +344,7 @@ impl<'a> InsertBuilder<'a> {
                     store_options: params.store_params.clone(),
                     commit_handler: params.commit_handler.clone(),
                     object_store_registry: params.object_store_registry.clone(),
+                    // session: params.session.clone(),
                     ..Default::default()
                 });
 
@@ -394,4 +395,31 @@ struct WriteContext<'a> {
     base_path: Path,
     commit_handler: Arc<dyn CommitHandler>,
     storage_version: LanceFileVersion,
+}
+
+#[cfg(test)]
+mod test {
+    use arrow_schema::{DataType, Field, Schema};
+
+    use crate::session::Session;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_pass_session() {
+        let session = Arc::new(Session::new(0, 0));
+        let dataset = InsertBuilder::new("memory://")
+            .with_params(&WriteParams {
+                session: Some(session.clone()),
+                ..Default::default()
+            })
+            .execute_stream(RecordBatchIterator::new(
+                vec![],
+                Arc::new(Schema::new(vec![Field::new("col", DataType::Int32, false)])),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(Arc::as_ptr(&dataset.session()), Arc::as_ptr(&session));
+    }
 }


### PR DESCRIPTION
If a user passes a shared session down with a URI, we should use that session when checking for an existing table.

The session in the returned dataset (after the commit) was already fine. We set it here:

https://github.com/lancedb/lance/blob/aba5fb7d1cc720390d1c7692d640ba7233f8a8b1/rust/lance/src/dataset/write/insert.rs#L131-L133
