### PR TITLE
feat!: move object store registry to the session, re-use stores

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -216,7 +216,7 @@ jobs:
       - name: Build tests
         run: cargo test --locked --no-run
       - name: Run lance-io tests first
-        run: cargo test --lib lance-io
+        run: cargo test -p lance-io
       - name: Run tests
         run: cargo test
       - name: Check benchmarks

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -173,7 +173,7 @@ jobs:
           - nightly
     defaults:
       run:
-        working-directory: ./rust/lance
+        working-directory: ./rust
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
@@ -200,7 +200,7 @@ jobs:
     runs-on: windows-latest
     defaults:
       run:
-        working-directory: rust/lance
+        working-directory: rust
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -215,8 +215,6 @@ jobs:
         shell: powershell
       - name: Build tests
         run: cargo test --locked --no-run
-      - name: Run lance-io tests first
-        run: cargo test -p lance-io
       - name: Run tests
         run: cargo test
       - name: Check benchmarks

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -215,6 +215,8 @@ jobs:
         shell: powershell
       - name: Build tests
         run: cargo test --locked --no-run
+      - name: Run lance-io tests first
+        run: cargo test --lib lance-io
       - name: Run tests
         run: cargo test
       - name: Check benchmarks

--- a/java/core/lance-jni/src/blocking_dataset.rs
+++ b/java/core/lance-jni/src/blocking_dataset.rs
@@ -116,7 +116,6 @@ impl BlockingDataset {
         read_version: Option<u64>,
         storage_options: HashMap<String, String>,
     ) -> Result<Self> {
-        let object_store_registry = Arc::new(ObjectStoreRegistry::default());
         let inner = RT.block_on(Dataset::commit(
             uri,
             operation,
@@ -126,7 +125,7 @@ impl BlockingDataset {
                 ..Default::default()
             }),
             None,
-            object_store_registry,
+            Default::default(),
             false, // TODO: support enable_v2_manifest_paths
         ))?;
         Ok(Self { inner })

--- a/java/core/lance-jni/src/file_reader.rs
+++ b/java/core/lance-jni/src/file_reader.rs
@@ -89,7 +89,6 @@ fn inner_open<'local>(env: &mut JNIEnv<'local>, file_uri: JString) -> Result<JOb
 
     let reader = RT.block_on(async move {
         let (obj_store, path) = ObjectStore::from_uri(&file_uri_str).await?;
-        let obj_store = Arc::new(obj_store);
         let config = SchedulerConfig::max_bandwidth(&obj_store);
         let scan_scheduler = ScanScheduler::new(obj_store, config);
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -2196,11 +2196,7 @@ impl PyFullTextQuery {
 
     #[staticmethod]
     #[pyo3(signature = (positive, negative,negative_boost=None))]
-    fn boost_query(
-        positive: PyFullTextQuery,
-        negative: PyFullTextQuery,
-        negative_boost: Option<f32>,
-    ) -> PyResult<Self> {
+    fn boost_query(positive: Self, negative: Self, negative_boost: Option<f32>) -> PyResult<Self> {
         Ok(Self {
             inner: BoostQuery::new(positive.inner, negative.inner, negative_boost).into(),
         })

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -333,7 +333,7 @@ fn path_to_parent(path: &Path) -> PyResult<(Path, String)> {
 
 pub async fn object_store_from_uri_or_path_no_options(
     uri_or_path: impl AsRef<str>,
-) -> PyResult<(ObjectStore, Path)> {
+) -> PyResult<(Arc<ObjectStore>, Path)> {
     object_store_from_uri_or_path(uri_or_path, None).await
 }
 
@@ -344,7 +344,7 @@ pub async fn object_store_from_uri_or_path_no_options(
 pub async fn object_store_from_uri_or_path(
     uri_or_path: impl AsRef<str>,
     storage_options: Option<HashMap<String, String>>,
-) -> PyResult<(ObjectStore, Path)> {
+) -> PyResult<(Arc<ObjectStore>, Path)> {
     if let Ok(mut url) = Url::parse(uri_or_path.as_ref()) {
         if url.scheme().len() > 1 {
             let path = object_store::path::Path::parse(url.path()).map_err(|e| {
@@ -376,7 +376,7 @@ pub async fn object_store_from_uri_or_path(
     let path = Path::parse(uri_or_path.as_ref()).map_err(|e| {
         PyIOError::new_err(format!("Invalid path `{}`: {}", uri_or_path.as_ref(), e))
     })?;
-    let object_store = ObjectStore::local();
+    let object_store = Arc::new(ObjectStore::local());
     Ok((object_store, path))
 }
 
@@ -393,7 +393,7 @@ impl LanceFileReader {
         let (object_store, path) =
             object_store_from_uri_or_path(uri_or_path, storage_options).await?;
         let scheduler = ScanScheduler::new(
-            Arc::new(object_store),
+            object_store,
             SchedulerConfig {
                 io_buffer_size_bytes: 2 * 1024 * 1024 * 1024,
             },

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -242,6 +242,7 @@ pub fn transform_vectors(
     )?
 }
 
+#[allow(deprecated)]
 async fn do_shuffle_transformed_vectors(
     unsorted_filenames: Vec<String>,
     dir_path: &str,

--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -766,6 +766,7 @@ mod tests {
     };
     use arrow_array::{BooleanArray, Int32Array};
     use arrow_schema::{Field as ArrowField, Fields as ArrowFields, Schema as ArrowSchema};
+    use lance_io::object_store::ObjectStoreParams;
 
     #[tokio::test]
     async fn test_take() {
@@ -1364,8 +1365,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_take_boolean_beyond_chunk() {
-        let mut store = ObjectStore::memory();
-        store.set_block_size(256);
+        let store = ObjectStore::from_uri_and_params(
+            Arc::new(Default::default()),
+            "memory://",
+            &ObjectStoreParams {
+                block_size: Some(256),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+        .0;
         let path = Path::from("/take_bools");
 
         let arrow_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(

--- a/rust/lance-index/benches/inverted.rs
+++ b/rust/lance-index/benches/inverted.rs
@@ -34,7 +34,7 @@ fn bench_inverted(c: &mut Criterion) {
     let index_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
     let store = rt.block_on(async {
         Arc::new(LanceIndexStore::new(
-            ObjectStore::local(),
+            Arc::new(ObjectStore::local()),
             index_dir,
             FileMetadataCache::no_cache(),
         ))

--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -31,7 +31,7 @@ fn bench_ngram(c: &mut Criterion) {
     let index_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
     let store = rt.block_on(async {
         Arc::new(LanceIndexStore::new(
-            ObjectStore::local(),
+            Arc::new(ObjectStore::local()),
             index_dir,
             FileMetadataCache::no_cache(),
         ))

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -1489,7 +1489,7 @@ mod tests {
     async fn test_nan_ordering() {
         let tmpdir = Arc::new(tempdir().unwrap());
         let test_store = Arc::new(LanceIndexStore::new(
-            ObjectStore::local(),
+            Arc::new(ObjectStore::local()),
             Path::from_filesystem_path(tmpdir.path()).unwrap(),
             FileMetadataCache::no_cache(),
         ));

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -1422,7 +1422,7 @@ mod tests {
     async fn test_null_ids() {
         let tmpdir = Arc::new(tempdir().unwrap());
         let test_store = Arc::new(LanceIndexStore::new(
-            ObjectStore::local(),
+            Arc::new(ObjectStore::local()),
             Path::from_filesystem_path(tmpdir.path()).unwrap(),
             FileMetadataCache::no_cache(),
         ));
@@ -1453,7 +1453,7 @@ mod tests {
 
         let remap_dir = Arc::new(tempdir().unwrap());
         let remap_store = Arc::new(LanceIndexStore::new(
-            ObjectStore::local(),
+            Arc::new(ObjectStore::local()),
             Path::from_filesystem_path(remap_dir.path()).unwrap(),
             FileMetadataCache::no_cache(),
         ));

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -446,7 +446,7 @@ impl IndexWorker {
     async fn new(existing_tokens: HashMap<String, u32>, with_position: bool) -> Result<Self> {
         let tmpdir = tempdir()?;
         let store = Arc::new(LanceIndexStore::new(
-            ObjectStore::local(),
+            Arc::new(ObjectStore::local()),
             Path::from_filesystem_path(tmpdir.path())?,
             FileMetadataCache::no_cache(),
         ));

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -643,7 +643,7 @@ impl NGramIndexBuilder {
 
         let tmpdir = Arc::new(tempdir()?);
         let spill_store = Arc::new(LanceIndexStore::new(
-            ObjectStore::local(),
+            Arc::new(ObjectStore::local()),
             Path::from_filesystem_path(tmpdir.path())?,
             FileMetadataCache::no_cache(),
         ));
@@ -1249,7 +1249,7 @@ mod tests {
 
         let tmpdir = Arc::new(tempdir().unwrap());
         let test_store = LanceIndexStore::new(
-            ObjectStore::local(),
+            Arc::new(ObjectStore::local()),
             Path::from_filesystem_path(tmpdir.path()).unwrap(),
             FileMetadataCache::no_cache(),
         );
@@ -1453,7 +1453,7 @@ mod tests {
 
         let new_tmpdir = Arc::new(tempdir().unwrap());
         let test_store = Arc::new(LanceIndexStore::new(
-            ObjectStore::local(),
+            Arc::new(ObjectStore::local()),
             Path::from_filesystem_path(new_tmpdir.path()).unwrap(),
             FileMetadataCache::no_cache(),
         ));
@@ -1488,7 +1488,7 @@ mod tests {
 
         let new_tmpdir = Arc::new(tempdir().unwrap());
         let test_store = Arc::new(LanceIndexStore::new(
-            ObjectStore::local(),
+            Arc::new(ObjectStore::local()),
             Path::from_filesystem_path(new_tmpdir.path()).unwrap(),
             FileMetadataCache::no_cache(),
         ));
@@ -1528,7 +1528,7 @@ mod tests {
 
         let new_tmpdir = Arc::new(tempdir().unwrap());
         let test_store = Arc::new(LanceIndexStore::new(
-            ObjectStore::local(),
+            Arc::new(ObjectStore::local()),
             Path::from_filesystem_path(new_tmpdir.path()).unwrap(),
             FileMetadataCache::no_cache(),
         ));

--- a/rust/lance-io/benches/scheduler.rs
+++ b/rust/lance-io/benches/scheduler.rs
@@ -46,7 +46,7 @@ async fn create_data(num_bytes: u64) -> (Arc<ObjectStore>, Path) {
     rand::thread_rng().fill_bytes(&mut some_data);
     obj_store.put(&tmp_file, &some_data).await.unwrap();
 
-    (Arc::new(obj_store), tmp_file)
+    (obj_store, tmp_file)
 }
 
 const DATA_SIZE: u64 = 128 * 1024 * 1024;

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -230,6 +230,7 @@ fn uri_to_url(uri: &str) -> Result<Url> {
             // On Windows, the drive is parsed as a scheme
             local_path_to_url(uri)
         }
+        Ok(url) if url.scheme() == "file" => local_path_to_url(uri),
         Ok(url) => Ok(url),
         Err(_) => local_path_to_url(uri),
     }

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -230,7 +230,6 @@ fn uri_to_url(uri: &str) -> Result<Url> {
             // On Windows, the drive is parsed as a scheme
             local_path_to_url(uri)
         }
-        Ok(url) if url.scheme() == "file" => local_path_to_url(uri),
         Ok(url) => Ok(url),
         Err(_) => local_path_to_url(uri),
     }

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -173,6 +173,7 @@ impl Default for ObjectStoreParams {
 impl std::hash::Hash for ObjectStoreParams {
     #[allow(deprecated)]
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // For hashing, we use pointer values for ObjectStore, S3 credentials, and wrapper
         self.block_size.hash(state);
         if let Some((store, url)) = &self.object_store {
             Arc::as_ptr(store).hash(state);
@@ -202,6 +203,7 @@ impl Eq for ObjectStoreParams {}
 impl PartialEq for ObjectStoreParams {
     #[allow(deprecated)]
     fn eq(&self, other: &Self) -> bool {
+        // For equality, we use pointer comparison for ObjectStore, S3 credentials, and wrapper
         self.block_size == other.block_size
             && self
                 .object_store
@@ -271,8 +273,9 @@ impl ObjectStore {
     ///
     /// Returns the ObjectStore instance and the absolute path to the object.
     ///
-    /// This uses the default [ObjectStoreRegistry] to find the object store.
-    /// To re-use object store instances, use [Self::from_uri_and_params].
+    /// This uses the default [ObjectStoreRegistry] to find the object store. To
+    /// allow for potential re-use of object store instances, it's recommended to
+    /// create a shared [ObjectStoreRegistry] and pass that to [Self::from_uri_and_params].
     pub async fn from_uri(uri: &str) -> Result<(Arc<Self>, Path)> {
         let registry = Arc::new(ObjectStoreRegistry::default());
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -5,7 +5,6 @@
 
 use std::collections::HashMap;
 use std::ops::Range;
-use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -22,7 +21,7 @@ use list_retry::ListRetryStream;
 #[cfg(feature = "aws")]
 use object_store::aws::AwsCredentialProvider;
 use object_store::DynObjectStore;
-use object_store::{local::LocalFileSystem, Error as ObjectStoreError};
+use object_store::Error as ObjectStoreError;
 use object_store::{path::Path, ObjectMeta, ObjectStore as OSObjectStore};
 use providers::local::FileStoreProvider;
 use providers::memory::MemoryStoreProvider;
@@ -35,7 +34,6 @@ use super::local::LocalObjectReader;
 mod list_retry;
 pub mod providers;
 mod tracing;
-use self::tracing::ObjectStoreTracingExt;
 use crate::object_writer::WriteResult;
 use crate::{object_reader::CloudObjectReader, object_writer::ObjectWriter, traits::Reader};
 use lance_core::{Error, Result};
@@ -224,11 +222,58 @@ impl PartialEq for ObjectStoreParams {
     }
 }
 
+fn uri_to_url(uri: &str) -> Result<Url> {
+    match Url::parse(uri) {
+        Ok(url) if url.scheme().len() == 1 && cfg!(windows) => {
+            // On Windows, the drive is parsed as a scheme
+            local_path_to_url(uri)
+        }
+        Ok(url) => Ok(url),
+        Err(_) => local_path_to_url(uri),
+    }
+}
+
+fn local_path_to_url(str_path: &str) -> Result<Url> {
+    let expanded = tilde(str_path).to_string();
+
+    let mut expanded_path = path_abs::PathAbs::new(expanded)
+        .unwrap()
+        .as_path()
+        .to_path_buf();
+    // path_abs::PathAbs::new(".") returns an empty string.
+    if let Some(s) = expanded_path.as_path().to_str() {
+        if s.is_empty() {
+            expanded_path = std::env::current_dir()?;
+        }
+    }
+
+    Url::from_directory_path(expanded_path).map_err(|_| Error::InvalidInput {
+        source: format!("Invalid table location: '{}'", str_path).into(),
+        location: location!(),
+    })
+}
+
+fn extract_path(url: &Url) -> Path {
+    if url.scheme() == "memory" {
+        let mut output = String::new();
+        if let Some(domain) = url.domain() {
+            output.push_str(domain);
+        }
+        output.push_str(url.path());
+        Path::from(output)
+    } else {
+        Path::from(url.path())
+    }
+}
+
 impl ObjectStore {
     /// Parse from a string URI.
     ///
     /// Returns the ObjectStore instance and the absolute path to the object.
-    pub async fn from_uri(uri: &str) -> Result<(Self, Path)> {
+    ///
+    /// This uses the default [ObjectStoreRegistry] to find the object store.
+    /// To re-use object store instances, use [Self::from_uri_and_params].
+    pub async fn from_uri(uri: &str) -> Result<(Arc<Self>, Path)> {
         let registry = Arc::new(ObjectStoreRegistry::default());
 
         Self::from_uri_and_params(registry, uri, &ObjectStoreParams::default()).await
@@ -241,7 +286,7 @@ impl ObjectStore {
         registry: Arc<ObjectStoreRegistry>,
         uri: &str,
         params: &ObjectStoreParams,
-    ) -> Result<(Self, Path)> {
+    ) -> Result<(Arc<Self>, Path)> {
         #[allow(deprecated)]
         if let Some((store, path)) = params.object_store.as_ref() {
             let mut inner = store.clone();
@@ -258,79 +303,23 @@ impl ObjectStore {
                 download_retry_count: DEFAULT_DOWNLOAD_RETRY_COUNT,
             };
             let path = Path::from(path.path());
-            return Ok((store, path));
+            return Ok((Arc::new(store), path));
         }
-        let (object_store, path) = match Url::parse(uri) {
-            Ok(url) if url.scheme().len() == 1 && cfg!(windows) => {
-                // On Windows, the drive is parsed as a scheme
-                Self::from_path(uri)
-            }
-            Ok(url) => {
-                let store = Self::new_from_url(registry, url.clone(), params.clone()).await?;
-                Ok((store, Path::from(url.path())))
-            }
-            Err(_) => Self::from_path(uri),
-        }?;
-
-        Ok((
-            Self {
-                inner: params
-                    .object_store_wrapper
-                    .as_ref()
-                    .map(|w| w.wrap(object_store.inner.clone()))
-                    .unwrap_or(object_store.inner),
-                ..object_store
-            },
-            path,
-        ))
+        let url = uri_to_url(uri)?;
+        let path = extract_path(&url);
+        let store = registry.get_store(url, params).await?;
+        Ok((store, path))
     }
 
-    pub fn from_path_with_scheme(str_path: &str, scheme: &str) -> Result<(Self, Path)> {
-        let expanded = tilde(str_path).to_string();
-
-        let mut expanded_path = path_abs::PathAbs::new(expanded)
-            .unwrap()
-            .as_path()
-            .to_path_buf();
-        // path_abs::PathAbs::new(".") returns an empty string.
-        if let Some(s) = expanded_path.as_path().to_str() {
-            if s.is_empty() {
-                expanded_path = std::env::current_dir()?;
-            }
-        }
-        Ok((
-            Self {
-                inner: Arc::new(LocalFileSystem::new()).traced(),
-                scheme: String::from(scheme),
-                block_size: 4 * 1024, // 4KB block size
-                use_constant_size_upload_parts: false,
-                list_is_lexically_ordered: false,
-                io_parallelism: DEFAULT_LOCAL_IO_PARALLELISM,
-                download_retry_count: DEFAULT_DOWNLOAD_RETRY_COUNT,
-            },
-            Path::from_absolute_path(expanded_path.as_path())?,
-        ))
-    }
-
-    pub fn from_path(str_path: &str) -> Result<(Self, Path)> {
-        Self::from_path_with_scheme(str_path, "file")
-    }
-
-    async fn new_from_url(
-        registry: Arc<ObjectStoreRegistry>,
-        url: Url,
-        params: ObjectStoreParams,
-    ) -> Result<Self> {
-        let url = ensure_table_uri(url)?;
-        let scheme = url.scheme();
-        if let Some(provider) = registry.get_provider(scheme) {
-            provider.new_store(url, &params).await
-        } else {
-            let err = lance_core::Error::from(object_store::Error::NotSupported {
-                source: format!("Unsupported URI scheme: {} in url {}", scheme, url).into(),
-            });
-            Err(err)
-        }
+    #[deprecated(note = "Use `from_uri` instead")]
+    pub fn from_path(str_path: &str) -> Result<(Arc<Self>, Path)> {
+        Self::from_uri_and_params(
+            Arc::new(ObjectStoreRegistry::default()),
+            str_path,
+            &Default::default(),
+        )
+        .now_or_never()
+        .unwrap()
     }
 
     /// Local object store.
@@ -364,14 +353,6 @@ impl ObjectStore {
 
     pub fn block_size(&self) -> usize {
         self.block_size
-    }
-
-    pub fn set_block_size(&mut self, new_size: usize) {
-        self.block_size = new_size;
-    }
-
-    pub fn set_io_parallelism(&mut self, io_parallelism: usize) {
-        self.io_parallelism = io_parallelism;
     }
 
     pub fn io_parallelism(&self) -> usize {
@@ -675,63 +656,6 @@ fn infer_block_size(scheme: &str) -> usize {
     }
 }
 
-/// Attempt to create a Url from given table location.
-///
-/// The location could be:
-///  * A valid URL, which will be parsed and returned
-///  * A path to a directory, which will be created and then converted to a URL.
-///
-/// If it is a local path, it will be created if it doesn't exist.
-///
-/// Extra slashes will be removed from the end path as well.
-///
-/// Will return an error if the location is not valid. For example,
-pub fn ensure_table_uri(table_uri: impl AsRef<str>) -> Result<Url> {
-    let table_uri = table_uri.as_ref();
-
-    enum UriType {
-        LocalPath(PathBuf),
-        Url(Url),
-    }
-    let uri_type: UriType = if let Ok(url) = Url::parse(table_uri) {
-        if url.scheme() == "file" {
-            UriType::LocalPath(url.to_file_path().map_err(|err| {
-                let msg = format!("Invalid table location: {}\nError: {:?}", table_uri, err);
-                Error::InvalidTableLocation { message: msg }
-            })?)
-        // NOTE this check is required to support absolute windows paths which may properly parse as url
-        } else {
-            UriType::Url(url)
-        }
-    } else {
-        UriType::LocalPath(PathBuf::from(table_uri))
-    };
-
-    // If it is a local path, we need to create it if it does not exist.
-    let mut url = match uri_type {
-        UriType::LocalPath(path) => {
-            let path = std::fs::canonicalize(path).map_err(|err| Error::DatasetNotFound {
-                path: table_uri.to_string(),
-                source: Box::new(err),
-                location: location!(),
-            })?;
-            Url::from_directory_path(path).map_err(|_| {
-                let msg = format!(
-                    "Could not construct a URL from canonicalized path: {}.\n\
-                  Something must be very wrong with the table path.",
-                    table_uri
-                );
-                Error::InvalidTableLocation { message: msg }
-            })?
-        }
-        UriType::Url(url) => url,
-    };
-
-    let trimmed_path = url.path().trim_end_matches('/').to_owned();
-    url.set_path(&trimmed_path);
-    Ok(url)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -751,7 +675,7 @@ mod tests {
         write(path, contents)
     }
 
-    async fn read_from_store(store: ObjectStore, path: &Path) -> Result<String> {
+    async fn read_from_store(store: &ObjectStore, path: &Path) -> Result<String> {
         let test_file_store = store.open(path).await.unwrap();
         let size = test_file_store.size().await.unwrap();
         let bytes = test_file_store.get_range(0..size).await.unwrap();
@@ -776,7 +700,7 @@ mod tests {
             format!("{tmp_path}/bar/foo.lance/../foo.lance"),
         ] {
             let (store, path) = ObjectStore::from_uri(uri).await.unwrap();
-            let contents = read_from_store(store, &path.child("test_file"))
+            let contents = read_from_store(store.as_ref(), &path.child("test_file"))
                 .await
                 .unwrap();
             assert_eq!(contents, "TEST_CONTENT");
@@ -875,7 +799,7 @@ mod tests {
         set_current_dir(StdPath::new(&tmp_path)).expect("Error changing current dir");
         let (store, path) = ObjectStore::from_uri("./bar/foo.lance").await.unwrap();
 
-        let contents = read_from_store(store, &path.child("test_file"))
+        let contents = read_from_store(store.as_ref(), &path.child("test_file"))
             .await
             .unwrap();
         assert_eq!(contents, "RELATIVE_URL");
@@ -886,7 +810,7 @@ mod tests {
         let uri = "~/foo.lance";
         write_to_file(&format!("{uri}/test_file"), "TILDE").unwrap();
         let (store, path) = ObjectStore::from_uri(uri).await.unwrap();
-        let contents = read_from_store(store, &path.child("test_file"))
+        let contents = read_from_store(store.as_ref(), &path.child("test_file"))
             .await
             .unwrap();
         assert_eq!(contents, "TILDE");
@@ -1022,6 +946,24 @@ mod tests {
 
         let buf = obj_store.read_one_range(&file_path_os, 0..5).await.unwrap();
         assert_eq!(buf.as_bytes(), b"LOCAL");
+    }
+
+    #[test]
+    fn test_path_parsing() {
+        let cases = [
+            ("file:///", ""),
+            ("file:///usr/local/bin", "usr/local/bin"),
+            ("memory://test/path", "test/path"),
+            ("s3://bucket/path", "path"),
+            ("s3+ddb://bucket/path", "path"),
+            ("gs://bucket/path", "path"),
+            ("az://account/path", "path"),
+        ];
+        for (uri, expected_path) in cases {
+            let url = uri_to_url(uri).unwrap();
+            let path = extract_path(&url);
+            assert_eq!(path.to_string(), expected_path);
+        }
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -1006,7 +1006,7 @@ mod tests {
             format!("{drive_letter}:\\test_folder\\test.lance"),
         ] {
             let (store, base) = ObjectStore::from_uri(uri).await.unwrap();
-            let contents = read_from_store(store, &base.child("test_file"))
+            let contents = read_from_store(store.as_ref(), &base.child("test_file"))
                 .await
                 .unwrap();
             assert_eq!(contents, "WINDOWS");

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -168,12 +168,13 @@ impl ObjectStoreRegistry {
 
         // Check if we have a cached store for this base path and params
         {
-            if let Some(store) = self
+            let maybe_store = self
                 .active_stores
                 .read()
                 .expect("ObjectStoreRegistry lock poisoned")
                 .get(&cache_key)
-            {
+                .cloned();
+            if let Some(store) = maybe_store {
                 if let Some(store) = store.upgrade() {
                     return Ok(store);
                 } else {

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, Weak},
+};
 
 use snafu::location;
+use tokio::sync::RwLock;
 use url::Url;
 
 use super::{ObjectStore, ObjectStoreParams};
@@ -25,28 +29,83 @@ pub trait ObjectStoreProvider: std::fmt::Debug + Sync + Send {
 
 #[derive(Debug)]
 pub struct ObjectStoreRegistry {
-    providers: HashMap<String, Arc<dyn ObjectStoreProvider>>,
-    // TODO: should the registry itself have a cache?
-    // Cache should probable have weak references?
+    providers: Mutex<HashMap<String, Arc<dyn ObjectStoreProvider>>>,
+    // Cache of object stores currently in use. We use a weak reference so the
+    // cache itself doesn't keep them alive if no object store is actually using
+    // it.
+    cache: RwLock<HashMap<(String, ObjectStoreParams), Weak<ObjectStore>>>,
+}
+
+/// Convert a URL to a cache key.
+///
+/// We truncate to the first path segment. This should capture
+/// buckets and prefixes. We keep URL params since those might be
+/// important.
+///
+/// * s3://bucket/path?param=value -> s3://bucket/path?param=value
+/// * file:///path/to/file -> file:///
+fn cache_url(url: &Url) -> String {
+    if url.scheme() == "file" || url.scheme() == "file-object-store" {
+        // For file URLs, we want to cache the URL without the path.
+        // This is because the path can be different for different
+        // object stores, but we want to cache the object store itself.
+        format!("{}://", url.scheme())
+    } else {
+        // drop path after bucket, but keep query params
+        // e.g. s3://bucket/path?param=value -> s3://bucket?param=value
+        let mut url = url.clone();
+        let first_segment = url
+            .path_segments()
+            .and_then(|mut iter| iter.next().map(|s| s.to_string()));
+        if let Some(first_segment) = first_segment {
+            url.set_path(&first_segment);
+        }
+        url.to_string()
+    }
 }
 
 impl ObjectStoreRegistry {
     pub fn empty() -> Self {
         Self {
-            providers: HashMap::new(),
+            providers: Mutex::new(HashMap::new()),
+            cache: RwLock::new(HashMap::new()),
         }
     }
 
     pub fn get_provider(&self, scheme: &str) -> Option<Arc<dyn ObjectStoreProvider>> {
-        self.providers.get(scheme).cloned()
+        self.providers
+            .lock()
+            .expect("ObjectStoreRegistry lock poisoned")
+            .get(scheme)
+            .cloned()
     }
 
     pub async fn get_store(
         &self,
         base_path: Url,
         params: &ObjectStoreParams,
-    ) -> Result<ObjectStore> {
-        // TODO: caching
+    ) -> Result<Arc<ObjectStore>> {
+        let cache_path = cache_url(&base_path);
+        let cache_key = (cache_path, params.clone());
+
+        // Check if we have a cached store for this base path and params
+        {
+            if let Some(store) = self.cache.read().await.get(&cache_key) {
+                if let Some(store) = store.upgrade() {
+                    return Ok(store);
+                } else {
+                    // Remove the weak reference if it is no longer valid
+                    let mut cache_lock = self.cache.write().await;
+                    if let Some(store) = cache_lock.get(&cache_key) {
+                        if store.upgrade().is_none() {
+                            // Remove the weak reference if it is no longer valid
+                            cache_lock.remove(&cache_key);
+                        }
+                    }
+                }
+            }
+        }
+
         let scheme = base_path.scheme();
         let provider = self.get_provider(scheme).ok_or_else(|| {
             Error::invalid_input(
@@ -54,39 +113,57 @@ impl ObjectStoreRegistry {
                 location!(),
             )
         })?;
-        provider.new_store(base_path, params).await
+        let store = provider.new_store(base_path, params).await?;
+        let store = Arc::new(store);
+
+        {
+            // Insert the store into the cache
+            let mut cache_lock = self.cache.write().await;
+            cache_lock.insert(cache_key, Arc::downgrade(&store));
+        }
+
+        Ok(store)
     }
 }
 
 impl Default for ObjectStoreRegistry {
     fn default() -> Self {
-        let mut registry = Self {
-            providers: HashMap::new(),
-        };
-        registry.insert("memory", Arc::new(memory::MemoryStoreProvider));
-        registry.insert("file", Arc::new(local::FileStoreProvider));
+        let mut providers: HashMap<String, Arc<dyn ObjectStoreProvider>> = HashMap::new();
+
+        providers.insert("memory".into(), Arc::new(memory::MemoryStoreProvider));
+        providers.insert("file".into(), Arc::new(local::FileStoreProvider));
         // The "file" scheme has special optimized code paths that bypass
         // the ObjectStore API for better performance. However, this can make it
         // hard to test when using ObjectStore wrappers, such as IOTrackingStore.
         // So we provide a "file-object-store" scheme that uses the ObjectStore API.
         // The specialized code paths are differentiated by the scheme name.
-        registry.insert("file-object-store", Arc::new(local::FileStoreProvider));
+        providers.insert(
+            "file-object-store".into(),
+            Arc::new(local::FileStoreProvider),
+        );
+
         #[cfg(feature = "aws")]
         {
             let aws = Arc::new(aws::AwsStoreProvider);
-            registry.insert("s3", aws.clone());
-            registry.insert("s3+ddb", aws);
+            providers.insert("s3".into(), aws.clone());
+            providers.insert("s3+ddb".into(), aws);
         }
         #[cfg(feature = "azure")]
-        registry.insert("az", Arc::new(azure::AzureBlobStoreProvider));
+        providers.insert("az".into(), Arc::new(azure::AzureBlobStoreProvider));
         #[cfg(feature = "gcp")]
-        registry.insert("gs", Arc::new(gcp::GcsStoreProvider));
-        registry
+        providers.insert("gs".into(), Arc::new(gcp::GcsStoreProvider));
+        Self {
+            providers: Mutex::new(providers),
+            cache: RwLock::new(HashMap::new()),
+        }
     }
 }
 
 impl ObjectStoreRegistry {
-    pub fn insert(&mut self, scheme: &str, provider: Arc<dyn ObjectStoreProvider>) {
-        self.providers.insert(scheme.into(), provider);
+    pub fn insert(&self, scheme: &str, provider: Arc<dyn ObjectStoreProvider>) {
+        self.providers
+            .lock()
+            .expect("ObjectStoreRegistry lock poisoned")
+            .insert(scheme.into(), provider);
     }
 }

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -396,4 +396,24 @@ mod tests {
         // Not called yet
         assert!(mock_provider.called.load(Ordering::Relaxed));
     }
+
+    #[test]
+    fn test_s3_path_parsing() {
+        let provider = AwsStoreProvider;
+
+        let cases = [
+            ("s3://bucket/path/to/file", "path/to/file"),
+            (
+                "s3+ddb://bucket/path/to/file?ddbTableName=test",
+                "path/to/file",
+            ),
+        ];
+
+        for (uri, expected_path) in cases {
+            let url = Url::parse(uri).unwrap();
+            let path = provider.extract_path(&url);
+            let expected_path = Path::from(expected_path);
+            assert_eq!(path, expected_path);
+        }
+    }
 }

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -25,8 +25,8 @@ use tokio::sync::RwLock;
 use url::Url;
 
 use crate::object_store::{
-    tracing::ObjectStoreTracingExt, ObjectStore, ObjectStoreParams, ObjectStoreProvider,
-    StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM,
+    ObjectStore, ObjectStoreParams, ObjectStoreProvider, StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE,
+    DEFAULT_CLOUD_IO_PARALLELISM,
 };
 use lance_core::error::{Error, Result};
 
@@ -92,10 +92,10 @@ impl ObjectStoreProvider for AwsStoreProvider {
             .with_credentials(aws_creds)
             .with_retry(retry_config)
             .with_region(region);
-        let store = builder.build()?;
+        let inner = Arc::new(builder.build()?);
 
         Ok(ObjectStore {
-            inner: Arc::new(store).traced(),
+            inner,
             scheme: String::from(base_path.scheme()),
             block_size,
             use_constant_size_upload_parts,

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -10,8 +10,8 @@ use object_store::{
 use url::Url;
 
 use crate::object_store::{
-    tracing::ObjectStoreTracingExt, ObjectStore, ObjectStoreParams, ObjectStoreProvider,
-    StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM,
+    ObjectStore, ObjectStoreParams, ObjectStoreProvider, StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE,
+    DEFAULT_CLOUD_IO_PARALLELISM,
 };
 use lance_core::error::Result;
 
@@ -41,11 +41,10 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
         for (key, value) in storage_options.as_azure_options() {
             builder = builder.with_config(key, value);
         }
-        let store = builder.build()?;
-        let store = Arc::new(store).traced();
+        let inner = Arc::new(builder.build()?);
 
         Ok(ObjectStore {
-            inner: store,
+            inner,
             scheme: String::from("az"),
             block_size,
             use_constant_size_upload_parts: false,

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -81,3 +81,18 @@ impl StorageOptions {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_azure_store_path() {
+        let provider = AzureBlobStoreProvider;
+
+        let url = Url::parse("az://bucket/path/to/file").unwrap();
+        let path = provider.extract_path(&url);
+        let expected_path = object_store::path::Path::from("path/to/file");
+        assert_eq!(path, expected_path);
+    }
+}

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -96,3 +96,18 @@ impl StorageOptions {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_gcs_store_path() {
+        let provider = GcsStoreProvider;
+
+        let url = Url::parse("gs://bucket/path/to/file").unwrap();
+        let path = provider.extract_path(&url);
+        let expected_path = object_store::path::Path::from("path/to/file");
+        assert_eq!(path, expected_path);
+    }
+}

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -10,8 +10,8 @@ use object_store::{
 use url::Url;
 
 use crate::object_store::{
-    tracing::ObjectStoreTracingExt, ObjectStore, ObjectStoreParams, ObjectStoreProvider,
-    StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM,
+    ObjectStore, ObjectStoreParams, ObjectStoreProvider, StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE,
+    DEFAULT_CLOUD_IO_PARALLELISM,
 };
 use lance_core::error::Result;
 
@@ -49,11 +49,10 @@ impl ObjectStoreProvider for GcsStoreProvider {
             let credential_provider = Arc::new(StaticCredentialProvider::new(credential)) as _;
             builder = builder.with_credentials(credential_provider);
         }
-        let store = builder.build()?;
-        let store = Arc::new(store).traced();
+        let inner = Arc::new(builder.build()?);
 
         Ok(ObjectStore {
-            inner: store,
+            inner,
             scheme: String::from("gs"),
             block_size,
             use_constant_size_upload_parts: false,

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use object_store::local::LocalFileSystem;
+use object_store::{local::LocalFileSystem, path::Path};
 use url::Url;
 
 use crate::object_store::{
@@ -30,5 +30,60 @@ impl ObjectStoreProvider for FileStoreProvider {
             io_parallelism: DEFAULT_LOCAL_IO_PARALLELISM,
             download_retry_count,
         })
+    }
+
+    fn extract_path(&self, url: &Url) -> object_store::path::Path {
+        url.to_file_path()
+            .ok()
+            .and_then(|p| Path::from_absolute_path(p).ok())
+            .unwrap_or_else(|| Path::from(url.path()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::object_store::uri_to_url;
+
+    use super::*;
+
+    #[test]
+    fn test_file_store_path() {
+        let provider = FileStoreProvider;
+
+        let cases = [
+            ("file:///", ""),
+            ("file:///usr/local/bin", "usr/local/bin"),
+            ("file-object-store:///path/to/file", "path/to/file"),
+            ("file:///path/to/foo/../bar", "path/to/bar"),
+        ];
+
+        for (uri, expected_path) in cases {
+            let url = uri_to_url(uri).unwrap();
+            let path = provider.extract_path(&url);
+            assert_eq!(path.as_ref(), expected_path, "uri: '{}'", uri);
+        }
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_file_store_path_windows() {
+        let provider = FileStoreProvider;
+
+        let cases = [
+            (
+                "C:\\Users\\ADMINI~1\\AppData\\Local\\",
+                "C:/Users/ADMINI~1/AppData/Local",
+            ),
+            (
+                "C:\\Users\\ADMINI~1\\AppData\\Local\\..\\",
+                "C:/Users/ADMINI~1/AppData",
+            ),
+        ];
+
+        for (uri, expected_path) in cases {
+            let url = uri_to_url(uri).unwrap();
+            let path = provider.extract_path(&url);
+            assert_eq!(path.as_ref(), expected_path);
+        }
     }
 }

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -7,8 +7,8 @@ use object_store::local::LocalFileSystem;
 use url::Url;
 
 use crate::object_store::{
-    tracing::ObjectStoreTracingExt, ObjectStore, ObjectStoreParams, ObjectStoreProvider,
-    StorageOptions, DEFAULT_LOCAL_BLOCK_SIZE, DEFAULT_LOCAL_IO_PARALLELISM,
+    ObjectStore, ObjectStoreParams, ObjectStoreProvider, StorageOptions, DEFAULT_LOCAL_BLOCK_SIZE,
+    DEFAULT_LOCAL_IO_PARALLELISM,
 };
 use lance_core::error::Result;
 
@@ -22,7 +22,7 @@ impl ObjectStoreProvider for FileStoreProvider {
         let storage_options = StorageOptions(params.storage_options.clone().unwrap_or_default());
         let download_retry_count = storage_options.download_retry_count();
         Ok(ObjectStore {
-            inner: Arc::new(LocalFileSystem::new()).traced(),
+            inner: Arc::new(LocalFileSystem::new()),
             scheme: base_path.scheme().to_owned(),
             block_size,
             use_constant_size_upload_parts: false,

--- a/rust/lance-io/src/object_store/providers/memory.rs
+++ b/rust/lance-io/src/object_store/providers/memory.rs
@@ -7,8 +7,7 @@ use object_store::memory::InMemory;
 use url::Url;
 
 use crate::object_store::{
-    tracing::ObjectStoreTracingExt, ObjectStore, ObjectStoreParams, ObjectStoreProvider,
-    StorageOptions, DEFAULT_LOCAL_BLOCK_SIZE,
+    ObjectStore, ObjectStoreParams, ObjectStoreProvider, StorageOptions, DEFAULT_LOCAL_BLOCK_SIZE,
 };
 use lance_core::{error::Result, utils::tokio::get_num_compute_intensive_cpus};
 
@@ -23,31 +22,7 @@ impl ObjectStoreProvider for MemoryStoreProvider {
         let storage_options = StorageOptions(params.storage_options.clone().unwrap_or_default());
         let download_retry_count = storage_options.download_retry_count();
         Ok(ObjectStore {
-            inner: Arc::new(InMemory::new()).traced(),
-            scheme: String::from("memory"),
-            block_size,
-            use_constant_size_upload_parts: false,
-            list_is_lexically_ordered: true,
-            io_parallelism: get_num_compute_intensive_cpus(),
-            download_retry_count,
-        })
-    }
-}
-
-/// Provides the given in-memory object store for each call to `new_store`.
-#[derive(Debug)]
-pub struct PersistentMemoryStoreProvider {
-    pub inner: Arc<InMemory>,
-}
-
-#[async_trait::async_trait]
-impl ObjectStoreProvider for PersistentMemoryStoreProvider {
-    async fn new_store(&self, _base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
-        let block_size = params.block_size.unwrap_or(DEFAULT_LOCAL_BLOCK_SIZE);
-        let storage_options = StorageOptions(params.storage_options.clone().unwrap_or_default());
-        let download_retry_count = storage_options.download_retry_count();
-        Ok(ObjectStore {
-            inner: self.inner.clone(),
+            inner: Arc::new(InMemory::new()),
             scheme: String::from("memory"),
             block_size,
             use_constant_size_upload_parts: false,

--- a/rust/lance-io/src/object_store/providers/memory.rs
+++ b/rust/lance-io/src/object_store/providers/memory.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Arc;
 
-use object_store::memory::InMemory;
+use object_store::{memory::InMemory, path::Path};
 use url::Url;
 
 use crate::object_store::{
@@ -30,5 +30,29 @@ impl ObjectStoreProvider for MemoryStoreProvider {
             io_parallelism: get_num_compute_intensive_cpus(),
             download_retry_count,
         })
+    }
+
+    fn extract_path(&self, url: &Url) -> Path {
+        let mut output = String::new();
+        if let Some(domain) = url.domain() {
+            output.push_str(domain);
+        }
+        output.push_str(url.path());
+        Path::from(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_memory_store_path() {
+        let provider = MemoryStoreProvider;
+
+        let url = Url::parse("memory://path/to/file").unwrap();
+        let path = provider.extract_path(&url);
+        let expected_path = Path::from("path/to/file");
+        assert_eq!(path, expected_path);
     }
 }

--- a/rust/lance-io/tests/gcs_integration.rs
+++ b/rust/lance-io/tests/gcs_integration.rs
@@ -4,13 +4,15 @@
 //! They do not work against any local emulator right now.
 #![cfg(feature = "gcs-test")]
 
+use std::sync::Arc;
+
 // TODO: Once we re-use this logic for S3, we can instead use tests against
 // Minio to validate the multipart upload logic.
 use lance_io::object_store::ObjectStore;
 use object_store::path::Path;
 use tokio::io::AsyncWriteExt;
 
-async fn get_store() -> ObjectStore {
+async fn get_store() -> Arc<ObjectStore> {
     let bucket_name = std::env::var("OBJECT_STORE_BUCKET").unwrap_or_else(|_| "test-bucket".into());
     ObjectStore::from_uri(&format!("gs://{}/object", bucket_name))
         .await

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -10,7 +10,7 @@ use arrow_array::{
 use async_trait::async_trait;
 use criterion::{criterion_group, criterion_main, Criterion};
 use datafusion::{physical_plan::SendableRecordBatchStream, scalar::ScalarValue};
-use futures::TryStreamExt;
+use futures::{FutureExt, TryStreamExt};
 use lance::{io::ObjectStore, Dataset};
 use lance_core::{cache::FileMetadataCache, Result};
 use lance_datafusion::utils::reader_to_stream;
@@ -64,7 +64,10 @@ impl BenchmarkFixture {
     fn test_store(tempdir: &TempDir) -> Arc<dyn IndexStore> {
         let test_path = tempdir.path();
         let (object_store, test_path) =
-            ObjectStore::from_path(test_path.as_os_str().to_str().unwrap()).unwrap();
+            ObjectStore::from_uri(test_path.as_os_str().to_str().unwrap())
+                .now_or_never()
+                .unwrap()
+                .unwrap();
         Arc::new(LanceIndexStore::new(
             object_store,
             test_path,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3162,6 +3162,8 @@ mod tests {
         .await
         .unwrap();
 
+        dbg!(&dataset.base);
+
         assert!(dataset.manifest_naming_scheme == ManifestNamingScheme::V2);
 
         assert_all_manifests_use_scheme(&test_dir, ManifestNamingScheme::V2);

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3162,8 +3162,6 @@ mod tests {
         .await
         .unwrap();
 
-        dbg!(&dataset.base);
-
         assert!(dataset.manifest_naming_scheme == ManifestNamingScheme::V2);
 
         assert_all_manifests_use_scheme(&test_dir, ManifestNamingScheme::V2);

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -22,7 +22,7 @@ use lance_datafusion::projection::ProjectionPlan;
 use lance_file::datatypes::populate_schema_dictionary;
 use lance_file::version::LanceFileVersion;
 use lance_index::DatasetIndexExt;
-use lance_io::object_store::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
+use lance_io::object_store::{ObjectStore, ObjectStoreParams};
 use lance_io::object_writer::{ObjectWriter, WriteResult};
 use lance_io::traits::WriteExt;
 use lance_io::utils::{read_last_block, read_metadata_offset, read_struct};
@@ -665,7 +665,7 @@ impl Dataset {
         read_version: Option<u64>,
         store_params: Option<ObjectStoreParams>,
         commit_handler: Option<Arc<dyn CommitHandler>>,
-        object_store_registry: Arc<ObjectStoreRegistry>,
+        session: Arc<Session>,
         enable_v2_manifest_paths: bool,
         detached: bool,
     ) -> Result<Self> {
@@ -683,8 +683,8 @@ impl Dataset {
         let transaction = Transaction::new(read_version, operation, blobs_op, None);
 
         let mut builder = CommitBuilder::new(base_uri)
-            .with_object_store_registry(object_store_registry)
             .enable_v2_manifest_paths(enable_v2_manifest_paths)
+            .with_session(session)
             .with_detached(detached);
 
         if let Some(store_params) = store_params {
@@ -738,7 +738,7 @@ impl Dataset {
         read_version: Option<u64>,
         store_params: Option<ObjectStoreParams>,
         commit_handler: Option<Arc<dyn CommitHandler>>,
-        object_store_registry: Arc<ObjectStoreRegistry>,
+        session: Arc<Session>,
         enable_v2_manifest_paths: bool,
     ) -> Result<Self> {
         Self::do_commit(
@@ -750,7 +750,7 @@ impl Dataset {
             read_version,
             store_params,
             commit_handler,
-            object_store_registry,
+            session,
             enable_v2_manifest_paths,
             /*detached=*/ false,
         )
@@ -771,7 +771,7 @@ impl Dataset {
         read_version: Option<u64>,
         store_params: Option<ObjectStoreParams>,
         commit_handler: Option<Arc<dyn CommitHandler>>,
-        object_store_registry: Arc<ObjectStoreRegistry>,
+        session: Arc<Session>,
         enable_v2_manifest_paths: bool,
     ) -> Result<Self> {
         Self::do_commit(
@@ -783,7 +783,7 @@ impl Dataset {
             read_version,
             store_params,
             commit_handler,
-            object_store_registry,
+            session,
             enable_v2_manifest_paths,
             /*detached=*/ true,
         )
@@ -3156,7 +3156,7 @@ mod tests {
             None,
             None,
             None,
-            Arc::new(ObjectStoreRegistry::default()),
+            Default::default(),
             true, // enable_v2_manifest_paths
         )
         .await

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -4,8 +4,7 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use lance_file::datatypes::populate_schema_dictionary;
 use lance_io::object_store::{
-    ObjectStore, ObjectStoreParams, ObjectStoreRegistry, StorageOptions,
-    DEFAULT_CLOUD_IO_PARALLELISM,
+    ObjectStore, ObjectStoreParams, StorageOptions, DEFAULT_CLOUD_IO_PARALLELISM,
 };
 use lance_table::{
     format::Manifest,
@@ -226,7 +225,7 @@ impl DatasetBuilder {
             .session
             .as_ref()
             .map(|s| s.store_registry())
-            .unwrap_or_else(|| Arc::new(ObjectStoreRegistry::default()));
+            .unwrap_or_default();
 
         #[allow(deprecated)]
         match &self.options.object_store {
@@ -260,8 +259,8 @@ impl DatasetBuilder {
 
     #[instrument(skip_all)]
     pub async fn load(mut self) -> Result<Dataset> {
-        let session = match self.session.take() {
-            Some(session) => session,
+        let session = match self.session.as_ref() {
+            Some(session) => session.clone(),
             None => Arc::new(Session::new(
                 self.index_cache_size,
                 self.metadata_cache_size,

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -2233,7 +2233,6 @@ mod tests {
     use lance_core::ROW_ID;
     use lance_datagen::{array, gen, RowCount};
     use lance_file::version::LanceFileVersion;
-    use lance_io::object_store::ObjectStoreRegistry;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use tempfile::tempdir;
@@ -2822,10 +2821,10 @@ mod tests {
             config_upsert_values: None,
         };
 
-        let registry = Arc::new(ObjectStoreRegistry::default());
-        let new_dataset = Dataset::commit(test_uri, op, None, None, None, registry, false)
-            .await
-            .unwrap();
+        let new_dataset =
+            Dataset::commit(test_uri, op, None, None, None, Default::default(), false)
+                .await
+                .unwrap();
 
         assert_eq!(new_dataset.count_rows(None).await.unwrap(), dataset_rows);
 
@@ -2931,10 +2930,10 @@ mod tests {
                 config_upsert_values: None,
             };
 
-            let registry = Arc::new(ObjectStoreRegistry::default());
-            let dataset = Dataset::commit(test_uri, op, None, None, None, registry, false)
-                .await
-                .unwrap();
+            let dataset =
+                Dataset::commit(test_uri, op, None, None, None, Default::default(), false)
+                    .await
+                    .unwrap();
 
             // We only kept the first fragment of 40 rows
             assert_eq!(
@@ -3152,7 +3151,6 @@ mod tests {
 
         // Rearrange schema so it's `s` then `i`.
         let schema = updater.schema().unwrap().clone().project(&["s", "i"])?;
-        let registry = Arc::new(ObjectStoreRegistry::default());
 
         let dataset = Dataset::commit(
             test_uri,
@@ -3163,7 +3161,7 @@ mod tests {
             Some(dataset.manifest.version),
             None,
             None,
-            registry,
+            Default::default(),
             false,
         )
         .await?;
@@ -3292,14 +3290,13 @@ mod tests {
         let op = Operation::Append {
             fragments: vec![frag],
         };
-        let object_store_registry = Arc::new(ObjectStoreRegistry::default());
         let dataset = Dataset::commit(
             &dataset.uri,
             op,
             Some(dataset.version().version),
             None,
             None,
-            object_store_registry,
+            Default::default(),
             false,
         )
         .await

--- a/rust/lance/src/dataset/fragment/write.rs
+++ b/rust/lance/src/dataset/fragment/write.rs
@@ -16,7 +16,6 @@ use lance_table::format::{DataFile, Fragment};
 use lance_table::io::manifest::ManifestDescribing;
 use snafu::location;
 use std::borrow::Cow;
-use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::dataset::builder::DatasetBuilder;
@@ -90,7 +89,7 @@ impl<'a> FragmentCreateBuilder<'a> {
         Self::validate_schema(&schema, stream.schema().as_ref())?;
 
         let (object_store, base_path) = ObjectStore::from_uri_and_params(
-            params.object_store_registry.clone(),
+            params.store_registry(),
             self.dataset_uri,
             &params.store_params.clone().unwrap_or_default(),
         )
@@ -156,13 +155,13 @@ impl<'a> FragmentCreateBuilder<'a> {
         Self::validate_schema(&schema, stream.schema().as_ref())?;
 
         let (object_store, base_path) = ObjectStore::from_uri_and_params(
-            params.object_store_registry.clone(),
+            params.store_registry(),
             self.dataset_uri,
             &params.store_params.clone().unwrap_or_default(),
         )
         .await?;
         do_write_fragments(
-            Arc::new(object_store),
+            object_store,
             &base_path,
             &schema,
             stream,
@@ -192,7 +191,7 @@ impl<'a> FragmentCreateBuilder<'a> {
         Self::validate_schema(&schema, stream.schema().as_ref())?;
 
         let (object_store, base_path) = ObjectStore::from_uri_and_params(
-            params.object_store_registry.clone(),
+            params.store_registry(),
             self.dataset_uri,
             &params.store_params.clone().unwrap_or_default(),
         )

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -78,7 +78,7 @@ impl LanceIndexStoreExt for LanceIndexStore {
     fn from_dataset(dataset: &Dataset, uuid: &str) -> Self {
         let index_dir = dataset.indices_dir().child(uuid);
         Self::new(
-            dataset.object_store.as_ref().clone(),
+            dataset.object_store.clone(),
             index_dir,
             dataset.session.file_metadata_cache.clone(),
         )

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -187,8 +187,6 @@ pub struct WriteParams {
     /// Default is False.
     pub enable_v2_manifest_paths: bool,
 
-    pub object_store_registry: Arc<ObjectStoreRegistry>,
-
     pub session: Option<Arc<Session>>,
 
     /// If Some and this is a new dataset, old dataset versions will be
@@ -215,7 +213,6 @@ impl Default for WriteParams {
             data_storage_version: None,
             enable_move_stable_row_ids: false,
             enable_v2_manifest_paths: false,
-            object_store_registry: Arc::new(ObjectStoreRegistry::default()),
             session: None,
             auto_cleanup: Some(AutoCleanupParams::default()),
         }
@@ -234,6 +231,13 @@ impl WriteParams {
 
     pub fn storage_version_or_default(&self) -> LanceFileVersion {
         self.data_storage_version.unwrap_or_default()
+    }
+
+    pub fn store_registry(&self) -> Arc<ObjectStoreRegistry> {
+        self.session
+            .as_ref()
+            .map(|s| s.store_registry())
+            .unwrap_or_default()
     }
 }
 
@@ -413,7 +417,6 @@ pub async fn write_fragments_internal(
         enable_move_stable_row_ids: true,
         // This shouldn't really matter since all commits are detached
         enable_v2_manifest_paths: true,
-        object_store_registry: params.object_store_registry.clone(),
         max_bytes_per_file: params.max_bytes_per_file,
         max_rows_per_file: params.max_rows_per_file,
         ..Default::default()

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use lance_file::version::LanceFileVersion;
-use lance_io::object_store::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
+use lance_io::object_store::{ObjectStore, ObjectStoreParams};
 use lance_table::{
     format::{is_detached_version, DataStorageFormat},
     io::commit::{CommitConfig, CommitHandler, ManifestNamingScheme},
@@ -36,7 +36,6 @@ pub struct CommitBuilder<'a> {
     storage_format: Option<LanceFileVersion>,
     commit_handler: Option<Arc<dyn CommitHandler>>,
     store_params: Option<ObjectStoreParams>,
-    object_store_registry: Arc<ObjectStoreRegistry>,
     object_store: Option<Arc<ObjectStore>>,
     session: Option<Arc<Session>>,
     detached: bool,
@@ -52,7 +51,6 @@ impl<'a> CommitBuilder<'a> {
             storage_format: None,
             commit_handler: None,
             store_params: None,
-            object_store_registry: Default::default(),
             object_store: None,
             session: None,
             detached: false,
@@ -104,17 +102,6 @@ impl<'a> CommitBuilder<'a> {
         self
     }
 
-    /// Pass an object store registry to use.
-    ///
-    /// If an object store is passed, this registry will be ignored.
-    pub fn with_object_store_registry(
-        mut self,
-        object_store_registry: Arc<ObjectStoreRegistry>,
-    ) -> Self {
-        self.object_store_registry = object_store_registry;
-        self
-    }
-
     /// Pass a session to use for the dataset.
     ///
     /// If a session is not passed, but a dataset is used as the destination,
@@ -162,6 +149,11 @@ impl<'a> CommitBuilder<'a> {
     }
 
     pub async fn execute(self, transaction: Transaction) -> Result<Dataset> {
+        let session = self
+            .session
+            .or_else(|| self.dest.dataset().map(|ds| ds.session.clone()))
+            .unwrap_or_default();
+
         let (object_store, base_path, commit_handler) = match &self.dest {
             WriteDestination::Dataset(dataset) => (
                 dataset.object_store.clone(),
@@ -170,7 +162,7 @@ impl<'a> CommitBuilder<'a> {
             ),
             WriteDestination::Uri(uri) => {
                 let (object_store, base_path) = ObjectStore::from_uri_and_params(
-                    self.object_store_registry.clone(),
+                    session.store_registry(),
                     uri,
                     &self.store_params.clone().unwrap_or_default(),
                 )
@@ -189,11 +181,6 @@ impl<'a> CommitBuilder<'a> {
                 (object_store, base_path, commit_handler)
             }
         };
-
-        let session = self
-            .session
-            .or_else(|| self.dest.dataset().map(|ds| ds.session.clone()))
-            .unwrap_or_default();
 
         let dest = match &self.dest {
             WriteDestination::Dataset(dataset) => WriteDestination::Dataset(dataset.clone()),
@@ -422,10 +409,7 @@ pub struct BatchCommitResult {
 mod tests {
     use arrow::array::{Int32Array, RecordBatch};
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
-    use lance_table::{
-        format::{DataFile, Fragment},
-        io::commit::ConditionalPutCommitHandler,
-    };
+    use lance_table::format::{DataFile, Fragment};
 
     use crate::dataset::{InsertBuilder, WriteParams};
 
@@ -465,7 +449,6 @@ mod tests {
         use crate::utils::test::IoTrackingStore;
 
         let session = Arc::new(Session::default());
-        let store_registry = session.store_registry();
         // Create new dataset
         let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
             "i",
@@ -485,7 +468,6 @@ mod tests {
         let dataset = InsertBuilder::new("memory://test")
             .with_params(&WriteParams {
                 store_params: Some(store_params.clone()),
-                commit_handler: Some(Arc::new(ConditionalPutCommitHandler)),
                 session: Some(session.clone()),
                 ..Default::default()
             })
@@ -533,8 +515,6 @@ mod tests {
         // Commit transaction with URI and session
         let new_ds = CommitBuilder::new("memory://test")
             .with_store_params(store_params.clone())
-            .with_object_store_registry(store_registry.clone())
-            .with_commit_handler(Arc::new(ConditionalPutCommitHandler))
             .with_session(dataset.session.clone())
             .execute(sample_transaction(1))
             .await
@@ -547,11 +527,12 @@ mod tests {
         assert_eq!(reads, 3);
         assert_eq!(writes, 2);
 
-        // Commit transaction with URI and no session
+        // Commit transaction with URI and new session. Re-use the store
+        // registry so we see the same store.
+        let new_session = Arc::new(Session::new(0, 0, session.store_registry()));
         let new_ds = CommitBuilder::new("memory://test")
             .with_store_params(store_params)
-            .with_commit_handler(Arc::new(ConditionalPutCommitHandler))
-            .with_object_store_registry(store_registry.clone())
+            .with_session(new_session)
             .execute(sample_transaction(1))
             .await
             .unwrap();

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -121,7 +121,6 @@ impl<'a> InsertBuilder<'a> {
         let mut commit_builder = CommitBuilder::new(context.dest.clone())
             .use_move_stable_row_ids(context.params.enable_move_stable_row_ids)
             .with_storage_format(context.storage_version)
-            .with_object_store_registry(context.params.object_store_registry.clone())
             .enable_v2_manifest_paths(context.params.enable_v2_manifest_paths)
             .with_commit_handler(context.commit_handler.clone())
             .with_object_store(context.object_store.clone());
@@ -360,8 +359,13 @@ impl<'a> InsertBuilder<'a> {
                 dataset.commit_handler.clone(),
             ),
             WriteDestination::Uri(uri) => {
+                let registry = params
+                    .session
+                    .as_ref()
+                    .map(|s| s.store_registry())
+                    .unwrap_or_else(|| Arc::new(Default::default()));
                 let (object_store, base_path) = ObjectStore::from_uri_and_params(
-                    params.object_store_registry.clone(),
+                    registry,
                     uri,
                     &params.store_params.clone().unwrap_or_default(),
                 )
@@ -372,7 +376,7 @@ impl<'a> InsertBuilder<'a> {
                     &params.store_params,
                 )
                 .await?;
-                (Arc::new(object_store), base_path, commit_handler)
+                (object_store, base_path, commit_handler)
             }
         };
         let dest = match &self.dest {
@@ -382,7 +386,6 @@ impl<'a> InsertBuilder<'a> {
                 let builder = DatasetBuilder::from_uri(uri).with_read_params(ReadParams {
                     store_options: params.store_params.clone(),
                     commit_handler: params.commit_handler.clone(),
-                    object_store_registry: params.object_store_registry.clone(),
                     ..Default::default()
                 });
 

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -29,7 +29,7 @@ pub struct Session {
 
     pub(crate) index_extensions: HashMap<(IndexType, String), Arc<dyn IndexExtension>>,
 
-    pub(crate) store_registry: Arc<ObjectStoreRegistry>,
+    store_registry: Arc<ObjectStoreRegistry>,
 }
 
 impl std::fmt::Debug for Session {
@@ -60,6 +60,10 @@ impl Session {
     /// Parameters:
     ///
     /// - ***index_cache_size***: the size of the index cache.
+    /// - ***metadata_cache_size***: the size of the metadata cache.
+    /// - ***store_registry***: the object store registry to use when opening
+    ///   datasets. This determines which schemes are available, and also allows
+    ///   re-using object stores.
     pub fn new(
         index_cache_size: usize,
         metadata_cache_size: usize,
@@ -135,6 +139,7 @@ impl Session {
             + self.index_extensions.len()
     }
 
+    /// Get the object store registry.
     pub fn store_registry(&self) -> Arc<ObjectStoreRegistry> {
         self.store_registry.clone()
     }

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -19,7 +19,7 @@ use self::index_extension::IndexExtension;
 pub mod index_extension;
 
 /// A user session tracks the runtime state.
-#[derive(Clone, DeepSizeOf)]
+#[derive(Clone)]
 pub struct Session {
     /// Cache for opened indices.
     pub(crate) index_cache: IndexCache,
@@ -30,6 +30,18 @@ pub struct Session {
     pub(crate) index_extensions: HashMap<(IndexType, String), Arc<dyn IndexExtension>>,
 
     store_registry: Arc<ObjectStoreRegistry>,
+}
+
+impl DeepSizeOf for Session {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        let mut size = 0;
+        size += self.index_cache.deep_size_of_children(context);
+        size += self.file_metadata_cache.deep_size_of_children(context);
+        for ext in self.index_extensions.values() {
+            size += ext.deep_size_of_children(context);
+        }
+        size
+    }
 }
 
 impl std::fmt::Debug for Session {

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -13,7 +13,7 @@ use lance_arrow::RecordBatchExt;
 use lance_core::datatypes::Schema;
 use lance_datagen::{BatchCount, BatchGeneratorBuilder, ByteCount, RowCount};
 use lance_file::version::LanceFileVersion;
-use lance_io::object_store::{ObjectStoreRegistry, WrappingObjectStore};
+use lance_io::object_store::WrappingObjectStore;
 use lance_table::format::Fragment;
 use object_store::path::Path;
 use object_store::{
@@ -118,14 +118,13 @@ impl TestDatasetGenerator {
             config_upsert_values: None,
         };
 
-        let registry = Arc::new(ObjectStoreRegistry::default());
         Dataset::commit(
             uri,
             operation,
             None,
             Default::default(),
             None,
-            registry,
+            Default::default(),
             false,
         )
         .await


### PR DESCRIPTION
BREAKING CHANGE: removes `object_store_registry` from `WriteParams` and `ReadParams`. The registry is now taken from the `Session`, which is already on those parameters. Also, most `ObjectStore` constructors now return `Arc<ObjectStore>`.

Closes #3684

* Add a cache of in-use datasets within the registry.
* Move `ObjectStoreRegistry` onto the `Session` object. Combined with the cache, this lets datasets using the same session share object stores, as long as they use the same parameters.