### PR TITLE
fix: use `e_tag` in cache key for cached manifests

### DIFF
--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -621,11 +621,11 @@ pub async fn commit_handler_from_url(
     let url = match Url::parse(url_or_path) {
         Ok(url) if url.scheme().len() == 1 && cfg!(windows) => {
             // On Windows, the drive is parsed as a scheme
-            return Ok(Arc::new(RenameCommitHandler));
+            return Ok(Arc::new(ConditionalPutCommitHandler));
         }
         Ok(url) => url,
         Err(_) => {
-            return Ok(Arc::new(RenameCommitHandler));
+            return Ok(Arc::new(ConditionalPutCommitHandler));
         }
     };
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -77,7 +77,7 @@ use crate::datatypes::Schema;
 use crate::error::box_error;
 use crate::io::commit::{
     commit_detached_transaction, commit_new_dataset, commit_transaction,
-    detect_overlapping_fragments,
+    detect_overlapping_fragments, manifest_cache_path,
 };
 use crate::session::Session;
 use crate::utils::temporal::{timestamp_to_nanos, utc_now, SystemTime};
@@ -598,7 +598,8 @@ impl Dataset {
             .await?;
 
         // Check if manifest is in cache before reading from storage
-        let cached_manifest = self.session.file_metadata_cache.get(&location.path);
+        let cache_path = manifest_cache_path(&location);
+        let cached_manifest = self.session.file_metadata_cache.get(&cache_path);
         if let Some(cached_manifest) = cached_manifest {
             return Ok((cached_manifest, location));
         }


### PR DESCRIPTION
This fixes the failing test like https://github.com/lancedb/lance/actions/runs/15223146317/job/42821795030

Background: if users drops a dataset, and then re-create it, it's possible for long-lived readers to have loaded a manifest from the dataset prior to deletion. We might have identical manifest file names `1.manifest` and `1.manifest`, but different contents. To detect these cases, we keep track of the `e_tag` of these. This PR makes sure we use this `e_tag` in the cache key.