### PR TITLE
feat: support large_string/large_binary in lance format v2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2651,7 +2651,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4289,6 +4289,7 @@ dependencies = [
  "test-log",
  "tokio",
  "tracing",
+ "xxhash-rust",
  "zstd",
 ]
 
@@ -4770,7 +4771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -8994,6 +8995,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yada"

--- a/deny.toml
+++ b/deny.toml
@@ -105,6 +105,7 @@ allow = [
     "ISC",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "BSL-1.0",
     "0BSD",
     "OpenSSL",
     "Zlib",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -3692,6 +3692,7 @@ dependencies = [
  "snafu",
  "tokio",
  "tracing",
+ "xxhash-rust",
  "zstd",
 ]
 
@@ -4941,8 +4942,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -4961,8 +4962,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4995,7 +4996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -5008,7 +5009,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -5973,7 +5974,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -7378,6 +7379,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "xz2"

--- a/rust/lance-encoding/Cargo.toml
+++ b/rust/lance-encoding/Cargo.toml
@@ -37,6 +37,7 @@ rand.workspace = true
 snafu.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
 zstd.workspace = true
 bytemuck = "1.14"
 arrayref = "0.3.7"

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -20,10 +20,11 @@ use std::{
 };
 
 use arrow::array::{ArrayData, ArrayDataBuilder, AsArray};
-use arrow_array::{new_empty_array, new_null_array, Array, ArrayRef, UInt64Array};
-use arrow_buffer::{ArrowNativeType, BooleanBuffer, BooleanBufferBuilder, NullBuffer};
+use arrow_array::{new_empty_array, new_null_array, Array, ArrayRef, OffsetSizeTrait, UInt64Array};
+use arrow_buffer::{
+    ArrowNativeType, BooleanBuffer, BooleanBufferBuilder, NullBuffer, ScalarBuffer,
+};
 use arrow_schema::DataType;
-use bytemuck::try_cast_slice;
 use lance_arrow::DataTypeExt;
 use snafu::location;
 
@@ -252,34 +253,33 @@ impl FixedWidthDataBlock {
 }
 
 #[derive(Debug)]
-pub struct VariableWidthDataBlockBuilder {
-    offsets: Vec<u32>,
+pub struct VariableWidthDataBlockBuilder<T: OffsetSizeTrait> {
+    offsets: Vec<T>,
     bytes: Vec<u8>,
 }
 
-impl VariableWidthDataBlockBuilder {
+impl<T: OffsetSizeTrait> VariableWidthDataBlockBuilder<T> {
     fn new(estimated_size_bytes: u64) -> Self {
         Self {
-            offsets: vec![0u32],
+            offsets: vec![T::from_usize(0).unwrap()],
             bytes: Vec::with_capacity(estimated_size_bytes as usize),
         }
     }
 }
 
-impl DataBlockBuilderImpl for VariableWidthDataBlockBuilder {
+impl<T: OffsetSizeTrait> DataBlockBuilderImpl for VariableWidthDataBlockBuilder<T> {
     fn append(&mut self, data_block: &DataBlock, selection: Range<u64>) {
         let block = data_block.as_variable_width_ref().unwrap();
-        assert!(block.bits_per_offset == 32);
+        assert!(block.bits_per_offset == T::get_byte_width() as u8 * 8);
 
-        let offsets: &[u32] = try_cast_slice(&block.offsets)
-            .expect("cast from a bits_per_offset=32 `VariableWidthDataBlock's offsets field field to &[32] should be fine.");
+        let offsets: ScalarBuffer<T> = block.offsets.try_clone().unwrap().borrow_to_typed_slice();
 
         let start_offset = offsets[selection.start as usize];
         let end_offset = offsets[selection.end as usize];
         let mut previous_len = self.bytes.len();
 
         self.bytes
-            .extend_from_slice(&block.data[start_offset as usize..end_offset as usize]);
+            .extend_from_slice(&block.data[start_offset.as_usize()..end_offset.as_usize()]);
 
         self.offsets.extend(
             offsets[selection.start as usize..selection.end as usize]
@@ -287,8 +287,8 @@ impl DataBlockBuilderImpl for VariableWidthDataBlockBuilder {
                 .zip(&offsets[selection.start as usize + 1..=selection.end as usize])
                 .map(|(&current, &next)| {
                     let this_value_len = next - current;
-                    previous_len += this_value_len as usize;
-                    previous_len as u32
+                    previous_len += this_value_len.as_usize();
+                    T::from_usize(previous_len).unwrap()
                 }),
         );
     }
@@ -298,59 +298,7 @@ impl DataBlockBuilderImpl for VariableWidthDataBlockBuilder {
         DataBlock::VariableWidth(VariableWidthBlock {
             data: LanceBuffer::Owned(self.bytes),
             offsets: LanceBuffer::reinterpret_vec(self.offsets),
-            bits_per_offset: 32,
-            num_values,
-            block_info: BlockInfo::new(),
-        })
-    }
-}
-
-#[derive(Debug)]
-pub struct LargeVariableWidthDataBlockBuilder {
-    offsets: Vec<u64>,
-    bytes: Vec<u8>,
-}
-
-impl LargeVariableWidthDataBlockBuilder {
-    fn new(estimated_size_bytes: u64) -> Self {
-        Self {
-            offsets: vec![0u64],
-            bytes: Vec::with_capacity(estimated_size_bytes as usize),
-        }
-    }
-}
-
-impl DataBlockBuilderImpl for LargeVariableWidthDataBlockBuilder {
-    fn append(&mut self, data_block: &DataBlock, selection: Range<u64>) {
-        let block = data_block.as_variable_width_ref().unwrap();
-        assert!(block.bits_per_offset == 64);
-        let offsets: &[u64] = try_cast_slice(&block.offsets)
-            .expect("cast from a bits_per_offset=64 `VariableWidthDataBlock's offsets field field to &[64] should be fine.");
-
-        let start_offset = offsets[selection.start as usize];
-        let end_offset = offsets[selection.end as usize];
-        let mut previous_len = self.bytes.len();
-
-        self.bytes
-            .extend_from_slice(&block.data[start_offset as usize..end_offset as usize]);
-
-        self.offsets.extend(
-            offsets[selection.start as usize..selection.end as usize]
-                .iter()
-                .zip(&offsets[selection.start as usize + 1..=selection.end as usize])
-                .map(|(&current, &next)| {
-                    let this_value_len = next - current;
-                    previous_len += this_value_len as usize;
-                    previous_len as u64
-                }),
-        );
-    }
-    fn finish(self: Box<Self>) -> DataBlock {
-        let num_values = (self.offsets.len() - 1) as u64;
-        DataBlock::VariableWidth(VariableWidthBlock {
-            data: LanceBuffer::Owned(self.bytes),
-            offsets: LanceBuffer::reinterpret_vec(self.offsets),
-            bits_per_offset: 64,
+            bits_per_offset: T::get_byte_width() as u8 * 8,
             num_values,
             block_info: BlockInfo::new(),
         })
@@ -1137,9 +1085,11 @@ impl DataBlock {
             }
             Self::VariableWidth(inner) => {
                 if inner.bits_per_offset == 32 {
-                    Box::new(VariableWidthDataBlockBuilder::new(estimated_size_bytes))
+                    Box::new(VariableWidthDataBlockBuilder::<i32>::new(
+                        estimated_size_bytes,
+                    ))
                 } else if inner.bits_per_offset == 64 {
-                    Box::new(LargeVariableWidthDataBlockBuilder::new(
+                    Box::new(VariableWidthDataBlockBuilder::<i64>::new(
                         estimated_size_bytes,
                     ))
                 } else {

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -829,6 +829,15 @@ impl CoreFieldDecoderStrategy {
                 column_infos.next_top_level();
                 Ok(scheduler)
             }
+            DataType::LargeBinary | DataType::LargeUtf8 => {
+                let column_info = column_infos.expect_next()?;
+                let scheduler = Box::new(StructuralPrimitiveFieldScheduler::try_new(
+                    column_info.as_ref(),
+                    self.decompressor_strategy.as_ref(),
+                )?);
+                column_infos.next_top_level();
+                Ok(scheduler)
+            }
             DataType::List(_) | DataType::LargeList(_) => {
                 let child = field
                     .children

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -517,9 +517,9 @@ impl DecompressorStrategy for CoreDecompressorStrategy {
             pb::array_encoding::ArrayEncoding::InlineBitpacking(description) => {
                 Ok(Box::new(InlineBitpacking::from_description(description)))
             }
-            pb::array_encoding::ArrayEncoding::Variable(_) => {
-                Ok(Box::new(BinaryMiniBlockDecompressor::default()))
-            }
+            pb::array_encoding::ArrayEncoding::Variable(description) => Ok(Box::new(
+                BinaryMiniBlockDecompressor::from_variable(description),
+            )),
             pb::array_encoding::ArrayEncoding::Fsst(description) => {
                 Ok(Box::new(FsstMiniBlockDecompressor::new(description)))
             }
@@ -786,6 +786,7 @@ impl CoreFieldDecoderStrategy {
             let scheduler = Box::new(StructuralPrimitiveFieldScheduler::try_new(
                 column_info.as_ref(),
                 self.decompressor_strategy.as_ref(),
+                32, // Use 32-bit offsets for standard primitive fields
             )?);
 
             // advance to the next top level column
@@ -800,6 +801,7 @@ impl CoreFieldDecoderStrategy {
                     let scheduler = Box::new(StructuralPrimitiveFieldScheduler::try_new(
                         column_info.as_ref(),
                         self.decompressor_strategy.as_ref(),
+                        32, // Use 32-bit offsets for packed struct fields
                     )?);
 
                     // advance to the next top level column
@@ -825,6 +827,7 @@ impl CoreFieldDecoderStrategy {
                 let scheduler = Box::new(StructuralPrimitiveFieldScheduler::try_new(
                     column_info.as_ref(),
                     self.decompressor_strategy.as_ref(),
+                    32, // Use 32-bit offsets for Binary/Utf8
                 )?);
                 column_infos.next_top_level();
                 Ok(scheduler)
@@ -834,6 +837,7 @@ impl CoreFieldDecoderStrategy {
                 let scheduler = Box::new(StructuralPrimitiveFieldScheduler::try_new(
                     column_info.as_ref(),
                     self.decompressor_strategy.as_ref(),
+                    64, // Use 64-bit offsets for LargeBinary/LargeUtf8
                 )?);
                 column_infos.next_top_level();
                 Ok(scheduler)

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -851,8 +851,11 @@ impl CompressionStrategy for CoreArrayEncodingStrategy {
                     } else {
                         Ok(Box::new(BinaryMiniBlockEncoder::default()))
                     }
+                } else if variable_width_data.bits_per_offset == 64 {
+                    // TODO: Support TSSTMiniBlockEncoder
+                    Ok(Box::new(BinaryMiniBlockEncoder::default()))
                 } else {
-                    todo!("Implement MiniBlockCompression for VariableWidth DataBlock with 64 bits offsets.")
+                    todo!("Implement MiniBlockCompression for VariableWidth DataBlock with {} bits offsets.", variable_width_data.bits_per_offset)
                 }
             }
             DataBlock::Struct(struct_data_block) => {

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -852,7 +852,7 @@ impl CompressionStrategy for CoreArrayEncodingStrategy {
                         Ok(Box::new(BinaryMiniBlockEncoder::default()))
                     }
                 } else if variable_width_data.bits_per_offset == 64 {
-                    // TODO: Support TSSTMiniBlockEncoder
+                    // TODO: Support FSSTMiniBlockEncoder
                     Ok(Box::new(BinaryMiniBlockEncoder::default()))
                 } else {
                     todo!("Implement MiniBlockCompression for VariableWidth DataBlock with {} bits offsets.", variable_width_data.bits_per_offset)

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -1328,6 +1328,7 @@ impl MiniBlockScheduler {
             .collect::<Vec<_>>();
         let value_decompressor = decompressors
             .create_miniblock_decompressor(layout.value_compression.as_ref().unwrap())?;
+
         let dictionary = if let Some(dictionary_encoding) = layout.dictionary.as_ref() {
             let num_dictionary_items = layout.num_dictionary_items;
             match dictionary_encoding.array_encoding.as_ref().unwrap() {
@@ -2780,6 +2781,7 @@ impl StructuralPrimitiveFieldScheduler {
     pub fn try_new(
         column_info: &ColumnInfo,
         decompressors: &dyn DecompressorStrategy,
+        bits_per_offset: u8,
     ) -> Result<Self> {
         let page_schedulers = column_info
             .page_infos
@@ -2791,6 +2793,7 @@ impl StructuralPrimitiveFieldScheduler {
                     page_index,
                     column_info.index as usize,
                     decompressors,
+                    bits_per_offset,
                 )
             })
             .collect::<Result<Vec<_>>>()?;
@@ -2805,6 +2808,7 @@ impl StructuralPrimitiveFieldScheduler {
         page_index: usize,
         _column_index: usize,
         decompressors: &dyn DecompressorStrategy,
+        bits_per_offset: u8,
     ) -> Result<PageInfoAndScheduler> {
         let scheduler: Box<dyn StructuralPageScheduler> =
             match page_info.encoding.as_structural().layout.as_ref() {
@@ -2824,7 +2828,7 @@ impl StructuralPrimitiveFieldScheduler {
                         page_info.num_rows,
                         full_zip,
                         decompressors,
-                        /*bits_per_offset=*/ 32,
+                        bits_per_offset,
                     )?)
                 }
                 Some(pb::page_layout::Layout::AllNullLayout(all_null)) => {

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -387,8 +387,9 @@ impl FsstMiniBlockDecompressor {
 impl MiniBlockDecompressor for FsstMiniBlockDecompressor {
     fn decompress(&self, data: Vec<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
         // Step 1. decompress data use `BinaryMiniBlockDecompressor`
+        // TODO: Support 64 bits for FSST compressor
         let binary_decompressor =
-            Box::new(BinaryMiniBlockDecompressor::default()) as Box<dyn MiniBlockDecompressor>;
+            Box::new(BinaryMiniBlockDecompressor::new(32)) as Box<dyn MiniBlockDecompressor>;
         let compressed_data_block = binary_decompressor.decompress(data, num_values)?;
         let DataBlock::VariableWidth(mut compressed_data_block) = compressed_data_block else {
             panic!("BinaryMiniBlockDecompressor should output VariableWidth DataBlock")


### PR DESCRIPTION
This PR addresses #3350. Now largeutf8 and largeBinary(64bits) are support in lance format v2.1