### PR TITLE
perf: bring back io optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4230,6 +4230,7 @@ dependencies = [
  "prost 0.13.5",
  "rand 0.8.5",
  "rstest",
+ "serde",
  "shellexpand",
  "snafu",
  "tempfile",

--- a/java/core/lance-jni/src/file_reader.rs
+++ b/java/core/lance-jni/src/file_reader.rs
@@ -92,7 +92,7 @@ fn inner_open<'local>(env: &mut JNIEnv<'local>, file_uri: JString) -> Result<JOb
         let config = SchedulerConfig::max_bandwidth(&obj_store);
         let scan_scheduler = ScanScheduler::new(obj_store, config);
 
-        let file_scheduler = scan_scheduler.open_file(&Path::parse(&path)?).await?;
+        let file_scheduler = scan_scheduler.open_file(&Path::parse(&path)?, None).await?;
         FileReader::try_open(
             file_scheduler,
             None,

--- a/java/core/lance-jni/src/file_reader.rs
+++ b/java/core/lance-jni/src/file_reader.rs
@@ -18,6 +18,7 @@ use lance_encoding::decoder::{DecoderPlugins, FilterExpression};
 use lance_file::v2::reader::{FileReader, FileReaderOptions};
 use lance_io::{
     scheduler::{ScanScheduler, SchedulerConfig},
+    utils::CachedFileSize,
     ReadBatchParams,
 };
 use object_store::path::Path;
@@ -92,7 +93,9 @@ fn inner_open<'local>(env: &mut JNIEnv<'local>, file_uri: JString) -> Result<JOb
         let config = SchedulerConfig::max_bandwidth(&obj_store);
         let scan_scheduler = ScanScheduler::new(obj_store, config);
 
-        let file_scheduler = scan_scheduler.open_file(&Path::parse(&path)?, None).await?;
+        let file_scheduler = scan_scheduler
+            .open_file(&Path::parse(&path)?, &CachedFileSize::unknown())
+            .await?;
         FileReader::try_open(
             file_scheduler,
             None,

--- a/java/core/lance-jni/src/fragment.rs
+++ b/java/core/lance-jni/src/fragment.rs
@@ -223,7 +223,7 @@ fn create_fragment<'a>(
 }
 
 const DATA_FILE_CLASS: &str = "com/lancedb/lance/fragment/DataFile";
-const DATA_FILE_CONSTRUCTOR_SIG: &str = "(Ljava/lang/String;[I[III)V";
+const DATA_FILE_CONSTRUCTOR_SIG: &str = "(Ljava/lang/String;[I[IIILjava/lang/Long;)V";
 const DELETE_FILE_CLASS: &str = "com/lancedb/lance/fragment/DeletionFile";
 const DELETE_FILE_CONSTRUCTOR_SIG: &str =
     "(JJLjava/lang/Long;Lcom/lancedb/lance/fragment/DeletionFileType;)V";
@@ -238,6 +238,10 @@ impl IntoJava for &DataFile {
         let path = env.new_string(self.path.clone())?.into();
         let fields = JLance(self.fields.clone()).into_java(env)?;
         let column_indices = JLance(self.column_indices.clone()).into_java(env)?;
+        let file_size_bytes = match self.file_size_bytes {
+            Some(f) => JLance(f as i64).into_java(env)?,
+            None => JObject::null(),
+        };
         Ok(env.new_object(
             DATA_FILE_CLASS,
             DATA_FILE_CONSTRUCTOR_SIG,
@@ -247,6 +251,7 @@ impl IntoJava for &DataFile {
                 JValueGen::Object(&column_indices),
                 JValueGen::Int(self.file_major_version as i32),
                 JValueGen::Int(self.file_minor_version as i32),
+                JValueGen::Object(&file_size_bytes),
             ],
         )?)
     }
@@ -453,12 +458,17 @@ impl FromJObjectWithEnv<DataFile> for JObject<'_> {
         let file_minor_version = env
             .call_method(self, "getFileMinorVersion", "()I", &[])?
             .i()? as u32;
+        let file_size_bytes: Option<i64> = env
+            .call_method(self, "getFileSizeBytes", "()Ljava/lang/Long;", &[])?
+            .l()?
+            .extract_object(env)?;
         Ok(DataFile {
             path,
             fields,
             column_indices,
             file_major_version,
             file_minor_version,
+            file_size_bytes: file_size_bytes.map(|r| r as u64),
         })
     }
 }

--- a/java/core/lance-jni/src/traits.rs
+++ b/java/core/lance-jni/src/traits.rs
@@ -173,6 +173,12 @@ impl IntoJava for JLance<usize> {
     }
 }
 
+impl IntoJava for JLance<i64> {
+    fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
+        Ok(env.new_object("java/lang/Long", "(J)V", &[JValueGen::Long(self.0)])?)
+    }
+}
+
 impl IntoJava for JLance<Option<usize>> {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
         let obj = match self.0 {

--- a/java/core/src/main/java/com/lancedb/lance/fragment/DataFile.java
+++ b/java/core/src/main/java/com/lancedb/lance/fragment/DataFile.java
@@ -24,14 +24,21 @@ public class DataFile implements Serializable {
   private final int[] columnIndices;
   private final int fileMajorVersion;
   private final int fileMinorVersion;
+  private final Long fileSizeBytes;
 
   public DataFile(
-      String path, int[] fields, int[] columnIndices, int fileMajorVersion, int fileMinorVersion) {
+      String path,
+      int[] fields,
+      int[] columnIndices,
+      int fileMajorVersion,
+      int fileMinorVersion,
+      Long fileSizeBytes) {
     this.path = path;
     this.fields = fields;
     this.columnIndices = columnIndices;
     this.fileMajorVersion = fileMajorVersion;
     this.fileMinorVersion = fileMinorVersion;
+    this.fileSizeBytes = fileSizeBytes;
   }
 
   public String getPath() {
@@ -52,6 +59,10 @@ public class DataFile implements Serializable {
 
   public int getFileMinorVersion() {
     return fileMinorVersion;
+  }
+
+  public Long getFileSizeBytes() {
+    return fileSizeBytes;
   }
 
   @Override

--- a/java/core/src/test/java/com/lancedb/lance/FileReaderWriterTest.java
+++ b/java/core/src/test/java/com/lancedb/lance/FileReaderWriterTest.java
@@ -151,16 +151,12 @@ public class FileReaderWriterTest {
       LanceFileReader.open("/tmp/does_not_exist.lance", allocator);
       fail("Expected LanceException to be thrown");
     } catch (IOException e) {
-      assertTrue(e.getMessage().contains("Not found: tmp/does_not_exist.lance"));
+      assertTrue(e.getMessage().contains("Object at location /tmp/does_not_exist.lance not found"));
     }
     try {
       LanceFileReader.open("", allocator);
       fail("Expected LanceException to be thrown");
-    } catch (RuntimeException e) {
-      // expected, would be nice if it was an IOException, but it's not because
-      // lance throws a wrapped error :(
     } catch (IOException e) {
-      fail("Expected RuntimeException to be thrown");
     }
   }
 }

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -308,6 +308,13 @@ message DataFile {
   // If both `file_major_version` and `file_minor_version` are set to 0,
   // then this is a version 0.1 or version 0.2 file.
   uint32 file_minor_version = 5;
+
+  // The known size of the file on disk in bytes.
+  //
+  // This is used to quickly find the footer of the file.
+  //
+  // When this is zero, it should be interpreted as "unknown".
+  uint64 file_size_bytes = 6;
 } // DataFile
 
 // Deletion File

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -3506,6 +3506,7 @@ dependencies = [
  "pin-project",
  "prost 0.13.5",
  "rand",
+ "serde",
  "shellexpand",
  "snafu",
  "tokio",

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -145,6 +145,8 @@ class DataFile:
         The major version of the data storage format.
     file_minor_version : int
         The minor version of the data storage format.
+    file_size_bytes : Optional[int]
+        The size of the data file in bytes, if available.
     """
 
     _path: str
@@ -152,6 +154,7 @@ class DataFile:
     column_indices: List[int] = field(default_factory=list)
     file_major_version: int = 0
     file_minor_version: int = 0
+    file_size_bytes: Optional[int] = None
 
     def __init__(
         self,
@@ -160,6 +163,7 @@ class DataFile:
         column_indices: List[int] = None,
         file_major_version: int = 0,
         file_minor_version: int = 0,
+        file_size_bytes: Optional[int] = None,
     ):
         # TODO: only we eliminate the path method, we can remove this
         self._path = path
@@ -167,6 +171,7 @@ class DataFile:
         self.column_indices = column_indices or []
         self.file_major_version = file_major_version
         self.file_minor_version = file_minor_version
+        self.file_size_bytes = file_size_bytes
 
     def __repr__(self):
         # pretend we have a 'path' attribute
@@ -174,7 +179,8 @@ class DataFile:
             f"DataFile(path='{self._path}', fields={self.fields}, "
             f"column_indices={self.column_indices}, "
             f"file_major_version={self.file_major_version}, "
-            f"file_minor_version={self.file_minor_version})"
+            f"file_minor_version={self.file_minor_version}, "
+            f"file_size_bytes={self.file_size_bytes})"
         )
 
     @property

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -245,7 +245,7 @@ def test_fragment_meta():
     data = {
         "id": 0,
         "files": [
-            {"path": "0.lance", "fields": [0]},
+            {"path": "0.lance", "fields": [0], "file_size_bytes": 100},
             {"path": "1.lance", "fields": [1]},
         ],
         "deletion_file": None,
@@ -261,10 +261,10 @@ def test_fragment_meta():
 
     assert repr(meta) == (
         "FragmentMetadata(id=0, files=[DataFile(path='0.lance', fields=[0], "
-        "column_indices=[], file_major_version=0, file_minor_version=0), "
-        "DataFile(path='1.lance', fields=[1], column_indices=[], "
-        "file_major_version=0, file_minor_version=0)], physical_rows=100, "
-        "deletion_file=None, row_id_meta=None)"
+        "column_indices=[], file_major_version=0, file_minor_version=0, "
+        "file_size_bytes=100), DataFile(path='1.lance', fields=[1], column_indices=[], "
+        "file_major_version=0, file_minor_version=0, file_size_bytes=None)], "
+        "physical_rows=100, deletion_file=None, row_id_meta=None)"
     )
 
 

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -33,6 +33,7 @@ use lance_file::{
 use lance_io::object_store::ObjectStoreParams;
 use lance_io::{
     scheduler::{ScanScheduler, SchedulerConfig},
+    utils::CachedFileSize,
     ReadBatchParams,
 };
 use object_store::path::Path;
@@ -398,7 +399,10 @@ impl LanceFileReader {
                 io_buffer_size_bytes: 2 * 1024 * 1024 * 1024,
             },
         );
-        let file = scheduler.open_file(&path, None).await.infer_error()?;
+        let file = scheduler
+            .open_file(&path, &CachedFileSize::unknown())
+            .await
+            .infer_error()?;
         let inner = FileReader::try_open(
             file,
             None,

--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -398,7 +398,7 @@ impl LanceFileReader {
                 io_buffer_size_bytes: 2 * 1024 * 1024 * 1024,
             },
         );
-        let file = scheduler.open_file(&path).await.infer_error()?;
+        let file = scheduler.open_file(&path, None).await.infer_error()?;
         let inner = FileReader::try_open(
             file,
             None,

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -658,6 +658,7 @@ impl FromPyObject<'_> for PyLance<DataFile> {
             column_indices: ob.getattr("column_indices")?.extract()?,
             file_major_version: ob.getattr("file_major_version")?.extract()?,
             file_minor_version: ob.getattr("file_minor_version")?.extract()?,
+            file_size_bytes: ob.getattr("file_size_bytes")?.extract()?,
         }))
     }
 }
@@ -679,6 +680,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&DataFile> {
             self.0.column_indices.clone(),
             self.0.file_major_version,
             self.0.file_minor_version,
+            self.0.file_size_bytes,
         ))
     }
 }

--- a/rust/lance-file/benches/reader.rs
+++ b/rust/lance-file/benches/reader.rs
@@ -19,6 +19,7 @@ use lance_file::{
 use lance_io::{
     object_store::ObjectStore,
     scheduler::{ScanScheduler, SchedulerConfig},
+    utils::CachedFileSize,
 };
 use rand::seq::SliceRandom;
 
@@ -66,7 +67,10 @@ fn bench_reader(c: &mut Criterion) {
                         object_store.clone(),
                         SchedulerConfig::default_for_testing(),
                     );
-                    let scheduler = store_scheduler.open_file(file_path, None).await.unwrap();
+                    let scheduler = store_scheduler
+                        .open_file(file_path, &CachedFileSize::unknown())
+                        .await
+                        .unwrap();
                     let reader = FileReader::try_open(
                         scheduler.clone(),
                         None,
@@ -159,7 +163,10 @@ fn bench_random_access(c: &mut Criterion) {
         let reader = rt.block_on(async move {
             let store_scheduler =
                 ScanScheduler::new(object_store.clone(), SchedulerConfig::default_for_testing());
-            let scheduler = store_scheduler.open_file(file_path, None).await.unwrap();
+            let scheduler = store_scheduler
+                .open_file(file_path, &CachedFileSize::unknown())
+                .await
+                .unwrap();
             Arc::new(
                 FileReader::try_open(
                     scheduler.clone(),

--- a/rust/lance-file/benches/reader.rs
+++ b/rust/lance-file/benches/reader.rs
@@ -66,7 +66,7 @@ fn bench_reader(c: &mut Criterion) {
                         object_store.clone(),
                         SchedulerConfig::default_for_testing(),
                     );
-                    let scheduler = store_scheduler.open_file(file_path).await.unwrap();
+                    let scheduler = store_scheduler.open_file(file_path, None).await.unwrap();
                     let reader = FileReader::try_open(
                         scheduler.clone(),
                         None,
@@ -159,7 +159,7 @@ fn bench_random_access(c: &mut Criterion) {
         let reader = rt.block_on(async move {
             let store_scheduler =
                 ScanScheduler::new(object_store.clone(), SchedulerConfig::default_for_testing());
-            let scheduler = store_scheduler.open_file(file_path).await.unwrap();
+            let scheduler = store_scheduler.open_file(file_path, None).await.unwrap();
             Arc::new(
                 FileReader::try_open(
                     scheduler.clone(),

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -1401,7 +1401,7 @@ pub mod tests {
         encoder::{encode_batch, CoreFieldEncodingStrategy, EncodedBatch, EncodingOptions},
         version::LanceFileVersion,
     };
-    use lance_io::stream::RecordBatchStream;
+    use lance_io::{stream::RecordBatchStream, utils::CachedFileSize};
     use log::debug;
     use tokio::sync::mpsc;
 
@@ -1498,7 +1498,11 @@ pub mod tests {
         let WrittenFile { data, .. } = create_some_file(&fs, LanceFileVersion::V2_0).await;
 
         for read_size in [32, 1024, 1024 * 1024] {
-            let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
+            let file_scheduler = fs
+                .scheduler
+                .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+                .await
+                .unwrap();
             let file_reader = FileReader::try_open(
                 file_scheduler,
                 None,
@@ -1592,7 +1596,11 @@ pub mod tests {
         let fs = FsFixture::default();
 
         let written_file = create_some_file(&fs, LanceFileVersion::V2_0).await;
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
+        let file_scheduler = fs
+            .scheduler
+            .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+            .await
+            .unwrap();
 
         let field_id_mapping = written_file
             .field_id_mapping
@@ -1735,7 +1743,11 @@ pub mod tests {
         let fs = FsFixture::default();
 
         let written_file = create_some_file(&fs, LanceFileVersion::V2_0).await;
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
+        let file_scheduler = fs
+            .scheduler
+            .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+            .await
+            .unwrap();
 
         // We can specify the projection as part of the read operation via read_stream_projected
         let file_reader = FileReader::try_open(
@@ -1787,7 +1799,11 @@ pub mod tests {
         let WrittenFile { data, .. } = create_some_file(&fs, LanceFileVersion::V2_0).await;
         let total_rows = data.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
+        let file_scheduler = fs
+            .scheduler
+            .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+            .await
+            .unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
@@ -1819,7 +1835,11 @@ pub mod tests {
         let WrittenFile { data, schema, .. } = create_some_file(&fs, LanceFileVersion::V2_1).await;
         let total_rows = data.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
+        let file_scheduler = fs
+            .scheduler
+            .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+            .await
+            .unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             Some(ReaderProjection::from_column_names(&schema, &["score"]).unwrap()),
@@ -1856,7 +1876,11 @@ pub mod tests {
         let WrittenFile { data, .. } = create_some_file(&fs, LanceFileVersion::V2_0).await;
         let total_rows = data.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
+        let file_scheduler = fs
+            .scheduler
+            .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+            .await
+            .unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
@@ -1904,7 +1928,11 @@ pub mod tests {
             .map(|batch| batch.num_rows())
             .sum::<usize>();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
+        let file_scheduler = fs
+            .scheduler
+            .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+            .await
+            .unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
@@ -1980,7 +2008,11 @@ pub mod tests {
 
         file_writer.finish().await.unwrap();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
+        let file_scheduler = fs
+            .scheduler
+            .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+            .await
+            .unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -1498,7 +1498,7 @@ pub mod tests {
         let WrittenFile { data, .. } = create_some_file(&fs, LanceFileVersion::V2_0).await;
 
         for read_size in [32, 1024, 1024 * 1024] {
-            let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+            let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
             let file_reader = FileReader::try_open(
                 file_scheduler,
                 None,
@@ -1592,7 +1592,7 @@ pub mod tests {
         let fs = FsFixture::default();
 
         let written_file = create_some_file(&fs, LanceFileVersion::V2_0).await;
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
 
         let field_id_mapping = written_file
             .field_id_mapping
@@ -1735,7 +1735,7 @@ pub mod tests {
         let fs = FsFixture::default();
 
         let written_file = create_some_file(&fs, LanceFileVersion::V2_0).await;
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
 
         // We can specify the projection as part of the read operation via read_stream_projected
         let file_reader = FileReader::try_open(
@@ -1787,7 +1787,7 @@ pub mod tests {
         let WrittenFile { data, .. } = create_some_file(&fs, LanceFileVersion::V2_0).await;
         let total_rows = data.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
@@ -1819,7 +1819,7 @@ pub mod tests {
         let WrittenFile { data, schema, .. } = create_some_file(&fs, LanceFileVersion::V2_1).await;
         let total_rows = data.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             Some(ReaderProjection::from_column_names(&schema, &["score"]).unwrap()),
@@ -1856,7 +1856,7 @@ pub mod tests {
         let WrittenFile { data, .. } = create_some_file(&fs, LanceFileVersion::V2_0).await;
         let total_rows = data.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
@@ -1904,7 +1904,7 @@ pub mod tests {
             .map(|batch| batch.num_rows())
             .sum::<usize>();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,
@@ -1980,7 +1980,7 @@ pub mod tests {
 
         file_writer.finish().await.unwrap();
 
-        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+        let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
             None,

--- a/rust/lance-file/src/v2/testing.rs
+++ b/rust/lance-file/src/v2/testing.rs
@@ -94,7 +94,7 @@ pub async fn read_lance_file(
     decoder_middleware: Arc<DecoderPlugins>,
     filter: FilterExpression,
 ) -> Vec<RecordBatch> {
-    let file_scheduler = fs.scheduler.open_file(&fs.tmp_path).await.unwrap();
+    let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
     let file_reader = FileReader::try_open(
         file_scheduler,
         None,

--- a/rust/lance-file/src/v2/testing.rs
+++ b/rust/lance-file/src/v2/testing.rs
@@ -14,6 +14,7 @@ use lance_encoding::decoder::{DecoderPlugins, FilterExpression};
 use lance_io::{
     object_store::ObjectStore,
     scheduler::{ScanScheduler, SchedulerConfig},
+    utils::CachedFileSize,
     ReadBatchParams,
 };
 use object_store::path::Path;
@@ -94,7 +95,11 @@ pub async fn read_lance_file(
     decoder_middleware: Arc<DecoderPlugins>,
     filter: FilterExpression,
 ) -> Vec<RecordBatch> {
-    let file_scheduler = fs.scheduler.open_file(&fs.tmp_path, None).await.unwrap();
+    let file_scheduler = fs
+        .scheduler
+        .open_file(&fs.tmp_path, &CachedFileSize::unknown())
+        .await
+        .unwrap();
     let file_reader = FileReader::try_open(
         file_scheduler,
         None,

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -21,6 +21,7 @@ use lance_file::{
     writer::{FileWriter, ManifestProvider},
 };
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
+use lance_io::utils::CachedFileSize;
 use lance_io::{object_store::ObjectStore, ReadBatchParams};
 use lance_table::format::SelfDescribingFileReader;
 use object_store::path::Path;
@@ -223,7 +224,10 @@ impl IndexStore for LanceIndexStore {
 
     async fn open_index_file(&self, name: &str) -> Result<Arc<dyn IndexReader>> {
         let path = self.index_dir.child(name);
-        let file_scheduler = self.scheduler.open_file(&path, None).await?;
+        let file_scheduler = self
+            .scheduler
+            .open_file(&path, &CachedFileSize::unknown())
+            .await?;
         match v2::reader::FileReader::try_open(
             file_scheduler,
             None,

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -223,7 +223,7 @@ impl IndexStore for LanceIndexStore {
 
     async fn open_index_file(&self, name: &str) -> Result<Arc<dyn IndexReader>> {
         let path = self.index_dir.child(name);
-        let file_scheduler = self.scheduler.open_file(&path).await?;
+        let file_scheduler = self.scheduler.open_file(&path, None).await?;
         match v2::reader::FileReader::try_open(
             file_scheduler,
             None,

--- a/rust/lance-index/src/vector/ivf/shuffler.rs
+++ b/rust/lance-index/src/vector/ivf/shuffler.rs
@@ -507,7 +507,7 @@ impl IvfShuffler {
             } else {
                 let scheduler_config = SchedulerConfig::max_bandwidth(&object_store);
                 let scheduler = ScanScheduler::new(object_store.into(), scheduler_config);
-                let file = scheduler.open_file(&path).await?;
+                let file = scheduler.open_file(&path, None).await?;
                 let cache =
                     FileMetadataCache::with_capacity(128 * 1024 * 1024, CapacityMode::Bytes);
 
@@ -565,7 +565,7 @@ impl IvfShuffler {
                     });
                 }
             } else {
-                let file = scheduler.open_file(&path).await?;
+                let file = scheduler.open_file(&path, None).await?;
                 let reader = Lancev2FileReader::try_open(
                     file,
                     None,
@@ -637,7 +637,7 @@ impl IvfShuffler {
             } else {
                 let scheduler_config = SchedulerConfig::max_bandwidth(&object_store);
                 let scheduler = ScanScheduler::new(Arc::new(object_store), scheduler_config);
-                let file = scheduler.open_file(&path).await?;
+                let file = scheduler.open_file(&path, None).await?;
                 let reader = Lancev2FileReader::try_open(
                     file,
                     None,
@@ -808,7 +808,7 @@ impl IvfShuffler {
             let path = basedir.child(file);
             let scheduler_config = SchedulerConfig::max_bandwidth(&object_store);
             let scan_scheduler = ScanScheduler::new(object_store, scheduler_config);
-            let file_scheduler = scan_scheduler.open_file(&path).await?;
+            let file_scheduler = scan_scheduler.open_file(&path, None).await?;
             let reader = lance_file::v2::reader::FileReader::try_open(
                 file_scheduler,
                 None,

--- a/rust/lance-index/src/vector/ivf/shuffler.rs
+++ b/rust/lance-index/src/vector/ivf/shuffler.rs
@@ -38,6 +38,7 @@ use lance_file::writer::FileWriter;
 use lance_io::object_store::ObjectStore;
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_io::stream::RecordBatchStream;
+use lance_io::utils::CachedFileSize;
 use lance_io::ReadBatchParams;
 use lance_table::format::SelfDescribingFileReader;
 use lance_table::io::manifest::ManifestDescribing;
@@ -507,7 +508,9 @@ impl IvfShuffler {
             } else {
                 let scheduler_config = SchedulerConfig::max_bandwidth(&object_store);
                 let scheduler = ScanScheduler::new(object_store.into(), scheduler_config);
-                let file = scheduler.open_file(&path, None).await?;
+                let file = scheduler
+                    .open_file(&path, &CachedFileSize::unknown())
+                    .await?;
                 let cache =
                     FileMetadataCache::with_capacity(128 * 1024 * 1024, CapacityMode::Bytes);
 
@@ -565,7 +568,9 @@ impl IvfShuffler {
                     });
                 }
             } else {
-                let file = scheduler.open_file(&path, None).await?;
+                let file = scheduler
+                    .open_file(&path, &CachedFileSize::unknown())
+                    .await?;
                 let reader = Lancev2FileReader::try_open(
                     file,
                     None,
@@ -637,7 +642,9 @@ impl IvfShuffler {
             } else {
                 let scheduler_config = SchedulerConfig::max_bandwidth(&object_store);
                 let scheduler = ScanScheduler::new(Arc::new(object_store), scheduler_config);
-                let file = scheduler.open_file(&path, None).await?;
+                let file = scheduler
+                    .open_file(&path, &CachedFileSize::unknown())
+                    .await?;
                 let reader = Lancev2FileReader::try_open(
                     file,
                     None,
@@ -808,7 +815,9 @@ impl IvfShuffler {
             let path = basedir.child(file);
             let scheduler_config = SchedulerConfig::max_bandwidth(&object_store);
             let scan_scheduler = ScanScheduler::new(object_store, scheduler_config);
-            let file_scheduler = scan_scheduler.open_file(&path, None).await?;
+            let file_scheduler = scan_scheduler
+                .open_file(&path, &CachedFileSize::unknown())
+                .await?;
             let reader = lance_file::v2::reader::FileReader::try_open(
                 file_scheduler,
                 None,

--- a/rust/lance-index/src/vector/v3/shuffler.rs
+++ b/rust/lance-index/src/vector/v3/shuffler.rs
@@ -272,7 +272,7 @@ impl ShuffleReader for IvfShufflerReader {
         let partition_path = self.output_dir.child(format!("ivf_{}.lance", partition_id));
 
         let reader = FileReader::try_open(
-            self.scheduler.open_file(&partition_path).await?,
+            self.scheduler.open_file(&partition_path, None).await?,
             None,
             Arc::<DecoderPlugins>::default(),
             &FileMetadataCache::no_cache(),

--- a/rust/lance-index/src/vector/v3/shuffler.rs
+++ b/rust/lance-index/src/vector/v3/shuffler.rs
@@ -26,6 +26,7 @@ use lance_io::{
     object_store::ObjectStore,
     scheduler::{ScanScheduler, SchedulerConfig},
     stream::{RecordBatchStream, RecordBatchStreamAdapter},
+    utils::CachedFileSize,
 };
 use object_store::path::Path;
 use snafu::location;
@@ -272,7 +273,9 @@ impl ShuffleReader for IvfShufflerReader {
         let partition_path = self.output_dir.child(format!("ivf_{}.lance", partition_id));
 
         let reader = FileReader::try_open(
-            self.scheduler.open_file(&partition_path, None).await?,
+            self.scheduler
+                .open_file(&partition_path, &CachedFileSize::unknown())
+                .await?,
             None,
             Arc::<DecoderPlugins>::default(),
             &FileMetadataCache::no_cache(),

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -37,6 +37,7 @@ lazy_static.workspace = true
 log.workspace = true
 pin-project.workspace = true
 prost.workspace = true
+serde.workspace = true
 shellexpand.workspace = true
 snafu.workspace = true
 tokio.workspace = true

--- a/rust/lance-io/benches/scheduler.rs
+++ b/rust/lance-io/benches/scheduler.rs
@@ -95,7 +95,7 @@ fn bench_full_read(c: &mut Criterion) {
                     runtime.block_on(async {
                         let scheduler =
                             ScanScheduler::new(obj_store, SchedulerConfig::default_for_testing());
-                        let file_scheduler = scheduler.open_file(&tmp_file).await.unwrap();
+                        let file_scheduler = scheduler.open_file(&tmp_file, None).await.unwrap();
 
                         let (tx, rx) = mpsc::channel(1024);
                         let drainer = tokio::spawn(drain_task(rx));
@@ -185,7 +185,8 @@ fn bench_random_read(c: &mut Criterion) {
                                 obj_store,
                                 SchedulerConfig::default_for_testing(),
                             );
-                            let file_scheduler = scheduler.open_file(&tmp_file).await.unwrap();
+                            let file_scheduler =
+                                scheduler.open_file(&tmp_file, None).await.unwrap();
 
                             let (tx, rx) = mpsc::channel(1024);
                             let drainer = tokio::spawn(drain_task(rx));

--- a/rust/lance-io/benches/scheduler.rs
+++ b/rust/lance-io/benches/scheduler.rs
@@ -7,6 +7,7 @@ use lance_core::Result;
 use lance_io::{
     object_store::ObjectStore,
     scheduler::{ScanScheduler, SchedulerConfig},
+    utils::CachedFileSize,
 };
 use object_store::path::Path;
 use rand::{seq::SliceRandom, RngCore};
@@ -95,7 +96,10 @@ fn bench_full_read(c: &mut Criterion) {
                     runtime.block_on(async {
                         let scheduler =
                             ScanScheduler::new(obj_store, SchedulerConfig::default_for_testing());
-                        let file_scheduler = scheduler.open_file(&tmp_file, None).await.unwrap();
+                        let file_scheduler = scheduler
+                            .open_file(&tmp_file, &CachedFileSize::unknown())
+                            .await
+                            .unwrap();
 
                         let (tx, rx) = mpsc::channel(1024);
                         let drainer = tokio::spawn(drain_task(rx));
@@ -185,8 +189,10 @@ fn bench_random_read(c: &mut Criterion) {
                                 obj_store,
                                 SchedulerConfig::default_for_testing(),
                             );
-                            let file_scheduler =
-                                scheduler.open_file(&tmp_file, None).await.unwrap();
+                            let file_scheduler = scheduler
+                                .open_file(&tmp_file, &CachedFileSize::unknown())
+                                .await
+                                .unwrap();
 
                             let (tx, rx) = mpsc::channel(1024);
                             let drainer = tokio::spawn(drain_task(rx));

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -35,6 +35,7 @@ use super::local::LocalObjectReader;
 mod list_retry;
 pub mod providers;
 mod tracing;
+use crate::object_reader::SmallReader;
 use crate::object_writer::WriteResult;
 use crate::{object_reader::CloudObjectReader, object_writer::ObjectWriter, traits::Reader};
 use lance_core::{Error, Result};
@@ -384,6 +385,16 @@ impl ObjectStore {
     /// cached metadata. By passing in the known size, we can skip a HEAD / metadata
     /// call.
     pub async fn open_with_size(&self, path: &Path, known_size: usize) -> Result<Box<dyn Reader>> {
+        // If we know the file is really small, we can read the whole thing
+        // as a single request.
+        if known_size <= self.block_size {
+            return Ok(Box::new(SmallReader::new(
+                self.inner.clone(),
+                path.clone(),
+                self.download_retry_count,
+            )));
+        }
+
         match self.scheme.as_str() {
             "file" => LocalObjectReader::open(path, self.block_size, Some(known_size)).await,
             _ => Ok(Box::new(CloudObjectReader::new(

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -392,6 +392,7 @@ impl ObjectStore {
                 self.inner.clone(),
                 path.clone(),
                 self.download_retry_count,
+                known_size,
             )));
         }
 

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -648,7 +648,7 @@ impl ScanScheduler {
             if let Some(size) = NonZero::new(size as u64) {
                 file_size_bytes.set(size);
             }
-            size as usize
+            size
         };
         let reader = self
             .object_store

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -35,6 +35,9 @@ pub struct DataFile {
     /// The minor version of the file format used to write this file.
     #[serde(default)]
     pub file_minor_version: u32,
+
+    /// The size of the file in bytes, if known.
+    pub file_size_bytes: Option<u64>,
 }
 
 impl DataFile {
@@ -44,6 +47,7 @@ impl DataFile {
         column_indices: Vec<i32>,
         file_major_version: u32,
         file_minor_version: u32,
+        file_size_bytes: Option<u64>,
     ) -> Self {
         Self {
             path: path.into(),
@@ -51,6 +55,7 @@ impl DataFile {
             column_indices,
             file_major_version,
             file_minor_version,
+            file_size_bytes,
         }
     }
 
@@ -66,6 +71,7 @@ impl DataFile {
             column_indices: vec![],
             file_major_version,
             file_minor_version,
+            file_size_bytes: None,
         }
     }
 
@@ -76,10 +82,15 @@ impl DataFile {
             vec![],
             MAJOR_VERSION as u32,
             MINOR_VERSION as u32,
+            None,
         )
     }
 
-    pub fn new_legacy(path: impl Into<String>, schema: &Schema) -> Self {
+    pub fn new_legacy(
+        path: impl Into<String>,
+        schema: &Schema,
+        file_size_bytes: Option<u64>,
+    ) -> Self {
         let mut field_ids = schema.field_ids();
         field_ids.sort();
         Self::new(
@@ -88,6 +99,7 @@ impl DataFile {
             vec![],
             MAJOR_VERSION as u32,
             MINOR_VERSION as u32,
+            file_size_bytes,
         )
     }
 
@@ -127,6 +139,7 @@ impl From<&DataFile> for pb::DataFile {
             column_indices: df.column_indices.clone(),
             file_major_version: df.file_major_version,
             file_minor_version: df.file_minor_version,
+            file_size_bytes: df.file_size_bytes.unwrap_or_default(),
         }
     }
 }
@@ -141,6 +154,11 @@ impl TryFrom<pb::DataFile> for DataFile {
             column_indices: proto.column_indices,
             file_major_version: proto.file_major_version,
             file_minor_version: proto.file_minor_version,
+            file_size_bytes: if proto.file_size_bytes > 0 {
+                Some(proto.file_size_bytes)
+            } else {
+                None
+            },
         })
     }
 }
@@ -298,7 +316,7 @@ impl Fragment {
     ) -> Self {
         Self {
             id,
-            files: vec![DataFile::new_legacy(path, schema)],
+            files: vec![DataFile::new_legacy(path, schema, None)],
             deletion_file: None,
             physical_rows,
             row_id_meta: None,
@@ -311,15 +329,22 @@ impl Fragment {
         field_ids: Vec<i32>,
         column_indices: Vec<i32>,
         version: &LanceFileVersion,
+        file_size_bytes: Option<u64>,
     ) {
         let (major, minor) = version.to_numbers();
-        self.files
-            .push(DataFile::new(path, field_ids, column_indices, major, minor));
+        self.files.push(DataFile::new(
+            path,
+            field_ids,
+            column_indices,
+            major,
+            minor,
+            file_size_bytes,
+        ));
     }
 
     /// Add a new [`DataFile`] to this fragment.
     pub fn add_file_legacy(&mut self, path: &str, schema: &Schema) {
-        self.files.push(DataFile::new_legacy(path, schema));
+        self.files.push(DataFile::new_legacy(path, schema, None));
     }
 
     // True if this fragment is made up of legacy v1 files, false otherwise
@@ -505,9 +530,12 @@ mod tests {
             json!({
                 "id": 123,
                 "files":[
-                    {"path": "foobar.lance", "fields": [0], "column_indices": [], "file_major_version": MAJOR_VERSION, "file_minor_version": MINOR_VERSION}],
-                     "deletion_file": {"read_version": 123, "id": 456, "file_type": "array",
-                                       "num_deleted_rows": 10},
+                    {"path": "foobar.lance", "fields": [0], "column_indices": [], 
+                     "file_major_version": MAJOR_VERSION, "file_minor_version": MINOR_VERSION,
+                     "file_size_bytes": null }
+                ],
+                "deletion_file": {"read_version": 123, "id": 456, "file_type": "array",
+                                  "num_deleted_rows": 10},
                 "physical_rows": None::<usize>}),
         );
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1795,6 +1795,7 @@ mod tests {
     use lance_index::scalar::inverted::TokenizerConfig;
     use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
     use lance_index::{scalar::ScalarIndexParams, vector::DIST_COL, DatasetIndexExt, IndexType};
+    use lance_io::utils::CachedFileSize;
     use lance_linalg::distance::MetricType;
     use lance_table::feature_flags;
     use lance_table::format::{DataFile, WriterVersion};
@@ -5963,7 +5964,7 @@ mod tests {
             column_indices: vec![0],
             file_major_version: 2,
             file_minor_version: 0,
-            file_size_bytes: None,
+            file_size_bytes: CachedFileSize::unknown(),
         };
 
         let dataset = Dataset::commit(
@@ -6017,7 +6018,7 @@ mod tests {
             column_indices: vec![0],
             file_major_version: 2,
             file_minor_version: 0,
-            file_size_bytes: None,
+            file_size_bytes: CachedFileSize::unknown(),
         };
 
         let dataset = Dataset::commit(
@@ -6115,7 +6116,7 @@ mod tests {
             column_indices: vec![0],
             file_major_version: 2,
             file_minor_version: 0,
-            file_size_bytes: None,
+            file_size_bytes: CachedFileSize::unknown(),
         };
 
         let new_data_file = DataFile {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -5963,6 +5963,7 @@ mod tests {
             column_indices: vec![0],
             file_major_version: 2,
             file_minor_version: 0,
+            file_size_bytes: None,
         };
 
         let dataset = Dataset::commit(
@@ -6016,6 +6017,7 @@ mod tests {
             column_indices: vec![0],
             file_major_version: 2,
             file_minor_version: 0,
+            file_size_bytes: None,
         };
 
         let dataset = Dataset::commit(
@@ -6113,6 +6115,7 @@ mod tests {
             column_indices: vec![0],
             file_major_version: 2,
             file_minor_version: 0,
+            file_size_bytes: None,
         };
 
         let new_data_file = DataFile {

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -666,7 +666,7 @@ impl FileFragment {
                 dataset.object_store.clone(),
                 SchedulerConfig::max_bandwidth(&dataset.object_store),
             );
-            let file_scheduler = scheduler.open_file(&filepath).await?;
+            let file_scheduler = scheduler.open_file(&filepath, None).await?;
             let reader = v2::reader::FileReader::try_open(
                 file_scheduler,
                 None,
@@ -698,6 +698,7 @@ impl FileFragment {
                 dataset.schema().field_ids(),
                 column_indices,
                 &file_version,
+                None,
             );
             Ok(frag)
         }
@@ -884,7 +885,7 @@ impl FileFragment {
                     )
                 };
             let file_scheduler = store_scheduler
-                .open_file_with_priority(&path, reader_priority as u64)
+                .open_file_with_priority(&path, reader_priority as u64, data_file.file_size_bytes)
                 .await?;
             let file_metadata = self.get_file_metadata(&file_scheduler).await?;
             let path = file_scheduler.reader().path().clone();
@@ -2239,13 +2240,18 @@ mod tests {
     use lance_core::ROW_ID;
     use lance_datagen::{array, gen, RowCount};
     use lance_file::version::LanceFileVersion;
+    use lance_io::object_store::ObjectStoreParams;
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use tempfile::tempdir;
     use v2::writer::FileWriterOptions;
 
     use super::*;
-    use crate::{dataset::transaction::Operation, utils::test::TestDatasetGenerator};
+    use crate::{
+        dataset::{transaction::Operation, InsertBuilder},
+        session::Session,
+        utils::test::{StatsHolder, TestDatasetGenerator},
+    };
 
     async fn create_dataset(test_uri: &str, data_storage_version: LanceFileVersion) -> Dataset {
         let schema = Arc::new(ArrowSchema::new(vec![
@@ -3315,5 +3321,71 @@ mod tests {
                 .unwrap(),
             256
         );
+    }
+
+    #[tokio::test]
+    async fn test_iops_read_small() {
+        // Create a file that has 10 columns.
+        let schema = Arc::new(ArrowSchema::new(
+            (0..10)
+                .map(|i| ArrowField::new(format!("col_{}", i), DataType::Int32, true))
+                .collect::<Vec<_>>(),
+        ));
+
+        // Single row batch
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            (0..10)
+                .map(|i| Arc::new(Int32Array::from(vec![i])) as ArrayRef)
+                .collect(),
+        )
+        .unwrap();
+        let session = Arc::new(Session::default());
+        let io_stats = Arc::new(StatsHolder::default());
+        let write_params = WriteParams {
+            store_params: Some(ObjectStoreParams {
+                object_store_wrapper: Some(io_stats.clone()),
+                ..Default::default()
+            }),
+            session: Some(session.clone()),
+            ..Default::default()
+        };
+        let dataset = InsertBuilder::new("memory://test")
+            .with_params(&write_params)
+            .execute(vec![batch])
+            .await
+            .unwrap();
+        let fragment = dataset.get_fragments().pop().unwrap();
+
+        // Assert file is small (< 4kb)
+        {
+            let stats = io_stats.incremental_stats();
+            assert_eq!(stats.write_iops, 3);
+            assert!(stats.write_bytes < 4096);
+        }
+
+        // Measure IOPS needed to scan all data first time.
+        let projection = Schema::try_from(schema.as_ref())
+            .unwrap()
+            .project_by_ids(&[0, 1, 2, 3, 4, 6, 7, 8, 9], true);
+        let reader = fragment
+            .open(&projection, Default::default())
+            .await
+            .unwrap();
+        let mut data = reader
+            .read_all(1024)
+            .unwrap()
+            .buffered(1)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(data.len(), 1);
+        let data = data.pop().unwrap();
+        assert_eq!(data.num_rows(), 1);
+        assert_eq!(data.num_columns(), 9);
+
+        let stats = io_stats.incremental_stats();
+        assert_eq!(stats.read_iops, 1);
+        assert!(stats.read_bytes < 4096);
     }
 }

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -996,6 +996,7 @@ impl Transaction {
                                 new_file.file_minor_version,
                             )
                             .expect("Expected valid file version"),
+                            new_file.file_size_bytes,
                         );
                     }
 

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -996,7 +996,7 @@ impl Transaction {
                                 new_file.file_minor_version,
                             )
                             .expect("Expected valid file version"),
-                            new_file.file_size_bytes,
+                            new_file.file_size_bytes.get(),
                         );
                     }
 

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::num::NonZero;
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
@@ -490,7 +491,11 @@ impl<M: ManifestProvider + Send + Sync> GenericWriter for (FileWriter<M>, String
         let size_bytes = self.0.tell().await?;
         Ok((
             self.0.finish().await? as u32,
-            DataFile::new_legacy(self.1.clone(), self.0.schema(), Some(size_bytes as u64)),
+            DataFile::new_legacy(
+                self.1.clone(),
+                self.0.schema(),
+                NonZero::new(size_bytes as u64),
+            ),
         ))
     }
 }
@@ -532,7 +537,7 @@ impl GenericWriter for V2WriterAdapter {
             column_indices,
             major,
             minor,
-            Some(self.writer.tell().await?),
+            NonZero::new(self.writer.tell().await?),
         );
         Ok((num_rows, data_file))
     }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -487,9 +487,10 @@ impl<M: ManifestProvider + Send + Sync> GenericWriter for (FileWriter<M>, String
         Ok(self.0.tell().await? as u64)
     }
     async fn finish(&mut self) -> Result<(u32, DataFile)> {
+        let size_bytes = self.0.tell().await?;
         Ok((
             self.0.finish().await? as u32,
-            DataFile::new_legacy(self.1.clone(), self.0.schema()),
+            DataFile::new_legacy(self.1.clone(), self.0.schema(), Some(size_bytes as u64)),
         ))
     }
 }
@@ -524,14 +525,15 @@ impl GenericWriter for V2WriterAdapter {
             .map(|(_, column_index)| *column_index as i32)
             .collect::<Vec<_>>();
         let (major, minor) = self.writer.version().to_numbers();
+        let num_rows = self.writer.finish().await? as u32;
         let data_file = DataFile::new(
             std::mem::take(&mut self.path),
             field_ids,
             column_indices,
             major,
             minor,
+            Some(self.writer.tell().await?),
         );
-        let num_rows = self.writer.finish().await? as u32;
         Ok((num_rows, data_file))
     }
 }

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -423,6 +423,7 @@ mod tests {
                 column_indices: vec![0],
                 file_major_version: 2,
                 file_minor_version: 0,
+                file_size_bytes: Some(100),
             }],
             deletion_file: None,
             row_id_meta: None,

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -408,6 +408,7 @@ pub struct BatchCommitResult {
 mod tests {
     use arrow::array::{Int32Array, RecordBatch};
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+    use lance_io::utils::CachedFileSize;
     use lance_table::format::{DataFile, Fragment};
 
     use crate::dataset::{InsertBuilder, WriteParams};
@@ -423,7 +424,7 @@ mod tests {
                 column_indices: vec![0],
                 file_major_version: 2,
                 file_minor_version: 0,
-                file_size_bytes: Some(100),
+                file_size_bytes: CachedFileSize::new(100),
             }],
             deletion_file: None,
             row_id_meta: None,

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -1109,6 +1109,7 @@ impl MergeInsertJob {
                     let sleep_fut =
                         maybe_timeout(&backoff, start, self.params.retry_timeout, sleep_fut);
                     sleep_fut.await?;
+
                     let mut ds = dataset_ref.as_ref().clone();
                     ds.checkout_latest().await?;
 

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -1109,7 +1109,6 @@ impl MergeInsertJob {
                     let sleep_fut =
                         maybe_timeout(&backoff, start, self.params.retry_timeout, sleep_fut);
                     sleep_fut.await?;
-
                     let mut ds = dataset_ref.as_ref().clone();
                     ds.checkout_latest().await?;
 

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -43,6 +43,7 @@ use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_io::traits::Reader;
 use lance_io::utils::{
     read_last_block, read_message, read_message_from_buf, read_metadata_offset, read_version,
+    CachedFileSize,
 };
 use lance_table::format::Index as IndexMetadata;
 use lance_table::format::{Fragment, SelfDescribingFileReader};
@@ -868,7 +869,9 @@ impl DatasetIndexInternalExt for Dataset {
                     self.object_store.clone(),
                     SchedulerConfig::max_bandwidth(&self.object_store),
                 );
-                let file = scheduler.open_file(&index_file, None).await?;
+                let file = scheduler
+                    .open_file(&index_file, &CachedFileSize::unknown())
+                    .await?;
                 let reader = v2::reader::FileReader::try_open(
                     file,
                     None,

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -868,7 +868,7 @@ impl DatasetIndexInternalExt for Dataset {
                     self.object_store.clone(),
                     SchedulerConfig::max_bandwidth(&self.object_store),
                 );
-                let file = scheduler.open_file(&index_file).await?;
+                let file = scheduler.open_file(&index_file, None).await?;
                 let reader = v2::reader::FileReader::try_open(
                     file,
                     None,

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -46,6 +46,7 @@ use lance_index::{
 use lance_index::{IndexMetadata, INDEX_METADATA_SCHEMA_KEY};
 use lance_io::scheduler::SchedulerConfig;
 use lance_io::stream::RecordBatchStream;
+use lance_io::utils::CachedFileSize;
 use lance_io::{
     object_store::ObjectStore, scheduler::ScanScheduler, stream::RecordBatchStreamAdapter,
     ReadBatchParams,
@@ -725,7 +726,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             } else {
                 let storage_part_path = self.temp_dir.child(format!("storage_part{}", part_id));
                 let reader = FileReader::try_open(
-                    scheduler.open_file(&storage_part_path, None).await?,
+                    scheduler
+                        .open_file(&storage_part_path, &CachedFileSize::unknown())
+                        .await?,
                     None,
                     Arc::<DecoderPlugins>::default(),
                     &FileMetadataCache::no_cache(),
@@ -759,7 +762,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             } else {
                 let index_part_path = self.temp_dir.child(format!("index_part{}", part_id));
                 let reader = FileReader::try_open(
-                    scheduler.open_file(&index_part_path, None).await?,
+                    scheduler
+                        .open_file(&index_part_path, &CachedFileSize::unknown())
+                        .await?,
                     None,
                     Arc::<DecoderPlugins>::default(),
                     &FileMetadataCache::no_cache(),

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -725,7 +725,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             } else {
                 let storage_part_path = self.temp_dir.child(format!("storage_part{}", part_id));
                 let reader = FileReader::try_open(
-                    scheduler.open_file(&storage_part_path).await?,
+                    scheduler.open_file(&storage_part_path, None).await?,
                     None,
                     Arc::<DecoderPlugins>::default(),
                     &FileMetadataCache::no_cache(),
@@ -759,7 +759,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             } else {
                 let index_part_path = self.temp_dir.child(format!("index_part{}", part_id));
                 let reader = FileReader::try_open(
-                    scheduler.open_file(&index_part_path).await?,
+                    scheduler.open_file(&index_part_path, None).await?,
                     None,
                     Arc::<DecoderPlugins>::default(),
                     &FileMetadataCache::no_cache(),

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -49,6 +49,7 @@ use lance_index::{
 use lance_index::{IndexMetadata, INDEX_METADATA_SCHEMA_KEY};
 use lance_io::local::to_local_path;
 use lance_io::scheduler::SchedulerConfig;
+use lance_io::utils::CachedFileSize;
 use lance_io::{
     object_store::ObjectStore, scheduler::ScanScheduler, traits::Reader, ReadBatchParams,
 };
@@ -133,7 +134,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             .unwrap_or_else(FileMetadataCache::no_cache);
         let uri = index_dir.child(uuid.as_str()).child(INDEX_FILE_NAME);
         let index_reader = FileReader::try_open(
-            scheduler.open_file(&uri, None).await?,
+            scheduler
+                .open_file(&uri, &CachedFileSize::unknown())
+                .await?,
             None,
             Arc::<DecoderPlugins>::default(),
             &file_metadata_cache,
@@ -185,7 +188,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
                     &index_dir
                         .child(uuid.as_str())
                         .child(INDEX_AUXILIARY_FILE_NAME),
-                    None,
+                    &CachedFileSize::unknown(),
                 )
                 .await?,
             None,

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -133,7 +133,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             .unwrap_or_else(FileMetadataCache::no_cache);
         let uri = index_dir.child(uuid.as_str()).child(INDEX_FILE_NAME);
         let index_reader = FileReader::try_open(
-            scheduler.open_file(&uri).await?,
+            scheduler.open_file(&uri, None).await?,
             None,
             Arc::<DecoderPlugins>::default(),
             &file_metadata_cache,
@@ -185,6 +185,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
                     &index_dir
                         .child(uuid.as_str())
                         .child(INDEX_AUXILIARY_FILE_NAME),
+                    None,
                 )
                 .await?,
             None,


### PR DESCRIPTION
Bring back changes from #3763 and build upon them.

Improvements made:

* Changed `file_size_bytes` into an atomic u64, so it can be filled in as we read values, rather than requiring a separate migration step.
* Adds an early return for `merge_insert` when we've exhausted retries.
* Make sure `SmallReader` caches the file size so we can return immediately on calls to `.size()` instead of waiting for the IO request to finish.