### PR TITLE
feat: add claude md for future agentic work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Project Overview
 
 Lance is a modern columnar data format optimized for ML workflows and datasets. It provides:
-- 100x faster random access than Parquet
-- Native vector search capabilities (IVF, HNSW, PQ)
-- Zero-copy automatic versioning
-- Deep integration with Apache Arrow, Pandas, Polars, DuckDB, Ray
-- Cloud-native with S3, Azure, GCS support
+
+- High-performance random access
+- Vector search
+- Zero-copy, automatic versioning
+- Ecosystem integrations
 
 ## Project Vision
 


### PR DESCRIPTION
This PR aims to add `CLAUDE.md` to help the code agent collaborate more effectively with humans.

Most of the content was generated by Claude itself; my own contributions are in the `Project Vision` and `Project Requirements` sections.