### PR TITLE
perf: optimize load_indices

### DIFF
--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -180,7 +180,7 @@ pub type ManifestWriter = for<'a> fn(
     path: &'a Path,
 ) -> BoxFuture<'a, Result<WriteResult>>;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ManifestLocation {
     /// The version the manifest corresponds to.
     pub version: u64,

--- a/rust/lance-table/src/io/manifest.rs
+++ b/rust/lance-table/src/io/manifest.rs
@@ -117,7 +117,6 @@ pub async fn read_manifest_indexes(
     manifest: &Manifest,
 ) -> Result<Vec<Index>> {
     if let Some(pos) = manifest.index_section.as_ref() {
-        println!("Reading index section at {}", pos);
         let reader = if let Some(size) = location.size {
             object_store
                 .open_with_size(&location.path, size as usize)

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -549,6 +549,10 @@ impl Dataset {
         &self.manifest
     }
 
+    pub fn manifest_location(&self) -> &ManifestLocation {
+        &self.manifest_location
+    }
+
     // TODO: Cache this
     pub async fn blobs_dataset(&self) -> Result<Option<Arc<Self>>> {
         if let Some(blobs_version) = self.manifest.blob_dataset_version {
@@ -1430,10 +1434,10 @@ impl Dataset {
     /// #  .into_reader_rows(RowCount::from(10), BatchCount::from(1));
     /// # let fut = async {
     /// let mut dataset = Dataset::write(data, "memory://test", None).await.unwrap();
-    /// assert_eq!(dataset.manifest_naming_scheme, ManifestNamingScheme::V1);
+    /// assert_eq!(dataset.manifest_location().naming_scheme, ManifestNamingScheme::V1);
     ///
     /// dataset.migrate_manifest_paths_v2().await.unwrap();
-    /// assert_eq!(dataset.manifest_naming_scheme, ManifestNamingScheme::V2);
+    /// assert_eq!(dataset.manifest_location().naming_scheme, ManifestNamingScheme::V2);
     /// # };
     /// # tokio::runtime::Runtime::new().unwrap().block_on(fut);
     /// ```

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -318,7 +318,13 @@ impl DatasetBuilder {
                     })?,
             };
 
-            let manifest = Dataset::load_manifest(&object_store, &manifest_location).await?;
+            let manifest = Dataset::load_manifest(
+                &object_store,
+                &manifest_location,
+                &base_path,
+                session.as_ref(),
+            )
+            .await?;
             (manifest, manifest_location)
         };
 

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -327,11 +327,9 @@ impl DatasetBuilder {
             base_path,
             table_uri,
             manifest,
-            location.path,
+            location,
             session,
             commit_handler,
-            location.naming_scheme,
-            location.e_tag,
         )
         .await
     }

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -192,7 +192,7 @@ impl<'a> CleanupTask<'a> {
         let is_tagged = tagged_versions.contains(&manifest.version);
         let in_working_set = is_latest || manifest.timestamp() >= self.before || is_tagged;
         let indexes =
-            read_manifest_indexes(&self.dataset.object_store, &location.path, &manifest).await?;
+            read_manifest_indexes(&self.dataset.object_store, &location, &manifest).await?;
 
         let mut inspection = inspection.lock().unwrap();
 

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -597,14 +597,14 @@ async fn reserve_fragment_ids(
         None,
     );
 
-    let (manifest, _, _) = commit_transaction(
+    let (manifest, _) = commit_transaction(
         dataset,
         dataset.object_store(),
         dataset.commit_handler.as_ref(),
         &transaction,
         &Default::default(),
         &Default::default(),
-        dataset.manifest_naming_scheme,
+        dataset.manifest_location.naming_scheme,
     )
     .await?;
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -4186,7 +4186,7 @@ mod test {
 
             assert_eq!(
                 dataset.index_cache_entry_count(),
-                1, // 1 for index metadata
+                2, // 2 for index metadata at version 1 and 2.
             );
             let results = scan
                 .try_into_stream()

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -5190,17 +5190,20 @@ mod test {
         assert!(filtered_scan_bytes < full_scan_bytes);
 
         // Now do a scan with pushdown, the benefit should be even greater
-        let start_bytes = get_bytes();
-        dataset
-            .scan()
-            .filter("not_indexed = 50")
-            .unwrap()
-            .try_into_batch()
-            .await
-            .unwrap();
-        let pushdown_scan_bytes = get_bytes() - start_bytes;
+        // Pushdown only works with the legacy format for now.
+        if data_storage_version == LanceFileVersion::Legacy {
+            let start_bytes = get_bytes();
+            dataset
+                .scan()
+                .filter("not_indexed = 50")
+                .unwrap()
+                .try_into_batch()
+                .await
+                .unwrap();
+            let pushdown_scan_bytes = get_bytes() - start_bytes;
 
-        assert!(pushdown_scan_bytes < filtered_scan_bytes);
+            assert!(pushdown_scan_bytes < filtered_scan_bytes);
+        }
 
         // Now do a scalar index scan, this should be better than a
         // full scan but since we have to load the index might be more

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -699,7 +699,7 @@ impl Transaction {
         let mut manifest = read_manifest(object_store, &location.path, location.size).await?;
         manifest.set_timestamp(timestamp_to_nanos(config.timestamp));
         manifest.transaction_file = Some(tx_path.to_string());
-        let indices = read_manifest_indexes(object_store, &location.path, &manifest).await?;
+        let indices = read_manifest_indexes(object_store, &location, &manifest).await?;
         Ok((manifest, indices))
     }
 

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -223,7 +223,7 @@ impl<'a> CommitBuilder<'a> {
         }
 
         let manifest_naming_scheme = if let Some(ds) = dest.dataset() {
-            ds.manifest_naming_scheme
+            ds.manifest_location.naming_scheme
         } else if self.enable_v2_manifest_paths {
             ManifestNamingScheme::V2
         } else {
@@ -261,7 +261,7 @@ impl<'a> CommitBuilder<'a> {
             ..Default::default()
         };
 
-        let (manifest, manifest_file, manifest_e_tag) = if let Some(dataset) = dest.dataset() {
+        let (manifest, manifest_location) = if let Some(dataset) = dest.dataset() {
             if self.detached {
                 if matches!(manifest_naming_scheme, ManifestNamingScheme::V1) {
                     return Err(Error::NotSupported {
@@ -318,9 +318,8 @@ impl<'a> CommitBuilder<'a> {
         match &self.dest {
             WriteDestination::Dataset(dataset) => Ok(Dataset {
                 manifest: Arc::new(manifest),
-                manifest_file,
+                manifest_location,
                 session,
-                manifest_e_tag,
                 ..dataset.as_ref().clone()
             }),
             WriteDestination::Uri(uri) => Ok(Dataset {
@@ -328,12 +327,10 @@ impl<'a> CommitBuilder<'a> {
                 base: base_path,
                 uri: uri.to_string(),
                 manifest: Arc::new(manifest),
-                manifest_file,
+                manifest_location,
                 session,
                 commit_handler,
                 tags,
-                manifest_naming_scheme,
-                manifest_e_tag,
             }),
         }
     }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -399,23 +399,23 @@ impl DatasetIndexExt for Dataset {
     }
 
     async fn load_indices(&self) -> Result<Arc<Vec<IndexMetadata>>> {
-        let dataset_dir = self.base.to_string();
         if let Some(indices) = self
             .session
             .index_cache
-            .get_metadata(&dataset_dir, self.version().version)
+            .get_metadata(self.base.as_ref(), self.version().version)
         {
+            println!("hit");
             return Ok(indices);
         }
 
-        let manifest_file = self.manifest_file().await?;
+        println!("miss");
         let loaded_indices: Arc<Vec<IndexMetadata>> =
-            read_manifest_indexes(&self.object_store, &manifest_file, &self.manifest)
+            read_manifest_indexes(&self.object_store, &self.manifest_location, &self.manifest)
                 .await?
                 .into();
 
         self.session.index_cache.insert_metadata(
-            &dataset_dir,
+            self.base.as_ref(),
             self.version().version,
             loaded_indices.clone(),
         );
@@ -1077,7 +1077,9 @@ impl DatasetIndexInternalExt for Dataset {
 mod tests {
     use crate::dataset::builder::DatasetBuilder;
     use crate::dataset::optimize::{compact_files, CompactionOptions};
-    use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
+    use crate::dataset::{ReadParams, WriteParams};
+    use crate::session::Session;
+    use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount, StatsHolder};
 
     use super::*;
 
@@ -1090,6 +1092,7 @@ mod tests {
     use lance_index::vector::{
         hnsw::builder::HnswBuildParams, ivf::IvfBuildParams, sq::builder::SQBuildParams,
     };
+    use lance_io::object_store::ObjectStoreParams;
     use lance_linalg::distance::{DistanceType, MetricType};
     use lance_testing::datagen::generate_random_array;
     use tempfile::tempdir;
@@ -1826,5 +1829,79 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(index.index_type(), IndexType::Bitmap);
+    }
+
+    #[tokio::test]
+    async fn test_load_indices() {
+        let session = Arc::new(Session::default());
+        let io_stats = Arc::new(StatsHolder::default());
+        let write_params = WriteParams {
+            store_params: Some(ObjectStoreParams {
+                object_store_wrapper: Some(io_stats.clone()),
+                ..Default::default()
+            }),
+            session: Some(session.clone()),
+            ..Default::default()
+        };
+
+        let test_dir = tempdir().unwrap();
+        let field = Field::new("tag", DataType::Utf8, false);
+        let schema = Arc::new(Schema::new(vec![field]));
+        let array = StringArray::from_iter_values((0..128).map(|i| ["a", "b", "c"][i % 3]));
+        let record_batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array)]).unwrap();
+        let reader = RecordBatchIterator::new(
+            vec![record_batch.clone()].into_iter().map(Ok),
+            schema.clone(),
+        );
+
+        let test_uri = test_dir.path().to_str().unwrap();
+        let mut dataset = Dataset::write(reader, test_uri, Some(write_params))
+            .await
+            .unwrap();
+        dataset
+            .create_index(
+                &["tag"],
+                IndexType::Bitmap,
+                None,
+                &ScalarIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+        io_stats.incremental_stats(); // Reset
+
+        let indices = dataset.load_indices().await.unwrap();
+        let stats = io_stats.incremental_stats();
+        // We should already have this cached since we just wrote it.
+        assert_eq!(stats.read_iops, 0);
+        assert_eq!(stats.read_bytes, 0);
+        assert_eq!(indices.len(), 1);
+
+        session.index_cache.clear(); // Clear the cache
+
+        let dataset2 = DatasetBuilder::from_uri(test_uri)
+            .with_session(session.clone())
+            .with_read_params(ReadParams {
+                store_options: Some(ObjectStoreParams {
+                    object_store_wrapper: Some(io_stats.clone()),
+                    ..Default::default()
+                }),
+                session: Some(session.clone()),
+                ..Default::default()
+            })
+            .load()
+            .await
+            .unwrap();
+        let stats = io_stats.incremental_stats(); // Reset
+        assert!(stats.read_bytes < 64 * 1024);
+
+        // Because the manifest is so small, we should have opportunistically
+        // cached the indices in memory already.
+        println!("loading");
+        let indices2 = dataset2.load_indices().await.unwrap();
+        let stats = io_stats.incremental_stats();
+        assert_eq!(stats.read_iops, 0);
+        assert_eq!(stats.read_bytes, 0);
+        assert_eq!(indices2.len(), 1);
     }
 }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -404,11 +404,9 @@ impl DatasetIndexExt for Dataset {
             .index_cache
             .get_metadata(self.base.as_ref(), self.version().version)
         {
-            println!("hit");
             return Ok(indices);
         }
 
-        println!("miss");
         let loaded_indices: Arc<Vec<IndexMetadata>> =
             read_manifest_indexes(&self.object_store, &self.manifest_location, &self.manifest)
                 .await?
@@ -1897,7 +1895,6 @@ mod tests {
 
         // Because the manifest is so small, we should have opportunistically
         // cached the indices in memory already.
-        println!("loading");
         let indices2 = dataset2.load_indices().await.unwrap();
         let stats = io_stats.incremental_stats();
         assert_eq!(stats.read_iops, 0);

--- a/rust/lance/src/index/cache.rs
+++ b/rust/lance/src/index/cache.rs
@@ -88,6 +88,25 @@ impl IndexCache {
         }
     }
 
+    /// Clear the cache
+    #[cfg(test)]
+    pub fn clear(&self) {
+        self.scalar_cache.invalidate_all();
+        self.scalar_cache.run_pending_tasks();
+
+        self.vector_cache.invalidate_all();
+        self.vector_cache.run_pending_tasks();
+
+        self.vector_partition_cache.invalidate_all();
+        self.vector_partition_cache.run_pending_tasks();
+
+        self.metadata_cache.invalidate_all();
+        self.metadata_cache.run_pending_tasks();
+
+        self.type_cache.invalidate_all();
+        self.type_cache.run_pending_tasks();
+    }
+
     #[allow(dead_code)]
     pub(crate) fn len_vector(&self) -> usize {
         self.vector_cache.run_pending_tasks();

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -293,8 +293,14 @@ impl Display for IoTrackingStore {
     }
 }
 
-#[derive(Debug)]
-struct StatsHolder(Arc<Mutex<IoStats>>);
+#[derive(Debug, Default, Clone)]
+pub struct StatsHolder(Arc<Mutex<IoStats>>);
+
+impl StatsHolder {
+    pub fn incremental_stats(&self) -> IoStats {
+        std::mem::take(&mut *self.0.lock().unwrap())
+    }
+}
 
 impl WrappingObjectStore for StatsHolder {
     fn wrap(&self, target: Arc<dyn ObjectStore>) -> Arc<dyn ObjectStore> {


### PR DESCRIPTION
* Eliminates a `HEAD` request to get the size of the manifest before attempting to read the index section.
* When we open a manifest file, if we happened to read the index section, decode it eagerly so we don't have to make an additional IO request later.
* When we write a manifest file, put the index metadata in the cache.