### PR TITLE
ci: use cargo nextest to speed up our tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,13 @@
+[profile.default]
+# Run tests in parallel using all available cores
+test-threads = "num-cpus"
+# Retry failed tests once
+retries = { backoff = "exponential", count = 1, delay = "1s" }
+
+[profile.ci]
+# More aggressive retries for CI
+retries = { backoff = "exponential", count = 2, delay = "1s" }
+# Detect slow tests
+slow-timeout = { period = "120s", terminate-after = 2 }
+# Fail fast on first failure
+fail-fast = false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -78,6 +78,8 @@ jobs:
         toolchain:
           - stable
           - nightly
+        partition: [1, 2, 3, 4, 5]
+        total-partitions: [5]
     env:
       # Need up-to-date compilers for kernels
       CC: clang
@@ -101,11 +103,15 @@ jobs:
         run: docker compose -f docker-compose.yml up -d --wait
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Run tests
         if: ${{ matrix.toolchain == 'stable' }}
         run: |
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v protoc | sort | uniq | paste -s -d "," -`
-          cargo llvm-cov  --locked --workspace --codecov --output-path coverage.codecov --features ${ALL_FEATURES}
+          cargo llvm-cov nextest --locked --workspace --codecov --output-path coverage-${{ matrix.partition }}.codecov --features ${ALL_FEATURES} -- --partition count:${{ matrix.partition }}/${{ matrix.total-partitions }}
       - name: Build tests (nightly)
         if: ${{ matrix.toolchain != 'stable' }}
         run: |
@@ -115,19 +121,46 @@ jobs:
         if: ${{ matrix.toolchain != 'stable' }}
         run: |
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v protoc | sort | uniq | paste -s -d "," -`
-          cargo test --features ${ALL_FEATURES} --workspace
-      - name: Upload coverage to Codecov
+          cargo nextest run --features ${ALL_FEATURES} --workspace --partition count:${{ matrix.partition }}/${{ matrix.total-partitions }}
+      - name: Upload coverage artifact
         if: ${{ matrix.toolchain == 'stable' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.partition }}
+          path: coverage-${{ matrix.partition }}.codecov
+          retention-days: 1
+  merge-coverage:
+    needs: linux-build
+    runs-on: ubuntu-24.04
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: coverage-artifacts
+      - name: Merge coverage files
+        run: |
+          # List all coverage files
+          ls -la coverage-artifacts/
+          # Merge all codecov files into one
+          cat coverage-artifacts/coverage-*/coverage-*.codecov > merged-coverage.codecov
+      - name: Upload merged coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           codecov_yml_path: codecov.yml
-          files: coverage.codecov
+          files: merged-coverage.codecov
           flags: unittests
           fail_ci_if_error: false
   linux-arm:
     runs-on: ubuntu-2404-4x-arm64
     timeout-minutes: 75
+    strategy:
+      matrix:
+        partition: [1, 2, 3, 4, 5]
+        total-partitions: [5]
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -135,6 +168,10 @@ jobs:
           toolchain: "stable"
       - uses: rui314/setup-mold@v1
       - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Install dependencies
         run: |
           sudo apt -y -qq update
@@ -148,7 +185,7 @@ jobs:
       - name: Run tests
         run: |
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v protoc | sort | uniq | paste -s -d "," -`
-          cargo test --locked --features ${ALL_FEATURES}
+          cargo nextest run --locked --features ${ALL_FEATURES} --partition count:${{ matrix.partition }}/${{ matrix.total-partitions }}
   build-no-lock:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -186,6 +223,8 @@ jobs:
         toolchain:
           - stable
           - nightly
+        partition: [1, 2, 3, 4, 5]
+        total-partitions: [5]
     defaults:
       run:
         working-directory: ./rust
@@ -199,6 +238,10 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_15.4.app
       - name: Install dependencies
         run: brew install protobuf
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Set up Rust
         run: |
           rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
@@ -207,12 +250,16 @@ jobs:
           cargo test --locked --features fp16kernels,cli,tensorflow,dynamodb,substrait --no-run
       - name: Run tests
         run: |
-          cargo test --features fp16kernels,cli,tensorflow,dynamodb,substrait
+          cargo nextest run --features fp16kernels,cli,tensorflow,dynamodb,substrait --partition count:${{ matrix.partition }}/${{ matrix.total-partitions }}
       - name: Check benchmarks
         run: |
           cargo check --benches --features fp16kernels,cli,tensorflow,dynamodb,substrait
   windows-build:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        partition: [1, 2, 3, 4, 5]
+        total-partitions: [5]
     defaults:
       run:
         working-directory: rust
@@ -228,10 +275,14 @@ jobs:
           7z x protoc.zip
           Add-Content $env:GITHUB_PATH "C:\protoc\bin"
         shell: powershell
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Build tests
         run: cargo test --locked --no-run
       - name: Run tests
-        run: cargo test
+        run: cargo nextest run --partition count:${{ matrix.partition }}/${{ matrix.total-partitions }}
       - name: Check benchmarks
         run: cargo check --benches
   msrv:


### PR DESCRIPTION
This PR introduces `cargo-nextest`, splits our test cases into parts, and runs them in parallel. Let's see if it works for us.