### PR TITLE
chore: temporarily revert retries in merge insert

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,3 +195,4 @@ print_stdout = "deny"
 print_stderr = "deny"
 # not too much we can do to avoid multiple crate versions
 multiple-crate-versions = "allow"
+await_holding_invalid_type = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,4 +195,3 @@ print_stdout = "deny"
 print_stderr = "deny"
 # not too much we can do to avoid multiple crate versions
 multiple-crate-versions = "allow"
-await_holding_invalid_type = "deny"

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -656,6 +656,9 @@ async fn resolve_commit_handler(
 /// data. Otherwise, the source will be spilled to a temporary file on disk.
 ///
 /// This is used to support retries on write operations.
+// TODO: we will use this again once we bring back
+// https://github.com/lancedb/lance/issues/3798
+#[allow(dead_code)]
 async fn new_source_iter(
     source: SendableRecordBatchStream,
     enable_retries: bool,
@@ -685,6 +688,9 @@ async fn new_source_iter(
     }
 }
 
+// We will use this again once we address this:
+// https://github.com/lancedb/lance/issues/3798
+#[allow(dead_code)]
 struct SpillStreamIter {
     receiver: SpillReceiver,
     #[allow(dead_code)] // Exists to keep the SpillSender alive

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -16,12 +16,10 @@
 //! key columns are identical in both the source and the target.  This means that you will need some kind of
 //! meaningful key column to be able to perform a merge insert.
 
-use futures::FutureExt;
 use std::{
     collections::BTreeMap,
-    future::Future,
     sync::{Arc, Mutex},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use arrow_array::{
@@ -55,14 +53,13 @@ use lance_datafusion::{
 
 use datafusion_physical_expr::expressions::Column;
 use futures::{
-    future::Either,
     stream::{self},
-    Stream, StreamExt, TryFutureExt, TryStreamExt,
+    Stream, StreamExt, TryStreamExt,
 };
 use lance_core::{
     datatypes::{OnMissing, OnTypeMismatch, SchemaCompareOptions},
     error::{box_error, InvalidInputSnafu},
-    utils::{backoff::SlotBackoff, futures::Capacity, tokio::get_num_compute_intensive_cpus},
+    utils::{futures::Capacity, tokio::get_num_compute_intensive_cpus},
     Error, Result, ROW_ADDR, ROW_ADDR_FIELD, ROW_ID, ROW_ID_FIELD,
 };
 use lance_datafusion::{


### PR DESCRIPTION
We believe this may be related to https://github.com/lancedb/lance/issues/3798, and so are reverting some of the changes in https://github.com/lancedb/lance/pull/3614 for now.