### PR TITLE
fix: correctly specify datafusion properties for input distribution in our custom exec nodes

### DIFF
--- a/rust/lance/src/io/exec/rowids.rs
+++ b/rust/lance/src/io/exec/rowids.rs
@@ -187,6 +187,11 @@ impl ExecutionPlan for AddRowAddrExec {
         vec![&self.input]
     }
 
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        // We aren't doing much work here, best to avoid the thread overhead
+        vec![false]
+    }
+
     fn with_new_children(
         self: Arc<Self>,
         children: Vec<Arc<dyn ExecutionPlan>>,

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -463,6 +463,14 @@ impl ExecutionPlan for TakeExec {
         vec![&self.input]
     }
 
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        // This is an I/O bound operation and wouldn't really benefit from partitioning
+        //
+        // Plus, if we did that, we would be creating multiple schedulers which could use
+        // a lot of RAM.
+        vec![false]
+    }
+
     /// This preserves the output schema.
     fn with_new_children(
         self: Arc<Self>,

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -326,6 +326,12 @@ impl ExecutionPlan for ReplayExec {
         unimplemented!()
     }
 
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        // We aren't doing any work here, and it would be a little confusing
+        // to have multiple replay queues.
+        vec![false]
+    }
+
     fn execute(
         &self,
         partition: usize,


### PR DESCRIPTION
Many of our nodes require a single input partition (for various reasons).  Other nodes don't benefit from multiple input partitions (and having them would use more RAM and/or violate I/O concurrency limits).  This PR correctly specifies these limitations.