### PR TITLE
perf: fast upsert with no indices

### DIFF
--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -16,6 +16,9 @@
 //! key columns are identical in both the source and the target.  This means that you will need some kind of
 //! meaningful key column to be able to perform a merge insert.
 
+use assign_action::merge_insert_action;
+use datafusion_expr::col;
+use exec::MergeInsertMetrics;
 use futures::FutureExt;
 use std::{
     collections::BTreeMap,
@@ -92,6 +95,9 @@ use crate::{
 };
 
 use super::{write_fragments_internal, CommitBuilder, WriteParams};
+
+mod assign_action;
+mod exec;
 
 // "update if" expressions typically compare fields from the source table to the target table.
 // These tables have the same schema and so filter expressions need to differentiate.  To do that
@@ -1144,10 +1150,91 @@ impl MergeInsertJob {
         self.execute_uncommitted_impl(stream).await
     }
 
+    async fn create_plan(
+        self,
+        source: SendableRecordBatchStream,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        // For upsert, we create a plan:
+        // MergeInsertWriteExec
+        //   ProjectionExec [action=merge_insert_action(), +keep input columns]
+        //     HashJoin [type=left, on=id]
+        //       OneShotRead [input]
+        //       Scan columns=[id, _rowid, _rowaddr]
+
+        // Goal: we shouldn't manually have to specify which columns to scan.
+        //       DataFusion's optimizer should be able to automatically perform
+        //       projection pushdown for us.
+        // Goal: we shouldn't have to add new branches in this code to handle
+        //       indexed vs non-indexed cases. That should be handled by optimizer rules.
+        let session_config = SessionConfig::default();
+        let session_ctx = SessionContext::new_with_config(session_config);
+        todo!("register planning rules to session ctx");
+        let scan = session_ctx.read_lance(self.dataset.clone(), true, true)?;
+        let on = self
+            .params
+            .on
+            .iter()
+            .map(|name| col(name))
+            .collect::<Vec<_>>();
+        let df = session_ctx
+            .read_one_shot(source)?
+            .join_on(scan, JoinType::Left, on)?
+            .select(vec![merge_insert_action(&self.params)?.alias("action")])?;
+        let df: DataFrame = todo!("apply the write node at the end");
+
+        let (session_state, logical_plan) = df.into_parts();
+
+        let logical_plan = session_state.optimize(&logical_plan)?;
+
+        // TODO: we need to register a planner that can take a logical write and make it a FullSchemaMergeInsertExec
+        let mut physical_plan = session_state.create_physical_plan(&logical_plan).await?;
+
+        // Do multiple passes (Maybe datafusion has a method for this, not sure?)
+        let optimizers = session_state.physical_optimizers();
+        for _ in 0..3 {
+            for optimizer in optimizers {
+                physical_plan =
+                    optimizer.optimize(physical_plan, session_state.config_options())?;
+            }
+        }
+
+        Ok(physical_plan)
+    }
+
+    async fn execute_uncommitted_v2(
+        self,
+        source: SendableRecordBatchStream,
+    ) -> Result<(Transaction, MergeStats)> {
+        let plan = self.create_plan(source).await?;
+
+        // We have to get the data off of the execution plan.
+        // Option 1: serialize the output to the recordbatch, then deserialize after
+        // Option 2: add methods on the write execution plan. Then after we run it,
+        //           downcast it and call the methods to get the data.
+        let output: RecordBatch = todo!("execute_plan");
+
+        let stats = MergeInsertMetrics::from(&output);
+        let stats = MergeStats::from(&stats);
+
+        let transaction = todo!("get transaction out of plan");
+
+        Ok((transaction, stats))
+    }
+
     async fn execute_uncommitted_impl(
         self,
         source: SendableRecordBatchStream,
     ) -> Result<(Transaction, MergeStats)> {
+        // We are migrating a new plan-based code path. For now, only using this
+        // for select supported queries. Right now that is just upsert without
+        // any scalar index.
+        if self.params.insert_not_matched
+            && matches!(self.params.when_matched, WhenMatched::UpdateAll)
+            && todo!("there is no scalar index")
+        {
+            return self.execute_uncommitted_v2(source).await;
+        }
+
         // Erase metadata on source / dataset schemas to avoid comparing metadata
         let schema = lance_core::datatypes::Schema::try_from(source.schema().as_ref())?;
         let full_schema = self.dataset.local_schema();

--- a/rust/lance/src/dataset/write/merge_insert/assign_action.rs
+++ b/rust/lance/src/dataset/write/merge_insert/assign_action.rs
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use super::{MergeInsertParams, WhenNotMatchedBySource};
+use crate::{dataset::WhenMatched, error::Result};
+use datafusion::scalar::ScalarValue;
+use datafusion_expr::{
+    col, expr::ScalarFunction, sqlparser::keywords::ROWID, Case, Expr, ScalarUDF,
+};
+use datafusion_functions::core::named_struct::NamedStructFunc;
+
+// Note: right now, this is a fixed enum. In the future, this will need to be
+// dynamic to support multiple merge insert update clauses like:
+// ```sql
+// MERGE my_table USING input ON table.id = input.id
+// WHEN MATCHED AND input.event = "new_date" THEN UPDATE SET my_table.date = input.date
+// WHEN MATCHED AND input.event = "new_name" THEN UPDATE SET my_table.name = input.new_name
+// ```
+// At that point we will have a variable number of actions.
+#[derive(Clone, Copy)]
+#[repr(u8)]
+enum Action {
+    Nothing = 0,
+    /// Update all columns with source values
+    UpdateAll = 1,
+    Insert = 2,
+    Delete = 3,
+}
+
+impl Action {
+    fn as_literal_expr(&self) -> Expr {
+        Expr::Literal(ScalarValue::UInt8(Some(*self as u8)))
+    }
+}
+
+/// Transforms merge insert parameters into a logical expression. The output
+/// is a single "action" column, that describes what to do with each row.
+pub fn merge_insert_action(params: &MergeInsertParams) -> Result<Expr> {
+    let source_has_key: Expr = todo!("Make sure at least one key column is non-null");
+
+    let row_id_is_not_null = col(ROWID).is_not_null();
+    let matched = source_has_key.and(row_id_is_not_null);
+
+    let row_id_is_null = col(ROWID).is_null();
+    let not_matched_in_target = source_has_key.and(row_id_is_null);
+
+    let not_matched_in_source = col(ROWID).is_null().is_not_true();
+
+    let cases = vec![];
+
+    if params.insert_not_matched {
+        cases.push((not_matched_in_target, Action::Insert.as_literal_expr()));
+    }
+
+    match params.when_matched {
+        WhenMatched::UpdateAll => {
+            cases.push((matched, Action::UpdateAll.as_literal_expr()));
+        }
+        WhenMatched::UpdateIf(condition) => {
+            cases.push((matched.and(condition), Action::UpdateAll.as_literal_expr()));
+        }
+        WhenMatched::DoNothing => {}
+    }
+
+    match params.delete_not_matched_by_source {
+        WhenNotMatchedBySource::Delete => {
+            cases.push((not_matched_in_source, Action::Delete.as_literal_expr()));
+        }
+        WhenNotMatchedBySource::DeleteIf(condition) => {
+            cases.push((
+                not_matched_in_source.and(condition),
+                Action::Delete.as_literal_expr(),
+            ));
+        }
+        WhenNotMatchedBySource::Keep => {}
+    }
+
+    Ok(Expr::Case(Case {
+        expr: None,
+        when_then_expr: cases
+            .into_iter()
+            .map(|(when, then)| (Box::new(when), Box::new(then)))
+            .collect(),
+        else_expr: Some(Box::new(Action::Nothing.as_literal_expr())),
+    }))
+}
+
+// Collect given columns into a struct
+///
+/// This is the inverse of [datafusion_expr::logical_plan::builder::get_struct_unnested_columns]
+pub fn collect_to_struct(columns: &[&str], prefix: Option<&str>) -> Expr {
+    let mut args = Vec::with_capacity(columns.len() * 2);
+    for column in columns {
+        let prefix_len = prefix.map(|p| p.len()).unwrap_or(0);
+        args.push(Expr::Literal(ScalarValue::Utf8(Some(
+            column[prefix_len..column.len()].to_string(),
+        ))));
+        args.push(col(*column));
+    }
+
+    Expr::ScalarFunction(ScalarFunction {
+        func: Arc::new(ScalarUDF::new_from_impl(NamedStructFunc::new())),
+        args,
+    })
+}

--- a/rust/lance/src/dataset/write/merge_insert/exec/mod.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/mod.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+mod write;
+
+use std::sync::{Arc, LazyLock};
+
+use arrow_array::{RecordBatch, UInt64Array};
+use arrow_schema::{DataType, Field, Schema};
+use datafusion::physical_plan::metrics::{Count, ExecutionPlanMetricsSet, MetricBuilder};
+pub use write::FullSchemaMergeInsertExec;
+
+use super::MergeStats;
+
+pub(crate) static MERGE_STATS_SCHEMA: LazyLock<Arc<Schema>> = LazyLock::new(|| {
+    Arc::new(Schema::new(vec![
+        Field::new("num_inserted_rows", DataType::UInt64, false),
+        Field::new("num_updated_rows", DataType::UInt64, false),
+        Field::new("num_deleted_rows", DataType::UInt64, false),
+    ]))
+});
+
+pub(super) struct MergeInsertMetrics {
+    pub num_inserted_rows: Count,
+    pub num_updated_rows: Count,
+    pub num_deleted_rows: Count,
+}
+
+impl From<&RecordBatch> for MergeInsertMetrics {
+    fn from(value: &RecordBatch) -> Self {
+        todo!("Read columns out of batch")
+    }
+}
+
+impl From<&MergeInsertMetrics> for RecordBatch {
+    fn from(value: &MergeInsertMetrics) -> Self {
+        let num_inserted_rows = UInt64Array::from(vec![value.num_inserted_rows.value() as u64]);
+        let num_updated_rows = UInt64Array::from(vec![value.num_updated_rows.value() as u64]);
+        let num_deleted_rows = UInt64Array::from(vec![value.num_deleted_rows.value() as u64]);
+        RecordBatch::try_new(
+            (*MERGE_STATS_SCHEMA).clone(),
+            vec![
+                Arc::new(num_inserted_rows),
+                Arc::new(num_updated_rows),
+                Arc::new(num_deleted_rows),
+            ],
+        )
+        .expect("Failed to create merge insert statistics batch")
+    }
+}
+
+impl From<&MergeInsertMetrics> for MergeStats {
+    fn from(value: &MergeInsertMetrics) -> Self {
+        Self {
+            num_deleted_rows: value.num_deleted_rows.value() as u64,
+            num_inserted_rows: value.num_inserted_rows.value() as u64,
+            num_updated_rows: value.num_updated_rows.value() as u64,
+            num_attempts: 1,
+        }
+    }
+}
+
+impl MergeInsertMetrics {
+    pub fn new(metrics: &ExecutionPlanMetricsSet, partition: usize) -> Self {
+        let num_inserted_rows = MetricBuilder::new(metrics).counter("num_inserted_rows", partition);
+        let num_updated_rows = MetricBuilder::new(metrics).counter("num_updated_rows", partition);
+        let num_deleted_rows = MetricBuilder::new(metrics).counter("num_deleted_rows", partition);
+        Self {
+            num_inserted_rows,
+            num_updated_rows,
+            num_deleted_rows,
+        }
+    }
+}

--- a/rust/lance/src/dataset/write/merge_insert/exec/write.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/write.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use datafusion::common::Result as DFResult;
+use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
+use datafusion::{
+    execution::{SendableRecordBatchStream, TaskContext},
+    physical_plan::{
+        execution_plan::{Boundedness, EmissionType},
+        DisplayAs, ExecutionPlan, PlanProperties,
+    },
+};
+use datafusion_physical_expr::{EquivalenceProperties, Partitioning};
+
+use crate::{
+    dataset::write::merge_insert::{exec::MergeInsertMetrics, MergeInsertParams},
+    Dataset,
+};
+
+use super::MERGE_STATS_SCHEMA;
+
+/// Inserts new rows and updates existing rows in the target table.
+///
+/// This does the actual write.
+///
+/// This is implemented by moving updated rows to new fragments. This mode
+/// is most optimal when updating the full schema.
+///
+/// It returns a single batch, containing the statistics.
+#[derive(Debug)]
+pub struct FullSchemaMergeInsertExec {
+    input: Arc<dyn ExecutionPlan>,
+    dataset: Arc<Dataset>,
+    params: MergeInsertParams,
+    properties: PlanProperties,
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl FullSchemaMergeInsertExec {
+    pub fn try_new(
+        input: Arc<dyn ExecutionPlan>,
+        dataset: Arc<Dataset>,
+        params: MergeInsertParams,
+    ) -> DFResult<Self> {
+        let properties = PlanProperties::new(
+            EquivalenceProperties::new((*MERGE_STATS_SCHEMA).clone()),
+            Partitioning::UnknownPartitioning(1),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        );
+
+        Ok(Self {
+            input,
+            dataset,
+            params,
+            properties,
+            metrics: ExecutionPlanMetricsSet::new(),
+        })
+    }
+}
+
+impl DisplayAs for FullSchemaMergeInsertExec {
+    fn fmt_as(
+        &self,
+        t: datafusion::physical_plan::DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        write!(f, "FullSchemaMergeInsertExec")
+    }
+}
+
+impl ExecutionPlan for FullSchemaMergeInsertExec {
+    fn name(&self) -> &str {
+        "FullSchemaMergeInsertExec"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn schema(&self) -> arrow_schema::SchemaRef {
+        (*MERGE_STATS_SCHEMA).clone()
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(datafusion::error::DataFusionError::Internal(
+                "FullSchemaMergeInsertExec requires exactly one child".to_string(),
+            ));
+        }
+        Ok(Arc::new(Self {
+            input: children[0].clone(),
+            dataset: self.dataset.clone(),
+            params: self.params.clone(),
+            properties: self.properties.clone(),
+            metrics: self.metrics.clone(),
+        }))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        todo!("Also record the metrics here")
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
+        let merge_metrics = MergeInsertMetrics::new(&self.metrics, partition);
+
+        todo!("Execute FullSchemaMergeInsertExec")
+    }
+}

--- a/rust/lance/src/dataset/write/merge_insert/logical_plan.rs
+++ b/rust/lance/src/dataset/write/merge_insert/logical_plan.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use async_trait::async_trait;
+use datafusion::common::Result as DFResult;
+use datafusion::{
+    common::DFSchema,
+    execution::SessionState,
+    physical_plan::ExecutionPlan,
+    physical_planner::{ExtensionPlanner, PhysicalPlanner},
+};
+use datafusion_expr::{LogicalPlan, UserDefinedLogicalNode, UserDefinedLogicalNodeCore};
+use std::{cmp::Ordering, sync::Arc};
+
+use crate::{
+    dataset::write::merge_insert::exec::{FullSchemaMergeInsertExec, PartialUpdateMergeInsertExec},
+    Dataset,
+};
+
+use super::{exec::MERGE_STATS_SCHEMA, MergeInsertParams};
+
+/// Logical plan node for merge insert write.
+///
+/// This takes a schema:
+/// * `target`
+/// * `source`
+/// * `_rowid`
+/// * `_rowaddr`
+/// * `action`
+///
+/// And does the appropriate write operation.
+///
+/// The output of this node is a single row containing statistics about the operation.
+#[derive(Debug)]
+struct MergeInsertWriteNode {
+    input: LogicalPlan,
+    pub(crate) dataset: Arc<Dataset>,
+    pub(crate) params: MergeInsertParams,
+    schema: Arc<DFSchema>,
+}
+
+impl PartialEq for MergeInsertWriteNode {
+    fn eq(&self, other: &Self) -> bool {
+        self.params == other.params
+            && self.input == other.input
+            && self.dataset.base == other.dataset.base
+    }
+}
+
+impl Eq for MergeInsertWriteNode {}
+
+impl std::hash::Hash for MergeInsertWriteNode {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.params.hash(state);
+        self.input.hash(state);
+        self.dataset.base.hash(state);
+    }
+}
+
+impl PartialOrd for MergeInsertWriteNode {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        match self.params.partial_cmp(&other.params) {
+            Some(Ordering::Equal) => self.input.partial_cmp(&other.input),
+            cmp => cmp,
+        }
+    }
+}
+
+impl MergeInsertWriteNode {
+    fn new(
+        input: LogicalPlan,
+        dataset: Arc<Dataset>,
+        params: MergeInsertParams,
+        write_style: MergeInsertWriteStyle,
+    ) -> Self {
+        let schema = Arc::new(DFSchema::try_from((*MERGE_STATS_SCHEMA).clone()).unwrap());
+        Self {
+            input,
+            dataset,
+            params,
+            schema,
+            write_style,
+        }
+    }
+}
+
+impl UserDefinedLogicalNodeCore for MergeInsertWriteNode {
+    fn name(&self) -> &str {
+        "MergeInsertWrite"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &Arc<DFSchema> {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<datafusion_expr::Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "MergeInsertWrite")
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        exprs: Vec<datafusion_expr::Expr>,
+        inputs: Vec<LogicalPlan>,
+    ) -> datafusion::error::Result<Self> {
+        if !exprs.is_empty() {
+            return Err(datafusion::error::DataFusionError::Internal(
+                "MergeInsertWriteNode does not accept expressions".to_string(),
+            ));
+        }
+        if inputs.len() != 1 {
+            return Err(datafusion::error::DataFusionError::Internal(
+                "MergeInsertWriteNode requires exactly one input".to_string(),
+            ));
+        }
+        Ok(Self::new(
+            inputs[0].clone(),
+            self.dataset.clone(),
+            self.params.clone,
+        ))
+    }
+
+    fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        todo!("Compute which columns are necessary for the write")
+    }
+}
+
+/// Physical planner for MergeInsertWriteNode.
+struct MergeInsertPlanner {}
+
+#[async_trait]
+impl ExtensionPlanner for MergeInsertPlanner {
+    async fn plan_extension(
+        &self,
+        _planner: &dyn PhysicalPlanner,
+        node: &dyn UserDefinedLogicalNode,
+        logical_inputs: &[&LogicalPlan],
+        physical_inputs: &[Arc<dyn ExecutionPlan>],
+        _session_state: &SessionState,
+    ) -> DFResult<Option<Arc<dyn ExecutionPlan>>> {
+        Ok(
+            if let Some(write_node) = node.as_any().downcast_ref::<MergeInsertWriteNode>() {
+                assert_eq!(logical_inputs.len(), 1, "Inconsistent number of inputs");
+                assert_eq!(physical_inputs.len(), 1, "Inconsistent number of inputs");
+                let exec = FullSchemaMergeInsertExec::try_new(
+                    physical_inputs[0].clone(),
+                    write_node.dataset.clone(),
+                    write_node.params.clone(),
+                )?;
+                Some(Arc::new(exec))
+            } else {
+                None
+            },
+        )
+    }
+}


### PR DESCRIPTION
Closes #3774

Refactor upsert with no indices to use a new code path. We will leverage DataFusion's optimizer rules to make projection pushdown happen, reducing the total IO necessary to do merge insert.

