### PR TITLE
feat: store data file size in manifest

### DIFF
--- a/java/core/lance-jni/src/file_reader.rs
+++ b/java/core/lance-jni/src/file_reader.rs
@@ -92,7 +92,7 @@ fn inner_open<'local>(env: &mut JNIEnv<'local>, file_uri: JString) -> Result<JOb
         let config = SchedulerConfig::max_bandwidth(&obj_store);
         let scan_scheduler = ScanScheduler::new(obj_store, config);
 
-        let file_scheduler = scan_scheduler.open_file(&Path::parse(&path)?).await?;
+        let file_scheduler = scan_scheduler.open_file(&Path::parse(&path)?, None).await?;
         FileReader::try_open(
             file_scheduler,
             None,

--- a/java/core/lance-jni/src/fragment.rs
+++ b/java/core/lance-jni/src/fragment.rs
@@ -223,7 +223,7 @@ fn create_fragment<'a>(
 }
 
 const DATA_FILE_CLASS: &str = "com/lancedb/lance/fragment/DataFile";
-const DATA_FILE_CONSTRUCTOR_SIG: &str = "(Ljava/lang/String;[I[III)V";
+const DATA_FILE_CONSTRUCTOR_SIG: &str = "(Ljava/lang/String;[I[IIILjava/lang/Long;)V";
 const DELETE_FILE_CLASS: &str = "com/lancedb/lance/fragment/DeletionFile";
 const DELETE_FILE_CONSTRUCTOR_SIG: &str =
     "(JJLjava/lang/Long;Lcom/lancedb/lance/fragment/DeletionFileType;)V";
@@ -238,6 +238,10 @@ impl IntoJava for &DataFile {
         let path = env.new_string(self.path.clone())?.into();
         let fields = JLance(self.fields.clone()).into_java(env)?;
         let column_indices = JLance(self.column_indices.clone()).into_java(env)?;
+        let file_size_bytes = match self.file_size_bytes {
+            Some(f) => JLance(f as i64).into_java(env)?,
+            None => JObject::null(),
+        };
         Ok(env.new_object(
             DATA_FILE_CLASS,
             DATA_FILE_CONSTRUCTOR_SIG,
@@ -247,6 +251,7 @@ impl IntoJava for &DataFile {
                 JValueGen::Object(&column_indices),
                 JValueGen::Int(self.file_major_version as i32),
                 JValueGen::Int(self.file_minor_version as i32),
+                JValueGen::Object(&file_size_bytes),
             ],
         )?)
     }

--- a/java/core/lance-jni/src/fragment.rs
+++ b/java/core/lance-jni/src/fragment.rs
@@ -453,12 +453,17 @@ impl FromJObjectWithEnv<DataFile> for JObject<'_> {
         let file_minor_version = env
             .call_method(self, "getFileMinorVersion", "()I", &[])?
             .i()? as u32;
+        let file_size_bytes: Option<i64> = env
+            .call_method(self, "getFileSizeBytes", "()Ljava/lang/Long;", &[])?
+            .l()?
+            .extract_object(env)?;
         Ok(DataFile {
             path,
             fields,
             column_indices,
             file_major_version,
             file_minor_version,
+            file_size_bytes: file_size_bytes.map(|r| r as u64),
         })
     }
 }

--- a/java/core/lance-jni/src/traits.rs
+++ b/java/core/lance-jni/src/traits.rs
@@ -173,6 +173,12 @@ impl IntoJava for JLance<usize> {
     }
 }
 
+impl IntoJava for JLance<i64> {
+    fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
+        Ok(env.new_object("java/lang/Long", "(J)V", &[JValueGen::Long(self.0)])?)
+    }
+}
+
 impl IntoJava for JLance<Option<usize>> {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
         let obj = match self.0 {

--- a/java/core/src/main/java/com/lancedb/lance/fragment/DataFile.java
+++ b/java/core/src/main/java/com/lancedb/lance/fragment/DataFile.java
@@ -24,7 +24,7 @@ public class DataFile implements Serializable {
   private final int[] columnIndices;
   private final int fileMajorVersion;
   private final int fileMinorVersion;
-  private final long fileSizeBytes;
+  private final Long fileSizeBytes;
 
   public DataFile(
       String path,
@@ -32,7 +32,7 @@ public class DataFile implements Serializable {
       int[] columnIndices,
       int fileMajorVersion,
       int fileMinorVersion,
-      long fileSizeBytes) {
+      Long fileSizeBytes) {
     this.path = path;
     this.fields = fields;
     this.columnIndices = columnIndices;
@@ -61,7 +61,7 @@ public class DataFile implements Serializable {
     return fileMinorVersion;
   }
 
-  public long getFileSizeBytes() {
+  public Long getFileSizeBytes() {
     return fileSizeBytes;
   }
 

--- a/java/core/src/main/java/com/lancedb/lance/fragment/DataFile.java
+++ b/java/core/src/main/java/com/lancedb/lance/fragment/DataFile.java
@@ -24,14 +24,16 @@ public class DataFile implements Serializable {
   private final int[] columnIndices;
   private final int fileMajorVersion;
   private final int fileMinorVersion;
+  private final long fileSizeBytes;
 
   public DataFile(
-      String path, int[] fields, int[] columnIndices, int fileMajorVersion, int fileMinorVersion) {
+      String path, int[] fields, int[] columnIndices, int fileMajorVersion, int fileMinorVersion, long fileSizeBytes) {
     this.path = path;
     this.fields = fields;
     this.columnIndices = columnIndices;
     this.fileMajorVersion = fileMajorVersion;
     this.fileMinorVersion = fileMinorVersion;
+    this.fileSizeBytes = fileSizeBytes;
   }
 
   public String getPath() {
@@ -52,6 +54,10 @@ public class DataFile implements Serializable {
 
   public int getFileMinorVersion() {
     return fileMinorVersion;
+  }
+
+  public long getFileSizeBytes() {
+    return fileSizeBytes;
   }
 
   @Override

--- a/java/core/src/main/java/com/lancedb/lance/fragment/DataFile.java
+++ b/java/core/src/main/java/com/lancedb/lance/fragment/DataFile.java
@@ -27,7 +27,12 @@ public class DataFile implements Serializable {
   private final long fileSizeBytes;
 
   public DataFile(
-      String path, int[] fields, int[] columnIndices, int fileMajorVersion, int fileMinorVersion, long fileSizeBytes) {
+      String path,
+      int[] fields,
+      int[] columnIndices,
+      int fileMajorVersion,
+      int fileMinorVersion,
+      long fileSizeBytes) {
     this.path = path;
     this.fields = fields;
     this.columnIndices = columnIndices;

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -308,6 +308,13 @@ message DataFile {
   // If both `file_major_version` and `file_minor_version` are set to 0,
   // then this is a version 0.1 or version 0.2 file.
   uint32 file_minor_version = 5;
+
+  // The known size of the file on disk in bytes.
+  //
+  // This is used to quickly find the footer of the file.
+  //
+  // When this is zero, it should be interpreted as "unknown".
+  uint64 file_size_bytes = 6;
 } // DataFile
 
 // Deletion File

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -145,6 +145,8 @@ class DataFile:
         The major version of the data storage format.
     file_minor_version : int
         The minor version of the data storage format.
+    file_size_bytes : Optional[int]
+        The size of the data file in bytes, if available.
     """
 
     _path: str
@@ -152,6 +154,7 @@ class DataFile:
     column_indices: List[int] = field(default_factory=list)
     file_major_version: int = 0
     file_minor_version: int = 0
+    file_size_bytes: Optional[int] = None
 
     def __init__(
         self,
@@ -160,6 +163,7 @@ class DataFile:
         column_indices: List[int] = None,
         file_major_version: int = 0,
         file_minor_version: int = 0,
+        file_size_bytes: Optional[int] = None,
     ):
         # TODO: only we eliminate the path method, we can remove this
         self._path = path
@@ -167,6 +171,7 @@ class DataFile:
         self.column_indices = column_indices or []
         self.file_major_version = file_major_version
         self.file_minor_version = file_minor_version
+        self.file_size_bytes = file_size_bytes
 
     def __repr__(self):
         # pretend we have a 'path' attribute
@@ -174,7 +179,8 @@ class DataFile:
             f"DataFile(path='{self._path}', fields={self.fields}, "
             f"column_indices={self.column_indices}, "
             f"file_major_version={self.file_major_version}, "
-            f"file_minor_version={self.file_minor_version})"
+            f"file_minor_version={self.file_minor_version}, "
+            f"file_size_bytes={self.file_size_bytes})"
         )
 
     @property

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -245,7 +245,7 @@ def test_fragment_meta():
     data = {
         "id": 0,
         "files": [
-            {"path": "0.lance", "fields": [0]},
+            {"path": "0.lance", "fields": [0], "file_size_bytes": 100},
             {"path": "1.lance", "fields": [1]},
         ],
         "deletion_file": None,
@@ -261,10 +261,10 @@ def test_fragment_meta():
 
     assert repr(meta) == (
         "FragmentMetadata(id=0, files=[DataFile(path='0.lance', fields=[0], "
-        "column_indices=[], file_major_version=0, file_minor_version=0), "
-        "DataFile(path='1.lance', fields=[1], column_indices=[], "
-        "file_major_version=0, file_minor_version=0)], physical_rows=100, "
-        "deletion_file=None, row_id_meta=None, file_size_bytes=None)"
+        "column_indices=[], file_major_version=0, file_minor_version=0, "
+        "file_size_bytes=100), DataFile(path='1.lance', fields=[1], column_indices=[], "
+        "file_major_version=0, file_minor_version=0, file_size_bytes=None)], "
+        "physical_rows=100, deletion_file=None, row_id_meta=None)"
     )
 
 

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -264,7 +264,7 @@ def test_fragment_meta():
         "column_indices=[], file_major_version=0, file_minor_version=0), "
         "DataFile(path='1.lance', fields=[1], column_indices=[], "
         "file_major_version=0, file_minor_version=0)], physical_rows=100, "
-        "deletion_file=None, row_id_meta=None)"
+        "deletion_file=None, row_id_meta=None, file_size_bytes=None)"
     )
 
 

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -398,7 +398,7 @@ impl LanceFileReader {
                 io_buffer_size_bytes: 2 * 1024 * 1024 * 1024,
             },
         );
-        let file = scheduler.open_file(&path).await.infer_error()?;
+        let file = scheduler.open_file(&path, None).await.infer_error()?;
         let inner = FileReader::try_open(
             file,
             None,

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -658,6 +658,7 @@ impl FromPyObject<'_> for PyLance<DataFile> {
             column_indices: ob.getattr("column_indices")?.extract()?,
             file_major_version: ob.getattr("file_major_version")?.extract()?,
             file_minor_version: ob.getattr("file_minor_version")?.extract()?,
+            file_size_bytes: ob.getattr("file_size_bytes")?.extract()?,
         }))
     }
 }
@@ -679,6 +680,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&DataFile> {
             self.0.column_indices.clone(),
             self.0.file_major_version,
             self.0.file_minor_version,
+            self.0.file_size_bytes,
         ))
     }
 }

--- a/rust/lance-file/benches/reader.rs
+++ b/rust/lance-file/benches/reader.rs
@@ -66,7 +66,7 @@ fn bench_reader(c: &mut Criterion) {
                         object_store.clone(),
                         SchedulerConfig::default_for_testing(),
                     );
-                    let scheduler = store_scheduler.open_file(file_path).await.unwrap();
+                    let scheduler = store_scheduler.open_file(file_path, None).await.unwrap();
                     let reader = FileReader::try_open(
                         scheduler.clone(),
                         None,
@@ -159,7 +159,7 @@ fn bench_random_access(c: &mut Criterion) {
         let reader = rt.block_on(async move {
             let store_scheduler =
                 ScanScheduler::new(object_store.clone(), SchedulerConfig::default_for_testing());
-            let scheduler = store_scheduler.open_file(file_path).await.unwrap();
+            let scheduler = store_scheduler.open_file(file_path, None).await.unwrap();
             Arc::new(
                 FileReader::try_open(
                     scheduler.clone(),

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -1498,7 +1498,7 @@ pub mod tests {
         let WrittenFile { data, .. } = create_some_file(&fs, LanceFileVersion::V2_0).await;
 
         for read_size in [32, 1024, 1024 * 1024] {
-            let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+            let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
             let file_reader = FileReader::try_open(
                 file_scheduler,
                 None,
@@ -1592,7 +1592,7 @@ pub mod tests {
         let fs = FsFixture::default();
 
         let written_file = create_some_file(&fs, LanceFileVersion::V2_0).await;
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
 
         let field_id_mapping = written_file
             .field_id_mapping
@@ -1735,7 +1735,7 @@ pub mod tests {
         let fs = FsFixture::default();
 
         let written_file = create_some_file(&fs, LanceFileVersion::V2_0).await;
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
 
         // We can specify the projection as part of the read operation via read_stream_projected
         let file_reader = FileReader::try_open(
@@ -1787,7 +1787,7 @@ pub mod tests {
         let WrittenFile { data, .. } = create_some_file(&fs, LanceFileVersion::V2_0).await;
         let total_rows = data.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
@@ -1819,7 +1819,7 @@ pub mod tests {
         let WrittenFile { data, schema, .. } = create_some_file(&fs, LanceFileVersion::V2_1).await;
         let total_rows = data.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             Some(ReaderProjection::from_column_names(&schema, &["score"]).unwrap()),
@@ -1856,7 +1856,7 @@ pub mod tests {
         let WrittenFile { data, .. } = create_some_file(&fs, LanceFileVersion::V2_0).await;
         let total_rows = data.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
@@ -1904,7 +1904,7 @@ pub mod tests {
             .map(|batch| batch.num_rows())
             .sum::<usize>();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
@@ -1980,7 +1980,7 @@ pub mod tests {
 
         file_writer.finish().await.unwrap();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,

--- a/rust/lance-file/src/v2/testing.rs
+++ b/rust/lance-file/src/v2/testing.rs
@@ -94,7 +94,7 @@ pub async fn read_lance_file(
     decoder_middleware: Arc<DecoderPlugins>,
     filter: FilterExpression,
 ) -> Vec<RecordBatch> {
-    let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+    let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
     let file_reader = FileReader::try_open(
         file_scheduler,
         None,

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -223,7 +223,7 @@ impl IndexStore for LanceIndexStore {
 
     async fn open_index_file(&self, name: &str) -> Result<Arc<dyn IndexReader>> {
         let path = self.index_dir.child(name);
-        let file_scheduler = self.scheduler.open_file(&path).await?;
+        let file_scheduler = self.scheduler.open_file(&path, None).await?;
         match v2::reader::FileReader::try_open(
             file_scheduler,
             None,

--- a/rust/lance-index/src/vector/ivf/shuffler.rs
+++ b/rust/lance-index/src/vector/ivf/shuffler.rs
@@ -507,7 +507,7 @@ impl IvfShuffler {
             } else {
                 let scheduler_config = SchedulerConfig::max_bandwidth(&object_store);
                 let scheduler = ScanScheduler::new(object_store.into(), scheduler_config);
-                let file = scheduler.open_file(&path).await?;
+                let file = scheduler.open_file(&path, None).await?;
                 let cache =
                     FileMetadataCache::with_capacity(128 * 1024 * 1024, CapacityMode::Bytes);
 
@@ -565,7 +565,7 @@ impl IvfShuffler {
                     });
                 }
             } else {
-                let file = scheduler.open_file(&path).await?;
+                let file = scheduler.open_file(&path, None).await?;
                 let reader = Lancev2FileReader::try_open(
                     file,
                     None,
@@ -637,7 +637,7 @@ impl IvfShuffler {
             } else {
                 let scheduler_config = SchedulerConfig::max_bandwidth(&object_store);
                 let scheduler = ScanScheduler::new(Arc::new(object_store), scheduler_config);
-                let file = scheduler.open_file(&path).await?;
+                let file = scheduler.open_file(&path, None).await?;
                 let reader = Lancev2FileReader::try_open(
                     file,
                     None,
@@ -808,7 +808,7 @@ impl IvfShuffler {
             let path = basedir.child(file);
             let scheduler_config = SchedulerConfig::max_bandwidth(&object_store);
             let scan_scheduler = ScanScheduler::new(object_store, scheduler_config);
-            let file_scheduler = scan_scheduler.open_file(&path).await?;
+            let file_scheduler = scan_scheduler.open_file(&path, None).await?;
             let reader = lance_file::v2::reader::FileReader::try_open(
                 file_scheduler,
                 None,

--- a/rust/lance-index/src/vector/v3/shuffler.rs
+++ b/rust/lance-index/src/vector/v3/shuffler.rs
@@ -272,7 +272,7 @@ impl ShuffleReader for IvfShufflerReader {
         let partition_path = self.output_dir.child(format!("ivf_{}.lance", partition_id));
 
         let reader = FileReader::try_open(
-            self.scheduler.open_file(&partition_path).await?,
+            self.scheduler.open_file(&partition_path, None).await?,
             None,
             Arc::<DecoderPlugins>::default(),
             &FileMetadataCache::no_cache(),

--- a/rust/lance-io/benches/scheduler.rs
+++ b/rust/lance-io/benches/scheduler.rs
@@ -95,7 +95,7 @@ fn bench_full_read(c: &mut Criterion) {
                     runtime.block_on(async {
                         let scheduler =
                             ScanScheduler::new(obj_store, SchedulerConfig::default_for_testing());
-                        let file_scheduler = scheduler.open_file(&tmp_file).await.unwrap();
+                        let file_scheduler = scheduler.open_file(&tmp_file, None).await.unwrap();
 
                         let (tx, rx) = mpsc::channel(1024);
                         let drainer = tokio::spawn(drain_task(rx));
@@ -185,7 +185,8 @@ fn bench_random_read(c: &mut Criterion) {
                                 obj_store,
                                 SchedulerConfig::default_for_testing(),
                             );
-                            let file_scheduler = scheduler.open_file(&tmp_file).await.unwrap();
+                            let file_scheduler =
+                                scheduler.open_file(&tmp_file, None).await.unwrap();
 
                             let (tx, rx) = mpsc::channel(1024);
                             let drainer = tokio::spawn(drain_task(rx));

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -530,9 +530,12 @@ mod tests {
             json!({
                 "id": 123,
                 "files":[
-                    {"path": "foobar.lance", "fields": [0], "column_indices": [], "file_major_version": MAJOR_VERSION, "file_minor_version": MINOR_VERSION}],
-                     "deletion_file": {"read_version": 123, "id": 456, "file_type": "array",
-                                       "num_deleted_rows": 10},
+                    {"path": "foobar.lance", "fields": [0], "column_indices": [], 
+                     "file_major_version": MAJOR_VERSION, "file_minor_version": MINOR_VERSION,
+                     "file_size_bytes": null }
+                ],
+                "deletion_file": {"read_version": 123, "id": 456, "file_type": "array",
+                                  "num_deleted_rows": 10},
                 "physical_rows": None::<usize>}),
         );
 

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -86,7 +86,11 @@ impl DataFile {
         )
     }
 
-    pub fn new_legacy(path: impl Into<String>, schema: &Schema) -> Self {
+    pub fn new_legacy(
+        path: impl Into<String>,
+        schema: &Schema,
+        file_size_bytes: Option<u64>,
+    ) -> Self {
         let mut field_ids = schema.field_ids();
         field_ids.sort();
         Self::new(
@@ -95,7 +99,7 @@ impl DataFile {
             vec![],
             MAJOR_VERSION as u32,
             MINOR_VERSION as u32,
-            None,
+            file_size_bytes,
         )
     }
 
@@ -312,7 +316,7 @@ impl Fragment {
     ) -> Self {
         Self {
             id,
-            files: vec![DataFile::new_legacy(path, schema)],
+            files: vec![DataFile::new_legacy(path, schema, None)],
             deletion_file: None,
             physical_rows,
             row_id_meta: None,
@@ -340,7 +344,7 @@ impl Fragment {
 
     /// Add a new [`DataFile`] to this fragment.
     pub fn add_file_legacy(&mut self, path: &str, schema: &Schema) {
-        self.files.push(DataFile::new_legacy(path, schema));
+        self.files.push(DataFile::new_legacy(path, schema, None));
     }
 
     // True if this fragment is made up of legacy v1 files, false otherwise

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -5925,6 +5925,7 @@ mod tests {
             column_indices: vec![0],
             file_major_version: 2,
             file_minor_version: 0,
+            file_size_bytes: None,
         };
 
         let dataset = Dataset::commit(
@@ -5978,6 +5979,7 @@ mod tests {
             column_indices: vec![0],
             file_major_version: 2,
             file_minor_version: 0,
+            file_size_bytes: None,
         };
 
         let dataset = Dataset::commit(
@@ -6075,6 +6077,7 @@ mod tests {
             column_indices: vec![0],
             file_major_version: 2,
             file_minor_version: 0,
+            file_size_bytes: None,
         };
 
         let new_data_file = DataFile {

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -665,7 +665,7 @@ impl FileFragment {
                 dataset.object_store.clone(),
                 SchedulerConfig::max_bandwidth(&dataset.object_store),
             );
-            let file_scheduler = scheduler.open_file(&filepath).await?;
+            let file_scheduler = scheduler.open_file(&filepath, None).await?;
             let reader = v2::reader::FileReader::try_open(
                 file_scheduler,
                 None,
@@ -697,6 +697,7 @@ impl FileFragment {
                 dataset.schema().field_ids(),
                 column_indices,
                 &file_version,
+                None,
             );
             Ok(frag)
         }
@@ -883,7 +884,7 @@ impl FileFragment {
                     )
                 };
             let file_scheduler = store_scheduler
-                .open_file_with_priority(&path, reader_priority as u64)
+                .open_file_with_priority(&path, reader_priority as u64, data_file.file_size_bytes)
                 .await?;
             let file_metadata = self.get_file_metadata(&file_scheduler).await?;
             let path = file_scheduler.reader().path().clone();

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -996,6 +996,7 @@ impl Transaction {
                                 new_file.file_minor_version,
                             )
                             .expect("Expected valid file version"),
+                            new_file.file_size_bytes,
                         );
                     }
 

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -531,7 +531,7 @@ impl GenericWriter for V2WriterAdapter {
             column_indices,
             major,
             minor,
-            Some(self.writer.tell().await? as u64),
+            Some(self.writer.tell().await?),
         );
         Ok((num_rows, data_file))
     }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -524,14 +524,15 @@ impl GenericWriter for V2WriterAdapter {
             .map(|(_, column_index)| *column_index as i32)
             .collect::<Vec<_>>();
         let (major, minor) = self.writer.version().to_numbers();
+        let num_rows = self.writer.finish().await? as u32;
         let data_file = DataFile::new(
             std::mem::take(&mut self.path),
             field_ids,
             column_indices,
             major,
             minor,
+            Some(self.writer.tell().await? as u64),
         );
-        let num_rows = self.writer.finish().await? as u32;
         Ok((num_rows, data_file))
     }
 }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -487,9 +487,10 @@ impl<M: ManifestProvider + Send + Sync> GenericWriter for (FileWriter<M>, String
         Ok(self.0.tell().await? as u64)
     }
     async fn finish(&mut self) -> Result<(u32, DataFile)> {
+        let size_bytes = self.0.tell().await?;
         Ok((
             self.0.finish().await? as u32,
-            DataFile::new_legacy(self.1.clone(), self.0.schema()),
+            DataFile::new_legacy(self.1.clone(), self.0.schema(), Some(size_bytes as u64)),
         ))
     }
 }

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -424,7 +424,7 @@ mod tests {
                 column_indices: vec![0],
                 file_major_version: 2,
                 file_minor_version: 0,
-                file_size_bytes: None,
+                file_size_bytes: Some(100),
             }],
             deletion_file: None,
             row_id_meta: None,

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -424,6 +424,7 @@ mod tests {
                 column_indices: vec![0],
                 file_major_version: 2,
                 file_minor_version: 0,
+                file_size_bytes: None,
             }],
             deletion_file: None,
             row_id_meta: None,

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -870,7 +870,7 @@ impl DatasetIndexInternalExt for Dataset {
                     self.object_store.clone(),
                     SchedulerConfig::max_bandwidth(&self.object_store),
                 );
-                let file = scheduler.open_file(&index_file).await?;
+                let file = scheduler.open_file(&index_file, None).await?;
                 let reader = v2::reader::FileReader::try_open(
                     file,
                     None,

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -725,7 +725,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             } else {
                 let storage_part_path = self.temp_dir.child(format!("storage_part{}", part_id));
                 let reader = FileReader::try_open(
-                    scheduler.open_file(&storage_part_path).await?,
+                    scheduler.open_file(&storage_part_path, None).await?,
                     None,
                     Arc::<DecoderPlugins>::default(),
                     &FileMetadataCache::no_cache(),
@@ -759,7 +759,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             } else {
                 let index_part_path = self.temp_dir.child(format!("index_part{}", part_id));
                 let reader = FileReader::try_open(
-                    scheduler.open_file(&index_part_path).await?,
+                    scheduler.open_file(&index_part_path, None).await?,
                     None,
                     Arc::<DecoderPlugins>::default(),
                     &FileMetadataCache::no_cache(),

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -133,7 +133,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             .unwrap_or_else(FileMetadataCache::no_cache);
         let uri = index_dir.child(uuid.as_str()).child(INDEX_FILE_NAME);
         let index_reader = FileReader::try_open(
-            scheduler.open_file(&uri).await?,
+            scheduler.open_file(&uri, None).await?,
             None,
             Arc::<DecoderPlugins>::default(),
             &file_metadata_cache,
@@ -185,6 +185,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
                     &index_dir
                         .child(uuid.as_str())
                         .child(INDEX_AUXILIARY_FILE_NAME),
+                    None,
                 )
                 .await?,
             None,

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -35,7 +35,7 @@ use rand::{thread_rng, Rng};
 use snafu::location;
 
 use futures::future::Either;
-use futures::{FutureExt, StreamExt, TryStreamExt};
+use futures::{FutureExt, StreamExt, TryFutureExt, TryStreamExt};
 use lance_core::{Error, Result};
 use lance_index::DatasetIndexExt;
 use log;
@@ -292,6 +292,7 @@ async fn migrate_manifest(
                     .as_ref()
                     .map(|d| d.num_deleted_rows.is_some())
                     .unwrap_or(true))
+                && f.files.iter().all(|f| f.file_size_bytes.is_some())
         })
     {
         return Ok(());
@@ -475,6 +476,30 @@ pub(crate) async fn migrate_fragments(
             let (physical_rows, num_deleted_rows) =
                 futures::future::try_join(physical_rows, num_deleted_rows).await?;
 
+            let mut data_files = fragment.files.clone();
+
+            // For each of the data files in the fragment, we need to get the file size
+            let object_store = dataset.object_store();
+            let get_sizes = data_files
+                .iter()
+                .map(|file| {
+                    if let Some(size) = file.file_size_bytes {
+                        Either::Left(futures::future::ready(Ok(size)))
+                    } else {
+                        Either::Right(async {
+                            object_store
+                                .size(&dataset.base.child("data").child(file.path.clone()))
+                                .map_ok(|size| size as u64)
+                                .await
+                        })
+                    }
+                })
+                .collect::<Vec<_>>();
+            let sizes = futures::future::try_join_all(get_sizes).await?;
+            data_files.iter_mut().zip(sizes).for_each(|(file, size)| {
+                file.file_size_bytes = Some(size);
+            });
+
             let deletion_file = fragment
                 .deletion_file
                 .as_ref()
@@ -486,6 +511,7 @@ pub(crate) async fn migrate_fragments(
             Ok::<_, Error>(Fragment {
                 physical_rows: Some(physical_rows),
                 deletion_file,
+                files: data_files,
                 ..fragment.clone()
             })
         })


### PR DESCRIPTION
Part of #3751.

* When we write data files, we store the size in bytes in the manifest.
* We use this size to skip the `HEAD` request needed to find the file footer byte range.
* When writing a dataset, we can read any missing sizes and fill them in.