### PR TITLE
bug: column_index could be greater than column len if complex type exists.

### DIFF
--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -717,9 +717,6 @@ impl FileReader {
                     location!(),
                 ));
             }
-            if *column_index >= metadata.column_infos.len() as u32 {
-                return Err(Error::invalid_input(format!("The projection specified the column index {} but there are only {} columns in the file", column_index, metadata.column_infos.len()), location!()));
-            }
         }
         Ok(())
     }


### PR DESCRIPTION
According to 
```
pub struct ReaderProjection {
    /// The data types (schema) of the selected columns.  The names
    /// of the schema are arbitrary and ignored.
    pub schema: Arc<Schema>,
    /// The indices of the columns to load.
    ///
    /// The mapping should be as follows:
    ///
    /// - Primitive: the index of the column in the schema
    /// - List: the index of the list column in the schema
    ///   followed by the column indices of the children
    /// - FixedSizeList (of primitive): the index of the column in the schema
    ///   (this case is not nested)
    /// - FixedSizeList (of non-primitive): not yet implemented
    /// - Dictionary: same as primitive
    /// - Struct: the index of the struct column in the schema
    ///   followed by the column indices of the children
    ///
    /// In other words, this should be a DFS listing of the desired schema.
    ///
    /// For example, if the goal is to load:
    ///
    ///   x: int32
    ///   y: struct<z: int32, w: string>
    ///   z: list<int32>
    ///
    /// and the schema originally used to store the data was:
    ///
    ///   a: struct<x: int32>
    ///   b: int64
    ///   y: struct<z: int32, c: int64, w: string>
    ///   z: list<int32>
    ///
    /// Then the column_indices should be [1, 3, 4, 6, 7, 8]
    pub column_indices: Vec<u32>,
}
```

We should not limit column_index assuming it smaller than column number.