### PR TITLE
fix: skip non-leaf fields when projecting by column names in 2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,6 +4214,7 @@ dependencies = [
  "protobuf-src",
  "rand 0.8.5",
  "roaring",
+ "rstest",
  "snafu",
  "tempfile",
  "test-log",

--- a/java/core/lance-jni/src/file_reader.rs
+++ b/java/core/lance-jni/src/file_reader.rs
@@ -210,11 +210,14 @@ pub extern "system" fn Java_com_lancedb_lance_file_LanceFileReader_readAllNative
             (*ptr).lock().unwrap()
         };
 
+        let file_version = reader.inner.metadata().version();
+
         if !projected_names.is_null() {
             let schema = Schema::try_from(reader.schema()?.as_ref())?;
             let column_names: Vec<String> = env.get_strings(&projected_names)?;
             let names: Vec<&str> = column_names.iter().map(|s| s.as_str()).collect();
             reader_projection = Some(ReaderProjection::from_column_names(
+                file_version,
                 &schema,
                 names.as_slice(),
             )?);

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -885,6 +885,13 @@ impl Field {
             .map(|v| v.to_lowercase() == "true")
             .unwrap_or(false)
     }
+
+    /// Return true if the field is a leaf field.
+    ///
+    /// A leaf field is a field that is not a struct or a list.
+    pub fn is_leaf(&self) -> bool {
+        self.children.is_empty()
+    }
 }
 
 impl fmt::Display for Field {

--- a/rust/lance-file/Cargo.toml
+++ b/rust/lance-file/Cargo.toml
@@ -45,6 +45,7 @@ lance-datagen.workspace = true
 lance-testing.workspace = true
 criterion.workspace = true
 rand.workspace = true
+rstest.workspace = true
 proptest.workspace = true
 pretty_assertions.workspace = true
 test-log.workspace = true

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -160,7 +160,11 @@ impl IndexReader for v2::reader::FileReader {
             )));
         }
         let projection = if let Some(projection) = projection {
-            v2::reader::ReaderProjection::from_column_names(self.schema(), projection)?
+            v2::reader::ReaderProjection::from_column_names(
+                self.metadata().version(),
+                self.schema(),
+                projection,
+            )?
         } else {
             v2::reader::ReaderProjection::from_whole_schema(
                 self.schema(),

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -331,7 +331,7 @@ mod v2_adapter {
             projection: Arc<Schema>,
         ) -> Result<ReadBatchTaskStream> {
             let projection = ReaderProjection::from_field_ids(
-                self.reader.as_ref(),
+                self.reader.metadata().version(),
                 projection.as_ref(),
                 self.field_id_to_column_idx.as_ref(),
             )?;
@@ -357,7 +357,7 @@ mod v2_adapter {
             projection: Arc<Schema>,
         ) -> Result<ReadBatchTaskStream> {
             let projection = ReaderProjection::from_field_ids(
-                self.reader.as_ref(),
+                self.reader.metadata().version(),
                 projection.as_ref(),
                 self.field_id_to_column_idx.as_ref(),
             )?;
@@ -382,7 +382,7 @@ mod v2_adapter {
             projection: Arc<Schema>,
         ) -> Result<ReadBatchTaskStream> {
             let projection = ReaderProjection::from_field_ids(
-                self.reader.as_ref(),
+                self.reader.metadata().version(),
                 projection.as_ref(),
                 self.field_id_to_column_idx.as_ref(),
             )?;
@@ -410,7 +410,7 @@ mod v2_adapter {
         ) -> Result<ReadBatchTaskStream> {
             let indices = UInt32Array::from(indices.to_vec());
             let projection = ReaderProjection::from_field_ids(
-                self.reader.as_ref(),
+                self.reader.metadata().version(),
                 projection.as_ref(),
                 self.field_id_to_column_idx.as_ref(),
             )?;


### PR DESCRIPTION
In 2.1 we changed what is expected from the `ReaderProjection`.  We had fixed the `from_field_ids` constructor but not the `from_column_names` constructor.  In addition, I cleaned up the comments for `ReaderProjection` to explain this change.