### PR TITLE
docs: fix write_dataset append mode obsolete description

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3934,8 +3934,8 @@ def write_dataset(
     mode: str
         **create** - create a new dataset (raises if uri already exists).
         **overwrite** - create a new snapshot version
-        **append** - create a new version that is the concat of the input the
-        latest version (raises if uri does not exist)
+        **append** - create a new version that is the concat of the input and the
+        latest version, or a new dataset if uri doesn't exist.
     max_rows_per_file: int, default 1024 * 1024
         The max number of rows to write before starting a new file
     max_rows_per_group: int, default 1024


### PR DESCRIPTION
Hi everyone, I'm new to lance. When I play with lance, I found the `write_dataset` behavior is different from the api documents. 

The document says it will raise an Error if uri doesn't exist. https://github.com/lancedb/lance/blob/main/python/python/lance/dataset.py#L3938

But actually it will create the dataset if uri doesn't exist. https://github.com/lancedb/lance/blob/main/rust/lance/src/dataset.rs#L498

I think this is a typo, fixing it will be more friendly to newcomers. Thanks.