### PR TITLE
fix: flat scan frags not covered by scalar index when doing prefilter search

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1584,6 +1584,96 @@ impl Scanner {
         Ok(plan)
     }
 
+    async fn fragments_covered_by_fts_leaf(
+        &self,
+        column: &str,
+        accum: &mut RoaringBitmap,
+    ) -> Result<bool> {
+        let index = self
+            .dataset
+            .load_scalar_index_for_column(column)
+            .await?
+            .ok_or(Error::invalid_input(
+                format!("Column {} has no inverted index", column),
+                location!(),
+            ))?;
+        if let Some(fragmap) = &index.fragment_bitmap {
+            *accum |= fragmap;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    #[async_recursion]
+    async fn fragments_covered_by_fts_query_helper(
+        &self,
+        query: &FtsQuery,
+        accum: &mut RoaringBitmap,
+    ) -> Result<bool> {
+        match query {
+            FtsQuery::Match(match_query) => {
+                self.fragments_covered_by_fts_leaf(
+                    match_query.column.as_ref().ok_or(Error::invalid_input(
+                        "the column must be specified in the query".to_string(),
+                        location!(),
+                    ))?,
+                    accum,
+                )
+                .await
+            }
+            FtsQuery::Boost(boost) => Ok(self
+                .fragments_covered_by_fts_query_helper(&boost.negative, accum)
+                .await?
+                & self
+                    .fragments_covered_by_fts_query_helper(&boost.positive, accum)
+                    .await?),
+            FtsQuery::MultiMatch(multi_match) => {
+                for mq in &multi_match.match_queries {
+                    if !self
+                        .fragments_covered_by_fts_leaf(
+                            mq.column.as_ref().ok_or(Error::invalid_input(
+                                "the column must be specified in the query".to_string(),
+                                location!(),
+                            ))?,
+                            accum,
+                        )
+                        .await?
+                    {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            FtsQuery::Phrase(phrase_query) => {
+                self.fragments_covered_by_fts_leaf(
+                    phrase_query.column.as_ref().ok_or(Error::invalid_input(
+                        "the column must be specified in the query".to_string(),
+                        location!(),
+                    ))?,
+                    accum,
+                )
+                .await
+            }
+        }
+    }
+
+    async fn fragments_covered_by_fts_query(&self, query: &FtsQuery) -> Result<RoaringBitmap> {
+        let all_fragments = self.get_fragments_as_bitmap();
+
+        let mut referenced_fragments = RoaringBitmap::new();
+        if !self
+            .fragments_covered_by_fts_query_helper(query, &mut referenced_fragments)
+            .await?
+        {
+            // One or more indices is missing the fragment bitmap, require all fragments in prefilter
+            Ok(all_fragments)
+        } else {
+            // Fragments required for prefilter is intersection of index fragments and query fragments
+            Ok(all_fragments & referenced_fragments)
+        }
+    }
+
     // Create an execution plan to do full text search
     async fn fts(
         &self,
@@ -1634,7 +1724,15 @@ impl Scanner {
             query.query.clone()
         };
 
-        let prefilter_source = self.prefilter_source(filter_plan).await?;
+        // TODO: Could maybe walk the query here to find all the indices that will be
+        // involved in the query to calculate a more accuarate required_fragments than
+        // get_fragments_as_bitmap but this is safe for now.
+        let prefilter_source = self
+            .prefilter_source(
+                filter_plan,
+                self.fragments_covered_by_fts_query(&query).await?,
+            )
+            .await?;
         let fts_exec = self
             .plan_fts(&query, &params, filter_plan, &prefilter_source)
             .await?;
@@ -2038,29 +2136,24 @@ impl Scanner {
         }
     }
 
-    // First perform a lookup in a scalar index for ids and then perform a take on the
-    // target fragments with those ids
-    async fn scalar_indexed_scan(
+    /// Given an index query, split the fragments into two sets
+    ///
+    /// The first set is the relevant fragments, which are covered by ALL indices in the query
+    /// The second set is the missing fragments, which are missed by at least one index
+    ///
+    /// There is no point in handling the case where a fragment is covered by some (but not all)
+    /// of the indices.  If we have to do a full scan of the fragment then we do it
+    async fn partition_frags_by_coverage(
         &self,
-        projection: Projection,
-        filter_plan: &FilterPlan,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        // One or more scalar indices cover this data and there is a filter which is
-        // compatible with the indices.  Use that filter to perform a take instead of
-        // a full scan.
+        index_expr: &ScalarIndexExpr,
+    ) -> Result<(Vec<Fragment>, Vec<Fragment>)> {
+        // Figure out which fragments are covered by ALL of the indices we are using
         let fragments = if let Some(fragment) = self.fragments.as_ref() {
             fragment.clone()
         } else {
             (**self.dataset.fragments()).clone()
         };
 
-        // If this unwrap fails we have a bug because we shouldn't be using this function unless we've already
-        // checked that there is an index query
-        let index_expr = filter_plan.index_query.as_ref().unwrap();
-
-        let needs_recheck = index_expr.needs_recheck();
-
-        // Figure out which fragments are covered by ALL of the indices we are using
         let covered_frags = self.fragments_covered_by_index_query(index_expr).await?;
         let mut relevant_frags = Vec::with_capacity(fragments.len());
         let mut missing_frags = Vec::with_capacity(fragments.len());
@@ -2071,6 +2164,58 @@ impl Scanner {
                 missing_frags.push(fragment);
             }
         }
+        Ok((relevant_frags, missing_frags))
+    }
+
+    async fn prefilter_scalar_indexed_query(
+        &self,
+        index_query: &ScalarIndexExpr,
+        filter_plan: &FilterPlan,
+        required_frags: RoaringBitmap,
+    ) -> Result<PreFilterSource> {
+        let (_, missing_frags) = self.partition_frags_by_coverage(index_query).await?;
+
+        // We want to use this as a pre-filter.  We don't need it to cover the _entire_ dataset.  It
+        // just needs to cover the same fragments as the vector index.  If it doesn't then we need to
+        // fall back to a scalar index scan.
+        if missing_frags
+            .iter()
+            .all(|frag| !required_frags.contains(frag.id as u32))
+        {
+            // The index covers the entire dataset, no need for materialization or scanning
+            return Ok(PreFilterSource::ScalarIndexQuery(Arc::new(
+                ScalarIndexExec::new(self.dataset.clone(), index_query.clone()),
+            )));
+        }
+
+        // The index is missing one or more fragments.  We need to scan and filter those fragments
+        // This also means we will need to materialize the index because we need to union it with
+        // the other results, so just fall back to a scalar_indexed_scan
+        Ok(PreFilterSource::FilteredRowIds(
+            self.scalar_indexed_scan(self.dataset.empty_projection().with_row_id(), filter_plan)
+                .await?,
+        ))
+    }
+
+    // First perform a lookup in a scalar index for ids and then perform a take on the
+    // target fragments with those ids
+    async fn scalar_indexed_scan(
+        &self,
+        projection: Projection,
+        filter_plan: &FilterPlan,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // One or more scalar indices cover this data and there is a filter which is
+        // compatible with the indices.  Use that filter to perform a take instead of
+        // a full scan.
+
+        // If this unwrap fails we have a bug because we shouldn't be using this function unless we've already
+        // checked that there is an index query
+        let index_expr = filter_plan.index_query.as_ref().unwrap();
+
+        let needs_recheck = index_expr.needs_recheck();
+
+        // Figure out which fragments are covered by ALL indices
+        let (relevant_frags, missing_frags) = self.partition_frags_by_coverage(index_expr).await?;
 
         let mut plan: Arc<dyn ExecutionPlan> = Arc::new(MaterializeIndexExec::new(
             self.dataset.clone(),
@@ -2345,6 +2490,31 @@ impl Scanner {
         Ok(Arc::new(not_nulls))
     }
 
+    fn get_fragments_as_bitmap(&self) -> RoaringBitmap {
+        if let Some(fragments) = &self.fragments {
+            RoaringBitmap::from_iter(fragments.iter().map(|f| f.id as u32))
+        } else {
+            RoaringBitmap::from_iter(self.dataset.fragments().iter().map(|f| f.id as u32))
+        }
+    }
+
+    fn get_indexed_frags(&self, index: &[Index]) -> RoaringBitmap {
+        let all_fragments = self.get_fragments_as_bitmap();
+
+        let mut all_indexed_frags = RoaringBitmap::new();
+        for idx in index {
+            if let Some(fragmap) = idx.fragment_bitmap.as_ref() {
+                all_indexed_frags |= fragmap;
+            } else {
+                // If any index is missing the fragment bitmap it is safest to just assume we
+                // need all fragments
+                return all_fragments;
+            }
+        }
+
+        all_indexed_frags & all_fragments
+    }
+
     /// Create an Execution plan to do indexed ANN search
     async fn ann(
         &self,
@@ -2352,7 +2522,9 @@ impl Scanner {
         index: &[Index],
         filter_plan: &FilterPlan,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let prefilter_source = self.prefilter_source(filter_plan).await?;
+        let prefilter_source = self
+            .prefilter_source(filter_plan, self.get_indexed_frags(index))
+            .await?;
         let inner_fanout_search = new_knn_exec(self.dataset.clone(), index, q, prefilter_source)?;
         let sort_expr = PhysicalSortExpr {
             expr: expressions::col(DIST_COL, inner_fanout_search.schema().as_ref())?,
@@ -2380,7 +2552,9 @@ impl Scanner {
 
         let over_fetch_factor = *DEFAULT_XTR_OVERFETCH;
 
-        let prefilter_source = self.prefilter_source(filter_plan).await?;
+        let prefilter_source = self
+            .prefilter_source(filter_plan, self.get_indexed_frags(index))
+            .await?;
         let dim = get_vector_dim(self.dataset.schema(), &q.column)?;
 
         let num_queries = q.key.len() / dim;
@@ -2436,7 +2610,11 @@ impl Scanner {
     }
 
     /// Create prefilter source from filter plan
-    async fn prefilter_source(&self, filter_plan: &FilterPlan) -> Result<PreFilterSource> {
+    async fn prefilter_source(
+        &self,
+        filter_plan: &FilterPlan,
+        required_frags: RoaringBitmap,
+    ) -> Result<PreFilterSource> {
         let prefilter_source = match (
             &filter_plan.index_query,
             &filter_plan.refine_expr,
@@ -2453,22 +2631,15 @@ impl Scanner {
                 PreFilterSource::FilteredRowIds(filtered_row_ids)
             } // Should be index_scan -> filter
             (Some(index_query), None, true, true) => {
-                // Index scan doesn't honor the fragment allowlist today.
-                // TODO: we could filter the index scan results to only include the allowed fragments.
-                self.ensure_not_fragment_scan()?;
-
-                // The filter is completely satisfied by the index.  We
-                // only need to search the index to determine the valid row
-                // ids.
-                let index_query = Arc::new(ScalarIndexExec::new(
-                    self.dataset.clone(),
-                    index_query.clone(),
-                ));
-                PreFilterSource::ScalarIndexQuery(index_query)
+                // The filter is completely satisfied by the index.  If it also covers all fragments we might
+                // be able to use a faster version that doesn't even require materialization
+                self.prefilter_scalar_indexed_query(index_query, filter_plan, required_frags)
+                    .await?
             }
             (None, Some(refine_expr), true, _) => {
                 // No indices match the filter.  We need to do a full scan
                 // of the filter columns to determine the valid row ids.
+
                 let columns_in_filter = Planner::column_names_in_expr(refine_expr);
                 let filter_schema = Arc::new(self.dataset.schema().project(&columns_in_filter)?);
                 let filter_input = self.scan(true, false, true, None, filter_schema);
@@ -5724,7 +5895,6 @@ mod test {
         .await?;
 
         // With prefilter
-        dataset.make_fts_index().await?;
         assert_plan_equals(
             &dataset.dataset,
             |scan| {
@@ -5738,7 +5908,12 @@ mod test {
   Take: columns="_rowid, _score, (s)"
     CoalesceBatchesExec: target_batch_size=8192
       MatchQuery: query=hello
-        ScalarIndexQuery: query=i > 10"#,
+        RepartitionExec: partitioning=RoundRobinBatch(1), input_partitions=2
+          UnionExec
+            MaterializeIndex: query=i > 10
+            ProjectionExec: expr=[_rowid@1 as _rowid]
+              FilterExec: i@0 > 10
+                LanceScan: uri=..., projection=[i], row_id=true, row_addr=false, ordered=false"#,
         )
         .await?;
 
@@ -5780,7 +5955,12 @@ mod test {
         RepartitionExec: partitioning=RoundRobinBatch(1), input_partitions=2
           UnionExec
             MatchQuery: query=hello
-              ScalarIndexQuery: query=i > 10
+              RepartitionExec: partitioning=RoundRobinBatch(1), input_partitions=2
+                UnionExec
+                  MaterializeIndex: query=i > 10
+                  ProjectionExec: expr=[_rowid@1 as _rowid]
+                    FilterExec: i@0 > 10
+                      LanceScan: uri=..., projection=[i], row_id=true, row_addr=false, ordered=false
             FlatMatchQuery: query=hello
               FilterExec: i@1 > 10
                 LanceScan: uri=..., projection=[s, i], row_id=true, row_addr=false, ordered=false"#,


### PR DESCRIPTION
When performing a search (vector or FTS) we can use a scalar index to help us calculate the prefilter.  In some cases we don't even have to materialize the scalar index.  However, our old logic was too loose here and didn't materialize even when the scalar index was behind the vector/FTS index (didn't cover all the fragments).

This PR restricts the non-materialization path to only be followed when the scalar index is fully caught up to the vector/fts index.