### PR TITLE
chore: fully remove lance-encoding-datafusion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ lance-core = { version = "=0.31.1", path = "./rust/lance-core" }
 lance-datafusion = { version = "=0.31.1", path = "./rust/lance-datafusion" }
 lance-datagen = { version = "=0.31.1", path = "./rust/lance-datagen" }
 lance-encoding = { version = "=0.31.1", path = "./rust/lance-encoding" }
-lance-encoding-datafusion = { version = "=0.31.0", path = "./rust/lance-encoding-datafusion" }
 lance-file = { version = "=0.31.1", path = "./rust/lance-file" }
 lance-index = { version = "=0.31.1", path = "./rust/lance-index" }
 lance-io = { version = "=0.31.1", path = "./rust/lance-io" }


### PR DESCRIPTION
#4046 removed lance-encoding-datafusion but did not fully remove its reference, causing version bump to miss it.