### PR TITLE
fix: fix bug in trim_ranges which could cause filtered read to miss rows

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -678,7 +678,6 @@ def test_limit_offset(tmp_path: Path, data_storage_version: str):
     dataset = dataset.checkout_version(full_ds_version)
     dataset.restore()
     dataset.delete("a > 2 AND a < 7")
-    print(dataset.to_table(offset=3, limit=1))
     filt_table = table.slice(7, 1)
 
     assert dataset.to_table(offset=3, limit=1) == filt_table


### PR DESCRIPTION
Minor logic bug in `trim_ranges` which is what applies the user's desired range (limit/offset) to the available (not deleted) rows in a fragment.  Without this fix the method would include some deleted rows in the output which would then get removed.  The end result was that a user would ask for something like `offset=20, limit=10` and get back less than 10 rows (even though 10 were available)