### PR TITLE
fix: make sure cloud features aren't implicitly enabled (lancedb/lancedb#2567)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ lance-datagen = { version = "=0.32.1", path = "./rust/lance-datagen" }
 lance-encoding = { version = "=0.32.1", path = "./rust/lance-encoding" }
 lance-file = { version = "=0.32.1", path = "./rust/lance-file" }
 lance-index = { version = "=0.32.1", path = "./rust/lance-index" }
-lance-io = { version = "=0.32.1", path = "./rust/lance-io" }
+lance-io = { version = "=0.32.1", path = "./rust/lance-io", default-features = false }
 lance-linalg = { version = "=0.32.1", path = "./rust/lance-linalg" }
 lance-table = { version = "=0.32.1", path = "./rust/lance-table" }
 lance-test-macros = { version = "=0.32.1", path = "./rust/lance-test-macros" }

--- a/rust/lance-core/Cargo.toml
+++ b/rust/lance-core/Cargo.toml
@@ -52,7 +52,7 @@ lance-testing.workspace = true
 proptest.workspace = true
 
 [features]
-datafusion = ["datafusion-common", "datafusion-sql"]
+datafusion = ["dep:datafusion-common", "dep:datafusion-sql"]
 
 [lints]
 workspace = true

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -76,8 +76,8 @@ rstest.workspace = true
 
 [features]
 protoc = ["dep:protobuf-src"]
-tokenizer-lindera = ["lindera", "lindera-tantivy"]
-tokenizer-jieba = ["jieba-rs"]
+tokenizer-lindera = ["dep:lindera", "dep:lindera-tantivy"]
+tokenizer-jieba = ["dep:jieba-rs"]
 
 [build-dependencies]
 prost-build.workspace = true

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -66,9 +66,9 @@ harness = false
 default = ["aws", "azure", "gcp"]
 gcs-test = []
 gcp = ["object_store/gcp"]
-aws = ["object_store/aws", "aws-config", "aws-credential-types"]
+aws = ["object_store/aws", "dep:aws-config", "dep:aws-credential-types"]
 azure = ["object_store/azure"]
-oss = ["opendal/services-oss", "object_store_opendal"]
+oss = ["dep:opendal", "opendal/services-oss", "dep:object_store_opendal"]
 
 [lints]
 workspace = true

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -61,7 +61,7 @@ prost-build.workspace = true
 protobuf-src = { version = "2.1", optional = true }
 
 [features]
-dynamodb = ["aws-sdk-dynamodb", "aws-credential-types", "lance-io/aws"]
+dynamodb = ["dep:aws-sdk-dynamodb", "dep:aws-credential-types", "lance-io/aws"]
 protoc = ["dep:protobuf-src"]
 
 [package.metadata.docs.rs]

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -47,6 +47,7 @@ half.workspace = true
 itertools.workspace = true
 object_store = { workspace = true }
 aws-credential-types.workspace = true
+aws-credential-types.optional = true
 pin-project.workspace = true
 prost.workspace = true
 prost-types.workspace = true
@@ -121,7 +122,7 @@ protoc = [
     "lance-index/protoc",
     "lance-table/protoc",
 ]
-aws = ["lance-io/aws"]
+aws = ["lance-io/aws", "dep:aws-credential-types"]
 gcp = ["lance-io/gcp"]
 azure = ["lance-io/azure"]
 oss = ["lance-io/oss"]

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -110,9 +110,9 @@ aws-sdk-s3 = { workspace = true }
 default = ["aws", "azure", "gcp", "oss"]
 fp16kernels = ["lance-linalg/fp16kernels"]
 # Prevent dynamic linking of lzma, which comes from datafusion
-cli = ["clap", "lzma-sys/static"]
-tensorflow = ["tfrecord", "prost_old"]
-dynamodb = ["lance-table/dynamodb", "aws-sdk-dynamodb"]
+cli = ["dep:clap", "lzma-sys/static"]
+tensorflow = ["dep:tfrecord", "dep:prost_old"]
+dynamodb = ["lance-table/dynamodb", "dep:aws-sdk-dynamodb"]
 dynamodb_tests = ["dynamodb"]
 substrait = ["lance-datafusion/substrait"]
 protoc = [

--- a/rust/lance/src/utils.rs
+++ b/rust/lance/src/utils.rs
@@ -7,7 +7,7 @@ pub(crate) mod future;
 pub(crate) mod temporal;
 #[cfg(test)]
 pub(crate) mod test;
-#[cfg(feature = "tfrecord")]
+#[cfg(feature = "tensorflow")]
 pub mod tfrecord;
 
 // Re-export


### PR DESCRIPTION
lance-io includes cloud features and critical types/methods that sibling libraries need without strictly needing cloud features. Make sure that lance-io is depended on by default without the default feature set except for lance which will pull in the requisite features as they're enabled.

This is so that building lancedb with default-features = false excludes the entire dependency chain for crates supporting the cloud features, shrinking the size and speeding up the build of the purely embedded version.

Both this and https://github.com/lancedb/lancedb/pull/2568 resolves https://github.com/lancedb/lancedb/issues/2567

Verified via:
```
cargo tree -p lancedb -e no-build -e no-dev --no-default-features -i aws-config | less
```