### PR TITLE
fix: unexpected posting block size when remap posting list

### DIFF
--- a/rust/lance-core/src/container/list.rs
+++ b/rust/lance-core/src/container/list.rs
@@ -157,6 +157,17 @@ impl<T> FromIterator<T> for ExpLinkedList<T> {
     }
 }
 
+impl<T> PartialEq for ExpLinkedList<T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.iter().zip(other.iter()).all(|(a, b)| a == b)
+    }
+}
+
+impl<T> Eq for ExpLinkedList<T> where T: Eq {}
+
 pub struct ExpLinkedListIter<'a, T> {
     inner: std::collections::linked_list::Iter<'a, Vec<T>>,
     inner_iter: Option<std::slice::Iter<'a, T>>,

--- a/rust/lance-core/src/container/list.rs
+++ b/rust/lance-core/src/container/list.rs
@@ -54,9 +54,7 @@ impl<T> ExpLinkedList<T> {
         match self.inner.back() {
             Some(last) => {
                 if last.len() == last.capacity() {
-                    let new_cap = if self.inner.len() == 1 {
-                        last.capacity()
-                    } else if self.limit > 0 && last.capacity() * 2 >= self.limit as usize {
+                    let new_cap = if self.limit > 0 && last.capacity() * 2 >= self.limit as usize {
                         self.limit as usize
                     } else {
                         last.capacity() * 2
@@ -65,7 +63,7 @@ impl<T> ExpLinkedList<T> {
                 }
             }
             None => {
-                self.inner.push_back(Vec::with_capacity(2));
+                self.inner.push_back(Vec::with_capacity(1));
             }
         }
         self.do_push(v);

--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -191,6 +191,8 @@ impl IndexType {
             | Self::IvfPq
             | Self::IvfHnswSq
             | Self::IvfHnswPq => 0,
+
+            Self::FragmentReuse => 0,
         }
     }
 }

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1406,8 +1406,8 @@ impl PostingListBuilder {
         }
         let compressed = compress_posting_list(
             self.doc_ids.len(),
-            self.doc_ids.block_iter(),
-            self.frequencies.block_iter(),
+            self.doc_ids.iter(),
+            self.frequencies.iter(),
             block_max_scores.into_iter(),
         )?;
         let schema = inverted_list_schema(self.has_positions());

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1474,14 +1474,6 @@ impl Default for PositionBuilder {
     }
 }
 
-impl PartialEq for PositionBuilder {
-    fn eq(&self, other: &Self) -> bool {
-        self.positions == other.positions && self.offsets == other.offsets
-    }
-}
-
-impl Eq for PositionBuilder {}
-
 impl PositionBuilder {
     pub fn new() -> Self {
         Self {

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -4,12 +4,9 @@
 //! Utilities for remapping row ids. Necessary before move-stable row ids.
 //!
 
+use crate::dataset::transaction::{Operation, Transaction};
 use crate::index::frag_reuse::{load_frag_reuse_index_details, open_frag_reuse_index};
 use crate::Result;
-use crate::{
-    dataset::transaction::{Operation, Transaction},
-    index::scalar::infer_index_type,
-};
 use crate::{index, Dataset};
 use async_trait::async_trait;
 use lance_core::utils::address::RowAddress;
@@ -260,9 +257,7 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                 dataset_version: dataset.manifest.version,
                 fragment_bitmap: bitmap_after_remap,
                 index_details: curr_index_meta.index_details.clone(),
-                index_version: infer_index_type(&curr_index_meta)
-                    .map(|index_type| index_type.version())
-                    .unwrap_or_default(),
+                index_version: 0,
             };
 
             let transaction = Transaction::new(

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -4,9 +4,12 @@
 //! Utilities for remapping row ids. Necessary before move-stable row ids.
 //!
 
-use crate::dataset::transaction::{Operation, Transaction};
 use crate::index::frag_reuse::{load_frag_reuse_index_details, open_frag_reuse_index};
 use crate::Result;
+use crate::{
+    dataset::transaction::{Operation, Transaction},
+    index::scalar::infer_index_type,
+};
 use crate::{index, Dataset};
 use async_trait::async_trait;
 use lance_core::utils::address::RowAddress;
@@ -257,6 +260,9 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                 dataset_version: dataset.manifest.version,
                 fragment_bitmap: bitmap_after_remap,
                 index_details: curr_index_meta.index_details.clone(),
+                index_version: infer_index_type(&curr_index_meta)
+                    .map(|index_type| index_type.version())
+                    .unwrap_or_default(),
             };
 
             let transaction = Transaction::new(

--- a/rust/lance/src/index/frag_reuse.rs
+++ b/rust/lance/src/index/frag_reuse.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use crate::dataset::optimize::remapping::transpose_row_ids;
 use crate::Dataset;
+use crate::{dataset::optimize::remapping::transpose_row_ids, index::scalar::infer_index_type};
 use lance_core::Error;
 use lance_index::frag_reuse::{
     FragReuseIndex, FragReuseIndexDetails, FragReuseVersion, FRAG_REUSE_DETAILS_FILE_NAME,
@@ -167,5 +167,6 @@ pub async fn build_new_frag_reuse_index(
         dataset_version: dataset.manifest.version,
         fragment_bitmap: Some(new_fragment_bitmap),
         index_details: Some(prost_types::Any::from_msg(&proto)?),
+        index_version: 0,
     })
 }

--- a/rust/lance/src/index/frag_reuse.rs
+++ b/rust/lance/src/index/frag_reuse.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use crate::dataset::optimize::remapping::transpose_row_ids;
 use crate::Dataset;
-use crate::{dataset::optimize::remapping::transpose_row_ids, index::scalar::infer_index_type};
 use lance_core::Error;
 use lance_index::frag_reuse::{
     FragReuseIndex, FragReuseIndexDetails, FragReuseVersion, FRAG_REUSE_DETAILS_FILE_NAME,


### PR DESCRIPTION
when remap a posting list we use `ExpLinkedList::with_capacity` to avoid re-allocation, but we were using `ExpLinkedList::block_iter` to process the posting lists, and expecting the size of each block to be less or equal to `BLOCK_SIZE`, remapping a posting list with length greater than BLOCK_SIZE would case this