### PR TITLE
fix: panic caused by reading empty posting list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4452,6 +4452,7 @@ dependencies = [
  "random_word",
  "rayon",
  "roaring",
+ "rstest",
  "serde",
  "serde_json",
  "snafu",

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -75,6 +75,7 @@ tempfile.workspace = true
 test-log.workspace = true
 datafusion-sql.workspace = true
 random_word = { version = "0.4.3", features = ["en"] }
+rstest.workspace = true
 
 [features]
 protoc = ["dep:protobuf-src"]

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1908,7 +1908,6 @@ pub fn flat_bm25_search_stream(
     query: String,
     index: &InvertedIndex,
 ) -> SendableRecordBatchStream {
-    log::debug!("doing flat bm25 search stream");
     let mut tokenizer = index.tokenizer.clone();
     let tokens = collect_tokens(&query, &mut tokenizer, None)
         .into_iter()
@@ -1924,7 +1923,6 @@ pub fn flat_bm25_search_stream(
         nq.insert(token.clone(), token_nq);
     }
     let stream = input.map(move |batch| {
-        log::debug!("doing flat bm25 search batch");
         let batch = batch?;
         let batch = flat_bm25_search(
             batch,
@@ -1947,12 +1945,7 @@ pub fn flat_bm25_search_stream(
         Ok(batch)
     });
 
-    Box::pin(RecordBatchStreamAdapter::new(
-        FTS_SCHEMA.clone(),
-        stream.inspect(|_| {
-            log::debug!("done flat bm25 search batch");
-        }),
-    )) as SendableRecordBatchStream
+    Box::pin(RecordBatchStreamAdapter::new(FTS_SCHEMA.clone(), stream)) as SendableRecordBatchStream
 }
 
 pub fn is_phrase_query(query: &str) -> bool {

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -227,6 +227,7 @@ impl ExecutionPlan for MatchQueryExec {
             };
             let tokens = collect_tokens(&query.terms, &mut tokenizer, None);
 
+            log::debug!("doing bm25 search");
             pre_filter.wait_for_ready().await?;
             let (doc_ids, mut scores) = inverted_idx
                 .bm25_search(
@@ -238,6 +239,7 @@ impl ExecutionPlan for MatchQueryExec {
                 )
                 .boxed()
                 .await?;
+            log::debug!("done bm25 search");
             scores.iter_mut().for_each(|s| {
                 *s *= query.boost;
             });

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -227,7 +227,6 @@ impl ExecutionPlan for MatchQueryExec {
             };
             let tokens = collect_tokens(&query.terms, &mut tokenizer, None);
 
-            log::debug!("doing bm25 search");
             pre_filter.wait_for_ready().await?;
             let (doc_ids, mut scores) = inverted_idx
                 .bm25_search(
@@ -239,7 +238,6 @@ impl ExecutionPlan for MatchQueryExec {
                 )
                 .boxed()
                 .await?;
-            log::debug!("done bm25 search");
             scores.iter_mut().for_each(|s| {
                 *s *= query.boost;
             });


### PR DESCRIPTION
it happens only if all conditions satisfied:
- search with new search algo (block max wand), this means it's on the version that new FTS format has been introduced
- the FTS index is still in legacy format
- some posting list produces a candidate doc, that its doc id is greater than the first posting list's max doc id