### PR TITLE
feat: add 64-bit offset support to FSST compression for large binary/string data in V2.1

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -2740,6 +2740,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 name = "fsst"
 version = "0.31.2"
 dependencies = [
+ "arrow-array",
  "rand 0.8.5",
 ]
 

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -27,6 +27,7 @@ pub use schema::{OnMissing, Projectable, Projection, Schema};
 pub const COMPRESSION_META_KEY: &str = "lance-encoding:compression";
 pub const COMPRESSION_LEVEL_META_KEY: &str = "lance-encoding:compression-level";
 pub const RLE_THRESHOLD_META_KEY: &str = "lance-encoding:rle-threshold";
+pub const DICT_DIVISOR_META_KEY: &str = "lance-encoding:dict-divisor";
 pub const BLOB_META_KEY: &str = "lance-encoding:blob";
 pub const PACKED_STRUCT_LEGACY_META_KEY: &str = "packed";
 pub const PACKED_STRUCT_META_KEY: &str = "lance-encoding:packed";

--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -4,7 +4,7 @@
 use std::{collections::HashMap, iter, marker::PhantomData, sync::Arc};
 
 use arrow::{
-    array::{ArrayData, AsArray, Float32Builder},
+    array::{ArrayData, AsArray, Float32Builder, GenericStringBuilder},
     buffer::{BooleanBuffer, Buffer, OffsetBuffer, ScalarBuffer},
     datatypes::{
         ArrowPrimitiveType, Float32Type, Int32Type, Int64Type, IntervalDayTime,
@@ -15,8 +15,8 @@ use arrow_array::{
     make_array,
     types::{ArrowDictionaryKeyType, BinaryType, ByteArrayType, Utf8Type},
     Array, BinaryArray, FixedSizeBinaryArray, FixedSizeListArray, Float32Array, LargeListArray,
-    LargeStringArray, ListArray, NullArray, PrimitiveArray, RecordBatch, RecordBatchOptions,
-    RecordBatchReader, StringArray, StructArray,
+    LargeStringArray, ListArray, NullArray, OffsetSizeTrait, PrimitiveArray, RecordBatch,
+    RecordBatchOptions, RecordBatchReader, StringArray, StructArray,
 };
 use arrow_schema::{ArrowError, DataType, Field, Fields, IntervalUnit, Schema, SchemaRef};
 use futures::{stream::BoxStream, StreamExt};
@@ -890,6 +890,79 @@ impl ArrayGenerator for RandomBinaryGenerator {
         Some(ByteCount::from(
             self.bytes_per_element.0 + std::mem::size_of::<i32>() as u64,
         ))
+    }
+}
+
+/// Generate a sequence of strings with a prefix and a counter
+///
+/// For example, if the prefix is "user_" the the strings will be "user_0", "user_1", ...
+#[derive(Debug)]
+pub struct PrefixPlusCounterGenerator {
+    prefix: String,
+    is_large: bool,
+    data_type: DataType,
+    current_counter: u64,
+}
+
+impl PrefixPlusCounterGenerator {
+    pub fn new(prefix: String, is_large: bool) -> Self {
+        Self {
+            prefix,
+            is_large,
+            data_type: if is_large {
+                DataType::LargeUtf8
+            } else {
+                DataType::Utf8
+            },
+            current_counter: 0,
+        }
+    }
+
+    fn generate_values<T: OffsetSizeTrait>(
+        &self,
+        start: u64,
+        num_values: u64,
+    ) -> Result<Arc<dyn Array>, ArrowError> {
+        let max_counter = start + num_values;
+        let max_digits_per_counter = (max_counter as f64).log10().ceil() as u64;
+        let max_bytes_per_str = max_digits_per_counter + self.prefix.len() as u64;
+        let max_bytes = max_bytes_per_str * num_values;
+        let mut builder =
+            GenericStringBuilder::<T>::with_capacity(num_values as usize, max_bytes as usize);
+        let mut word = String::with_capacity(max_bytes_per_str as usize);
+        word.push_str(&self.prefix);
+        for i in 0..num_values {
+            let counter = start + i;
+            word.truncate(self.prefix.len());
+            word.push_str(&counter.to_string());
+            builder.append_value(&word);
+        }
+        Ok(Arc::new(builder.finish()))
+    }
+}
+
+impl ArrayGenerator for PrefixPlusCounterGenerator {
+    fn generate(
+        &mut self,
+        length: RowCount,
+        _rng: &mut rand_xoshiro::Xoshiro256PlusPlus,
+    ) -> Result<Arc<dyn arrow_array::Array>, ArrowError> {
+        let start = self.current_counter;
+        self.current_counter += length.0;
+        if self.is_large {
+            self.generate_values::<i64>(start, length.0)
+        } else {
+            self.generate_values::<i32>(start, length.0)
+        }
+    }
+
+    fn data_type(&self) -> &DataType {
+        &self.data_type
+    }
+
+    fn element_size_bytes(&self) -> Option<ByteCount> {
+        // It's not consistent
+        None
     }
 }
 
@@ -2284,6 +2357,16 @@ pub mod array {
         ))
     }
 
+    /// Creates a generator of strings with a prefix and a counter
+    ///
+    /// For example, if the prefix is "user_" the the strings will be "user_0", "user_1", ...
+    pub fn utf8_prefix_plus_counter(
+        prefix: impl Into<String>,
+        is_large: bool,
+    ) -> Box<dyn ArrayGenerator> {
+        Box::new(PrefixPlusCounterGenerator::new(prefix.into(), is_large))
+    }
+
     /// Create a random generator of boolean values
     pub fn rand_boolean() -> Box<dyn ArrayGenerator> {
         Box::<RandomBooleanGenerator>::default()
@@ -2522,6 +2605,16 @@ mod tests {
         assert_eq!(
             *gen.generate(RowCount::from(3), &mut rng).unwrap(),
             arrow_array::StringArray::from_iter_values(["xyz", "xyz", "xyz"])
+        );
+    }
+
+    #[test]
+    fn test_utf8_prefix_plus_counter() {
+        let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
+        let mut gen = array::utf8_prefix_plus_counter("user_", false);
+        assert_eq!(
+            *gen.generate(RowCount::from(3), &mut rng).unwrap(),
+            arrow_array::StringArray::from_iter_values(["user_0", "user_1", "user_2"])
         );
     }
 

--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -393,6 +393,7 @@ impl DecompressionStrategy for DefaultDecompressionStrategy {
                     general.inner.as_ref().ok_or_else(|| {
                         Error::invalid_input("GeneralMiniBlock missing inner encoding", location!())
                     })?,
+                    decompression_strategy,
                 )?;
 
                 // Parse compression config

--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -186,7 +186,7 @@ impl CompressionStrategy for DefaultCompressionStrategy {
                     let max_len =
                         variable_width_data.expect_single_stat::<UInt64Type>(Stat::MaxLength);
 
-                    println!("max_len={}, data_size={}", max_len, data_size);
+                    //println!("max_len={}, data_size={}", max_len, data_size);
                     if max_len >= FSST_LEAST_INPUT_MAX_LENGTH
                         && data_size >= FSST_LEAST_INPUT_SIZE as u64
                     {

--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -178,12 +178,15 @@ impl CompressionStrategy for DefaultCompressionStrategy {
                 }
             }
             DataBlock::VariableWidth(variable_width_data) => {
-                if variable_width_data.bits_per_offset == 32 {
+                if variable_width_data.bits_per_offset == 32
+                    || variable_width_data.bits_per_offset == 64
+                {
                     let data_size =
                         variable_width_data.expect_single_stat::<UInt64Type>(Stat::DataSize);
                     let max_len =
                         variable_width_data.expect_single_stat::<UInt64Type>(Stat::MaxLength);
 
+                    println!("max_len={}, data_size={}", max_len, data_size);
                     if max_len >= FSST_LEAST_INPUT_MAX_LENGTH
                         && data_size >= FSST_LEAST_INPUT_SIZE as u64
                     {
@@ -191,9 +194,6 @@ impl CompressionStrategy for DefaultCompressionStrategy {
                     } else {
                         Ok(Box::new(BinaryMiniBlockEncoder::default()))
                     }
-                } else if variable_width_data.bits_per_offset == 64 {
-                    // TODO: Support FSSTMiniBlockEncoder
-                    Ok(Box::new(BinaryMiniBlockEncoder::default()))
                 } else {
                     todo!(
                         "Implement MiniBlockCompression for VariableWidth DataBlock with {} bit offsets.",

--- a/rust/lance-encoding/src/compression_algo/fsst/Cargo.toml
+++ b/rust/lance-encoding/src/compression_algo/fsst/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+arrow-array.workspace = true
 rand.workspace = true
 
 # this should be put in dev-dependencies, TODO: remove it from here

--- a/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
+++ b/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
@@ -1054,13 +1054,21 @@ impl<T: OffsetSizeTrait> FsstEncoder<T> {
         if in_buf.len() > out_buf.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "output buffer too small for FSST encoder",
+                format!(
+                    "output buffer ({}) too small for FSST encoder (need at least {})",
+                    out_buf.len(),
+                    in_buf.len()
+                ),
             ));
         }
         if in_offsets_buf.len() > out_offsets_buf.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "output offsets buffer too small for FSST encoder",
+                format!(
+                    "output offsets buffer ({}) too small for FSST encoder (need at least {})",
+                    out_offsets_buf.len(),
+                    in_offsets_buf.len()
+                ),
             ));
         }
 
@@ -1204,7 +1212,11 @@ impl<T: OffsetSizeTrait> FsstDecoder<T> {
         if in_offsets_buf.len() > out_offsets_buf.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "output offsets buffer too small for FSST decoder",
+                format!(
+                    "output offsets buffer ({}) too small for FSST decoder (need at least {})",
+                    out_offsets_buf.len(),
+                    in_offsets_buf.len()
+                ),
             ));
         }
         let symbol_num = (st_info & 255) as u8;
@@ -1413,7 +1425,7 @@ mod tests {
             Doth make the night joint-labourer with the day?
             Who is't that can inform me?";
 
-    const TEST_PARAGRAPH2: &str = "Towards the end of November, during a thaw, at nine o’clock one morning, a train on the Warsaw and Petersburg railway was approaching the latter city at full speed.
+    const TEST_PARAGRAPH2: &str = "Towards the end of November, during a thaw, at nine o'clock one morning, a train on the Warsaw and Petersburg railway was approaching the latter city at full speed.
 The morning was so damp and misty that it was only with great difficulty that the day succeeded in breaking;
 and it was impossible to distinguish anything more than a few yards away from the carriage windows.
 Some of the passengers by this particular train were returning from abroad; but the third-class carriages were the best filled, chiefly with insignificant persons of various occupations and degrees,
@@ -1435,48 +1447,48 @@ his eyes were large and blue, and had an intent look about them, yet that heavy 
 His face was decidedly a pleasant one for all that; refined, but quite colourless, except for the circumstance that at this moment it was blue with cold.
 He held a bundle made up of an old faded silk handkerchief that apparently contained all his travelling wardrobe, and wore thick shoes and gaiters, his whole appearance being very un-Russian.
 His black-haired neighbour inspected these peculiarities, having nothing better to do, and at length remarked, with that rude enjoyment of the discomforts of others which the common classes so often show:
-“Cold?”
-“Very,” said his neighbour, readily, “and this is a thaw, too. Fancy if it had been a hard frost! I never thought it would be so cold in the old country. I’ve grown quite out of the way of it.”
-“What, been abroad, I suppose?”
-“Yes, straight from Switzerland.”
-“Wheugh! my goodness!” The black-haired young fellow whistled, and then laughed.
-The conversation proceeded. The readiness of the fair-haired young man in the cloak to answer all his opposite neighbour’s questions was surprising.
+"Cold?"
+"Very," said his neighbour, readily, "and this is a thaw, too. Fancy if it had been a hard frost! I never thought it would be so cold in the old country. I've grown quite out of the way of it."
+"What, been abroad, I suppose?"
+"Yes, straight from Switzerland."
+"Wheugh! my goodness!" The black-haired young fellow whistled, and then laughed.
+The conversation proceeded. The readiness of the fair-haired young man in the cloak to answer all his opposite neighbour's questions was surprising.
 He seemed to have no suspicion of any impertinence or inappropriateness in the fact of such questions being put to him.
 Replying to them, he made known to the inquirer that he certainly had been long absent from Russia, more than four years; that he had been sent abroad for his health;
-that he had suffered from some strange nervous malady—a kind of epilepsy, with convulsive spasms. His interlocutor burst out laughing several times at his answers; and more than ever, when to the question, “whether he had been cured?” the patient replied:
-“No, they did not cure me.”
-“Hey! that’s it! You stumped up your money for nothing, and we believe in those fellows, here!” remarked the black-haired individual, sarcastically.";
+that he had suffered from some strange nervous malady—a kind of epilepsy, with convulsive spasms. His interlocutor burst out laughing several times at his answers; and more than ever, when to the question, "whether he had been cured?" the patient replied:
+"No, they did not cure me."
+"Hey! that's it! You stumped up your money for nothing, and we believe in those fellows, here!" remarked the black-haired individual, sarcastically.";
 
-    const TEST_PARAGRAPH3: &str = "When the widow hurried away to Pavlofsk, she went straight to Daria Alexeyevna’s house, and telling all she knew, threw her into a state of great alarm.
+    const TEST_PARAGRAPH3: &str = "When the widow hurried away to Pavlofsk, she went straight to Daria Alexeyevna's house, and telling all she knew, threw her into a state of great alarm.
 Both ladies decided to communicate at once with Lebedeff, who, as the friend and landlord of the prince, was also much agitated.
-Vera Lebedeff told all she knew, and by Lebedeff’s advice it was decided that all three should go to Petersburg as quickly as possible, in order to avert “what might so easily happen.”
-This is how it came about that at eleven o’clock next morning Rogojin’s flat was opened by the police in the presence of Lebedeff, the two ladies, and Rogojin’s own brother, who lived in the wing.
+Vera Lebedeff told all she knew, and by Lebedeff's advice it was decided that all three should go to Petersburg as quickly as possible, in order to avert "what might so easily happen."
+This is how it came about that at eleven o'clock next morning Rogojin's flat was opened by the police in the presence of Lebedeff, the two ladies, and Rogojin's own brother, who lived in the wing.
 The evidence of the porter went further than anything else towards the success of Lebedeff in gaining the assistance of the police.
 He declared that he had seen Rogojin return to the house last night, accompanied by a friend, and that both had gone upstairs very secretly and cautiously.
 After this there was no hesitation about breaking open the door, since it could not be got open in any other way.
 Rogojin suffered from brain fever for two months. When he recovered from the attack he was at once brought up on trial for murder.
-He gave full, satisfactory, and direct evidence on every point; and the prince’s name was, thanks to this, not brought into the proceedings.
+He gave full, satisfactory, and direct evidence on every point; and the prince's name was, thanks to this, not brought into the proceedings.
 Rogojin was very quiet during the progress of the trial. He did not contradict his clever and eloquent counsel, who argued that the brain fever,
 or inflammation of the brain, was the cause of the crime; clearly proving that this malady had existed long before the murder was perpetrated, and had been brought on by the sufferings of the accused.
 But Rogojin added no words of his own in confirmation of this view, and as before, he recounted with marvellous exactness the details of his crime.
 He was convicted, but with extenuating circumstances, and condemned to hard labour in Siberia for fifteen years. He heard his sentence grimly, silently, and thoughtfully. His colossal fortune,
 with the exception of the comparatively small portion wasted in the first wanton period of his inheritance, went to his brother, to the great satisfaction of the latter.
-The old lady, Rogojin’s mother, is still alive, and remembers her favourite son Parfen sometimes, but not clearly. God spared her the knowledge of this dreadful calamity which had overtaken her house.
+The old lady, Rogojin's mother, is still alive, and remembers her favourite son Parfen sometimes, but not clearly. God spared her the knowledge of this dreadful calamity which had overtaken her house.
 Lebedeff, Keller, Gania, Ptitsin, and many other friends of ours continue to live as before. There is scarcely any change in them, so that there is no need to tell of their subsequent doings.
-Hippolyte died in great agitation, and rather sooner than he expected, about a fortnight after Nastasia Philipovna’s death. Colia was much affected by these events,
-and drew nearer to his mother in heart and sympathy. Nina Alexandrovna is anxious, because he is “thoughtful beyond his years,” but he will, we think, make a useful and active man.
-The prince’s further fate was more or less decided by Colia, who selected, out of all the persons he had met during the last six or seven months, Evgenie Pavlovitch, as friend and confidant.
+Hippolyte died in great agitation, and rather sooner than he expected, about a fortnight after Nastasia Philipovna's death. Colia was much affected by these events,
+and drew nearer to his mother in heart and sympathy. Nina Alexandrovna is anxious, because he is "thoughtful beyond his years," but he will, we think, make a useful and active man.
+The prince's further fate was more or less decided by Colia, who selected, out of all the persons he had met during the last six or seven months, Evgenie Pavlovitch, as friend and confidant.
 To him he made over all that he knew as to the events above recorded, and as to the present condition of the prince. He was not far wrong in his choice.
-Evgenie Pavlovitch took the deepest interest in the fate of the unfortunate “idiot,” and, thanks to his influence, the prince found himself once more with Dr. Schneider, in Switzerland.
-Evgenie Pavlovitch, who went abroad at this time, intending to live a long while on the continent, being, as he often said, quite superfluous in Russia, visits his sick friend at Schneider’s every few months.
+Evgenie Pavlovitch took the deepest interest in the fate of the unfortunate "idiot," and, thanks to his influence, the prince found himself once more with Dr. Schneider, in Switzerland.
+Evgenie Pavlovitch, who went abroad at this time, intending to live a long while on the continent, being, as he often said, quite superfluous in Russia, visits his sick friend at Schneider's every few months.
 But Dr. Schneider frowns ever more and more and shakes his head; he hints that the brain is fatally injured; he does not as yet declare that his patient is incurable, but he allows himself to express the gravest fears.
 Evgenie takes this much to heart, and he has a heart, as is proved by the fact that he receives and even answers letters from Colia. But besides this,
 another trait in his character has become apparent, and as it is a good trait we will make haste to reveal it.
-After each visit to Schneider’s establishment, Evgenie Pavlovitch writes another letter, besides that to Colia, giving the most minute particulars concerning the invalid’s condition.
+After each visit to Schneider's establishment, Evgenie Pavlovitch writes another letter, besides that to Colia, giving the most minute particulars concerning the invalid's condition.
 In these letters is to be detected, and in each one more than the last, a growing feeling of friendship and sympathy.
 The individual who corresponds thus with Evgenie Pavlovitch, and who engages so much of his attention and respect, is Vera Lebedeff.
 We have never been able to discover clearly how such relations sprang up.
-Of course the root of them was in the events which we have already recorded, and which so filled Vera with grief on the prince’s account that she fell seriously ill.
+Of course the root of them was in the events which we have already recorded, and which so filled Vera with grief on the prince's account that she fell seriously ill.
 But exactly how the acquaintance and friendship came about, we cannot say.";
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
+++ b/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
@@ -46,7 +46,7 @@ const MAX_SYMBOL_LENGTH: usize = 8;
 
 pub const FSST_SYMBOL_TABLE_SIZE: usize = 8 + 256 * 8 + 256; // 8 bytes for the header, 256 symbols(8 bytes each), 256 bytes for lens
 
-use arrow_array::{LargeStringArray, OffsetSizeTrait};
+use arrow_array::OffsetSizeTrait;
 use rand::rngs::StdRng;
 use rand::Rng;
 use rand::SeedableRng;
@@ -596,7 +596,7 @@ fn build_symbol_table<T: OffsetSizeTrait>(
             let symbol_len = st.symbols[prev_code as usize].symbol_len() as usize;
             let escape_cost = if is_escape_code(prev_code) { 1 } else { 0 };
             let gain_contribution = symbol_len.saturating_sub(1 + escape_cost);
-            gain = gain + T::from_usize(gain_contribution).unwrap();
+            gain += T::from_usize(gain_contribution).unwrap();
 
             while curr < word.len() {
                 counters.count1_inc(prev_code);
@@ -635,7 +635,7 @@ fn build_symbol_table<T: OffsetSizeTrait>(
                 let symbol_len_usize = symbol_len as usize;
                 let escape_cost = if is_escape_code(curr_code) { 1 } else { 0 };
                 let gain_contribution = symbol_len_usize.saturating_sub(1 + escape_cost);
-                gain = gain + T::from_usize(gain_contribution).unwrap();
+                gain += T::from_usize(gain_contribution).unwrap();
 
                 // no need to count pairs in final round
                 if sample_frac < 128 {
@@ -1623,6 +1623,7 @@ But exactly how the acquaintance and friendship came about, we cannot say.";
     }
 
     fn helper_64_bit(test_input: &str) {
+        use arrow_array::LargeStringArray;
         let lines_vec = test_input.lines().collect::<Vec<&str>>();
         let string_array = LargeStringArray::from(lines_vec);
         let mut compress_output_buf: Vec<u8> = vec![0; string_array.value_data().len()];

--- a/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
+++ b/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
@@ -984,10 +984,6 @@ fn decompress_bulk<T: OffsetSizeTrait>(
         if in_curr < in_end {
             // last code cannot be an escape code
             let code = compressed_strs[in_curr] as usize;
-            let required_space = *out_curr + lens[code] as usize;
-            if required_space > out.len() {
-                out.resize(required_space.max(out.len() * 2), 0);
-            }
             unsafe {
                 let src = symbols[code];
                 ptr::write_unaligned(out.as_mut_ptr().add(*out_curr) as *mut u64, src);
@@ -1425,7 +1421,7 @@ mod tests {
             Doth make the night joint-labourer with the day?
             Who is't that can inform me?";
 
-    const TEST_PARAGRAPH2: &str = "Towards the end of November, during a thaw, at nine o'clock one morning, a train on the Warsaw and Petersburg railway was approaching the latter city at full speed.
+    const TEST_PARAGRAPH2: &str = "Towards the end of November, during a thaw, at nine o’clock one morning, a train on the Warsaw and Petersburg railway was approaching the latter city at full speed.
 The morning was so damp and misty that it was only with great difficulty that the day succeeded in breaking;
 and it was impossible to distinguish anything more than a few yards away from the carriage windows.
 Some of the passengers by this particular train were returning from abroad; but the third-class carriages were the best filled, chiefly with insignificant persons of various occupations and degrees,
@@ -1447,48 +1443,48 @@ his eyes were large and blue, and had an intent look about them, yet that heavy 
 His face was decidedly a pleasant one for all that; refined, but quite colourless, except for the circumstance that at this moment it was blue with cold.
 He held a bundle made up of an old faded silk handkerchief that apparently contained all his travelling wardrobe, and wore thick shoes and gaiters, his whole appearance being very un-Russian.
 His black-haired neighbour inspected these peculiarities, having nothing better to do, and at length remarked, with that rude enjoyment of the discomforts of others which the common classes so often show:
-"Cold?"
-"Very," said his neighbour, readily, "and this is a thaw, too. Fancy if it had been a hard frost! I never thought it would be so cold in the old country. I've grown quite out of the way of it."
-"What, been abroad, I suppose?"
-"Yes, straight from Switzerland."
-"Wheugh! my goodness!" The black-haired young fellow whistled, and then laughed.
-The conversation proceeded. The readiness of the fair-haired young man in the cloak to answer all his opposite neighbour's questions was surprising.
+“Cold?”
+“Very,” said his neighbour, readily, “and this is a thaw, too. Fancy if it had been a hard frost! I never thought it would be so cold in the old country. I’ve grown quite out of the way of it.”
+“What, been abroad, I suppose?”
+“Yes, straight from Switzerland.”
+“Wheugh! my goodness!” The black-haired young fellow whistled, and then laughed.
+The conversation proceeded. The readiness of the fair-haired young man in the cloak to answer all his opposite neighbour’s questions was surprising.
 He seemed to have no suspicion of any impertinence or inappropriateness in the fact of such questions being put to him.
 Replying to them, he made known to the inquirer that he certainly had been long absent from Russia, more than four years; that he had been sent abroad for his health;
-that he had suffered from some strange nervous malady—a kind of epilepsy, with convulsive spasms. His interlocutor burst out laughing several times at his answers; and more than ever, when to the question, "whether he had been cured?" the patient replied:
-"No, they did not cure me."
-"Hey! that's it! You stumped up your money for nothing, and we believe in those fellows, here!" remarked the black-haired individual, sarcastically.";
+that he had suffered from some strange nervous malady—a kind of epilepsy, with convulsive spasms. His interlocutor burst out laughing several times at his answers; and more than ever, when to the question, “whether he had been cured?” the patient replied:
+“No, they did not cure me.”
+“Hey! that’s it! You stumped up your money for nothing, and we believe in those fellows, here!” remarked the black-haired individual, sarcastically.";
 
-    const TEST_PARAGRAPH3: &str = "When the widow hurried away to Pavlofsk, she went straight to Daria Alexeyevna's house, and telling all she knew, threw her into a state of great alarm.
+    const TEST_PARAGRAPH3: &str = "When the widow hurried away to Pavlofsk, she went straight to Daria Alexeyevna’s house, and telling all she knew, threw her into a state of great alarm.
 Both ladies decided to communicate at once with Lebedeff, who, as the friend and landlord of the prince, was also much agitated.
-Vera Lebedeff told all she knew, and by Lebedeff's advice it was decided that all three should go to Petersburg as quickly as possible, in order to avert "what might so easily happen."
-This is how it came about that at eleven o'clock next morning Rogojin's flat was opened by the police in the presence of Lebedeff, the two ladies, and Rogojin's own brother, who lived in the wing.
+Vera Lebedeff told all she knew, and by Lebedeff’s advice it was decided that all three should go to Petersburg as quickly as possible, in order to avert “what might so easily happen.”
+This is how it came about that at eleven o’clock next morning Rogojin’s flat was opened by the police in the presence of Lebedeff, the two ladies, and Rogojin’s own brother, who lived in the wing.
 The evidence of the porter went further than anything else towards the success of Lebedeff in gaining the assistance of the police.
 He declared that he had seen Rogojin return to the house last night, accompanied by a friend, and that both had gone upstairs very secretly and cautiously.
 After this there was no hesitation about breaking open the door, since it could not be got open in any other way.
 Rogojin suffered from brain fever for two months. When he recovered from the attack he was at once brought up on trial for murder.
-He gave full, satisfactory, and direct evidence on every point; and the prince's name was, thanks to this, not brought into the proceedings.
+He gave full, satisfactory, and direct evidence on every point; and the prince’s name was, thanks to this, not brought into the proceedings.
 Rogojin was very quiet during the progress of the trial. He did not contradict his clever and eloquent counsel, who argued that the brain fever,
 or inflammation of the brain, was the cause of the crime; clearly proving that this malady had existed long before the murder was perpetrated, and had been brought on by the sufferings of the accused.
 But Rogojin added no words of his own in confirmation of this view, and as before, he recounted with marvellous exactness the details of his crime.
 He was convicted, but with extenuating circumstances, and condemned to hard labour in Siberia for fifteen years. He heard his sentence grimly, silently, and thoughtfully. His colossal fortune,
 with the exception of the comparatively small portion wasted in the first wanton period of his inheritance, went to his brother, to the great satisfaction of the latter.
-The old lady, Rogojin's mother, is still alive, and remembers her favourite son Parfen sometimes, but not clearly. God spared her the knowledge of this dreadful calamity which had overtaken her house.
+The old lady, Rogojin’s mother, is still alive, and remembers her favourite son Parfen sometimes, but not clearly. God spared her the knowledge of this dreadful calamity which had overtaken her house.
 Lebedeff, Keller, Gania, Ptitsin, and many other friends of ours continue to live as before. There is scarcely any change in them, so that there is no need to tell of their subsequent doings.
-Hippolyte died in great agitation, and rather sooner than he expected, about a fortnight after Nastasia Philipovna's death. Colia was much affected by these events,
-and drew nearer to his mother in heart and sympathy. Nina Alexandrovna is anxious, because he is "thoughtful beyond his years," but he will, we think, make a useful and active man.
-The prince's further fate was more or less decided by Colia, who selected, out of all the persons he had met during the last six or seven months, Evgenie Pavlovitch, as friend and confidant.
+Hippolyte died in great agitation, and rather sooner than he expected, about a fortnight after Nastasia Philipovna’s death. Colia was much affected by these events,
+and drew nearer to his mother in heart and sympathy. Nina Alexandrovna is anxious, because he is “thoughtful beyond his years,” but he will, we think, make a useful and active man.
+The prince’s further fate was more or less decided by Colia, who selected, out of all the persons he had met during the last six or seven months, Evgenie Pavlovitch, as friend and confidant.
 To him he made over all that he knew as to the events above recorded, and as to the present condition of the prince. He was not far wrong in his choice.
-Evgenie Pavlovitch took the deepest interest in the fate of the unfortunate "idiot," and, thanks to his influence, the prince found himself once more with Dr. Schneider, in Switzerland.
-Evgenie Pavlovitch, who went abroad at this time, intending to live a long while on the continent, being, as he often said, quite superfluous in Russia, visits his sick friend at Schneider's every few months.
+Evgenie Pavlovitch took the deepest interest in the fate of the unfortunate “idiot,” and, thanks to his influence, the prince found himself once more with Dr. Schneider, in Switzerland.
+Evgenie Pavlovitch, who went abroad at this time, intending to live a long while on the continent, being, as he often said, quite superfluous in Russia, visits his sick friend at Schneider’s every few months.
 But Dr. Schneider frowns ever more and more and shakes his head; he hints that the brain is fatally injured; he does not as yet declare that his patient is incurable, but he allows himself to express the gravest fears.
 Evgenie takes this much to heart, and he has a heart, as is proved by the fact that he receives and even answers letters from Colia. But besides this,
 another trait in his character has become apparent, and as it is a good trait we will make haste to reveal it.
-After each visit to Schneider's establishment, Evgenie Pavlovitch writes another letter, besides that to Colia, giving the most minute particulars concerning the invalid's condition.
+After each visit to Schneider’s establishment, Evgenie Pavlovitch writes another letter, besides that to Colia, giving the most minute particulars concerning the invalid’s condition.
 In these letters is to be detected, and in each one more than the last, a growing feeling of friendship and sympathy.
 The individual who corresponds thus with Evgenie Pavlovitch, and who engages so much of his attention and respect, is Vera Lebedeff.
 We have never been able to discover clearly how such relations sprang up.
-Of course the root of them was in the events which we have already recorded, and which so filled Vera with grief on the prince's account that she fell seriously ill.
+Of course the root of them was in the events which we have already recorded, and which so filled Vera with grief on the prince’s account that she fell seriously ill.
 But exactly how the acquaintance and friendship came about, we cannot say.";
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
+++ b/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
@@ -19,7 +19,8 @@ const FSST_SAMPLETARGET: usize = 1 << 14;
 const FSST_SAMPLEMAXSZ: usize = 2 * FSST_SAMPLETARGET;
 
 // if the input size is less than 4MB, we mark the file header and copy the input to the output as is
-pub const FSST_LEAST_INPUT_SIZE: usize = 4 * 1024 * 1024; // 4MB
+//  TODO: FIX ME
+pub const FSST_LEAST_INPUT_SIZE: usize = 32 * 1024; // 4MB
 
 // if the max length of the input strings are less than `FSST_LEAST_INPUT_MAX_LENGTH`, we shouldn't use FSST.
 pub const FSST_LEAST_INPUT_MAX_LENGTH: u64 = 5;

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -269,13 +269,6 @@ impl<T: OffsetSizeTrait> VariableWidthDataBlockBuilder<T> {
 
 impl<T: OffsetSizeTrait> DataBlockBuilderImpl for VariableWidthDataBlockBuilder<T> {
     fn append(&mut self, data_block: &DataBlock, selection: Range<u64>) {
-        println!(
-            "VariableWidthDataBlockBuilder::append - selection={:?}, current offsets.len()={}, appending block with {} values",
-            selection,
-            self.offsets.len(),
-            selection.end - selection.start
-        );
-
         let block = data_block.as_variable_width_ref().unwrap();
         assert!(block.bits_per_offset == T::get_byte_width() as u8 * 8);
 
@@ -298,21 +291,10 @@ impl<T: OffsetSizeTrait> DataBlockBuilderImpl for VariableWidthDataBlockBuilder<
                     T::from_usize(previous_len).unwrap()
                 }),
         );
-
-        println!(
-            "VariableWidthDataBlockBuilder::append - after append, offsets.len()={}",
-            self.offsets.len()
-        );
     }
 
     fn finish(self: Box<Self>) -> DataBlock {
         let num_values = (self.offsets.len() - 1) as u64;
-        println!(
-            "VariableWidthDataBlockBuilder::finish - offsets.len()={}, calculated num_values={}",
-            self.offsets.len(),
-            num_values
-        );
-
         DataBlock::VariableWidth(VariableWidthBlock {
             data: LanceBuffer::Owned(self.bytes),
             offsets: LanceBuffer::reinterpret_vec(self.offsets),
@@ -676,13 +658,6 @@ pub struct VariableWidthBlock {
 
 impl VariableWidthBlock {
     fn into_arrow(self, data_type: DataType, validate: bool) -> Result<ArrayData> {
-        println!(
-            "VariableWidthBlock::into_arrow - num_values={}, offsets.len()={}, bits_per_offset={}",
-            self.num_values,
-            self.offsets.len() / (self.bits_per_offset as usize / 8),
-            self.bits_per_offset
-        );
-
         let data_buffer = self.data.into_buffer();
         let offsets_buffer = self.offsets.into_buffer();
         let builder = ArrayDataBuilder::new(data_type)

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -269,6 +269,13 @@ impl<T: OffsetSizeTrait> VariableWidthDataBlockBuilder<T> {
 
 impl<T: OffsetSizeTrait> DataBlockBuilderImpl for VariableWidthDataBlockBuilder<T> {
     fn append(&mut self, data_block: &DataBlock, selection: Range<u64>) {
+        println!(
+            "VariableWidthDataBlockBuilder::append - selection={:?}, current offsets.len()={}, appending block with {} values",
+            selection,
+            self.offsets.len(),
+            selection.end - selection.start
+        );
+
         let block = data_block.as_variable_width_ref().unwrap();
         assert!(block.bits_per_offset == T::get_byte_width() as u8 * 8);
 
@@ -291,10 +298,21 @@ impl<T: OffsetSizeTrait> DataBlockBuilderImpl for VariableWidthDataBlockBuilder<
                     T::from_usize(previous_len).unwrap()
                 }),
         );
+
+        println!(
+            "VariableWidthDataBlockBuilder::append - after append, offsets.len()={}",
+            self.offsets.len()
+        );
     }
 
     fn finish(self: Box<Self>) -> DataBlock {
         let num_values = (self.offsets.len() - 1) as u64;
+        println!(
+            "VariableWidthDataBlockBuilder::finish - offsets.len()={}, calculated num_values={}",
+            self.offsets.len(),
+            num_values
+        );
+
         DataBlock::VariableWidth(VariableWidthBlock {
             data: LanceBuffer::Owned(self.bytes),
             offsets: LanceBuffer::reinterpret_vec(self.offsets),
@@ -658,6 +676,13 @@ pub struct VariableWidthBlock {
 
 impl VariableWidthBlock {
     fn into_arrow(self, data_type: DataType, validate: bool) -> Result<ArrayData> {
+        println!(
+            "VariableWidthBlock::into_arrow - num_values={}, offsets.len()={}, bits_per_offset={}",
+            self.num_values,
+            self.offsets.len() / (self.bits_per_offset as usize / 8),
+            self.bits_per_offset
+        );
+
         let data_buffer = self.data.into_buffer();
         let offsets_buffer = self.offsets.into_buffer();
         let builder = ArrayDataBuilder::new(data_type)

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -79,6 +79,8 @@ pub mod fullzip;
 pub mod miniblock;
 
 const FILL_BYTE: u8 = 0xFE;
+pub const MINIBLOCK_MAX_VALUES: u64 = 4 * 1024;
+pub const MINIBLOCK_MAX_BYTES: u64 = 32 * 1024;
 
 /// A trait for figuring out how to schedule the data within
 /// a single page.

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -79,8 +79,6 @@ pub mod fullzip;
 pub mod miniblock;
 
 const FILL_BYTE: u8 = 0xFE;
-pub const MINIBLOCK_MAX_VALUES: u64 = 4 * 1024;
-pub const MINIBLOCK_MAX_BYTES: u64 = 32 * 1024;
 
 /// A trait for figuring out how to schedule the data within
 /// a single page.

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -437,8 +437,8 @@ pub mod tests {
     #[rstest]
     #[test_log::test(tokio::test)]
     async fn test_binary_fsst(
-        #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
-        structural_encoding: &str,
+        //#[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
+        #[values(STRUCTURAL_ENCODING_MINIBLOCK)] structural_encoding: &str,
     ) {
         let mut field_metadata = HashMap::new();
         field_metadata.insert(
@@ -446,15 +446,17 @@ pub mod tests {
             structural_encoding.into(),
         );
         field_metadata.insert(COMPRESSION_META_KEY.to_string(), "fsst".into());
-
-        let field = Field::new("", DataType::Utf8, true).with_metadata(field_metadata);
+        // TODO: support large binary
+        println!("test_binary_fsst");
+        let field = Field::new("", DataType::LargeUtf8, true).with_metadata(field_metadata);
         check_round_trip_encoding_random(field, LanceFileVersion::V2_1).await;
     }
 
     #[rstest]
     #[test_log::test(tokio::test)]
     async fn test_large_binary(
-        #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
+        //#[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
+        #[values(LanceFileVersion::V2_1)] version: LanceFileVersion,
     ) {
         let field = Field::new("", DataType::LargeBinary, true);
         check_round_trip_encoding_random(field, version).await;

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -492,7 +492,10 @@ pub mod tests {
     use std::{collections::HashMap, sync::Arc, vec};
 
     use crate::{
-        testing::{check_round_trip_encoding_of_data, check_round_trip_encoding_random, TestCases},
+        testing::{
+            check_round_trip_encoding_generated, check_round_trip_encoding_of_data,
+            check_round_trip_encoding_random, FnArrayGeneratorProvider, TestCases,
+        },
         version::LanceFileVersion,
     };
 
@@ -572,6 +575,28 @@ pub mod tests {
     async fn test_large_utf8() {
         let field = Field::new("", DataType::LargeUtf8, true);
         check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+    }
+
+    #[rstest]
+    #[test_log::test(tokio::test)]
+    async fn test_small_strings(
+        #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
+        structural_encoding: &str,
+    ) {
+        let mut field_metadata = HashMap::new();
+        field_metadata.insert(
+            STRUCTURAL_ENCODING_META_KEY.to_string(),
+            structural_encoding.into(),
+        );
+        let field = Field::new("", DataType::Utf8, true).with_metadata(field_metadata);
+        check_round_trip_encoding_generated(
+            field,
+            Box::new(FnArrayGeneratorProvider::new(move || {
+                lance_datagen::array::utf8_prefix_plus_counter("user_", /*is_large=*/ false)
+            })),
+            LanceFileVersion::V2_1,
+        )
+        .await;
     }
 
     #[rstest]

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -448,7 +448,8 @@ pub mod tests {
         field_metadata.insert(COMPRESSION_META_KEY.to_string(), "fsst".into());
         // TODO: support large binary
         println!("test_binary_fsst");
-        let field = Field::new("", DataType::LargeUtf8, true).with_metadata(field_metadata);
+        //let field = Field::new("", DataType::LargeUtf8, true).with_metadata(field_metadata);
+        let field = Field::new("", DataType::Utf8, true).with_metadata(field_metadata);
         check_round_trip_encoding_random(field, LanceFileVersion::V2_1).await;
     }
 

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -556,14 +556,15 @@ pub mod tests {
     async fn test_large_binary_fsst_with_dict(
         #[values(DataType::LargeBinary, DataType::LargeUtf8)] data_type: DataType,
     ) {
-        // A workaround to test the dictionary encoding with large data. see issue #4249
-        // Set the environment variable for this test
-        std::env::set_var("LANCE_ENCODING_DICT_DIVISOR", "1");
+        use lance_core::datatypes::DICT_DIVISOR_META_KEY;
+
         let mut field_metadata = HashMap::new();
         field_metadata.insert(
             STRUCTURAL_ENCODING_META_KEY.to_string(),
             STRUCTURAL_ENCODING_MINIBLOCK.to_string(),
         );
+        // Force it to use dictionary encoding
+        field_metadata.insert(DICT_DIVISOR_META_KEY.to_string(), "1".into());
         field_metadata.insert(COMPRESSION_META_KEY.to_string(), "fsst".into());
         let field = Field::new("", data_type, true).with_metadata(field_metadata);
         check_round_trip_encoding_random(field, LanceFileVersion::V2_1).await;

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -448,8 +448,8 @@ pub mod tests {
         field_metadata.insert(COMPRESSION_META_KEY.to_string(), "fsst".into());
         // TODO: support large binary
         println!("test_binary_fsst");
-        //let field = Field::new("", DataType::LargeUtf8, true).with_metadata(field_metadata);
-        let field = Field::new("", DataType::Utf8, true).with_metadata(field_metadata);
+        let field = Field::new("", DataType::LargeUtf8, true).with_metadata(field_metadata);
+        //let field = Field::new("", DataType::Utf8, true).with_metadata(field_metadata);
         check_round_trip_encoding_random(field, LanceFileVersion::V2_1).await;
     }
 

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -79,39 +79,39 @@ impl FsstCompressed {
                             symbol_table,
                         })
                     }
-                    // 64 => {
-                    //     let offsets = variable_width.offsets.borrow_to_typed_slice::<i64>();
-                    //     let offsets_slice = offsets.as_ref();
-                    //     let bytes_data = variable_width.data.into_buffer();
+                    64 => {
+                        let offsets = variable_width.offsets.borrow_to_typed_slice::<i64>();
+                        let offsets_slice = offsets.as_ref();
+                        let bytes_data = variable_width.data.into_buffer();
 
-                    //     // prepare compression output buffer
-                    //     let mut dest_offsets = vec![0_i64; offsets_slice.len() * 2];
-                    //     let mut dest_values = vec![0_u8; bytes_data.len() * 2];
-                    //     let mut symbol_table = vec![0_u8; fsst::fsst::FSST_SYMBOL_TABLE_SIZE];
+                        // prepare compression output buffer
+                        let mut dest_offsets = vec![0_i64; offsets_slice.len() * 2];
+                        let mut dest_values = vec![0_u8; bytes_data.len() * 2];
+                        let mut symbol_table = vec![0_u8; fsst::fsst::FSST_SYMBOL_TABLE_SIZE];
 
-                    //     // fsst compression
-                    //     fsst::fsst::compress(
-                    //         &mut symbol_table,
-                    //         bytes_data.as_slice(),
-                    //         offsets_slice,
-                    //         &mut dest_values,
-                    //         &mut dest_offsets,
-                    //     )?;
+                        // fsst compression
+                        fsst::fsst::compress(
+                            &mut symbol_table,
+                            bytes_data.as_slice(),
+                            offsets_slice,
+                            &mut dest_values,
+                            &mut dest_offsets,
+                        )?;
 
-                    //     // construct `DataBlock` for BinaryMiniBlockEncoder, we may want some `DataBlock` construct methods later
-                    //     let compressed = VariableWidthBlock {
-                    //         data: LanceBuffer::reinterpret_vec(dest_values),
-                    //         bits_per_offset: 32,
-                    //         offsets: LanceBuffer::reinterpret_vec(dest_offsets),
-                    //         num_values: variable_width.num_values,
-                    //         block_info: BlockInfo::new(),
-                    //     };
+                        // construct `DataBlock` for BinaryMiniBlockEncoder, we may want some `DataBlock` construct methods later
+                        let compressed = VariableWidthBlock {
+                            data: LanceBuffer::reinterpret_vec(dest_values),
+                            bits_per_offset: 64,
+                            offsets: LanceBuffer::reinterpret_vec(dest_offsets),
+                            num_values: variable_width.num_values,
+                            block_info: BlockInfo::new(),
+                        };
 
-                    //     Ok(Self {
-                    //         data: compressed,
-                    //         symbol_table,
-                    //     })
-                    // }
+                        Ok(Self {
+                            data: compressed,
+                            symbol_table,
+                        })
+                    }
                     _ => panic!(
                         "Unsupported offsets type {}",
                         variable_width.bits_per_offset
@@ -256,13 +256,14 @@ impl FsstMiniBlockDecompressor {
 impl MiniBlockDecompressor for FsstMiniBlockDecompressor {
     fn decompress(&self, data: Vec<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
         // Step 1. decompress data use `BinaryMiniBlockDecompressor`
-        // TODO: Support 64 bits for FSST compressor
+        // TODO: detect 64 bits for FSST compressor before calling decompress function
         let binary_decompressor =
-            Box::new(BinaryMiniBlockDecompressor::new(32)) as Box<dyn MiniBlockDecompressor>;
+            Box::new(BinaryMiniBlockDecompressor::new(64)) as Box<dyn MiniBlockDecompressor>;
         let compressed_data_block = binary_decompressor.decompress(data, num_values)?;
         let DataBlock::VariableWidth(mut compressed_data_block) = compressed_data_block else {
             panic!("BinaryMiniBlockDecompressor should output VariableWidth DataBlock")
         };
+        println!("bits_per_offset={}", compressed_data_block.bits_per_offset);
 
         // Step 2. FSST decompress
         let bytes = compressed_data_block.data.borrow_to_typed_slice::<u8>();

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -202,6 +202,7 @@ impl FsstPerValueDecompressor {
 
 impl VariablePerValueDecompressor for FsstPerValueDecompressor {
     fn decompress(&self, data: VariableWidthBlock) -> Result<DataBlock> {
+        // TODO: extend me to support 64 bits
         // Step 1. Run inner decompressor
         let mut compressed_variable_data = self
             .inner_decompressor

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -41,7 +41,7 @@ struct FsstCompressed {
 
 impl FsstCompressed {
     fn fsst_compress(data: DataBlock) -> Result<Self> {
-        println!("Calling fsst_compress");
+        //println!("Calling fsst_compress");
         match data {
             DataBlock::VariableWidth(mut variable_width) => {
                 // TODO: support 64

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -311,6 +311,8 @@ impl MiniBlockDecompressor for FsstMiniBlockDecompressor {
                 let offsets = compressed_data_block.offsets.borrow_to_typed_slice::<i64>();
                 let offsets = offsets.as_ref();
 
+                // The data will expand at most 8 times
+                // The offsets will be the same size because we have the same # of strings
                 let mut decompress_bytes_buf = vec![0u8; bytes.len() * 8];
                 let mut decompress_offset_buf = vec![0i64; offsets.len()];
                 fsst::fsst::decompress(
@@ -332,6 +334,8 @@ impl MiniBlockDecompressor for FsstMiniBlockDecompressor {
                 let offsets = compressed_data_block.offsets.borrow_to_typed_slice::<i32>();
                 let offsets = offsets.as_ref();
 
+                // The data will expand at most 8 times
+                // The offsets will be the same size because we have the same # of strings
                 let mut decompress_bytes_buf = vec![0u8; bytes.len() * 8];
                 let mut decompress_offset_buf = vec![0i32; offsets.len()];
                 fsst::fsst::decompress(

--- a/rust/lance-encoding/src/encodings/physical/general.rs
+++ b/rust/lance-encoding/src/encodings/physical/general.rs
@@ -354,7 +354,7 @@ mod tests {
 
             // Create a decompressor for this chunk
             let decompressor = decompression_strategy
-                .create_miniblock_decompressor(encoding)
+                .create_miniblock_decompressor(encoding, &decompression_strategy)
                 .unwrap();
 
             // Decompress the chunk
@@ -608,7 +608,7 @@ mod tests {
             // Create a decompressor for this chunk
             let decompression_strategy = DefaultDecompressionStrategy::default();
             let decompressor = decompression_strategy
-                .create_miniblock_decompressor(&encoding)
+                .create_miniblock_decompressor(&encoding, &decompression_strategy)
                 .unwrap();
 
             // Decompress the chunk

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -267,6 +267,30 @@ pub async fn check_round_trip_encoding_random(field: Field, version: LanceFileVe
     check_round_trip_encoding_generated(field, Box::new(array_generator_provider), version).await;
 }
 
+pub struct FnArrayGeneratorProvider<F: Fn() -> Box<dyn ArrayGenerator> + Clone + 'static> {
+    provider_fn: F,
+}
+
+impl<F: Fn() -> Box<dyn ArrayGenerator> + Clone + 'static> FnArrayGeneratorProvider<F> {
+    pub fn new(provider_fn: F) -> Self {
+        Self { provider_fn }
+    }
+}
+
+impl<F: Fn() -> Box<dyn ArrayGenerator> + Clone + 'static> ArrayGeneratorProvider
+    for FnArrayGeneratorProvider<F>
+{
+    fn provide(&self) -> Box<dyn ArrayGenerator> {
+        (self.provider_fn)()
+    }
+
+    fn copy(&self) -> Box<dyn ArrayGeneratorProvider> {
+        Box::new(FnArrayGeneratorProvider {
+            provider_fn: self.provider_fn.clone(),
+        })
+    }
+}
+
 pub async fn check_round_trip_encoding_generated(
     field: Field,
     array_generator_provider: Box<dyn ArrayGeneratorProvider>,

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -202,7 +202,6 @@ async fn test_decode(
             let expected_size = (batch_size as usize).min(expected.len() - offset);
             let expected = expected.slice(offset, expected_size);
             assert_eq!(expected.data_type(), actual.data_type());
-            println!("expected={}, actual={}", expected.len(), actual.len());
             if expected.len() != actual.len() {
                 panic!(
                     "Mismatch in length (at offset={}) expected {} but got {}",
@@ -265,8 +264,6 @@ pub async fn check_round_trip_encoding_random(field: Field, version: LanceFileVe
     let array_generator_provider = RandomArrayGeneratorProvider {
         field: field.clone(),
     };
-
-    let test_cases = TestCases::default().with_batch_size(50);
     check_round_trip_encoding_generated(field, Box::new(array_generator_provider), version).await;
 }
 

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -202,6 +202,7 @@ async fn test_decode(
             let expected_size = (batch_size as usize).min(expected.len() - offset);
             let expected = expected.slice(offset, expected_size);
             assert_eq!(expected.data_type(), actual.data_type());
+            println!("expected={}, actual={}", expected.len(), actual.len());
             if expected.len() != actual.len() {
                 panic!(
                     "Mismatch in length (at offset={}) expected {} but got {}",
@@ -264,6 +265,8 @@ pub async fn check_round_trip_encoding_random(field: Field, version: LanceFileVe
     let array_generator_provider = RandomArrayGeneratorProvider {
         field: field.clone(),
     };
+
+    let test_cases = TestCases::default().with_batch_size(50);
     check_round_trip_encoding_generated(field, Box::new(array_generator_provider), version).await;
 }
 

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -285,7 +285,7 @@ impl<F: Fn() -> Box<dyn ArrayGenerator> + Clone + 'static> ArrayGeneratorProvide
     }
 
     fn copy(&self) -> Box<dyn ArrayGeneratorProvider> {
-        Box::new(FnArrayGeneratorProvider {
+        Box::new(Self {
             provider_fn: self.provider_fn.clone(),
         })
     }


### PR DESCRIPTION
This PR addresses https://github.com/lancedb/lance/issues/3350. 
This enhancement enables Lance to handle datasets with string/binary fields exceeding 4GB in total size while maintaining optimal compression ratios through FSST.
It breaks the binary data layout for binary/string data in lance V2.1(unstable) format.

It also absorbs PR #4095 to not error on highly compressible FSST by Weston.

# Summary
* Extends FSST compression support to handle large binary and string data by implementing 64-bit offset support alongside the existing 32-bit offsets for miniblock, fullzip and dictionary encoding. This enables efficient compression of variable-width data that exceeds the 4GB limit imposed by 32-bit offsets. 

# Changes Made
* Made FSST compression generic - Updated FSST implementation to work with both 32-bit and 64-bit offset types using generic programming
* Updated compression strategy - Modified DefaultCompressionStrategy to support both 32-bit and 64-bit offsets in variable-width data blocks
* Enhanced decompressors - Added auto-detection of offset bit width in FsstMiniBlockDecompressor with layered decompression architecture
* Extended block compressor - Updated BinaryBlockDecompressor and related components to handle 64-bit offsets
* Updated primitive encoder - Enhanced PrimitiveStructuralEncoder to support 64-bit offset encoding
Added dependencies - Included arrow-array dependency in FSST Cargo.toml

# Breaking Change Context
It introduces a new u8 byte - used for `bits_per_offset` - to the current datablock compression memory layout. Now it supports both 32 and 64 bits. Since Lance 2.1 is on an unstable version, it should not affect any existing prod users.
```
/// ----------------------------------------------------------------------------------------
/// | bits_per_offset(NEW!) | number of values  | bytes_start_offset | offsets data | bytes data
/// ----------------------------------------------------------------------------------------
/// |       1 byte    | bits_per_offset/8 | bits_per_offset/8  |  offsets_len | dat_len
/// ----------------------------------------------------------------------------------------
```

# Test Results
✅ All existing ones are passing
✅ A new test:`test_fsst_64_bit_offsets` in fsst.rs is passing
✅ A new test: `test_large_binary_fsst` in binary.rs is passing

# API Impact
None
