### PR TITLE
ci(java): improve caching for lance-jni

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -56,11 +56,18 @@ jobs:
       run:
         working-directory: ./java
     steps:
+      # pin the toolchain version to avoid surprises
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: rui314/setup-mold@v1
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
       - name: Checkout repository
         uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: java/core/lance-jni 
+          workspaces: java/core/lance-jni -> ../target/rust-maven-plugin/lance-jni
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -35,11 +35,20 @@ jobs:
         uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: java/core/lance-jni
+          workspaces: |
+            lance
+            java/core/lance-jni -> ../target/rust-maven-plugin/lance-jni
       - name: Install dependencies
         run: |
           sudo apt update
           sudo apt install -y protobuf-compiler libssl-dev
+      # pin the toolchain version to avoid surprises
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+      - uses: rui314/setup-mold@v1
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run cargo fmt
         run: cargo fmt --check
       - name: Rust Clippy

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -27,9 +27,6 @@ jobs:
   rust-clippy-fmt:
     runs-on: ubuntu-24.04
     name: Rust Clippy and Fmt Check
-    defaults:
-      run:
-        working-directory: ./java/core/lance-jni
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -50,8 +47,10 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Run cargo fmt
+        working-directory: java/core/lance-jni
         run: cargo fmt --check
       - name: Rust Clippy
+        working-directory: java/core/lance-jni
         run: cargo clippy --all-targets -- -D warnings
 
   build-and-test-java:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -124,4 +124,4 @@ jobs:
             -Djdk.reflect.useDirectMethodHandle=false \
             -Dio.netty.tryReflectionSetAccessible=true"
           fi
-          mvn clean install
+          mvn install

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: java/core/lance-jni
+          workspaces: java/core/lance-jni 
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -56,6 +56,10 @@ jobs:
       run:
         working-directory: ./java
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y protobuf-compiler libssl-dev
       # pin the toolchain version to avoid surprises
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -68,10 +72,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: java/core/lance-jni -> ../target/rust-maven-plugin/lance-jni
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y protobuf-compiler libssl-dev
       - name: Set up Java ${{ matrix.java-version }}
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -52,9 +52,6 @@ jobs:
       matrix:
         java-version: [8, 11, 17]
     name: Build and Test with Java ${{ matrix.java-version }}
-    defaults:
-      run:
-        working-directory: ./java
     steps:
       - name: Install dependencies
         run: |
@@ -79,6 +76,7 @@ jobs:
           java-version: ${{ matrix.java-version }}
           cache: "maven"
       - name: Running code style check with Java ${{ matrix.java-version }}
+        working-directory: java
         run: |
           if [ "${{ matrix.java-version }}" == "17" ]; then
             export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS \
@@ -103,6 +101,7 @@ jobs:
           fi
           mvn spotless:check
       - name: Running tests with Java ${{ matrix.java-version }}
+        working-directory: java
         run: |
           if [ "${{ matrix.java-version }}" == "17" ]; then
             export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS \


### PR DESCRIPTION
Reduce the runtime of Java CI from over 10 minutes to 3 minutes. The caching configuration in CI requires (1) the working directory to be at the root, (2) the existence of cargo runtime, and (3) a correct mapping of the JNI build to the maven target directory, (4) do not clean the build artifact because that will clean all compiled rust artifacts.