### PR TITLE
fix: allow rowid in columns for scanner

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -559,6 +559,15 @@ impl Dataset {
         strict_batch_size: Option<bool>,
     ) -> PyResult<Scanner> {
         let mut scanner: LanceScanner = self_.ds.scan();
+
+        if with_row_id.unwrap_or(false) {
+            scanner.with_row_id();
+        }
+
+        if with_row_address.unwrap_or(false) {
+            scanner.with_row_address();
+        }
+
         match (columns, columns_with_transform) {
             (Some(_), Some(_)) => {
                 return Err(PyValueError::new_err(
@@ -675,14 +684,6 @@ impl Dataset {
         }
 
         scanner.scan_in_order(scan_in_order.unwrap_or(true));
-
-        if with_row_id.unwrap_or(false) {
-            scanner.with_row_id();
-        }
-
-        if with_row_address.unwrap_or(false) {
-            scanner.with_row_address();
-        }
 
         if let Some(use_stats) = use_stats {
             scanner.use_stats(use_stats);

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -192,7 +192,7 @@ impl Schema {
                 } else {
                     candidates.push(projected_field)
                 }
-            } else if err_on_missing {
+            } else if err_on_missing && first != ROW_ID && first != ROW_ADDR {
                 return Err(Error::Schema {
                     message: format!("Column {} does not exist", col.as_ref()),
                     location: location!(),


### PR DESCRIPTION
Currently, the scanner does not support passing in hidden columns, such as rowid and rowaddr, which will result in an error.
```
self = <lance.dataset.LanceScanner object at 0x7f330d7cbf60>

    def to_reader(self) -> pa.RecordBatchReader:
>       return self._scanner.to_pyarrow()
E       ValueError: LanceError(Schema): Schema error: No field named _rowid. Valid fields are data_item_id., /data00/code/emr/lance/rust/lance-datafusion/src/projection.rs:171:25

```

This PR mainly allows both with_row_id in the scanner and rowid in the columns. The reason for this is that when performing push - down on the computing side, the schema in the dataframe is generally pushed directly to the columns, rather than setting properties specifically for a certain with_row_id or with_row_addr. 

Therefore, there is a hope to make a compatibility on the lance side, similar to allowing such behavior. 
```
lance_ds = lance.dataset(path)
table = lance_ds.scanner(
        with_row_id=True, columns=["data_item_id", "_rowid"]
    ).to_table()
```
