### PR TITLE
feat: add columns msg for count_rows

### DIFF
--- a/docs/integrations/pytorch.rst
+++ b/docs/integrations/pytorch.rst
@@ -23,8 +23,15 @@ it takes just one line of Python to convert a HuggingFace dataset to a Lance dat
     lance.write_dataset(hf_ds, "diffusiondb_train.lance")
 
 Then, you can use the Lance dataset in PyTorch training and inference loops.
-Not that the PyTorch dataset automatically convert data into :class:`torch.Tensor`
 
+Note:
+
+1. the PyTorch dataset automatically convert data into :class:`torch.Tensor`
+
+2. lance is not fork-safe. If you are using multiprocessing, use spawn instead.
+The safe dataloader uses the spawning method.
+
+* UnSafe Dataloader
 .. code-block:: python
 
     import torch
@@ -47,6 +54,21 @@ Not that the PyTorch dataset automatically convert data into :class:`torch.Tenso
         inputs, targets = batch["prompt"], batch["image"]
         outputs = model(inputs)
         ...
+* Safe Dataloader
+.. code-block:: python
+    from lance.torch.data import SafeLanceDataset, get_safe_loader
+    dataset = SafeLanceDataset(temp_lance_dataset)
+    loader = get_safe_loader(
+        dataset,
+        num_workers=2,
+        batch_size=16,
+        drop_last=False,
+    )
+
+    total_samples = 0
+    for batch in loader:
+        total_samples += batch["id"].shape[0]
+
 
 :class:`~lance.torch.data.LanceDataset` can composite with the :class:`~lance.sampler.Sampler` classes
 to control the sampling strategy. For example, you can use :class:`~lance.sampler.ShardedFragmentSampler`

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1080,10 +1080,17 @@ impl Scanner {
         // Future intentionally boxed here to avoid large futures on the stack
         async move {
             if !self.projection_plan.physical_schema.fields.is_empty() {
-                return Err(Error::invalid_input(
-                    "count_rows should not be called on a plan selecting columns".to_string(),
-                    location!(),
-                ));
+                let columns: Vec<&str> = self.projection_plan.physical_schema.fields
+                .iter()
+                .map(|field| field.name.as_str())
+                .collect();
+
+                let msg = format!(
+                    "count_rows should not be called on a plan selecting columns. selected columns: [{}]",
+                    columns.join(", ")
+                );
+
+                return Err(Error::invalid_input(msg, location!()));
             }
 
             if self.limit.is_some() || self.offset.is_some() {


### PR DESCRIPTION
Because when testing the calculation engine, not passing columns by default actually represents *, that is, all columns. However, the error message here is not very user - friendly, making it unclear how to pass columns. Therefore, I have added some descriptions of the error here.