### PR TITLE
fix: don't emit the IO core reservation warning on 2-core systems

### DIFF
--- a/rust/lance-core/src/utils/tokio.rs
+++ b/rust/lance-core/src/utils/tokio.rs
@@ -17,8 +17,9 @@ pub fn get_num_compute_intensive_cpus() -> usize {
     let cpus = num_cpus::get();
 
     if cpus <= *IO_CORE_RESERVATION {
-        // on systems with only 1 CPU there is no point in warning
-        if cpus > 1 {
+        // If the user is not setting a custom value for LANCE_IO_CORE_RESERVATION then we don't emit
+        // a warning because they're just on a small machine and there isn't much they can do about it.
+        if cpus > 2 {
             log::warn!(
                 "Number of CPUs is less than or equal to the number of IO core reservations. \
                 This is not a supported configuration. using 1 CPU for compute intensive tasks."


### PR DESCRIPTION
The default value for LANCE_IO_CORE_RESERVATION is 2.  So if users are on a 2-core system we are always going to warn them.  This is generally just confusing for users and not really something they can do much about.  This changes the check to only emit the warning if the user is modifying LANCE_IO_CORE_RESERVATION (e.g. it is something other than 2).