### PR TITLE
refactor: change the default process-wide IOPS limit to be 128

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -164,3 +164,9 @@ with 1024 rows per batch is more appropriate.
 In summary, scans could use up to ``(2 * io_buffer_size) + (batch_size * num_compute_threads)`` bytes of memory.
 Keep in mind that ``io_buffer_size`` is a soft limit (e.g. we cannot read less than one page at a time right now)
 and so it is not necessarily a bug if you see memory usage exceed this limit by a small margin.
+
+The above limits refer to limits per-scan.  There is an additional limit on the number of IOPS that is applied
+across the entire process.  This limit is specified by the ``LANCE_PROCESS_IO_THREADS_LIMIT`` environment variable.
+The default is 128 which is more than enough for most workloads.  You can increase this limit if you are working
+with a high-throughput workload.  You can even disable this limit entirely by setting it to zero.  Note that this
+can often lead to issues with excessive retries and timeouts from the object store.


### PR DESCRIPTION
The 2.1 reader has various limits that will cause it to pause.  It will not read too much data at once (the readahead queue) and it will be limited by the `LANCE_IO_THREADS` variable which controls how many concurrent requests we allow for a single scan.

There is a further limit, which is a process-wide limit, on the number of concurrent IOPS.  Previously this limit was disabled.  However, it is rather easy to get in a situation where excessive IOPS are generated when doing any kind of multi-threaded workload.  For example, compaction will trigger this as it spawns multiple compaction tasks and each task needs to read from object storage.

This PR changes the default to enabled and sets it at 128.