### PR TITLE
fix: respect prefilter transformation in ANNIvfSubIndexExec

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -3883,6 +3883,7 @@ mod test {
         let mut scan = dataset.scan();
         scan.filter("filterable > 5").unwrap();
         scan.nearest("vector", query_key.as_ref(), 1).unwrap();
+        scan.nprobs(100);
         scan.with_row_id();
 
         let batches = scan
@@ -3892,6 +3893,7 @@ mod test {
             .try_collect::<Vec<_>>()
             .await
             .unwrap();
+
         assert_eq!(batches.len(), 0);
 
         scan.prefilter(true);

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -562,16 +562,27 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
         mut children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let plan = if children.len() == 1 || children.len() == 2 {
-            if children.len() == 2 {
-                let _prefilter = children.pop().expect("length checked");
-            }
-            // NOTE!!!! Prefilter transformation is ignored.
+            let prefilter_source = if children.len() == 2 {
+                let prefilter = children.pop().expect("length checked");
+                match &self.prefilter_source {
+                    PreFilterSource::None => PreFilterSource::None,
+                    PreFilterSource::FilteredRowIds(_) => {
+                        PreFilterSource::FilteredRowIds(prefilter)
+                    }
+                    PreFilterSource::ScalarIndexQuery(_) => {
+                        PreFilterSource::ScalarIndexQuery(prefilter)
+                    }
+                }
+            } else {
+                self.prefilter_source.clone()
+            };
+
             Self {
                 input: children.pop().expect("length checked"),
                 dataset: self.dataset.clone(),
                 indices: self.indices.clone(),
                 query: self.query.clone(),
-                prefilter_source: self.prefilter_source.clone(),
+                prefilter_source: prefilter_source,
                 properties: self.properties.clone(),
                 metrics: ExecutionPlanMetricsSet::new(),
             }

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -582,7 +582,7 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                 dataset: self.dataset.clone(),
                 indices: self.indices.clone(),
                 query: self.query.clone(),
-                prefilter_source: prefilter_source,
+                prefilter_source,
                 properties: self.properties.clone(),
                 metrics: ExecutionPlanMetricsSet::new(),
             }


### PR DESCRIPTION
Updates the new_with_children method to update the node's prefilter source where applicable. Prior to this commit, the implementation prevented plan optimization from happening under some circumstances.