### PR TITLE
ci: do nightly runs only on the main repository

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   run:
     runs-on: ubuntu-24.04
+    if: github.repository == 'lancedb/lance'
     steps:
       - name: Nightly Run File Verification Workflow
         uses: benc-uk/workflow-dispatch@v1


### PR DESCRIPTION
Prevent forked repositories to keep running nightly jobs and fail. Example: https://github.com/jackye1995/lance/actions/runs/16394030190/job/46323723362