### PR TITLE
perf: improve L2 distance perf

### DIFF
--- a/rust/lance-linalg/benches/l2.rs
+++ b/rust/lance-linalg/benches/l2.rs
@@ -45,24 +45,26 @@ where
 
     c.bench_function(format!("L2({type_name}, scalar)").as_str(), |b| {
         b.iter(|| {
-            Float32Array::from_iter_values(
+            black_box(
                 target
                     .as_slice()
                     .chunks(DIMENSION)
-                    .map(|arr| l2_scalar(key.as_slice(), arr).as_()),
-            );
+                    .map(|arr| l2_scalar(key.as_slice(), arr).as_())
+                    .fold(0.0, |acc: f32, v: f32| acc + v),
+            )
         });
     });
 
     c.bench_function(
         format!("L2({type_name}, auto-vectorization)").as_str(),
         |b| {
-            b.iter(|| unsafe {
-                Float32Array::from_trusted_len_iter(
+            b.iter(|| {
+                black_box(
                     target
                         .as_slice()
                         .chunks(DIMENSION)
-                        .map(|y| Some(black_box(l2(key.as_slice(), y)))),
+                        .map(|y| black_box(l2(key.as_slice(), y)))
+                        .fold(0.0, |acc: f32, v: f32| acc + v),
                 );
             });
         },
@@ -77,7 +79,10 @@ fn bench_distance(c: &mut Criterion) {
         generate_random_array_with_seed::<Float32Type>(TOTAL * DIMENSION, [42; 32]);
     c.bench_function("L2(f32, simd)", |b| {
         b.iter(|| {
-            black_box(l2_distance_batch(key.values(), target.values(), DIMENSION).count());
+            black_box(
+                l2_distance_batch(key.values(), target.values(), DIMENSION)
+                    .fold(0.0, |acc: f32, v: f32| acc + v),
+            );
         })
     });
 
@@ -90,7 +95,10 @@ fn bench_small_distance(c: &mut Criterion) {
     let target = generate_random_array_with_seed::<Float32Type>(TOTAL * 8, [7; 32]);
     c.bench_function("L2(simd,f32x8)", |b| {
         b.iter(|| {
-            black_box(l2_distance_batch(key.values(), target.values(), 8).count());
+            black_box(
+                l2_distance_batch(key.values(), target.values(), 8)
+                    .fold(0.0, |acc: f32, v: f32| acc + v),
+            );
         })
     });
 }
@@ -134,7 +142,7 @@ fn bench_uint_distance(c: &mut Criterion) {
                 target
                     .chunks_exact(DIMENSION)
                     .map(|tgt| l2_distance_uint_scalar(&key, tgt))
-                    .collect::<Vec<_>>(),
+                    .fold(0.0, |acc, v| acc + v),
             );
         });
     });
@@ -145,7 +153,7 @@ fn bench_uint_distance(c: &mut Criterion) {
                 target
                     .chunks_exact(DIMENSION)
                     .map(|tgt| l2_distance_uint_scalar_auto_vectorized(&key, tgt))
-                    .collect::<Vec<_>>(),
+                    .fold(0.0, |acc, v| acc + v),
             );
         });
     });

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -8,6 +8,7 @@ use std::iter::Sum;
 use std::ops::AddAssign;
 use std::sync::Arc;
 
+use crate::{Error, Result};
 use arrow_array::{
     cast::AsArray,
     types::{Float16Type, Float32Type, Float64Type, Int8Type},
@@ -21,24 +22,14 @@ use lance_core::utils::cpu::SimdSupport;
 use lance_core::utils::cpu::FP16_SIMD_SUPPORT;
 use num_traits::{AsPrimitive, Num};
 
-use crate::simd::{
-    f32::{f32x16, f32x8},
-    SIMD,
-};
-use crate::{Error, Result};
-
 /// Calculate the L2 distance between two vectors.
 ///
 pub trait L2: Num {
     /// Calculate the L2 distance between two vectors.
     fn l2(x: &[Self], y: &[Self]) -> f32;
 
-    fn l2_batch<'a>(
-        x: &'a [Self],
-        y: &'a [Self],
-        dimension: usize,
-    ) -> Box<dyn Iterator<Item = f32> + 'a> {
-        Box::new(y.chunks_exact(dimension).map(|v| Self::l2(x, v)))
+    fn l2_batch(x: &[Self], y: &[Self], dimension: usize) -> impl Iterator<Item = f32> {
+        y.chunks_exact(dimension).map(|v| Self::l2(x, v))
     }
 }
 
@@ -173,26 +164,6 @@ impl L2 for f32 {
         // See https://github.com/lancedb/lance/pull/2450.
         l2_scalar::<Self, Self, 16>(x, y)
     }
-
-    fn l2_batch<'a>(
-        x: &'a [Self],
-        y: &'a [Self],
-        dimension: usize,
-    ) -> Box<dyn Iterator<Item = f32> + 'a> {
-        use self::f32::l2_once;
-        // Dispatch based on the dimension.
-        match dimension {
-            8 => Box::new(
-                y.chunks_exact(dimension)
-                    .map(move |v| l2_once::<f32x8, 8>(x, v)),
-            ),
-            16 => Box::new(
-                y.chunks_exact(dimension)
-                    .map(move |v| l2_once::<f32x16, 16>(x, v)),
-            ),
-            _ => Box::new(y.chunks_exact(dimension).map(|v| Self::l2(x, v))),
-        }
-    }
 }
 
 impl L2 for f64 {
@@ -209,19 +180,19 @@ pub fn l2_distance(from: &[f32], to: &[f32]) -> f32 {
 }
 
 // f32 kernels for L2
-mod f32 {
-    use super::*;
+// mod f32 {
+//     use super::*;
 
-    #[inline]
-    pub fn l2_once<S: SIMD<f32, N>, const N: usize>(x: &[f32], y: &[f32]) -> f32 {
-        debug_assert_eq!(x.len(), N);
-        debug_assert_eq!(y.len(), N);
-        let x = unsafe { S::load_unaligned(x.as_ptr()) };
-        let y = unsafe { S::load_unaligned(y.as_ptr()) };
-        let s = x - y;
-        (s * s).reduce_sum()
-    }
-}
+//     #[inline]
+//     pub fn l2_once<S: SIMD<f32, N>, const N: usize>(x: &[f32], y: &[f32]) -> f32 {
+//         debug_assert_eq!(x.len(), N);
+//         debug_assert_eq!(y.len(), N);
+//         let x = unsafe { S::load_unaligned(x.as_ptr()) };
+//         let y = unsafe { S::load_unaligned(y.as_ptr()) };
+//         let s = x - y;
+//         (s * s).reduce_sum()
+//     }
+// }
 
 /// Compute L2 distance between a vector and a batch of vectors.
 ///
@@ -238,7 +209,7 @@ pub fn l2_distance_batch<'a, T: L2>(
     from: &'a [T],
     to: &'a [T],
     dimension: usize,
-) -> Box<dyn Iterator<Item = f32> + 'a> {
+) -> impl Iterator<Item = f32> + 'a {
     debug_assert_eq!(from.len(), dimension);
     debug_assert_eq!(to.len() % dimension, 0);
 


### PR DESCRIPTION
this improves the L2 performance by 10%+ but slows the L2 performance with small dimensions 5% (8, 16).
8, 16 dimensions are so rare in vector search so it's worth.

this also avoids dynamic dispatching and any heap allocations when calculating batch L2 distances

this also fix some incorrect benchmark:
- `iter::count()` may be optimized if the length is already known, so replace it with `iter::fold`
- `collect()` may impact the benchmark result significantly, so also replace it with `iter::fold`

