### PR TITLE
ci: disable problem matchers on nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,6 +88,8 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: ${{ matrix.toolchain }}
+          # When using the nightly toolchain, do not surface warnings as check annotations
+          matcher: ${{ matrix.toolchain != 'nightly'}}
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
       - name: Install dependencies


### PR DESCRIPTION
We run some jobs with the nightly version of cargo.  These jobs may trigger compiler warnings that are not present on the pinned cargo version.  These compiler warnings then pollute PRs by showing up as check annotations.  This PR disables problem matchers when using the nightly toolchain.