### PR TITLE
fix: move BYTES_READ_COUNTER update after await to ensure accuracy

### DIFF
--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -479,7 +479,6 @@ impl IoTask {
                 .reader
                 .get_range(self.to_read.start as usize..self.to_read.end as usize);
             IOPS_COUNTER.fetch_add(1, Ordering::Release);
-            // Read and add bytes read counter if success
             let num_bytes = self.num_bytes();
             bytes_fut
                 .inspect(move |_| {

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -479,8 +479,11 @@ impl IoTask {
                 .reader
                 .get_range(self.to_read.start as usize..self.to_read.end as usize);
             IOPS_COUNTER.fetch_add(1, Ordering::Release);
-            BYTES_READ_COUNTER.fetch_add(self.num_bytes(), Ordering::Release);
-            bytes_fut.await.map_err(Error::from)
+            let result = bytes_fut.await.map_err(Error::from);
+            if result.is_ok() {
+                BYTES_READ_COUNTER.fetch_add(self.num_bytes(), Ordering::Release);
+            }
+            result
         };
         IOPS_QUOTA.release();
         (self.when_done)(bytes);

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -478,7 +478,6 @@ impl IoTask {
             let bytes_fut = self
                 .reader
                 .get_range(self.to_read.start as usize..self.to_read.end as usize);
-            // Add global IOPS counter
             IOPS_COUNTER.fetch_add(1, Ordering::Release);
             // Read and add bytes read counter if success
             let num_bytes = self.num_bytes();


### PR DESCRIPTION
Previously, BYTES_READ_COUNTER was incremented before awaiting the result of the async read operation. This could lead to incorrect metrics in case of I/O errors or failed reads.