### PR TITLE
perf: read tiny files in 1 IOP

### DIFF
--- a/java/core/src/test/java/com/lancedb/lance/FileReaderWriterTest.java
+++ b/java/core/src/test/java/com/lancedb/lance/FileReaderWriterTest.java
@@ -151,16 +151,12 @@ public class FileReaderWriterTest {
       LanceFileReader.open("/tmp/does_not_exist.lance", allocator);
       fail("Expected LanceException to be thrown");
     } catch (IOException e) {
-      assertTrue(e.getMessage().contains("Not found: tmp/does_not_exist.lance"));
+      assertTrue(e.getMessage().contains("Object at location /tmp/does_not_exist.lance not found"));
     }
     try {
       LanceFileReader.open("", allocator);
       fail("Expected LanceException to be thrown");
-    } catch (RuntimeException e) {
-      // expected, would be nice if it was an IOException, but it's not because
-      // lance throws a wrapped error :(
     } catch (IOException e) {
-      fail("Expected RuntimeException to be thrown");
     }
   }
 }

--- a/rust/lance-io/src/object_reader.rs
+++ b/rust/lance-io/src/object_reader.rs
@@ -180,7 +180,6 @@ impl Reader for CloudObjectReader {
 #[derive(Debug)]
 pub struct SmallReader {
     path: Path,
-    block_size: usize,
     state: Arc<std::sync::Mutex<SmallReaderState>>,
 }
 
@@ -221,7 +220,6 @@ impl SmallReader {
         );
         Self {
             path,
-            block_size: 64 * 1024,
             state: Arc::new(std::sync::Mutex::new(state)),
         }
     }
@@ -254,7 +252,7 @@ impl Reader for SmallReader {
     }
 
     fn block_size(&self) -> usize {
-        self.block_size
+        64 * 1024
     }
 
     fn io_parallelism(&self) -> usize {

--- a/rust/lance-io/src/object_reader.rs
+++ b/rust/lance-io/src/object_reader.rs
@@ -7,8 +7,11 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::Bytes;
 use deepsize::DeepSizeOf;
-use futures::future::BoxFuture;
-use lance_core::Result;
+use futures::{
+    future::{BoxFuture, Shared},
+    FutureExt,
+};
+use lance_core::{error::CloneableError, Error, Result};
 use object_store::{path::Path, GetOptions, GetResult, ObjectStore, Result as OSResult};
 use tokio::sync::OnceCell;
 use tracing::instrument;
@@ -164,5 +167,140 @@ impl Reader for CloudObjectReader {
             || "read_all".to_string(),
         )
         .await
+    }
+}
+
+/// A reader for a file so small, we just eagerly read it all into memory.
+///
+/// When created, it represents a future that will read the whole file into memory.
+///
+/// On the first read call, it will start the read. Multiple threads can call read at the same time.
+///
+/// Once the read is complete, any thread can call read again to get the result.
+#[derive(Debug)]
+pub struct SmallReader {
+    path: Path,
+    block_size: usize,
+    state: Arc<std::sync::Mutex<SmallReaderState>>,
+}
+
+enum SmallReaderState {
+    Loading(Shared<BoxFuture<'static, std::result::Result<Bytes, CloneableError>>>),
+    Finished(std::result::Result<Bytes, CloneableError>),
+}
+
+impl std::fmt::Debug for SmallReaderState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Loading(_) => write!(f, "Loading"),
+            Self::Finished(Ok(data)) => {
+                write!(f, "Finished({} bytes)", data.len())
+            }
+            Self::Finished(Err(err)) => {
+                write!(f, "Finished({})", err.0)
+            }
+        }
+    }
+}
+
+impl SmallReader {
+    pub fn new(store: Arc<dyn ObjectStore>, path: Path, download_retry_count: usize) -> Self {
+        let path_ref = path.clone();
+        let state = SmallReaderState::Loading(
+            Box::pin(async move {
+                let object_reader =
+                    CloudObjectReader::new(store, path_ref, 0, None, download_retry_count)
+                        .map_err(CloneableError)?;
+                object_reader
+                    .get_all()
+                    .await
+                    .map_err(|err| CloneableError(Error::from(err)))
+            })
+            .boxed()
+            .shared(),
+        );
+        Self {
+            path,
+            block_size: 64 * 1024,
+            state: Arc::new(std::sync::Mutex::new(state)),
+        }
+    }
+
+    async fn wait(&self) -> OSResult<Bytes> {
+        let future = {
+            let state = self.state.lock().unwrap();
+            match &*state {
+                SmallReaderState::Loading(future) => future.clone(),
+                SmallReaderState::Finished(result) => {
+                    return result.clone().map_err(|err| err.0.into());
+                }
+            }
+        };
+
+        let result = future.await;
+        let result_to_return = result.clone().map_err(|err| err.0.into());
+        let mut state = self.state.lock().unwrap();
+        if matches!(*state, SmallReaderState::Loading(_)) {
+            *state = SmallReaderState::Finished(result);
+        }
+        result_to_return
+    }
+}
+
+#[async_trait]
+impl Reader for SmallReader {
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    fn io_parallelism(&self) -> usize {
+        1024
+    }
+
+    /// Object/File Size.
+    async fn size(&self) -> OSResult<usize> {
+        self.wait().await.map(|bytes| bytes.len())
+    }
+
+    async fn get_range(&self, range: Range<usize>) -> OSResult<Bytes> {
+        self.wait().await.and_then(|bytes| {
+            let start = range.start;
+            let end = range.end;
+            if start >= bytes.len() || end > bytes.len() {
+                return Err(object_store::Error::Generic {
+                    store: "memory",
+                    source: format!(
+                        "Invalid range {}..{} for object of size {} bytes",
+                        start,
+                        end,
+                        bytes.len()
+                    )
+                    .into(),
+                });
+            }
+            Ok(bytes.slice(range))
+        })
+    }
+
+    async fn get_all(&self) -> OSResult<Bytes> {
+        self.wait().await
+    }
+}
+
+impl DeepSizeOf for SmallReader {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        let mut size = self.path.as_ref().deep_size_of_children(context);
+
+        if let Ok(guard) = self.state.try_lock() {
+            if let SmallReaderState::Finished(Ok(data)) = &*guard {
+                size += data.len();
+            }
+        }
+
+        size
     }
 }

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -35,6 +35,7 @@ use super::local::LocalObjectReader;
 mod list_retry;
 pub mod providers;
 mod tracing;
+use crate::object_reader::SmallReader;
 use crate::object_writer::WriteResult;
 use crate::{object_reader::CloudObjectReader, object_writer::ObjectWriter, traits::Reader};
 use lance_core::{Error, Result};
@@ -384,6 +385,16 @@ impl ObjectStore {
     /// cached metadata. By passing in the known size, we can skip a HEAD / metadata
     /// call.
     pub async fn open_with_size(&self, path: &Path, known_size: usize) -> Result<Box<dyn Reader>> {
+        // If we know the file is really small, we can read the whole thing
+        // as a single request.
+        if known_size <= self.block_size {
+            return Ok(Box::new(SmallReader::new(
+                self.inner.clone(),
+                path.clone(),
+                self.download_retry_count,
+            )));
+        }
+
         match self.scheme.as_str() {
             "file" => LocalObjectReader::open(path, self.block_size, Some(known_size)).await,
             _ => Ok(Box::new(CloudObjectReader::new(

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -637,13 +637,15 @@ impl ScanScheduler {
         base_priority: u64,
         file_size_bytes: Option<u64>,
     ) -> Result<FileScheduler> {
-        let reader = if let Some(size) = file_size_bytes {
-            self.object_store
-                .open_with_size(path, size as usize)
-                .await?
+        let file_size_bytes = if let Some(size) = file_size_bytes {
+            size as usize
         } else {
-            self.object_store.open(path).await?
+            self.object_store.size(path).await?
         };
+        let reader = self
+            .object_store
+            .open_with_size(path, file_size_bytes)
+            .await?;
         let block_size = self.object_store.block_size() as u64;
         Ok(FileScheduler {
             reader: reader.into(),

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -958,7 +958,7 @@ mod tests {
         let obj_store = Arc::new(ObjectStore::new(
             Arc::new(obj_store),
             Url::parse("mem://").unwrap(),
-            None,
+            Some(500),
             None,
             false,
             false,
@@ -973,7 +973,7 @@ mod tests {
         let scan_scheduler = ScanScheduler::new(obj_store, config);
 
         let file_scheduler = scan_scheduler
-            .open_file(&Path::parse("foo").unwrap(), None)
+            .open_file(&Path::parse("foo").unwrap(), Some(1000))
             .await
             .unwrap();
 

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -1047,7 +1047,7 @@ mod tests {
         let obj_store = Arc::new(ObjectStore::new(
             Arc::new(obj_store),
             Url::parse("mem://").unwrap(),
-            None,
+            Some(500),
             None,
             false,
             false,
@@ -1062,7 +1062,7 @@ mod tests {
         let scan_scheduler = ScanScheduler::new(obj_store.clone(), config);
 
         let file_scheduler = scan_scheduler
-            .open_file(&Path::parse("foo").unwrap(), None)
+            .open_file(&Path::parse("foo").unwrap(), Some(100000))
             .await
             .unwrap();
 
@@ -1135,7 +1135,7 @@ mod tests {
 
         let scan_scheduler = ScanScheduler::new(obj_store, config);
         let file_scheduler = scan_scheduler
-            .open_file(&Path::parse("foo").unwrap(), None)
+            .open_file(&Path::parse("foo").unwrap(), Some(100000))
             .await
             .unwrap();
 

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -2235,13 +2235,18 @@ mod tests {
     use lance_core::ROW_ID;
     use lance_datagen::{array, gen, RowCount};
     use lance_file::version::LanceFileVersion;
+    use lance_io::object_store::ObjectStoreParams;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use tempfile::tempdir;
     use v2::writer::FileWriterOptions;
 
     use super::*;
-    use crate::{dataset::transaction::Operation, utils::test::TestDatasetGenerator};
+    use crate::{
+        dataset::{transaction::Operation, InsertBuilder},
+        session::Session,
+        utils::test::{StatsHolder, TestDatasetGenerator},
+    };
 
     async fn create_dataset(test_uri: &str, data_storage_version: LanceFileVersion) -> Dataset {
         let schema = Arc::new(ArrowSchema::new(vec![
@@ -3311,5 +3316,71 @@ mod tests {
                 .unwrap(),
             256
         );
+    }
+
+    #[tokio::test]
+    async fn test_iops_read_small() {
+        // Create a file that has 10 columns.
+        let schema = Arc::new(ArrowSchema::new(
+            (0..10)
+                .map(|i| ArrowField::new(format!("col_{}", i), DataType::Int32, true))
+                .collect::<Vec<_>>(),
+        ));
+
+        // Single row batch
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            (0..10)
+                .map(|i| Arc::new(Int32Array::from(vec![i])) as ArrayRef)
+                .collect(),
+        )
+        .unwrap();
+        let session = Arc::new(Session::default());
+        let io_stats = Arc::new(StatsHolder::default());
+        let write_params = WriteParams {
+            store_params: Some(ObjectStoreParams {
+                object_store_wrapper: Some(io_stats.clone()),
+                ..Default::default()
+            }),
+            session: Some(session.clone()),
+            ..Default::default()
+        };
+        let dataset = InsertBuilder::new("memory://test")
+            .with_params(&write_params)
+            .execute(vec![batch])
+            .await
+            .unwrap();
+        let fragment = dataset.get_fragments().pop().unwrap();
+
+        // Assert file is small (< 4kb)
+        {
+            let stats = io_stats.incremental_stats();
+            assert_eq!(stats.write_iops, 3);
+            assert!(stats.write_bytes < 4096);
+        }
+
+        // Measure IOPS needed to scan all data first time.
+        let projection = Schema::try_from(schema.as_ref())
+            .unwrap()
+            .project_by_ids(&[0, 1, 2, 3, 4, 6, 7, 8, 9], true);
+        let reader = fragment
+            .open(&projection, Default::default())
+            .await
+            .unwrap();
+        let mut data = reader
+            .read_all(1024)
+            .unwrap()
+            .buffered(1)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(data.len(), 1);
+        let data = data.pop().unwrap();
+        assert_eq!(data.num_rows(), 1);
+        assert_eq!(data.num_columns(), 9);
+
+        let stats = io_stats.incremental_stats();
+        assert_eq!(stats.read_iops, 1);
+        assert!(stats.read_bytes < 4096);
     }
 }

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -293,8 +293,14 @@ impl Display for IoTrackingStore {
     }
 }
 
-#[derive(Debug)]
-struct StatsHolder(Arc<Mutex<IoStats>>);
+#[derive(Debug, Default, Clone)]
+pub struct StatsHolder(Arc<Mutex<IoStats>>);
+
+impl StatsHolder {
+    pub fn incremental_stats(&self) -> IoStats {
+        std::mem::take(&mut *self.0.lock().unwrap())
+    }
+}
 
 impl WrappingObjectStore for StatsHolder {
     fn wrap(&self, target: Arc<dyn ObjectStore>) -> Arc<dyn ObjectStore> {


### PR DESCRIPTION
If a whole data file is smaller than the `block_size`, just read the whole thing in one IO request. Part of #3751. Stacked on #3750.

This changes makes writing many small rows have much less of an impact on the scan performance. This helps the performance of anything that involves a scan:

1. Exact KNN search
2. Merge-insert
3. Compaction


<img width="595" alt="Screenshot 2025-04-28 at 3 41 04 PM" src="https://github.com/user-attachments/assets/1cecaa82-a327-495b-ac45-b910027c29fb" />

