### PR TITLE
chore: bump dirs to 6.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4420,7 +4420,7 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-sql",
  "deepsize",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "env_logger",
  "fst",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ datafusion-physical-expr = { version = "47.0" }
 datafusion-physical-plan = { version = "47.0" }
 datafusion-substrait = { version = "47.0" }
 deepsize = "0.2.0"
-dirs = "5.0.0"
+dirs = "6.0.0"
 either = "1.0"
 fst = { version = "0.4.7", features = ["levenshtein"] }
 fsst = { version = "=0.29.1", path = "./rust/lance-encoding/src/compression_algo/fsst" }


### PR DESCRIPTION
This is a minor PR that bumps `dirs` dependency to v6. Right now we have `lance-io` that uses `shellexpand` that depends on `dirs 6.0.0` and we have `lance-index` that uses `dirs 5.0.0` directly. This reduces the duplicate dependencies.

We still have `dirs 5.0.0` in examples due to hugging face, but I think that's less important for production code. 