### PR TITLE
docs: update README to mention table format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 
 <img width="257" alt="Lance Logo" src="https://user-images.githubusercontent.com/917119/199353423-d3e202f7-0269-411d-8ff2-e747e419e492.png">
 
-**Modern columnar data format for ML. Convert from Parquet in 2-lines of code for 100x faster random access, zero-cost schema evolution, rich secondary indices, versioning, and more.<br/>**
+**Modern data lake built for AI & ML workflows. Lance combines classic data lake features (table operations, time travel, filter pushdown), with better support for multimodal data, the ability to run in embedded mode (no catalog needed), 100x faster random access, zero-cost column evolution (not just schema evolution), rich secondary indices, and more.<br/><br/>**
+
 **Compatible with Pandas, DuckDB, Polars, Pyarrow, and Ray with more integrations on the way.**
 
 <a href="https://lancedb.github.io/lance/">Documentation</a> •
@@ -30,21 +31,24 @@
 
 <hr />
 
-Lance is a modern columnar data format that is optimized for ML workflows and datasets. Lance is perfect for:
+Lance is a modern data lake that is optimized for ML workflows and tables. Lance is perfect for:
 
-1. Building search engines and feature stores.
+1. Building search engines with any combination of semantic (vector) search, full
+   text search, and filtering.
 2. Large-scale ML training requiring high performance IO and shuffles.
-3. Storing, querying, and inspecting deeply nested data for robotics or large blobs like images, point clouds, and more.
+3. Running experiments by quickly adding and removing features without data copies.
+4. Storing, querying, and inspecting deeply nested data for robotics or large blobs like images, point clouds, and more.
 
-The key features of Lance include:
+The following table summarizes the key features of Lance compared with other options.
 
-* **High-performance random access:** 100x faster than Parquet without sacrificing scan performance.
-
-* **Vector search:** find nearest neighbors in milliseconds and combine OLAP-queries with vector search.
-
-* **Zero-copy, automatic versioning:** manage versions of your data without needing extra infrastructure.
-
-* **Ecosystem integrations:** Apache Arrow, Pandas, Polars, DuckDB, Ray, Spark and more on the way.
+| Feature          | Lance             | WebDataset    | Iceberg / Delta Lake        | Parquet                     |
+| ---------------- | ----------------- | ------------- | --------------------------- | --------------------------- |
+| Random Access    | ✅ Fast           | ❌ No Support | ⚠️ Slow                     | ⚠️ Slow                     |
+| Fast Scan        | ✅ Yes            | ✅ Yes        | ✅ Yes                      | ✅ Yes                      |
+| Schema Evolution | ✅ Yes, zero-copy | ❌ No Support | ⚠️ Copy table to add column | ⚠️ Copy table to add column |
+| Multimodal       | ✅ Yes            | ✅ Yes        | ❌ No                       | ❌ No                       |
+| Search           | ✅ Yes            | ❌ No Support | ⚠️ Slow                     | ⚠️ Slow                     |
+| Analytics        | ✅ Fast           | ❌ No Support | ✅ Fast                     | ✅ Fast                     |
 
 > [!TIP]
 > Lance is in active development and we welcome contributions. Please see our [contributing guide](docs/contributing.rst) for more information.
@@ -88,18 +92,21 @@ lance.write_dataset(parquet, "/tmp/test.lance")
 ```
 
 **Reading Lance data**
+
 ```python
 dataset = lance.dataset("/tmp/test.lance")
 assert isinstance(dataset, pa.dataset.Dataset)
 ```
 
 **Pandas**
+
 ```python
 df = dataset.to_table().to_pandas()
 df
 ```
 
 **DuckDB**
+
 ```python
 import duckdb
 
@@ -165,7 +172,7 @@ rs = [dataset.to_table(nearest={"column": "vector", "k": 10, "q": q})
 ## Directory structure
 
 | Directory          | Description                               |
-|--------------------|-------------------------------------------|
+| ------------------ | ----------------------------------------- |
 | [rust](./rust)     | Core Rust implementation                  |
 | [python](./python) | Python bindings (PyO3)                    |
 | [java](./java)     | Java bindings (JNI) and Spark integration |
@@ -175,19 +182,18 @@ rs = [dataset.to_table(nearest={"column": "vector", "k": 10, "q": q})
 
 Here we will highlight a few aspects of Lance’s design. For more details, see the full [Lance design document](https://lancedb.github.io/lance/format.html).
 
-**Vector index**: Vector index for similarity search over embedding space.
-Support both CPUs (``x86_64`` and ``arm``) and GPU (``Nvidia (cuda)`` and ``Apple Silicon (mps)``).
+**Vector index**: Lance includes a state of the art vector index implementation for
+similarity search over embedding space. Supports both CPUs (`x86_64` and `arm`) and GPU (`Nvidia (cuda)` and `Apple Silicon (mps)`).
 
-**Encodings**: To achieve both fast columnar scan and sub-linear point queries, Lance uses custom encodings and layouts.
+**Columnar + Random Access**: To achieve both fast columnar scan and sub-linear point queries, Lance uses a custom storage format that is optimized for both random access and sequential scans.
 
 **Nested fields**: Lance stores each subfield as a separate column to support efficient filters like “find images where detected objects include cats”.
 
-**Versioning**: A Manifest can be used to record snapshots. Currently we support creating new versions automatically via appends, overwrites, and index creation .
-
-**Fast updates** (ROADMAP): Updates will be supported via write-ahead logs.
+**Versioning**: Similar to Iceberg and Delta Lake, Lance files are immutable and changes are done by creating new files. This enables time travel, allowing the dataset to be queried at or easily restored to a previous state.
 
 **Rich secondary indices**: Support `BTree`, `Bitmap`, `Full text search`, `Label list`,
-`NGrams`, and more.
+`NGrams`, and more. These indices can speed up vector search, analytics, and filtering.
+They can also speed up dataset maintenance tasks such as upserts and deletes.
 
 ## Benchmarks
 
@@ -209,7 +215,7 @@ We create a Lance dataset using the Oxford Pet dataset to do some preliminary pe
 
 ![](docs/lance_perf.png)
 
-## Why are you building yet another data format?!
+## Why are you building yet another table format?!
 
 The machine learning development cycle involves the steps:
 
@@ -217,7 +223,7 @@ The machine learning development cycle involves the steps:
 graph LR
     A[Collection] --> B[Exploration];
     B --> C[Analytics];
-    C --> D[Feature Engineer];
+    C --> D[Feature Engineering];
     D --> E[Training];
     E --> F[Evaluation];
     F --> C;
@@ -226,43 +232,31 @@ graph LR
     H --> A;
 ```
 
-People use different data representations to varying stages for the performance or limited by the tooling available.
-Academia mainly uses XML / JSON for annotations and zipped images/sensors data for deep learning, which
-is difficult to integrated into data infrastructure and slow to train over cloud storage.
-While industry uses data lakes (Parquet-based techniques, i.e., Delta Lake, Iceberg) or data warehouses (AWS Redshift
-or Google BigQuery) to collect and analyze data, they have to convert the data into training-friendly formats, such
-as [Rikai](https://github.com/eto-ai/rikai)/[Petastorm](https://github.com/uber/petastorm)
-or [TFRecord](https://www.tensorflow.org/tutorials/load_data/tfrecord).
-Multiple single-purpose data transforms, as well as syncing copies between cloud storage to local training
-instances have become a common practice.
+Currently, people use different data representations at the various stages due to limited performance or tooling.
 
-While each of the existing data formats excels at the workload it was originally designed for, we need a new data format
-tailored for multistage ML development cycles to reduce and data silos.
+Academia mainly uses XML / JSON for annotations and zipped images/sensors data for deep learning, which is difficult to integrate into data infrastructure and slow to train over cloud storage.
 
-A comparison of different data formats in each stage of ML development cycle.
+Industry uses classic Parquet-based data lakes (e.g. Delta Lake, Iceberg) or data warehouses (e.g. AWS Redshift, Google BigQuery) to collect and analyze data. These have limited support for multimodal types, are difficult to experiment with, and are often slow or expensive when it comes to data exploration and search.
 
-|                     | Lance | Parquet & ORC | JSON & XML | TFRecord | Database | Warehouse |
-|---------------------|-------|---------------|------------|----------|----------|-----------|
-| Analytics           | Fast  | Fast          | Slow       | Slow     | Decent   | Fast      |
-| Feature Engineering | Fast  | Fast          | Decent     | Slow     | Decent   | Good      |
-| Training            | Fast  | Decent        | Slow       | Fast     | N/A      | N/A       |
-| Exploration         | Fast  | Slow          | Fast       | Slow     | Fast     | Decent    |
-| Infra Support       | Rich  | Rich          | Decent     | Limited  | Rich     | Rich      |
+Multiple single-purpose data transforms, manually syncing copies between cloud storage to local training instances, and ad-hoc infrastructure has become a common practice.
+
+While each of the existing storage choices excels at the workload it was originally designed for, we need a new choice tailored for multistage ML development cycles to reduce costs, engineering overhead, and data silos.
 
 ## Community Highlights
 
 Lance is currently used in production by:
-* [LanceDB](https://github.com/lancedb/lancedb), a serverless, low-latency vector database for ML applications
-* [LanceDB Enterprise](https://docs.lancedb.com/enterprise/introduction), hyperscale LanceDB with enterprise SLA.
-* Leading multimodal Gen AI companies for training over petabyte-scale multimodal data.
-* Self-driving car company for large-scale storage, retrieval and processing of multi-modal data.
-* E-commerce company for billion-scale+ vector personalized search.
-* and more.
+
+- [LanceDB](https://github.com/lancedb/lancedb), a serverless, low-latency vector database for ML applications
+- [LanceDB Enterprise](https://docs.lancedb.com/enterprise/introduction), hyperscale LanceDB with enterprise SLA.
+- Leading multimodal Gen AI companies for training over petabyte-scale multimodal data.
+- Self-driving car company for large-scale storage, retrieval and processing of multi-modal data.
+- E-commerce company for billion-scale+ vector personalized search.
+- and more.
 
 ## Presentations, Blogs and Talks
 
-* [Designing a Table Format for ML Workloads](https://blog.lancedb.com/designing-a-table-format-for-ml-workloads/), Feb 2025.
-* [Transforming Multimodal Data Management with LanceDB, Ray Summit](https://www.youtube.com/watch?v=xmTFEzAh8ho), Oct 2024.
-* [Lance v2: A columnar container format for modern data](https://blog.lancedb.com/lance-v2/), Apr 2024.
-* [Lance Deep Dive](https://drive.google.com/file/d/1Orh9rK0Mpj9zN_gnQF1eJJFpAc6lStGm/view?usp=drive_link). July 2023.
-* [Lance: A New Columnar Data Format](https://docs.google.com/presentation/d/1a4nAiQAkPDBtOfXFpPg7lbeDAxcNDVKgoUkw3cUs2rE/edit#slide=id.p), [Scipy 2022, Austin, TX](https://www.scipy2022.scipy.org/posters). July, 2022.
+- [Designing a Table Format for ML Workloads](https://blog.lancedb.com/designing-a-table-format-for-ml-workloads/), Feb 2025.
+- [Transforming Multimodal Data Management with LanceDB, Ray Summit](https://www.youtube.com/watch?v=xmTFEzAh8ho), Oct 2024.
+- [Lance v2: A columnar container format for modern data](https://blog.lancedb.com/lance-v2/), Apr 2024.
+- [Lance Deep Dive](https://drive.google.com/file/d/1Orh9rK0Mpj9zN_gnQF1eJJFpAc6lStGm/view?usp=drive_link). July 2023.
+- [Lance: A New Columnar Data Format](https://docs.google.com/presentation/d/1a4nAiQAkPDBtOfXFpPg7lbeDAxcNDVKgoUkw3cUs2rE/edit#slide=id.p), [Scipy 2022, Austin, TX](https://www.scipy2022.scipy.org/posters). July, 2022.


### PR DESCRIPTION
The original README was written as if Lance is primarily a file format.  The repo includes both a file format and a table format.  I believe it is easier to understand if it is thought of as a table format (the higher level abstraction) that also uses a custom file format.