### PR TITLE
fix: escape `type` keyword in `tracing::info!` macros

### DIFF
--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -431,7 +431,7 @@ fn report_plan_summary_metrics(plan: &dyn ExecutionPlan, options: &LanceExecutio
     visit_node(plan, &mut counts);
     tracing::info!(
         target: TRACE_EXECUTION,
-        type = EXECUTION_PLAN_RUN,
+        r#type = EXECUTION_PLAN_RUN,
         output_rows,
         iops = counts.iops,
         requests = counts.requests,


### PR DESCRIPTION
Similar to https://github.com/lancedb/lance/pull/4068

Fixes
```
error: no rules expected keyword `type`
    --> /Users/.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lance-datafusion-0.31.1/src/exec.rs:350:5
     |
350  | /     tracing::info!(
351  | |         target: TRACE_EXECUTION,
352  | |         type = EXECUTION_PLAN_RUN,
353  | |         output_rows,
...    |
359  | |         index_comparisons = counts.index_comparisons,
360  | |     );
     | |_____^ no rules expected this token in macro call
```