### PR TITLE
perf: reduce retry thrashing in merge_insert

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -179,6 +179,32 @@ class MergeInsertBuilder(_MergeInsertBuilder):
         """
         return super(MergeInsertBuilder, self).when_not_matched_by_source_delete(expr)
 
+    def conflict_retries(self, max_retries: int) -> "MergeInsertBuilder":
+        """
+        Set number of times to retry the operation if there is contention.
+
+        If this is set > 0, then the operation will keep a copy of the input data
+        either in memory or on disk (depending on the size of the data) and will
+        retry the operation if there is contention.
+
+        Default is 10.
+        """
+        return super(MergeInsertBuilder, self).conflict_retries(max_retries)
+
+    def retry_timeout(self, timeout: timedelta) -> "MergeInsertBuilder":
+        """
+        Set the timeout used to limit retries.
+
+        This is the maximum time to spend on the operation before giving up. At
+        least one attempt will be made, regardless of how long it takes to complete.
+        Subsequent attempts will be cancelled once this timeout is reached. If
+        the timeout has been reached during the first attempt, the operation
+        will be cancelled immediately.
+
+        The default is 30 seconds.
+        """
+        return super(MergeInsertBuilder, self).retry_timeout(timeout)
+
 
 class LanceDataset(pa.dataset.Dataset):
     """A Lance Dataset in Lance format where the data is stored at the given uri."""
@@ -1320,7 +1346,7 @@ class LanceDataset(pa.dataset.Dataset):
     def merge_insert(
         self,
         on: Union[str, Iterable[str]],
-    ):
+    ) -> MergeInsertBuilder:
         """
         Returns a builder that can be used to create a "merge insert" operation
 

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -199,7 +199,7 @@ class MergeInsertBuilder(_MergeInsertBuilder):
         least one attempt will be made, regardless of how long it takes to complete.
         Subsequent attempts will be cancelled once this timeout is reached. If
         the timeout has been reached during the first attempt, the operation
-        will be cancelled immediately.
+        will be cancelled immediately before making a second attempt.
 
         The default is 30 seconds.
         """

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1416,7 +1416,11 @@ def test_merge_insert(tmp_path: Path):
     is_new = pc.field("b") == 2
 
     merge_dict = (
-        dataset.merge_insert("a").when_not_matched_insert_all().execute(new_table)
+        dataset.merge_insert("a")
+        .when_not_matched_insert_all()
+        .retry_timeout(timedelta(seconds=5))
+        .conflict_retries(0)
+        .execute(new_table)
     )
     table = dataset.to_table()
     assert table.num_rows == 1300

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -188,6 +188,22 @@ impl MergeInsertBuilder {
         Ok(slf)
     }
 
+    pub fn conflict_retries(
+        mut slf: PyRefMut<'_, Self>,
+        max_retries: u32,
+    ) -> PyResult<PyRefMut<'_, Self>> {
+        slf.builder.conflict_retries(max_retries);
+        Ok(slf)
+    }
+
+    pub fn retry_timeout(
+        mut slf: PyRefMut<'_, Self>,
+        timeout: std::time::Duration,
+    ) -> PyResult<PyRefMut<'_, Self>> {
+        slf.builder.retry_timeout(timeout);
+        Ok(slf)
+    }
+
     pub fn execute(&mut self, new_data: &Bound<PyAny>) -> PyResult<PyObject> {
         let py = new_data.py();
         let new_data = convert_reader(new_data)?;

--- a/rust/lance-core/src/utils/backoff.rs
+++ b/rust/lance-core/src/utils/backoff.rs
@@ -41,6 +41,10 @@ impl Backoff {
         Self { base, ..self }
     }
 
+    pub fn with_unit(self, unit: u32) -> Self {
+        Self { unit, ..self }
+    }
+
     pub fn with_jitter(self, jitter: i32) -> Self {
         Self { jitter, ..self }
     }

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -2229,6 +2229,9 @@ mod tests {
         }
     }
 
+    // For some reason, Windows isn't able to handle the timeout test. Possibly
+    // a performance bug in their timer implementation?
+    #[cfg(not(windows))]
     #[rstest::rstest]
     #[case::all_success(Duration::from_secs(100_000))]
     #[case::timeout(Duration::from_millis(200))]

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -2331,7 +2331,7 @@ mod tests {
         let attempts = try_join_all(handles).await.unwrap();
         let elapsed = start.elapsed();
 
-        let buffer = Duration::from_millis(20);
+        let buffer = Duration::from_millis(100);
         assert!(
             elapsed < timeout + buffer,
             "Elapsed time should be less than {} ms, was {} ms",

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -354,6 +354,8 @@ impl MergeInsertBuilder {
     /// Subsequent attempts will be cancelled once this timeout is reached. If
     /// the timeout has been reached during the first attempt, the operation
     /// will be cancelled immediately.
+    ///
+    /// The default is 30 seconds.
     pub fn retry_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.params.retry_timeout = timeout;
         self

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -1061,12 +1061,9 @@ impl MergeInsertJob {
                             location: location!(),
                         });
                     }
-
-                    // We going to configure the backoff time based on how long
-                    // the operation took. This becomes the unit.
-                    // If the op took 5s, then the backoff will be 5s, 10s, 20s, 40s, etc.
-                    // If the op took 0.5s, then the backoff will be 0.5s, 1s, 2s, 4s, etc.
                     if backoff.attempt() == 0 {
+                        // We add 10% buffer here, to allow concurrent writes to complete.
+                        // See SlotBackoff implementation for more details on how this works.
                         backoff = backoff.with_unit((start.elapsed().as_millis() * 11 / 10) as u32);
                     }
 

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -29,6 +29,10 @@ use crate::dataset::transaction::Operation;
 use crate::dataset::WriteParams;
 use crate::Dataset;
 
+mod throttle_store;
+
+pub use throttle_store::ThrottledStoreWrapper;
+
 /// A dataset generator that can generate random layouts. This is used to test
 /// dataset operations are robust to different layouts.
 ///

--- a/rust/lance/src/utils/test/throttle_store.rs
+++ b/rust/lance/src/utils/test/throttle_store.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use lance_io::object_store::WrappingObjectStore;
+use object_store::{
+    throttle::{ThrottleConfig, ThrottledStore},
+    ObjectStore,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct ThrottledStoreWrapper {
+    pub config: ThrottleConfig,
+}
+
+impl WrappingObjectStore for ThrottledStoreWrapper {
+    fn wrap(&self, original: Arc<dyn ObjectStore>) -> Arc<dyn ObjectStore> {
+        let throttle_store = ThrottledStore::new(original, self.config);
+        Arc::new(throttle_store)
+    }
+}


### PR DESCRIPTION
Fixes #3776

This introduces a new retry strategy, called `SlotBackoff`, designed specifically for operations that can't overlap. Exponential backoff is more appropriate for adapting to rate limits.

The following are result for N concurrent upserts where each upsert takes about 300ms.

* Current is the current behavior
* "Long exponential" is using exponential backoff, but sizing the unit based on the elapsed time after the first attempt.
* Slots is the new `SlotBackoff` strategy.

<img width="599" alt="Screenshot 2025-05-06 at 12 42 39 PM" src="https://github.com/user-attachments/assets/4d0880e4-1bda-4b7c-98da-90f73c54b691" />
<img width="599" alt="Screenshot 2025-05-06 at 12 42 49 PM" src="https://github.com/user-attachments/assets/02e39be8-2bbd-4f13-a0cb-933728e029dd" />


