### PR TITLE
chore(ci): maximize build space to avoid no space left for rust build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -168,7 +168,6 @@ jobs:
       - name: Remove Cargo.lock
         run: rm -f Cargo.lock
       - uses: rui314/setup-mold@v1
-      - uses: Swatinem/rust-cache@v2
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -168,6 +168,7 @@ jobs:
       - name: Remove Cargo.lock
         run: rm -f Cargo.lock
       - uses: rui314/setup-mold@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -155,12 +155,19 @@ jobs:
       CC: clang
       CXX: clang++
     steps:
+      # Remove not needed tools from runner
+      - uses: easimon/maximize-build-space@v10
+        with:
+          remove-dotnet: true
+          remove-android: true
+          remove-haskell: true
+          remove-codeql: true
+          remove-docker-images: true
       - uses: actions/checkout@v4
       # Remote cargo.lock to force a fresh build
       - name: Remove Cargo.lock
         run: rm -f Cargo.lock
       - uses: rui314/setup-mold@v1
-      - uses: Swatinem/rust-cache@v2
       - name: Install dependencies
         run: |
           sudo apt update


### PR DESCRIPTION
This PR tend to address a build failure over the main branch.

---

[This task](https://github.com/lancedb/lance/actions/runs/15511966061/job/43674024324) failed for:

```shell
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: mold: failed to write to an output file. Disk full?
          collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped
          compilation terminated.
```

This PR can address this by:

- Maximize build space by removing not needed tools from runner
- ~~Don't use rust-cache for this job since rust deps can have update every day. The cache doesn't work most of the time.~~