### PR TITLE
fix(doc): fix doc typo in Ray integration documentation for Lance Data Sink

### DIFF
--- a/docs/integrations/ray.rst
+++ b/docs/integrations/ray.rst
@@ -11,7 +11,7 @@ Basic Operations
 Lance format is one of the official `Ray data sources <https://docs.ray.io/en/latest/data/api/input_output.html#lance>`_:
 
 * Lance Data Source :py:meth:`ray.data.read_lance`
-* Lance Data Sink :py:meth:`ray.data.Dataste.write_lance`
+* Lance Data Sink :py:meth:`ray.data.Dataset.write_lance`
 
 .. testsetup::
 


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the Ray integration documentation. The method reference for "Lance Data Sink" was previously written as py:meth:`ray.data.Dataste.write_lance` and has been updated to the correct py:meth:`ray.data.Dataset.write_lance`. This ensures accurate documentation and prevents confusion for users referencing the API. No other changes were made.