### PR TITLE
ci(java): fix java release workflow

### DIFF
--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -12,7 +12,7 @@ on:
       dry_run:
         description: 'Dry run (just test publish build, do not publish to Maven Central)'
         required: true
-        default: false
+        default: true
         type: boolean
 
 jobs:
@@ -201,14 +201,14 @@ jobs:
       - name: Dry run
         if: |
           github.event_name == 'pull_request' ||
-          inputs.dry_run == 'true'
+          inputs.dry_run
         working-directory: java
         run: |
           mvn --batch-mode -DskipTests -Drust.release.build=true package
       - name: Publish with Java 8
         if: |
           github.event_name == 'release' ||
-          inputs.dry_run == 'false'
+          !inputs.dry_run
         working-directory: java
         run: |
           echo "use-agent" >> ~/.gnupg/gpg.conf

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -81,7 +81,6 @@ jobs:
             ldd --version
 
             cargo build --release
-            cp ../target/release/liblance_jni.so liblance_jni.so
           "
       - uses: actions/upload-artifact@v4
         with:
@@ -154,7 +153,6 @@ jobs:
             ldd --version
 
             cargo build --release
-            cp ../target/release/liblance_jni.so liblance_jni.so
           "
       - uses: actions/upload-artifact@v4
         with:
@@ -194,8 +192,8 @@ jobs:
       - name: Copy native libs
         run: |
           mkdir -p ./java/core/target/classes/nativelib/linux-x86-64 ./java/core/target/classes/nativelib/linux-aarch64
-          cp ../liblance_jni_linux_x86_64.zip/liblance_jni.so ./core/target/classes/nativelib/linux-x86-64/liblance_jni.sp
-          cp ../liblance_jni_linux_arm_64.zip/liblance_jni.so ./core/target/classes/nativelib/linux-aarch64/liblance_jni.so
+          cp ../liblance_jni_linux_x86_64.zip/liblance_jni.so ./java/core/target/classes/nativelib/linux-x86-64/liblance_jni.sp
+          cp ../liblance_jni_linux_arm_64.zip/liblance_jni.so ./java/core/target/classes/nativelib/linux-aarch64/liblance_jni.so
       - name: Set github
         run: |
           git config --global user.email "Lance Github Runner"

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Set up Java 8
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: corretto
           java-version: 8
           cache: "maven"
           server-id: ossrh

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -10,35 +10,12 @@ on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Directly publish the Java artifact under the current version'
+        description: 'Dry run (just test publish build, do not publish to Maven Central)'
         required: true
         default: false
-
+        type: boolean
 
 jobs:
-  macos-arm64:
-    name: Build on MacOS Arm64
-    runs-on: macos-14
-    timeout-minutes: 60
-    defaults:
-      run:
-        working-directory: ./java
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Install dependencies
-        run: |
-          brew install protobuf
-      - name: Build release
-        run: |
-          cargo build --release
-      - uses: actions/upload-artifact@v4
-        with:
-          name: liblance_jni_darwin_aarch64.zip
-          path: target/release/liblance_jni.dylib
-          retention-days: 1
-          if-no-files-found: error
   linux-arm64:
     name: Build on Linux Arm64
     runs-on: ubuntu-2404-8x-arm64
@@ -50,7 +27,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Check glibc version outside docker
         run: ldd --version
-      - name: Build and run in Ubuntu 20.04 container
+      - name: Build and run in Debian 10 Arm64 container
         run: |
           docker run --platform linux/arm64 -v ${{ github.workspace }}:/workspace -w /workspace debian:10 bash -c "
             
@@ -94,6 +71,7 @@ jobs:
           
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
             source \$HOME/.cargo/env
+            cargo --version
             
             cd java
             
@@ -107,123 +85,28 @@ jobs:
           "
       - uses: actions/upload-artifact@v4
         with:
-          name: liblance_jni_linux_aarch64.zip
+          name: liblance_jni_linux_arm_64.zip
           path: target/release/liblance_jni.so
           retention-days: 1
           if-no-files-found: error
   linux-x86:
+    name: Build on Linux x86-64
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    needs: [macos-arm64, linux-arm64]
-    defaults:
-      run:
-        working-directory: ./java
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - uses: Swatinem/rust-cache@v2
-      - name: Set up Java 8
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 8
-          cache: "maven"
-          server-id: ossrh
-          server-username: SONATYPE_USER
-          server-password: SONATYPE_TOKEN
-          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
-      - name: Install dependencies
-        run: |
-          sudo apt -y -qq update
-          sudo apt install -y protobuf-compiler libssl-dev pkg-config
-      - name: Download artifact
-        uses: actions/download-artifact@v4
-      - name: Copy native libs
-        run: |
-          mkdir -p ./core/target/classes/nativelib/darwin-aarch64 ./core/target/classes/nativelib/linux-aarch64
-          cp ../liblance_jni_darwin_aarch64.zip/liblance_jni.dylib ./core/target/classes/nativelib/darwin-aarch64/liblance_jni.dylib
-          cp ../liblance_jni_linux_aarch64.zip/liblance_jni.so ./core/target/classes/nativelib/linux-aarch64/liblance_jni.so
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Check glibc version outside docker
         run: ldd --version
-      - name: Build and run in Ubuntu 20.04 container (Dry Run)
-        if: |
-          github.event_name == 'pull_request' ||
-          inputs.dry_run == 'true'
+      - name: Build and run in Debian 10 X86-64 container
         run: |
-          docker run --platform linux/amd64 -v ${{ github.workspace }}:/workspace -w /workspace openjdk:8-jdk-buster bash -c "
+          docker run --platform linux/amd64 -v ${{ github.workspace }}:/workspace -w /workspace debian:10 bash -c "
+          
             set -ex
             apt-get update
           
-            DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --assume-yes \
-              apt-transport-https \
-              ca-certificates \
-              curl \
-              gpg \
-              bash \
-              less \
-              openssl \
-              libssl-dev \
-              pkg-config \
-              libsqlite3-dev \
-              libsqlite3-0 \
-              libreadline-dev \
-              git \
-              cmake \
-              dh-autoreconf \
-              clang \
-              g++ \
-              libc++-dev \
-              libc++abi-dev \
-              libprotobuf-dev \
-              libncurses5-dev \
-              libncursesw5-dev \
-              libudev-dev \
-              libhidapi-dev \
-              zip \
-              unzip \
-          
-            # manually install maven, apt will use java11
-            MAVEN_VERSION=3.9.6
-            curl -OL https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
-            tar -xzf apache-maven-3.9.9-bin.tar.gz
-            mv apache-maven-3.9.9 /opt/maven
-            ln -s /opt/maven/bin/mvn /usr/bin/mvn
-          
-            # https://github.com/databendlabs/databend/issues/8035
-            PROTOC_ZIP=protoc-3.15.0-linux-x86_64.zip
-            curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/\$PROTOC_ZIP
-            unzip -o \$PROTOC_ZIP -d /usr/local
-            rm -f \$PROTOC_ZIP
-            protoc --version
-          
-            # set Github
-            git config --global user.email \"Lance Github Runner\"
-            git config --global user.name \"dev+gha@lancedb.com\"
-          
-            curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
-            source \$HOME/.cargo/env
-          
-            cd java
-          
-            # https://github.com/rustls/rustls/issues/1967
-            export CC=clang
-            export CXX=clang++
-            ldd --version
-
-            mvn --batch-mode -DskipTests -Drust.release.build=true package
-          "
-      - name: Build and run in Ubuntu 20.04 container (Publish to Sonatype)
-        if: |
-          github.event_name == 'release' ||
-          inputs.dry_run == 'false'
-        run: |
-          docker run --platform linux/amd64 -v ${{ github.workspace }}:/workspace -w /workspace openjdk:8-jdk-buster bash -c "
-            set -ex
-            apt-get update
-
             DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --assume-yes \
               apt-transport-https \
               ca-certificates \
@@ -251,13 +134,6 @@ jobs:
               libhidapi-dev \
               zip \
               unzip
-
-            # manually install maven, apt will use java11
-            MAVEN_VERSION=3.9.6
-            curl -OL https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
-            tar -xzf apache-maven-3.9.9-bin.tar.gz
-            mv apache-maven-3.9.9 /opt/maven
-            ln -s /opt/maven/bin/mvn /usr/bin/mvn
           
             # https://github.com/databendlabs/databend/issues/8035
             PROTOC_ZIP=protoc-3.15.0-linux-x86_64.zip
@@ -265,36 +141,82 @@ jobs:
             unzip -o \$PROTOC_ZIP -d /usr/local
             rm -f \$PROTOC_ZIP
             protoc --version
-
-            # set Github
-            git config --global user.email \"Lance Github Runner\"
-            git config --global user.name \"dev+gha@lancedb.com\"
-
+          
             curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
             source \$HOME/.cargo/env
-
+            cargo --version
+          
             cd java
-
+          
             # https://github.com/rustls/rustls/issues/1967
             export CC=clang
             export CXX=clang++
             ldd --version
-            
-            export SONATYPE_USER=${{ secrets.SONATYPE_USER }}
-            export SONATYPE_TOKEN=${{ secrets.SONATYPE_TOKEN }}
 
-            mkdir -p /root/.gnupg
-            touch /root/.gnupg/gpg.conf
-            echo 'use-agent' >> /root/.gnupg/gpg.conf
-            echo 'pinentry-mode loopback' >> /root/.gnupg/gpg.conf
-            cat /root/.gnupg/gpg.conf
-          
-            export GPG_TTY=\$TTY
-            
-            touch signing.key
-            echo '${{ secrets.GPG_PRIVATE_KEY }}' >> signing.key
-            cat signing.key
-            gpg --import signing.key
-            
-            mvn --batch-mode -DskipTests -Drust.release.build=true -DpushChanges=false -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} deploy -P deploy-to-ossrh -P shade-jar
+            cargo build --release
+            cp ../target/release/liblance_jni.so liblance_jni.so
           "
+      - uses: actions/upload-artifact@v4
+        with:
+          name: liblance_jni_linux_x86_64.zip
+          path: target/release/liblance_jni.so
+          retention-days: 1
+          if-no-files-found: error
+  macos-arm64:
+    name: Build on MacOS Arm64 and release
+    runs-on: macos-14
+    timeout-minutes: 60
+    needs:
+      - linux-arm64
+      - linux-x86
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - name: Set up Java 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: "maven"
+          server-id: ossrh
+          server-username: SONATYPE_USER
+          server-password: SONATYPE_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - uses: Homebrew/actions/setup-homebrew@master
+      - name: Install dependencies
+        run: |
+          brew install protobuf
+          brew install gpg
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+      - name: Copy native libs
+        run: |
+          mkdir -p ./java/core/target/classes/nativelib/linux-x86-64 ./java/core/target/classes/nativelib/linux-aarch64
+          cp ../liblance_jni_linux_x86_64.zip/liblance_jni.so ./core/target/classes/nativelib/linux-x86-64/liblance_jni.sp
+          cp ../liblance_jni_linux_arm_64.zip/liblance_jni.so ./core/target/classes/nativelib/linux-aarch64/liblance_jni.so
+      - name: Set github
+        run: |
+          git config --global user.email "Lance Github Runner"
+          git config --global user.name "dev+gha@lancedb.com"
+      - name: Dry run
+        if: |
+          github.event_name == 'pull_request' ||
+          inputs.dry_run
+        working-directory: java
+        run: |
+          mvn --batch-mode -DskipTests -Drust.release.build=true package
+      - name: Publish with Java 8
+        if: |
+          github.event_name == 'release' ||
+          !inputs.dry_run
+        working-directory: java
+        run: |
+          echo "use-agent" >> ~/.gnupg/gpg.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          export GPG_TTY=$(tty)
+          mvn --batch-mode -DskipTests -Drust.release.build=true -DpushChanges=false -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} deploy -P deploy-to-ossrh -P shade-jar
+        env:
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -192,8 +192,8 @@ jobs:
       - name: Copy native libs
         run: |
           mkdir -p ./java/core/target/classes/nativelib/linux-x86-64 ./java/core/target/classes/nativelib/linux-aarch64
-          cp ../liblance_jni_linux_x86_64.zip/liblance_jni.so ./java/core/target/classes/nativelib/linux-x86-64/liblance_jni.sp
-          cp ../liblance_jni_linux_arm_64.zip/liblance_jni.so ./java/core/target/classes/nativelib/linux-aarch64/liblance_jni.so
+          cp ./liblance_jni_linux_x86_64.zip/liblance_jni.so ./java/core/target/classes/nativelib/linux-x86-64/liblance_jni.sp
+          cp ./liblance_jni_linux_arm_64.zip/liblance_jni.so ./java/core/target/classes/nativelib/linux-aarch64/liblance_jni.so
       - name: Set github
         run: |
           git config --global user.email "Lance Github Runner"

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -201,16 +201,18 @@ jobs:
       - name: Dry run
         if: |
           github.event_name == 'pull_request' ||
-          inputs.dry_run
+          inputs.dry_run == true
         working-directory: java
         run: |
+          echo "${{ inputs.dry_run }}"
           mvn --batch-mode -DskipTests -Drust.release.build=true package
       - name: Publish with Java 8
         if: |
           github.event_name == 'release' ||
-          !inputs.dry_run
+          inputs.dry_run == 'false'
         working-directory: java
         run: |
+          echo "${{ inputs.dry_run }}"
           echo "use-agent" >> ~/.gnupg/gpg.conf
           echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
           export GPG_TTY=$(tty)

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -201,14 +201,14 @@ jobs:
       - name: Dry run
         if: |
           github.event_name == 'pull_request' ||
-          inputs.dry_run
+          inputs.dry_run == 'true'
         working-directory: java
         run: |
           mvn --batch-mode -DskipTests -Drust.release.build=true package
       - name: Publish with Java 8
         if: |
           github.event_name == 'release' ||
-          !inputs.dry_run
+          inputs.dry_run == 'false'
         working-directory: java
         run: |
           echo "use-agent" >> ~/.gnupg/gpg.conf

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -201,10 +201,9 @@ jobs:
       - name: Dry run
         if: |
           github.event_name == 'pull_request' ||
-          inputs.dry_run == true
+          inputs.dry_run == 'true'
         working-directory: java
         run: |
-          echo "${{ inputs.dry_run }}"
           mvn --batch-mode -DskipTests -Drust.release.build=true package
       - name: Publish with Java 8
         if: |
@@ -212,7 +211,6 @@ jobs:
           inputs.dry_run == 'false'
         working-directory: java
         run: |
-          echo "${{ inputs.dry_run }}"
           echo "use-agent" >> ~/.gnupg/gpg.conf
           echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
           export GPG_TTY=$(tty)


### PR DESCRIPTION
Execute release build on Linux x86 and arm64 and then release on mac so that we get consistent docker linux build