### PR TITLE
feat(build): add make clean target for Python temporary files

### DIFF
--- a/python/DEVELOPMENT.md
+++ b/python/DEVELOPMENT.md
@@ -80,6 +80,12 @@ ruff.....................................................................Passed
  1 file changed, 1 insertion(+), 1 deletion(-)
 ```
 
+## Cleaning build artifacts
+To clean up build artifacts, run:
+```shell
+make clean
+```
+
 ## Benchmarks
 
 The benchmarks in `python/benchmarks` can be used to identify and diagnose

--- a/python/Makefile
+++ b/python/Makefile
@@ -38,3 +38,8 @@ lint-rust:
 	cargo fmt -- --check
 	cargo clippy -- -D warnings
 .PHONY: lint-rust
+
+clean:
+	cargo clean
+	rm -rf target
+.PHONY: clean


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9d57b752-2156-4e3e-b7e4-9a18cd03f4a0)
![image](https://github.com/user-attachments/assets/1625ca87-afce-4bc9-b974-a01fdd6a7a00)

The target generated by Python is relatively large. Here, add a clean mechanism in the makefile to ensure that temporary builds can be deleted frequently.

@westonpace @wjones127 Could you help me review this part of the changes?