### PR TITLE
fix: don't raise an error if reading a fragment with a null reader and deleted rows

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1578,6 +1578,19 @@ def test_flat_vector_search_with_delete(tmp_path: Path):
     )
 
 
+def test_null_reader_with_deletes(tmp_path: Path):
+    full_schema = pa.schema(
+        [
+            pa.field("id", pa.int64()),
+            pa.field("other", pa.int64()),
+        ]
+    )
+    ds = lance.write_dataset([], tmp_path, schema=full_schema, mode="create")
+    ds.insert(pa.table({"id": [1, 2, 3, 4, 5]}))
+    ds.delete("id in (1, 2)")
+    ds.to_table()
+
+
 def test_merge_insert_conditional_upsert_example(tmp_path: Path):
     table = pa.Table.from_pydict(
         {

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -939,8 +939,9 @@ impl FileFragment {
             }
         }
 
-        // This should return immediately on modern datasets.
-        let num_rows = self.count_rows(None).await?;
+        // This should return immediately on modern datasets.  Need to use physical_rows because
+        // deletions will be applied later
+        let num_rows = self.physical_rows().await?;
 
         // Check if there are any fields that are not in any data files
         let field_ids_in_files = opened_files


### PR DESCRIPTION
The null reader is applied before deletions happen and so it needs to generate rows based on the physical row count and not the logical row count.