### PR TITLE
fix: don't lose rows during bitmap remap if rows not being remapped

### DIFF
--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -274,12 +274,14 @@ impl ScalarIndex for BitmapIndex {
             .index_map
             .iter()
             .map(|(key, bitmap)| {
-                let bitmap = RowIdTreeMap::from_iter(
-                    bitmap
-                        .row_ids()
-                        .unwrap()
-                        .filter_map(|addr| *mapping.get(&u64::from(addr))?),
-                );
+                let bitmap =
+                    RowIdTreeMap::from_iter(bitmap.row_ids().unwrap().filter_map(|addr| {
+                        let addr_as_u64 = u64::from(addr);
+                        mapping
+                            .get(&addr_as_u64)
+                            .copied()
+                            .unwrap_or(Some(addr_as_u64))
+                    }));
                 (key.0.clone(), bitmap)
             })
             .collect::<HashMap<_, _>>();


### PR DESCRIPTION
If a compaction rewrites some (but not all) fragments in an index then the remapping will be partial remapping.  The bitmap index was not properly respecting this and was dropping rows that were not in the remapping (instead of keeping them as they were originally).