### PR TITLE
fix: don't panic on DF table provider if test has filter on indexed column

### DIFF
--- a/python/python/tests/test_table_provider.py
+++ b/python/python/tests/test_table_provider.py
@@ -6,47 +6,83 @@ import shutil
 import lance
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 from datafusion import SessionContext, col
 from lance import FFILanceTableProvider, LanceDataset
 
 
-def test_table_loading():
-    ctx = SessionContext()
+def normalize(batches: list[pa.RecordBatch]) -> pa.RecordBatch:
+    normalized = pa.Table.from_batches(batches).combine_chunks()
+    batches = normalized.to_batches()
+    assert len(batches) == 1
+    return batches[0]
 
+
+def test_table_loading():
     lancedb_temp_path = "/tmp/test.lance"
     shutil.rmtree(lancedb_temp_path, ignore_errors=True)
-    df = pd.DataFrame({"col1": [4, 2], "col2": ["a", "b"], "col3": [4.2, 2.4]})
+
+    big_str = ("a" * 1000000).encode("utf-8")
+    # Need a good amount of data to expose certain I/O patterns (if the file is too
+    # small we trigger the small-files path which avoids I/O entirely during scan.)
+    df = pa.table(
+        {
+            "col1": range(1000000),
+            "col2": [str(i) for i in range(1000000)],
+            "col3": [float(i) for i in range(1000000)],
+        },
+        schema=pa.schema(
+            [
+                pa.field("col1", pa.int64()),
+                pa.field("col2", pa.string()),
+                pa.field("col3", pa.float64()),
+            ],
+            metadata={
+                b"big_str": big_str,
+            },
+        ),
+    )
     dataset: LanceDataset = lance.write_dataset(df, lancedb_temp_path)
     dataset.create_scalar_index("col1", "BTREE")
 
-    ffi_lance_table = FFILanceTableProvider(
-        dataset, with_row_id=True, with_row_addr=True
-    )
-    ctx.register_table_provider("ffi_lance_table", ffi_lance_table)
-    result = ctx.table("ffi_lance_table").collect()
+    # We remake the context each time.  This ensures we are not skipping over any
+    # I/O because we just happen to have data in the cache.
+    def make_ctx():
+        ctx = SessionContext()
 
-    assert len(result) == 1
-    assert result[0].num_columns == 5
+        dataset = lance.dataset(lancedb_temp_path)
+        ffi_lance_table = FFILanceTableProvider(
+            dataset, with_row_id=True, with_row_addr=True
+        )
+        ctx.register_table_provider("ffi_lance_table", ffi_lance_table)
+        return ctx
+
+    result = normalize(make_ctx().table("ffi_lance_table").collect())
+
+    assert len(result) == 1000000
+    assert result.num_columns == 5
 
     expected = pd.DataFrame(
         {
-            "col1": np.array([4, 2], dtype=np.int64),
-            "col2": ["a", "b"],
-            "col3": np.array([4.2, 2.4], dtype=np.float64),
-            "_rowid": np.array([0, 1], dtype=np.uint64),
-            "_rowaddr": np.array([0, 1], dtype=np.uint64),
+            "col1": np.array(range(1000000), dtype=np.int64),
+            "col2": [str(i) for i in range(1000000)],
+            "col3": np.array([float(i) for i in range(1000000)], dtype=np.float64),
+            "_rowid": np.array(range(1000000), dtype=np.uint64),
+            "_rowaddr": np.array(range(1000000), dtype=np.uint64),
         }
     )
 
-    pd.testing.assert_frame_equal(result[0].to_pandas(), expected)
+    pd.testing.assert_frame_equal(result.to_pandas(), expected)
 
-    result = ctx.table("ffi_lance_table").filter(col("col1") == 4).collect()
+    result = normalize(
+        make_ctx().table("ffi_lance_table").filter(col("col1") == 4).collect()
+    )
     assert len(result) == 1
 
-    result = ctx.table("ffi_lance_table").limit(1).collect()
+    result = normalize(make_ctx().table("ffi_lance_table").limit(1).collect())
     assert len(result) == 1
-    assert result[0]["col1"][0].as_py() == 4
+    assert result["col1"][0].as_py() == 0
 
-    result = ctx.table("ffi_lance_table").limit(1, offset=1).collect()
+    result = normalize(make_ctx().table("ffi_lance_table").limit(1, offset=1).collect())
     assert len(result) == 1
-    assert result[0]["col1"][0].as_py() == 2
+    assert result["col1"][0].as_py() == 1

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -385,6 +385,8 @@ impl FFILanceTableProvider {
         let py = dataset.py();
         let dataset = dataset.getattr("_ds")?.extract::<Py<Dataset>>()?;
         let dataset_ref = &dataset.bind(py).borrow().ds;
+        // TODO: https://github.com/lancedb/lance/issues/3966 remove this workaround
+        let _ = RT.block_on(Some(py), dataset_ref.load_indices())?;
         Ok(Self {
             dataset: dataset_ref.clone(),
             with_row_id,


### PR DESCRIPTION
We need to ensure all of our exec nodes do not spawn tasks in the execute fn until https://github.com/apache/datafusion/issues/16312 is addressed.  The `AddRowAddrExec` was violating this and this PR fixes that.