### PR TITLE
ci: disable torch tests on macos CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -183,6 +183,8 @@ jobs:
           workspaces: python
       - uses: ./.github/workflows/build_mac_wheel
       - uses: ./.github/workflows/run_tests
+        with:
+          skip-torch: "true"
       # Make sure wheels are not included in the Rust cache
       - name: Delete wheels
         run: rm -rf target/wheels

--- a/.github/workflows/run_tests/action.yml
+++ b/.github/workflows/run_tests/action.yml
@@ -5,17 +5,26 @@ inputs:
   python-minor-version:
     required: true
     description: "9 10 11 12"
+  skip-torch:
+    required: false
+    description: "Skip pytorch tests"
+    default: "false"
 runs:
   using: "composite"
   steps:
-  - name: Install dependencies
-    working-directory: python
-    shell: bash
-    run: |
-      # Install cpu only pytorch
-      pip install torch --index-url https://download.pytorch.org/whl/cpu
-      pip3 install $(ls target/wheels/pylance-*.whl)[tests,ray]
-  - name: Run python tests
-    shell: bash
-    working-directory: python
-    run: make test
+    - name: Install dependencies
+      working-directory: python
+      shell: bash
+      run: |
+        pip3 install $(ls target/wheels/pylance-*.whl)[tests,ray]
+    - name: Install torch
+      working-directory: python
+      shell: bash
+      if: inputs.skip-torch == 'false'
+      run: |
+        # Install cpu only pytorch
+        pip install torch --index-url https://download.pytorch.org/whl/cpu
+    - name: Run python tests
+      shell: bash
+      working-directory: python
+      run: make test

--- a/python/python/tests/test_torch.py
+++ b/python/python/tests/test_torch.py
@@ -5,6 +5,9 @@ import lance
 import numpy as np
 import pyarrow as pa
 import pytest
+
+pytest.importorskip("torch")
+
 from lance.torch.data import SafeLanceDataset, get_safe_loader  # noqa: E402
 
 


### PR DESCRIPTION
The macos CI jobs have been hanging consistently for quite some time.  After pytest finishes the python interpreter hangs on exit.  I was able to extract a stack trace using the `faulthandler` module combined with `gtimeout`:

```
 Thread 0x00000001edfacf80 (most recent call first):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/resource_tracker.py", line 111 in _stop_locked
  File Current thread 0x00000001edfacf80 (most recent call first):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/resource_tracker.py"", line /Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/resource_tracker.py111" in _stop_locked
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/resource_tracker.py", line 86 in _stop
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/resource_tracker.py", line 77 in __del__
, line 86 in _stop
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/multiprocessing/resource_tracker.py", line 77 in __del__
```

My guess is that somehow the pytorch tests are managing to trigger a fork and it's related to https://github.com/python/cpython/issues/96971

I tried setting the multiprocessing start method to spawn in `conftest.py` but that didn't seem to help.  For now, I think we need to get CI passing again and move on.  I would like to just disable pytorch tests on macos.