### PR TITLE
fix: update broken README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The key features of Lance include:
 * **Ecosystem integrations:** Apache Arrow, Pandas, Polars, DuckDB, Ray, Spark and more on the way.
 
 > [!TIP]
-> Lance is in active development and we welcome contributions. Please see our [contributing guide](https://lancedb.github.io/lance/community/contributing/) for more information.
+> Lance is in active development and we welcome contributions. Please see our [contributing guide](https://lancedb.github.io/lance/community) for more information.
 
 ## Quick Start
 
@@ -173,7 +173,7 @@ rs = [dataset.to_table(nearest={"column": "vector", "k": 10, "q": q})
 
 ## What makes Lance different
 
-Here we will highlight a few aspects of Lance’s design. For more details, see the full [Lance design document](https://lancedb.github.io/lance/format.html).
+Here we will highlight a few aspects of Lance’s design. For more details, see the full [Lance design document](https://lancedb.github.io/lance/format).
 
 **Vector index**: Vector index for similarity search over embedding space.
 Support both CPUs (``x86_64`` and ``arm``) and GPU (``Nvidia (cuda)`` and ``Apple Silicon (mps)``).


### PR DESCRIPTION
### Description
Closes #4183 

- The “Contributing” link now points to the correct page: https://lancedb.github.io/lance/community
- The “Lance design document” link now points to the correct page: https://lancedb.github.io/lance/format


Reviewer: @jackye1995 
Lmk if there are any other changes that needs to be done!