### PR TITLE
fix: contributing link fixed on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The key features of Lance include:
 * **Ecosystem integrations:** Apache Arrow, Pandas, Polars, DuckDB, Ray, Spark and more on the way.
 
 > [!TIP]
-> Lance is in active development and we welcome contributions. Please see our [contributing guide](docs/contributing.rst) for more information.
+> Lance is in active development and we welcome contributions. Please see our [contributing guide](https://lancedb.github.io/lance/community/contributing/) for more information.
 
 ## Quick Start
 


### PR DESCRIPTION
The contributing link on the README.md page was broken, addressed by the issue #4183. This PR fixes the simple issue.