### PR TITLE
feat: allow empty projection

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -2737,9 +2737,11 @@ def test_scan_no_columns(tmp_path: Path):
     for batch in batches:
         assert batch.schema == expected_schema
 
-    # if with_row_id is not True then columns=[] is an error
-    with pytest.raises(ValueError, match="no columns were selected"):
-        dataset.scanner(columns=[]).to_table()
+    # Can specify nothing at all to get empty batches (with correct counts)
+    batches = list(dataset.scanner(columns=[], batch_size=10).to_batches())
+    assert len(batches) == 10
+    for batch in batches:
+        assert batch.num_rows == 10
 
     # also test with deleted data to make sure deleted ids not included
     dataset.delete("a = 5")

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -2741,6 +2741,7 @@ def test_scan_no_columns(tmp_path: Path):
     batches = list(dataset.scanner(columns=[], batch_size=10).to_batches())
     assert len(batches) == 10
     for batch in batches:
+        assert batch.schema.names == []
         assert batch.num_rows == 10
 
     # also test with deleted data to make sure deleted ids not included

--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -1150,6 +1150,11 @@ impl Projection {
         self.field_ids.is_empty() && (self.with_row_addr || self.with_row_id)
     }
 
+    /// True if the projection has at least one non-metadata column
+    pub fn has_non_meta_cols(&self) -> bool {
+        !self.field_ids.is_empty()
+    }
+
     /// Convert the projection to a schema that does not include metadata columns
     pub fn to_bare_schema(&self) -> Schema {
         self.base.schema().apply_projection(self)

--- a/rust/lance/src/datafusion/dataframe.rs
+++ b/rust/lance/src/datafusion/dataframe.rs
@@ -124,7 +124,7 @@ impl TableProvider for LanceTableProvider {
         scan.limit(limit.map(|l| l as i64), None)?;
         scan.scan_in_order(self.ordered);
 
-        dbg!(scan.create_plan().await).map_err(DataFusionError::from)
+        scan.create_plan().await.map_err(DataFusionError::from)
     }
 
     // Since we are using datafusion itself to apply the filters it should

--- a/rust/lance/src/datafusion/dataframe.rs
+++ b/rust/lance/src/datafusion/dataframe.rs
@@ -124,7 +124,7 @@ impl TableProvider for LanceTableProvider {
         scan.limit(limit.map(|l| l as i64), None)?;
         scan.scan_in_order(self.ordered);
 
-        scan.create_plan().await.map_err(DataFusionError::from)
+        dbg!(scan.create_plan().await).map_err(DataFusionError::from)
     }
 
     // Since we are using datafusion itself to apply the filters it should

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -95,16 +95,6 @@ impl SqlQuery {
     pub async fn into_batch_records(self) -> lance_core::Result<Vec<RecordBatch>> {
         use futures::TryStreamExt;
 
-        let plan = self.dataframe.clone().into_optimized_plan().unwrap();
-        println!("{:#?}", plan);
-
-        let plan = self.dataframe.clone().create_physical_plan().await.unwrap();
-        println!(
-            "{}",
-            datafusion_physical_plan::display::DisplayableExecutionPlan::new(plan.as_ref())
-                .indent(true)
-        );
-
         Ok(self
             .dataframe
             .execute_stream()

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -94,6 +94,17 @@ impl SqlQuery {
 
     pub async fn into_batch_records(self) -> lance_core::Result<Vec<RecordBatch>> {
         use futures::TryStreamExt;
+
+        let plan = self.dataframe.clone().into_optimized_plan().unwrap();
+        println!("{:#?}", plan);
+
+        let plan = self.dataframe.clone().create_physical_plan().await.unwrap();
+        println!(
+            "{}",
+            datafusion_physical_plan::display::DisplayableExecutionPlan::new(plan.as_ref())
+                .indent(true)
+        );
+
         Ok(self
             .dataframe
             .execute_stream()


### PR DESCRIPTION
Recent changes made it so we didn't report an error in `project` if a column did not exist.  This made it possible to get an error "no columns selected" when all columns asked for did not exist.  This was quite confusing.

This PR cleans up that behavior by reworking the projection slightly.

Previously, if a user requested zero columns, then they would receive an error "no columns selected and with_row_id is False, there is nothing to scan".  With this PR we now return empty record batches (with the correct number of rows).