### PR TITLE
chore: fix broken spark doc link

### DIFF
--- a/docs/distributed_write.rst
+++ b/docs/distributed_write.rst
@@ -4,7 +4,7 @@ Distributed Write
 .. warning::
 
     Lance provides out-of-the-box :doc:`Ray <./integrations/ray>` and
-    `Spark <https://github.com/lancedb/lance/tree/main/java/spark>`_ integrations.
+    `Spark <https://github.com/lancedb/lance-spark>`_ integrations.
 
     This page is intended for users who wish to perform distributed operations in a custom manner,
     i.e. using `slurm` or `Kubernetes` without the Lance integration.


### PR DESCRIPTION
Fixes https://github.com/lancedb/lance/actions/runs/15718440005/job/44293946196. Note that this does not fix all the out of date Spark-Lance documentation. I am working on an update for that in https://github.com/lancedb/lance-spark/pull/24