### PR TITLE
ci: huggingface dataset scripts are no longer supported

### DIFF
--- a/python/python/tests/test_huggingface.py
+++ b/python/python/tests/test_huggingface.py
@@ -13,10 +13,8 @@ pil = pytest.importorskip("PIL")
 
 def test_write_hf_dataset(tmp_path: Path):
     hf_ds = datasets.load_dataset(
-        "poloclub/diffusiondb",
-        name="2m_first_1k",
+        "rotten_tomatoes",
         split="train[:50]",
-        trust_remote_code=True,
     )
 
     ds = lance.write_dataset(hf_ds, tmp_path)


### PR DESCRIPTION
Fixes breaking CI like https://github.com/lancedb/lance/actions/runs/16180444945/job/45675632080 by using a different HF dataset that do not use its own script.