### PR TITLE
chore: allow pass object store request timeout configuration

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -568,6 +568,9 @@ impl StorageOptions {
         if let Ok(value) = std::env::var("OBJECT_STORE_CLIENT_RETRY_TIMEOUT") {
             options.insert("client_retry_timeout".into(), value);
         }
+        if let Ok(value) = std::env::var("OBJECT_STORE_CLIENT_REQUEST_TIMEOUT") {
+            options.insert("client_request_timeout".into(), value);
+        }
         Self(options)
     }
 
@@ -603,6 +606,14 @@ impl StorageOptions {
             .find(|(key, _)| key.eq_ignore_ascii_case("client_retry_timeout"))
             .and_then(|(_, value)| value.parse::<u64>().ok())
             .unwrap_or(180)
+    }
+
+    pub fn client_request_timeout(&self) -> u64 {
+        self.0
+            .iter()
+            .find(|(key, _)| key.eq_ignore_ascii_case("client_request_timeout"))
+            .and_then(|(_, value)| value.parse::<u64>().ok())
+            .unwrap_or(30)
     }
 
     pub fn get(&self, key: &str) -> Option<&String> {

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -3,9 +3,10 @@
 
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
+use aws_config::imds::{client, Client};
 use object_store::{
     azure::{AzureConfigKey, MicrosoftAzureBuilder},
-    RetryConfig,
+    ClientOptions, RetryConfig,
 };
 use url::Url;
 
@@ -34,9 +35,14 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
             retry_timeout: Duration::from_secs(retry_timeout),
         };
 
+        let client_options = ClientOptions::default().with_timeout(Duration::from_secs(
+            storage_options.client_request_timeout(),
+        ));
+
         storage_options.with_env_azure();
         let mut builder = MicrosoftAzureBuilder::new()
             .with_url(base_path.as_ref())
+            .with_client_options(client_options)
             .with_retry(retry_config);
         for (key, value) in storage_options.as_azure_options() {
             builder = builder.with_config(key, value);

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
 use object_store::{
     gcp::{GcpCredential, GoogleCloudStorageBuilder, GoogleConfigKey},
-    RetryConfig, StaticCredentialProvider,
+    ClientOptions, RetryConfig, StaticCredentialProvider,
 };
 use url::Url;
 
@@ -34,9 +34,14 @@ impl ObjectStoreProvider for GcsStoreProvider {
             retry_timeout: Duration::from_secs(retry_timeout),
         };
 
+        let client_options = ClientOptions::default().with_timeout(Duration::from_secs(
+            storage_options.client_request_timeout(),
+        ));
+
         storage_options.with_env_gcs();
         let mut builder = GoogleCloudStorageBuilder::new()
             .with_url(base_path.as_ref())
+            .with_client_options(client_options)
             .with_retry(retry_config);
         for (key, value) in storage_options.as_gcs_options() {
             builder = builder.with_config(key, value);


### PR DESCRIPTION
The object_store client uses a default HTTP timeout of 30 seconds, which is often too short for large range reads (>100MB) from Azure Blob Storage. These reads can fail mid-transfer with a Generic MicrosoftAzure error: error decoding response body. This PR makes the request timeout configurable, allowing users to increase it as needed for large payloads.