### PR TITLE
feat: auto conflict resolution for upsert

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -43,8 +43,8 @@ use lance::dataset::{
     scanner::Scanner as LanceScanner,
     transaction::{Operation, Transaction},
     Dataset as LanceDataset, MergeInsertBuilder as LanceMergeInsertBuilder, ReadParams,
-    UpdateBuilder, Version, WhenMatched, WhenNotMatched, WhenNotMatchedBySource, WriteMode,
-    WriteParams,
+    UncommittedMergeInsert, UpdateBuilder, Version, WhenMatched, WhenNotMatched,
+    WhenNotMatchedBySource, WriteMode, WriteParams,
 };
 use lance::dataset::{
     BatchInfo, BatchUDF, CommitBuilder, MergeStats, NewColumnTransform, UDFCheckpointStore,
@@ -236,7 +236,9 @@ impl MergeInsertBuilder {
             .try_build()
             .map_err(|err| PyValueError::new_err(err.to_string()))?;
 
-        let (transaction, stats) = RT
+        let UncommittedMergeInsert {
+            transaction, stats, ..
+        } = RT
             .spawn(Some(py), job.execute_uncommitted(new_data))?
             .map_err(|err| PyIOError::new_err(err.to_string()))?;
 

--- a/rust/lance-core/src/cache.rs
+++ b/rust/lance-core/src/cache.rs
@@ -182,7 +182,7 @@ impl FileMetadataCache {
         loader: F,
     ) -> Result<Arc<T>>
     where
-        F: Fn(&Path) -> Fut,
+        F: FnOnce(&Path) -> Fut,
         Fut: Future<Output = Result<T>>,
     {
         if let Some(metadata) = self.get::<T>(path) {

--- a/rust/lance-core/src/utils/deletion.rs
+++ b/rust/lance-core/src/utils/deletion.rs
@@ -287,6 +287,16 @@ impl FromIterator<u32> for DeletionVector {
     }
 }
 
+impl From<RoaringBitmap> for DeletionVector {
+    fn from(bitmap: RoaringBitmap) -> Self {
+        if bitmap.is_empty() {
+            Self::NoDeletions
+        } else {
+            Self::Bitmap(bitmap)
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/rust/lance-core/src/utils/mask.rs
+++ b/rust/lance-core/src/utils/mask.rs
@@ -455,6 +455,14 @@ impl RowIdTreeMap {
         self.inner.insert(fragment_id, RowIdSelection::Full);
     }
 
+    pub fn get_fragment_bitmap(&self, fragment_id: u32) -> Option<&RoaringBitmap> {
+        match self.inner.get(&fragment_id) {
+            None => None,
+            Some(RowIdSelection::Full) => None,
+            Some(RowIdSelection::Partial(set)) => Some(set),
+        }
+    }
+
     /// Returns whether the set contains the given value
     pub fn contains(&self, value: u64) -> bool {
         let upper = (value >> 32) as u32;

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -322,6 +322,32 @@ impl Fragment {
         }
     }
 
+    pub fn with_file(
+        mut self,
+        path: impl Into<String>,
+        field_ids: Vec<i32>,
+        column_indices: Vec<i32>,
+        version: &LanceFileVersion,
+        file_size_bytes: Option<NonZero<u64>>,
+    ) -> Self {
+        let (major, minor) = version.to_numbers();
+        let data_file = DataFile::new(
+            path,
+            field_ids,
+            column_indices,
+            major,
+            minor,
+            file_size_bytes,
+        );
+        self.files.push(data_file);
+        self
+    }
+
+    pub fn with_physical_rows(mut self, physical_rows: usize) -> Self {
+        self.physical_rows = Some(physical_rows);
+        self
+    }
+
     pub fn add_file(
         &mut self,
         path: impl Into<String>,

--- a/rust/lance-table/src/format/index.rs
+++ b/rust/lance-table/src/format/index.rs
@@ -12,7 +12,7 @@ use super::pb;
 use lance_core::{Error, Result};
 
 /// Index metadata
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Index {
     /// Unique ID across all dataset versions.
     pub uuid: Uuid,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -91,8 +91,8 @@ pub use schema_evolution::{
 };
 pub use take::TakeBuilder;
 pub use write::merge_insert::{
-    MergeInsertBuilder, MergeInsertJob, MergeStats, WhenMatched, WhenNotMatched,
-    WhenNotMatchedBySource,
+    MergeInsertBuilder, MergeInsertJob, MergeStats, UncommittedMergeInsert, WhenMatched,
+    WhenNotMatched, WhenNotMatchedBySource,
 };
 pub use write::update::{UpdateBuilder, UpdateJob};
 #[allow(deprecated)]

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -2344,7 +2344,7 @@ mod tests {
     use lance_core::ROW_ID;
     use lance_datagen::{array, gen, RowCount};
     use lance_file::version::LanceFileVersion;
-    use lance_io::object_store::ObjectStore;
+    use lance_io::object_store::{ObjectStore, ObjectStoreParams};
     use pretty_assertions::assert_eq;
     use rstest::rstest;
     use tempfile::tempdir;

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -800,10 +800,9 @@ async fn rechunk_stable_row_ids(
                 .await?;
 
                 let mut new_seq = seq.as_ref().clone();
-                new_seq.mask(deletions.iter())?;
+                new_seq.mask(deletions.to_sorted_iter())?;
                 *seq = Arc::new(new_seq);
             }
-
             Ok::<(), crate::Error>(())
         })
         .await?;

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -605,6 +605,7 @@ async fn reserve_fragment_ids(
         &Default::default(),
         &Default::default(),
         dataset.manifest_location.naming_scheme,
+        None,
     )
     .await?;
 

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -240,7 +240,7 @@ impl Operation {
     /// Returns the IDs of fragments that have been modified by this operation.
     ///
     /// This does not include new fragments.
-    fn modified_fragment_ids(&self) -> Box<dyn Iterator<Item = u64> + '_> {
+    pub(crate) fn modified_fragment_ids(&self) -> Box<dyn Iterator<Item = u64> + '_> {
         match self {
             // These operations add new fragments or don't modify any.
             Self::Append { .. }

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -654,16 +654,17 @@ mod tests {
         // * num_other_txns read txn files (cache-able)
         // * 1 write txn file
         // * 1 write manifest
-        // For total of 7 io requests. If we have caching enabled, we can skip 4
+        // For total of 3 + 2 * num_other_txns io requests. If we have caching enabled, we can skip 2 * num_other_txns
         // of those. We should be able to read in 5 hops.
         if use_cache {
             assert_eq!(io_stats.read_iops, 1); // Just list versions
+            assert_eq!(io_stats.num_hops, 3);
         } else {
             // We need to read the other manifests and transactions.
             assert_eq!(io_stats.read_iops, 1 + num_other_txns * 2);
+            assert_eq!(io_stats.num_hops, 5);
         }
         assert_eq!(io_stats.write_iops, 2); // txn + manifest
-        assert_eq!(io_stats.num_hops, 5);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -10,7 +10,6 @@ use lance_table::{
     format::{is_detached_version, DataStorageFormat},
     io::commit::{CommitConfig, CommitHandler, ManifestNamingScheme},
 };
-use roaring::RoaringTreemap;
 use snafu::location;
 
 use crate::{

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -2262,7 +2262,10 @@ mod tests {
             Field::new("id", DataType::UInt32, false),
             Field::new("value", DataType::UInt32, false),
         ]));
-        let concurrency = 10;
+        // To benchmark scaling curve: measure how long to run
+        //
+        // And vary `concurrency` to see how it scales. Compare this again `main`.
+        let concurrency = 4;
         let initial_data = RecordBatch::try_new(
             schema.clone(),
             vec![
@@ -2278,8 +2281,10 @@ mod tests {
         // Increase likelihood of contention by throttling the store
         let throttled = Arc::new(ThrottledStoreWrapper {
             config: ThrottleConfig {
-                wait_list_per_call: Duration::from_millis(1),
-                wait_get_per_call: Duration::from_millis(1),
+                // For benchmarking: Increase this to simulate object storage.
+                wait_list_per_call: Duration::from_millis(20),
+                wait_get_per_call: Duration::from_millis(20),
+                wait_put_per_call: Duration::from_millis(20),
                 ..Default::default()
             },
         });

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -1174,7 +1174,7 @@ impl MergeInsertJob {
             .try_flatten();
         let stream = RecordBatchStreamAdapter::new(merger_schema, stream);
 
-        let operation = if !is_full_schema {
+        let (operation, affected_rows) = if !is_full_schema {
             if !matches!(
                 self.params.delete_not_matched_by_source,
                 WhenNotMatchedBySource::Keep
@@ -1188,11 +1188,14 @@ impl MergeInsertJob {
             let (updated_fragments, new_fragments) =
                 Self::update_fragments(self.dataset.clone(), Box::pin(stream)).await?;
 
-            Operation::Update {
+            let operation = Operation::Update {
                 removed_fragment_ids: Vec::new(),
                 updated_fragments,
                 new_fragments,
-            }
+            };
+            // We have rewritten the fragments, not just the deletion files, so
+            // we can't use affected rows here.
+            (operation, None)
         } else {
             let written = write_fragments_internal(
                 Some(&self.dataset),
@@ -1214,11 +1217,14 @@ impl MergeInsertJob {
                 Self::apply_deletions(&self.dataset, &removed_row_ids).await?;
 
             // Commit updated and new fragments
-            Operation::Update {
+            let operation = Operation::Update {
                 removed_fragment_ids,
                 updated_fragments: old_fragments,
                 new_fragments,
-            }
+            };
+
+            let affected_rows = Some(RowIdTreeMap::from(removed_row_ids));
+            (operation, affected_rows)
         };
 
         let stats = Arc::into_inner(merge_statistics)
@@ -1235,7 +1241,7 @@ impl MergeInsertJob {
 
         Ok(UncommittedMergeInsert {
             transaction,
-            affected_rows: todo!("Compute affected rows"),
+            affected_rows,
             stats,
         })
     }

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -16,6 +16,7 @@
 //! key columns are identical in both the source and the target.  This means that you will need some kind of
 //! meaningful key column to be able to perform a merge insert.
 
+use aws_sdk_dynamodb::types::error::TransactionCanceledException;
 use futures::FutureExt;
 use std::{
     collections::BTreeMap,
@@ -62,7 +63,10 @@ use futures::{
 use lance_core::{
     datatypes::{OnMissing, OnTypeMismatch, SchemaCompareOptions},
     error::{box_error, InvalidInputSnafu},
-    utils::{backoff::SlotBackoff, futures::Capacity, tokio::get_num_compute_intensive_cpus},
+    utils::{
+        backoff::SlotBackoff, futures::Capacity, mask::RowIdTreeMap,
+        tokio::get_num_compute_intensive_cpus,
+    },
     Error, Result, ROW_ADDR, ROW_ADDR_FIELD, ROW_ID, ROW_ID_FIELD,
 };
 use lance_datafusion::{
@@ -1076,10 +1080,18 @@ impl MergeInsertJob {
                 .execute_uncommitted_impl(source_iter.next().unwrap());
             let execute_fut =
                 maybe_timeout(&backoff, start, self.params.retry_timeout, execute_fut);
-            let (transaction, mut stats) = execute_fut.await??;
+            let UncommittedMergeInsert {
+                transaction,
+                mut stats,
+                affected_rows,
+            } = execute_fut.await??;
             stats.num_attempts = backoff.attempt() + 1;
 
-            let commit_future = CommitBuilder::new(ds.clone()).execute(transaction);
+            let mut commit_builder = CommitBuilder::new(ds.clone());
+            if let Some(affected_rows) = affected_rows {
+                commit_builder = commit_builder.with_affected_rows(affected_rows);
+            }
+            let commit_future = commit_builder.execute(transaction);
             let commit_future =
                 maybe_timeout(&backoff, start, self.params.retry_timeout, commit_future);
             match commit_future.await? {
@@ -1131,7 +1143,7 @@ impl MergeInsertJob {
     pub async fn execute_uncommitted(
         self,
         source: impl StreamingWriteSource,
-    ) -> Result<(Transaction, MergeStats)> {
+    ) -> Result<UncommittedMergeInsert> {
         let stream = source.into_stream();
         self.execute_uncommitted_impl(stream).await
     }
@@ -1139,7 +1151,7 @@ impl MergeInsertJob {
     async fn execute_uncommitted_impl(
         self,
         source: SendableRecordBatchStream,
-    ) -> Result<(Transaction, MergeStats)> {
+    ) -> Result<UncommittedMergeInsert> {
         // Erase metadata on source / dataset schemas to avoid comparing metadata
         let schema = lance_core::datatypes::Schema::try_from(source.schema().as_ref())?;
         let full_schema = self.dataset.local_schema();
@@ -1221,7 +1233,11 @@ impl MergeInsertJob {
             None,
         );
 
-        Ok((transaction, stats))
+        Ok(UncommittedMergeInsert {
+            transaction,
+            affected_rows: todo!("Compute affected rows"),
+            stats,
+        })
     }
 
     // Delete a batch of rows by id, returns the fragments modified and the fragments removed
@@ -1287,6 +1303,12 @@ pub struct MergeStats {
     ///
     /// See [`MergeInsertBuilder::conflict_retries`] for more information.
     pub num_attempts: u32,
+}
+
+pub struct UncommittedMergeInsert {
+    pub transaction: Transaction,
+    pub affected_rows: Option<RowIdTreeMap>,
+    pub stats: MergeStats,
 }
 
 // A sync-safe structure that is shared by all of the "process batch" tasks.
@@ -2409,19 +2431,21 @@ mod tests {
             ],
         )
         .unwrap();
-        let (transaction1, _stats) =
-            MergeInsertBuilder::try_new(dataset.clone(), vec!["id".to_string()])
-                .unwrap()
-                .when_matched(WhenMatched::UpdateAll)
-                .when_not_matched(WhenNotMatched::InsertAll)
-                .try_build()
-                .unwrap()
-                .execute_uncommitted(RecordBatchIterator::new(
-                    vec![Ok(new_data1)],
-                    schema.clone(),
-                ))
-                .await
-                .unwrap();
+        let UncommittedMergeInsert {
+            transaction: transaction1,
+            ..
+        } = MergeInsertBuilder::try_new(dataset.clone(), vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::InsertAll)
+            .try_build()
+            .unwrap()
+            .execute_uncommitted(RecordBatchIterator::new(
+                vec![Ok(new_data1)],
+                schema.clone(),
+            ))
+            .await
+            .unwrap();
 
         // Setup a "large" merge insert, with many batches
         let new_data2 = RecordBatch::try_new(

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -16,7 +16,6 @@
 //! key columns are identical in both the source and the target.  This means that you will need some kind of
 //! meaningful key column to be able to perform a merge insert.
 
-use aws_sdk_dynamodb::types::error::TransactionCanceledException;
 use futures::FutureExt;
 use std::{
     collections::BTreeMap,

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, RwLock};
 
 use super::super::utils::make_rowid_capture_stream;
-use super::{write_fragments_internal, WriteParams};
+use super::{write_fragments_internal, CommitBuilder, WriteParams};
 use arrow_array::RecordBatch;
 use arrow_schema::{ArrowError, DataType, Schema as ArrowSchema};
 use datafusion::common::DFSchema;
@@ -18,6 +18,7 @@ use datafusion::scalar::ScalarValue;
 use futures::StreamExt;
 use lance_arrow::RecordBatchExt;
 use lance_core::error::{box_error, InvalidInputSnafu};
+use lance_core::utils::mask::RowIdTreeMap;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use lance_datafusion::expr::safe_coerce_scalar;
 use lance_table::format::Fragment;
@@ -288,6 +289,7 @@ impl UpdateJob {
             .into_inner()
             .unwrap();
         let (old_fragments, removed_fragment_ids) = self.apply_deletions(&removed_row_ids).await?;
+        let affected_rows = RowIdTreeMap::from(removed_row_ids);
 
         let num_updated_rows = new_fragments
             .iter()
@@ -295,7 +297,12 @@ impl UpdateJob {
             .sum::<u64>();
         // Commit updated and new fragments
         let new_dataset = self
-            .commit(removed_fragment_ids, old_fragments, new_fragments)
+            .commit(
+                removed_fragment_ids,
+                old_fragments,
+                new_fragments,
+                affected_rows,
+            )
             .await?;
         Ok(UpdateResult {
             new_dataset,
@@ -368,6 +375,7 @@ impl UpdateJob {
         removed_fragment_ids: Vec<u64>,
         updated_fragments: Vec<Fragment>,
         new_fragments: Vec<Fragment>,
+        affected_rows: RowIdTreeMap,
     ) -> Result<Arc<Dataset>> {
         let operation = Operation::Update {
             removed_fragment_ids,
@@ -381,28 +389,37 @@ impl UpdateJob {
             None,
         );
 
-        let mut dataset = self.dataset.as_ref().clone();
-        dataset
-            .apply_commit(transaction, &Default::default(), &Default::default())
-            .await?;
-
-        Ok(Arc::new(dataset))
+        CommitBuilder::new(self.dataset.clone())
+            .with_affected_rows(affected_rows)
+            .execute(transaction)
+            .await
+            .map(Arc::new)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::dataset::WriteParams;
+    use std::time::Duration;
+
+    use crate::{
+        dataset::{builder::DatasetBuilder, InsertBuilder, ReadParams, WriteParams},
+        session::Session,
+        utils::test::ThrottledStoreWrapper,
+    };
 
     use super::*;
 
-    use arrow_array::{Int64Array, RecordBatchIterator, StringArray};
+    use arrow::{array::AsArray, datatypes::UInt32Type};
+    use arrow_array::{Int64Array, RecordBatchIterator, StringArray, UInt32Array};
     use arrow_schema::{Field, Schema as ArrowSchema};
     use arrow_select::concat::concat_batches;
-    use futures::TryStreamExt;
+    use futures::{future::try_join_all, TryStreamExt};
     use lance_file::version::LanceFileVersion;
+    use lance_io::object_store::ObjectStoreParams;
+    use object_store::throttle::ThrottleConfig;
     use rstest::rstest;
     use tempfile::{tempdir, TempDir};
+    use tokio::sync::Barrier;
 
     /// Returns a dataset with 3 fragments, each with 10 rows.
     ///
@@ -587,5 +604,99 @@ mod tests {
         );
         // One fragment fully modified
         assert_eq!(fragments[2].metadata.physical_rows, Some(15));
+    }
+
+    #[tokio::test]
+    async fn test_update_concurrency() {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::UInt32, false),
+            Field::new("value", DataType::UInt32, false),
+        ]));
+        let concurrency = 3;
+        let initial_data = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt32Array::from_iter_values(0..concurrency)),
+                Arc::new(UInt32Array::from_iter_values(std::iter::repeat_n(
+                    0,
+                    concurrency as usize,
+                ))),
+            ],
+        )
+        .unwrap();
+
+        // Increase likelihood of contention by throttling the store
+        let throttled = Arc::new(ThrottledStoreWrapper {
+            config: ThrottleConfig {
+                wait_list_per_call: Duration::from_millis(1),
+                wait_get_per_call: Duration::from_millis(1),
+                ..Default::default()
+            },
+        });
+        let session = Arc::new(Session::default());
+
+        let mut dataset = InsertBuilder::new("memory://")
+            .with_params(&WriteParams {
+                store_params: Some(ObjectStoreParams {
+                    object_store_wrapper: Some(throttled.clone()),
+                    ..Default::default()
+                }),
+                session: Some(session.clone()),
+                ..Default::default()
+            })
+            .execute(vec![initial_data])
+            .await
+            .unwrap();
+
+        let barrier = Arc::new(Barrier::new(concurrency as usize));
+        let mut handles = Vec::new();
+        for i in 0..concurrency {
+            let session_ref = session.clone();
+            let barrier_ref = barrier.clone();
+            let throttled_ref = throttled.clone();
+            let handle = tokio::task::spawn(async move {
+                let dataset = DatasetBuilder::from_uri("memory://")
+                    .with_read_params(ReadParams {
+                        store_options: Some(ObjectStoreParams {
+                            object_store_wrapper: Some(throttled_ref.clone()),
+                            ..Default::default()
+                        }),
+                        session: Some(session_ref.clone()),
+                        ..Default::default()
+                    })
+                    .load()
+                    .await
+                    .unwrap();
+
+                let job = UpdateBuilder::new(Arc::new(dataset))
+                    .update_where(&format!("id = {}", i))
+                    .unwrap()
+                    .set("value", "1")
+                    .unwrap()
+                    .build()
+                    .unwrap();
+                barrier_ref.wait().await;
+
+                job.execute().await.unwrap();
+            });
+            handles.push(handle);
+        }
+
+        try_join_all(handles).await.unwrap();
+
+        dataset.checkout_latest().await.unwrap();
+
+        let data = dataset.scan().try_into_batch().await.unwrap();
+
+        let mut ids = data["id"]
+            .as_primitive::<UInt32Type>()
+            .values()
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        ids.sort();
+        assert_eq!(ids, vec![0, 1, 2],);
+        let values = data["value"].as_primitive::<UInt32Type>().values();
+        assert!(values.iter().all(|&value| value == 1));
     }
 }

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -147,7 +147,6 @@ impl DatasetPreFilter {
         session
             .file_metadata_cache
             .get_or_insert(&path, move |_| {
-                let dataset = dataset.clone();
                 async move {
                     let row_ids_and_deletions = load_row_ids_and_deletions(&dataset).await?;
 

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -740,7 +740,6 @@ pub(crate) async fn commit_transaction(
 
     // Note: object_store has been configured with WriteParams, but dataset.object_store()
     // has not necessarily. So for anything involving writing, use `object_store`.
-    let transaction_file = write_transaction_file(object_store, &dataset.base, transaction).await?;
     let read_version = transaction.read_version;
     let mut target_version = read_version + 1;
     let original_dataset = dataset.clone();
@@ -795,8 +794,8 @@ pub(crate) async fn commit_transaction(
 
         transaction = rebase.finish(&dataset).await?;
 
-        // TODO: how about writing a new transaction file with the rebased transaction?
-        // TODO: how about deleting the old transaction file?
+        let transaction_file =
+            write_transaction_file(object_store, &dataset.base, &transaction).await?;
 
         target_version = dataset.manifest.version + 1;
         if is_detached_version(target_version) {

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -760,6 +760,7 @@ pub(crate) async fn commit_transaction(
     let mut transaction = transaction.clone();
 
     let num_attempts = std::cmp::max(commit_config.num_retries, 1);
+    // TODO: use SlotBackoff here instead and size unit off of attempt time.
     let mut backoff = Backoff::default();
     while backoff.attempt() < num_attempts {
         // See if we can retry the commit. Try to account for all

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -575,6 +575,8 @@ mod tests {
                     final_fragment.deletion_file.as_ref().unwrap(),
                 );
                 assert!(dataset.object_store().exists(&new_path).await.unwrap());
+
+                assert_eq!(io_stats.num_hops, 1);
             } else {
                 // No IO should have happened.
                 assert_eq!(io_stats.read_iops, 0);

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1,28 +1,83 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use lance_core::Result;
-use lance_table::format::{Fragment, Manifest};
-use snafu::location;
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+};
+
+use futures::{StreamExt, TryStreamExt};
+use lance_core::{
+    utils::{deletion::DeletionVector, mask::RowIdTreeMap},
+    Result,
+};
+use lance_table::{
+    format::Fragment,
+    io::deletion::{read_deletion_file_cached, write_deletion_file},
+};
+use snafu::{location, Location};
 
 use crate::{
-    dataset::transaction::{ConflictResult, Transaction},
+    dataset::transaction::{ConflictResult, Operation, Transaction},
     Dataset,
 };
 
-pub struct ConflictResolver {
+pub struct TransactionRebase<'a> {
+    transaction: Transaction,
     /// Relevant fragments as they were at the read version of the transaction.
     /// Has original fragment, plus a bool indicating whether a rewrite is needed.
-    initial_fragments: Vec<(Fragment, bool)>,
+    initial_fragments: HashMap<u64, (Fragment, bool)>,
+    affected_rows: Option<&'a RowIdTreeMap>,
 }
 
-impl ConflictResolver {
-    pub async fn try_new(dataset: &Dataset, transaction: &Transaction) -> Result<Self> {
-        todo!("assert that dataset is at the read version of the transaction");
+impl<'a> TransactionRebase<'a> {
+    pub async fn try_new(
+        dataset: &Dataset,
+        transaction: Transaction,
+        affected_rows: Option<&'a RowIdTreeMap>,
+    ) -> Result<Self> {
+        let dataset = if dataset.manifest.version != transaction.read_version {
+            Cow::Owned(dataset.checkout_version(transaction.read_version).await?)
+        } else {
+            Cow::Borrowed(dataset)
+        };
 
-        // Get the affected fragments, so we can watch them.
+        let fragments = dataset.fragments().as_slice();
 
-        todo!()
+        let modified_fragment_ids = transaction
+            .operation
+            .modified_fragment_ids()
+            .collect::<HashSet<_>>();
+
+        let initial_fragments = fragments
+            .iter()
+            .filter(|fragment| {
+                // Check if the fragment is modified by the transaction.
+                modified_fragment_ids.contains(&fragment.id)
+            })
+            .map(|fragment| (fragment.id, (fragment.clone(), false)))
+            .collect::<HashMap<_, _>>();
+
+        Ok(Self {
+            initial_fragments,
+            transaction,
+            affected_rows,
+        })
+    }
+
+    fn retryable_conflict_err(
+        &self,
+        other_transaction: &Transaction,
+        other_version: u64,
+        location: Location,
+    ) -> crate::Error {
+        crate::Error::RetryableCommitConflict {
+            version: other_version,
+            source: format!(
+                "This {} transaction was preempted by concurrent transaction {} at version {}. Please retry.",
+                self.transaction.operation, other_transaction.operation, other_version).into(),
+            location,
+        }
     }
 
     /// Check whether the transaction conflicts with another transaction.
@@ -31,11 +86,9 @@ impl ConflictResolver {
     /// return Ok(()).
     pub fn check_txn(
         &mut self,
-        transaction: &Transaction,
         other_transaction: Option<&Transaction>,
-        other_manifest: &Manifest,
+        other_version: u64,
     ) -> Result<()> {
-        let other_version = other_manifest.version;
         let Some(other_transaction) = other_transaction else {
             return Err(crate::Error::Internal {
                 message: format!(
@@ -47,41 +100,185 @@ impl ConflictResolver {
             });
         };
 
-        match transaction.conflicts_with(other_transaction) {
+        match self.transaction.conflicts_with(other_transaction) {
             ConflictResult::Compatible => Ok(()),
             ConflictResult::NotCompatible => {
                 Err(crate::Error::CommitConflict {
                     version: other_version,
                     source: format!(
                         "This {} transaction is incompatible with concurrent transaction {} at version {}.",
-                        transaction.operation, other_transaction.operation, other_version).into(),
+                        self.transaction.operation, other_transaction.operation, other_version).into(),
                     location: location!(),
                 })
             },
             ConflictResult::Retryable => {
-                todo!("check if we can just rewrite deletion files");
+                match &other_transaction.operation {
+                    Operation::Update { updated_fragments, .. } |
+                    Operation::Delete { updated_fragments, .. } => {
+                        for updated in updated_fragments {
+                            if let Some((fragment, needs_rewrite)) = self.initial_fragments.get_mut(&updated.id) {
+                                if self.affected_rows.is_none() {
+                                    // We don't have any affected rows, so we can't
+                                    // do the rebase anyways.
+                                    return Err(self.retryable_conflict_err(
+                                        other_transaction,
+                                        other_version,
+                                        location!()
+                                    ));
+                                }
 
-                Err(crate::Error::RetryableCommitConflict {
-                    version: other_version,
-                    source: format!(
-                        "This {} transaction was preempted by concurrent transaction {} at version {}. Please retry.",
-                        transaction.operation, other_transaction.operation, other_version).into(),
-                    location: location!() })
+                                // If data files, not just deletion files, are modified,
+                                // then we can't rebase.
+                                if fragment.files != updated.files {
+                                    return Err(self.retryable_conflict_err(
+                                        other_transaction,
+                                        other_version,
+                                        location!()
+                                    ));
+                                }
+
+                                // Mark any modified fragments as needing a rewrite.
+                                *needs_rewrite |= updated.deletion_file != fragment.deletion_file;
+                            }
+                        }
+                        return Ok(());
+                    },
+                    _ => {}
+                }
+
+                Err(self.retryable_conflict_err(other_transaction, other_version, location!()))
             }
         }
     }
 
     /// Writes
-    pub async fn update_files(&self) -> Result<Transaction> {
-        // TODO: What do we do when the other transaction was an upsert that rewrote
-        // fragments rather than just touched the deletion file? This would generally
-        // be easier to handle if the transaction was simply a diff.
-        // Maybe what we can do, is:
-        // (1) We grab the fragments as they are at read_version
-        // (2) We keep around the data files that were (a) present at read_version
-        //     and (b) are in fragments this transaction is touching.
-        // (3) We can use those sets of data files to check if the other transaction
-        //     modified the data files we are touching, and not just the deletion files.
-        todo!()
+    pub async fn finish(mut self, dataset: &Dataset) -> Result<Transaction> {
+        if self
+            .initial_fragments
+            .iter()
+            .any(|(_, (_, needs_rewrite))| *needs_rewrite)
+        {
+            if let Some(affected_rows) = self.affected_rows {
+                // Then we do the rebase
+
+                // 1. Load the deletion files that need a rewrite.
+                // 2. Validate there is no overlap with the affected rows. (if there is, return retryable conflict error)
+                // 3. Write out new deletion files with existing deletes | affected rows.
+                // 4. Update the transaction with the new deletion files.
+
+                let fragments_ids_to_rewrite = self
+                    .initial_fragments
+                    .iter()
+                    .filter_map(|(_, (fragment, needs_rewrite))| {
+                        if *needs_rewrite {
+                            Some(fragment.id)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                // We are rewriting the deletion files on the *current* dataset.
+                let files_to_rewrite = dataset
+                    .fragments()
+                    .as_slice()
+                    .iter()
+                    .filter_map(|fragment| {
+                        if fragments_ids_to_rewrite.contains(&fragment.id) {
+                            Some((fragment.id, fragment.deletion_file.clone()))
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                let existing_deletion_vecs = futures::stream::iter(files_to_rewrite)
+                    .map(|(fragment_id, deletion_file)| async move {
+                        read_deletion_file_cached(
+                            fragment_id,
+                            &deletion_file.expect("there should be a deletion file"),
+                            &dataset.base,
+                            dataset.object_store(),
+                            &dataset.session.file_metadata_cache,
+                        )
+                        .await
+                        .map(|dv| (fragment_id, dv))
+                    })
+                    .buffered(dataset.object_store().io_parallelism())
+                    .try_collect::<Vec<_>>()
+                    .await?;
+
+                // Check for row-level conflicts
+                let mut existing_deletions = RowIdTreeMap::new();
+                for (fragment_id, deletion_vec) in existing_deletion_vecs {
+                    existing_deletions
+                        .insert_bitmap(fragment_id as u32, deletion_vec.as_ref().into());
+                }
+                let conflicting_rows = existing_deletions.clone() & affected_rows.clone();
+                if conflicting_rows.len().map(|v| v > 0).unwrap_or(true) {
+                    let sample_addressed = conflicting_rows
+                        .row_ids()
+                        .unwrap()
+                        .take(5)
+                        .collect::<Vec<_>>();
+                    return Err(crate::Error::RetryableCommitConflict {
+                        version: dataset.manifest.version,
+                        source: format!(
+                            "Found conflicts for row addresses {:?}",
+                            sample_addressed.as_slice()
+                        )
+                        .into(),
+                        location: location!(),
+                    });
+                }
+
+                let merged = existing_deletions.clone() | affected_rows.clone();
+
+                let mut new_deletion_files = HashMap::with_capacity(fragments_ids_to_rewrite.len());
+                for fragment_id in fragments_ids_to_rewrite.iter() {
+                    let dv = DeletionVector::from(
+                        merged
+                            .get_fragment_bitmap(*fragment_id as u32)
+                            .unwrap()
+                            .clone(),
+                    );
+                    let new_deletion_file = write_deletion_file(
+                        &dataset.base,
+                        *fragment_id,
+                        dataset.manifest.version,
+                        &dv,
+                        dataset.object_store(),
+                    )
+                    .await?;
+                    new_deletion_files.insert(*fragment_id, new_deletion_file);
+                }
+
+                match &mut self.transaction.operation {
+                    Operation::Update {
+                        updated_fragments, ..
+                    }
+                    | Operation::Delete {
+                        updated_fragments, ..
+                    } => {
+                        for updated in updated_fragments {
+                            if let Some(new_deletion_file) = new_deletion_files.get(&updated.id) {
+                                updated.deletion_file = new_deletion_file.clone();
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+
+                // TODO: what do we do with the old deletion files?
+
+                Ok(self.transaction)
+            } else {
+                // We shouldn't hit this.
+                Err(crate::Error::Internal {
+                        message: "We have a transaction that needs to be rebased, but we don't have any affected rows.".into(),
+                        location: location!(),
+                    })
+            }
+        } else {
+            Ok(self.transaction)
+        }
     }
 }

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use lance_core::Result;
+use lance_table::format::{Fragment, Manifest};
+use snafu::location;
+
+use crate::{
+    dataset::transaction::{ConflictResult, Transaction},
+    Dataset,
+};
+
+pub struct ConflictResolver {
+    /// Relevant fragments as they were at the read version of the transaction.
+    /// Has original fragment, plus a bool indicating whether a rewrite is needed.
+    initial_fragments: Vec<(Fragment, bool)>,
+}
+
+impl ConflictResolver {
+    pub async fn try_new(dataset: &Dataset, transaction: &Transaction) -> Result<Self> {
+        todo!("assert that dataset is at the read version of the transaction");
+
+        // Get the affected fragments, so we can watch them.
+
+        todo!()
+    }
+
+    /// Check whether the transaction conflicts with another transaction.
+    ///
+    /// Will return an error if the transaction is not valid. Otherwise, it will
+    /// return Ok(()).
+    pub fn check_txn(
+        &mut self,
+        transaction: &Transaction,
+        other_transaction: Option<&Transaction>,
+        other_manifest: &Manifest,
+    ) -> Result<()> {
+        let other_version = other_manifest.version;
+        let Some(other_transaction) = other_transaction else {
+            return Err(crate::Error::Internal {
+                message: format!(
+                    "There was a conflicting transaction at version {}, \
+                    and it was missing transaction metadata.",
+                    other_version
+                ),
+                location: location!(),
+            });
+        };
+
+        match transaction.conflicts_with(other_transaction) {
+            ConflictResult::Compatible => Ok(()),
+            ConflictResult::NotCompatible => {
+                Err(crate::Error::CommitConflict {
+                    version: other_version,
+                    source: format!(
+                        "This {} transaction is incompatible with concurrent transaction {} at version {}.",
+                        transaction.operation, other_transaction.operation, other_version).into(),
+                    location: location!(),
+                })
+            },
+            ConflictResult::Retryable => {
+                todo!("check if we can just rewrite deletion files");
+
+                Err(crate::Error::RetryableCommitConflict {
+                    version: other_version,
+                    source: format!(
+                        "This {} transaction was preempted by concurrent transaction {} at version {}. Please retry.",
+                        transaction.operation, other_transaction.operation, other_version).into(),
+                    location: location!() })
+            }
+        }
+    }
+
+    /// Writes
+    pub async fn update_files(&self) -> Result<Transaction> {
+        // TODO: What do we do when the other transaction was an upsert that rewrote
+        // fragments rather than just touched the deletion file? This would generally
+        // be easier to handle if the transaction was simply a diff.
+        // Maybe what we can do, is:
+        // (1) We grab the fragments as they are at read_version
+        // (2) We keep around the data files that were (a) present at read_version
+        //     and (b) are in fragments this transaction is touching.
+        // (3) We can use those sets of data files to check if the other transaction
+        //     modified the data files we are touching, and not just the deletion files.
+        todo!()
+    }
+}

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -3,6 +3,7 @@
 
 use std::fmt::{Display, Formatter};
 use std::ops::Range;
+use std::sync::atomic::AtomicU16;
 use std::sync::{Arc, Mutex};
 
 use arrow_array::{RecordBatch, RecordBatchIterator};
@@ -277,6 +278,8 @@ pub struct IoStats {
     pub read_bytes: u64,
     pub write_iops: u64,
     pub write_bytes: u64,
+    /// Number of disjoint periods where at least one IO is in-flight.
+    pub num_hops: u64,
 }
 
 impl Display for IoStats {
@@ -289,6 +292,7 @@ impl Display for IoStats {
 pub struct IoTrackingStore {
     target: Arc<dyn ObjectStore>,
     stats: Arc<Mutex<IoStats>>,
+    active_requests: Arc<AtomicU16>,
 }
 
 impl Display for IoTrackingStore {
@@ -311,6 +315,7 @@ impl WrappingObjectStore for StatsHolder {
         Arc::new(IoTrackingStore {
             target,
             stats: self.0.clone(),
+            active_requests: Arc::new(AtomicU16::new(0)),
         })
     }
 }
@@ -332,12 +337,17 @@ impl IoTrackingStore {
         stats.write_iops += 1;
         stats.write_bytes += num_bytes;
     }
+
+    fn hop_guard(&self) -> HopGuard {
+        HopGuard::new(self.active_requests.clone(), self.stats.clone())
+    }
 }
 
 #[async_trait::async_trait]
 #[deny(clippy::missing_trait_methods)]
 impl ObjectStore for IoTrackingStore {
     async fn put(&self, location: &Path, bytes: PutPayload) -> OSResult<PutResult> {
+        let _guard = self.hop_guard();
         self.record_write(bytes.content_length() as u64);
         self.target.put(location, bytes).await
     }
@@ -348,15 +358,18 @@ impl ObjectStore for IoTrackingStore {
         bytes: PutPayload,
         opts: PutOptions,
     ) -> OSResult<PutResult> {
+        let _guard = self.hop_guard();
         self.record_write(bytes.content_length() as u64);
         self.target.put_opts(location, bytes, opts).await
     }
 
     async fn put_multipart(&self, location: &Path) -> OSResult<Box<dyn MultipartUpload>> {
+        let _guard = self.hop_guard();
         let target = self.target.put_multipart(location).await?;
         Ok(Box::new(IoTrackingMultipartUpload {
             target,
             stats: self.stats.clone(),
+            _guard,
         }))
     }
 
@@ -365,14 +378,17 @@ impl ObjectStore for IoTrackingStore {
         location: &Path,
         opts: PutMultipartOpts,
     ) -> OSResult<Box<dyn MultipartUpload>> {
+        let _guard = self.hop_guard();
         let target = self.target.put_multipart_opts(location, opts).await?;
         Ok(Box::new(IoTrackingMultipartUpload {
             target,
             stats: self.stats.clone(),
+            _guard,
         }))
     }
 
     async fn get(&self, location: &Path) -> OSResult<GetResult> {
+        let _guard = self.hop_guard();
         let result = self.target.get(location).await;
         if let Ok(result) = &result {
             let num_bytes = result.range.end - result.range.start;
@@ -382,6 +398,7 @@ impl ObjectStore for IoTrackingStore {
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+        let _guard = self.hop_guard();
         let result = self.target.get_opts(location, options).await;
         if let Ok(result) = &result {
             let num_bytes = result.range.end - result.range.start;
@@ -391,6 +408,7 @@ impl ObjectStore for IoTrackingStore {
     }
 
     async fn get_range(&self, location: &Path, range: Range<usize>) -> OSResult<Bytes> {
+        let _guard = self.hop_guard();
         let result = self.target.get_range(location, range).await;
         if let Ok(result) = &result {
             self.record_read(result.len() as u64);
@@ -399,6 +417,7 @@ impl ObjectStore for IoTrackingStore {
     }
 
     async fn get_ranges(&self, location: &Path, ranges: &[Range<usize>]) -> OSResult<Vec<Bytes>> {
+        let _guard = self.hop_guard();
         let result = self.target.get_ranges(location, ranges).await;
         if let Ok(result) = &result {
             self.record_read(result.iter().map(|b| b.len() as u64).sum());
@@ -407,11 +426,13 @@ impl ObjectStore for IoTrackingStore {
     }
 
     async fn head(&self, location: &Path) -> OSResult<ObjectMeta> {
+        let _guard = self.hop_guard();
         self.record_read(0);
         self.target.head(location).await
     }
 
     async fn delete(&self, location: &Path) -> OSResult<()> {
+        let _guard = self.hop_guard();
         self.record_write(0);
         self.target.delete(location).await
     }
@@ -424,6 +445,7 @@ impl ObjectStore for IoTrackingStore {
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, OSResult<ObjectMeta>> {
+        let _guard = self.hop_guard();
         self.record_read(0);
         self.target.list(prefix)
     }
@@ -438,26 +460,31 @@ impl ObjectStore for IoTrackingStore {
     }
 
     async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+        let _guard = self.hop_guard();
         self.record_read(0);
         self.target.list_with_delimiter(prefix).await
     }
 
     async fn copy(&self, from: &Path, to: &Path) -> OSResult<()> {
+        let _guard = self.hop_guard();
         self.record_write(0);
         self.target.copy(from, to).await
     }
 
     async fn rename(&self, from: &Path, to: &Path) -> OSResult<()> {
+        let _guard = self.hop_guard();
         self.record_write(0);
         self.target.rename(from, to).await
     }
 
     async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
+        let _guard = self.hop_guard();
         self.record_write(0);
         self.target.rename_if_not_exists(from, to).await
     }
 
     async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
+        let _guard = self.hop_guard();
         self.record_write(0);
         self.target.copy_if_not_exists(from, to).await
     }
@@ -467,6 +494,7 @@ impl ObjectStore for IoTrackingStore {
 struct IoTrackingMultipartUpload {
     target: Box<dyn MultipartUpload>,
     stats: Arc<Mutex<IoStats>>,
+    _guard: HopGuard,
 }
 
 #[async_trait::async_trait]
@@ -486,6 +514,35 @@ impl MultipartUpload for IoTrackingMultipartUpload {
             stats.write_bytes += payload.content_length() as u64;
         }
         self.target.put_part(payload)
+    }
+}
+
+#[derive(Debug)]
+struct HopGuard {
+    active_requests: Arc<AtomicU16>,
+    stats: Arc<Mutex<IoStats>>,
+}
+
+impl HopGuard {
+    fn new(active_requests: Arc<AtomicU16>, stats: Arc<Mutex<IoStats>>) -> Self {
+        active_requests.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Self {
+            active_requests,
+            stats,
+        }
+    }
+}
+
+impl Drop for HopGuard {
+    fn drop(&mut self) {
+        if self
+            .active_requests
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst)
+            == 1
+        {
+            let mut stats = self.stats.lock().unwrap();
+            stats.num_hops += 1;
+        }
     }
 }
 


### PR DESCRIPTION
Makes `merge_insert` and `update` transactions do row-level conflict resolution checks, to see if we can quickly resolve conflicts by rewriting deletion files.

Core changes:
* `merge_insert` and `update` transactions now produce an `affected_rows` output, with a map of the affected row addresses.
* Create a `TransactionRebase` struct to handle conflict resolution. This uses the `affected_rows` output to attempt to rewrite deletion files.

Auxiliary changes:
* Changed all code paths reading deletion files to go through `read_deletion_file_cached()`. 

Closes #3772