### PR TITLE
feat: add cache stats for new cache

### DIFF
--- a/rust/lance-core/src/cache.rs
+++ b/rust/lance-core/src/cache.rs
@@ -365,15 +365,9 @@ mod tests {
         #[derive(Debug, DeepSizeOf)]
         struct MyType(i32);
 
-        trait MyTrait: DeepSizeOf + Send + Sync + Any {
-            fn as_any(&self) -> &dyn Any;
-        }
+        trait MyTrait: DeepSizeOf + Send + Sync + Any {}
 
-        impl MyTrait for MyType {
-            fn as_any(&self) -> &dyn Any {
-                self
-            }
-        }
+        impl MyTrait for MyType {}
 
         let cache = LanceCache::with_capacity(1000);
 

--- a/rust/lance-core/src/cache.rs
+++ b/rust/lance-core/src/cache.rs
@@ -218,7 +218,9 @@ impl LanceCache {
 
 #[derive(Debug, Clone)]
 pub struct CacheStats {
+    /// Number of times `get`, `get_unsized`, or `get_or_insert` found an item in the cache.
     pub hits: u64,
+    /// Number of times `get`, `get_unsized`, or `get_or_insert` did not find an item in the cache.
     pub misses: u64,
 }
 

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -160,6 +160,10 @@ impl Session {
     pub fn store_registry(&self) -> Arc<ObjectStoreRegistry> {
         self.store_registry.clone()
     }
+
+    pub fn metadata_cache_stats(&self) -> lance_core::cache::CacheStats {
+        self.metadata_cache.stats()
+    }
 }
 
 impl Default for Session {


### PR DESCRIPTION
This can be used to compute the hit and miss rate of the caches.