### PR TITLE
feat: allow configuring bss for encoding

### DIFF
--- a/rust/lance-encoding/src/compression_config.rs
+++ b/rust/lance-encoding/src/compression_config.rs
@@ -10,6 +10,38 @@ use std::collections::HashMap;
 
 use arrow::datatypes::DataType;
 
+/// Byte stream split encoding mode
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum BssMode {
+    /// Never use BSS
+    Off,
+    /// Always use BSS for floating point data
+    On,
+    /// Automatically decide based on data characteristics
+    Auto,
+}
+
+impl BssMode {
+    /// Convert to internal sensitivity value
+    pub fn to_sensitivity(&self) -> f32 {
+        match self {
+            Self::Off => 0.0,
+            Self::On => 1.0,
+            Self::Auto => 0.5, // Default sensitivity for auto mode
+        }
+    }
+
+    /// Parse from string
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "off" => Some(Self::Off),
+            "on" => Some(Self::On),
+            "auto" => Some(Self::Auto),
+            _ => None,
+        }
+    }
+}
+
 /// Compression parameter configuration
 #[derive(Debug, Clone, PartialEq)]
 pub struct CompressionParams {
@@ -32,6 +64,9 @@ pub struct CompressionFieldParams {
 
     /// Compression level (only for schemes that support it, e.g., zstd)
     pub compression_level: Option<i32>,
+
+    /// Byte stream split mode for floating point data
+    pub bss: Option<BssMode>,
 }
 
 impl CompressionParams {
@@ -93,6 +128,9 @@ impl CompressionFieldParams {
         if other.compression_level.is_some() {
             self.compression_level = other.compression_level;
         }
+        if other.bss.is_some() {
+            self.bss = other.bss;
+        }
     }
 }
 
@@ -152,28 +190,33 @@ mod tests {
         assert_eq!(params.rle_threshold, None);
         assert_eq!(params.compression, None);
         assert_eq!(params.compression_level, None);
+        assert_eq!(params.bss, None);
 
         let other = CompressionFieldParams {
             rle_threshold: Some(0.3),
             compression: Some("lz4".to_string()),
             compression_level: None,
+            bss: Some(BssMode::On),
         };
 
         params.merge(&other);
         assert_eq!(params.rle_threshold, Some(0.3));
         assert_eq!(params.compression, Some("lz4".to_string()));
         assert_eq!(params.compression_level, None);
+        assert_eq!(params.bss, Some(BssMode::On));
 
         let another = CompressionFieldParams {
             rle_threshold: None,
             compression: Some("zstd".to_string()),
             compression_level: Some(3),
+            bss: Some(BssMode::Auto),
         };
 
         params.merge(&another);
         assert_eq!(params.rle_threshold, Some(0.3)); // Not overridden
         assert_eq!(params.compression, Some("zstd".to_string())); // Overridden
         assert_eq!(params.compression_level, Some(3)); // New value
+        assert_eq!(params.bss, Some(BssMode::Auto)); // Overridden
     }
 
     #[test]
@@ -197,6 +240,7 @@ mod tests {
                 rle_threshold: Some(0.3),
                 compression: Some("zstd".to_string()),
                 compression_level: Some(3),
+                bss: None,
             },
         );
 

--- a/rust/lance-encoding/src/constants.rs
+++ b/rust/lance-encoding/src/constants.rs
@@ -33,3 +33,9 @@ pub const STRUCTURAL_ENCODING_META_KEY: &str = "lance-encoding:structural-encodi
 pub const STRUCTURAL_ENCODING_MINIBLOCK: &str = "miniblock";
 /// Value for fullzip structural encoding
 pub const STRUCTURAL_ENCODING_FULLZIP: &str = "fullzip";
+
+// Byte stream split metadata keys
+/// Metadata key for byte stream split encoding configuration
+pub const BSS_META_KEY: &str = "lance-encoding:bss";
+/// Default BSS mode
+pub const DEFAULT_BSS_MODE: &str = "auto";

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -648,6 +648,7 @@ mod tests {
                 rle_threshold: Some(0.5),
                 compression: Some("lz4".to_string()),
                 compression_level: None,
+                bss: None,
             },
         );
 

--- a/rust/lance-encoding/src/encodings/physical/rle.rs
+++ b/rust/lance-encoding/src/encodings/physical/rle.rs
@@ -525,10 +525,8 @@ impl MiniBlockDecompressor for RleMiniBlockDecompressor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::compression::{CompressionStrategy, DefaultCompressionStrategy};
     use crate::data::DataBlock;
     use arrow_array::Int32Array;
-    use lance_core::datatypes::Field;
 
     // ========== Core Functionality Tests ==========
 
@@ -566,30 +564,6 @@ mod tests {
         // Should have 6 runs total (4 for first value, 2 for second)
         let lengths_buffer = &compressed.data[1];
         assert_eq!(lengths_buffer.len(), 6);
-    }
-
-    #[test]
-    fn test_compression_strategy_selection() {
-        let strategy = DefaultCompressionStrategy::new();
-        let field = Field::new_arrow("test", arrow_schema::DataType::Int32, false).unwrap();
-
-        // High repetition - should select RLE
-        let repetitive_array = Int32Array::from(vec![1; 1000]);
-        let repetitive_block = DataBlock::from_array(repetitive_array);
-
-        let compressor = strategy
-            .create_miniblock_compressor(&field, &repetitive_block)
-            .unwrap();
-        assert!(format!("{:?}", compressor).contains("RleMiniBlockEncoder"));
-
-        // No repetition - should NOT select RLE
-        let unique_array = Int32Array::from((0..1000).collect::<Vec<i32>>());
-        let unique_block = DataBlock::from_array(unique_array);
-
-        let compressor = strategy
-            .create_miniblock_compressor(&field, &unique_block)
-            .unwrap();
-        assert!(!format!("{:?}", compressor).contains("RleMiniBlockEncoder"));
     }
 
     // ========== Round-trip Tests for Different Types ==========

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -1049,6 +1049,7 @@ mod tests {
                 rle_threshold: Some(0.5), // Lower threshold to trigger RLE more easily
                 compression: None,        // Will use default compression if any
                 compression_level: None,
+                bss: None,
             },
         );
 


### PR DESCRIPTION
This PR enables users to configure BSS for encoding.

We have implemented an internal BSS sensitivity concept to measure how sensitive we want to be, based on our byte position entity. However, we will not expose these details directly to users. Instead, we provide a simple interface for users to choose between `on`, `off`, and `auto`. The default value is `auto`, which means BSS will be enabled based on the data's statistics.

We can introduce additional statistics functions in the future. I don't see any blockers or conflicts.