### PR TITLE
docs: clean up table.proto

### DIFF
--- a/protos/file.proto
+++ b/protos/file.proto
@@ -4,7 +4,7 @@
 syntax = "proto3";
 
 package lance.file;
-  
+
 // A file descriptor that describes the contents of a Lance file
 message FileDescriptor {
   // The schema of the file

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -27,7 +27,7 @@ Format:
 +----------------------------------------+
  */
 
-/// UUID type. encoded as 16 bytes.
+// UUID type. encoded as 16 bytes.
 message UUID {
   bytes uuid = 1;
 }
@@ -92,32 +92,31 @@ message Manifest {
 
   // Feature flags for writers.
   //
-  // A bitmap of flags that indicate which features are required to be able to
-  // write to the dataset. if a writer does not recognize a flag that is set, it
-  // should not attempt to write to the dataset.
+  // A bitmap of flags that indicate which features must be used when writing to the
+  // dataset. If a writer does not recognize a flag that is set, it should not attempt to
+  // write to the dataset.
   //
-  // The flags are the same as for reader_feature_flags, although they will not
-  // always apply to both.
+  // The flag identities are the same as for reader_feature_flags, but the values of
+  // reader_feature_flags and writer_feature_flags are not required to be identical.
   uint64 writer_feature_flags = 10;
 
   // The highest fragment ID that has been used so far.
   //
   // This ID is not guaranteed to be present in the current version, but it may
   // have been used in previous versions.
-  // 
-  // For a single file, will be zero.
+  //
+  // For a single fragment, will be zero. For no fragments, will be absent.
   optional uint32 max_fragment_id = 11;
 
-  // Path to the transaction file, relative to `{root}/_transactions`
+  // Path to the transaction file, relative to `{root}/_transactions`. The file at that
+  // location contains a wire-format serialized Transaction message representing the
+  // transaction that created this version.
   //
-  // This contains a serialized Transaction message representing the transaction
-  // that created this version.
+  // This string field "transaction_file" may be empty if no transaction file was written.
   //
-  // May be empty if no transaction file was written.
-  //
-  // The path format is "{read_version}-{uuid}.txn" where {read_version} is the
-  // version of the table the transaction read from, and {uuid} is a 
-  // hyphen-separated UUID.
+  // The path format is "{read_version}-{uuid}.txn" where {read_version} is the version of
+  // the table the transaction read from (serialized to decimal with no padding digits),
+  // and {uuid} is a hyphen-separated UUID.
   string transaction_file = 12;
 
   // The next unused row id. If zero, then the table does not have any rows.
@@ -128,11 +127,10 @@ message Manifest {
   message DataStorageFormat {
     // The format of the data files (e.g. "lance")
     string file_format = 1;
-    // The max format version of the data files.
+    // The max format version of the data files. The format of the version can vary by
+    // file_format and is not required to follow semver.
     //
-    // This is the maximum version of the file format that the dataset will create.
-    // This may be lower than the maximum version that can be written in order to allow
-    // older readers to read the dataset.
+    // Every file in this version of the dataset has the same file_format version.
     string version = 2;
   }
 
@@ -140,7 +138,7 @@ message Manifest {
   //
   // This specifies what format is used to store the data files.
   DataStorageFormat data_format = 15;
-  
+
   // Table config.
   //
   // Keys with the prefix "lance." are reserved for the Lance library. Other
@@ -164,12 +162,12 @@ message VersionAuxData {
   map<string, bytes> metadata = 3;
 }
 
-// Metadata describing the index.
+// Metadata describing an index.
 message IndexMetadata {
   // Unique ID of an index. It is unique across all the dataset versions.
   UUID uuid = 1;
 
-  // The columns to build the index.
+  // The columns to build the index. These refer to file.Field.id.
   repeated int32 fields = 2;
 
   // Index name. Must be unique within one dataset version.
@@ -178,30 +176,30 @@ message IndexMetadata {
   // The version of the dataset this index was built from.
   uint64 dataset_version = 4;
 
-  /// A bitmap of the included fragment ids.
-  ///
-  /// This may by used to determine how much of the dataset is covered by the
-  /// index. This information can be retrieved from the dataset by looking at
-  /// the dataset at `dataset_version`. However, since the old version may be
-  /// deleted while the index is still in use, this information is also stored
-  /// in the index.
-  /// 
-  /// The bitmap is stored as a 32-bit Roaring bitmap.
+  // A bitmap of the included fragment ids.
+  //
+  // This may by used to determine how much of the dataset is covered by the
+  // index. This information can be retrieved from the dataset by looking at
+  // the dataset at `dataset_version`. However, since the old version may be
+  // deleted while the index is still in use, this information is also stored
+  // in the index.
+  //
+  // The bitmap is stored as a 32-bit Roaring bitmap.
   bytes fragment_bitmap = 5;
 
-  /// Details, specific to the index type, which are needed to load / interpret the index
-  ///
-  /// Indices should avoid putting large amounts of information in this field, as it will
-  /// bloat the manifest.
+  // Details, specific to the index type, which are needed to load / interpret the index
+  //
+  // Indices should avoid putting large amounts of information in this field, as it will
+  // bloat the manifest.
   google.protobuf.Any index_details = 6;
 
-  /// The minimum lance version that this index is compatible with.
+  // The minimum lance version that this index is compatible with.
   optional int32 index_version = 7;
 
-  /// Timestamp when the index was created (UTC timestamp in milliseconds since epoch)
-  ///
-  /// This field is optional for backward compatibility. For existing indices created before
-  /// this field was added, this will be None/null.
+  // Timestamp when the index was created (UTC timestamp in milliseconds since epoch)
+  //
+  // This field is optional for backward compatibility. For existing indices created before
+  // this field was added, this will be None/null.
   optional uint64 created_at = 8;
 }
 
@@ -210,12 +208,12 @@ message IndexSection {
   repeated IndexMetadata indices = 1;
 }
 
-// Data fragment. A fragment is a set of files which represent the
-// different columns of the same rows.
-// If column exists in the schema, but the related file does not exist,
-// treat this column as nulls.
+// A DataFragment is a set of files which represent the different columns of the same
+// rows. If column exists in the schema of a dataset, but the file for that column does
+// not exist within a DataFragment of that dataset, that column consists entirely of
+// nulls.
 message DataFragment {
-  // Unique ID of each DataFragment
+  // The ID of a DataFragment is unique within a dataset.
   uint64 id = 1;
 
   repeated DataFile files = 2;
@@ -237,28 +235,26 @@ message DataFragment {
     ExternalFile external_row_ids = 6;
   } // row_id_sequence
 
-  // Number of original rows in the fragment, this includes rows that are 
-  // now marked with deletion tombstones. To compute the current number of rows, 
-  // subtract `deletion_file.num_deleted_rows` from this value.
+  // Number of original rows in the fragment, this includes rows that are now marked with
+  // deletion tombstones. To compute the current number of rows, subtract
+  // `deletion_file.num_deleted_rows` from this value.
   uint64 physical_rows = 4;
 }
 
-// Lance Data File
 message DataFile {
-  // Relative path to the root.
+  // Path to the root relative to the dataset's URI.
   string path = 1;
   // The ids of the fields/columns in this file.
   //
-  // -1 is used for "unassigned" while in memory. It is not meant to be written
-  // to disk. -2 is used for "tombstoned", meaningful a field that is no longer
-  // in use. This is often because the original field id was reassigned to a
-  // different data file.
+  // When a DataFile object is created in memory, every value in fields is assigned -1 by
+  // default. An object with a value in fields of -1 must not be stored to disk. -2 is
+  // used for "tombstoned", meaning a field that is no longer in use. This is often
+  // because the original field id was reassigned to a different data file.
   //
   // In Lance v1 IDs are assigned based on position in the file, offset by the max
-  // existing field id in the table (if any already). So when a fragment is first
-  // created with one file of N columns, the field ids will be 1, 2, ..., N. If a
-  // second, fragment is created with M columns, the field ids will be N+1, N+2,
-  // ..., N+M.
+  // existing field id in the table (if any already). So when a fragment is first created
+  // with one file of N columns, the field ids will be 1, 2, ..., N. If a second fragment
+  // is created with M columns, the field ids will be N+1, N+2, ..., N+M.
   //
   // In Lance v1 there is one field for each field in the input schema, this includes
   // nested fields (both struct and list).  Fixed size list fields have only a single
@@ -358,16 +354,16 @@ message DeletionFile {
 message ExternalFile {
   // Path to the file, relative to the root of the table.
   string path = 1;
-  // The offset in the file where the data starts.
+  // The byte offset in the file where the data starts.
   uint64 offset = 2;
-  // The size of the data in the file.
+  // The size of the data in the file, in bytes.
   uint64 size = 3;
 }
 
-/// The following messages are used for the index_details field in IndexMetadata.
-///
-/// This is not an exhaustive set of index types and just lists the index types supported
-/// by a base distribution of Lance.
+// The following messages are used for the index_details field in IndexMetadata.
+//
+// This is not an exhaustive set of index types and just lists the index types supported
+// by a base distribution of Lance.
 
 // Currently these are all empty messages because all needed details are either hard-coded (e.g.
 // filenames) or stored in the index itself.  However, we may want to add more details in the


### PR DESCRIPTION
This patch fixes some formatting, but mainly wording and clarity in the comments in the table.proto file in order to remove ambiguity or fix accidents like mixing up file and fragment.

(This patch also cleans up file.proto a tiny bit)