### PR TITLE
feat: add tracing spans to ScanExec and TakeExec

### DIFF
--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -57,7 +57,7 @@ serde_json = "1"
 serde = "1.0.197"
 serde_yaml = "0.9.34"
 snafu = "0.8"
-tracing-chrome = "0.7.1"
+tracing-chrome = "0.7.2"
 tracing-subscriber = "0.3.17"
 tracing = { version = "0.1" }
 url = "2.5.0"

--- a/rust/lance-core/src/utils.rs
+++ b/rust/lance-core/src/utils.rs
@@ -11,6 +11,7 @@ pub mod hash;
 pub mod mask;
 pub mod parse;
 pub mod path;
+pub mod stream;
 pub mod testing;
 pub mod tokio;
 pub mod tracing;

--- a/rust/lance-core/src/utils/stream.rs
+++ b/rust/lance-core/src/utils/stream.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use futures::{
+    stream::{BoxStream, TryStream, TryStreamExt},
+    StreamExt, TryFuture,
+};
+
+pub trait LanceTryStreamExt: TryStream {
+    fn try_buffered_with_ordering<'a>(
+        self,
+        buffer_size: usize,
+        ordered: bool,
+    ) -> BoxStream<'a, Result<<Self::Ok as TryFuture>::Ok, Self::Error>>
+    where
+        Self::Ok: TryFuture<Error = Self::Error> + Send,
+        Self: Sized + 'a + Send,
+        <Self as TryStream>::Error: Send,
+        <Self as TryStream>::Ok: Send,
+        <<Self as TryStream>::Ok as TryFuture>::Ok: Send,
+    {
+        if ordered {
+            self.try_buffered(buffer_size).boxed()
+        } else {
+            self.try_buffer_unordered(buffer_size).boxed()
+        }
+    }
+}
+
+impl<S: ?Sized + TryStream> LanceTryStreamExt for S {}

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -1970,36 +1970,39 @@ fn create_scheduler_decoder(
         rx,
     );
 
-    let scheduler_handle = tokio::task::spawn(async move {
-        let mut decode_scheduler = match DecodeBatchScheduler::try_new(
-            target_schema.as_ref(),
-            &column_indices,
-            &column_infos,
-            &vec![],
-            num_rows,
-            config.decoder_plugins,
-            config.io.clone(),
-            config.cache,
-            &filter,
-        )
-        .await
-        {
-            Ok(scheduler) => scheduler,
-            Err(e) => {
-                let _ = tx.send(Err(e));
-                return;
-            }
-        };
+    let scheduler_handle = tokio::task::spawn(
+        (async move {
+            let mut decode_scheduler = match DecodeBatchScheduler::try_new(
+                target_schema.as_ref(),
+                &column_indices,
+                &column_infos,
+                &vec![],
+                num_rows,
+                config.decoder_plugins,
+                config.io.clone(),
+                config.cache,
+                &filter,
+            )
+            .await
+            {
+                Ok(scheduler) => scheduler,
+                Err(e) => {
+                    let _ = tx.send(Err(e));
+                    return;
+                }
+            };
 
-        match requested_rows {
-            RequestedRows::Ranges(ranges) => {
-                decode_scheduler.schedule_ranges(&ranges, &filter, tx, config.io)
+            match requested_rows {
+                RequestedRows::Ranges(ranges) => {
+                    decode_scheduler.schedule_ranges(&ranges, &filter, tx, config.io)
+                }
+                RequestedRows::Indices(indices) => {
+                    decode_scheduler.schedule_take(&indices, &filter, tx, config.io)
+                }
             }
-            RequestedRows::Indices(indices) => {
-                decode_scheduler.schedule_take(&indices, &filter, tx, config.io)
-            }
-        }
-    });
+        })
+        .in_current_span(),
+    );
 
     Ok(check_scheduler_on_drop(decode_stream, scheduler_handle))
 }

--- a/rust/lance-io/src/local.rs
+++ b/rust/lance-io/src/local.rs
@@ -85,7 +85,7 @@ impl LocalObjectReader {
     }
 
     /// Open a local object reader, with default prefetch size.
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip(path), fields(path = path.as_ref()))]
     pub async fn open(
         path: &Path,
         block_size: usize,

--- a/rust/lance-io/src/object_store/tracing.rs
+++ b/rust/lance-io/src/object_store/tracing.rs
@@ -59,12 +59,14 @@ impl std::fmt::Display for TracedObjectStore {
 #[async_trait::async_trait]
 #[deny(clippy::missing_trait_methods)]
 impl object_store::ObjectStore for TracedObjectStore {
-    #[instrument(level = "debug", skip(self, bytes))]
+    // Instead of using Path in trace span, use use Path.as_ref() -> &str which
+    // is cleaner.
+    #[instrument(level = "debug", skip(self, bytes, location), fields(path = location.as_ref()))]
     async fn put(&self, location: &Path, bytes: PutPayload) -> OSResult<PutResult> {
         self.target.put(location, bytes).await
     }
 
-    #[instrument(level = "debug", skip(self, bytes))]
+    #[instrument(level = "debug", skip(self, bytes, location), fields(path = location.as_ref()))]
     async fn put_opts(
         &self,
         location: &Path,
@@ -97,32 +99,32 @@ impl object_store::ObjectStore for TracedObjectStore {
         }))
     }
 
-    #[instrument(level = "debug", skip(self, location))]
+    #[instrument(level = "debug", skip(self, location), fields(path = location.as_ref()))]
     async fn get(&self, location: &Path) -> OSResult<GetResult> {
         self.target.get(location).await
     }
 
-    #[instrument(level = "debug", skip(self, options))]
+    #[instrument(level = "debug", skip(self, options, location), fields(path = location.as_ref()))]
     async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
         self.target.get_opts(location, options).await
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self, location), fields(path = location.as_ref()))]
     async fn get_range(&self, location: &Path, range: Range<usize>) -> OSResult<Bytes> {
         self.target.get_range(location, range).await
     }
 
-    #[instrument(level = "debug", skip(self, ranges))]
+    #[instrument(level = "debug", skip(self, location), fields(path = location.as_ref()))]
     async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> OSResult<Vec<Bytes>> {
         self.target.get_ranges(location, ranges).await
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self, location), fields(path = location.as_ref()))]
     async fn head(&self, location: &Path) -> OSResult<ObjectMeta> {
         self.target.head(location).await
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self, location), fields(path = location.as_ref()))]
     async fn delete(&self, location: &Path) -> OSResult<()> {
         self.target.delete(location).await
     }
@@ -138,12 +140,12 @@ impl object_store::ObjectStore for TracedObjectStore {
             .boxed()
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self, prefix), fields(prefix = prefix.map(|p| p.as_ref())))]
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, OSResult<ObjectMeta>> {
         self.target.list(prefix).stream_in_current_span().boxed()
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self, prefix, offset), fields(prefix = prefix.map(|p| p.as_ref()), offset = offset.as_ref()))]
     fn list_with_offset(
         &self,
         prefix: Option<&Path>,
@@ -155,27 +157,27 @@ impl object_store::ObjectStore for TracedObjectStore {
             .boxed()
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self, prefix), fields(prefix = prefix.map(|p| p.as_ref())))]
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
         self.target.list_with_delimiter(prefix).await
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self, from, to), fields(from = from.as_ref(), to = to.as_ref()))]
     async fn copy(&self, from: &Path, to: &Path) -> OSResult<()> {
         self.target.copy(from, to).await
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self, from, to), fields(from = from.as_ref(), to = to.as_ref()))]
     async fn rename(&self, from: &Path, to: &Path) -> OSResult<()> {
         self.target.rename(from, to).await
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self, from, to), fields(from = from.as_ref(), to = to.as_ref()))]
     async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
         self.target.rename_if_not_exists(from, to).await
     }
 
-    #[instrument(level = "debug", skip(self))]
+    #[instrument(level = "debug", skip(self, from, to), fields(from = from.as_ref(), to = to.as_ref()))]
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
         self.target.copy_if_not_exists(from, to).await
     }

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -14,6 +14,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::sync::{Notify, Semaphore, SemaphorePermit};
+use tracing::{instrument, Instrument};
 
 use lance_core::{Error, Result};
 
@@ -480,6 +481,7 @@ impl IoTask {
 
 // Every time a scheduler starts up it launches a task to run the I/O loop.  This loop
 // repeats endlessly until the scheduler is destroyed.
+#[instrument(skip(tasks))]
 async fn run_io_loop(tasks: Arc<IoQueue>) {
     // Pop the first finished task off the queue and submit another until
     // we are done
@@ -487,7 +489,7 @@ async fn run_io_loop(tasks: Arc<IoQueue>) {
         let next_task = tasks.pop().await;
         match next_task {
             Some(task) => {
-                tokio::spawn(task.run());
+                tokio::spawn(task.run().in_current_span());
             }
             None => {
                 // The sender has been dropped, we are done

--- a/rust/lance-table/src/io/deletion.rs
+++ b/rust/lance-table/src/io/deletion.rs
@@ -18,7 +18,7 @@ use object_store::path::Path;
 use rand::Rng;
 use roaring::bitmap::RoaringBitmap;
 use snafu::{location, ResultExt};
-use tracing::{info, instrument};
+use tracing::info;
 
 use crate::format::{DeletionFile, DeletionFileType, Fragment};
 
@@ -123,7 +123,6 @@ pub async fn write_deletion_file(
 /// Returns the deletion vector if one was present. Otherwise returns `Ok(None)`.
 ///
 /// Will return an error if the file is present but invalid.
-#[instrument(level = "debug", skip_all)]
 pub async fn read_deletion_file(
     base: &Path,
     fragment: &Fragment,
@@ -133,11 +132,19 @@ pub async fn read_deletion_file(
         return Ok(None);
     };
 
+    // Create span after early return to avoid creating a span if we don't need it.
+    let span = tracing::debug_span!(
+        "lance::io::deletion::read_deletion_file",
+        fragment_id = fragment.id,
+        bytes_read = tracing::field::Empty,
+    );
+
     match deletion_file.file_type {
         DeletionFileType::Array => {
             let path = deletion_file_path(base, fragment.id, deletion_file);
 
             let data = object_store.read_one_all(&path).await?;
+            span.record("bytes_read", data.len());
             let data = std::io::Cursor::new(data);
             let mut batches: Vec<RecordBatch> = ArrowFileReader::try_new(data, None)?
                 .collect::<std::result::Result<_, ArrowError>>()
@@ -195,6 +202,7 @@ pub async fn read_deletion_file(
             let path = deletion_file_path(base, fragment.id, deletion_file);
 
             let data = object_store.read_one_all(&path).await?;
+            span.record("bytes_read", data.len());
             let reader = data.reader();
             let bitmap = RoaringBitmap::deserialize_from(reader)
                 .map_err(box_error)

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -10,6 +10,7 @@ use lance_table::{
     io::commit::{CommitConfig, CommitHandler, ManifestNamingScheme},
 };
 use snafu::location;
+use tracing::instrument;
 
 use crate::{
     dataset::{
@@ -148,6 +149,7 @@ impl<'a> CommitBuilder<'a> {
         self
     }
 
+    #[instrument(name = "CommitBuilder::execute", level = "debug", skip_all)]
     pub async fn execute(self, transaction: Transaction) -> Result<Dataset> {
         let session = self
             .session

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -72,6 +72,7 @@ use log::info;
 use roaring::RoaringTreemap;
 use snafu::{location, ResultExt};
 use tokio::task::JoinSet;
+use tracing::instrument;
 
 use crate::{
     datafusion::dataframe::SessionContextExt,
@@ -1053,6 +1054,11 @@ impl MergeInsertJob {
         self.execute_uncommitted_impl(stream).await
     }
 
+    #[instrument(
+        name = "MergeInsertJob::execute_uncommitted_impl",
+        level = "debug",
+        skip_all
+    )]
     async fn execute_uncommitted_impl(
         self,
         source: SendableRecordBatchStream,

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -258,6 +258,7 @@ impl TakeStream {
     fn apply<S: Stream<Item = Result<RecordBatch>> + Send + 'static>(
         self: Arc<Self>,
         input: S,
+        span: tracing::Span,
     ) -> impl Stream<Item = Result<RecordBatch>> {
         let scan_scheduler = self.scan_scheduler.clone();
         let metrics = self.metrics.clone();
@@ -276,6 +277,11 @@ impl TakeStream {
             .try_buffered(get_num_compute_intensive_cpus())
             .finally(move || {
                 metrics.io_metrics.record_final(scan_scheduler.as_ref());
+
+                let scan_stats = scan_scheduler.stats();
+                span.record("iops", scan_stats.iops);
+                span.record("requests", scan_stats.requests);
+                span.record("bytes_read", scan_stats.bytes_read);
             })
     }
 }
@@ -494,7 +500,11 @@ impl ExecutionPlan for TakeExec {
         }
     }
 
-    #[instrument(level = "debug", skip(self, context))]
+    #[instrument(level = "debug", skip(self, context), fields(
+        iops = tracing::field::Empty,
+        requests = tracing::field::Empty,
+        bytes_read = tracing::field::Empty,
+    ))]
     fn execute(
         &self,
         partition: usize,
@@ -505,6 +515,8 @@ impl ExecutionPlan for TakeExec {
         let schema_to_take = self.schema_to_take.clone();
         let output_schema = self.output_schema.clone();
         let metrics = self.metrics.clone();
+
+        let span = tracing::Span::current();
 
         // ScanScheduler::new launches the I/O scheduler in the background.
         // We aren't allowed to do work in `execute` and so we defer creation of the
@@ -522,7 +534,7 @@ impl ExecutionPlan for TakeExec {
                 &metrics,
                 partition,
             ));
-            take_stream.apply(input_stream)
+            take_stream.apply(input_stream, span)
         });
         let output_schema = self.output_schema.clone();
         Ok(Box::pin(RecordBatchStreamAdapter::new(


### PR DESCRIPTION
* Fixes spans to record `object_store::path::Path` with `.as_ref()`, so it displays as `"/my/path"` instead of `Path { inner: "/my/path/" }`.
* Add `size` fields to some object store spans
* Pass span does into the background IO loop of the scheduler. This way we can see all IO calls associated with a query in its spans.
* Changes `read_deletion_file` span to only start if there is a deletion file. This reduces span spam in the traces where there are no deletion files.
* Change `apply_deletions` span to only start if there are deletions. Similar to above, reduces span clutter in traces.
* Add spans to `MergeInsertJob::execute_uncommitted_impl` and `CommitBuilder::execute` so we can clearly see the write and commit step in each attempt of `MergeInsert` job retries.
* Add spans for `LanceScanExec::execute` and `TakeExec::execute`. Each of these will also record the IO metrics as part of their span attributes.
* perf: In V2 scans, use out-of-order buffering of read futures if the user didn't request ordered output for the scan.