### PR TITLE
fix: `PrimitiveStructualEncoder` extract_validity buffer should follow flag keep_original_array

### DIFF
--- a/rust/lance-arrow/src/deepcopy.rs
+++ b/rust/lance-arrow/src/deepcopy.rs
@@ -11,7 +11,7 @@ pub fn deep_copy_buffer(buffer: &Buffer) -> Buffer {
     Buffer::from(buffer.as_slice())
 }
 
-fn deep_copy_nulls(nulls: Option<&NullBuffer>) -> Option<NullBuffer> {
+pub fn deep_copy_nulls(nulls: Option<&NullBuffer>) -> Option<NullBuffer> {
     let nulls = nulls?;
     let bit_buffer = deep_copy_buffer(nulls.inner().inner());
     Some(unsafe {

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -1286,7 +1286,10 @@ impl StructuralEncodingStrategy {
                         options,
                         root_field_metadata,
                     )?;
-                    Ok(Box::new(ListStructuralEncoder::new(child_encoder)))
+                    Ok(Box::new(ListStructuralEncoder::new(
+                        options.keep_original_array,
+                        child_encoder,
+                    )))
                 }
                 DataType::Struct(_) => {
                     if field.is_packed_struct() {
@@ -1311,7 +1314,10 @@ impl StructuralEncodingStrategy {
                                 )
                             })
                             .collect::<Result<Vec<_>>>()?;
-                        Ok(Box::new(StructStructuralEncoder::new(children_encoders)))
+                        Ok(Box::new(StructStructuralEncoder::new(
+                            options.keep_original_array,
+                            children_encoders,
+                        )))
                     }
                 }
                 DataType::Dictionary(_, value_type) => {

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -12,12 +12,12 @@ use arrow_array::{
 use arrow_buffer::{BooleanBuffer, BooleanBufferBuilder, Buffer, NullBuffer, OffsetBuffer};
 use arrow_schema::{DataType, Field, Fields};
 use futures::{future::BoxFuture, FutureExt};
+use lance_arrow::deepcopy::deep_copy_nulls;
 use lance_arrow::list::ListArrayExt;
+use lance_core::{cache::FileMetadataCache, Error, Result};
 use log::trace;
 use snafu::location;
 use tokio::task::JoinHandle;
-
-use lance_core::{cache::FileMetadataCache, Error, Result};
 
 use crate::{
     buffer::LanceBuffer,
@@ -1268,12 +1268,16 @@ impl FieldEncoder for ListFieldEncoder {
 /// The values will have any garbage values removed and will be trimmed
 /// to only include the values that are actually used.
 pub struct ListStructuralEncoder {
+    keep_original_array: bool,
     child: Box<dyn FieldEncoder>,
 }
 
 impl ListStructuralEncoder {
-    pub fn new(child: Box<dyn FieldEncoder>) -> Self {
-        Self { child }
+    pub fn new(keep_original_array: bool, child: Box<dyn FieldEncoder>) -> Self {
+        Self {
+            keep_original_array,
+            child,
+        }
     }
 }
 
@@ -1287,16 +1291,29 @@ impl FieldEncoder for ListStructuralEncoder {
         num_rows: u64,
     ) -> Result<Vec<EncodeTask>> {
         let values = if let Some(list_arr) = array.as_list_opt::<i32>() {
-            let has_garbage_values =
-                repdef.add_offsets(list_arr.offsets().clone(), array.nulls().cloned());
+            let has_garbage_values = if self.keep_original_array {
+                repdef.add_offsets(list_arr.offsets().clone(), array.nulls().cloned())
+            } else {
+                // there is no need to deep copy offsets, because offset buffers will be cast to a common type (i64).
+                repdef.add_offsets(
+                    list_arr.offsets().clone(),
+                    deep_copy_nulls(Some(array.nulls().unwrap())),
+                )
+            };
             if has_garbage_values {
                 list_arr.filter_garbage_nulls().trimmed_values()
             } else {
                 list_arr.trimmed_values()
             }
         } else if let Some(list_arr) = array.as_list_opt::<i64>() {
-            let has_garbage_values =
-                repdef.add_offsets(list_arr.offsets().clone(), array.nulls().cloned());
+            let has_garbage_values = if self.keep_original_array {
+                repdef.add_offsets(list_arr.offsets().clone(), array.nulls().cloned())
+            } else {
+                repdef.add_offsets(
+                    list_arr.offsets().clone(),
+                    deep_copy_nulls(Some(array.nulls().unwrap())),
+                )
+            };
             if has_garbage_values {
                 list_arr.filter_garbage_nulls().trimmed_values()
             } else {

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -1295,10 +1295,7 @@ impl FieldEncoder for ListStructuralEncoder {
                 repdef.add_offsets(list_arr.offsets().clone(), array.nulls().cloned())
             } else {
                 // there is no need to deep copy offsets, because offset buffers will be cast to a common type (i64).
-                repdef.add_offsets(
-                    list_arr.offsets().clone(),
-                    deep_copy_nulls(Some(array.nulls().unwrap())),
-                )
+                repdef.add_offsets(list_arr.offsets().clone(), deep_copy_nulls(array.nulls()))
             };
             if has_garbage_values {
                 list_arr.filter_garbage_nulls().trimmed_values()
@@ -1309,10 +1306,7 @@ impl FieldEncoder for ListStructuralEncoder {
             let has_garbage_values = if self.keep_original_array {
                 repdef.add_offsets(list_arr.offsets().clone(), array.nulls().cloned())
             } else {
-                repdef.add_offsets(
-                    list_arr.offsets().clone(),
-                    deep_copy_nulls(Some(array.nulls().unwrap())),
-                )
+                repdef.add_offsets(list_arr.offsets().clone(), deep_copy_nulls(array.nulls()))
             };
             if has_garbage_values {
                 list_arr.filter_garbage_nulls().trimmed_values()

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -4538,7 +4538,7 @@ impl PrimitiveStructuralEncoder {
     ) {
         if let Some(validity) = array.nulls() {
             if keep_original_array {
-                repdef.add_validity_bitmap(Some(validity.clone()).unwrap());
+                repdef.add_validity_bitmap(validity.clone());
             } else {
                 repdef.add_validity_bitmap(deep_copy_nulls(Some(validity)).unwrap());
             }


### PR DESCRIPTION
Close: https://github.com/lancedb/lance/issues/3825