### PR TITLE
feat: add random take bench based on file reader api and fragment api

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1069,7 +1069,7 @@ impl Dataset {
         &self.object_store
     }
 
-    pub(crate) fn data_dir(&self) -> Path {
+    pub fn data_dir(&self) -> Path {
         self.base.child(DATA_DIR)
     }
 


### PR DESCRIPTION
We noticed a performance gap when using the dataset, fragment, and file reader APIs for point query. Here we add bench cases to help investigating the problem.