### PR TITLE
feat: support unenforced primary key concept in schema

### DIFF
--- a/protos/file.proto
+++ b/protos/file.proto
@@ -186,4 +186,6 @@ message Field {
   /// Fields that have non-default storage classes are stored in different
   /// datasets (e.g. blob fields are stored in the nested "_blobs" dataset)
   string storage_class = 11;
+
+  bool unenforced_primary_key = 12;
 }

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -966,7 +966,6 @@ impl TryFrom<&ArrowField> for Field {
             .get(LANCE_UNENFORCED_PRIMARY_KEY)
             .map(|s| match s.to_lowercase().as_str() {
                 "true" | "1" | "yes" => true,
-                "false" | "0" | "no" => false,
                 _ => false,
             })
             .unwrap_or(false);

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -964,10 +964,7 @@ impl TryFrom<&ArrowField> for Field {
         let unenforced_primary_key = field
             .metadata()
             .get(LANCE_UNENFORCED_PRIMARY_KEY)
-            .map(|s| match s.to_lowercase().as_str() {
-                "true" | "1" | "yes" => true,
-                _ => false,
-            })
+            .map(|s| matches!(s.to_lowercase().as_str(), "true" | "1" | "yes"))
             .unwrap_or(false);
 
         Ok(Self {

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -31,11 +31,12 @@ use crate::{Error, Result};
 
 pub const LANCE_STORAGE_CLASS_SCHEMA_META_KEY: &str = "lance-schema:storage-class";
 
-/// Use this config key in Arrow schema metadata to indicate a column is a part of the primary key.
-/// If this is a composite primary key, use `,` to delimit the column name.
+/// Use this config key in Arrow field metadata to indicate a column is a part of the primary key.
+/// The value can be any true values like `true`, `1`, `yes` (case-insensitive).
 /// A primary key column must satisfy:
-/// (1) The column, and all its parents must not be nullable.
-/// (2) The column must be of a leaf column without child columns.
+/// (1) The field, and all its ancestors must not be nullable.
+/// (2) The field must be a leaf without child (i.e. it is a primitive data type).
+/// (3) The field must not be within a list type.
 pub const LANCE_UNENFORCED_PRIMARY_KEY: &str = "lance-schema:unenforced-primary-key";
 
 #[derive(Debug, Default)]

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -60,6 +60,13 @@ impl<'a> Iterator for SchemaFieldIterPreOrder<'a> {
 }
 
 impl Schema {
+    /// The primary key fields in the schema
+    pub fn unenforced_primary_key(&self) -> Vec<&Field> {
+        self.fields_pre_order()
+            .filter(|f| f.unenforced_primary_key)
+            .collect::<Vec<_>>()
+    }
+
     pub fn compare_with_options(&self, expected: &Self, options: &SchemaCompareOptions) -> bool {
         compare_fields(&self.fields, &expected.fields, options)
             && (!options.compare_metadata || self.metadata == expected.metadata)
@@ -597,6 +604,30 @@ impl TryFrom<&ArrowSchema> for Schema {
             metadata: schema.metadata.clone(),
         };
         schema.set_field_id(None);
+
+        let pk = schema.unenforced_primary_key();
+        for pk_col in pk.into_iter() {
+            if !pk_col.is_leaf() {
+                return Err(Error::Schema {
+                    message: format!("Primary key column must be a leaf: {}", pk_col),
+                    location: location!(),
+                });
+            }
+
+            if let Some(ancestors) = schema.field_ancestry_by_id(pk_col.id) {
+                for ancestor in ancestors {
+                    if ancestor.nullable {
+                        return Err(Error::Schema {
+                            message: format!(
+                                "Primary key column and all its ancestors must not be nullable: {}",
+                                ancestor
+                            ),
+                            location: location!(),
+                        });
+                    }
+                }
+            }
+        }
 
         Ok(schema)
     }
@@ -1737,6 +1768,129 @@ mod tests {
                 metadata: Default::default(),
             };
             assert_eq!(schema.all_fields_nullable(), expected);
+        }
+    }
+
+    #[test]
+    fn test_schema_unenforced_primary_key() {
+        let cases = vec![
+            ArrowSchema::new(vec![ArrowField::new("a", DataType::Int32, false)]),
+            ArrowSchema::new(vec![ArrowField::new("a", DataType::Int32, false)
+                .with_metadata(
+                    vec![(
+                        "lance-schema:unenforced-primary-key".to_owned(),
+                        "true".to_owned(),
+                    )]
+                    .into_iter()
+                    .collect::<HashMap<_, _>>(),
+                )]),
+            ArrowSchema::new(vec![
+                ArrowField::new("a", DataType::Int32, false).with_metadata(
+                    vec![(
+                        "lance-schema:unenforced-primary-key".to_owned(),
+                        "true".to_owned(),
+                    )]
+                    .into_iter()
+                    .collect::<HashMap<_, _>>(),
+                ),
+                ArrowField::new(
+                    "b",
+                    DataType::Struct(ArrowFields::from(vec![ArrowField::new(
+                        "f1",
+                        DataType::Utf8,
+                        false,
+                    )
+                    .with_metadata(
+                        vec![(
+                            "lance-schema:unenforced-primary-key".to_owned(),
+                            "true".to_owned(),
+                        )]
+                        .into_iter()
+                        .collect::<HashMap<_, _>>(),
+                    )])),
+                    false,
+                ),
+            ]),
+        ];
+        let expected = [
+            vec![],
+            vec!["a".to_owned()],
+            vec!["a".to_owned(), "f1".to_owned()],
+        ];
+
+        for (idx, case) in cases.into_iter().enumerate() {
+            let schema = Schema::try_from(&case).unwrap();
+            assert_eq!(
+                schema
+                    .unenforced_primary_key()
+                    .iter()
+                    .map(|f| f.name.clone())
+                    .collect::<Vec<_>>(),
+                expected[idx]
+            );
+        }
+    }
+
+    #[test]
+    fn test_schema_unenforced_primary_key_failures() {
+        let cases = vec![
+            ArrowSchema::new(vec![ArrowField::new("a", DataType::Int32, true)
+                .with_metadata(
+                    vec![(
+                        "lance-schema:unenforced-primary-key".to_owned(),
+                        "true".to_owned(),
+                    )]
+                    .into_iter()
+                    .collect::<HashMap<_, _>>(),
+                )]),
+            ArrowSchema::new(vec![ArrowField::new(
+                "b",
+                DataType::Struct(ArrowFields::from(vec![ArrowField::new(
+                    "f1",
+                    DataType::Utf8,
+                    false,
+                )])),
+                false,
+            )
+            .with_metadata(
+                vec![(
+                    "lance-schema:unenforced-primary-key".to_owned(),
+                    "true".to_owned(),
+                )]
+                .into_iter()
+                .collect::<HashMap<_, _>>(),
+            )]),
+            ArrowSchema::new(vec![ArrowField::new(
+                "b",
+                DataType::Struct(ArrowFields::from(vec![ArrowField::new(
+                    "f1",
+                    DataType::Utf8,
+                    false,
+                )
+                .with_metadata(
+                    vec![(
+                        "lance-schema:unenforced-primary-key".to_owned(),
+                        "true".to_owned(),
+                    )]
+                    .into_iter()
+                    .collect::<HashMap<_, _>>(),
+                )])),
+                true,
+            )]),
+        ];
+        let error_message_contains = [
+            "Primary key column and all its ancestors must not be nullable",
+            "Primary key column must be a leaf",
+            "Primary key column and all its ancestors must not be nullable",
+        ];
+
+        for (idx, case) in cases.into_iter().enumerate() {
+            let result = Schema::try_from(&case);
+            assert!(result.is_err());
+            assert!(result
+                .unwrap_err()
+                .to_string()
+                .contains(error_message_contains[idx]));
         }
     }
 }

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -60,7 +60,7 @@ impl<'a> Iterator for SchemaFieldIterPreOrder<'a> {
 }
 
 impl Schema {
-    /// The primary key fields in the schema
+    /// The unenforced primary key fields in the schema
     pub fn unenforced_primary_key(&self) -> Vec<&Field> {
         self.fields_pre_order()
             .filter(|f| f.unenforced_primary_key)
@@ -1889,19 +1889,16 @@ mod tests {
             )]),
             ArrowSchema::new(vec![ArrowField::new(
                 "b",
-                DataType::List(Arc::new(ArrowField::new(
-                    "f1",
-                    DataType::Utf8,
-                    false,
-                )
-                    .with_metadata(
+                DataType::List(Arc::new(
+                    ArrowField::new("f1", DataType::Utf8, false).with_metadata(
                         vec![(
                             "lance-schema:unenforced-primary-key".to_owned(),
                             "true".to_owned(),
                         )]
-                            .into_iter()
-                            .collect::<HashMap<_, _>>(),
-                    ))),
+                        .into_iter()
+                        .collect::<HashMap<_, _>>(),
+                    ),
+                )),
                 false,
             )]),
         ];
@@ -1909,7 +1906,7 @@ mod tests {
             "Primary key column and all its ancestors must not be nullable",
             "Primary key column must be a leaf",
             "Primary key column and all its ancestors must not be nullable",
-            "Primary key column must not be in a list type"
+            "Primary key column must not be in a list type",
         ];
 
         for (idx, case) in cases.into_iter().enumerate() {

--- a/rust/lance-file/src/datatypes.rs
+++ b/rust/lance-file/src/datatypes.rs
@@ -46,6 +46,7 @@ impl From<&pb::Field> for Field {
             children: vec![],
             dictionary: field.dictionary.as_ref().map(Dictionary::from),
             storage_class: field.storage_class.parse().unwrap(),
+            unenforced_primary_key: field.unenforced_primary_key,
         }
     }
 }
@@ -79,6 +80,7 @@ impl From<&Field> for pb::Field {
                 .unwrap_or_default(),
             r#type: 0,
             storage_class: field.storage_class.to_string(),
+            unenforced_primary_key: field.unenforced_primary_key,
         }
     }
 }


### PR DESCRIPTION
Allow users to set primary key through Arrow schema metadata with `primary_key` config key. A primary key column must not be nullable. User can configure composite primary key through `,` delimiter, or using a custom delimiter specified by another `primary_key_delim` config key.

Closes #4003 