### PR TITLE
feat: fix various spans

### DIFF
--- a/rust/lance-core/src/utils/tracing.rs
+++ b/rust/lance-core/src/utils/tracing.rs
@@ -33,6 +33,11 @@ pub trait StreamTracingExt {
     where
         Self: Stream,
         Self: Sized;
+
+    fn stream_in_span(self, span: Span) -> InstrumentedStream<Self>
+    where
+        Self: Stream,
+        Self: Sized;
 }
 
 impl<S: Stream> StreamTracingExt for S {
@@ -41,10 +46,15 @@ impl<S: Stream> StreamTracingExt for S {
         Self: Stream,
         Self: Sized,
     {
-        InstrumentedStream {
-            stream: self,
-            span: Span::current(),
-        }
+        self.stream_in_span(Span::current())
+    }
+
+    fn stream_in_span(self, span: Span) -> InstrumentedStream<Self>
+    where
+        Self: Stream,
+        Self: Sized,
+    {
+        InstrumentedStream { stream: self, span }
     }
 }
 

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -37,7 +37,6 @@ use log::warn;
 use object_store::PutOptions;
 use object_store::{path::Path, Error as ObjectStoreError, ObjectStore as OSObjectStore};
 use snafu::location;
-use tracing::instrument;
 use url::Url;
 
 #[cfg(feature = "dynamodb")]

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -37,6 +37,7 @@ use log::warn;
 use object_store::PutOptions;
 use object_store::{path::Path, Error as ObjectStoreError, ObjectStore as OSObjectStore};
 use snafu::location;
+use tracing::instrument;
 use url::Url;
 
 #[cfg(feature = "dynamodb")]

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -23,6 +23,7 @@ use futures::{join, stream, FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use lance_core::datatypes::{OnMissing, OnTypeMismatch, SchemaCompareOptions};
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
+use lance_core::utils::tracing::StreamTracingExt;
 use lance_core::{datatypes::Schema, Error, Result};
 use lance_core::{ROW_ADDR, ROW_ADDR_FIELD, ROW_ID, ROW_ID_FIELD};
 use lance_datafusion::utils::StreamingWriteSource;

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -2103,6 +2103,10 @@ impl FragmentReader {
                         })
                         .boxed()
                 })
+                .stream_in_span(tracing::debug_span!(
+                    "ReadBatchFutStream",
+                    id = self.fragment_id,
+                ))
                 .boxed(),
         )
     }


### PR DESCRIPTION
* Change `TracedObjectStore` methods that return streams to attach the span to the streams, rather than just the creation of the streams.
* Attach a stream to `ReadBatchFutStream` returned from reading a fragment.
* Pass down span at various `tokio::spawn()` calls.

Perfetto still shows a jumbled mess, but I'm hoping this shows up more comprehensible in grafana.