### PR TITLE
fix: partition not used yet panic

### DIFF
--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -1236,3 +1236,26 @@ def test_read_partition(indexed_dataset):
     with pytest.raises(ValueError, match="not vector index"):
         indexed_dataset.create_scalar_index("id", index_type="BTREE")
         VectorIndexReader(indexed_dataset, "id_idx")
+
+
+def test_vector_index_with_prefilter_and_scalar_index(indexed_dataset):
+    uri = indexed_dataset.uri
+    new_table = create_table()
+    ds = lance.write_dataset(new_table, uri, mode="append")
+    ds.optimize.optimize_indices(num_indices_to_merge=0)
+    ds.create_scalar_index("id", index_type="BTREE")
+
+    raw_table = create_table()
+    ds = lance.write_dataset(raw_table, uri, mode="append")
+
+    res = ds.to_table(
+        nearest={
+            "column": "vector",
+            "q": np.random.randn(128),
+            "k": 10,
+        },
+        filter="id > 0",
+        with_row_id=True,
+        prefilter=True,
+    )
+    assert len(res) == 10

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -1247,6 +1247,7 @@ def test_vector_index_with_prefilter_and_scalar_index(indexed_dataset):
 
     raw_table = create_table()
     ds = lance.write_dataset(raw_table, uri, mode="append")
+    ds.optimize.optimize_indices(num_indices_to_merge=0, index_names=["vector_idx"])
 
     res = ds.to_table(
         nearest={

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -629,11 +629,11 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
             .try_flatten();
         let prefilter_loader = match &prefilter_source {
             PreFilterSource::FilteredRowIds(src_node) => {
-                let stream = src_node.execute(partition, context.clone())?;
+                let stream = src_node.execute(partition, context)?;
                 Some(Box::new(FilteredRowIdsToPrefilter(stream)) as Box<dyn FilterLoader>)
             }
             PreFilterSource::ScalarIndexQuery(src_node) => {
-                let stream = src_node.execute(partition, context.clone())?;
+                let stream = src_node.execute(partition, context)?;
                 Some(Box::new(SelectionVectorToPrefilter(stream)) as Box<dyn FilterLoader>)
             }
             PreFilterSource::None => None,

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -627,6 +627,23 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                 async move { Ok(stream::iter(plan)) }
             })
             .try_flatten();
+        let prefilter_loader = match &prefilter_source {
+            PreFilterSource::FilteredRowIds(src_node) => {
+                let stream = src_node.execute(partition, context.clone())?;
+                Some(Box::new(FilteredRowIdsToPrefilter(stream)) as Box<dyn FilterLoader>)
+            }
+            PreFilterSource::ScalarIndexQuery(src_node) => {
+                let stream = src_node.execute(partition, context.clone())?;
+                Some(Box::new(SelectionVectorToPrefilter(stream)) as Box<dyn FilterLoader>)
+            }
+            PreFilterSource::None => None,
+        };
+
+        let pre_filter = Arc::new(DatasetPreFilter::new(
+            ds.clone(),
+            &indices,
+            prefilter_loader,
+        ));
 
         Ok(Box::pin(InstrumentedRecordBatchStreamAdapter::new(
             schema,
@@ -634,36 +651,10 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                 .and_then(move |(part_ids, index_uuid)| {
                     let ds = ds.clone();
                     let column = column.clone();
-                    let indices = indices.clone();
-                    let context = context.clone();
-                    let prefilter_source = prefilter_source.clone();
                     let metrics = metrics.clone();
-                    let index_meta = indices
-                        .iter()
-                        .find(|idx| idx.uuid.to_string() == index_uuid)
-                        .unwrap()
-                        .clone();
+                    let pre_filter = pre_filter.clone();
 
                     async move {
-                        let prefilter_loader = match &prefilter_source {
-                            PreFilterSource::FilteredRowIds(src_node) => {
-                                let stream = src_node.execute(partition, context.clone())?;
-                                Some(Box::new(FilteredRowIdsToPrefilter(stream))
-                                    as Box<dyn FilterLoader>)
-                            }
-                            PreFilterSource::ScalarIndexQuery(src_node) => {
-                                let stream = src_node.execute(partition, context.clone())?;
-                                Some(Box::new(SelectionVectorToPrefilter(stream))
-                                    as Box<dyn FilterLoader>)
-                            }
-                            PreFilterSource::None => None,
-                        };
-                        let pre_filter = Arc::new(DatasetPreFilter::new(
-                            ds.clone(),
-                            &[index_meta],
-                            prefilter_loader,
-                        ));
-
                         let raw_index = ds
                             .open_vector_index(&column, &index_uuid, &metrics.index_metrics)
                             .await?;


### PR DESCRIPTION
the bug is that we may call `execute` multiple times, and it causes a panic in datafusion `RepartitionExec`, the conditions to repro:
1. the dataset has vector index and the vector index contains at least 2 deltas
2. the dataset has a scalar index, there are any unindexed rows for the scalar index
3. do vector search with prefilter

This also improves the performance of vector search with prefilter when there are more than 1 deltas, because before it performed scalar index query & scanning for each delta, but now it does only once