### PR TITLE
fix: last item could be dropped from directory listing

### DIFF
--- a/rust/lance-io/src/object_store/list_retry.rs
+++ b/rust/lance-io/src/object_store/list_retry.rs
@@ -53,7 +53,6 @@ impl Stream for StaticListStream {
         match this.rx.poll_recv(cx) {
             Poll::Ready(Some(item)) => Poll::Ready(Some(item)),
             Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending if this.handle.is_finished() => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
         }
     }


### PR DESCRIPTION
https://github.com/lancedb/lance/pull/3644 introduced a static listing stream, with a bug that listing result could be dropped if the sender has finished sending all items but the receiver is still in pending state. When this bug happens, the dataset would checkout_latest to an old version, and when the the dataset is used in commit, writer continuously tries to commit to an existing version.