### PR TITLE
fix: don't error on highly compressible FSST

### DIFF
--- a/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
+++ b/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
@@ -19,7 +19,7 @@ const FSST_SAMPLETARGET: usize = 1 << 14;
 const FSST_SAMPLEMAXSZ: usize = 2 * FSST_SAMPLETARGET;
 
 // if the input size is less than 4MB, we mark the file header and copy the input to the output as is
-pub const FSST_LEAST_INPUT_SIZE: usize = 4 * 1024 * 1024; // 4MB
+pub const FSST_LEAST_INPUT_SIZE: usize = 32 * 1024; // 4MB
 
 // if the max length of the input strings are less than `FSST_LEAST_INPUT_MAX_LENGTH`, we shouldn't use FSST.
 pub const FSST_LEAST_INPUT_MAX_LENGTH: u64 = 5;
@@ -1032,13 +1032,21 @@ impl FsstEncoder {
         if in_buf.len() > out_buf.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "output buffer too small for FSST encoder",
+                format!(
+                    "output buffer ({}) too small for FSST encoder (need at least {})",
+                    out_buf.len(),
+                    in_buf.len()
+                ),
             ));
         }
         if in_offsets_buf.len() > out_offsets_buf.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "output offsets buffer too small for FSST encoder",
+                format!(
+                    "output offsets buffer ({}) too small for FSST encoder (need at least {})",
+                    out_offsets_buf.len(),
+                    in_offsets_buf.len()
+                ),
             ));
         }
 
@@ -1180,7 +1188,11 @@ impl FsstDecoder {
         if in_offsets_buf.len() > out_offsets_buf.len() {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "output offsets buffer too small for FSST decoder",
+                format!(
+                    "output offsets buffer ({}) too small for FSST decoder (need at least {})",
+                    out_offsets_buf.len(),
+                    in_offsets_buf.len()
+                ),
             ));
         }
         let symbol_num = (st_info & 255) as u8;

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -79,6 +79,8 @@ pub mod fullzip;
 pub mod miniblock;
 
 const FILL_BYTE: u8 = 0xFE;
+pub const MINIBLOCK_MAX_VALUES: u64 = 4 * 1024;
+pub const MINIBLOCK_MAX_BYTES: u64 = 32 * 1024;
 
 /// A trait for figuring out how to schedule the data within
 /// a single page.

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -227,11 +227,9 @@ impl MiniBlockDecompressor for FsstMiniBlockDecompressor {
         let offsets = compressed_data_block.offsets.borrow_to_typed_slice::<i32>();
         let offsets = offsets.as_ref();
 
-        // FSST decompression output buffer, the `MiniBlock` has a size limit of `4 KiB` and
-        // the FSST decompression algorithm output is at most `8 * input_size`
-        // Since `MiniBlock Size` <= 4 KiB and `offsets` are type `i32, it has number of `offsets` <= 1024.
-        let mut decompress_bytes_buf = vec![0u8; 4 * 1024 * 8];
-        let mut decompress_offset_buf = vec![0i32; 1024];
+        // At most we get an 8x expansion and we will have the same # of offsets as the input
+        let mut decompress_bytes_buf = vec![0u8; bytes.len() * 8];
+        let mut decompress_offset_buf = vec![0i32; offsets.len()];
         fsst::fsst::decompress(
             &self.symbol_table,
             bytes,

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -284,7 +284,7 @@ impl<F: Fn() -> Box<dyn ArrayGenerator> + Clone + 'static> ArrayGeneratorProvide
     }
 
     fn copy(&self) -> Box<dyn ArrayGeneratorProvider> {
-        Box::new(FnArrayGeneratorProvider {
+        Box::new(Self {
             provider_fn: self.provider_fn.clone(),
         })
     }

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -266,6 +266,30 @@ pub async fn check_round_trip_encoding_random(field: Field, version: LanceFileVe
     check_round_trip_encoding_generated(field, Box::new(array_generator_provider), version).await;
 }
 
+pub struct FnArrayGeneratorProvider<F: Fn() -> Box<dyn ArrayGenerator> + Clone + 'static> {
+    provider_fn: F,
+}
+
+impl<F: Fn() -> Box<dyn ArrayGenerator> + Clone + 'static> FnArrayGeneratorProvider<F> {
+    pub fn new(provider_fn: F) -> Self {
+        Self { provider_fn }
+    }
+}
+
+impl<F: Fn() -> Box<dyn ArrayGenerator> + Clone + 'static> ArrayGeneratorProvider
+    for FnArrayGeneratorProvider<F>
+{
+    fn provide(&self) -> Box<dyn ArrayGenerator> {
+        (self.provider_fn)()
+    }
+
+    fn copy(&self) -> Box<dyn ArrayGeneratorProvider> {
+        Box::new(FnArrayGeneratorProvider {
+            provider_fn: self.provider_fn.clone(),
+        })
+    }
+}
+
 pub async fn check_round_trip_encoding_generated(
     field: Field,
     array_generator_provider: Box<dyn ArrayGeneratorProvider>,


### PR DESCRIPTION
If we got a lot of highly compressible strings (user example was small prefix + counter) then its possible we have 1024 values in a single mini-block.  The old logic assumed we would have at most 1024 output offsets and, in this case, we have 1025 and this would fail.

However, it's actually very easy to know exactly how many output offsets we will have (it's the same as the input) and so this sets the expected value exactly.  We also add a test case to trigger this situation.

Closes #4079 