### PR TITLE
fix: don't panic when reading files if the last row was deleted

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -236,6 +236,11 @@ impl Eq for ObjectStoreParams {}
 impl PartialEq for ObjectStoreParams {
     #[allow(deprecated)]
     fn eq(&self, other: &Self) -> bool {
+        #[cfg(feature = "aws")]
+        if self.aws_credentials.is_some() != other.aws_credentials.is_some() {
+            return false;
+        }
+
         // For equality, we use pointer comparison for ObjectStore, S3 credentials, and wrapper
         self.block_size == other.block_size
             && self
@@ -247,8 +252,6 @@ impl PartialEq for ObjectStoreParams {
                     .as_ref()
                     .map(|(store, url)| (Arc::as_ptr(store), url))
             && self.s3_credentials_refresh_offset == other.s3_credentials_refresh_offset
-            && self.aws_credentials.as_ref().map(Arc::as_ptr)
-                == other.aws_credentials.as_ref().map(Arc::as_ptr)
             && self.object_store_wrapper.as_ref().map(Arc::as_ptr)
                 == other.object_store_wrapper.as_ref().map(Arc::as_ptr)
             && self.storage_options == other.storage_options


### PR DESCRIPTION
The new filtered read applies deletion vectors before the read.  There was a bug in this logic so that, if the last row in the fragment was deleted, an empty range would be sent to the file reader.  For example, if a file had 50 rows and row 49 was deleted we would ask for rows `[0..49], [50..50]`.

The file reader then had a bug that, when it processed that empty range, it would panic.  This seems specific to 2.0 files with the list data type though the fix is to just ignore empty ranges at the top level.