### PR TITLE
feat: expose public accessor for LanceScanExec config

### DIFF
--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -570,6 +570,11 @@ impl LanceScanExec {
     pub fn projection(&self) -> &Arc<Schema> {
         &self.projection
     }
+
+    // Get the scan config for this scan.
+    pub fn config(&self) -> &LanceScanConfig {
+        &self.config
+    }
 }
 
 impl ExecutionPlan for LanceScanExec {


### PR DESCRIPTION
This exposes a public accessor for LanceScanExec's scan config, so that it may be used in optimizer rules.