### PR TITLE
refactor(rust)!: move all object stores to use `ObjectStoreProvider`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,7 +2831,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow-array",
  "lance-datagen",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "all_asserts",
  "approx",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3916,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3955,7 +3955,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrayref",
  "arrow",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding-datafusion"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4082,7 +4082,7 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "approx",
  "arrow",
@@ -4191,7 +4191,7 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "lance-jni"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "approx",
  "arrow-arith",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4334,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "lance-test-macros"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "lance-testing"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = ["python"]
 resolver = "2"
 
 [workspace.package]
-version = "0.25.3"
+version = "0.26.0"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 license = "Apache-2.0"
@@ -44,21 +44,21 @@ categories = [
 rust-version = "1.82.0"
 
 [workspace.dependencies]
-lance = { version = "=0.25.3", path = "./rust/lance" }
-lance-arrow = { version = "=0.25.3", path = "./rust/lance-arrow" }
-lance-core = { version = "=0.25.3", path = "./rust/lance-core" }
-lance-datafusion = { version = "=0.25.3", path = "./rust/lance-datafusion" }
-lance-datagen = { version = "=0.25.3", path = "./rust/lance-datagen" }
-lance-encoding = { version = "=0.25.3", path = "./rust/lance-encoding" }
-lance-encoding-datafusion = { version = "=0.25.3", path = "./rust/lance-encoding-datafusion" }
-lance-file = { version = "=0.25.3", path = "./rust/lance-file" }
-lance-index = { version = "=0.25.3", path = "./rust/lance-index" }
-lance-io = { version = "=0.25.3", path = "./rust/lance-io" }
-lance-jni = { version = "=0.25.3", path = "./java/core/lance-jni" }
-lance-linalg = { version = "=0.25.3", path = "./rust/lance-linalg" }
-lance-table = { version = "=0.25.3", path = "./rust/lance-table" }
-lance-test-macros = { version = "=0.25.3", path = "./rust/lance-test-macros" }
-lance-testing = { version = "=0.25.3", path = "./rust/lance-testing" }
+lance = { version = "=0.26.0", path = "./rust/lance" }
+lance-arrow = { version = "=0.26.0", path = "./rust/lance-arrow" }
+lance-core = { version = "=0.26.0", path = "./rust/lance-core" }
+lance-datafusion = { version = "=0.26.0", path = "./rust/lance-datafusion" }
+lance-datagen = { version = "=0.26.0", path = "./rust/lance-datagen" }
+lance-encoding = { version = "=0.26.0", path = "./rust/lance-encoding" }
+lance-encoding-datafusion = { version = "=0.26.0", path = "./rust/lance-encoding-datafusion" }
+lance-file = { version = "=0.26.0", path = "./rust/lance-file" }
+lance-index = { version = "=0.26.0", path = "./rust/lance-index" }
+lance-io = { version = "=0.26.0", path = "./rust/lance-io" }
+lance-jni = { version = "=0.26.0", path = "./java/core/lance-jni" }
+lance-linalg = { version = "=0.26.0", path = "./rust/lance-linalg" }
+lance-table = { version = "=0.26.0", path = "./rust/lance-table" }
+lance-test-macros = { version = "=0.26.0", path = "./rust/lance-test-macros" }
+lance-testing = { version = "=0.26.0", path = "./rust/lance-testing" }
 approx = "0.5.1"
 # Note that this one does not include pyarrow
 arrow = { version = "54.1", optional = false, features = ["prettyprint"] }
@@ -118,7 +118,7 @@ deepsize = "0.2.0"
 dirs = "5.0.0"
 either = "1.0"
 fst = { version = "0.4.7", features = ["levenshtein"] }
-fsst = { version = "=0.25.3", path = "./rust/lance-encoding/src/compression_algo/fsst" }
+fsst = { version = "=0.26.0", path = "./rust/lance-encoding/src/compression_algo/fsst" }
 futures = "0.3"
 http = "1.1.0"
 hyperloglogplus = { version = "0.4.1", features = ["const-loop"] }

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lancedb</groupId>
         <artifactId>lance-parent</artifactId>
-        <version>0.25.3</version>
+        <version>0.26.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.lancedb</groupId>
     <artifactId>lance-parent</artifactId>
-    <version>0.25.3</version>
+    <version>0.26.0</version>
     <packaging>pom</packaging>
 
     <name>Lance Parent</name>

--- a/java/spark/pom.xml
+++ b/java/spark/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.lancedb</groupId>
         <artifactId>lance-parent</artifactId>
-        <version>0.25.3</version>
+        <version>0.26.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -151,7 +151,7 @@
         <dependency>
             <groupId>com.lancedb</groupId>
             <artifactId>lance-core</artifactId>
-            <version>0.25.3</version>
+            <version>0.26.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "fsst"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "rand",
 ]
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3247,7 +3247,7 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrayref",
  "arrow",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3472,7 +3472,7 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow-array",
  "arrow-ord",
@@ -3533,7 +3533,7 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "pylance"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -543,9 +543,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.17"
+version = "1.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490aa7465ee685b2ced076bb87ef654a47724a7844e2c7d3af4e749ce5b875dd"
+checksum = "90aff65e86db5fe300752551c1b015ef72b708ac54bded8ef43d0d53cb7cb0b1"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -553,7 +553,7 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -592,7 +592,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -617,7 +617,7 @@ dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -633,14 +633,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.60.0"
+version = "1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60186fab60b24376d3e33b9ff0a43485f99efd470e3b75a9160c849741d63d56"
+checksum = "e65ff295979977039a25f5a0bf067a64bc5e6aa38f3cef4037cf42516265553c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -655,14 +655,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.61.0"
+version = "1.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7033130ce1ee13e6018905b7b976c915963755aef299c1521897679d6cd4f8ef"
+checksum = "91430a60f754f235688387b75ee798ef00cfd09709a582be2b7525ebb5306d4f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -677,14 +677,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.61.0"
+version = "1.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c1cac7677179d622b4448b0d31bcb359185295dc6fca891920cfb17e2b5156"
+checksum = "9276e139d39fff5a0b0c984fc2d30f970f9a202da67234f948fda02e5bea1dbe"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -705,7 +705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bfe75fad52793ce6dec0dc3d4b1f388f038b5eb866c8d4d7f3a8e21b5ea5051"
 dependencies = [
  "aws-credential-types",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -753,6 +753,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-smithy-http"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f276f21c7921fe902826618d1423ae5bf74cf8c1b8472aee8434f3dfd31824"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
 name = "aws-smithy-json"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,7 +798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d526a12d9ed61fadefda24abe2e682892ba288c2018bcb38b1b4c111d13f6d92"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pylance"
-version = "0.25.3"
+version = "0.26.0"
 edition = "2021"
 authors = ["Lance Devs <dev@lancedb.com>"]
 rust-version = "1.65"

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -13,7 +13,7 @@ rust-version.workspace = true
 
 [dependencies]
 
-object_store = { workspace = true, features = ["aws", "gcp", "azure"] }
+object_store = { workspace = true }
 lance-arrow.workspace = true
 lance-core.workspace = true
 arrow = { workspace = true, features = ["ffi"] }
@@ -26,8 +26,8 @@ arrow-schema.workspace = true
 arrow-select.workspace = true
 async-recursion.workspace = true
 async-trait.workspace = true
-aws-config.workspace = true
-aws-credential-types.workspace = true
+aws-config = { workspace = true, optional = true }
+aws-credential-types = { workspace = true, optional = true }
 byteorder.workspace = true
 bytes.workspace = true
 chrono.workspace = true
@@ -62,7 +62,11 @@ name = "scheduler"
 harness = false
 
 [features]
+default = ["aws", "azure", "gcp"]
 gcs-test = []
+gcp = ["object_store/gcp"]
+aws = ["object_store/aws", "aws-config", "aws-credential-types"]
+azure = ["object_store/azure"]
 
 [lints]
 workspace = true

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -9,11 +9,9 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use async_trait::async_trait;
-use aws_config::default_provider::credentials::DefaultCredentialsChain;
-use aws_credential_types::provider::ProvideCredentials;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use deepsize::DeepSizeOf;
@@ -22,25 +20,19 @@ use futures::{future, stream::BoxStream, StreamExt, TryStreamExt};
 use lance_core::utils::parse::str_is_truthy;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use list_retry::ListRetryStream;
-use object_store::aws::{
-    AmazonS3ConfigKey, AwsCredential as ObjectStoreAwsCredential, AwsCredentialProvider,
-};
-use object_store::azure::MicrosoftAzureBuilder;
-use object_store::gcp::{GcpCredential, GoogleCloudStorageBuilder};
-use object_store::{
-    aws::AmazonS3Builder, azure::AzureConfigKey, gcp::GoogleConfigKey, local::LocalFileSystem,
-    memory::InMemory, CredentialProvider, Error as ObjectStoreError, Result as ObjectStoreResult,
-};
+#[cfg(feature = "aws")]
+use object_store::aws::AwsCredentialProvider;
+use object_store::DynObjectStore;
+use object_store::{local::LocalFileSystem, memory::InMemory, Error as ObjectStoreError};
 use object_store::{path::Path, ObjectMeta, ObjectStore as OSObjectStore};
-use object_store::{ClientOptions, DynObjectStore, RetryConfig, StaticCredentialProvider};
 use shellexpand::tilde;
 use snafu::location;
 use tokio::io::AsyncWriteExt;
-use tokio::sync::RwLock;
 use url::Url;
 
 use super::local::LocalObjectReader;
 mod list_retry;
+pub mod providers;
 mod tracing;
 use self::tracing::ObjectStoreTracingExt;
 use crate::object_writer::WriteResult;
@@ -55,7 +47,13 @@ pub const DEFAULT_LOCAL_IO_PARALLELISM: usize = 8;
 // Cloud disks often need many many threads to saturate the network
 pub const DEFAULT_CLOUD_IO_PARALLELISM: usize = 64;
 
+const DEFAULT_LOCAL_BLOCK_SIZE: usize = 4 * 1024; // 4KB block size
+#[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
+const DEFAULT_CLOUD_BLOCK_SIZE: usize = 64 * 1024; // 64KB block size
+
 pub const DEFAULT_DOWNLOAD_RETRY_COUNT: usize = 3;
+
+pub use providers::{ObjectStoreProvider, ObjectStoreRegistry};
 
 #[async_trait]
 pub trait ObjectStoreExt {
@@ -131,212 +129,6 @@ impl std::fmt::Display for ObjectStore {
     }
 }
 
-pub trait ObjectStoreProvider: std::fmt::Debug + Sync + Send {
-    fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore>;
-}
-
-#[derive(Default, Debug)]
-pub struct ObjectStoreRegistry {
-    providers: HashMap<String, Arc<dyn ObjectStoreProvider>>,
-}
-
-impl ObjectStoreRegistry {
-    pub fn insert(&mut self, scheme: &str, provider: Arc<dyn ObjectStoreProvider>) {
-        self.providers.insert(scheme.into(), provider);
-    }
-}
-
-const AWS_CREDS_CACHE_KEY: &str = "aws_credentials";
-
-/// Adapt an AWS SDK cred into object_store credentials
-#[derive(Debug)]
-pub struct AwsCredentialAdapter {
-    pub inner: Arc<dyn ProvideCredentials>,
-
-    // RefCell can't be shared across threads, so we use HashMap
-    cache: Arc<RwLock<HashMap<String, Arc<aws_credential_types::Credentials>>>>,
-
-    // The amount of time before expiry to refresh credentials
-    credentials_refresh_offset: Duration,
-}
-
-impl AwsCredentialAdapter {
-    pub fn new(
-        provider: Arc<dyn ProvideCredentials>,
-        credentials_refresh_offset: Duration,
-    ) -> Self {
-        Self {
-            inner: provider,
-            cache: Arc::new(RwLock::new(HashMap::new())),
-            credentials_refresh_offset,
-        }
-    }
-}
-
-#[async_trait]
-impl CredentialProvider for AwsCredentialAdapter {
-    type Credential = ObjectStoreAwsCredential;
-
-    async fn get_credential(&self) -> ObjectStoreResult<Arc<Self::Credential>> {
-        let cached_creds = {
-            let cache_value = self.cache.read().await.get(AWS_CREDS_CACHE_KEY).cloned();
-            let expired = cache_value
-                .clone()
-                .map(|cred| {
-                    cred.expiry()
-                        .map(|exp| {
-                            exp.checked_sub(self.credentials_refresh_offset)
-                                .expect("this time should always be valid")
-                                < SystemTime::now()
-                        })
-                        // no expiry is never expire
-                        .unwrap_or(false)
-                })
-                .unwrap_or(true); // no cred is the same as expired;
-            if expired {
-                None
-            } else {
-                cache_value.clone()
-            }
-        };
-
-        if let Some(creds) = cached_creds {
-            Ok(Arc::new(Self::Credential {
-                key_id: creds.access_key_id().to_string(),
-                secret_key: creds.secret_access_key().to_string(),
-                token: creds.session_token().map(|s| s.to_string()),
-            }))
-        } else {
-            let refreshed_creds = Arc::new(self.inner.provide_credentials().await.map_err(
-                |e| Error::Internal {
-                    message: format!("Failed to get AWS credentials: {}", e),
-                    location: location!(),
-                },
-            )?);
-
-            self.cache
-                .write()
-                .await
-                .insert(AWS_CREDS_CACHE_KEY.to_string(), refreshed_creds.clone());
-
-            Ok(Arc::new(Self::Credential {
-                key_id: refreshed_creds.access_key_id().to_string(),
-                secret_key: refreshed_creds.secret_access_key().to_string(),
-                token: refreshed_creds.session_token().map(|s| s.to_string()),
-            }))
-        }
-    }
-}
-
-/// Figure out the S3 region of the bucket.
-///
-/// This resolves in order of precedence:
-/// 1. The region provided in the storage options
-/// 2. (If endpoint is not set), the region returned by the S3 API for the bucket
-///
-/// It can return None if no region is provided and the endpoint is set.
-async fn resolve_s3_region(
-    url: &Url,
-    storage_options: &HashMap<AmazonS3ConfigKey, String>,
-) -> Result<Option<String>> {
-    if let Some(region) = storage_options.get(&AmazonS3ConfigKey::Region) {
-        Ok(Some(region.clone()))
-    } else if storage_options.get(&AmazonS3ConfigKey::Endpoint).is_none() {
-        // If no endpoint is set, we can assume this is AWS S3 and the region
-        // can be resolved from the bucket.
-        let bucket = url.host_str().ok_or_else(|| {
-            Error::invalid_input(
-                format!("Could not parse bucket from url: {}", url),
-                location!(),
-            )
-        })?;
-
-        let mut client_options = ClientOptions::default();
-        for (key, value) in storage_options {
-            if let AmazonS3ConfigKey::Client(client_key) = key {
-                client_options = client_options.with_config(*client_key, value.clone());
-            }
-        }
-
-        let bucket_region =
-            object_store::aws::resolve_bucket_region(bucket, &client_options).await?;
-        Ok(Some(bucket_region))
-    } else {
-        Ok(None)
-    }
-}
-
-/// Build AWS credentials
-///
-/// This resolves credentials from the following sources in order:
-/// 1. An explicit `credentials` provider
-/// 2. Explicit credentials in storage_options (as in `aws_access_key_id`,
-///    `aws_secret_access_key`, `aws_session_token`)
-/// 3. The default credential provider chain from AWS SDK.
-///
-/// `credentials_refresh_offset` is the amount of time before expiry to refresh credentials.
-pub async fn build_aws_credential(
-    credentials_refresh_offset: Duration,
-    credentials: Option<AwsCredentialProvider>,
-    storage_options: Option<&HashMap<AmazonS3ConfigKey, String>>,
-    region: Option<String>,
-) -> Result<(AwsCredentialProvider, String)> {
-    // TODO: make this return no credential provider not using AWS
-    use aws_config::meta::region::RegionProviderChain;
-    const DEFAULT_REGION: &str = "us-west-2";
-
-    let region = if let Some(region) = region {
-        region
-    } else {
-        RegionProviderChain::default_provider()
-            .or_else(DEFAULT_REGION)
-            .region()
-            .await
-            .map(|r| r.as_ref().to_string())
-            .unwrap_or(DEFAULT_REGION.to_string())
-    };
-
-    if let Some(creds) = credentials {
-        Ok((creds, region))
-    } else if let Some(creds) = storage_options.and_then(extract_static_s3_credentials) {
-        Ok((Arc::new(creds), region))
-    } else {
-        let credentials_provider = DefaultCredentialsChain::builder().build().await;
-
-        Ok((
-            Arc::new(AwsCredentialAdapter::new(
-                Arc::new(credentials_provider),
-                credentials_refresh_offset,
-            )),
-            region,
-        ))
-    }
-}
-
-fn extract_static_s3_credentials(
-    options: &HashMap<AmazonS3ConfigKey, String>,
-) -> Option<StaticCredentialProvider<ObjectStoreAwsCredential>> {
-    let key_id = options
-        .get(&AmazonS3ConfigKey::AccessKeyId)
-        .map(|s| s.to_string());
-    let secret_key = options
-        .get(&AmazonS3ConfigKey::SecretAccessKey)
-        .map(|s| s.to_string());
-    let token = options
-        .get(&AmazonS3ConfigKey::Token)
-        .map(|s| s.to_string());
-    match (key_id, secret_key, token) {
-        (Some(key_id), Some(secret_key), token) => {
-            Some(StaticCredentialProvider::new(ObjectStoreAwsCredential {
-                key_id,
-                secret_key,
-                token,
-            }))
-        }
-        _ => None,
-    }
-}
-
 pub trait WrappingObjectStore: std::fmt::Debug + Send + Sync {
     fn wrap(&self, original: Arc<dyn OSObjectStore>) -> Arc<dyn OSObjectStore>;
 }
@@ -348,6 +140,7 @@ pub struct ObjectStoreParams {
     pub block_size: Option<usize>,
     pub object_store: Option<(Arc<DynObjectStore>, Url)>,
     pub s3_credentials_refresh_offset: Duration,
+    #[cfg(feature = "aws")]
     pub aws_credentials: Option<AwsCredentialProvider>,
     pub object_store_wrapper: Option<Arc<dyn WrappingObjectStore>>,
     pub storage_options: Option<HashMap<String, String>>,
@@ -365,26 +158,12 @@ impl Default for ObjectStoreParams {
             object_store: None,
             block_size: None,
             s3_credentials_refresh_offset: Duration::from_secs(60),
+            #[cfg(feature = "aws")]
             aws_credentials: None,
             object_store_wrapper: None,
             storage_options: None,
             use_constant_size_upload_parts: false,
             list_is_lexically_ordered: None,
-        }
-    }
-}
-
-impl ObjectStoreParams {
-    /// Create a new instance of [`ObjectStoreParams`] based on the AWS credentials.
-    pub fn with_aws_credentials(
-        aws_credentials: Option<AwsCredentialProvider>,
-        region: Option<String>,
-    ) -> Self {
-        Self {
-            aws_credentials,
-            storage_options: region
-                .map(|region| [("region".into(), region)].iter().cloned().collect()),
-            ..Default::default()
         }
     }
 }
@@ -749,55 +528,6 @@ impl StorageOptions {
         Self(options)
     }
 
-    /// Add values from the environment to storage options
-    pub fn with_env_azure(&mut self) {
-        for (os_key, os_value) in std::env::vars_os() {
-            if let (Some(key), Some(value)) = (os_key.to_str(), os_value.to_str()) {
-                if let Ok(config_key) = AzureConfigKey::from_str(&key.to_ascii_lowercase()) {
-                    if !self.0.contains_key(config_key.as_ref()) {
-                        self.0
-                            .insert(config_key.as_ref().to_string(), value.to_string());
-                    }
-                }
-            }
-        }
-    }
-
-    /// Add values from the environment to storage options
-    pub fn with_env_gcs(&mut self) {
-        for (os_key, os_value) in std::env::vars_os() {
-            if let (Some(key), Some(value)) = (os_key.to_str(), os_value.to_str()) {
-                let lowercase_key = key.to_ascii_lowercase();
-                let token_key = "google_storage_token";
-
-                if let Ok(config_key) = GoogleConfigKey::from_str(&lowercase_key) {
-                    if !self.0.contains_key(config_key.as_ref()) {
-                        self.0
-                            .insert(config_key.as_ref().to_string(), value.to_string());
-                    }
-                }
-                // Check for GOOGLE_STORAGE_TOKEN until GoogleConfigKey supports storage token
-                else if lowercase_key == token_key && !self.0.contains_key(token_key) {
-                    self.0.insert(token_key.to_string(), value.to_string());
-                }
-            }
-        }
-    }
-
-    /// Add values from the environment to storage options
-    pub fn with_env_s3(&mut self) {
-        for (os_key, os_value) in std::env::vars_os() {
-            if let (Some(key), Some(value)) = (os_key.to_str(), os_value.to_str()) {
-                if let Ok(config_key) = AmazonS3ConfigKey::from_str(&key.to_ascii_lowercase()) {
-                    if !self.0.contains_key(config_key.as_ref()) {
-                        self.0
-                            .insert(config_key.as_ref().to_string(), value.to_string());
-                    }
-                }
-            }
-        }
-    }
-
     /// Denotes if unsecure connections via http are allowed
     pub fn allow_http(&self) -> bool {
         self.0.iter().any(|(key, value)| {
@@ -832,39 +562,6 @@ impl StorageOptions {
             .unwrap_or(180)
     }
 
-    /// Subset of options relevant for azure storage
-    pub fn as_azure_options(&self) -> HashMap<AzureConfigKey, String> {
-        self.0
-            .iter()
-            .filter_map(|(key, value)| {
-                let az_key = AzureConfigKey::from_str(&key.to_ascii_lowercase()).ok()?;
-                Some((az_key, value.clone()))
-            })
-            .collect()
-    }
-
-    /// Subset of options relevant for s3 storage
-    pub fn as_s3_options(&self) -> HashMap<AmazonS3ConfigKey, String> {
-        self.0
-            .iter()
-            .filter_map(|(key, value)| {
-                let s3_key = AmazonS3ConfigKey::from_str(&key.to_ascii_lowercase()).ok()?;
-                Some((s3_key, value.clone()))
-            })
-            .collect()
-    }
-
-    /// Subset of options relevant for gcs storage
-    pub fn as_gcs_options(&self) -> HashMap<GoogleConfigKey, String> {
-        self.0
-            .iter()
-            .filter_map(|(key, value)| {
-                let gcs_key = GoogleConfigKey::from_str(&key.to_ascii_lowercase()).ok()?;
-                Some((gcs_key, value.clone()))
-            })
-            .collect()
-    }
-
     pub fn get(&self, key: &str) -> Option<&String> {
         self.0.get(key)
     }
@@ -881,170 +578,15 @@ async fn configure_store(
     url: &str,
     options: ObjectStoreParams,
 ) -> Result<ObjectStore> {
-    let mut storage_options = StorageOptions(options.storage_options.clone().unwrap_or_default());
-    let download_retry_count = storage_options.download_retry_count();
-    let mut url = ensure_table_uri(url)?;
-    // Block size: On local file systems, we use 4KB block size. On cloud
-    // object stores, we use 64KB block size. This is generally the largest
-    // block size where we don't see a latency penalty.
-    let file_block_size = options.block_size.unwrap_or(4 * 1024);
-    let cloud_block_size = options.block_size.unwrap_or(64 * 1024);
-    let max_retries = storage_options.client_max_retries();
-    let retry_timeout = storage_options.client_retry_timeout();
-    let retry_config = RetryConfig {
-        backoff: Default::default(),
-        max_retries,
-        retry_timeout: Duration::from_secs(retry_timeout),
-    };
-    match url.scheme() {
-        "s3" | "s3+ddb" => {
-            storage_options.with_env_s3();
-
-            // if url.scheme() == "s3+ddb" && options.commit_handler.is_some() {
-            //     return Err(Error::InvalidInput {
-            //         source: "`s3+ddb://` scheme and custom commit handler are mutually exclusive"
-            //             .into(),
-            //         location: location!(),
-            //     });
-            // }
-
-            let mut storage_options = storage_options.as_s3_options();
-            let region = resolve_s3_region(&url, &storage_options).await?;
-            let (aws_creds, region) = build_aws_credential(
-                options.s3_credentials_refresh_offset,
-                options.aws_credentials.clone(),
-                Some(&storage_options),
-                region,
-            )
-            .await?;
-
-            // This will be default in next version of object store.
-            // https://github.com/apache/arrow-rs/pull/7181
-            storage_options
-                .entry(AmazonS3ConfigKey::ConditionalPut)
-                .or_insert_with(|| "etag".to_string());
-
-            // Cloudflare does not support varying part sizes.
-            let use_constant_size_upload_parts = storage_options
-                .get(&AmazonS3ConfigKey::Endpoint)
-                .map(|endpoint| endpoint.contains("r2.cloudflarestorage.com"))
-                .unwrap_or(false);
-
-            // before creating the OSObjectStore we need to rewrite the url to drop ddb related parts
-            url.set_scheme("s3").map_err(|()| Error::Internal {
-                message: "could not set scheme".into(),
-                location: location!(),
-            })?;
-
-            url.set_query(None);
-
-            // we can't use parse_url_opts here because we need to manually set the credentials provider
-            let mut builder = AmazonS3Builder::new();
-            for (key, value) in storage_options {
-                builder = builder.with_config(key, value);
-            }
-            builder = builder
-                .with_url(url.as_ref())
-                .with_credentials(aws_creds)
-                .with_retry(retry_config)
-                .with_region(region);
-            let store = builder.build()?;
-
-            Ok(ObjectStore {
-                inner: Arc::new(store).traced(),
-                scheme: String::from(url.scheme()),
-                block_size: cloud_block_size,
-                use_constant_size_upload_parts,
-                list_is_lexically_ordered: true,
-                io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
-                download_retry_count,
-            })
-        }
-        "gs" => {
-            storage_options.with_env_gcs();
-            let mut builder = GoogleCloudStorageBuilder::new()
-                .with_url(url.as_ref())
-                .with_retry(retry_config);
-            for (key, value) in storage_options.as_gcs_options() {
-                builder = builder.with_config(key, value);
-            }
-            let token_key = "google_storage_token";
-            if let Some(storage_token) = storage_options.get(token_key) {
-                let credential = GcpCredential {
-                    bearer: storage_token.to_string(),
-                };
-                let credential_provider = Arc::new(StaticCredentialProvider::new(credential)) as _;
-                builder = builder.with_credentials(credential_provider);
-            }
-            let store = builder.build()?;
-            let store = Arc::new(store).traced();
-
-            Ok(ObjectStore {
-                inner: store,
-                scheme: String::from("gs"),
-                block_size: cloud_block_size,
-                use_constant_size_upload_parts: false,
-                list_is_lexically_ordered: true,
-                io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
-                download_retry_count,
-            })
-        }
-        "az" => {
-            storage_options.with_env_azure();
-            let mut builder = MicrosoftAzureBuilder::new()
-                .with_url(url.as_ref())
-                .with_retry(retry_config);
-            for (key, value) in storage_options.as_azure_options() {
-                builder = builder.with_config(key, value);
-            }
-            let store = builder.build()?;
-            let store = Arc::new(store).traced();
-
-            Ok(ObjectStore {
-                inner: store,
-                scheme: String::from("az"),
-                block_size: cloud_block_size,
-                use_constant_size_upload_parts: false,
-                list_is_lexically_ordered: true,
-                io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
-                download_retry_count,
-            })
-        }
-        // we have a bypass logic to use `tokio::fs` directly to lower overhead
-        // however this makes testing harder as we can't use the same code path
-        // "file-object-store" forces local file system dataset to use the same
-        // code path as cloud object stores
-        "file" => {
-            let mut object_store = ObjectStore::from_path(url.path())?.0;
-            object_store.set_block_size(file_block_size);
-            Ok(object_store)
-        }
-        "file-object-store" => {
-            let mut object_store =
-                ObjectStore::from_path_with_scheme(url.path(), "file-object-store")?.0;
-            object_store.set_block_size(file_block_size);
-            Ok(object_store)
-        }
-        "memory" => Ok(ObjectStore {
-            inner: Arc::new(InMemory::new()).traced(),
-            scheme: String::from("memory"),
-            block_size: file_block_size,
-            use_constant_size_upload_parts: false,
-            list_is_lexically_ordered: true,
-            io_parallelism: get_num_compute_intensive_cpus(),
-            download_retry_count,
-        }),
-        unknown_scheme => {
-            if let Some(provider) = registry.providers.get(unknown_scheme) {
-                provider.new_store(url, &options)
-            } else {
-                let err = lance_core::Error::from(object_store::Error::NotSupported {
-                    source: format!("Unsupported URI scheme: {} in url {}", unknown_scheme, url)
-                        .into(),
-                });
-                Err(err)
-            }
-        }
+    let url = ensure_table_uri(url)?;
+    let scheme = url.scheme();
+    if let Some(provider) = registry.get_provider(scheme) {
+        provider.new_store(url, &options).await
+    } else {
+        let err = lance_core::Error::from(object_store::Error::NotSupported {
+            source: format!("Unsupported URI scheme: {} in url {}", scheme, url).into(),
+        });
+        Err(err)
     }
 }
 
@@ -1413,54 +955,6 @@ mod tests {
         // hard to compare two trait pointers as the point to vtables
         // using the ref count as a proxy to make sure that the store is correctly kept
         assert_eq!(Arc::strong_count(&mock_inner_store), 2);
-    }
-
-    #[derive(Debug, Default)]
-    struct MockAwsCredentialsProvider {
-        called: AtomicBool,
-    }
-
-    #[async_trait]
-    impl CredentialProvider for MockAwsCredentialsProvider {
-        type Credential = ObjectStoreAwsCredential;
-
-        async fn get_credential(&self) -> ObjectStoreResult<Arc<Self::Credential>> {
-            self.called.store(true, Ordering::Relaxed);
-            Ok(Arc::new(Self::Credential {
-                key_id: "".to_string(),
-                secret_key: "".to_string(),
-                token: None,
-            }))
-        }
-    }
-
-    #[tokio::test]
-    async fn test_injected_aws_creds_option_is_used() {
-        let mock_provider = Arc::new(MockAwsCredentialsProvider::default());
-        let registry = Arc::new(ObjectStoreRegistry::default());
-
-        let params = ObjectStoreParams {
-            aws_credentials: Some(mock_provider.clone() as AwsCredentialProvider),
-            ..ObjectStoreParams::default()
-        };
-
-        // Not called yet
-        assert!(!mock_provider.called.load(Ordering::Relaxed));
-
-        let (store, _) = ObjectStore::from_uri_and_params(registry, "s3://not-a-bucket", &params)
-            .await
-            .unwrap();
-
-        // fails, but we don't care
-        let _ = store
-            .open(&Path::parse("/").unwrap())
-            .await
-            .unwrap()
-            .get_range(0..1)
-            .await;
-
-        // Not called yet
-        assert!(mock_provider.called.load(Ordering::Relaxed));
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -65,6 +65,11 @@ impl Default for ObjectStoreRegistry {
         };
         registry.insert("memory", Arc::new(memory::MemoryStoreProvider));
         registry.insert("file", Arc::new(local::FileStoreProvider));
+        // The "file" scheme has special optimized code paths that bypass
+        // the ObjectStore API for better performance. However, this can make it
+        // hard to test when using ObjectStore wrappers, such as IOTrackingStore.
+        // So we provide a "file-object-store" scheme that uses the ObjectStore API.
+        // The specialized code paths are differentiated by the scheme name.
         registry.insert("file-object-store", Arc::new(local::FileStoreProvider));
         #[cfg(feature = "aws")]
         {

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{collections::HashMap, sync::Arc};
+
+use snafu::location;
+use url::Url;
+
+use super::{ObjectStore, ObjectStoreParams};
+use lance_core::error::{Error, Result};
+
+#[cfg(feature = "aws")]
+pub mod aws;
+#[cfg(feature = "azure")]
+pub mod azure;
+#[cfg(feature = "gcp")]
+pub mod gcp;
+pub mod local;
+pub mod memory;
+
+#[async_trait::async_trait]
+pub trait ObjectStoreProvider: std::fmt::Debug + Sync + Send {
+    async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore>;
+}
+
+#[derive(Debug)]
+pub struct ObjectStoreRegistry {
+    providers: HashMap<String, Arc<dyn ObjectStoreProvider>>,
+    // TODO: should the registry itself have a cache?
+    // Cache should probable have weak references?
+}
+
+impl ObjectStoreRegistry {
+    pub fn empty() -> Self {
+        Self {
+            providers: HashMap::new(),
+        }
+    }
+
+    pub fn get_provider(&self, scheme: &str) -> Option<Arc<dyn ObjectStoreProvider>> {
+        self.providers.get(scheme).cloned()
+    }
+
+    pub async fn get_store(
+        &self,
+        base_path: Url,
+        params: &ObjectStoreParams,
+    ) -> Result<ObjectStore> {
+        // TODO: caching
+        let scheme = base_path.scheme();
+        let provider = self.get_provider(scheme).ok_or_else(|| {
+            Error::invalid_input(
+                format!("No object store provider found for scheme: {}", scheme),
+                location!(),
+            )
+        })?;
+        provider.new_store(base_path, params).await
+    }
+}
+
+impl Default for ObjectStoreRegistry {
+    fn default() -> Self {
+        let mut registry = Self {
+            providers: HashMap::new(),
+        };
+        registry.insert("memory", Arc::new(memory::MemoryStoreProvider));
+        registry.insert("file", Arc::new(local::FileStoreProvider));
+        registry.insert("file-object-store", Arc::new(local::FileStoreProvider));
+        #[cfg(feature = "aws")]
+        {
+            let aws = Arc::new(aws::AwsStoreProvider);
+            registry.insert("s3", aws.clone());
+            registry.insert("s3+ddb", aws);
+        }
+        #[cfg(feature = "azure")]
+        registry.insert("az", Arc::new(azure::AzureBlobStoreProvider));
+        #[cfg(feature = "gcp")]
+        registry.insert("gs", Arc::new(gcp::GcsStoreProvider));
+        registry
+    }
+}
+
+impl ObjectStoreRegistry {
+    pub fn insert(&mut self, scheme: &str, provider: Arc<dyn ObjectStoreProvider>) {
+        self.providers.insert(scheme.into(), provider);
+    }
+}

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{
+    collections::HashMap,
+    str::FromStr,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
+use aws_config::default_provider::credentials::DefaultCredentialsChain;
+use aws_credential_types::provider::ProvideCredentials;
+use object_store::{
+    aws::{
+        AmazonS3Builder, AmazonS3ConfigKey, AwsCredential as ObjectStoreAwsCredential,
+        AwsCredentialProvider,
+    },
+    ClientOptions, CredentialProvider, Result as ObjectStoreResult, RetryConfig,
+    StaticCredentialProvider,
+};
+use snafu::location;
+use tokio::sync::RwLock;
+use url::Url;
+
+use crate::object_store::{
+    tracing::ObjectStoreTracingExt, ObjectStore, ObjectStoreParams, ObjectStoreProvider,
+    StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM,
+};
+use lance_core::error::{Error, Result};
+
+#[derive(Default, Debug)]
+pub struct AwsStoreProvider;
+
+#[async_trait::async_trait]
+impl ObjectStoreProvider for AwsStoreProvider {
+    async fn new_store(
+        &self,
+        mut base_path: Url,
+        params: &ObjectStoreParams,
+    ) -> Result<ObjectStore> {
+        let block_size = params.block_size.unwrap_or(DEFAULT_CLOUD_BLOCK_SIZE);
+        let mut storage_options =
+            StorageOptions(params.storage_options.clone().unwrap_or_default());
+        let download_retry_count = storage_options.download_retry_count();
+
+        let max_retries = storage_options.client_max_retries();
+        let retry_timeout = storage_options.client_retry_timeout();
+        let retry_config = RetryConfig {
+            backoff: Default::default(),
+            max_retries,
+            retry_timeout: Duration::from_secs(retry_timeout),
+        };
+
+        storage_options.with_env_s3();
+
+        let mut storage_options = storage_options.as_s3_options();
+        let region = resolve_s3_region(&base_path, &storage_options).await?;
+        let (aws_creds, region) = build_aws_credential(
+            params.s3_credentials_refresh_offset,
+            params.aws_credentials.clone(),
+            Some(&storage_options),
+            region,
+        )
+        .await?;
+
+        // This will be default in next version of object store.
+        // https://github.com/apache/arrow-rs/pull/7181
+        // We can do this when we upgrade to 0.12.
+        storage_options
+            .entry(AmazonS3ConfigKey::ConditionalPut)
+            .or_insert_with(|| "etag".to_string());
+
+        // Cloudflare does not support varying part sizes.
+        let use_constant_size_upload_parts = storage_options
+            .get(&AmazonS3ConfigKey::Endpoint)
+            .map(|endpoint| endpoint.contains("r2.cloudflarestorage.com"))
+            .unwrap_or(false);
+
+        // before creating the OSObjectStore we need to rewrite the url to drop ddb related parts
+        base_path.set_scheme("s3").unwrap();
+        base_path.set_query(None);
+
+        // we can't use parse_url_opts here because we need to manually set the credentials provider
+        let mut builder = AmazonS3Builder::new();
+        for (key, value) in storage_options {
+            builder = builder.with_config(key, value);
+        }
+        builder = builder
+            .with_url(base_path.as_ref())
+            .with_credentials(aws_creds)
+            .with_retry(retry_config)
+            .with_region(region);
+        let store = builder.build()?;
+
+        Ok(ObjectStore {
+            inner: Arc::new(store).traced(),
+            scheme: String::from(base_path.scheme()),
+            block_size,
+            use_constant_size_upload_parts,
+            list_is_lexically_ordered: true,
+            io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
+            download_retry_count,
+        })
+    }
+}
+
+/// Figure out the S3 region of the bucket.
+///
+/// This resolves in order of precedence:
+/// 1. The region provided in the storage options
+/// 2. (If endpoint is not set), the region returned by the S3 API for the bucket
+///
+/// It can return None if no region is provided and the endpoint is set.
+async fn resolve_s3_region(
+    url: &Url,
+    storage_options: &HashMap<AmazonS3ConfigKey, String>,
+) -> Result<Option<String>> {
+    if let Some(region) = storage_options.get(&AmazonS3ConfigKey::Region) {
+        Ok(Some(region.clone()))
+    } else if storage_options.get(&AmazonS3ConfigKey::Endpoint).is_none() {
+        // If no endpoint is set, we can assume this is AWS S3 and the region
+        // can be resolved from the bucket.
+        let bucket = url.host_str().ok_or_else(|| {
+            Error::invalid_input(
+                format!("Could not parse bucket from url: {}", url),
+                location!(),
+            )
+        })?;
+
+        let mut client_options = ClientOptions::default();
+        for (key, value) in storage_options {
+            if let AmazonS3ConfigKey::Client(client_key) = key {
+                client_options = client_options.with_config(*client_key, value.clone());
+            }
+        }
+
+        let bucket_region =
+            object_store::aws::resolve_bucket_region(bucket, &client_options).await?;
+        Ok(Some(bucket_region))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Build AWS credentials
+///
+/// This resolves credentials from the following sources in order:
+/// 1. An explicit `credentials` provider
+/// 2. Explicit credentials in storage_options (as in `aws_access_key_id`,
+///    `aws_secret_access_key`, `aws_session_token`)
+/// 3. The default credential provider chain from AWS SDK.
+///
+/// `credentials_refresh_offset` is the amount of time before expiry to refresh credentials.
+pub async fn build_aws_credential(
+    credentials_refresh_offset: Duration,
+    credentials: Option<AwsCredentialProvider>,
+    storage_options: Option<&HashMap<AmazonS3ConfigKey, String>>,
+    region: Option<String>,
+) -> Result<(AwsCredentialProvider, String)> {
+    // TODO: make this return no credential provider not using AWS
+    use aws_config::meta::region::RegionProviderChain;
+    const DEFAULT_REGION: &str = "us-west-2";
+
+    let region = if let Some(region) = region {
+        region
+    } else {
+        RegionProviderChain::default_provider()
+            .or_else(DEFAULT_REGION)
+            .region()
+            .await
+            .map(|r| r.as_ref().to_string())
+            .unwrap_or(DEFAULT_REGION.to_string())
+    };
+
+    if let Some(creds) = credentials {
+        Ok((creds, region))
+    } else if let Some(creds) = storage_options.and_then(extract_static_s3_credentials) {
+        Ok((Arc::new(creds), region))
+    } else {
+        let credentials_provider = DefaultCredentialsChain::builder().build().await;
+
+        Ok((
+            Arc::new(AwsCredentialAdapter::new(
+                Arc::new(credentials_provider),
+                credentials_refresh_offset,
+            )),
+            region,
+        ))
+    }
+}
+
+fn extract_static_s3_credentials(
+    options: &HashMap<AmazonS3ConfigKey, String>,
+) -> Option<StaticCredentialProvider<ObjectStoreAwsCredential>> {
+    let key_id = options
+        .get(&AmazonS3ConfigKey::AccessKeyId)
+        .map(|s| s.to_string());
+    let secret_key = options
+        .get(&AmazonS3ConfigKey::SecretAccessKey)
+        .map(|s| s.to_string());
+    let token = options
+        .get(&AmazonS3ConfigKey::Token)
+        .map(|s| s.to_string());
+    match (key_id, secret_key, token) {
+        (Some(key_id), Some(secret_key), token) => {
+            Some(StaticCredentialProvider::new(ObjectStoreAwsCredential {
+                key_id,
+                secret_key,
+                token,
+            }))
+        }
+        _ => None,
+    }
+}
+
+/// Adapt an AWS SDK cred into object_store credentials
+#[derive(Debug)]
+pub struct AwsCredentialAdapter {
+    pub inner: Arc<dyn ProvideCredentials>,
+
+    // RefCell can't be shared across threads, so we use HashMap
+    cache: Arc<RwLock<HashMap<String, Arc<aws_credential_types::Credentials>>>>,
+
+    // The amount of time before expiry to refresh credentials
+    credentials_refresh_offset: Duration,
+}
+
+impl AwsCredentialAdapter {
+    pub fn new(
+        provider: Arc<dyn ProvideCredentials>,
+        credentials_refresh_offset: Duration,
+    ) -> Self {
+        Self {
+            inner: provider,
+            cache: Arc::new(RwLock::new(HashMap::new())),
+            credentials_refresh_offset,
+        }
+    }
+}
+
+const AWS_CREDS_CACHE_KEY: &str = "aws_credentials";
+
+#[async_trait::async_trait]
+impl CredentialProvider for AwsCredentialAdapter {
+    type Credential = ObjectStoreAwsCredential;
+
+    async fn get_credential(&self) -> ObjectStoreResult<Arc<Self::Credential>> {
+        let cached_creds = {
+            let cache_value = self.cache.read().await.get(AWS_CREDS_CACHE_KEY).cloned();
+            let expired = cache_value
+                .clone()
+                .map(|cred| {
+                    cred.expiry()
+                        .map(|exp| {
+                            exp.checked_sub(self.credentials_refresh_offset)
+                                .expect("this time should always be valid")
+                                < SystemTime::now()
+                        })
+                        // no expiry is never expire
+                        .unwrap_or(false)
+                })
+                .unwrap_or(true); // no cred is the same as expired;
+            if expired {
+                None
+            } else {
+                cache_value.clone()
+            }
+        };
+
+        if let Some(creds) = cached_creds {
+            Ok(Arc::new(Self::Credential {
+                key_id: creds.access_key_id().to_string(),
+                secret_key: creds.secret_access_key().to_string(),
+                token: creds.session_token().map(|s| s.to_string()),
+            }))
+        } else {
+            let refreshed_creds = Arc::new(self.inner.provide_credentials().await.map_err(
+                |e| Error::Internal {
+                    message: format!("Failed to get AWS credentials: {}", e),
+                    location: location!(),
+                },
+            )?);
+
+            self.cache
+                .write()
+                .await
+                .insert(AWS_CREDS_CACHE_KEY.to_string(), refreshed_creds.clone());
+
+            Ok(Arc::new(Self::Credential {
+                key_id: refreshed_creds.access_key_id().to_string(),
+                secret_key: refreshed_creds.secret_access_key().to_string(),
+                token: refreshed_creds.session_token().map(|s| s.to_string()),
+            }))
+        }
+    }
+}
+
+impl StorageOptions {
+    /// Add values from the environment to storage options
+    pub fn with_env_s3(&mut self) {
+        for (os_key, os_value) in std::env::vars_os() {
+            if let (Some(key), Some(value)) = (os_key.to_str(), os_value.to_str()) {
+                if let Ok(config_key) = AmazonS3ConfigKey::from_str(&key.to_ascii_lowercase()) {
+                    if !self.0.contains_key(config_key.as_ref()) {
+                        self.0
+                            .insert(config_key.as_ref().to_string(), value.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    /// Subset of options relevant for s3 storage
+    pub fn as_s3_options(&self) -> HashMap<AmazonS3ConfigKey, String> {
+        self.0
+            .iter()
+            .filter_map(|(key, value)| {
+                let s3_key = AmazonS3ConfigKey::from_str(&key.to_ascii_lowercase()).ok()?;
+                Some((s3_key, value.clone()))
+            })
+            .collect()
+    }
+}
+
+impl ObjectStoreParams {
+    /// Create a new instance of [`ObjectStoreParams`] based on the AWS credentials.
+    pub fn with_aws_credentials(
+        aws_credentials: Option<AwsCredentialProvider>,
+        region: Option<String>,
+    ) -> Self {
+        Self {
+            aws_credentials,
+            storage_options: region
+                .map(|region| [("region".into(), region)].iter().cloned().collect()),
+            ..Default::default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use object_store::path::Path;
+
+    use crate::object_store::ObjectStoreRegistry;
+
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct MockAwsCredentialsProvider {
+        called: AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl CredentialProvider for MockAwsCredentialsProvider {
+        type Credential = ObjectStoreAwsCredential;
+
+        async fn get_credential(&self) -> ObjectStoreResult<Arc<Self::Credential>> {
+            self.called.store(true, Ordering::Relaxed);
+            Ok(Arc::new(Self::Credential {
+                key_id: "".to_string(),
+                secret_key: "".to_string(),
+                token: None,
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_injected_aws_creds_option_is_used() {
+        let mock_provider = Arc::new(MockAwsCredentialsProvider::default());
+        let registry = Arc::new(ObjectStoreRegistry::default());
+
+        let params = ObjectStoreParams {
+            aws_credentials: Some(mock_provider.clone() as AwsCredentialProvider),
+            ..ObjectStoreParams::default()
+        };
+
+        // Not called yet
+        assert!(!mock_provider.called.load(Ordering::Relaxed));
+
+        let (store, _) = ObjectStore::from_uri_and_params(registry, "s3://not-a-bucket", &params)
+            .await
+            .unwrap();
+
+        // fails, but we don't care
+        let _ = store
+            .open(&Path::parse("/").unwrap())
+            .await
+            .unwrap()
+            .get_range(0..1)
+            .await;
+
+        // Not called yet
+        assert!(mock_provider.called.load(Ordering::Relaxed));
+    }
+}

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
+
+use object_store::{
+    azure::{AzureConfigKey, MicrosoftAzureBuilder},
+    RetryConfig,
+};
+use url::Url;
+
+use crate::object_store::{
+    tracing::ObjectStoreTracingExt, ObjectStore, ObjectStoreParams, ObjectStoreProvider,
+    StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM,
+};
+use lance_core::error::Result;
+
+#[derive(Default, Debug)]
+pub struct AzureBlobStoreProvider;
+
+#[async_trait::async_trait]
+impl ObjectStoreProvider for AzureBlobStoreProvider {
+    async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
+        let block_size = params.block_size.unwrap_or(DEFAULT_CLOUD_BLOCK_SIZE);
+        let mut storage_options =
+            StorageOptions(params.storage_options.clone().unwrap_or_default());
+        let download_retry_count = storage_options.download_retry_count();
+
+        let max_retries = storage_options.client_max_retries();
+        let retry_timeout = storage_options.client_retry_timeout();
+        let retry_config = RetryConfig {
+            backoff: Default::default(),
+            max_retries,
+            retry_timeout: Duration::from_secs(retry_timeout),
+        };
+
+        storage_options.with_env_azure();
+        let mut builder = MicrosoftAzureBuilder::new()
+            .with_url(base_path.as_ref())
+            .with_retry(retry_config);
+        for (key, value) in storage_options.as_azure_options() {
+            builder = builder.with_config(key, value);
+        }
+        let store = builder.build()?;
+        let store = Arc::new(store).traced();
+
+        Ok(ObjectStore {
+            inner: store,
+            scheme: String::from("az"),
+            block_size,
+            use_constant_size_upload_parts: false,
+            list_is_lexically_ordered: true,
+            io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
+            download_retry_count,
+        })
+    }
+}
+
+impl StorageOptions {
+    /// Add values from the environment to storage options
+    pub fn with_env_azure(&mut self) {
+        for (os_key, os_value) in std::env::vars_os() {
+            if let (Some(key), Some(value)) = (os_key.to_str(), os_value.to_str()) {
+                if let Ok(config_key) = AzureConfigKey::from_str(&key.to_ascii_lowercase()) {
+                    if !self.0.contains_key(config_key.as_ref()) {
+                        self.0
+                            .insert(config_key.as_ref().to_string(), value.to_string());
+                    }
+                }
+            }
+        }
+    }
+
+    /// Subset of options relevant for azure storage
+    pub fn as_azure_options(&self) -> HashMap<AzureConfigKey, String> {
+        self.0
+            .iter()
+            .filter_map(|(key, value)| {
+                let az_key = AzureConfigKey::from_str(&key.to_ascii_lowercase()).ok()?;
+                Some((az_key, value.clone()))
+            })
+            .collect()
+    }
+}

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
+
+use object_store::{
+    gcp::{GcpCredential, GoogleCloudStorageBuilder, GoogleConfigKey},
+    RetryConfig, StaticCredentialProvider,
+};
+use url::Url;
+
+use crate::object_store::{
+    tracing::ObjectStoreTracingExt, ObjectStore, ObjectStoreParams, ObjectStoreProvider,
+    StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM,
+};
+use lance_core::error::Result;
+
+#[derive(Default, Debug)]
+pub struct GcsStoreProvider;
+
+#[async_trait::async_trait]
+impl ObjectStoreProvider for GcsStoreProvider {
+    async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
+        let block_size = params.block_size.unwrap_or(DEFAULT_CLOUD_BLOCK_SIZE);
+        let mut storage_options =
+            StorageOptions(params.storage_options.clone().unwrap_or_default());
+        let download_retry_count = storage_options.download_retry_count();
+
+        let max_retries = storage_options.client_max_retries();
+        let retry_timeout = storage_options.client_retry_timeout();
+        let retry_config = RetryConfig {
+            backoff: Default::default(),
+            max_retries,
+            retry_timeout: Duration::from_secs(retry_timeout),
+        };
+
+        storage_options.with_env_gcs();
+        let mut builder = GoogleCloudStorageBuilder::new()
+            .with_url(base_path.as_ref())
+            .with_retry(retry_config);
+        for (key, value) in storage_options.as_gcs_options() {
+            builder = builder.with_config(key, value);
+        }
+        let token_key = "google_storage_token";
+        if let Some(storage_token) = storage_options.get(token_key) {
+            let credential = GcpCredential {
+                bearer: storage_token.to_string(),
+            };
+            let credential_provider = Arc::new(StaticCredentialProvider::new(credential)) as _;
+            builder = builder.with_credentials(credential_provider);
+        }
+        let store = builder.build()?;
+        let store = Arc::new(store).traced();
+
+        Ok(ObjectStore {
+            inner: store,
+            scheme: String::from("gs"),
+            block_size,
+            use_constant_size_upload_parts: false,
+            list_is_lexically_ordered: true,
+            io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
+            download_retry_count,
+        })
+    }
+}
+
+impl StorageOptions {
+    /// Add values from the environment to storage options
+    pub fn with_env_gcs(&mut self) {
+        for (os_key, os_value) in std::env::vars_os() {
+            if let (Some(key), Some(value)) = (os_key.to_str(), os_value.to_str()) {
+                let lowercase_key = key.to_ascii_lowercase();
+                let token_key = "google_storage_token";
+
+                if let Ok(config_key) = GoogleConfigKey::from_str(&lowercase_key) {
+                    if !self.0.contains_key(config_key.as_ref()) {
+                        self.0
+                            .insert(config_key.as_ref().to_string(), value.to_string());
+                    }
+                }
+                // Check for GOOGLE_STORAGE_TOKEN until GoogleConfigKey supports storage token
+                else if lowercase_key == token_key && !self.0.contains_key(token_key) {
+                    self.0.insert(token_key.to_string(), value.to_string());
+                }
+            }
+        }
+    }
+
+    /// Subset of options relevant for gcs storage
+    pub fn as_gcs_options(&self) -> HashMap<GoogleConfigKey, String> {
+        self.0
+            .iter()
+            .filter_map(|(key, value)| {
+                let gcs_key = GoogleConfigKey::from_str(&key.to_ascii_lowercase()).ok()?;
+                Some((gcs_key, value.clone()))
+            })
+            .collect()
+    }
+}

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use object_store::local::LocalFileSystem;
+use url::Url;
+
+use crate::object_store::{
+    tracing::ObjectStoreTracingExt, ObjectStore, ObjectStoreParams, ObjectStoreProvider,
+    StorageOptions, DEFAULT_LOCAL_BLOCK_SIZE, DEFAULT_LOCAL_IO_PARALLELISM,
+};
+use lance_core::error::Result;
+
+#[derive(Default, Debug)]
+pub struct FileStoreProvider;
+
+#[async_trait::async_trait]
+impl ObjectStoreProvider for FileStoreProvider {
+    async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
+        let block_size = params.block_size.unwrap_or(DEFAULT_LOCAL_BLOCK_SIZE);
+        let storage_options = StorageOptions(params.storage_options.clone().unwrap_or_default());
+        let download_retry_count = storage_options.download_retry_count();
+        Ok(ObjectStore {
+            inner: Arc::new(LocalFileSystem::new()).traced(),
+            scheme: base_path.scheme().to_owned(),
+            block_size,
+            use_constant_size_upload_parts: false,
+            list_is_lexically_ordered: false,
+            io_parallelism: DEFAULT_LOCAL_IO_PARALLELISM,
+            download_retry_count,
+        })
+    }
+}

--- a/rust/lance-io/src/object_store/providers/memory.rs
+++ b/rust/lance-io/src/object_store/providers/memory.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use object_store::memory::InMemory;
+use url::Url;
+
+use crate::object_store::{
+    tracing::ObjectStoreTracingExt, ObjectStore, ObjectStoreParams, ObjectStoreProvider,
+    StorageOptions, DEFAULT_LOCAL_BLOCK_SIZE,
+};
+use lance_core::{error::Result, utils::tokio::get_num_compute_intensive_cpus};
+
+#[derive(Default, Debug)]
+pub struct MemoryStoreProvider;
+
+#[async_trait::async_trait]
+impl ObjectStoreProvider for MemoryStoreProvider {
+    async fn new_store(&self, _base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
+        let block_size = params.block_size.unwrap_or(DEFAULT_LOCAL_BLOCK_SIZE);
+        let storage_options = StorageOptions(params.storage_options.clone().unwrap_or_default());
+        let download_retry_count = storage_options.download_retry_count();
+        Ok(ObjectStore {
+            inner: Arc::new(InMemory::new()).traced(),
+            scheme: String::from("memory"),
+            block_size,
+            use_constant_size_upload_parts: false,
+            list_is_lexically_ordered: true,
+            io_parallelism: get_num_compute_intensive_cpus(),
+            download_retry_count,
+        })
+    }
+}

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -60,7 +60,7 @@ prost-build.workspace = true
 protobuf-src = { version = "2.1", optional = true }
 
 [features]
-dynamodb = ["aws-sdk-dynamodb", "lazy_static", "aws-credential-types"]
+dynamodb = ["aws-sdk-dynamodb", "lazy_static", "aws-credential-types", "lance-io/aws"]
 protoc = ["dep:protobuf-src"]
 
 [package.metadata.docs.rs]

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -22,7 +22,7 @@ arrow-buffer.workspace = true
 arrow-ipc.workspace = true
 arrow-schema.workspace = true
 async-trait.workspace = true
-aws-credential-types.workspace = true
+aws-credential-types = { workspace = true, optional = true }
 aws-sdk-dynamodb = { workspace = true, optional = true }
 byteorder.workspace = true
 bytes.workspace = true
@@ -60,7 +60,7 @@ prost-build.workspace = true
 protobuf-src = { version = "2.1", optional = true }
 
 [features]
-dynamodb = ["aws-sdk-dynamodb", "lazy_static"]
+dynamodb = ["aws-sdk-dynamodb", "lazy_static", "aws-credential-types"]
 protoc = ["dep:protobuf-src"]
 
 [package.metadata.docs.rs]

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -51,7 +51,7 @@ use {
     self::external_manifest::{ExternalManifestCommitHandler, ExternalManifestStore},
     aws_credential_types::provider::error::CredentialsError,
     aws_credential_types::provider::ProvideCredentials,
-    lance_io::object_store::{build_aws_credential, StorageOptions},
+    lance_io::object_store::{providers::aws::build_aws_credential, StorageOptions},
     object_store::aws::AmazonS3ConfigKey,
     object_store::aws::AwsCredentialProvider,
     std::borrow::Cow,

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -44,7 +44,7 @@ deepsize.workspace = true
 # matches arrow-rs use
 half.workspace = true
 itertools.workspace = true
-object_store = { workspace = true, features = ["aws", "gcp", "azure"] }
+object_store = { workspace = true }
 aws-credential-types.workspace = true
 pin-project.workspace = true
 prost.workspace = true
@@ -104,6 +104,7 @@ aws-sdk-s3 = { workspace = true }
 
 
 [features]
+default = ["aws", "azure", "gcp"]
 fp16kernels = ["lance-linalg/fp16kernels"]
 # Prevent dynamic linking of lzma, which comes from datafusion
 cli = ["clap", "lzma-sys/static"]
@@ -117,6 +118,9 @@ protoc = [
     "lance-index/protoc",
     "lance-table/protoc",
 ]
+aws = ["lance-io/aws"]
+gcp = ["lance-io/gcp"]
+azure = ["lance-io/azure"]
 
 [[bin]]
 name = "lq"

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2059,6 +2059,7 @@ mod tests {
                     object_store_wrapper: Some(io_stats_wrapper),
                     ..Default::default()
                 }),
+                object_store_registry: store_registry.clone(),
                 ..Default::default()
             })
             .load()

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1769,17 +1769,17 @@ mod tests {
     use lance_index::scalar::inverted::TokenizerConfig;
     use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
     use lance_index::{scalar::ScalarIndexParams, vector::DIST_COL, DatasetIndexExt, IndexType};
+    use lance_io::object_store::providers::memory::PersistentMemoryStoreProvider;
     use lance_linalg::distance::MetricType;
     use lance_table::feature_flags;
     use lance_table::format::{DataFile, WriterVersion};
-    use lance_table::io::commit::RenameCommitHandler;
+
     use lance_table::io::deletion::read_deletion_file;
     use lance_testing::datagen::generate_random_array;
     use pretty_assertions::assert_eq;
     use rand::seq::SliceRandom;
     use rstest::rstest;
     use tempfile::{tempdir, TempDir};
-    use url::Url;
 
     // Used to validate that futures returned are Send.
     fn require_send<T: Send>(t: T) -> T {
@@ -2019,6 +2019,16 @@ mod tests {
         // Need to use in-memory for accurate IOPS tracking.
         use crate::utils::test::IoTrackingStore;
 
+        let mut store_registry = ObjectStoreRegistry::empty();
+        let memory_store = Arc::new(object_store::memory::InMemory::new());
+        store_registry.insert(
+            "memory",
+            Arc::new(PersistentMemoryStoreProvider {
+                inner: memory_store,
+            }),
+        );
+        let store_registry = Arc::new(store_registry);
+
         let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "i",
             DataType::Int32,
@@ -2030,12 +2040,18 @@ mod tests {
         )
         .unwrap();
         let batches = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
-        let dataset = Dataset::write(batches, "memory://test", None)
-            .await
-            .unwrap();
+        Dataset::write(
+            batches,
+            "memory://test",
+            Some(WriteParams {
+                object_store_registry: store_registry.clone(),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
 
         // Then open with wrapping store.
-        let memory_store = dataset.object_store.inner.clone();
         let (io_stats_wrapper, io_stats) = IoTrackingStore::new_wrapper();
         let _dataset = DatasetBuilder::from_uri("memory://test")
             .with_read_params(ReadParams {
@@ -2045,11 +2061,6 @@ mod tests {
                 }),
                 ..Default::default()
             })
-            .with_object_store(
-                memory_store,
-                Url::parse("memory://test").unwrap(),
-                Arc::new(RenameCommitHandler),
-            )
             .load()
             .await
             .unwrap();

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -114,6 +114,8 @@ impl DatasetBuilder {
     }
 
     /// Directly set the object store to use.
+    #[deprecated(note = "Implement an ObjectStoreProvider instead")]
+    #[allow(deprecated)]
     pub fn with_object_store(
         mut self,
         object_store: Arc<DynObjectStore>,
@@ -229,6 +231,7 @@ impl DatasetBuilder {
             .unwrap_or_default();
         let download_retry_count = storage_options.download_retry_count();
 
+        #[allow(deprecated)]
         match &self.options.object_store {
             Some(store) => Ok((
                 ObjectStore::new(

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -591,6 +591,7 @@ async fn resolve_commit_handler(
 ) -> Result<Arc<dyn CommitHandler>> {
     match commit_handler {
         None => {
+            #[allow(deprecated)]
             if store_options
                 .as_ref()
                 .map(|opts| opts.object_store.is_some())


### PR DESCRIPTION
BREAKING CHANGE: `ObjectStoreProvider::new_store` is now async.

* Moves all objects stores to be configured using a `ObjectStoreProvider`. This consolidation is a step towards being able to cache object stores for #3684
* Makes `aws`, `gcp`, and `azure` specific code optional under feature flags. This addresses part of #2646
* Deprecated passing object store explicitly in favor of implementing `ObjectStoreProvider`.
