### PR TITLE
fix: call remove_outer_validity() before dictionary_encode

### DIFF
--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -3919,11 +3919,6 @@ impl PrimitiveStructuralEncoder {
             todo!()
         }
 
-        // The top-level validity is encoded in repdef so we can remove it.  There may be inner
-        // validities if we have FSL fields but those are not included in the repdef and need to
-        // be encoded.
-        let data = data.remove_outer_validity();
-
         let num_items = data.num_values();
 
         let compressor = compression_strategy.create_miniblock_compressor(field, &data)?;
@@ -4236,9 +4231,6 @@ impl PrimitiveStructuralEncoder {
             .as_ref()
             .map_or(0, |d| d.iter().max().copied().unwrap_or(0));
 
-        // The top-level validity is encoded in repdef so we can remove it
-        let data = data.remove_outer_validity();
-
         // To handle FSL we just flatten
         // let data = data.flatten();
 
@@ -4466,6 +4458,9 @@ impl PrimitiveStructuralEncoder {
                         panic!("packed struct encoding currently only supports fixed-width fields.")
                     }
                 }
+
+                // The top-level validity is encoded in repdef so we can remove it.
+                let data_block = data_block.remove_outer_validity();
 
                 let dictionary_encoding_threshold: u64 = 100.max(data_block.num_values() / 4);
                 let cardinality =

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -1108,8 +1108,9 @@ pub mod tests {
         check_round_trip_encoding_of_data(arrs, &test_cases, HashMap::new()).await;
     }
 
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_binary_dictionary_encoding() {
+    async fn test_binary_dictionary_encoding(#[values(true, false)] with_nulls: bool) {
         let test_cases = TestCases::default().with_file_version(LanceFileVersion::V2_1);
         let strings = [
             "Hal Abelson",
@@ -1123,7 +1124,14 @@ pub mod tests {
             .iter()
             .cycle()
             .take(strings.len() * 10000)
-            .cloned()
+            .enumerate()
+            .map(|(i, s)| {
+                if with_nulls && i % 7 == 0 {
+                    None
+                } else {
+                    Some(s.to_string())
+                }
+            })
             .collect();
         let string_array = Arc::new(StringArray::from(repeated_strings)) as ArrayRef;
         check_round_trip_encoding_of_data(vec![string_array], &test_cases, HashMap::new()).await;


### PR DESCRIPTION
fixes https://github.com/lancedb/lance/issues/3962

`remove_outer_validity()` is called inside `encode_miniblock` and `encode_fullzip` which comes after dictionary encoding. This PR moves `remove_outer_validity` call before dictionary encoding.