### PR TITLE
fix: allow nulls when blob data files are missing

### DIFF
--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -133,6 +133,46 @@ def test_blob_file_seek(tmp_path, dataset_with_blobs):
         assert f.read(1) == b"a"
 
 
+def test_null_blobs(tmp_path):
+    table = pa.table(
+        {
+            "id": range(100),
+            "blob": pa.array([None] * 100, pa.large_binary()),
+        },
+        schema=pa.schema(
+            [
+                pa.field("id", pa.uint64()),
+                pa.field(
+                    "blob", pa.large_binary(), metadata={"lance-encoding:blob": "true"}
+                ),
+            ]
+        ),
+    )
+    ds = lance.write_dataset(table, tmp_path / "test_ds")
+
+    blobs = ds.take_blobs("blob", ids=range(100))
+    for blob in blobs:
+        assert blob.size() == 0
+
+    ds.insert(pa.table({"id": pa.array(range(100, 200), pa.uint64())}))
+
+    blobs = ds.take_blobs("blob", indices=range(100, 200))
+    for blob in blobs:
+        assert blob.size() == 0
+
+    blobs = ds.to_table(columns=["blob"])
+    for blob in blobs.column("blob"):
+        py_blob = blob.as_py()
+        # When we write blobs to a file we store the position as 1 and size as 0
+        # to avoid needing a validity buffer.
+        #
+        # TODO: We should probably convert these to null on read.
+        assert py_blob == {"position": None, "size": None} or py_blob == {
+            "position": 1,
+            "size": 0,
+        }
+
+
 def test_blob_file_read_middle(tmp_path, dataset_with_blobs):
     # This regresses an issue where we were not setting the cursor
     # correctly after a call to `read` when the blob was not the

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -36,11 +36,11 @@ pub const STRUCTURAL_ENCODING_FULLZIP: &str = "fullzip";
 lazy_static::lazy_static! {
     pub static ref BLOB_DESC_FIELDS: Fields =
         Fields::from(vec![
-            ArrowField::new("position", DataType::UInt64, false),
-            ArrowField::new("size", DataType::UInt64, false),
+            ArrowField::new("position", DataType::UInt64, true),
+            ArrowField::new("size", DataType::UInt64, true),
         ]);
     pub static ref BLOB_DESC_FIELD: ArrowField =
-    ArrowField::new("description", DataType::Struct(BLOB_DESC_FIELDS.clone()), false);
+    ArrowField::new("description", DataType::Struct(BLOB_DESC_FIELDS.clone()), true);
     pub static ref BLOB_DESC_LANCE_FIELD: Field = Field::try_from(&*BLOB_DESC_FIELD).unwrap();
 }
 

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -279,33 +279,6 @@ impl DecodeArrayTask for BlobArrayDecodeTask {
     }
 }
 
-// impl DecodeArrayTask for BlobFieldDecodeTask {
-//     fn decode(self: Box<Self>) -> Result<ArrayRef> {
-//     }
-// }
-
-// impl LogicalPageDecoder for PrimitiveFieldDecoder {
-//     // TODO: In the future, at some point, we may consider partially waiting for primitive pages by
-//     // breaking up large I/O into smaller I/O as a way to accelerate the "time-to-first-decode"
-//     fn wait_for_loaded(&mut self, loaded_need: u64) -> BoxFuture<Result<()>> {
-//     }
-
-//     fn drain(&mut self, num_rows: u64) -> Result<NextDecodeTask> {
-//     }
-
-//     fn rows_loaded(&self) -> u64 {
-//     }
-
-//     fn rows_drained(&self) -> u64 {
-//     }
-
-//     fn num_rows(&self) -> u64 {
-//     }
-
-//     fn data_type(&self) -> &DataType {
-//     }
-// }
-
 pub struct BlobFieldEncoder {
     description_encoder: Box<dyn FieldEncoder>,
 }


### PR DESCRIPTION
Currently we translate nulls into a struct `{"position": 1, "size": 0}`.  As a result, we had the descriptions schema marked as non-nullable.  However, this is slightly confusing (if user scans blob column they should get null, not this placeholder struct) and caused issues when data files were missing (since we populate those with null).

This fixes the latter problem by changing the descriptions schema to nullable.  However, we should also fix the other problem at some point.  We would need to wrap the packed struct decoder we use for blob descriptions with a layer that converts this placeholder value to null.

That being said, we could probably enact this cleanup in 2.1 and not worry about it for 2.0 as it is fairly minor (users aren't generally looking at the blob descriptions).

Closes #3840 