### PR TITLE
fix: dictionary_encoding_threshold must be smaller than u8::MAX

### DIFF
--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -4467,7 +4467,7 @@ impl PrimitiveStructuralEncoder {
                     }
                 }
 
-                let dictionary_encoding_threshold: u64 = 100.max(data_block.num_values() / 4);
+                let dictionary_encoding_threshold: u64 = 100.min(data_block.num_values() / 4);
                 let cardinality =
                     if let Some(cardinality_array) = data_block.get_stat(Stat::Cardinality) {
                         cardinality_array.as_primitive::<UInt64Type>().value(0)


### PR DESCRIPTION
fixes https://github.com/lancedb/lance/issues/3897