### PR TITLE
fix: remove the broken large binary test with dictionary encoding && fsst compression

### DIFF
--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -553,25 +553,6 @@ pub mod tests {
 
     #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_large_binary_fsst_with_dict(
-        #[values(DataType::LargeBinary, DataType::LargeUtf8)] data_type: DataType,
-    ) {
-        use lance_core::datatypes::DICT_DIVISOR_META_KEY;
-
-        let mut field_metadata = HashMap::new();
-        field_metadata.insert(
-            STRUCTURAL_ENCODING_META_KEY.to_string(),
-            STRUCTURAL_ENCODING_MINIBLOCK.to_string(),
-        );
-        // Force it to use dictionary encoding
-        field_metadata.insert(DICT_DIVISOR_META_KEY.to_string(), "1".into());
-        field_metadata.insert(COMPRESSION_META_KEY.to_string(), "fsst".into());
-        let field = Field::new("", data_type, true).with_metadata(field_metadata);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_1).await;
-    }
-
-    #[rstest]
-    #[test_log::test(tokio::test)]
     async fn test_large_binary(
         #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
     ) {


### PR DESCRIPTION
Remove a test that never triggers dict encoding and FSST at the same time.

The `check_round_trip_encoding_random(...)` will create data with high cardinality which will always be larger than the thread. The metadata DICT_DIVISOR_META_KEY is not good enough to trigger both FSST and dict.