### PR TITLE
fix: rebase transactions from oldest to latest

### DIFF
--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -770,7 +770,8 @@ pub(crate) async fn commit_transaction(
         let mut rebase =
             TransactionRebase::try_new(&original_dataset, transaction, affected_rows).await?;
 
-        for (other_version, other_transaction) in other_transactions.iter() {
+        // Check against committed transactions from oldest to latest
+        for (other_version, other_transaction) in other_transactions.iter().rev() {
             rebase.check_txn(other_transaction, *other_version)?;
         }
 


### PR DESCRIPTION
#3882 introduced the improvement to list transactions in descending order, and we use the output list to rebase an ongoing transaction. This is logically incorrect because we should rebase in ascending order from oldest transaction to latest transaction. I think currently there is no correctness issue because for merge-insert we do not handle upserts of the same row, and for FRI related operations the handling always sort the related fragment reuse versions internally. But it's still better to fix this logical error which might impact conflict resolution cases we might handle in the future.