### PR TITLE
perf: use size prefixing for zstd buffer compressor for better decompressing performance

### DIFF
--- a/rust/lance-encoding/src/encodings/physical/block.rs
+++ b/rust/lance-encoding/src/encodings/physical/block.rs
@@ -22,13 +22,13 @@
 //! transparent).
 
 use arrow_buffer::ArrowNativeType;
-use snafu::location;
-use std::{
-    io::{Cursor, Write},
-    str::FromStr,
-};
-
 use lance_core::{Error, Result};
+use snafu::location;
+
+use std::io::Cursor;
+use std::{io::Write, str::FromStr};
+use zstd::bulk::decompress_to_buffer;
+use zstd::stream::copy_decode;
 
 use crate::{
     buffer::LanceBuffer,
@@ -109,11 +109,66 @@ impl ZstdBufferCompressor {
     pub fn new(compression_level: i32) -> Self {
         Self { compression_level }
     }
+
+    // https://datatracker.ietf.org/doc/html/rfc8878
+    fn is_raw_stream_format(&self, input_buf: &[u8]) -> bool {
+        if input_buf.len() < 8 {
+            return true; // can't be length prefixed format if less than 8 bytes
+        }
+        // read the first 4 bytes as the magic number
+        let mut magic_buf = [0u8; 4];
+        magic_buf.copy_from_slice(&input_buf[..4]);
+        let magic = u32::from_le_bytes(magic_buf);
+
+        // see RFC 8878, section 3.1.1. Zstandard Frames, which defines the magic number
+        const ZSTD_MAGIC_NUMBER: u32 = 0xFD2FB528;
+        if magic == ZSTD_MAGIC_NUMBER {
+            // the compressed buffer starts like a Zstd frame.
+            // Per RFC 8878, the reserved bit (with Bit Number 3, the 4th bit) in the FHD (frame header descriptor) MUST be 0
+            // see section 3.1.1.1.1. 'Frame_Header_Descriptor' and section 3.1.1.1.1.4. 'Reserved Bit' for details
+            const FHD_BYTE_INDEX: usize = 4;
+            let fhd_byte = input_buf[FHD_BYTE_INDEX];
+            const FHD_RESERVED_BIT_MASK: u8 = 0b0001_0000;
+            let reserved_bit = fhd_byte & FHD_RESERVED_BIT_MASK;
+
+            if reserved_bit != 0 {
+                // this bit is 1. This is NOT a valid zstd frame.
+                // therefore, it must be length prefixed format where the length coincidentally
+                // started with the magic number
+                false
+            } else {
+                // the reserved bit is 0. This is consistent with a valid Zstd frame.
+                // treat it as raw stream format
+                true
+            }
+        } else {
+            // doesn't start with the magic number, so it can't be the raw stream format
+            false
+        }
+    }
+
+    fn decompress_length_prefixed_zstd(
+        &self,
+        input_buf: &[u8],
+        output_buf: &mut Vec<u8>,
+    ) -> Result<()> {
+        let mut len_buf = [0u8; 8];
+        len_buf.copy_from_slice(&input_buf[..8]);
+        let uncompressed_len = u64::from_le_bytes(len_buf) as usize;
+
+        let compressed_data = &input_buf[8..];
+        output_buf.resize(uncompressed_len, 0);
+
+        decompress_to_buffer(compressed_data, output_buf)?;
+        Ok(())
+    }
 }
 
 impl BufferCompressor for ZstdBufferCompressor {
     fn compress(&self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
-        let mut encoder = zstd::Encoder::new(output_buf, self.compression_level)?;
+        output_buf.write_all(&(input_buf.len() as u64).to_le_bytes())?;
+        let mut encoder = zstd::stream::Encoder::new(output_buf, self.compression_level)?;
+
         encoder.write_all(input_buf)?;
         match encoder.finish() {
             Ok(_) => Ok(()),
@@ -122,8 +177,17 @@ impl BufferCompressor for ZstdBufferCompressor {
     }
 
     fn decompress(&self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
-        let source = Cursor::new(input_buf);
-        zstd::stream::copy_decode(source, output_buf)?;
+        if input_buf.is_empty() {
+            return Ok(());
+        }
+
+        let is_raw_stream_format = self.is_raw_stream_format(input_buf);
+        if is_raw_stream_format {
+            copy_decode(Cursor::new(input_buf), output_buf)?;
+        } else {
+            self.decompress_length_prefixed_zstd(input_buf, output_buf)?;
+        }
+
         Ok(())
     }
 
@@ -359,5 +423,40 @@ mod tests {
     #[test]
     fn test_compression_scheme_from_str_invalid() {
         assert!(CompressionScheme::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn test_compress_zstd_with_length_prefixed() {
+        let compressor = ZstdBufferCompressor::new(0);
+        let input_data = b"Hello, world!";
+        let mut compressed_data = Vec::new();
+
+        compressor
+            .compress(input_data, &mut compressed_data)
+            .unwrap();
+        let mut decompressed_data = Vec::new();
+        compressor
+            .decompress(&compressed_data, &mut decompressed_data)
+            .unwrap();
+        assert_eq!(input_data, decompressed_data.as_slice());
+    }
+
+    #[test]
+    fn test_compress_zstd_raw_stream_format_and_decompress_with_length_prefixed() {
+        let compressor = ZstdBufferCompressor::new(0);
+        let input_data = b"Hello, world!";
+        let mut compressed_data = Vec::new();
+
+        // compress using raw stream format
+        let mut encoder = zstd::Encoder::new(&mut compressed_data, 0).unwrap();
+        encoder.write_all(input_data).unwrap();
+        encoder.finish().expect("failed to encode data with zstd");
+
+        // decompress using length prefixed format
+        let mut decompressed_data = Vec::new();
+        compressor
+            .decompress(&compressed_data, &mut decompressed_data)
+            .unwrap();
+        assert_eq!(input_data, decompressed_data.as_slice());
     }
 }

--- a/rust/lance-encoding/src/v2/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/v2/encodings/logical/primitive.rs
@@ -16,7 +16,7 @@ use crate::utils::accumulation::AccumulationQueue;
 use crate::v2::decoder::{FieldScheduler, LogicalPageDecoder, SchedulingJob};
 use crate::v2::encoder::ArrayEncodingStrategy;
 use crate::{data::DataBlock, v2::encodings::physical::decoder_from_array_encoding};
-use lance_core::{datatypes::Field, Result};
+use lance_core::{datatypes::Field, Error, Result};
 
 use crate::{
     decoder::{
@@ -443,7 +443,14 @@ impl PrimitiveFieldEncoder {
                 row_number: 0, // legacy encoders do not use
             })
         })
-        .map(|res_res| res_res.unwrap())
+        .map(|res_res| {
+            res_res.unwrap_or_else(|err| {
+                Err(Error::Internal {
+                    message: format!("Encoding task failed with error: {:?}", err),
+                    location: location!(),
+                })
+            })
+        })
         .boxed())
     }
 


### PR DESCRIPTION
# Summary

This PR addresses [lancedb/lance#4028](https://github.com/lancedb/lance/issues/4028) by introducing a length-prefixed format for the Zstd buffer compressor. The goal is to improve the decompression performance of Zstd-compressed buffers.

# Solution

Currently, the Zstd buffer compressor uses the standard compression API and decompresses data using the Zstd streaming API. While functional, this approach is not optimal as the streaming decompression introduces overhead.

In this PR, I switch to a block decompression approach by:
* Prefixing each compressed buffer with its original (uncompressed) length (encoded as a 64-bit little-endian integer)
* Using Zstd’s block decompression API during decoding, which avoids the overhead of stream mode.
* Leveraging the Zstd magic number and a reserved bit in the Zstd frame header descriptor (as defined in RFC 8878) to distinguish between a standard Zstd stream and the new length-prefixed format, so that compatibility can be guaranteed 

# Consistency with Existing Approaches
* This technique is consistent with the one used by the [Apache Arrow IPC format][1][2], which also embeds the uncompressed size to enable faster, more efficient decompression.
* The LZ4 buffer compressor in lance already follows a similar approach, as its API natively supports it via the `prepend_size` parameter in the `compress_to_buffer` function.

# Benchmark Results

In limited benchmarks across several input sizes:

* Decompression speed improved by 30% to 200%, depending on the data.
* Compression speed remains unchanged.
* Compressed size increases by 8 bytes (due to the uncompressed size prefix).

# References
* [1] Arrow IPC writer: https://github.com/apache/arrow/blob/bd31f83aaa93db8427bc90285658e29d79ce5efd/cpp/src/arrow/ipc/writer.cc#L230-L233
* [2] Arrow IPC reader: https://github.com/apache/arrow/blob/bd31f83aaa93db8427bc90285658e29d79ce5efd/cpp/src/arrow/ipc/reader.cc#L398-L407