### PR TITLE
feat: support inferring system index type

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -58,7 +58,9 @@ use lance_arrow::as_fixed_size_list_array;
 use lance_index::scalar::inverted::query::{
     BooleanQuery, BoostQuery, FtsQuery, MatchQuery, MultiMatchQuery, Operator, PhraseQuery,
 };
-use lance_index::{infer_system_index_type, metrics::NoOpMetricsCollector, scalar::inverted::query::Occur};
+use lance_index::{
+    infer_system_index_type, metrics::NoOpMetricsCollector, scalar::inverted::query::Occur,
+};
 use lance_index::{
     optimize::OptimizeOptions,
     scalar::{FullTextSearchQuery, InvertedIndexParams, ScalarIndexParams, ScalarIndexType},

--- a/rust/lance-index/src/lib.rs
+++ b/rust/lance-index/src/lib.rs
@@ -232,3 +232,13 @@ pub struct IndexMetadata {
 pub fn is_system_index(index_meta: &lance_table::format::Index) -> bool {
     index_meta.name == FRAG_REUSE_INDEX_NAME || index_meta.name == MEM_WAL_INDEX_NAME
 }
+
+pub fn infer_system_index_type(index_meta: &lance_table::format::Index) -> Option<IndexType> {
+    if index_meta.name == FRAG_REUSE_INDEX_NAME {
+        Some(IndexType::FragmentReuse)
+    } else if index_meta.name == MEM_WAL_INDEX_NAME {
+        Some(IndexType::MemWal)
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
This feature allows pylance to show the system index instead of ignoring them so they can be used by callers if necessary.