### PR TITLE
Fix: Handle case-insensitive 'is not null' filter for column[0]

### DIFF
--- a/python/python/lance/sampler.py
+++ b/python/python/lance/sampler.py
@@ -143,7 +143,7 @@ def _filtered_efficient_sample(
             limit=(end - start),
             batch_size=shard_size,
         )
-        if len(columns) == 1 and filter.lower() == f"{columns[0]} is not null":
+        if len(columns) == 1 and filter.lower() == f"{columns[0]}.lower() is not null":
             table = pc.drop_null(table)
         elif filter is not None:
             raise NotImplementedError(f"Can't yet run filter <{filter}> in-memory")


### PR DESCRIPTION
When I was creating index with accelerator, I was getting raise NotImplementedError(f"Can't yet run filter <{filter}> in-memory") error. But apparently it's because my column name has capital characters.