### PR TITLE
feat: add dev profile for cargo compile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,6 +9,16 @@ debug = true
 codegen-units = 16
 lto = "thin"
 
+[profile.dev]
+opt-level = 1
+debug = 2
+lto = "off"
+split-debuginfo = "unpacked"
+# Prioritize compile time over runtime performance
+codegen-units = 32
+panic = "unwind"
+incremental = true
+
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "target-cpu=haswell", "-C", "target-feature=+avx2,+fma,+f16c"]
 


### PR DESCRIPTION
Add a dev mode compilation. Because each time there are only a small number of updates to the Rust content, but full compilation takes a long time. Here, in dev mode, use incremental compilation mode to ensure that the changed parts can be compiled and efficiency can also be guaranteed.

@westonpace  @wjones127  WDYT