### PR TITLE
Fix Typos in Documentation Comments

### DIFF
--- a/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
+++ b/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
@@ -1227,7 +1227,7 @@ impl FsstDecoder {
 
 /// This is the public API for the FSST compression, when the in_buf is less than FSST_LEAST_INPUT_SIZE, we put the FSST_MAGIC header and then copy the input to the output
 /// we check to make sure the out_buf's size is at least the same as the in_buf's size, otherwise Err is returned, this is actually
-/// risky as in some ramdomly generated data, the output size can be larger than the input size.
+/// risky as in some randomly generated data, the output size can be larger than the input size.
 /// the out_offsets_buf should be at least the same size as the in_offsets_buf, otherwise Err is returned
 /// the symbol_table is used to store the symbol table created by `compression`, it's size should be FSST_SYMBOL_TABLE_SIZE
 /// after compression, the first 64 bits of the output buffer is the fsst header:

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -395,7 +395,7 @@ impl DecodeMiniBlockTask {
     ///
     /// So the start (1) maps to the second 1 (idx=3) and the end (2) maps to the third 1 (idx=5)
     ///
-    /// If there are invisible items then we don't count them when calcuating the range of items we
+    /// If there are invisible items then we don't count them when calculating the range of items we
     /// are interested in but we do count them when calculating the range of levels we are interested
     /// in.  As a result we have to return both the item range (first return value) and the level range
     /// (second return value).


### PR DESCRIPTION


Description:  
This pull request corrects minor typos in documentation comments within the codebase. Specifically, it fixes the spelling of "randomly" and "calculating" in the following files:
- `fsst.rs`: Corrected "ramdomly" to "randomly".
- `primitive.rs`: Corrected "calcuating" to "calculating".

These changes improve the clarity and professionalism of the documentation without affecting any functional code.