### PR TITLE
chore: use less sample size for multivector

### DIFF
--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -129,9 +129,9 @@ pub async fn maybe_sample_training_data(
             // but each multivector is a list of vectors, but we don't know how many
             // vectors are in each multivector. For now we just assume there are 1030 vectors
             // in each multivector (Copali case).
-            // Set a minimum sample size of 32 to avoid too small samples,
-            // it's not a problem because 32 multivectors is just about 16 MiB
-            sample_size_hint.div_ceil(1030).max(32)
+            // Set a minimum sample size of 64 to avoid too small samples,
+            // it's not a problem because 64 multivectors is just about 32 MiB
+            sample_size_hint.div_ceil(1030).max(64)
         }
         _ => sample_size_hint,
     };

--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -129,9 +129,9 @@ pub async fn maybe_sample_training_data(
             // but each multivector is a list of vectors, but we don't know how many
             // vectors are in each multivector. For now we just assume there are 1030 vectors
             // in each multivector (Copali case).
-            // Set a minimum sample size of 64 to avoid too small samples,
-            // it's not a problem because 64 multivectors is just about 32 MiB
-            sample_size_hint.div_ceil(1030).max(64)
+            // Set a minimum sample size of 128 to avoid too small samples,
+            // it's not a problem because 128 multivectors is just about 64 MiB
+            sample_size_hint.div_ceil(1030).max(128)
         }
         _ => sample_size_hint,
     };

--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -123,6 +123,19 @@ pub async fn maybe_sample_training_data(
     })?;
     let is_nullable = vector_field.nullable;
 
+    let sample_size_hint = match vector_field.data_type() {
+        arrow::datatypes::DataType::List(_) => {
+            // for multivector, we need `sample_size_hint` vectors for training,
+            // but each multivector is a list of vectors, but we don't know how many
+            // vectors are in each multivector. For now we just assume there are 1030 vectors
+            // in each multivector (Copali case).
+            // Set a minimum sample size of 32 to avoid too small samples,
+            // it's not a problem because 32 multivectors is just about 16 MiB
+            sample_size_hint.div_ceil(1030).max(32)
+        }
+        _ => sample_size_hint,
+    };
+
     let batch = if num_rows > sample_size_hint && !is_nullable {
         let projection = dataset.schema().project(&[column])?;
         let batch = dataset.sample(sample_size_hint, &projection).await?;


### PR DESCRIPTION
we are sampling by the number of rows, but in multivector case, single row contains many vectors