### PR TITLE
refactor: defer any task spanwing until first read

### DIFF
--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -790,7 +790,7 @@ pub mod tests {
         );
 
         let boost_input_two = MatchQueryExec::new(
-            Arc::new(fixture.dataset.clone()),
+            Arc::new(fixture.dataset),
             MatchQuery::new("blah".to_string()).with_column(Some("text".to_string())),
             FtsSearchParams::default(),
             PreFilterSource::None,

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -723,3 +723,95 @@ impl ExecutionPlan for BoostQueryExec {
         &self.properties
     }
 }
+
+#[cfg(test)]
+pub mod tests {
+    use std::sync::Arc;
+
+    use datafusion::{execution::TaskContext, physical_plan::ExecutionPlan};
+    use lance_datafusion::datagen::DatafusionDatagenExt;
+    use lance_datagen::{BatchCount, ByteCount, RowCount};
+    use lance_index::scalar::inverted::query::{
+        BoostQuery, FtsQuery, FtsSearchParams, MatchQuery, PhraseQuery,
+    };
+
+    use crate::{io::exec::PreFilterSource, utils::test::NoContextTestFixture};
+
+    use super::{BoostQueryExec, FlatMatchQueryExec, MatchQueryExec, PhraseQueryExec};
+
+    #[test]
+    fn execute_without_context() {
+        // These tests ensure we can create nodes and call execute without a tokio Runtime
+        // being active.  This is a requirement for proper implementation of a Datafusion foreign
+        // table provider.
+        let fixture = NoContextTestFixture::new();
+        let match_query = MatchQueryExec::new(
+            Arc::new(fixture.dataset.clone()),
+            MatchQuery::new("blah".to_string()).with_column(Some("text".to_string())),
+            FtsSearchParams::default(),
+            PreFilterSource::None,
+        );
+        match_query
+            .execute(0, Arc::new(TaskContext::default()))
+            .unwrap();
+
+        let flat_input = lance_datagen::gen()
+            .col(
+                "text",
+                lance_datagen::array::rand_utf8(ByteCount::from(10), false),
+            )
+            .into_df_exec(RowCount::from(15), BatchCount::from(2));
+
+        let flat_match_query = FlatMatchQueryExec::new(
+            Arc::new(fixture.dataset.clone()),
+            MatchQuery::new("blah".to_string()).with_column(Some("text".to_string())),
+            FtsSearchParams::default(),
+            flat_input,
+        );
+        flat_match_query
+            .execute(0, Arc::new(TaskContext::default()))
+            .unwrap();
+
+        let phrase_query = PhraseQueryExec::new(
+            Arc::new(fixture.dataset.clone()),
+            PhraseQuery::new("blah".to_string()),
+            FtsSearchParams::default(),
+            PreFilterSource::None,
+        );
+        phrase_query
+            .execute(0, Arc::new(TaskContext::default()))
+            .unwrap();
+
+        let boost_input_one = MatchQueryExec::new(
+            Arc::new(fixture.dataset.clone()),
+            MatchQuery::new("blah".to_string()).with_column(Some("text".to_string())),
+            FtsSearchParams::default(),
+            PreFilterSource::None,
+        );
+
+        let boost_input_two = MatchQueryExec::new(
+            Arc::new(fixture.dataset.clone()),
+            MatchQuery::new("blah".to_string()).with_column(Some("text".to_string())),
+            FtsSearchParams::default(),
+            PreFilterSource::None,
+        );
+
+        let boost_query = BoostQueryExec::new(
+            BoostQuery::new(
+                FtsQuery::Match(
+                    MatchQuery::new("blah".to_string()).with_column(Some("text".to_string())),
+                ),
+                FtsQuery::Match(
+                    MatchQuery::new("test".to_string()).with_column(Some("text".to_string())),
+                ),
+                Some(1.0),
+            ),
+            FtsSearchParams::default(),
+            Arc::new(boost_input_one),
+            Arc::new(boost_input_two),
+        );
+        boost_query
+            .execute(0, Arc::new(TaskContext::default()))
+            .unwrap();
+    }
+}

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -791,7 +791,7 @@ mod tests {
         // being active.  This is a requirement for proper implementation of a Datafusion foreign
         // table provider.
         let fixture = NoContextTestFixture::new();
-        let arc_dasaset = Arc::new(fixture.dataset.clone());
+        let arc_dasaset = Arc::new(fixture.dataset);
 
         let query = ScalarIndexExpr::Query(
             "ordered".to_string(),

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -708,9 +708,11 @@ mod tests {
 
     use crate::{
         io::exec::scalar_index::MaterializeIndexExec,
-        utils::test::{DatagenExt, FragmentCount, FragmentRowCount},
+        utils::test::{DatagenExt, FragmentCount, FragmentRowCount, NoContextTestFixture},
         Dataset,
     };
+
+    use super::{MapIndexExec, ScalarIndexExec};
 
     struct TestFixture {
         dataset: Arc<Dataset>,
@@ -781,5 +783,34 @@ mod tests {
 
         assert_eq!(batches.len(), 10);
         assert_eq!(batches[0].num_rows(), 5);
+    }
+
+    #[test]
+    fn no_context_scalar_index() {
+        // These tests ensure we can create nodes and call execute without a tokio Runtime
+        // being active.  This is a requirement for proper implementation of a Datafusion foreign
+        // table provider.
+        let fixture = NoContextTestFixture::new();
+        let arc_dasaset = Arc::new(fixture.dataset.clone());
+
+        let query = ScalarIndexExpr::Query(
+            "ordered".to_string(),
+            Arc::new(SargableQuery::Range(
+                Bound::Unbounded,
+                Bound::Excluded(ScalarValue::UInt64(Some(47))),
+            )),
+        );
+
+        // These plans aren't even valid but it appears we defer all work (even validation) until
+        // read time.
+        let plan = ScalarIndexExec::new(arc_dasaset.clone(), query.clone());
+        plan.execute(0, Arc::new(TaskContext::default())).unwrap();
+
+        let plan = MapIndexExec::new(arc_dasaset.clone(), "ordered".to_string(), Arc::new(plan));
+        plan.execute(0, Arc::new(TaskContext::default())).unwrap();
+
+        let plan =
+            MaterializeIndexExec::new(arc_dasaset.clone(), query, arc_dasaset.fragments().clone());
+        plan.execute(0, Arc::new(TaskContext::default())).unwrap();
     }
 }

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -13,6 +13,7 @@ use datafusion::common::stats::Precision;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, RecordBatchStream,
     SendableRecordBatchStream, Statistics,
@@ -587,15 +588,23 @@ impl ExecutionPlan for LanceScanExec {
         partition: usize,
         _context: Arc<datafusion::execution::context::TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        Ok(Box::pin(LanceStream::try_new(
-            self.dataset.clone(),
-            self.fragments.clone(),
-            self.range.clone(),
-            self.projection.clone(),
-            self.config.clone(),
-            &self.metrics,
-            partition,
-        )?))
+        let dataset = self.dataset.clone();
+        let fragments = self.fragments.clone();
+        let range = self.range.clone();
+        let projection = self.projection.clone();
+        let config = self.config.clone();
+        let metrics = self.metrics.clone();
+
+        let lance_fut_stream = stream::once(async move {
+            LanceStream::try_new(
+                dataset, fragments, range, projection, config, &metrics, partition,
+            )
+        });
+        let lance_stream = lance_fut_stream.try_flatten();
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            lance_stream,
+        )))
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
@@ -627,5 +636,32 @@ impl ExecutionPlan for LanceScanExec {
 
     fn properties(&self) -> &PlanProperties {
         &self.properties
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::execution::TaskContext;
+
+    use crate::utils::test::NoContextTestFixture;
+
+    use super::*;
+
+    #[test]
+    fn no_context_scan() {
+        // These tests ensure we can create nodes and call execute without a tokio Runtime
+        // being active.  This is a requirement for proper implementation of a Datafusion foreign
+        // table provider.
+        let fixture = NoContextTestFixture::new();
+
+        let scan = LanceScanExec::new(
+            Arc::new(fixture.dataset.clone()),
+            fixture.dataset.fragments().clone(),
+            None,
+            Arc::new(fixture.dataset.schema().clone()),
+            LanceScanConfig::default(),
+        );
+
+        scan.execute(0, Arc::new(TaskContext::default())).unwrap();
     }
 }

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -909,7 +909,7 @@ mod tests {
         // being active.  This is a requirement for proper implementation of a Datafusion foreign
         // table provider.
         let fixture = NoContextTestFixture::new();
-        let arc_dasaset = Arc::new(fixture.dataset.clone());
+        let arc_dasaset = Arc::new(fixture.dataset);
 
         let input = lance_datagen::gen()
             .col(ROW_ID, lance_datagen::array::step::<UInt64Type>())


### PR DESCRIPTION
This ensures that our custom `ExecutionPlan` implementations do not spawn tasks until they are first polled.  Unfortunately, this appears to be a Datafusion requirement for foreign table providers.  It also introduces a bit of test utility to verify this.