### PR TITLE
feat(rust): add get config interface for dataset

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -850,6 +850,11 @@ impl Dataset {
         Ok(())
     }
 
+    /// Get the table config from manifest
+    pub fn config(&self) -> impl Iterator<Item = (&String, &String)> {
+        self.manifest.config.iter()
+    }
+
     /// Create a Scanner to scan the dataset.
     pub fn scan(&self) -> Scanner {
         Scanner::new(Arc::new(self.clone()))


### PR DESCRIPTION
I don't know why this table config is not retrievable.

I added an interface for this. If this is unnecessary, I expect someone could tell me how to get it by any means