### PR TITLE
fix: Python-level strict overwrite

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1227,6 +1227,20 @@ def test_create_from_commit(tmp_path: Path):
     tbl = dataset.to_table()
     assert tbl == table
 
+def test_strict_overwrite(tmp_path: Path):
+    table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
+    base_dir = tmp_path / "test"
+    dataset_v1 = lance.write_dataset(table, base_dir)
+
+    fragment = lance.fragment.LanceFragment.create(base_dir, table)
+    operation = lance.LanceOperation.Overwrite(table.schema, [fragment])
+    lance.LanceDataset.commit(base_dir, operation, read_version=dataset_v1.version)
+    with pytest.raises(
+        OSError, match=f"Commit conflict for version {dataset_v1.version+1}"
+    ):
+        lance.LanceDataset.commit(
+            base_dir, operation, read_version=dataset_v1.version, max_retries=0
+        )
 
 def test_append_with_commit(tmp_path: Path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -717,6 +717,7 @@ pub(crate) async fn commit_transaction(
 
     // read_version sometimes defaults to zero for overwrite.
     // If num_retries is zero, we are in "strict overwrite" mode.
+    // Strict overwrites are not subject to any sort of automatic conflict resolution.
     let strict_overwrite = matches!(transaction.operation, Operation::Overwrite { .. })
         && commit_config.num_retries == 0;
     let mut dataset =
@@ -746,30 +747,33 @@ pub(crate) async fn commit_transaction(
         // slower performance for concurrent writes. But that makes the fast path
         // faster and the slow path slower, which makes performance less predictable
         // for users. So we always check for other transactions.
-        (dataset, other_transactions) = {
-            // Load new dataset and other transactions concurrently
-            let NewTransactionResult {
-                dataset: new_ds,
-                new_transactions,
-            } = load_new_transactions(&dataset);
-            let new_transactions = new_transactions.try_collect::<Vec<_>>();
-            futures::future::try_join(new_ds, new_transactions).await?
-        };
+        // We skip this for strict overwrites, because strict overwrites can't be rebased.
+        if !strict_overwrite {
+            (dataset, other_transactions) = {
+                // Load new dataset and other transactions concurrently
+                let NewTransactionResult {
+                    dataset: new_ds,
+                    new_transactions,
+                } = load_new_transactions(&dataset);
+                let new_transactions = new_transactions.try_collect::<Vec<_>>();
+                futures::future::try_join(new_ds, new_transactions).await?
+            };
 
-        // See if we can retry the commit. Try to account for all
-        // transactions that have been committed since the read_version.
-        // Use small amount of backoff to handle transactions that all
-        // started at exact same time better.
+            // See if we can retry the commit. Try to account for all
+            // transactions that have been committed since the read_version.
+            // Use small amount of backoff to handle transactions that all
+            // started at exact same time better.
 
-        let mut rebase =
-            TransactionRebase::try_new(&original_dataset, transaction, affected_rows).await?;
+            let mut rebase =
+                TransactionRebase::try_new(&original_dataset, transaction, affected_rows).await?;
 
-        // Check against committed transactions from oldest to latest
-        for (other_version, other_transaction) in other_transactions.iter().rev() {
-            rebase.check_txn(other_transaction, *other_version)?;
+            // Check against committed transactions from oldest to latest
+            for (other_version, other_transaction) in other_transactions.iter().rev() {
+                rebase.check_txn(other_transaction, *other_version)?;
+            }
+
+            transaction = rebase.finish(&dataset).await?;
         }
-
-        transaction = rebase.finish(&dataset).await?;
 
         let transaction_file =
             write_transaction_file(object_store, &dataset.base, &transaction).await?;


### PR DESCRIPTION
The "strict overwrite" commit type, which respects `read_version` and skips all retries for Overwrite operations when `num_retries=0`, was broken at the Python level by the automatic rebasing added to improve transaction performance.

The rebasing was checking out the most recent version of the dataset, causing `read_version` to be ignored.

This PR fixes the issue by skipping automatic rebasing when in strict overwrite mode, and adds a Python test for the behavior.