### PR TITLE
refactor(datagen): add RandomWord and RandomSentence to replace RandomWords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4124,7 +4124,6 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "rand 0.8.5",
- "random_word 0.4.3",
  "roaring",
  "rstest",
  "serde",
@@ -4244,7 +4243,7 @@ dependencies = [
  "pprof",
  "rand 0.8.5",
  "rand_xoshiro",
- "random_word 0.5.0",
+ "random_word",
 ]
 
 [[package]]
@@ -4311,12 +4310,12 @@ dependencies = [
  "itertools 0.13.0",
  "lance",
  "lance-core",
+ "lance-datagen",
  "lance-index",
  "lance-linalg",
  "object_store",
  "parquet",
  "rand 0.8.5",
- "random_word 0.4.3",
  "tempfile",
  "tokenizers",
  "tokio",
@@ -4420,7 +4419,6 @@ dependencies = [
  "prost-build 0.13.5",
  "protobuf-src",
  "rand 0.8.5",
- "random_word 0.4.3",
  "rayon",
  "roaring",
  "rstest",
@@ -6237,20 +6235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "random_word"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07eed67a16dde2cc3c7f65c072acd8d5b2e53d4aab95067c320db851c7651f29"
-dependencies = [
- "ahash",
- "brotli 3.5.0",
- "once_cell",
- "paste",
- "rand 0.8.5",
- "unicase",
 ]
 
 [[package]]

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -42,6 +42,7 @@ lance = { workspace = true }
 lance-index = { workspace = true }
 lance-core = { workspace = true }
 lance-linalg = { workspace = true }
+lance-datagen = { workspace = true }
 object_store = {workspace = true}
 tempfile = { workspace = true }
 tokio = { workspace = true }
@@ -50,5 +51,4 @@ env_logger = "0.11.7"
 hf-hub = "0.4.2"
 parquet = "55.1"
 tokenizers = "0.15.2"
-random_word = { version = "0.4.3", features = ["en"] }
 rand.workspace = true

--- a/rust/examples/src/full_text_search.rs
+++ b/rust/examples/src/full_text_search.rs
@@ -10,12 +10,13 @@ use std::sync::Arc;
 
 use all_asserts::assert_gt;
 use arrow::array::AsArray;
-use arrow::array::{LargeStringArray, RecordBatch, RecordBatchIterator, UInt64Array};
+use arrow::array::{Array, LargeStringArray, RecordBatch, RecordBatchIterator, UInt64Array};
 use arrow::datatypes::UInt64Type;
 use arrow_schema::{DataType, Field, Schema};
 use itertools::Itertools;
 use lance::Dataset;
 use lance_core::ROW_ID;
+use lance_datagen::{array, RowCount};
 use lance_index::scalar::inverted::flat_full_text_search;
 use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
 use lance_index::DatasetIndexExt;
@@ -27,24 +28,18 @@ async fn main() {
     const TOTAL: usize = 10_000_000;
     let tempdir = tempfile::tempdir().unwrap();
     let dataset_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
-    let tokens = (0..10_000)
-        .map(|_| random_word::gen(random_word::Lang::En))
-        .collect_vec();
+    
     let create_index = true;
     if create_index {
         let row_id_col = Arc::new(UInt64Array::from(
             (0..TOTAL).map(|i| i as u64).collect_vec(),
         ));
-        let docs = (0..TOTAL)
-            .map(|_| {
-                let num_words = rand::random::<usize>() % 100 + 1;
-                let doc = (0..num_words)
-                    .map(|_| tokens[rand::random::<usize>() % tokens.len()])
-                    .collect::<Vec<_>>();
-                doc.join(" ")
-            })
-            .collect_vec();
-        let doc_col = Arc::new(LargeStringArray::from(docs));
+        
+        // Generate random words using lance-datagen
+        let mut words_gen = array::random_sentence(1, 100, true);
+        let doc_col = words_gen
+            .generate_default(RowCount::from(TOTAL as u64))
+            .unwrap();
         let batch = RecordBatch::try_new(
             Arc::new(Schema::new(vec![
                 Field::new("doc", DataType::LargeUtf8, false),
@@ -74,7 +69,22 @@ async fn main() {
     }
 
     let dataset = Dataset::open(dataset_dir.as_ref()).await.unwrap();
-    let query_string = tokens[0];
+    // Use a sample word for query - fetch first doc and pick a word from it
+    let sample_batch = dataset
+        .scan()
+        .project(&["doc"])
+        .unwrap()
+        .limit(Some(1), None)
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    let sample_doc = sample_batch["doc"]
+        .as_any()
+        .downcast_ref::<LargeStringArray>()
+        .unwrap()
+        .value(0);
+    let query_string = sample_doc.split_whitespace().next().unwrap();
     let query = FullTextSearchQuery::new(query_string.to_owned()).limit(Some(10));
     println!("query: {:?}", query);
     let batch = dataset

--- a/rust/examples/src/full_text_search.rs
+++ b/rust/examples/src/full_text_search.rs
@@ -28,13 +28,13 @@ async fn main() {
     const TOTAL: usize = 10_000_000;
     let tempdir = tempfile::tempdir().unwrap();
     let dataset_dir = Path::from_filesystem_path(tempdir.path()).unwrap();
-    
+
     let create_index = true;
     if create_index {
         let row_id_col = Arc::new(UInt64Array::from(
             (0..TOTAL).map(|i| i as u64).collect_vec(),
         ));
-        
+
         // Generate random words using lance-datagen
         let mut words_gen = array::random_sentence(1, 100, true);
         let doc_col = words_gen

--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -2292,7 +2292,11 @@ pub mod array {
     /// Create a generator of random sentences
     ///
     /// Generates strings containing between min_words and max_words random English words joined by spaces
-    pub fn random_sentence(min_words: usize, max_words: usize, is_large: bool) -> Box<dyn ArrayGenerator> {
+    pub fn random_sentence(
+        min_words: usize,
+        max_words: usize,
+        is_large: bool,
+    ) -> Box<dyn ArrayGenerator> {
         Box::new(RandomSentenceGenerator::new(min_words, max_words, is_large))
     }
 

--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -15,8 +15,8 @@ use arrow_array::{
     make_array,
     types::{ArrowDictionaryKeyType, BinaryType, ByteArrayType, Utf8Type},
     Array, BinaryArray, FixedSizeBinaryArray, FixedSizeListArray, Float32Array, LargeListArray,
-    ListArray, NullArray, PrimitiveArray, RecordBatch, RecordBatchOptions, RecordBatchReader,
-    StringArray, StructArray,
+    LargeStringArray, ListArray, NullArray, PrimitiveArray, RecordBatch, RecordBatchOptions,
+    RecordBatchReader, StringArray, StructArray,
 };
 use arrow_schema::{ArrowError, DataType, Field, Fields, IntervalUnit, Schema, SchemaRef};
 use futures::{stream::BoxStream, StreamExt};
@@ -894,24 +894,26 @@ impl ArrayGenerator for RandomBinaryGenerator {
 }
 
 #[derive(Debug)]
-struct RandomWordsGenerator {
+struct RandomSentenceGenerator {
     min_words: usize,
     max_words: usize,
     words: &'static [&'static str],
+    is_large: bool,
 }
 
-impl RandomWordsGenerator {
-    fn new(min_words: usize, max_words: usize) -> Self {
+impl RandomSentenceGenerator {
+    pub fn new(min_words: usize, max_words: usize, is_large: bool) -> Self {
         let words = random_word::all(random_word::Lang::En);
         Self {
             min_words,
             max_words,
             words,
+            is_large,
         }
     }
 }
 
-impl ArrayGenerator for RandomWordsGenerator {
+impl ArrayGenerator for RandomSentenceGenerator {
     fn generate(
         &mut self,
         length: RowCount,
@@ -928,11 +930,19 @@ impl ArrayGenerator for RandomWordsGenerator {
             values.push(sentence);
         }
 
-        Ok(Arc::new(StringArray::from(values)))
+        if self.is_large {
+            Ok(Arc::new(LargeStringArray::from(values)))
+        } else {
+            Ok(Arc::new(StringArray::from(values)))
+        }
     }
 
     fn data_type(&self) -> &DataType {
-        &DataType::Utf8
+        if self.is_large {
+            &DataType::LargeUtf8
+        } else {
+            &DataType::Utf8
+        }
     }
 
     fn element_size_bytes(&self) -> Option<ByteCount> {
@@ -941,6 +951,53 @@ impl ArrayGenerator for RandomWordsGenerator {
         let avg_word_length = 6;
         let avg_words = (self.min_words + self.max_words) / 2;
         Some(ByteCount::from((avg_word_length * avg_words) as u64))
+    }
+}
+
+#[derive(Debug)]
+struct RandomWordGenerator {
+    words: &'static [&'static str],
+    is_large: bool,
+}
+
+impl RandomWordGenerator {
+    pub fn new(is_large: bool) -> Self {
+        let words = random_word::all(random_word::Lang::En);
+        Self { words, is_large }
+    }
+}
+
+impl ArrayGenerator for RandomWordGenerator {
+    fn generate(
+        &mut self,
+        length: RowCount,
+        rng: &mut rand_xoshiro::Xoshiro256PlusPlus,
+    ) -> Result<Arc<dyn Array>, ArrowError> {
+        let mut values = Vec::with_capacity(length.0 as usize);
+
+        for _ in 0..length.0 {
+            let word = self.words[rng.gen_range(0..self.words.len())];
+            values.push(word.to_string());
+        }
+
+        if self.is_large {
+            Ok(Arc::new(LargeStringArray::from(values)))
+        } else {
+            Ok(Arc::new(StringArray::from(values)))
+        }
+    }
+
+    fn data_type(&self) -> &DataType {
+        if self.is_large {
+            &DataType::LargeUtf8
+        } else {
+            &DataType::Utf8
+        }
+    }
+
+    fn element_size_bytes(&self) -> Option<ByteCount> {
+        // Average English word length is ~5 characters
+        Some(ByteCount::from(5))
     }
 }
 
@@ -2232,11 +2289,18 @@ pub mod array {
         Box::<RandomBooleanGenerator>::default()
     }
 
-    /// Create a generator of random words
+    /// Create a generator of random sentences
     ///
-    /// Generates strings containing between min_words and max_words random English words
-    pub fn random_words(min_words: usize, max_words: usize) -> Box<dyn ArrayGenerator> {
-        Box::new(RandomWordsGenerator::new(min_words, max_words))
+    /// Generates strings containing between min_words and max_words random English words joined by spaces
+    pub fn random_sentence(min_words: usize, max_words: usize, is_large: bool) -> Box<dyn ArrayGenerator> {
+        Box::new(RandomSentenceGenerator::new(min_words, max_words, is_large))
+    }
+
+    /// Create a generator of random words (one word per row)
+    ///
+    /// Generates strings containing a single random English word per row
+    pub fn random_word(is_large: bool) -> Box<dyn ArrayGenerator> {
+        Box::new(RandomWordGenerator::new(is_large))
     }
 
     pub fn rand_list(item_type: &DataType, is_large: bool) -> Box<dyn ArrayGenerator> {
@@ -2483,7 +2547,7 @@ mod tests {
             arrow_array::StringArray::from_iter_values([">@p", "n `", "NWa"])
         );
 
-        let mut gen = array::random_words(1, 5);
+        let mut gen = array::random_sentence(1, 5, false);
         let words = gen.generate(RowCount::from(10), &mut rng).unwrap();
         assert_eq!(words.data_type(), &DataType::Utf8);
         let words_array = words.as_any().downcast_ref::<StringArray>().unwrap();

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -74,7 +74,6 @@ lance-testing.workspace = true
 tempfile.workspace = true
 test-log.workspace = true
 datafusion-sql.workspace = true
-random_word = { version = "0.4.3", features = ["en"] }
 rstest.workspace = true
 
 [features]

--- a/rust/lance-index/benches/inverted.rs
+++ b/rust/lance-index/benches/inverted.rs
@@ -47,7 +47,7 @@ fn bench_inverted(c: &mut Criterion) {
     let row_id_col = Arc::new(UInt64Array::from(
         (0..TOTAL).map(|i| i as u64).collect_vec(),
     ));
-    
+
     // Generate random words with 1-100 words per document
     let mut words_gen = array::random_sentence(1, 100, true);
     let doc_col = words_gen
@@ -82,12 +82,15 @@ fn bench_inverted(c: &mut Criterion) {
 
     let params = FtsSearchParams::new().with_limit(Some(10));
     let no_filter = Arc::new(NoFilter);
-    
+
     // Get some sample words from the generated documents for search
     let large_string_array = doc_col.as_any().downcast_ref::<LargeStringArray>().unwrap();
     let sample_doc = large_string_array.value(0);
-    let sample_words: Vec<String> = sample_doc.split_whitespace().map(|s| s.to_owned()).collect();
-    
+    let sample_words: Vec<String> = sample_doc
+        .split_whitespace()
+        .map(|s| s.to_owned())
+        .collect();
+
     c.bench_function(format!("invert_search({TOTAL})").as_str(), |b| {
         b.to_async(&rt).iter(|| async {
             // Pick a random word from our sample

--- a/rust/lance-index/benches/inverted.rs
+++ b/rust/lance-index/benches/inverted.rs
@@ -14,6 +14,7 @@ use futures::stream;
 use itertools::Itertools;
 use lance_core::cache::LanceCache;
 use lance_core::ROW_ID;
+use lance_datagen::{array, RowCount};
 use lance_index::prefilter::NoFilter;
 use lance_index::scalar::inverted::query::{FtsSearchParams, Operator};
 use lance_index::scalar::inverted::{InvertedIndex, InvertedIndexBuilder};
@@ -42,28 +43,23 @@ fn bench_inverted(c: &mut Criterion) {
         ))
     });
 
-    // generate 2000 different tokens
-    let tokens = random_word::all(random_word::Lang::En);
+    // generate random words using lance-datagen
     let row_id_col = Arc::new(UInt64Array::from(
         (0..TOTAL).map(|i| i as u64).collect_vec(),
     ));
-    let docs = (0..TOTAL)
-        .map(|_| {
-            let num_words = rand::random::<usize>() % 100 + 1;
-            let doc = (0..num_words)
-                .map(|_| tokens[rand::random::<usize>() % tokens.len()])
-                .collect::<Vec<_>>();
-            doc.join(" ")
-        })
-        .collect_vec();
-    let doc_col = Arc::new(LargeStringArray::from(docs));
+    
+    // Generate random words with 1-100 words per document
+    let mut words_gen = array::random_sentence(1, 100, true);
+    let doc_col = words_gen
+        .generate_default(RowCount::from(TOTAL as u64))
+        .unwrap();
     let batch = RecordBatch::try_new(
         arrow_schema::Schema::new(vec![
             arrow_schema::Field::new("doc", arrow_schema::DataType::LargeUtf8, false),
             arrow_schema::Field::new(ROW_ID, arrow_schema::DataType::UInt64, false),
         ])
         .into(),
-        vec![doc_col, row_id_col],
+        vec![doc_col.clone(), row_id_col],
     )
     .unwrap();
 
@@ -86,14 +82,20 @@ fn bench_inverted(c: &mut Criterion) {
 
     let params = FtsSearchParams::new().with_limit(Some(10));
     let no_filter = Arc::new(NoFilter);
+    
+    // Get some sample words from the generated documents for search
+    let large_string_array = doc_col.as_any().downcast_ref::<LargeStringArray>().unwrap();
+    let sample_doc = large_string_array.value(0);
+    let sample_words: Vec<String> = sample_doc.split_whitespace().map(|s| s.to_owned()).collect();
+    
     c.bench_function(format!("invert_search({TOTAL})").as_str(), |b| {
         b.to_async(&rt).iter(|| async {
+            // Pick a random word from our sample
+            let word_idx = rand::random::<usize>() % sample_words.len();
             black_box(
                 invert_index
                     .bm25_search(
-                        [tokens[rand::random::<usize>() % tokens.len()].to_owned()]
-                            .to_vec()
-                            .into(),
+                        vec![sample_words[word_idx].clone()].into(),
                         params.clone().into(),
                         Operator::Or,
                         no_filter.clone(),

--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -42,7 +42,7 @@ fn bench_ngram(c: &mut Criterion) {
     let row_id_col = Arc::new(UInt64Array::from(
         (0..TOTAL).map(|i| i as u64).collect_vec(),
     ));
-    
+
     // Generate random words with 1-30 words per document
     let mut words_gen = array::random_sentence(1, 30, false);
     let doc_col = words_gen

--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -4,13 +4,14 @@
 use std::{sync::Arc, time::Duration};
 
 use arrow::array::AsArray;
-use arrow_array::{RecordBatch, StringArray, UInt64Array};
+use arrow_array::{RecordBatch, UInt64Array};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::stream;
 use itertools::Itertools;
 use lance_core::cache::LanceCache;
 use lance_core::ROW_ID;
+use lance_datagen::{array, RowCount};
 use lance_index::metrics::NoOpMetricsCollector;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::ngram::{NGramIndex, NGramIndexBuilder, NGramIndexBuilderOptions};
@@ -37,21 +38,16 @@ fn bench_ngram(c: &mut Criterion) {
         ))
     });
 
-    // generate 2000 different tokens
-    let tokens = random_word::all(random_word::Lang::En);
+    // generate random words using lance-datagen
     let row_id_col = Arc::new(UInt64Array::from(
         (0..TOTAL).map(|i| i as u64).collect_vec(),
     ));
-    let docs = (0..TOTAL)
-        .map(|_| {
-            let num_words = rand::random::<usize>() % 30 + 1;
-            let doc = (0..num_words)
-                .map(|_| tokens[rand::random::<usize>() % tokens.len()])
-                .collect::<Vec<_>>();
-            doc.join(" ")
-        })
-        .collect_vec();
-    let doc_col = Arc::new(StringArray::from(docs));
+    
+    // Generate random words with 1-30 words per document
+    let mut words_gen = array::random_sentence(1, 30, false);
+    let doc_col = words_gen
+        .generate_default(RowCount::from(TOTAL as u64))
+        .unwrap();
     let batch = RecordBatch::try_new(
         arrow_schema::Schema::new(vec![
             arrow_schema::Field::new("doc", arrow_schema::DataType::Utf8, false),

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -102,7 +102,6 @@ env_logger = "0.11.7"
 test-log.workspace = true
 tracing-chrome = "0.7.1"
 rstest = { workspace = true }
-random_word = { version = "0.4.3", features = ["en"] }
 # For S3 / DynamoDB tests
 aws-config = { workspace = true }
 aws-sdk-s3 = { workspace = true }

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -2922,7 +2922,8 @@ mod tests {
         // Get initial counts for some word searches
         // Extract some test words from the generated documents
         let large_string_array = doc_col.as_any().downcast_ref::<LargeStringArray>().unwrap();
-        let sample_words: Vec<String> = large_string_array.value(0)
+        let sample_words: Vec<String> = large_string_array
+            .value(0)
             .split_whitespace()
             .take(10)
             .map(|s| s.to_string())
@@ -3063,7 +3064,8 @@ mod tests {
         // Get initial counts for some word searches
         // Extract some test words from the generated documents
         let large_string_array = doc_col.as_any().downcast_ref::<LargeStringArray>().unwrap();
-        let sample_words: Vec<String> = large_string_array.value(0)
+        let sample_words: Vec<String> = large_string_array
+            .value(0)
             .split_whitespace()
             .take(10)
             .map(|s| s.to_string())

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -2895,21 +2895,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_inverted_index_with_defer_index_remap() {
-        // Generate random words for documents
-        let tokens = random_word::all(random_word::Lang::En);
-        let docs: Vec<String> = (0..6000)
-            .map(|_| {
-                let num_words = rand::random::<usize>() % 100 + 1;
-                let doc = (0..num_words)
-                    .map(|_| tokens[rand::random::<usize>() % tokens.len()])
-                    .collect::<Vec<_>>();
-                doc.join(" ")
-            })
-            .collect();
+        // Generate random words using lance-datagen
+        let mut words_gen = lance_datagen::array::random_sentence(1, 100, true);
+        let doc_col = words_gen
+            .generate_default(lance_datagen::RowCount::from(6000))
+            .unwrap();
 
         let batch = RecordBatch::try_new(
             Schema::new(vec![Field::new("doc", DataType::LargeUtf8, false)]).into(),
-            vec![Arc::new(LargeStringArray::from(docs))],
+            vec![doc_col.clone()],
         )
         .unwrap();
         let schema_ref = batch.schema();
@@ -2926,9 +2920,16 @@ mod tests {
         .unwrap();
 
         // Get initial counts for some word searches
-        let test_word1 = tokens[100];
-        let test_word2 = tokens[200];
-        let test_word3 = tokens[300];
+        // Extract some test words from the generated documents
+        let large_string_array = doc_col.as_any().downcast_ref::<LargeStringArray>().unwrap();
+        let sample_words: Vec<String> = large_string_array.value(0)
+            .split_whitespace()
+            .take(10)
+            .map(|s| s.to_string())
+            .collect();
+        let test_word1 = &sample_words[0];
+        let test_word2 = &sample_words[1];
+        let test_word3 = &sample_words[2];
 
         // Create an inverted index on the doc column
         let index_name = Some("doc_idx".into());
@@ -3035,21 +3036,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_read_ngram_index_with_defer_index_remap() {
-        // Generate random words for documents
-        let tokens = random_word::all(random_word::Lang::En);
-        let docs: Vec<String> = (0..6000)
-            .map(|_| {
-                let num_words = rand::random::<usize>() % 100 + 1;
-                let doc = (0..num_words)
-                    .map(|_| tokens[rand::random::<usize>() % tokens.len()])
-                    .collect::<Vec<_>>();
-                doc.join(" ")
-            })
-            .collect();
+        // Generate random words using lance-datagen
+        let mut words_gen = lance_datagen::array::random_sentence(1, 100, true);
+        let doc_col = words_gen
+            .generate_default(lance_datagen::RowCount::from(6000))
+            .unwrap();
 
         let batch = RecordBatch::try_new(
             Schema::new(vec![Field::new("doc", DataType::LargeUtf8, false)]).into(),
-            vec![Arc::new(LargeStringArray::from(docs))],
+            vec![doc_col.clone()],
         )
         .unwrap();
         let schema_ref = batch.schema();
@@ -3066,9 +3061,16 @@ mod tests {
         .unwrap();
 
         // Get initial counts for some word searches
-        let test_word1 = tokens[100];
-        let test_word2 = tokens[200];
-        let test_word3 = tokens[300];
+        // Extract some test words from the generated documents
+        let large_string_array = doc_col.as_any().downcast_ref::<LargeStringArray>().unwrap();
+        let sample_words: Vec<String> = large_string_array.value(0)
+            .split_whitespace()
+            .take(10)
+            .map(|s| s.to_string())
+            .collect();
+        let test_word1 = &sample_words[0];
+        let test_word2 = &sample_words[1];
+        let test_word3 = &sample_words[2];
 
         // Create an inverted index on the doc column
         let index_name = Some("doc_idx".into());


### PR DESCRIPTION
While working with `RandomWords` in actual code, I realized that our previous API design wasn't ideal, so I proposed a new design that supports larger strings for easier use.

close https://github.com/lancedb/lance/issues/4013