### PR TITLE
fix: prevent infinite loop of writing manifest

### DIFF
--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -884,6 +884,8 @@ pub(crate) async fn commit_transaction(
                 if next_attempt_i < num_attempts {
                     tokio::time::sleep(backoff.next_backoff()).await;
                     dataset.checkout_latest().await?;
+                } else {
+                    break;
                 }
             }
             Err(CommitError::OtherError(err)) => {


### PR DESCRIPTION
If we got near the max retries, we would start retrying *without* any sleep or calling `dataset.checkout_latest()`. The latter guaranteed it would fail with `CommitConflict` (and then retry). The former made it eventually fail on a 429 from object store.

Bug was introduced in https://github.com/lancedb/lance/pull/3712