### PR TITLE
ci: use toolchain file in Java builds

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -41,8 +41,6 @@ jobs:
           sudo apt install -y protobuf-compiler libssl-dev
       # pin the toolchain version to avoid surprises
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          toolchain: stable
       - uses: rui314/setup-mold@v1
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -41,6 +41,8 @@ jobs:
           sudo apt install -y protobuf-compiler libssl-dev
       # pin the toolchain version to avoid surprises
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy, rustfmt
       - uses: rui314/setup-mold@v1
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov


### PR DESCRIPTION
If we specify the toolchain in the `.yml` file then it will ignore the value of https://github.com/lancedb/lance/blob/main/rust-toolchain.toml

Instead, we should not specify it, and update `rust-toolchain.toml` when we are ready to move rust versions.