### PR TITLE
feat: split large reads into smaller parallel reads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,3 +195,5 @@ print_stdout = "deny"
 print_stderr = "deny"
 # not too much we can do to avoid multiple crate versions
 multiple-crate-versions = "allow"
+# We use Vec<Range<u64>> in a lot of places and it is very common to use a single range in the vec.
+single_range_in_vec_init = "allow"

--- a/python/python/tests/test_file.py
+++ b/python/python/tests/test_file.py
@@ -474,4 +474,13 @@ def test_blob(tmp_path):
 
     reader = LanceFileReader(str(path))
     assert len(reader.metadata().columns[0].pages) == 1
-    assert reader.read_all().to_table() == pa.table({"val": vals})
+
+    actual = reader.read_all().to_table()
+    expected = pa.table({"val": vals})
+
+    assert actual.num_rows == expected.num_rows
+    for row_num in range(expected.num_rows):
+        actual_bytes = actual.column("val").chunk(0)[row_num].as_py()
+        expected_bytes = expected.column("val").chunk(0)[row_num].as_py()
+        assert len(actual_bytes) == len(expected_bytes)
+        assert actual_bytes == expected_bytes

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -53,7 +53,7 @@ const DEFAULT_LOCAL_BLOCK_SIZE: usize = 4 * 1024; // 4KB block size
 const DEFAULT_CLOUD_BLOCK_SIZE: usize = 64 * 1024; // 64KB block size
 
 lazy_static::lazy_static! {
-    pub static ref DEFAULT_MAX_IOP_SIZE: u64 = std::env::var("LANCE_DEFAULT_MAX_IOP_SIZE")
+    pub static ref DEFAULT_MAX_IOP_SIZE: u64 = std::env::var("LANCE_MAX_IOP_SIZE")
         .map(|val| val.parse().unwrap()).unwrap_or(16 * 1024 * 1024);
 }
 

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -26,7 +26,7 @@ use url::Url;
 
 use crate::object_store::{
     ObjectStore, ObjectStoreParams, ObjectStoreProvider, StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE,
-    DEFAULT_CLOUD_IO_PARALLELISM,
+    DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE,
 };
 use lance_core::error::{Error, Result};
 
@@ -98,6 +98,7 @@ impl ObjectStoreProvider for AwsStoreProvider {
             inner,
             scheme: String::from(base_path.scheme()),
             block_size,
+            max_iop_size: *DEFAULT_MAX_IOP_SIZE,
             use_constant_size_upload_parts,
             list_is_lexically_ordered: true,
             io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 use crate::object_store::{
     ObjectStore, ObjectStoreParams, ObjectStoreProvider, StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE,
-    DEFAULT_CLOUD_IO_PARALLELISM,
+    DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE,
 };
 use lance_core::error::Result;
 
@@ -47,6 +47,7 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
             inner,
             scheme: String::from("az"),
             block_size,
+            max_iop_size: *DEFAULT_MAX_IOP_SIZE,
             use_constant_size_upload_parts: false,
             list_is_lexically_ordered: true,
             io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 use crate::object_store::{
     ObjectStore, ObjectStoreParams, ObjectStoreProvider, StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE,
-    DEFAULT_CLOUD_IO_PARALLELISM,
+    DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE,
 };
 use lance_core::error::Result;
 
@@ -55,6 +55,7 @@ impl ObjectStoreProvider for GcsStoreProvider {
             inner,
             scheme: String::from("gs"),
             block_size,
+            max_iop_size: *DEFAULT_MAX_IOP_SIZE,
             use_constant_size_upload_parts: false,
             list_is_lexically_ordered: true,
             io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -8,7 +8,7 @@ use url::Url;
 
 use crate::object_store::{
     ObjectStore, ObjectStoreParams, ObjectStoreProvider, StorageOptions, DEFAULT_LOCAL_BLOCK_SIZE,
-    DEFAULT_LOCAL_IO_PARALLELISM,
+    DEFAULT_LOCAL_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE,
 };
 use lance_core::error::Result;
 
@@ -25,6 +25,7 @@ impl ObjectStoreProvider for FileStoreProvider {
             inner: Arc::new(LocalFileSystem::new()),
             scheme: base_path.scheme().to_owned(),
             block_size,
+            max_iop_size: *DEFAULT_MAX_IOP_SIZE,
             use_constant_size_upload_parts: false,
             list_is_lexically_ordered: false,
             io_parallelism: DEFAULT_LOCAL_IO_PARALLELISM,

--- a/rust/lance-io/src/object_store/providers/memory.rs
+++ b/rust/lance-io/src/object_store/providers/memory.rs
@@ -8,6 +8,7 @@ use url::Url;
 
 use crate::object_store::{
     ObjectStore, ObjectStoreParams, ObjectStoreProvider, StorageOptions, DEFAULT_LOCAL_BLOCK_SIZE,
+    DEFAULT_MAX_IOP_SIZE,
 };
 use lance_core::{error::Result, utils::tokio::get_num_compute_intensive_cpus};
 
@@ -25,6 +26,7 @@ impl ObjectStoreProvider for MemoryStoreProvider {
             inner: Arc::new(InMemory::new()),
             scheme: String::from("memory"),
             block_size,
+            max_iop_size: *DEFAULT_MAX_IOP_SIZE,
             use_constant_size_upload_parts: false,
             list_is_lexically_ordered: true,
             io_parallelism: get_num_compute_intensive_cpus(),

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -653,11 +653,13 @@ impl ScanScheduler {
             .open_with_size(path, file_size_bytes)
             .await?;
         let block_size = self.object_store.block_size() as u64;
+        let max_iop_size = self.object_store.max_iop_size();
         Ok(FileScheduler {
             reader: reader.into(),
             block_size,
             root: self.clone(),
             base_priority,
+            max_iop_size,
         })
     }
 
@@ -755,6 +757,7 @@ pub struct FileScheduler {
     root: Arc<ScanScheduler>,
     block_size: u64,
     base_priority: u64,
+    max_iop_size: u64,
 }
 
 fn is_close_together(range1: &Range<u64>, range2: &Range<u64>, block_size: u64) -> bool {
@@ -784,12 +787,10 @@ impl FileScheduler {
         request: Vec<Range<u64>>,
         priority: u64,
     ) -> impl Future<Output = Result<Vec<Bytes>>> + Send {
-        self.root.stats.record_request(&request);
-
         // The final priority is a combination of the row offset and the file number
         let priority = ((self.base_priority as u128) << 64) + priority as u128;
 
-        let mut updated_requests = Vec::with_capacity(request.len());
+        let mut merged_requests = Vec::with_capacity(request.len());
 
         if !request.is_empty() {
             let mut curr_interval = request[0].clone();
@@ -798,13 +799,35 @@ impl FileScheduler {
                 if is_close_together(&curr_interval, req, self.block_size) {
                     curr_interval.end = curr_interval.end.max(req.end);
                 } else {
-                    updated_requests.push(curr_interval);
+                    merged_requests.push(curr_interval);
                     curr_interval = req.clone();
                 }
             }
 
-            updated_requests.push(curr_interval);
+            merged_requests.push(curr_interval);
         }
+
+        let mut updated_requests = Vec::with_capacity(merged_requests.len());
+        for req in merged_requests {
+            if req.is_empty() {
+                updated_requests.push(req);
+            } else {
+                let num_requests = (req.end - req.start).div_ceil(self.max_iop_size);
+                let bytes_per_request = (req.end - req.start) / num_requests;
+                for i in 0..num_requests {
+                    let start = req.start + i * bytes_per_request;
+                    let end = if i == num_requests - 1 {
+                        // Last request is a bit bigger due to rounding
+                        req.end
+                    } else {
+                        start + bytes_per_request
+                    };
+                    updated_requests.push(start..end);
+                }
+            }
+        }
+
+        self.root.stats.record_request(&updated_requests);
 
         let bytes_vec_fut =
             self.root
@@ -823,13 +846,32 @@ impl FileScheduler {
                 let byte_offset = updated_range.start as usize;
 
                 if is_overlapping(updated_range, orig_range) {
-                    // Rescale the ranges since they correspond to the entire set of bytes, while
-                    // But we need to slice into a subset of the bytes in a particular index of bytes_vec
+                    // We need to undo the coalescing and splitting done earlier
                     let start = orig_range.start as usize - byte_offset;
-                    let end = orig_range.end as usize - byte_offset;
-
-                    let sliced_range = bytes_vec[updated_index].slice(start..end);
-                    final_bytes.push(sliced_range);
+                    if orig_range.end <= updated_range.end {
+                        // The original range is fully contained in the updated range, can do
+                        // zero-copy slice
+                        let end = orig_range.end as usize - byte_offset;
+                        final_bytes.push(bytes_vec[updated_index].slice(start..end));
+                    } else {
+                        // The original read was split into multiple requests, need to copy
+                        // back into a single buffer
+                        let orig_size = orig_range.end - orig_range.start;
+                        let mut merged_bytes = Vec::with_capacity(orig_size as usize);
+                        merged_bytes.extend_from_slice(&bytes_vec[updated_index].slice(start..));
+                        let mut copy_offset = merged_bytes.len() as u64;
+                        while copy_offset < orig_size {
+                            updated_index += 1;
+                            let next_range = &updated_requests[updated_index];
+                            let bytes_to_take = (orig_range.end - copy_offset)
+                                .min(next_range.end - next_range.start);
+                            merged_bytes.extend_from_slice(
+                                &bytes_vec[updated_index].slice(0..bytes_to_take as usize),
+                            );
+                            copy_offset += bytes_to_take;
+                        }
+                        final_bytes.push(Bytes::from(merged_bytes));
+                    }
                     orig_index += 1;
                 } else {
                     updated_index += 1;
@@ -845,6 +887,7 @@ impl FileScheduler {
             reader: self.reader.clone(),
             root: self.root.clone(),
             block_size: self.block_size,
+            max_iop_size: self.max_iop_size,
             base_priority: priority,
         }
     }
@@ -886,7 +929,10 @@ mod tests {
     use tokio::{runtime::Handle, time::timeout};
     use url::Url;
 
-    use crate::{object_store::DEFAULT_DOWNLOAD_RETRY_COUNT, testing::MockObjectStore};
+    use crate::{
+        object_store::{DEFAULT_DOWNLOAD_RETRY_COUNT, DEFAULT_MAX_IOP_SIZE},
+        testing::MockObjectStore,
+    };
 
     use super::*;
 
@@ -938,6 +984,80 @@ mod tests {
             assert_eq!(expected, actual);
             offset += READ_SIZE;
         }
+    }
+
+    #[tokio::test]
+    async fn test_split_coalesce() {
+        let tmpdir = tempdir().unwrap();
+        let tmp_path = tmpdir.path().to_str().unwrap();
+        let tmp_path = Path::parse(tmp_path).unwrap();
+        let tmp_file = tmp_path.child("foo.file");
+
+        let obj_store = Arc::new(ObjectStore::local());
+
+        // Write 75MiB of data
+        const DATA_SIZE: u64 = 75 * 1024 * 1024;
+        let mut some_data = vec![0; DATA_SIZE as usize];
+        rand::thread_rng().fill_bytes(&mut some_data);
+        obj_store.put(&tmp_file, &some_data).await.unwrap();
+
+        let config = SchedulerConfig::default_for_testing();
+
+        let scheduler = ScanScheduler::new(obj_store, config);
+
+        let file_scheduler = scheduler
+            .open_file(&tmp_file, &CachedFileSize::unknown())
+            .await
+            .unwrap();
+
+        // These 3 requests should be coalesced into a single I/O because they are within 4KiB
+        // of each other
+        let req =
+            file_scheduler.submit_request(vec![50_000..51_000, 52_000..53_000, 54_000..55_000], 0);
+
+        let bytes = req.await.unwrap();
+
+        assert_eq!(bytes[0], &some_data[50_000..51_000]);
+        assert_eq!(bytes[1], &some_data[52_000..53_000]);
+        assert_eq!(bytes[2], &some_data[54_000..55_000]);
+
+        assert_eq!(1, scheduler.stats().iops);
+
+        // This should be split into 5 requests because it is so large
+        let req = file_scheduler.submit_request(vec![0..DATA_SIZE], 0);
+        let bytes = req.await.unwrap();
+        assert!(bytes[0] == some_data, "data is not the same");
+
+        assert_eq!(6, scheduler.stats().iops);
+
+        // None of these requests are bigger than the max IOP size but they will be coalesced into
+        // one IOP that is bigger and then split back into 2 requests that don't quite align with the original
+        // ranges.
+        let chunk_size = *DEFAULT_MAX_IOP_SIZE;
+        let req = file_scheduler.submit_request(
+            vec![
+                10..chunk_size,
+                chunk_size + 10..(chunk_size * 2) - 20,
+                chunk_size * 2..(chunk_size * 2) + 10,
+            ],
+            0,
+        );
+
+        let bytes = req.await.unwrap();
+        let chunk_size = chunk_size as usize;
+        assert!(
+            bytes[0] == some_data[10..chunk_size],
+            "data is not the same"
+        );
+        assert!(
+            bytes[1] == some_data[chunk_size + 10..(chunk_size * 2) - 20],
+            "data is not the same"
+        );
+        assert!(
+            bytes[2] == some_data[chunk_size * 2..(chunk_size * 2) + 10],
+            "data is not the same"
+        );
+        assert_eq!(8, scheduler.stats().iops);
     }
 
     #[tokio::test]


### PR DESCRIPTION
We can often end up with large pages.  This is easier in 2.1 than it is in 2.0 but it can happen in 2.0 as well.  When this happens we make one large request into object storage.  However, these large requests are problematic.  Partly because we get less performance (less parallelism) and partly because they are prone to failure, especially timeout, when the object store is under stress.  As a result, it is better to split requests into smaller requests.