### PR TITLE
ci: enable crates.io trust publishing

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -23,6 +23,8 @@ jobs:
   build:
     # Needs additional disk space for the full build.
     runs-on: ubuntu-2404-8x-x64
+    permissions:
+      id-token: write
     timeout-minutes: 60
     env:
       # Need up-to-date compilers for kernels
@@ -53,8 +55,10 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y protobuf-compiler libssl-dev
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - uses: albertlockett/publish-crates@v2.2
         with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          registry-token: ${{ steps.auth.outputs.token }}
           args: "--all-features"
           path: .


### PR DESCRIPTION
This PR will enable trust publishing for all our rust crates. After this change, we don't need to have static key from crates.io anymore.