### PR TITLE
docs:clarify instructions on where to run maturin develop

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -101,7 +101,11 @@ To make a dev install:
 
 .. code-block::
 
+    cd python
     maturin develop
+
+To use the local python bindings, it's recommended to use venv or conda
+environment.
 
 Documentation
 ~~~~~~~~~~~~~


### PR DESCRIPTION
`maturin develop` does not work at the top level directory, make it explicit in the guide.

```
➜  lance git:(improve-developer-guide-on-build) ✗ source .venv/bin/activate                  
((.venv) ) ➜  lance git:(improve-developer-guide-on-build) ✗ maturin develop          
💥 maturin failed
  Caused by: Failed to parse Cargo.toml at /Users/haochengliu/Documents/projects/lance/Cargo.toml
  Caused by: TOML parse error at line 1, column 1
  |
1 | [workspace]
  | ^
missing field `package`
```