### PR TITLE
chore: upgrade rand crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3100,7 +3100,7 @@ version = "0.32.2"
 dependencies = [
  "arrow-array",
  "lance-datagen",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rand_xoshiro",
  "test-log",
  "tokio",
@@ -4134,7 +4134,7 @@ dependencies = [
  "prost 0.12.6",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "rand 0.8.5",
+ "rand 0.9.1",
  "roaring",
  "rstest",
  "serde",
@@ -4166,7 +4166,7 @@ dependencies = [
  "getrandom 0.2.16",
  "half",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.9.1",
 ]
 
 [[package]]
@@ -4195,7 +4195,7 @@ dependencies = [
  "pin-project",
  "proptest",
  "prost 0.13.5",
- "rand 0.8.5",
+ "rand 0.9.1",
  "roaring",
  "serde_json",
  "snafu",
@@ -4250,7 +4250,7 @@ dependencies = [
  "futures",
  "hex",
  "pprof",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rand_xoshiro",
  "random_word",
 ]
@@ -4290,7 +4290,7 @@ dependencies = [
  "prost-build 0.13.5",
  "prost-types 0.13.5",
  "protobuf-src",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rand_xoshiro",
  "rstest",
  "seq-macro",
@@ -4323,7 +4323,7 @@ dependencies = [
  "lance-linalg",
  "object_store",
  "parquet",
- "rand 0.8.5",
+ "rand 0.9.1",
  "tempfile",
  "tokenizers",
  "tokio",
@@ -4363,7 +4363,7 @@ dependencies = [
  "prost-build 0.13.5",
  "prost-types 0.13.5",
  "protobuf-src",
- "rand 0.8.5",
+ "rand 0.9.1",
  "roaring",
  "rstest",
  "snafu",
@@ -4424,7 +4424,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-build 0.13.5",
  "protobuf-src",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rayon",
  "roaring",
  "rstest",
@@ -4473,7 +4473,7 @@ dependencies = [
  "pin-project",
  "pprof",
  "prost 0.13.5",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rstest",
  "serde",
  "shellexpand",
@@ -4508,7 +4508,7 @@ dependencies = [
  "num-traits",
  "pprof",
  "proptest",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rayon",
  "tokio",
  "tracing",
@@ -4546,7 +4546,7 @@ dependencies = [
  "prost-build 0.13.5",
  "prost-types 0.13.5",
  "protobuf-src",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rangemap",
  "roaring",
  "rstest",
@@ -4577,7 +4577,7 @@ dependencies = [
  "arrow-schema",
  "lance-arrow",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.9.1",
 ]
 
 [[package]]
@@ -6332,11 +6332,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,9 @@ proptest = "1.3.1"
 prost = "0.13.2"
 prost-build = "0.13.2"
 prost-types = "0.13.2"
-rand = { version = "0.8.3", features = ["small_rng"] }
+rand = { version = "0.9.1", features = ["small_rng"] }
+rand_distr = { version = "0.5.1" }
+rand_xoshiro = "0.7.0"
 rangemap = { version = "1.0" }
 rayon = "1.10"
 roaring = "0.10.1"

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1111,7 +1111,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -2759,7 +2759,7 @@ name = "fsst"
 version = "0.32.2"
 dependencies = [
  "arrow-array",
- "rand 0.8.5",
+ "rand 0.9.1",
 ]
 
 [[package]]
@@ -3685,7 +3685,7 @@ dependencies = [
  "prost 0.12.6",
  "prost 0.13.5",
  "prost-types 0.13.5",
- "rand 0.8.5",
+ "rand 0.9.1",
  "roaring",
  "serde",
  "serde_json",
@@ -3713,7 +3713,7 @@ dependencies = [
  "getrandom 0.2.16",
  "half",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.9.1",
 ]
 
 [[package]]
@@ -3740,7 +3740,7 @@ dependencies = [
  "object_store",
  "pin-project",
  "prost 0.13.5",
- "rand 0.8.5",
+ "rand 0.9.1",
  "roaring",
  "serde_json",
  "snafu",
@@ -3791,7 +3791,7 @@ dependencies = [
  "chrono",
  "futures",
  "hex",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rand_xoshiro",
  "random_word",
 ]
@@ -3826,7 +3826,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-build 0.13.5",
  "prost-types 0.13.5",
- "rand 0.8.5",
+ "rand 0.9.1",
  "seq-macro",
  "snafu",
  "tokio",
@@ -3912,7 +3912,7 @@ dependencies = [
  "object_store",
  "prost 0.13.5",
  "prost-build 0.13.5",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rayon",
  "roaring",
  "serde",
@@ -3956,7 +3956,7 @@ dependencies = [
  "path_abs",
  "pin-project",
  "prost 0.13.5",
- "rand 0.8.5",
+ "rand 0.9.1",
  "serde",
  "shellexpand",
  "snafu",
@@ -3982,7 +3982,7 @@ dependencies = [
  "lance-core",
  "log",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rayon",
  "tokio",
  "tracing",
@@ -4014,7 +4014,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-build 0.13.5",
  "prost-types 0.13.5",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rangemap",
  "roaring",
  "serde",
@@ -5226,8 +5226,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -5246,8 +5246,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5280,7 +5280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -5293,7 +5293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -5603,11 +5603,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xoshiro"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -6334,7 +6334,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",

--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -260,7 +260,7 @@ impl FixedSizeListArrayExt for FixedSizeListArray {
         if n >= self.len() {
             return Ok(self.clone());
         }
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::from_os_rng();
         let chosen = (0..self.len() as u32).choose_multiple(&mut rng, n);
         take(self, &UInt32Array::from(chosen), None).map(|arr| arr.as_fixed_size_list().clone())
     }

--- a/rust/lance-core/src/utils/backoff.rs
+++ b/rust/lance-core/src/utils/backoff.rs
@@ -62,7 +62,7 @@ impl Backoff {
             .base
             .saturating_pow(self.attempt)
             .saturating_mul(self.unit);
-        let jitter = rand::thread_rng().gen_range(-self.jitter..=self.jitter);
+        let jitter = rand::rng().random_range(-self.jitter..=self.jitter);
         let backoff = (backoff.saturating_add_signed(jitter)).clamp(self.min, self.max);
         self.attempt += 1;
         Duration::from_millis(backoff as u64)
@@ -123,7 +123,7 @@ impl Default for SlotBackoff {
             unit: 50,
             starting_i: 2, // start with 4 slots
             attempt: 0,
-            rng: rand::rngs::SmallRng::from_entropy(),
+            rng: rand::rngs::SmallRng::from_os_rng(),
         }
     }
 }
@@ -139,7 +139,7 @@ impl SlotBackoff {
 
     pub fn next_backoff(&mut self) -> Duration {
         let num_slots = self.base.saturating_pow(self.attempt + self.starting_i);
-        let slot_i = self.rng.gen_range(0..num_slots);
+        let slot_i = self.rng.random_range(0..num_slots);
         self.attempt += 1;
         Duration::from_millis((slot_i * self.unit) as u64)
     }

--- a/rust/lance-datafusion/src/chunker.rs
+++ b/rust/lance-datafusion/src/chunker.rs
@@ -314,7 +314,7 @@ mod tests {
         ]));
 
         let make_batch = |num_rows: u32| {
-            lance_datagen::gen()
+            lance_datagen::gen_batch()
                 .anon_col(lance_datagen::array::step::<Int32Type>())
                 .into_batch_rows(RowCount::from(num_rows as u64))
                 .unwrap()
@@ -371,7 +371,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_strict_batch_size_stream() {
-        let batches = lance_datagen::gen()
+        let batches = lance_datagen::gen_batch()
             .anon_col(array::step::<Int32Type>())
             .anon_col(array::step::<Int64Type>())
             .into_df_stream(RowCount::from(7), BatchCount::from(10));

--- a/rust/lance-datagen/Cargo.toml
+++ b/rust/lance-datagen/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { workspace = true }
 futures = { workspace = true }
 hex = "0.4.3"
 rand = { workspace = true }
-rand_xoshiro = "0.6.0"
+rand_xoshiro = { workspace = true }
 random_word = { version = "0.5", features = ["en"] }
 
 [dev-dependencies]

--- a/rust/lance-datagen/benches/array_gen.rs
+++ b/rust/lance-datagen/benches/array_gen.rs
@@ -28,7 +28,7 @@ fn bench_gen<M: Measurement>(
 
     group.bench_function(id, |b| {
         b.iter(|| {
-            let reader = lance_datagen::gen()
+            let reader = lance_datagen::gen_batch()
                 .anon_col(gen_factory())
                 .into_reader_bytes(
                     ByteCount::from(BYTES_PER_BATCH),

--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -1593,7 +1593,7 @@ impl ArrayGenerator for RandomStructGenerator {
         let child_arrays = self
             .child_gens
             .iter_mut()
-            .map(|gen| gen.generate(length, rng))
+            .map(|genn| genn.generate(length, rng))
             .collect::<Result<Vec<_>, ArrowError>>()?;
         let struct_arr = StructArray::new(self.fields.clone(), child_arrays, None);
         Ok(Arc::new(struct_arr))
@@ -1631,23 +1631,23 @@ impl FixedSizeBatchGenerator {
     ) -> Self {
         let mut fields = Vec::with_capacity(generators.len());
         for (field_index, field_gen) in generators.iter().enumerate() {
-            let (name, gen) = field_gen;
+            let (name, genn) = field_gen;
             let default_name = format!("field_{}", field_index);
             let name = name.clone().unwrap_or(default_name);
-            let mut field = Field::new(name, gen.data_type().clone(), true);
-            if let Some(metadata) = gen.metadata() {
+            let mut field = Field::new(name, genn.data_type().clone(), true);
+            if let Some(metadata) = genn.metadata() {
                 field = field.with_metadata(metadata);
             }
             fields.push(field);
         }
         let mut generators = generators
             .into_iter()
-            .map(|(_, gen)| gen)
+            .map(|(_, genn)| genn)
             .collect::<Vec<_>>();
         if let Some(null_probability) = default_null_probability {
             generators = generators
                 .into_iter()
-                .map(|gen| gen.with_random_nulls(null_probability))
+                .map(|genn| genn.with_random_nulls(null_probability))
                 .collect();
         }
         let schema = Arc::new(Schema::new(fields));
@@ -1664,8 +1664,8 @@ impl FixedSizeBatchGenerator {
 
     fn gen_next(&mut self) -> Result<RecordBatch, ArrowError> {
         let mut arrays = Vec::with_capacity(self.generators.len());
-        for gen in self.generators.iter_mut() {
-            let arr = gen.generate(self.batch_size, &mut self.rng)?;
+        for genn in self.generators.iter_mut() {
+            let arr = genn.generate(self.batch_size, &mut self.rng)?;
             arrays.push(arr);
         }
         self.num_batches.0 -= 1;
@@ -1729,16 +1729,16 @@ impl BatchGeneratorBuilder {
     /// Adds a new column to the generator
     ///
     /// See [`crate::generator::array`] for methods to create generators
-    pub fn col(mut self, name: impl Into<String>, gen: Box<dyn ArrayGenerator>) -> Self {
-        self.generators.push((Some(name.into()), gen));
+    pub fn col(mut self, name: impl Into<String>, genn: Box<dyn ArrayGenerator>) -> Self {
+        self.generators.push((Some(name.into()), genn));
         self
     }
 
     /// Adds a new column to the generator with a generated unique name
     ///
     /// See [`crate::generator::array`] for methods to create generators
-    pub fn anon_col(mut self, gen: Box<dyn ArrayGenerator>) -> Self {
-        self.generators.push((None, gen));
+    pub fn anon_col(mut self, genn: Box<dyn ArrayGenerator>) -> Self {
+        self.generators.push((None, genn));
         self
     }
 
@@ -1800,7 +1800,7 @@ impl BatchGeneratorBuilder {
         let bytes_per_row = self
             .generators
             .iter()
-            .map(|gen| gen.1.element_size_bytes().map(|byte_count| byte_count.0).ok_or(
+            .map(|genn| genn.1.element_size_bytes().map(|byte_count| byte_count.0).ok_or(
                         ArrowError::NotYetImplemented("The function into_reader_bytes currently requires each array generator to have a fixed element size".to_string())
                 )
             )
@@ -2497,13 +2497,13 @@ pub mod array {
 }
 
 /// Create a BatchGeneratorBuilder to start generating batch data
-pub fn gen() -> BatchGeneratorBuilder {
+pub fn gen_batch() -> BatchGeneratorBuilder {
     BatchGeneratorBuilder::default()
 }
 
 /// Create an ArrayGeneratorBuilder to start generating array data
-pub fn gen_array(gen: Box<dyn ArrayGenerator>) -> ArrayGeneratorBuilder {
-    ArrayGeneratorBuilder::new(gen)
+pub fn gen_array(genn: Box<dyn ArrayGenerator>) -> ArrayGeneratorBuilder {
+    ArrayGeneratorBuilder::new(genn)
 }
 
 /// Create a BatchGeneratorBuilder with the given schema
@@ -2528,35 +2528,35 @@ mod tests {
     #[test]
     fn test_step() {
         let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
-        let mut gen = array::step::<Int32Type>();
+        let mut genn = array::step::<Int32Type>();
         assert_eq!(
-            *gen.generate(RowCount::from(5), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(5), &mut rng).unwrap(),
             Int32Array::from_iter([0, 1, 2, 3, 4])
         );
         assert_eq!(
-            *gen.generate(RowCount::from(5), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(5), &mut rng).unwrap(),
             Int32Array::from_iter([5, 6, 7, 8, 9])
         );
 
-        let mut gen = array::step::<Int8Type>();
+        let mut genn = array::step::<Int8Type>();
         assert_eq!(
-            *gen.generate(RowCount::from(3), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(3), &mut rng).unwrap(),
             Int8Array::from_iter([0, 1, 2])
         );
 
-        let mut gen = array::step::<Float32Type>();
+        let mut genn = array::step::<Float32Type>();
         assert_eq!(
-            *gen.generate(RowCount::from(3), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(3), &mut rng).unwrap(),
             Float32Array::from_iter([0.0, 1.0, 2.0])
         );
 
-        let mut gen = array::step_custom::<Int16Type>(4, 8);
+        let mut genn = array::step_custom::<Int16Type>(4, 8);
         assert_eq!(
-            *gen.generate(RowCount::from(3), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(3), &mut rng).unwrap(),
             Int16Array::from_iter([4, 12, 20])
         );
         assert_eq!(
-            *gen.generate(RowCount::from(2), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(2), &mut rng).unwrap(),
             Int16Array::from_iter([28, 36])
         );
     }
@@ -2564,19 +2564,19 @@ mod tests {
     #[test]
     fn test_cycle() {
         let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
-        let mut gen = array::cycle::<Int32Type>(vec![1, 2, 3]);
+        let mut genn = array::cycle::<Int32Type>(vec![1, 2, 3]);
         assert_eq!(
-            *gen.generate(RowCount::from(5), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(5), &mut rng).unwrap(),
             Int32Array::from_iter([1, 2, 3, 1, 2])
         );
 
-        let mut gen = array::cycle_utf8_literals(&["abc", "def", "xyz"]);
+        let mut genn = array::cycle_utf8_literals(&["abc", "def", "xyz"]);
         assert_eq!(
-            *gen.generate(RowCount::from(5), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(5), &mut rng).unwrap(),
             StringArray::from_iter_values(["abc", "def", "xyz", "abc", "def"])
         );
         assert_eq!(
-            *gen.generate(RowCount::from(1), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(1), &mut rng).unwrap(),
             StringArray::from_iter_values(["xyz"])
         );
     }
@@ -2584,19 +2584,19 @@ mod tests {
     #[test]
     fn test_fill() {
         let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
-        let mut gen = array::fill::<Int32Type>(42);
+        let mut genn = array::fill::<Int32Type>(42);
         assert_eq!(
-            *gen.generate(RowCount::from(3), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(3), &mut rng).unwrap(),
             Int32Array::from_iter([42, 42, 42])
         );
         assert_eq!(
-            *gen.generate(RowCount::from(3), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(3), &mut rng).unwrap(),
             Int32Array::from_iter([42, 42, 42])
         );
 
-        let mut gen = array::fill_varbin(vec![0, 1, 2]);
+        let mut genn = array::fill_varbin(vec![0, 1, 2]);
         assert_eq!(
-            *gen.generate(RowCount::from(3), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(3), &mut rng).unwrap(),
             arrow_array::BinaryArray::from_iter_values([
                 "\x00\x01\x02",
                 "\x00\x01\x02",
@@ -2604,9 +2604,9 @@ mod tests {
             ])
         );
 
-        let mut gen = array::fill_utf8("xyz".to_string());
+        let mut genn = array::fill_utf8("xyz".to_string());
         assert_eq!(
-            *gen.generate(RowCount::from(3), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(3), &mut rng).unwrap(),
             arrow_array::StringArray::from_iter_values(["xyz", "xyz", "xyz"])
         );
     }
@@ -2614,9 +2614,9 @@ mod tests {
     #[test]
     fn test_utf8_prefix_plus_counter() {
         let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
-        let mut gen = array::utf8_prefix_plus_counter("user_", false);
+        let mut genn = array::utf8_prefix_plus_counter("user_", false);
         assert_eq!(
-            *gen.generate(RowCount::from(3), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(3), &mut rng).unwrap(),
             arrow_array::StringArray::from_iter_values(["user_0", "user_1", "user_2"])
         );
     }
@@ -2625,15 +2625,15 @@ mod tests {
     fn test_rng() {
         // Note: these tests are heavily dependent on the default seed.
         let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
-        let mut gen = array::rand::<Int32Type>();
+        let mut genn = array::rand::<Int32Type>();
         assert_eq!(
-            *gen.generate(RowCount::from(3), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(3), &mut rng).unwrap(),
             Int32Array::from_iter([-797553329, 1369325940, -69174021])
         );
 
-        let mut gen = array::rand_fixedbin(ByteCount::from(3), false);
+        let mut genn = array::rand_fixedbin(ByteCount::from(3), false);
         assert_eq!(
-            *gen.generate(RowCount::from(3), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(3), &mut rng).unwrap(),
             arrow_array::BinaryArray::from_iter_values([
                 [184, 53, 216],
                 [12, 96, 159],
@@ -2641,14 +2641,14 @@ mod tests {
             ])
         );
 
-        let mut gen = array::rand_utf8(ByteCount::from(3), false);
+        let mut genn = array::rand_utf8(ByteCount::from(3), false);
         assert_eq!(
-            *gen.generate(RowCount::from(3), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(3), &mut rng).unwrap(),
             arrow_array::StringArray::from_iter_values([">@p", "n `", "NWa"])
         );
 
-        let mut gen = array::random_sentence(1, 5, false);
-        let words = gen.generate(RowCount::from(10), &mut rng).unwrap();
+        let mut genn = array::random_sentence(1, 5, false);
+        let words = genn.generate(RowCount::from(10), &mut rng).unwrap();
         assert_eq!(words.data_type(), &DataType::Utf8);
         let words_array = words.as_any().downcast_ref::<StringArray>().unwrap();
         // Verify each string contains 1-5 words
@@ -2658,29 +2658,29 @@ mod tests {
             assert!((1..=5).contains(&word_count));
         }
 
-        let mut gen = array::rand_date32();
-        let days_32 = gen.generate(RowCount::from(3), &mut rng).unwrap();
+        let mut genn = array::rand_date32();
+        let days_32 = genn.generate(RowCount::from(3), &mut rng).unwrap();
         assert_eq!(days_32.data_type(), &DataType::Date32);
 
-        let mut gen = array::rand_date64();
-        let days_64 = gen.generate(RowCount::from(3), &mut rng).unwrap();
+        let mut genn = array::rand_date64();
+        let days_64 = genn.generate(RowCount::from(3), &mut rng).unwrap();
         assert_eq!(days_64.data_type(), &DataType::Date64);
 
-        let mut gen = array::rand_boolean();
-        let bools = gen.generate(RowCount::from(1024), &mut rng).unwrap();
+        let mut genn = array::rand_boolean();
+        let bools = genn.generate(RowCount::from(1024), &mut rng).unwrap();
         assert_eq!(bools.data_type(), &DataType::Boolean);
         let bools = bools.as_any().downcast_ref::<BooleanArray>().unwrap();
         // Sanity check to ensure we're getting at least some rng
         assert!(bools.false_count() > 100);
         assert!(bools.true_count() > 100);
 
-        let mut gen = array::rand_varbin(ByteCount::from(2), ByteCount::from(4));
+        let mut genn = array::rand_varbin(ByteCount::from(2), ByteCount::from(4));
         assert_eq!(
-            *gen.generate(RowCount::from(3), &mut rng).unwrap(),
+            *genn.generate(RowCount::from(3), &mut rng).unwrap(),
             arrow_array::BinaryArray::from_iter_values([
-                vec![211, 239],
-                vec![126, 73, 74, 131],
-                vec![145, 222]
+                vec![234, 107],
+                vec![220, 152],
+                vec![21, 16, 184, 220]
             ])
         );
     }
@@ -2689,8 +2689,8 @@ mod tests {
     fn test_rng_list() {
         // Note: these tests are heavily dependent on the default seed.
         let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
-        let mut gen = array::rand_list(&DataType::Int32, false);
-        let arr = gen.generate(RowCount::from(100), &mut rng).unwrap();
+        let mut genn = array::rand_list(&DataType::Int32, false);
+        let arr = genn.generate(RowCount::from(100), &mut rng).unwrap();
         // Make sure we can generate empty lists (note, test is dependent on seed)
         let arr = arr.as_list::<i32>();
         assert!(arr.iter().any(|l| l.unwrap().is_empty()));
@@ -2704,9 +2704,9 @@ mod tests {
         // We generates some 4-byte integers, histogram them into 8 buckets, and make
         // sure each bucket has a good # of values
         let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
-        let mut gen = array::rand::<UInt32Type>();
+        let mut genn = array::rand::<UInt32Type>();
         for _ in 0..10 {
-            let arr = gen.generate(RowCount::from(10000), &mut rng).unwrap();
+            let arr = genn.generate(RowCount::from(10000), &mut rng).unwrap();
             let int_arr = arr.as_any().downcast_ref::<UInt32Array>().unwrap();
             let mut buckets = vec![0_u32; 256];
             for val in int_arr.values() {
@@ -2723,15 +2723,15 @@ mod tests {
     #[test]
     fn test_nulls() {
         let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
-        let mut gen = array::rand::<Int32Type>().with_random_nulls(0.3);
+        let mut genn = array::rand::<Int32Type>().with_random_nulls(0.3);
 
-        let arr = gen.generate(RowCount::from(1000), &mut rng).unwrap();
+        let arr = genn.generate(RowCount::from(1000), &mut rng).unwrap();
 
         // This assert depends on the default seed
         assert_eq!(arr.null_count(), 297);
 
         for len in 0..100 {
-            let arr = gen.generate(RowCount::from(len), &mut rng).unwrap();
+            let arr = genn.generate(RowCount::from(len), &mut rng).unwrap();
             // Make sure the null count we came up with matches the actual # of unset bits
             assert_eq!(
                 arr.null_count(),
@@ -2742,19 +2742,19 @@ mod tests {
             );
         }
 
-        let mut gen = array::rand::<Int32Type>().with_random_nulls(0.0);
-        let arr = gen.generate(RowCount::from(10), &mut rng).unwrap();
+        let mut genn = array::rand::<Int32Type>().with_random_nulls(0.0);
+        let arr = genn.generate(RowCount::from(10), &mut rng).unwrap();
 
         assert_eq!(arr.null_count(), 0);
 
-        let mut gen = array::rand::<Int32Type>().with_random_nulls(1.0);
-        let arr = gen.generate(RowCount::from(10), &mut rng).unwrap();
+        let mut genn = array::rand::<Int32Type>().with_random_nulls(1.0);
+        let arr = genn.generate(RowCount::from(10), &mut rng).unwrap();
 
         assert_eq!(arr.null_count(), 10);
         assert!((0..10).all(|idx| arr.is_null(idx)));
 
-        let mut gen = array::rand::<Int32Type>().with_nulls(&[false, false, true]);
-        let arr = gen.generate(RowCount::from(7), &mut rng).unwrap();
+        let mut genn = array::rand::<Int32Type>().with_nulls(&[false, false, true]);
+        let arr = genn.generate(RowCount::from(7), &mut rng).unwrap();
         assert!((0..2).all(|idx| arr.is_valid(idx)));
         assert!(arr.is_null(2));
         assert!((3..5).all(|idx| arr.is_valid(idx)));
@@ -2765,8 +2765,8 @@ mod tests {
     #[test]
     fn test_unit_circle() {
         let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
-        let mut gen = array::cycle_unit_circle(4);
-        let arr = gen.generate(RowCount::from(6), &mut rng).unwrap();
+        let mut genn = array::cycle_unit_circle(4);
+        let arr = genn.generate(RowCount::from(6), &mut rng).unwrap();
 
         let arr_values = arr
             .as_fixed_size_list()

--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -20,7 +20,7 @@ use arrow_array::{
 };
 use arrow_schema::{ArrowError, DataType, Field, Fields, IntervalUnit, Schema, SchemaRef};
 use futures::{stream::BoxStream, StreamExt};
-use rand::{distributions::Uniform, Rng, RngCore, SeedableRng};
+use rand::{distr::Uniform, Rng, RngCore, SeedableRng};
 use random_word;
 
 use self::array::rand_with_distribution;
@@ -233,7 +233,7 @@ impl ArrayGenerator for NullGenerator {
             let threshold = (self.null_probability * u8::MAX as f64) as u8;
             let bytes = (0..num_validity_bytes)
                 .map(|byte_idx| {
-                    let mut sample = rng.gen::<u64>();
+                    let mut sample = rng.random::<u64>();
                     let mut byte: u8 = 0;
                     for bit_idx in 0..8 {
                         // We could probably overshoot and fill in extra bits with random data but
@@ -534,7 +534,7 @@ impl CycleListGenerator {
             underlying_gen.data_type().clone(),
             true,
         )));
-        let lengths_dist = Uniform::new(min_list_size.0, max_list_size.0);
+        let lengths_dist = Uniform::new(min_list_size.0, max_list_size.0).unwrap();
         let lengths_gen = rand_with_distribution::<UInt32Type, Uniform<u32>>(lengths_dist);
         Self {
             underlying_gen,
@@ -772,12 +772,14 @@ impl ArrayGenerator for RandomIntervalGenerator {
     ) -> Result<Arc<dyn arrow_array::Array>, ArrowError> {
         match self.unit {
             IntervalUnit::YearMonth => {
-                let months = (0..length.0).map(|_| rng.gen::<i32>()).collect::<Vec<_>>();
+                let months = (0..length.0)
+                    .map(|_| rng.random::<i32>())
+                    .collect::<Vec<_>>();
                 Ok(Arc::new(arrow_array::IntervalYearMonthArray::from(months)))
             }
             IntervalUnit::MonthDayNano => {
                 let day_time_array = (0..length.0)
-                    .map(|_| IntervalMonthDayNano::new(rng.gen(), rng.gen(), rng.gen()))
+                    .map(|_| IntervalMonthDayNano::new(rng.random(), rng.random(), rng.random()))
                     .collect::<Vec<_>>();
                 Ok(Arc::new(arrow_array::IntervalMonthDayNanoArray::from(
                     day_time_array,
@@ -785,7 +787,7 @@ impl ArrayGenerator for RandomIntervalGenerator {
             }
             IntervalUnit::DayTime => {
                 let day_time_array = (0..length.0)
-                    .map(|_| IntervalDayTime::new(rng.gen(), rng.gen()))
+                    .map(|_| IntervalDayTime::new(rng.random(), rng.random()))
                     .collect::<Vec<_>>();
                 Ok(Arc::new(arrow_array::IntervalDayTimeArray::from(
                     day_time_array,
@@ -995,9 +997,9 @@ impl ArrayGenerator for RandomSentenceGenerator {
         let mut values = Vec::with_capacity(length.0 as usize);
 
         for _ in 0..length.0 {
-            let num_words = rng.gen_range(self.min_words..=self.max_words);
+            let num_words = rng.random_range(self.min_words..=self.max_words);
             let sentence: String = (0..num_words)
-                .map(|_| self.words[rng.gen_range(0..self.words.len())])
+                .map(|_| self.words[rng.random_range(0..self.words.len())])
                 .collect::<Vec<_>>()
                 .join(" ");
             values.push(sentence);
@@ -1049,7 +1051,7 @@ impl ArrayGenerator for RandomWordGenerator {
         let mut values = Vec::with_capacity(length.0 as usize);
 
         for _ in 0..length.0 {
-            let word = self.words[rng.gen_range(0..self.words.len())];
+            let word = self.words[rng.random_range(0..self.words.len())];
             values.push(word.to_string());
         }
 
@@ -1085,7 +1087,8 @@ impl VariableRandomBinaryGenerator {
         let lengths_dist = Uniform::new_inclusive(
             min_bytes_per_element.0 as i32,
             max_bytes_per_element.0 as i32,
-        );
+        )
+        .unwrap();
         let lengths_gen = rand_with_distribution::<Int32Type, Uniform<i32>>(lengths_dist);
 
         Self {
@@ -1343,10 +1346,10 @@ impl RandomListGenerator {
         };
         let field = Field::new("", list_type, true);
         let lengths_gen = if is_large {
-            let lengths_dist = Uniform::new_inclusive(0, 10);
+            let lengths_dist = Uniform::new_inclusive(0, 10).unwrap();
             rand_with_distribution::<Int64Type, Uniform<i64>>(lengths_dist)
         } else {
-            let lengths_dist = Uniform::new_inclusive(0, 10);
+            let lengths_dist = Uniform::new_inclusive(0, 10).unwrap();
             rand_with_distribution::<Int32Type, Uniform<i32>>(lengths_dist)
         };
         Self {
@@ -1524,7 +1527,7 @@ impl ArrayGenerator for JitterCentroidsGenerator {
         for _ in 0..length.0 {
             // Generate random N dimensional point
             let mut noise = (0..self.dimension as usize)
-                .map(|_| rng.gen::<f32>())
+                .map(|_| rng.random::<f32>())
                 .collect::<Vec<_>>();
             // Scale point to noise_level length
             let scale = self.noise_level / noise.iter().map(|v| v * v).sum::<f32>().sqrt();
@@ -2053,12 +2056,12 @@ pub mod array {
         DataType::Native: Copy + 'static,
         PrimitiveArray<DataType>: From<Vec<DataType::Native>> + 'static,
         DataType: ArrowPrimitiveType,
-        rand::distributions::Standard: rand::distributions::Distribution<DataType::Native>,
+        rand::distr::StandardUniform: rand::distr::Distribution<DataType::Native>,
     {
         Box::new(
             FnGen::<DataType::Native, PrimitiveArray<DataType>, _>::new_known_size(
                 DataType::DATA_TYPE,
-                move |rng| rng.gen(),
+                move |rng| rng.random(),
                 1,
                 DataType::DATA_TYPE
                     .primitive_width()
@@ -2071,7 +2074,7 @@ pub mod array {
     /// Create a generator of primitive values that are randomly sampled from the entire range available for the value
     pub fn rand_with_distribution<
         DataType,
-        Dist: rand::distributions::Distribution<DataType::Native> + Clone + Send + Sync + 'static,
+        Dist: rand::distr::Distribution<DataType::Native> + Clone + Send + Sync + 'static,
     >(
         dist: Dist,
     ) -> Box<dyn ArrayGenerator>
@@ -2099,7 +2102,7 @@ pub mod array {
         DataType::Native: Copy + 'static,
         PrimitiveArray<DataType>: From<Vec<DataType::Native>> + 'static,
         DataType: ArrowPrimitiveType,
-        rand::distributions::Standard: rand::distributions::Distribution<DataType::Native>,
+        rand::distr::StandardUniform: rand::distr::Distribution<DataType::Native>,
     {
         let underlying = rand::<DataType>();
         cycle_vec(underlying, dimension)
@@ -2117,7 +2120,7 @@ pub mod array {
 
         let data_type = DataType::Time32(*resolution);
         let size = ByteCount::from(data_type.primitive_width().unwrap() as u64);
-        let dist = Uniform::new(start, end);
+        let dist = Uniform::new(start, end).unwrap();
         let sample_fn = move |rng: &mut _| dist.sample(rng);
 
         match resolution {
@@ -2145,7 +2148,7 @@ pub mod array {
 
         let data_type = DataType::Time64(*resolution);
         let size = ByteCount::from(data_type.primitive_width().unwrap() as u64);
-        let dist = Uniform::new(start, end);
+        let dist = Uniform::new(start, end).unwrap();
         let sample_fn = move |rng: &mut _| dist.sample(rng);
 
         match resolution {
@@ -2216,7 +2219,7 @@ pub mod array {
         let end_days = (end_ms / MS_PER_DAY) as i32;
         let start_ms = start.timestamp_millis();
         let start_days = (start_ms / MS_PER_DAY) as i32;
-        let dist = Uniform::new(start_days, end_days);
+        let dist = Uniform::new(start_days, end_days).unwrap();
 
         Box::new(FnGen::<i32, Date32Array, _>::new_known_size(
             data_type,
@@ -2258,7 +2261,7 @@ pub mod array {
             DataType::Timestamp(TimeUnit::Second, _) => (start.timestamp(), end.timestamp()),
             _ => panic!(),
         };
-        let dist = Uniform::new(start_ticks, end_ticks);
+        let dist = Uniform::new(start_ticks, end_ticks).unwrap();
 
         let data_type = data_type.clone();
         let sample_fn = move |rng: &mut _| (dist.sample(rng));
@@ -2311,7 +2314,7 @@ pub mod array {
         let end_days = end_ms / MS_PER_DAY;
         let start_ms = start.timestamp_millis();
         let start_days = start_ms / MS_PER_DAY;
-        let dist = Uniform::new(start_days, end_days);
+        let dist = Uniform::new(start_days, end_days).unwrap();
 
         Box::new(FnGen::<i64, Date64Array, _>::new_known_size(
             data_type,

--- a/rust/lance-encoding/Cargo.toml
+++ b/rust/lance-encoding/Cargo.toml
@@ -53,7 +53,7 @@ rstest.workspace = true
 tempfile.workspace = true
 test-log.workspace = true
 criterion = { workspace = true }
-rand_xoshiro = "0.6.0"
+rand_xoshiro = { workspace = true }
 
 [build-dependencies]
 prost-build.workspace = true

--- a/rust/lance-encoding/benches/decoder.rs
+++ b/rust/lance-encoding/benches/decoder.rs
@@ -182,8 +182,8 @@ fn bench_decode_str_with_dict_encoding(c: &mut Criterion) {
         let string_array = string_data.column(0);
 
         // generate random int column with 100000 rows
-        let mut rng = rand::thread_rng();
-        let integer_arr: Vec<u32> = (0..100_000).map(|_| rng.gen_range(0..20)).collect();
+        let mut rng = rand::rng();
+        let integer_arr: Vec<u32> = (0..100_000).map(|_| rng.random_range(0..20)).collect();
         let integer_array = UInt32Array::from(integer_arr);
 
         let mapped_strings = take(string_array, &integer_array, None).unwrap();

--- a/rust/lance-encoding/benches/decoder.rs
+++ b/rust/lance-encoding/benches/decoder.rs
@@ -61,7 +61,7 @@ fn bench_decode(c: &mut Criterion) {
         let func_name = format!("{:?}", data_type).to_lowercase();
         let num_rows = NUM_BYTES / data_type.primitive_width().unwrap() as u64;
         group.bench_function(func_name, |b| {
-            let data = lance_datagen::gen()
+            let data = lance_datagen::gen_batch()
                 .anon_col(lance_datagen::array::rand_type(data_type))
                 .into_batch_rows(lance_datagen::RowCount::from(num_rows))
                 .unwrap();
@@ -124,7 +124,7 @@ fn bench_decode_fsl(c: &mut Criterion) {
                         if *nullable {
                             arraygen = arraygen.with_random_nulls(0.5);
                         }
-                        let data = lance_datagen::gen()
+                        let data = lance_datagen::gen_batch()
                             .anon_col(arraygen)
                             .into_batch_rows(lance_datagen::RowCount::from(num_rows))
                             .unwrap();
@@ -168,7 +168,7 @@ fn bench_decode_str_with_dict_encoding(c: &mut Criterion) {
 
     let data_type = DataType::Utf8;
     // generate string column with 20 rows
-    let string_data = lance_datagen::gen()
+    let string_data = lance_datagen::gen_batch()
         .anon_col(lance_datagen::array::rand_type(&DataType::Utf8))
         .into_batch_rows(lance_datagen::RowCount::from(20))
         .unwrap();
@@ -246,7 +246,7 @@ fn bench_decode_packed_struct(c: &mut Criterion) {
         .into();
 
         // generate struct column with 1M rows
-        let data = lance_datagen::gen()
+        let data = lance_datagen::gen_batch()
             .anon_col(lance_datagen::array::rand_type(&DataType::Struct(fields)))
             .into_batch_rows(lance_datagen::RowCount::from(NUM_ROWS))
             .unwrap();
@@ -315,7 +315,7 @@ fn bench_decode_str_with_fixed_size_binary_encoding(c: &mut Criterion) {
         // generate string column with 10k rows
         // Currently the generator generates fixed size strings by default
         // This function will need to be updated once that changes.
-        let string_data = lance_datagen::gen()
+        let string_data = lance_datagen::gen_batch()
             .anon_col(lance_datagen::array::rand_type(&DataType::Utf8))
             .into_batch_rows(lance_datagen::RowCount::from(10000))
             .unwrap();

--- a/rust/lance-encoding/src/compression_algo/fsst/Cargo.toml
+++ b/rust/lance-encoding/src/compression_algo/fsst/Cargo.toml
@@ -20,7 +20,7 @@ rand.workspace = true
 arrow-array.workspace = true
 test-log.workspace = true
 tokio.workspace = true
-rand_xoshiro = "0.6.0"
+rand_xoshiro = { workspace = true }
 lance-datagen = { workspace = true }
 
 [[example]]

--- a/rust/lance-encoding/src/compression_algo/fsst/examples/benchmark.rs
+++ b/rust/lance-encoding/src/compression_algo/fsst/examples/benchmark.rs
@@ -18,8 +18,8 @@ fn read_random_8_m_chunk(file_path: &str) -> Result<StringArray, std::io::Error>
     let lines: Vec<String> = reader.lines().collect::<std::result::Result<_, _>>()?;
     let num_lines = lines.len();
 
-    let mut rng = rand::thread_rng();
-    let mut curr_line = rng.gen_range(0..num_lines);
+    let mut rng = rand::rng();
+    let mut curr_line = rng.random_range(0..num_lines);
 
     let chunk_size = BUFFER_SIZE;
     let mut size = 0;

--- a/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
+++ b/rust/lance-encoding/src/compression_algo/fsst/src/fsst.rs
@@ -47,8 +47,7 @@ pub const FSST_SYMBOL_TABLE_SIZE: usize = 8 + 256 * 8 + 256; // 8 bytes for the 
 
 use arrow_array::OffsetSizeTrait;
 use rand::rngs::StdRng;
-use rand::Rng;
-use rand::SeedableRng;
+use rand::{Rng, SeedableRng};
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::collections::HashSet;
@@ -539,9 +538,9 @@ fn make_sample<T: OffsetSizeTrait>(in_buf: &[u8], offsets: &[T]) -> (Vec<u8>, Ve
     let mut sample_offsets: Vec<T> = Vec::new();
 
     sample_offsets.push(T::from_usize(0).unwrap());
-    let mut rng = StdRng::from_entropy();
+    let mut rng = StdRng::from_os_rng();
     while sample_buf.len() < FSST_SAMPLETARGET {
-        let rand_num = rng.gen_range(0..offsets.len()) % (offsets.len() - 1);
+        let rand_num = rng.random_range(0..offsets.len()) % (offsets.len() - 1);
         sample_buf.extend_from_slice(
             &in_buf[offsets[rand_num].as_usize()..offsets[rand_num + 1].as_usize()],
         );

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -2023,19 +2023,19 @@ mod tests {
     fn test_data_size() {
         let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
         // test data_size() when input has no nulls
-        let mut gen = array::rand::<Int32Type>().with_nulls(&[false, false, false]);
+        let mut genn = array::rand::<Int32Type>().with_nulls(&[false, false, false]);
 
-        let arr = gen.generate(RowCount::from(3), &mut rng).unwrap();
+        let arr = genn.generate(RowCount::from(3), &mut rng).unwrap();
         let block = DataBlock::from_array(arr.clone());
         assert!(block.data_size() == arr.get_buffer_memory_size() as u64);
 
-        let arr = gen.generate(RowCount::from(400), &mut rng).unwrap();
+        let arr = genn.generate(RowCount::from(400), &mut rng).unwrap();
         let block = DataBlock::from_array(arr.clone());
         assert!(block.data_size() == arr.get_buffer_memory_size() as u64);
 
         // test data_size() when input has nulls
-        let mut gen = array::rand::<Int32Type>().with_nulls(&[false, true, false]);
-        let arr = gen.generate(RowCount::from(3), &mut rng).unwrap();
+        let mut genn = array::rand::<Int32Type>().with_nulls(&[false, true, false]);
+        let arr = genn.generate(RowCount::from(3), &mut rng).unwrap();
         let block = DataBlock::from_array(arr.clone());
 
         let array_data = arr.to_data();
@@ -2044,7 +2044,7 @@ mod tests {
         let array_nulls_size_in_bytes = arr.nulls().unwrap().len().div_ceil(8);
         assert!(block.data_size() == (total_buffer_size + array_nulls_size_in_bytes) as u64);
 
-        let arr = gen.generate(RowCount::from(400), &mut rng).unwrap();
+        let arr = genn.generate(RowCount::from(400), &mut rng).unwrap();
         let block = DataBlock::from_array(arr.clone());
 
         let array_data = arr.to_data();
@@ -2052,8 +2052,8 @@ mod tests {
         let array_nulls_size_in_bytes = arr.nulls().unwrap().len().div_ceil(8);
         assert!(block.data_size() == (total_buffer_size + array_nulls_size_in_bytes) as u64);
 
-        let mut gen = array::rand::<Int32Type>().with_nulls(&[true, true, false]);
-        let arr = gen.generate(RowCount::from(3), &mut rng).unwrap();
+        let mut genn = array::rand::<Int32Type>().with_nulls(&[true, true, false]);
+        let arr = genn.generate(RowCount::from(3), &mut rng).unwrap();
         let block = DataBlock::from_array(arr.clone());
 
         let array_data = arr.to_data();
@@ -2061,7 +2061,7 @@ mod tests {
         let array_nulls_size_in_bytes = arr.nulls().unwrap().len().div_ceil(8);
         assert!(block.data_size() == (total_buffer_size + array_nulls_size_in_bytes) as u64);
 
-        let arr = gen.generate(RowCount::from(400), &mut rng).unwrap();
+        let arr = genn.generate(RowCount::from(400), &mut rng).unwrap();
         let block = DataBlock::from_array(arr.clone());
 
         let array_data = arr.to_data();
@@ -2069,10 +2069,10 @@ mod tests {
         let array_nulls_size_in_bytes = arr.nulls().unwrap().len().div_ceil(8);
         assert!(block.data_size() == (total_buffer_size + array_nulls_size_in_bytes) as u64);
 
-        let mut gen = array::rand::<Int32Type>().with_nulls(&[false, true, false]);
-        let arr1 = gen.generate(RowCount::from(3), &mut rng).unwrap();
-        let arr2 = gen.generate(RowCount::from(3), &mut rng).unwrap();
-        let arr3 = gen.generate(RowCount::from(3), &mut rng).unwrap();
+        let mut genn = array::rand::<Int32Type>().with_nulls(&[false, true, false]);
+        let arr1 = genn.generate(RowCount::from(3), &mut rng).unwrap();
+        let arr2 = genn.generate(RowCount::from(3), &mut rng).unwrap();
+        let arr3 = genn.generate(RowCount::from(3), &mut rng).unwrap();
         let block = DataBlock::from_arrays(&[arr1.clone(), arr2.clone(), arr3.clone()], 9);
 
         let concatenated_array = concat(&[

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -782,7 +782,7 @@ pub mod tests {
 
         // Test both automatic selection and explicit configuration
         // 1. Test automatic binary encoding selection (small strings that won't trigger FSST)
-        let arr_small = lance_datagen::gen()
+        let arr_small = lance_datagen::gen_batch()
             .anon_col(lance_datagen::array::rand_utf8(ByteCount::from(10), false))
             .into_batch_rows(RowCount::from(1000))
             .unwrap()
@@ -793,7 +793,7 @@ pub mod tests {
         // 2. Test explicit "none" compression to force binary encoding
         let metadata_explicit =
             HashMap::from([("lance-encoding:compression".to_string(), "none".to_string())]);
-        let arr_large = lance_datagen::gen()
+        let arr_large = lance_datagen::gen_batch()
             .anon_col(lance_datagen::array::rand_utf8(ByteCount::from(50), false))
             .into_batch_rows(RowCount::from(2000))
             .unwrap()

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -384,7 +384,7 @@ mod tests {
             .with_file_version(LanceFileVersion::V2_1);
 
         // Generate data suitable for FSST (large strings, total size > 32KB)
-        let arr = lance_datagen::gen()
+        let arr = lance_datagen::gen_batch()
             .anon_col(lance_datagen::array::rand_utf8(ByteCount::from(100), false))
             .into_batch_rows(RowCount::from(5000))
             .unwrap()

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -743,7 +743,7 @@ pub(crate) mod tests {
     };
     use arrow_buffer::{BooleanBuffer, NullBuffer};
     use arrow_schema::{DataType, Field, TimeUnit};
-    use lance_datagen::{array, gen, ArrayGeneratorExt, Dimension, RowCount};
+    use lance_datagen::{array, gen_batch, ArrayGeneratorExt, Dimension, RowCount};
     use rstest::rstest;
 
     use crate::{
@@ -1020,7 +1020,7 @@ pub(crate) mod tests {
         let list_three = array::cycle_vec(list_two, Dimension::from(2));
 
         // Should be 256Ki rows ~ 1MiB of data
-        let batch = gen()
+        let batch = gen_batch()
             .anon_col(list_three)
             .into_batch_rows(RowCount::from(8 * 1024))
             .unwrap();

--- a/rust/lance-encoding/src/previous/encodings/physical/bitpack.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/bitpack.rs
@@ -1170,14 +1170,14 @@ pub mod test {
     use arrow_schema::Field;
     use lance_datagen::{
         array::{fill, rand_with_distribution},
-        gen, ArrayGenerator, ArrayGeneratorExt, RowCount,
+        gen_batch, ArrayGenerator, ArrayGeneratorExt, RowCount,
     };
     use rand::distr::Uniform;
 
     #[test]
     fn test_bitpack_params() {
         fn gen_array(generator: Box<dyn ArrayGenerator>) -> ArrayRef {
-            let arr = gen()
+            let arr = gen_batch()
                 .anon_col(generator)
                 .into_batch_rows(RowCount::from(10000))
                 .unwrap()

--- a/rust/lance-encoding/src/previous/encodings/physical/bitpack.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/bitpack.rs
@@ -1172,7 +1172,7 @@ pub mod test {
         array::{fill, rand_with_distribution},
         gen, ArrayGenerator, ArrayGeneratorExt, RowCount,
     };
-    use rand::distributions::Uniform;
+    use rand::distr::Uniform;
 
     #[test]
     fn test_bitpack_params() {
@@ -1471,7 +1471,7 @@ pub mod test {
 
     struct DistributionArrayGeneratorProvider<
         DataType,
-        Dist: rand::distributions::Distribution<DataType::Native> + Clone + Send + Sync + 'static,
+        Dist: rand::distr::Distribution<DataType::Native> + Clone + Send + Sync + 'static,
     >
     where
         DataType::Native: Copy + 'static,
@@ -1484,7 +1484,7 @@ pub mod test {
 
     impl<DataType, Dist> DistributionArrayGeneratorProvider<DataType, Dist>
     where
-        Dist: rand::distributions::Distribution<DataType::Native> + Clone + Send + Sync + 'static,
+        Dist: rand::distr::Distribution<DataType::Native> + Clone + Send + Sync + 'static,
         DataType::Native: Copy + 'static,
         PrimitiveArray<DataType>: From<Vec<DataType::Native>> + 'static,
         DataType: ArrowPrimitiveType,
@@ -1499,7 +1499,7 @@ pub mod test {
 
     impl<DataType, Dist> ArrayGeneratorProvider for DistributionArrayGeneratorProvider<DataType, Dist>
     where
-        Dist: rand::distributions::Distribution<DataType::Native> + Clone + Send + Sync + 'static,
+        Dist: rand::distr::Distribution<DataType::Native> + Clone + Send + Sync + 'static,
         DataType::Native: Copy + 'static,
         PrimitiveArray<DataType>: From<Vec<DataType::Native>> + 'static,
         DataType: ArrowPrimitiveType,
@@ -1524,7 +1524,7 @@ pub mod test {
                 DataType::UInt32,
                 Box::new(
                     DistributionArrayGeneratorProvider::<UInt32Type, Uniform<u32>>::new(
-                        Uniform::new(0, 19),
+                        Uniform::new(0, 19).unwrap(),
                     ),
                 ),
             ),
@@ -1533,7 +1533,7 @@ pub mod test {
                 DataType::UInt32,
                 Box::new(
                     DistributionArrayGeneratorProvider::<UInt32Type, Uniform<u32>>::new(
-                        Uniform::new(5 << 7, 6 << 7),
+                        Uniform::new(5 << 7, 6 << 7).unwrap(),
                     ),
                 ),
             ),
@@ -1541,7 +1541,7 @@ pub mod test {
                 DataType::UInt64,
                 Box::new(
                     DistributionArrayGeneratorProvider::<UInt64Type, Uniform<u64>>::new(
-                        Uniform::new(5 << 42, 6 << 42),
+                        Uniform::new(5 << 42, 6 << 42).unwrap(),
                     ),
                 ),
             ),
@@ -1550,7 +1550,7 @@ pub mod test {
                 DataType::UInt8,
                 Box::new(
                     DistributionArrayGeneratorProvider::<UInt8Type, Uniform<u8>>::new(
-                        Uniform::new(0, 19),
+                        Uniform::new(0, 19).unwrap(),
                     ),
                 ),
             ),
@@ -1559,7 +1559,7 @@ pub mod test {
                 DataType::UInt64,
                 Box::new(
                     DistributionArrayGeneratorProvider::<UInt64Type, Uniform<u64>>::new(
-                        Uniform::new(129, 259),
+                        Uniform::new(129, 259).unwrap(),
                     ),
                 ),
             ),
@@ -1569,7 +1569,7 @@ pub mod test {
                 Box::new(
                     DistributionArrayGeneratorProvider::<UInt32Type, Uniform<u32>>::new(
                         // this range should always give 8 bits
-                        Uniform::new(200, 250),
+                        Uniform::new(200, 250).unwrap(),
                     ),
                 ),
             ),
@@ -1578,7 +1578,7 @@ pub mod test {
                 DataType::UInt64,
                 Box::new(
                     DistributionArrayGeneratorProvider::<UInt64Type, Uniform<u64>>::new(
-                        Uniform::new(1, 3), // 2 bits
+                        Uniform::new(1, 3).unwrap(), // 2 bits
                     ),
                 ),
             ),
@@ -1588,7 +1588,7 @@ pub mod test {
                 Box::new(
                     DistributionArrayGeneratorProvider::<UInt32Type, Uniform<u32>>::new(
                         // this range should always always give 16 bits
-                        Uniform::new(200 << 8, 250 << 8),
+                        Uniform::new(200 << 8, 250 << 8).unwrap(),
                     ),
                 ),
             ),
@@ -1598,7 +1598,7 @@ pub mod test {
                 Box::new(
                     DistributionArrayGeneratorProvider::<UInt64Type, Uniform<u64>>::new(
                         // this range should always give 24 hits
-                        Uniform::new(200 << 16, 250 << 16),
+                        Uniform::new(200 << 16, 250 << 16).unwrap(),
                     ),
                 ),
             ),
@@ -1607,7 +1607,7 @@ pub mod test {
                 DataType::UInt32,
                 Box::new(
                     DistributionArrayGeneratorProvider::<UInt32Type, Uniform<u32>>::new(
-                        Uniform::new(0, 1),
+                        Uniform::new(0, 1).unwrap(),
                     ),
                 ),
             ),
@@ -1616,7 +1616,7 @@ pub mod test {
                 DataType::Int16,
                 Box::new(
                     DistributionArrayGeneratorProvider::<Int16Type, Uniform<i16>>::new(
-                        Uniform::new(-5, 5),
+                        Uniform::new(-5, 5).unwrap(),
                     ),
                 ),
             ),
@@ -1624,7 +1624,7 @@ pub mod test {
                 DataType::Int64,
                 Box::new(
                     DistributionArrayGeneratorProvider::<Int64Type, Uniform<i64>>::new(
-                        Uniform::new(-(5 << 42), 6 << 42),
+                        Uniform::new(-(5 << 42), 6 << 42).unwrap(),
                     ),
                 ),
             ),
@@ -1632,7 +1632,7 @@ pub mod test {
                 DataType::Int32,
                 Box::new(
                     DistributionArrayGeneratorProvider::<Int32Type, Uniform<i32>>::new(
-                        Uniform::new(-(5 << 7), 6 << 7),
+                        Uniform::new(-(5 << 7), 6 << 7).unwrap(),
                     ),
                 ),
             ),
@@ -1641,7 +1641,7 @@ pub mod test {
                 DataType::Int32,
                 Box::new(
                     DistributionArrayGeneratorProvider::<Int32Type, Uniform<i32>>::new(
-                        Uniform::new(-19, 19),
+                        Uniform::new(-19, 19).unwrap(),
                     ),
                 ),
             ),
@@ -1651,7 +1651,7 @@ pub mod test {
                 Box::new(
                     DistributionArrayGeneratorProvider::<Int32Type, Uniform<i32>>::new(
                         // this range should always give 8 bits
-                        Uniform::new(-120, 120),
+                        Uniform::new(-120, 120).unwrap(),
                     ),
                 ),
             ),
@@ -1661,7 +1661,7 @@ pub mod test {
                 Box::new(
                     DistributionArrayGeneratorProvider::<Int32Type, Uniform<i32>>::new(
                         // this range should always give 16 bits
-                        Uniform::new(-120 << 8, 120 << 8),
+                        Uniform::new(-120 << 8, 120 << 8).unwrap(),
                     ),
                 ),
             ),
@@ -1670,7 +1670,7 @@ pub mod test {
                 DataType::Int32,
                 Box::new(
                     DistributionArrayGeneratorProvider::<Int32Type, Uniform<i32>>::new(
-                        Uniform::new(10, 20),
+                        Uniform::new(10, 20).unwrap(),
                     ),
                 ),
             ),
@@ -1679,7 +1679,7 @@ pub mod test {
                 DataType::Int32,
                 Box::new(
                     DistributionArrayGeneratorProvider::<Int32Type, Uniform<i32>>::new(
-                        Uniform::new(0, 1),
+                        Uniform::new(0, 1).unwrap(),
                     ),
                 ),
             ),

--- a/rust/lance-encoding/src/statistics.rs
+++ b/rust/lance-encoding/src/statistics.rs
@@ -525,10 +525,10 @@ mod tests {
     #[test]
     fn test_data_size_stat() {
         let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
-        let mut gen = array::rand::<Int32Type>().with_nulls(&[false, false, false]);
-        let arr1 = gen.generate(RowCount::from(3), &mut rng).unwrap();
-        let arr2 = gen.generate(RowCount::from(3), &mut rng).unwrap();
-        let arr3 = gen.generate(RowCount::from(3), &mut rng).unwrap();
+        let mut genn = array::rand::<Int32Type>().with_nulls(&[false, false, false]);
+        let arr1 = genn.generate(RowCount::from(3), &mut rng).unwrap();
+        let arr2 = genn.generate(RowCount::from(3), &mut rng).unwrap();
+        let arr3 = genn.generate(RowCount::from(3), &mut rng).unwrap();
         let block = DataBlock::from_arrays(&[arr1.clone(), arr2.clone(), arr3.clone()], 9);
 
         let concatenated_array = concat(&[
@@ -549,8 +549,8 @@ mod tests {
         assert!(data_size == total_buffer_size as u64);
 
         // test DataType::Binary
-        let mut gen = lance_datagen::array::rand_type(&DataType::Binary);
-        let arr = gen.generate(RowCount::from(3), &mut rng).unwrap();
+        let mut genn = lance_datagen::array::rand_type(&DataType::Binary);
+        let arr = genn.generate(RowCount::from(3), &mut rng).unwrap();
         let block = DataBlock::from_array(arr.clone());
         let data_size = block.expect_single_stat::<UInt64Type>(Stat::DataSize);
 
@@ -569,8 +569,8 @@ mod tests {
         ]
         .into();
 
-        let mut gen = lance_datagen::array::rand_type(&DataType::Struct(fields));
-        let arr = gen.generate(RowCount::from(3), &mut rng).unwrap();
+        let mut genn = lance_datagen::array::rand_type(&DataType::Struct(fields));
+        let arr = genn.generate(RowCount::from(3), &mut rng).unwrap();
         let block = DataBlock::from_array(arr.clone());
         let (_, arr_parts, _) = arr.as_struct().clone().into_parts();
         let total_buffer_size: usize = arr_parts
@@ -587,16 +587,16 @@ mod tests {
         assert!(data_size == total_buffer_size as u64);
 
         // test DataType::Dictionary
-        let mut gen = array::rand_type(&DataType::Dictionary(
+        let mut genn = array::rand_type(&DataType::Dictionary(
             Box::new(DataType::Int32),
             Box::new(DataType::Utf8),
         ));
-        let arr = gen.generate(RowCount::from(3), &mut rng).unwrap();
+        let arr = genn.generate(RowCount::from(3), &mut rng).unwrap();
         let block = DataBlock::from_array(arr.clone());
         assert!(block.get_stat(Stat::DataSize).is_none());
 
-        let mut gen = array::rand::<Int32Type>().with_nulls(&[false, true, false]);
-        let arr = gen.generate(RowCount::from(3), &mut rng).unwrap();
+        let mut genn = array::rand::<Int32Type>().with_nulls(&[false, true, false]);
+        let arr = genn.generate(RowCount::from(3), &mut rng).unwrap();
         let block = DataBlock::from_array(arr.clone());
         let data_size = block.expect_single_stat::<UInt64Type>(Stat::DataSize);
         let total_buffer_size: usize = arr
@@ -966,8 +966,8 @@ mod tests {
     #[test]
     fn test_bit_width_when_none() {
         let mut rng = rand_xoshiro::Xoshiro256PlusPlus::seed_from_u64(DEFAULT_SEED.0);
-        let mut gen = lance_datagen::array::rand_type(&DataType::Binary);
-        let arr = gen.generate(RowCount::from(3), &mut rng).unwrap();
+        let mut genn = lance_datagen::array::rand_type(&DataType::Binary);
+        let arr = genn.generate(RowCount::from(3), &mut rng).unwrap();
         let block = DataBlock::from_array(arr.clone());
         assert!(block.get_stat(Stat::BitWidth).is_none(),);
     }

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -15,7 +15,7 @@ use log::{debug, trace};
 use tokio::sync::mpsc::{self, UnboundedSender};
 
 use lance_core::{cache::LanceCache, utils::bit::pad_bytes, Result};
-use lance_datagen::{array, gen, ArrayGenerator, RowCount, Seed};
+use lance_datagen::{array, gen_batch, ArrayGenerator, RowCount, Seed};
 
 use crate::{
     buffer::LanceBuffer,
@@ -931,7 +931,7 @@ async fn check_round_trip_field_encoding_random(
                 // example, a list array sliced into smaller arrays will have arrays whose
                 // starting offset is not 0.
                 if use_slicing {
-                    let mut generator = gen().anon_col(array_generator_provider.provide());
+                    let mut generator = gen_batch().anon_col(array_generator_provider.provide());
                     if let Some(null_rate) = null_rate {
                         // The null generator is the only generator that already inserts nulls
                         // and attempting to do so again makes arrow-rs grumpy
@@ -951,7 +951,7 @@ async fn check_round_trip_field_encoding_random(
                     }
                 } else {
                     for i in 0..num_ingest_batches {
-                        let mut generator = gen()
+                        let mut generator = gen_batch()
                             .with_seed(Seed::from(i as u64))
                             .anon_col(array_generator_provider.provide());
                         if let Some(null_rate) = null_rate {

--- a/rust/lance-file/benches/reader.rs
+++ b/rust/lance-file/benches/reader.rs
@@ -26,7 +26,7 @@ use rand::seq::SliceRandom;
 fn bench_reader(c: &mut Criterion) {
     for version in [LanceFileVersion::V2_0, LanceFileVersion::V2_1] {
         let mut group = c.benchmark_group(format!("reader_{}", version));
-        let data = lance_datagen::gen()
+        let data = lance_datagen::gen_batch()
             .anon_col(lance_datagen::array::rand_type(&DataType::Int32))
             .into_batch_rows(lance_datagen::RowCount::from(2 * 1024 * 1024))
             .unwrap();
@@ -125,7 +125,7 @@ fn bench_random_access(c: &mut Criterion) {
     const TAKE_SIZE: usize = 100;
     for version in [LanceFileVersion::V2_0, LanceFileVersion::V2_1] {
         let mut group = c.benchmark_group(format!("reader_{}", version));
-        let data = lance_datagen::gen()
+        let data = lance_datagen::gen_batch()
             .anon_col(lance_datagen::array::rand_type(&DataType::Int32).with_random_nulls(0.1))
             .into_batch_rows(lance_datagen::RowCount::from(2 * 1024 * 1024))
             .unwrap();

--- a/rust/lance-file/benches/reader.rs
+++ b/rust/lance-file/benches/reader.rs
@@ -154,7 +154,7 @@ fn bench_random_access(c: &mut Criterion) {
         rt.block_on(writer.finish()).unwrap();
 
         let mut indices = (0..data.num_rows() as u32).collect::<Vec<_>>();
-        indices.partial_shuffle(&mut rand::thread_rng(), TAKE_SIZE);
+        indices.partial_shuffle(&mut rand::rng(), TAKE_SIZE);
         indices.truncate(TAKE_SIZE);
         let indices: UInt32Array = indices.into();
 

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -1533,7 +1533,7 @@ pub mod tests {
     use futures::{prelude::stream::TryStreamExt, StreamExt};
     use lance_arrow::RecordBatchExt;
     use lance_core::{datatypes::Schema, ArrowResult};
-    use lance_datagen::{array, gen, BatchCount, ByteCount, RowCount};
+    use lance_datagen::{array, gen_batch, BatchCount, ByteCount, RowCount};
     use lance_encoding::{
         decoder::{decode_batch, DecodeBatchScheduler, DecoderPlugins, FilterExpression},
         encoder::{default_encoding_strategy, encode_batch, EncodedBatch, EncodingOptions},
@@ -1558,7 +1558,7 @@ pub mod tests {
         ]));
         let categories_type = DataType::List(Arc::new(Field::new("item", DataType::Utf8, true)));
 
-        let mut reader = gen()
+        let mut reader = gen_batch()
             .col("score", array::rand::<Float64Type>())
             .col("location", array::rand_type(&location_type))
             .col("categories", array::rand_type(&categories_type))
@@ -1675,7 +1675,7 @@ pub mod tests {
         // TODO: Add V2_1 (currently fails)
         #[values(LanceFileVersion::V2_0)] version: LanceFileVersion,
     ) {
-        let data = gen()
+        let data = gen_batch()
             .col("x", array::rand::<Int32Type>())
             .col("y", array::rand_utf8(ByteCount::from(16), false))
             .into_batch_rows(RowCount::from(10000))

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -769,7 +769,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Field as ArrowField, Schema, Schema as ArrowSchema};
     use lance_core::cache::LanceCache;
     use lance_core::datatypes::Schema as LanceSchema;
-    use lance_datagen::{array, gen, BatchCount, RowCount};
+    use lance_datagen::{array, gen_batch, BatchCount, RowCount};
     use lance_encoding::compression_config::{CompressionFieldParams, CompressionParams};
     use lance_encoding::decoder::DecoderPlugins;
     use lance_encoding::version::LanceFileVersion;
@@ -786,7 +786,7 @@ mod tests {
         let tmp_path = tmp_path.child("some_file.lance");
         let obj_store = Arc::new(ObjectStore::local());
 
-        let reader = gen()
+        let reader = gen_batch()
             .col("score", array::rand::<Float64Type>())
             .into_reader_rows(RowCount::from(1000), BatchCount::from(10));
 
@@ -814,7 +814,7 @@ mod tests {
         let tmp_path = tmp_path.child("some_file.lance");
         let obj_store = Arc::new(ObjectStore::local());
 
-        let reader = gen()
+        let reader = gen_batch()
             .col("score", array::rand::<Float64Type>())
             .into_reader_rows(RowCount::from(0), BatchCount::from(0));
 

--- a/rust/lance-index/benches/4bitpq_dist_table.rs
+++ b/rust/lance-index/benches/4bitpq_dist_table.rs
@@ -74,7 +74,7 @@ fn compute_distances(c: &mut Criterion) {
     let query = generate_random_array_with_seed::<Float32Type>(DIM, [32; 32]);
 
     let mut rnd = StdRng::from_seed([32; 32]);
-    let code = UInt8Array::from_iter_values(repeat_n(rnd.gen::<u8>(), TOTAL * PQ));
+    let code = UInt8Array::from_iter_values(repeat_n(rnd.random::<u8>(), TOTAL * PQ));
 
     for dt in [DistanceType::L2, DistanceType::Cosine, DistanceType::Dot].iter() {
         let pq = ProductQuantizer::new(

--- a/rust/lance-index/benches/inverted.rs
+++ b/rust/lance-index/benches/inverted.rs
@@ -96,7 +96,7 @@ fn bench_inverted(c: &mut Criterion) {
     c.bench_function(format!("invert_search({TOTAL})").as_str(), |b| {
         b.to_async(&rt).iter(|| async {
             // Pick a random word from our sample
-            let word_idx = rand::random::<usize>() % sample_words.len();
+            let word_idx = rand::random_range(0..sample_words.len());
             black_box(
                 invert_index
                     .bm25_search(

--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -93,7 +93,7 @@ fn bench_ngram(c: &mut Criterion) {
         .unwrap();
     group.bench_function(format!("ngram_search({TOTAL})").as_str(), |b| {
         b.to_async(&rt).iter(|| async {
-            let sample_idx = rand::random::<usize>() % batch.num_rows();
+            let sample_idx = rand::random_range(0..batch.num_rows());
             let sample = batch
                 .column(0)
                 .as_string::<i32>()

--- a/rust/lance-index/benches/pq_dist_table.rs
+++ b/rust/lance-index/benches/pq_dist_table.rs
@@ -72,7 +72,7 @@ fn compute_distances(c: &mut Criterion) {
     let query = generate_random_array_with_seed::<Float32Type>(DIM, [32; 32]);
 
     let mut rnd = StdRng::from_seed([32; 32]);
-    let code = UInt8Array::from_iter_values(repeat_n(rnd.gen::<u8>(), TOTAL * PQ));
+    let code = UInt8Array::from_iter_values(repeat_n(rnd.random::<u8>(), TOTAL * PQ));
 
     for dt in [DistanceType::L2, DistanceType::Cosine, DistanceType::Dot].iter() {
         let pq = ProductQuantizer::new(

--- a/rust/lance-index/benches/sq.rs
+++ b/rust/lance-index/benches/sq.rs
@@ -21,10 +21,10 @@ use pprof::criterion::{Output, PProfProfiler};
 use rand::prelude::*;
 
 fn create_full_batch(range: Range<u64>, dim: usize) -> RecordBatch {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let row_ids = UInt64Array::from_iter_values(range);
     let sq_code =
-        UInt8Array::from_iter_values(repeat_with(|| rng.gen::<u8>()).take(row_ids.len() * dim));
+        UInt8Array::from_iter_values(repeat_with(|| rng.random::<u8>()).take(row_ids.len() * dim));
     let sq_code_fsl = FixedSizeListArray::try_new_from_values(sq_code, dim as i32).unwrap();
 
     let vector_data = generate_random_array(row_ids.len() * dim);
@@ -67,7 +67,7 @@ fn create_sq_batch(row_id_range: Range<u64>, dim: usize) -> RecordBatch {
 
 #[allow(dead_code)]
 pub fn bench_storage(c: &mut Criterion) {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
     const TOTAL: usize = 8 * 1024 * 1024; // 8M rows
 
@@ -85,8 +85,8 @@ pub fn bench_storage(c: &mut Criterion) {
             |b| {
                 let total = storage.len();
                 b.iter(|| {
-                    let a = rng.gen_range(0..total as u32);
-                    let b = rng.gen_range(0..total as u32);
+                    let a = rng.random_range(0..total as u32);
+                    let b = rng.random_range(0..total as u32);
                     storage.dist_calculator_from_id(a).distance(b);
                 });
             },

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -1455,7 +1455,7 @@ mod tests {
     use futures::TryStreamExt;
     use lance_core::{cache::LanceCache, utils::mask::RowIdTreeMap};
     use lance_datafusion::{chunker::break_stream, datagen::DatafusionDatagenExt};
-    use lance_datagen::{array, gen, ArrayGeneratorExt, BatchCount, RowCount};
+    use lance_datagen::{array, gen_batch, ArrayGeneratorExt, BatchCount, RowCount};
     use lance_io::object_store::ObjectStore;
     use object_store::path::Path;
     use tempfile::tempdir;
@@ -1499,7 +1499,7 @@ mod tests {
         ));
 
         // Generate 50,000 rows of random data with 80% nulls
-        let stream = gen()
+        let stream = gen_batch()
             .col(
                 "value",
                 array::rand::<Float32Type>().with_nulls(&[true, false, false, false, false]),
@@ -1582,7 +1582,7 @@ mod tests {
         // This is a bit overkill but we've had bugs in the past where DF's sort
         // didn't agree with Arrow's sort so we do an end-to-end test here
         // and use DF to sort the data like we would in a real dataset.
-        let data = gen()
+        let data = gen_batch()
             .col("value", array::cycle::<Float64Type>(values.clone()))
             .col("_rowid", array::step::<UInt64Type>())
             .into_df_exec(RowCount::from(10), BatchCount::from(100));
@@ -1625,7 +1625,7 @@ mod tests {
             Arc::new(LanceCache::no_cache()),
         ));
 
-        let data = gen()
+        let data = gen_batch()
             .col("value", array::step::<Float32Type>())
             .col("_rowid", array::step::<UInt64Type>())
             .into_df_exec(RowCount::from(1000), BatchCount::from(10));

--- a/rust/lance-index/src/scalar/flat.rs
+++ b/rust/lance-index/src/scalar/flat.rs
@@ -361,10 +361,10 @@ mod tests {
     use super::*;
     use arrow_array::types::Int32Type;
     use datafusion_common::ScalarValue;
-    use lance_datagen::{array, gen, RowCount};
+    use lance_datagen::{array, gen_batch, RowCount};
 
     fn example_index() -> FlatIndex {
-        let batch = gen()
+        let batch = gen_batch()
             .col(
                 "values",
                 array::cycle::<Int32Type>(vec![10, 100, 1000, 1234]),
@@ -449,7 +449,7 @@ mod tests {
             .await
             .unwrap();
 
-        let expected = gen()
+        let expected = gen_batch()
             .col("values", array::cycle::<Int32Type>(vec![10, 100, 1234]))
             .col("ids", array::cycle::<UInt64Type>(vec![5, 2000, 100]))
             .into_batch_rows(RowCount::from(3))

--- a/rust/lance-index/src/scalar/inverted/encoding.rs
+++ b/rust/lance-index/src/scalar/inverted/encoding.rs
@@ -279,10 +279,16 @@ mod tests {
     #[test]
     fn test_compress_posting_list() -> Result<()> {
         let num_rows: usize = BLOCK_SIZE * 1024 - 7;
-        let mut rng = rand::thread_rng();
-        let doc_ids: Vec<u32> = (0..num_rows).map(|_| rng.gen()).sorted_unstable().collect();
-        let frequencies: Vec<u32> = (0..num_rows).map(|_| rng.gen_range(1..=u32::MAX)).collect();
-        let block_max_scores = (0..num_rows.div_ceil(BLOCK_SIZE)).map(|_| rng.gen_range(0.0..1.0));
+        let mut rng = rand::rng();
+        let doc_ids: Vec<u32> = (0..num_rows)
+            .map(|_| rng.random())
+            .sorted_unstable()
+            .collect();
+        let frequencies: Vec<u32> = (0..num_rows)
+            .map(|_| rng.random_range(1..=u32::MAX))
+            .collect();
+        let block_max_scores =
+            (0..num_rows.div_ceil(BLOCK_SIZE)).map(|_| rng.random_range(0.0..1.0));
         let posting_list = compress_posting_list(
             doc_ids.len(),
             doc_ids.iter(),
@@ -310,9 +316,9 @@ mod tests {
     #[test]
     fn test_compress_positions() -> Result<()> {
         let num_positions: usize = BLOCK_SIZE * 2 - 7;
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let positions: Vec<u32> = (0..num_positions)
-            .map(|_| rng.gen())
+            .map(|_| rng.random())
             .sorted_unstable()
             .collect();
         let compressed = compress_positions(&positions)?;

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -331,7 +331,7 @@ pub mod tests {
     use datafusion_common::ScalarValue;
     use futures::FutureExt;
     use lance_core::utils::mask::RowIdTreeMap;
-    use lance_datagen::{array, gen, ArrayGeneratorExt, BatchCount, ByteCount, RowCount};
+    use lance_datagen::{array, gen_batch, ArrayGeneratorExt, BatchCount, ByteCount, RowCount};
     use tempfile::{tempdir, TempDir};
 
     fn test_store(tempdir: &TempDir) -> Arc<dyn IndexStore> {
@@ -404,7 +404,7 @@ pub mod tests {
     async fn test_basic_btree() {
         let tempdir = tempdir().unwrap();
         let index_store = test_store(&tempdir);
-        let data = gen()
+        let data = gen_batch()
             .col("values", array::step::<Int32Type>())
             .col("row_ids", array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(4096), BatchCount::from(100));
@@ -463,7 +463,7 @@ pub mod tests {
     async fn test_btree_update() {
         let index_dir = tempdir().unwrap();
         let index_store = test_store(&index_dir);
-        let data = gen()
+        let data = gen_batch()
             .col("values", array::step::<Int32Type>())
             .col("row_ids", array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(4096), BatchCount::from(100));
@@ -472,7 +472,7 @@ pub mod tests {
             .await
             .unwrap();
 
-        let data = gen()
+        let data = gen_batch()
             .col("values", array::step_custom::<Int32Type>(4096 * 100, 1))
             .col("row_ids", array::step_custom::<UInt64Type>(4096 * 100, 1))
             .into_reader_rows(RowCount::from(4096), BatchCount::from(100));
@@ -530,22 +530,22 @@ pub mod tests {
     async fn test_btree_with_gaps() {
         let tempdir = tempdir().unwrap();
         let index_store = test_store(&tempdir);
-        let batch_one = gen()
+        let batch_one = gen_batch()
             .col("values", array::cycle::<Int32Type>(vec![0, 1, 4, 5]))
             .col("row_ids", array::cycle::<UInt64Type>(vec![0, 1, 2, 3]))
             .into_batch_rows(RowCount::from(4));
-        let batch_two = gen()
+        let batch_two = gen_batch()
             .col("values", array::cycle::<Int32Type>(vec![10, 11, 11, 15]))
             .col("row_ids", array::cycle::<UInt64Type>(vec![40, 50, 60, 70]))
             .into_batch_rows(RowCount::from(4));
-        let batch_three = gen()
+        let batch_three = gen_batch()
             .col("values", array::cycle::<Int32Type>(vec![15, 15, 15, 15]))
             .col(
                 "row_ids",
                 array::cycle::<UInt64Type>(vec![400, 500, 600, 700]),
             )
             .into_batch_rows(RowCount::from(4));
-        let batch_four = gen()
+        let batch_four = gen_batch()
             .col("values", array::cycle::<Int32Type>(vec![15, 16, 20, 20]))
             .col(
                 "row_ids",
@@ -758,7 +758,7 @@ pub mod tests {
         ] {
             let tempdir = tempdir().unwrap();
             let index_store = test_store(&tempdir);
-            let data: RecordBatch = gen()
+            let data: RecordBatch = gen_batch()
                 .col("values", array::rand_type(data_type))
                 .col("row_ids", array::step::<UInt64Type>())
                 .into_batch_rows(RowCount::from(4096 * 3))
@@ -821,7 +821,7 @@ pub mod tests {
     async fn btree_entire_null_page() {
         let tempdir = tempdir().unwrap();
         let index_store = test_store(&tempdir);
-        let batch = gen()
+        let batch = gen_batch()
             .col(
                 "values",
                 array::rand_utf8(ByteCount::from(0), false).with_nulls(&[true]),
@@ -956,7 +956,7 @@ pub mod tests {
     async fn test_basic_bitmap() {
         let tempdir = tempdir().unwrap();
         let index_store = test_store(&tempdir);
-        let data = gen()
+        let data = gen_batch()
             .col("values", array::step::<Int32Type>())
             .col("row_ids", array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(4096), BatchCount::from(100));
@@ -1020,22 +1020,22 @@ pub mod tests {
     async fn test_bitmap_with_gaps() {
         let tempdir = tempdir().unwrap();
         let index_store = test_store(&tempdir);
-        let batch_one = gen()
+        let batch_one = gen_batch()
             .col("values", array::cycle::<Int32Type>(vec![0, 1, 4, 5]))
             .col("row_ids", array::cycle::<UInt64Type>(vec![0, 1, 2, 3]))
             .into_batch_rows(RowCount::from(4));
-        let batch_two = gen()
+        let batch_two = gen_batch()
             .col("values", array::cycle::<Int32Type>(vec![10, 11, 11, 15]))
             .col("row_ids", array::cycle::<UInt64Type>(vec![40, 50, 60, 70]))
             .into_batch_rows(RowCount::from(4));
-        let batch_three = gen()
+        let batch_three = gen_batch()
             .col("values", array::cycle::<Int32Type>(vec![15, 15, 15, 15]))
             .col(
                 "row_ids",
                 array::cycle::<UInt64Type>(vec![400, 500, 600, 700]),
             )
             .into_batch_rows(RowCount::from(4));
-        let batch_four = gen()
+        let batch_four = gen_batch()
             .col("values", array::cycle::<Int32Type>(vec![15, 16, 20, 20]))
             .col(
                 "row_ids",
@@ -1232,7 +1232,7 @@ pub mod tests {
     async fn test_bitmap_update() {
         let index_dir = tempdir().unwrap();
         let index_store = test_store(&index_dir);
-        let data = gen()
+        let data = gen_batch()
             .col("values", array::step::<Int32Type>())
             .col("row_ids", array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(4096), BatchCount::from(1));
@@ -1241,7 +1241,7 @@ pub mod tests {
             .await
             .unwrap();
 
-        let data = gen()
+        let data = gen_batch()
             .col("values", array::step_custom::<Int32Type>(4096, 1))
             .col("row_ids", array::step_custom::<UInt64Type>(4096, 1))
             .into_reader_rows(RowCount::from(4096), BatchCount::from(1));
@@ -1277,7 +1277,7 @@ pub mod tests {
     async fn test_bitmap_remap() {
         let index_dir = tempdir().unwrap();
         let index_store = test_store(&index_dir);
-        let data = gen()
+        let data = gen_batch()
             .col("values", array::step::<Int32Type>())
             .col("row_ids", array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(50), BatchCount::from(1));
@@ -1355,7 +1355,7 @@ pub mod tests {
     async fn test_label_list_index() {
         let tempdir = tempdir().unwrap();
         let index_store = test_store(&tempdir);
-        let data = gen()
+        let data = gen_batch()
             .col(
                 "values",
                 array::rand_type(&DataType::List(Arc::new(Field::new(

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -1604,7 +1604,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_ngram_index_with_spill() {
-        let (data, schema) = lance_datagen::gen()
+        let (data, schema) = lance_datagen::gen_batch()
             .col(
                 "values",
                 lance_datagen::array::rand_utf8(ByteCount::from(50), false),

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -25,7 +25,7 @@ use std::sync::RwLock;
 use tracing::instrument;
 
 use lance_core::{Error, Result};
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use serde::{Deserialize, Serialize};
 
 use super::super::graph::beam_search;
@@ -384,10 +384,10 @@ impl HnswBuilder {
     ///
     /// See paper `Algorithm 1`
     fn random_level(&self) -> u16 {
-        let mut rng = thread_rng();
+        let mut rng = rng();
         let ml = 1.0 / (self.params.m as f32).ln();
         min(
-            (-rng.gen::<f32>().ln() * ml) as u16,
+            (-rng.random::<f32>().ln() * ml) as u16,
             self.params.max_level - 1,
         )
     }

--- a/rust/lance-index/src/vector/ivf/shuffler.rs
+++ b/rust/lance-index/src/vector/ivf/shuffler.rs
@@ -1119,7 +1119,7 @@ mod test {
         let schema2 = schema.clone();
 
         let stream = stream::iter(0..num_batches).map(move |idx| {
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             let row_ids = Arc::new(UInt64Array::from_iter(
                 (idx * 1024..(idx + 1) * 1024).map(u64::from),
             ));

--- a/rust/lance-index/src/vector/kmeans.rs
+++ b/rust/lance-index/src/vector/kmeans.rs
@@ -140,13 +140,13 @@ fn split_clusters<T: Float + MulAssign>(
     dim: usize,
 ) {
     let eps = T::from(1.0 / 1024.0).unwrap();
-    let mut rng = SmallRng::from_entropy();
+    let mut rng = SmallRng::from_os_rng();
     for i in 0..cnts.len() {
         if cnts[i] == 0 {
             let mut j = 0;
             loop {
                 let p = (cnts[j] as f32 - 1.0) / (n - cnts.len()) as f32;
-                if rng.gen::<f32>() < p {
+                if rng.random::<f32>() < p {
                     break;
                 }
                 j += 1;
@@ -540,7 +540,7 @@ impl KMeans {
         let mut best_stddev = f32::MAX;
 
         // TODO: use seed for Rng.
-        let rng = SmallRng::from_entropy();
+        let rng = SmallRng::from_os_rng();
         for redo in 1..=params.redos {
             let mut kmeans: Self = match &params.init {
                 KMeanInit::Random => Self::init_random::<T>(
@@ -1051,9 +1051,9 @@ mod tests {
         const K: usize = 32;
         const NUM_VALUES: usize = 256 * K;
 
-        let mut rng = SmallRng::from_entropy();
+        let mut rng = SmallRng::from_os_rng();
         let values =
-            UInt8Array::from_iter_values((0..NUM_VALUES * DIM).map(|_| rng.gen_range(0..255)));
+            UInt8Array::from_iter_values((0..NUM_VALUES * DIM).map(|_| rng.random_range(0..255)));
 
         let fsl = FixedSizeListArray::try_new_from_values(values, DIM as i32).unwrap();
 

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -1139,10 +1139,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_dist_between() {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let storage = create_pq_storage().await;
-        let u = rng.gen_range(0..storage.len() as u32);
-        let v = rng.gen_range(0..storage.len() as u32);
+        let u = rng.random_range(0..storage.len() as u32);
+        let v = rng.random_range(0..storage.len() as u32);
         let dist1 = storage.dist_between(u, v);
         let dist2 = storage.dist_between(v, u);
         assert_eq!(dist1, dist2);

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -506,10 +506,11 @@ mod tests {
     fn create_record_batch(row_ids: Range<u64>) -> RecordBatch {
         const DIM: usize = 64;
 
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let row_ids = UInt64Array::from_iter_values(row_ids);
-        let sq_code =
-            UInt8Array::from_iter_values(repeat_with(|| rng.gen::<u8>()).take(row_ids.len() * DIM));
+        let sq_code = UInt8Array::from_iter_values(
+            repeat_with(|| rng.random::<u8>()).take(row_ids.len() * DIM),
+        );
         let code_arr = FixedSizeListArray::try_new_from_values(sq_code, DIM as i32).unwrap();
 
         let schema = Arc::new(Schema::new(vec![

--- a/rust/lance-io/benches/scheduler.rs
+++ b/rust/lance-io/benches/scheduler.rs
@@ -44,7 +44,7 @@ async fn create_data(num_bytes: u64) -> (Arc<ObjectStore>, Path) {
     let tmp_file = path.child("foo.file");
 
     let mut some_data = vec![0; num_bytes as usize];
-    rand::thread_rng().fill_bytes(&mut some_data);
+    rand::rng().fill_bytes(&mut some_data);
     obj_store.put(&tmp_file, &some_data).await.unwrap();
 
     (obj_store, tmp_file)
@@ -156,7 +156,7 @@ fn bench_random_read(c: &mut Criterion) {
     for io_parallelism in [1, 16, 32, 64] {
         for item_size in [8, 1024, 4096] {
             let num_indices = DATA_SIZE as u32 / item_size;
-            let mut rng = rand::thread_rng();
+            let mut rng = rand::rng();
             let mut indices = (0..num_indices).collect::<Vec<_>>();
             let (shuffled, _) = indices.partial_shuffle(&mut rng, INDICES_PER_ITER);
             let mut indices = shuffled.to_vec();

--- a/rust/lance-io/src/encodings/plain.rs
+++ b/rust/lance-io/src/encodings/plain.rs
@@ -539,8 +539,8 @@ mod tests {
         }
 
         let float_types = vec![DataType::Float16, DataType::Float32, DataType::Float64];
-        let mut rng = rand::thread_rng();
-        let input: Vec<f64> = (1..127).map(|_| rng.gen()).collect();
+        let mut rng = rand::rng();
+        let input: Vec<f64> = (1..127).map(|_| rng.random()).collect();
         for t in float_types {
             let buffer = Buffer::from_slice_ref(input.as_slice());
             let mut arrs: Vec<ArrayRef> = Vec::new();

--- a/rust/lance-io/src/object_writer.rs
+++ b/rust/lance-io/src/object_writer.rs
@@ -258,7 +258,7 @@ impl ObjectWriter {
                                     mut_self.connection_resets += 1;
 
                                     // Resubmit with random jitter
-                                    let sleep_time_ms = rand::thread_rng().gen_range(2_000..8_000);
+                                    let sleep_time_ms = rand::rng().random_range(2_000..8_000);
                                     let sleep_time =
                                         std::time::Duration::from_millis(sleep_time_ms);
 

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -960,7 +960,7 @@ mod tests {
         // Write 1MiB of data
         const DATA_SIZE: u64 = 1024 * 1024;
         let mut some_data = vec![0; DATA_SIZE as usize];
-        rand::thread_rng().fill_bytes(&mut some_data);
+        rand::rng().fill_bytes(&mut some_data);
         obj_store.put(&tmp_file, &some_data).await.unwrap();
 
         let config = SchedulerConfig::default_for_testing();
@@ -1010,7 +1010,7 @@ mod tests {
         // Write 75MiB of data
         const DATA_SIZE: u64 = 75 * 1024 * 1024;
         let mut some_data = vec![0; DATA_SIZE as usize];
-        rand::thread_rng().fill_bytes(&mut some_data);
+        rand::rng().fill_bytes(&mut some_data);
         obj_store.put(&tmp_file, &some_data).await.unwrap();
 
         let config = SchedulerConfig::default_for_testing();

--- a/rust/lance-linalg/benches/dot.rs
+++ b/rust/lance-linalg/benches/dot.rs
@@ -86,12 +86,12 @@ fn bench_distance(c: &mut Criterion) {
         });
     });
 
-    let mut rng = rand::thread_rng();
-    let key = repeat_with(|| rng.gen::<u16>())
+    let mut rng = rand::rng();
+    let key = repeat_with(|| rng.random::<u16>())
         .map(bf16::from_bits)
         .take(DIMENSION)
         .collect::<Vec<_>>();
-    let target = repeat_with(|| rng.gen::<u16>())
+    let target = repeat_with(|| rng.random::<u16>())
         .map(bf16::from_bits)
         .take(TOTAL * DIMENSION)
         .collect::<Vec<_>>();

--- a/rust/lance-linalg/benches/hamming.rs
+++ b/rust/lance-linalg/benches/hamming.rs
@@ -11,12 +11,12 @@ const DIMENSION: usize = 1024;
 const TOTAL: usize = 1024 * 1024; // 1M vectors
 
 fn bench_hamming(c: &mut Criterion) {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
 
-    let key = repeat_with(|| rng.gen::<u8>())
+    let key = repeat_with(|| rng.random::<u8>())
         .take(DIMENSION)
         .collect::<Vec<_>>();
-    let target = repeat_with(|| rng.gen::<u8>())
+    let target = repeat_with(|| rng.random::<u8>())
         .take(TOTAL * DIMENSION)
         .collect::<Vec<_>>();
 

--- a/rust/lance-linalg/benches/l2.rs
+++ b/rust/lance-linalg/benches/l2.rs
@@ -128,11 +128,11 @@ fn l2_distance_uint_scalar_auto_vectorized(key: &[u8], target: &[u8]) -> f32 {
 }
 
 fn bench_uint_distance(c: &mut Criterion) {
-    let mut rng = rand::thread_rng();
-    let key = repeat_with(|| rng.gen::<u8>())
+    let mut rng = rand::rng();
+    let key = repeat_with(|| rng.random::<u8>())
         .take(DIMENSION)
         .collect::<Vec<_>>();
-    let target = repeat_with(|| rng.gen::<u8>())
+    let target = repeat_with(|| rng.random::<u8>())
         .take(TOTAL * DIMENSION)
         .collect::<Vec<_>>();
 

--- a/rust/lance-linalg/benches/norm_l2.rs
+++ b/rust/lance-linalg/benches/norm_l2.rs
@@ -74,8 +74,8 @@ fn run_bench<T: ArrowFloatType>(
 }
 
 fn bench_distance(c: &mut Criterion) {
-    let mut rng = rand::thread_rng();
-    let target = repeat_with(|| rng.gen::<u16>())
+    let mut rng = rand::rng();
+    let target = repeat_with(|| rng.random::<u16>())
         .map(bf16::from_bits)
         .take(TOTAL * DIMENSION)
         .collect::<Vec<_>>();

--- a/rust/lance-table/src/io/deletion.rs
+++ b/rust/lance-table/src/io/deletion.rs
@@ -60,7 +60,7 @@ pub async fn write_deletion_file(
     let deletion_file = match removed_rows {
         DeletionVector::NoDeletions => None,
         DeletionVector::Set(set) => {
-            let id = rand::thread_rng().gen::<u64>();
+            let id = rand::rng().random::<u64>();
             let deletion_file = DeletionFile {
                 read_version,
                 id,
@@ -96,7 +96,7 @@ pub async fn write_deletion_file(
             Some(deletion_file)
         }
         DeletionVector::Bitmap(bitmap) => {
-            let id = rand::thread_rng().gen::<u64>();
+            let id = rand::rng().random::<u64>();
             let deletion_file = DeletionFile {
                 read_version,
                 id,

--- a/rust/lance-table/src/io/manifest.rs
+++ b/rust/lance-table/src/io/manifest.rs
@@ -242,7 +242,7 @@ mod test {
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
     use lance_file::format::{MAGIC, MAJOR_VERSION, MINOR_VERSION};
     use lance_file::{reader::FileReader, writer::FileWriter};
-    use rand::{distributions::Alphanumeric, Rng};
+    use rand::{distr::Alphanumeric, Rng};
     use tokio::io::AsyncWriteExt;
 
     use super::*;
@@ -254,13 +254,13 @@ mod test {
         let mut writer = store.create(&path).await.unwrap();
 
         // Write prefix we should ignore
-        let prefix: Vec<u8> = rand::thread_rng()
+        let prefix: Vec<u8> = rand::rng()
             .sample_iter(&Alphanumeric)
             .take(prefix_size)
             .collect();
         writer.write_all(&prefix).await.unwrap();
 
-        let long_name: String = rand::thread_rng()
+        let long_name: String = rand::rng()
             .sample_iter(&Alphanumeric)
             .take(manifest_min_size)
             .map(char::from)

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -348,13 +348,13 @@ mod tests {
     #[tokio::test]
     async fn test_basic_zip() {
         let left = batch_task_stream(
-            lance_datagen::gen()
+            lance_datagen::gen_batch()
                 .col("x", lance_datagen::array::step::<Int32Type>())
                 .into_reader_stream(RowCount::from(100), BatchCount::from(10))
                 .0,
         );
         let right = batch_task_stream(
-            lance_datagen::gen()
+            lance_datagen::gen_batch()
                 .col("y", lance_datagen::array::step::<Int32Type>())
                 .into_reader_stream(RowCount::from(100), BatchCount::from(10))
                 .0,
@@ -367,7 +367,7 @@ mod tests {
             .await
             .unwrap();
 
-        let expected = lance_datagen::gen()
+        let expected = lance_datagen::gen_batch()
             .col("x", lance_datagen::array::step::<Int32Type>())
             .col("y", lance_datagen::array::step::<Int32Type>())
             .into_reader_rows(RowCount::from(100), BatchCount::from(10))
@@ -382,7 +382,7 @@ mod tests {
         for has_columns in [false, true] {
             for fragment_id in [0, 10] {
                 // 100 rows across 10 batches of 10 rows
-                let mut datagen = lance_datagen::gen();
+                let mut datagen = lance_datagen::gen_batch();
                 if has_columns {
                     datagen = datagen.col("x", lance_datagen::array::rand::<Int32Type>());
                 }
@@ -476,7 +476,7 @@ mod tests {
                                 continue;
                             }
 
-                            let mut datagen = lance_datagen::gen();
+                            let mut datagen = lance_datagen::gen_batch();
                             if has_columns {
                                 datagen =
                                     datagen.col("x", lance_datagen::array::rand::<Int32Type>());

--- a/rust/lance-testing/src/datagen.rs
+++ b/rust/lance-testing/src/datagen.rs
@@ -15,9 +15,9 @@ use arrow_array::{
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
 use lance_arrow::{fixed_size_list_type, ArrowFloatType, FixedSizeListArrayExt};
 use num_traits::{real::Real, FromPrimitive};
-use rand::distributions::uniform::SampleUniform;
+use rand::distr::uniform::SampleUniform;
 use rand::{
-    distributions::Uniform, prelude::Distribution, rngs::StdRng, seq::SliceRandom, Rng, SeedableRng,
+    distr::Uniform, prelude::Distribution, rngs::StdRng, seq::SliceRandom, Rng, SeedableRng,
 };
 
 pub trait ArrayGenerator {
@@ -210,7 +210,7 @@ where
     let mut rng = StdRng::from_seed(seed);
 
     T::ArrayType::from(
-        repeat_with(|| T::Native::from_f32(rng.gen::<f32>()).unwrap())
+        repeat_with(|| T::Native::from_f32(rng.random::<f32>()).unwrap())
             .take(n)
             .collect::<Vec<_>>(),
     )
@@ -219,15 +219,15 @@ where
 /// Create a random float32 array where each element is uniformly
 /// distributed between [0..1]
 pub fn generate_random_array(n: usize) -> Float32Array {
-    let mut rng = rand::thread_rng();
-    Float32Array::from_iter_values(repeat_with(|| rng.gen::<f32>()).take(n))
+    let mut rng = rand::rng();
+    Float32Array::from_iter_values(repeat_with(|| rng.random::<f32>()).take(n))
 }
 
 /// Create a random float32 array where each element is uniformly
 /// distributed between [0..1]
 pub fn generate_random_int8_array(n: usize) -> Int8Array {
-    let mut rng = rand::thread_rng();
-    Int8Array::from_iter_values(repeat_with(|| rng.gen::<i8>()).take(n))
+    let mut rng = rand::rng();
+    Int8Array::from_iter_values(repeat_with(|| rng.random::<i8>()).take(n))
 }
 
 /// Create a random primitive array where each element is uniformly distributed a
@@ -240,21 +240,21 @@ where
     T::Native: SampleUniform,
 {
     let mut rng = StdRng::from_seed([13; 32]);
-    let distribution = Uniform::new(range.start, range.end);
+    let distribution = Uniform::new(range.start, range.end).unwrap();
     PrimitiveArray::<T>::from_iter_values(repeat_with(|| distribution.sample(&mut rng)).take(n))
 }
 
 /// Create a random float32 array where each element is uniformly
 /// distributed across the given range
 pub fn generate_scaled_random_array(n: usize, min: f32, max: f32) -> Float32Array {
-    let mut rng = rand::thread_rng();
-    let distribution = Uniform::new(min, max);
+    let mut rng = rand::rng();
+    let distribution = Uniform::new(min, max).unwrap();
     Float32Array::from_iter_values(repeat_with(|| distribution.sample(&mut rng)).take(n))
 }
 
 pub fn sample_indices(range: Range<usize>, num_picks: u32) -> Vec<usize> {
-    let mut rng = rand::thread_rng();
-    let dist = Uniform::new(range.start, range.end);
+    let mut rng = rand::rng();
+    let dist = Uniform::new(range.start, range.end).unwrap();
     let ratio = num_picks as f32 / range.len() as f32;
     if ratio < 0.1_f32 && num_picks > 1000 {
         // We want to pick a large number of values from a big range.  Better to
@@ -279,7 +279,7 @@ pub fn sample_indices(range: Range<usize>, num_picks: u32) -> Vec<usize> {
 }
 
 pub fn sample_without_replacement<T: Copy>(choices: &[T], num_picks: u32) -> Vec<T> {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut shuffled = Vec::from(choices);
     shuffled.partial_shuffle(&mut rng, num_picks as usize);
     shuffled.truncate(num_picks as usize);

--- a/rust/lance-testing/src/datagen.rs
+++ b/rust/lance-testing/src/datagen.rs
@@ -146,18 +146,18 @@ impl BatchGenerator {
         Default::default()
     }
 
-    pub fn col(mut self, gen: Box<dyn ArrayGenerator>) -> Self {
-        self.generators.push(gen);
+    pub fn col(mut self, genn: Box<dyn ArrayGenerator>) -> Self {
+        self.generators.push(genn);
         self
     }
 
     fn gen_batch(&mut self, num_rows: u32) -> RecordBatch {
         let mut fields = Vec::with_capacity(self.generators.len());
         let mut arrays = Vec::with_capacity(self.generators.len());
-        for (field_index, gen) in self.generators.iter_mut().enumerate() {
-            let arr = gen.generate(num_rows as usize);
+        for (field_index, genn) in self.generators.iter_mut().enumerate() {
+            let arr = genn.generate(num_rows as usize);
             let default_name = format!("field_{}", field_index);
-            let name = gen.name().unwrap_or(&default_name);
+            let name = genn.name().unwrap_or(&default_name);
             fields.push(Field::new(name, arr.data_type().clone(), true));
             arrays.push(arr);
         }

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -14,7 +14,7 @@ use futures::{FutureExt, TryStreamExt};
 use lance::{io::ObjectStore, Dataset};
 use lance_core::{cache::LanceCache, Result};
 use lance_datafusion::utils::reader_to_stream;
-use lance_datagen::{array, gen, BatchCount, RowCount};
+use lance_datagen::{array, gen_batch, BatchCount, RowCount};
 use lance_index::metrics::NoOpMetricsCollector;
 use lance_index::scalar::{
     btree::{train_btree_index, BTreeIndex, TrainingSource, DEFAULT_BTREE_BATCH_SIZE},
@@ -36,7 +36,7 @@ struct BenchmarkDataSource {}
 
 impl BenchmarkDataSource {
     fn test_data() -> impl RecordBatchReader {
-        gen()
+        gen_batch()
             .col("values", array::step::<UInt32Type>())
             .col("row_ids", array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(1024), BatchCount::from(100 * 1024))

--- a/rust/lance/benches/take.rs
+++ b/rust/lance/benches/take.rs
@@ -29,11 +29,11 @@ use std::time::Duration;
 
 const BATCH_SIZE: u64 = 1024;
 
-fn gen_ranges(num_rows: u64, file_size: u64, n: usize) -> Vec<u64> {
-    let mut rng = rand::thread_rng();
+fn random_ranges(num_rows: u64, file_size: u64, n: usize) -> Vec<u64> {
+    let mut rng = rand::rng();
     let mut ranges = Vec::with_capacity(n);
     for i in 0..n {
-        ranges.push(rng.gen_range(1..num_rows));
+        ranges.push(rng.random_range(1..num_rows));
         ranges[i] = ((ranges[i] / file_size) << 32) | (ranges[i] % file_size);
     }
 
@@ -87,7 +87,7 @@ fn dataset_take(
             ), |b| {
                 b.to_async(rt).iter(|| async {
                     let rows =
-                        gen_ranges(num_batches as u64 * BATCH_SIZE, file_size as u64, num_rows);
+                        random_ranges(num_batches as u64 * BATCH_SIZE, file_size as u64, num_rows);
                     let batch = dataset
                         .take_rows(&rows, ProjectionRequest::Schema(schema.clone()))
                         .await
@@ -105,7 +105,7 @@ fn bench_random_single_take_with_file_reader(c: &mut Criterion) {
     let num_batches: u64 = 1024;
     let file_size: u64 = num_batches * BATCH_SIZE + 1;
     let rows_gen = Box::new(|num_batches, file_size, num_rows| {
-        let rows = gen_ranges(num_batches * BATCH_SIZE, file_size, num_rows);
+        let rows = random_ranges(num_batches * BATCH_SIZE, file_size, num_rows);
         let mut rows_list: Vec<Vec<u32>> = Vec::with_capacity(rows.len());
         for row in rows {
             rows_list.push(vec![row as u32]);
@@ -139,7 +139,7 @@ fn bench_random_batch_take_with_file_reader(c: &mut Criterion) {
     let num_batches: u64 = 1024;
     let file_size: u64 = num_batches * BATCH_SIZE + 1;
     let rows_gen = Box::new(|num_batches, file_size, num_rows| {
-        let rows = gen_ranges(num_batches * BATCH_SIZE, file_size, num_rows);
+        let rows = random_ranges(num_batches * BATCH_SIZE, file_size, num_rows);
         let mut rows: Vec<u32> = rows.iter().map(|&x| x as u32).collect();
         rows.sort();
         vec![rows]
@@ -257,7 +257,7 @@ fn bench_random_single_take_with_file_fragment(c: &mut Criterion) {
     // Make sure there is only one fragment.
     let file_size: u64 = num_batches * BATCH_SIZE + 1;
     let rows_gen = Box::new(|num_batches, file_size, num_rows| {
-        let rows = gen_ranges(num_batches * BATCH_SIZE, file_size, num_rows);
+        let rows = random_ranges(num_batches * BATCH_SIZE, file_size, num_rows);
         let mut rows_list: Vec<Vec<u32>> = Vec::with_capacity(rows.len());
         for row in rows {
             rows_list.push(vec![row as u32]);
@@ -292,7 +292,7 @@ fn bench_random_batch_take_with_file_fragment(c: &mut Criterion) {
     // Make sure there is only one fragment.
     let file_size: u64 = num_batches * BATCH_SIZE + 1;
     let rows_gen = Box::new(|num_batches, file_size, num_rows| {
-        let rows = gen_ranges(num_batches * BATCH_SIZE, file_size, num_rows);
+        let rows = random_ranges(num_batches * BATCH_SIZE, file_size, num_rows);
         let mut rows: Vec<u32> = rows.iter().map(|&x| x as u32).collect();
         rows.sort();
         vec![rows]

--- a/rust/lance/benches/vector_index.rs
+++ b/rust/lance/benches/vector_index.rs
@@ -42,10 +42,10 @@ fn bench_ivf_pq_index(c: &mut Criterion) {
             .unwrap()
     });
 
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let vector_column = first_batch.column_by_name("vector").unwrap();
     let value =
-        as_fixed_size_list_array(&vector_column).value(rng.gen_range(0..vector_column.len()));
+        as_fixed_size_list_array(&vector_column).value(rng.random_range(0..vector_column.len()));
     let q: &Float32Array = as_primitive_array(&value);
 
     c.bench_function(
@@ -188,10 +188,10 @@ async fn create_file(path: &std::path::Path, mode: WriteMode) {
 
 fn create_float32_array(num_elements: i32) -> Float32Array {
     // generate an Arrow Float32Array with 10000*128 elements randomly
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut values = Vec::with_capacity(num_elements as usize);
     for _ in 0..num_elements {
-        values.push(rng.gen_range(0.0..1.0));
+        values.push(rng.random_range(0.0..1.0));
     }
     Float32Array::from(values)
 }

--- a/rust/lance/src/datafusion/dataframe.rs
+++ b/rust/lance/src/datafusion/dataframe.rs
@@ -261,7 +261,7 @@ pub mod tests {
     pub async fn test_table_provider() {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
-        let data = lance_datagen::gen()
+        let data = lance_datagen::gen_batch()
             .col("x", array::step::<Int32Type>())
             .col("y", array::step_custom::<Int32Type>(0, 2))
             .into_dataset(

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1109,7 +1109,7 @@ impl Dataset {
     pub(crate) async fn sample(&self, n: usize, projection: &Schema) -> Result<RecordBatch> {
         use rand::seq::IteratorRandom;
         let num_rows = self.count_rows(None).await?;
-        let ids = (0..num_rows as u64).choose_multiple(&mut rand::thread_rng(), n);
+        let ids = (0..num_rows as u64).choose_multiple(&mut rand::rng(), n);
         self.take(&ids, projection.clone()).await
     }
 
@@ -3700,7 +3700,7 @@ mod tests {
         let len = new_value.len() as u32;
         let new_batch = RecordBatch::try_new(new_schema.clone(), vec![row_ids, new_value]).unwrap();
         // shuffle new_batch
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut indices: Vec<u32> = (0..len).collect();
         indices.shuffle(&mut rng);
         let indices = arrow_array::UInt32Array::from_iter_values(indices);
@@ -3769,7 +3769,7 @@ mod tests {
         let new_batch =
             RecordBatch::try_new(new_schema.clone(), vec![row_addrs, new_value]).unwrap();
         // shuffle new_batch
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let mut indices: Vec<u32> = (0..len).collect();
         indices.shuffle(&mut rng);
         let indices = arrow_array::UInt32Array::from_iter_values(indices);
@@ -5676,10 +5676,10 @@ mod tests {
         let mut full_text_count = 0;
         let mut doc_array = (0..4096)
             .map(|_| {
-                let mut rng = rand::thread_rng();
+                let mut rng = rand::rng();
                 let mut text = String::with_capacity(4);
-                for _ in 0..rng.gen_range(127..512) {
-                    text.push_str(words[rng.gen_range(0..words.len())]);
+                for _ in 0..rng.random_range(127..512) {
+                    text.push_str(words[rng.random_range(0..words.len())]);
                 }
                 if text.contains("lance search") {
                     lance_search_count += 1;

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -311,7 +311,7 @@ mod tests {
             let test_dir = tempdir().unwrap();
             let test_uri = test_dir.path().to_str().unwrap();
 
-            let data = lance_datagen::gen()
+            let data = lance_datagen::gen_batch()
                 .col("filterme", array::step::<UInt64Type>())
                 .col("blobs", array::blob())
                 .into_reader_rows(RowCount::from(10), BatchCount::from(10))

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -2371,7 +2371,7 @@ mod tests {
     use arrow_array::{ArrayRef, Int32Array, RecordBatchIterator, StringArray};
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
     use lance_core::ROW_ID;
-    use lance_datagen::{array, gen, RowCount};
+    use lance_datagen::{array, gen_batch, RowCount};
     use lance_file::version::LanceFileVersion;
     use lance_io::object_store::{ObjectStore, ObjectStoreParams};
     use pretty_assertions::assert_eq;
@@ -3416,7 +3416,7 @@ mod tests {
         let test_uri = test_dir.path().to_str().unwrap();
 
         let make_gen = || {
-            gen()
+            gen_batch()
                 .col("str", array::rand_type(&DataType::Utf8))
                 .col("int", array::rand_type(&DataType::Int32))
         };

--- a/rust/lance/src/dataset/index/frag_reuse.rs
+++ b/rust/lance/src/dataset/index/frag_reuse.rs
@@ -160,7 +160,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cleanup_frag_reuse_index() {
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -2401,7 +2401,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_cleanup_and_compaction_rebase_cleanup() {
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -2527,7 +2527,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_cleanup_and_compaction_rebase_compaction() {
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -2640,7 +2640,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_concurrent_compactions_with_defer_index_remap() {
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -2706,7 +2706,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_bitmap_index_with_defer_index_remap() {
         // Create a dataset with categorical values
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -2806,7 +2806,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_btree_index_with_defer_index_remap() {
         // Create a dataset with an incremental ID column
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -3164,7 +3164,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_label_list_index_with_defer_index_remap() {
         // Create a dataset with list data for labels
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -3262,7 +3262,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_ivf_pq_index_v3_with_defer_index_remap() {
         // Create a dataset with vector data
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -474,7 +474,7 @@ mod test {
             dataset.delete(expr).await.unwrap();
         }
 
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col("i", lance_datagen::array::step::<Int32Type>())
             .col(
                 "vec",

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -3412,7 +3412,7 @@ mod test {
     use datafusion::logical_expr::{col, lit};
     use half::f16;
     use lance_arrow::SchemaExt;
-    use lance_datagen::{array, gen, BatchCount, ByteCount, Dimension, RowCount};
+    use lance_datagen::{array, gen_batch, BatchCount, ByteCount, Dimension, RowCount};
     use lance_file::version::LanceFileVersion;
     use lance_index::scalar::inverted::query::{MatchQuery, PhraseQuery};
     use lance_index::vector::hnsw::builder::HnswBuildParams;
@@ -3493,7 +3493,7 @@ mod test {
 
     #[tokio::test]
     async fn test_strict_batch_size() {
-        let dataset = lance_datagen::gen()
+        let dataset = lance_datagen::gen_batch()
             .col("x", array::step::<Int32Type>())
             .anon_col(array::step::<Int64Type>())
             .into_ram_dataset(FragmentCount::from(7), FragmentRowCount::from(6))
@@ -3520,7 +3520,7 @@ mod test {
 
     #[tokio::test]
     async fn test_column_not_exist() {
-        let dataset = lance_datagen::gen()
+        let dataset = lance_datagen::gen_batch()
             .col("x", array::step::<Int32Type>())
             .into_ram_dataset(FragmentCount::from(7), FragmentRowCount::from(6))
             .await
@@ -4243,14 +4243,14 @@ mod test {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
 
-        let data = gen()
+        let data = gen_batch()
             .col("int", array::cycle::<Int32Type>(vec![5, 4, 1, 2, 3]))
             .col(
                 "str",
                 array::cycle_utf8_literals(&["a", "b", "c", "e", "d"]),
             );
 
-        let sorted_by_int = gen()
+        let sorted_by_int = gen_batch()
             .col("int", array::cycle::<Int32Type>(vec![1, 2, 3, 4, 5]))
             .col(
                 "str",
@@ -4259,7 +4259,7 @@ mod test {
             .into_batch_rows(RowCount::from(5))
             .unwrap();
 
-        let sorted_by_str = gen()
+        let sorted_by_str = gen_batch()
             .col("int", array::cycle::<Int32Type>(vec![5, 4, 1, 3, 2]))
             .col(
                 "str",
@@ -4333,14 +4333,14 @@ mod test {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
 
-        let data = gen()
+        let data = gen_batch()
             .col("int", array::cycle::<Int32Type>(vec![5, 5, 1, 1, 3]))
             .col(
                 "float",
                 array::cycle::<Float32Type>(vec![7.3, -f32::NAN, f32::NAN, 4.3, f32::INFINITY]),
             );
 
-        let sorted_by_int_then_float = gen()
+        let sorted_by_int_then_float = gen_batch()
             .col("int", array::cycle::<Int32Type>(vec![1, 1, 3, 5, 5]))
             .col(
                 "float",
@@ -4864,7 +4864,7 @@ mod test {
     #[tokio::test]
     async fn test_projection_order() {
         let vec_params = VectorIndexParams::ivf_pq(4, 8, 2, MetricType::L2, 2);
-        let mut data = gen()
+        let mut data = gen_batch()
             .col("vec", array::rand_vec::<Float32Type>(Dimension::from(4)))
             .col("text", array::rand_utf8(ByteCount::from(10), false))
             .into_ram_dataset(FragmentCount::from(3), FragmentRowCount::from(100))
@@ -5079,7 +5079,7 @@ mod test {
             //
             // The first row where indexed == 50 is our sample query.
             // The first row where indexed == 75 is our deleted row (and delete query)
-            let data = gen()
+            let data = gen_batch()
                 .col(
                     "vector",
                     array::rand_vec::<Float32Type>(Dimension::from(32)),
@@ -5533,7 +5533,7 @@ mod test {
 
     #[tokio::test]
     async fn can_filter_row_id() {
-        let dataset = lance_datagen::gen()
+        let dataset = lance_datagen::gen_batch()
             .col("x", array::step::<Int32Type>())
             .into_ram_dataset(FragmentCount::from(1), FragmentRowCount::from(1000))
             .await
@@ -5631,7 +5631,7 @@ mod test {
 
     #[tokio::test]
     async fn test_inexact_scalar_index_plans() {
-        let data = gen()
+        let data = gen_batch()
             .col("ngram", array::rand_utf8(ByteCount::from(5), false))
             .col("exact", array::rand_type(&DataType::UInt32))
             .col("no_index", array::rand_type(&DataType::UInt32))
@@ -5709,7 +5709,7 @@ mod test {
         // Create a large dataset with a scalar indexed column and a sorted but not scalar
         // indexed column
         use lance_table::io::commit::RenameCommitHandler;
-        let data = gen()
+        let data = gen_batch()
             .col(
                 "vector",
                 array::rand_vec::<Float32Type>(Dimension::from(32)),
@@ -6859,7 +6859,7 @@ mod test {
         // indexed column
 
         use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
-        let data = gen()
+        let data = gen_batch()
             .col(
                 "vector",
                 array::rand_vec::<Float32Type>(Dimension::from(32)),

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -137,11 +137,11 @@ mod tests {
     use all_asserts::assert_true;
     use arrow_array::cast::AsArray;
     use arrow_array::types::{Int32Type, Int64Type, UInt64Type};
-    use lance_datagen::{array, gen};
+    use lance_datagen::{array, gen_batch};
 
     #[tokio::test]
     async fn test_sql_execute() {
-        let mut ds = gen()
+        let mut ds = gen_batch()
             .col("x", array::step::<Int32Type>())
             .col("y", array::step_custom::<Int32Type>(0, 2))
             .into_dataset(
@@ -190,7 +190,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_sql_count() {
-        let mut ds = gen()
+        let mut ds = gen_batch()
             .col("x", array::step::<Int32Type>())
             .col("y", array::step_custom::<Int32Type>(0, 2))
             .into_dataset(
@@ -234,7 +234,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_sql_explain_plan() {
-        let mut ds = gen()
+        let mut ds = gen_batch()
             .col("x", array::step::<Int32Type>())
             .col("y", array::step_custom::<Int32Type>(0, 2))
             .into_dataset(

--- a/rust/lance/src/dataset/updater.rs
+++ b/rust/lance/src/dataset/updater.rs
@@ -420,7 +420,7 @@ mod tests {
                 *batch_size,
             );
 
-            let batch = lance_datagen::gen()
+            let batch = lance_datagen::gen_batch()
                 .col("x", lance_datagen::array::step::<Int32Type>())
                 .into_batch_rows(RowCount::from(10))
                 .unwrap();
@@ -428,7 +428,7 @@ mod tests {
             let restored = restorer.restore(batch.clone()).unwrap();
             assert_eq!(restored, batch);
 
-            let batch = lance_datagen::gen()
+            let batch = lance_datagen::gen_batch()
                 .col("x", lance_datagen::array::step::<Int32Type>())
                 .into_batch_rows(RowCount::from(7))
                 .unwrap();
@@ -457,7 +457,7 @@ mod tests {
 
     #[test]
     fn test_add_blanks() {
-        let batch = lance_datagen::gen()
+        let batch = lance_datagen::gen_batch()
             .col("x", lance_datagen::array::step::<Int32Type>())
             .into_batch_rows(RowCount::from(10))
             .unwrap();

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -798,7 +798,7 @@ mod tests {
     use arrow_schema::{DataType, Field as ArrowField, Fields, Schema as ArrowSchema};
     use datafusion::{error::DataFusionError, physical_plan::stream::RecordBatchStreamAdapter};
     use futures::TryStreamExt;
-    use lance_datagen::{array, gen, BatchCount, RowCount};
+    use lance_datagen::{array, gen_batch, BatchCount, RowCount};
     use lance_file::reader::FileReader;
     use lance_io::traits::Reader;
 
@@ -925,7 +925,7 @@ mod tests {
         // To avoid generating and writing millions of rows (which is a bit slow for a unit
         // test) we can use a large data type (1KiB binary)
         let data_reader = Box::new(
-            gen()
+            gen_batch()
                 .anon_col(array::rand_fsb(1024))
                 .into_reader_rows(RowCount::from(10 * 1024), BatchCount::from(2)),
         );

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -2257,7 +2257,7 @@ mod tests {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
 
-        let data = lance_datagen::gen()
+        let data = lance_datagen::gen_batch()
             .with_seed(Seed::from(1))
             .col("value", array::step::<UInt32Type>())
             .col("key", array::rand_pseudo_uuid_hex());
@@ -2272,7 +2272,7 @@ mod tests {
             .unwrap();
 
         // Create some new (unindexed) data
-        let data = lance_datagen::gen()
+        let data = lance_datagen::gen_batch()
             .with_seed(Seed::from(2))
             .col("value", array::step::<UInt32Type>())
             .col("key", array::rand_pseudo_uuid_hex());
@@ -2298,7 +2298,7 @@ mod tests {
             .await
             .unwrap();
         let some_indices = some_indices.column(0).clone();
-        let some_vals = lance_datagen::gen()
+        let some_vals = lance_datagen::gen_batch()
             .anon_col(array::fill::<UInt32Type>(9999999))
             .into_batch_rows(RowCount::from(2048))
             .unwrap();
@@ -2384,7 +2384,7 @@ mod tests {
         }
 
         async fn setup(scalar_index: bool) -> Fixtures {
-            let data = lance_datagen::gen()
+            let data = lance_datagen::gen_batch()
                 .with_seed(Seed::from(1))
                 .col("other", array::rand_utf8(4.into(), false))
                 .col("value", array::step::<UInt32Type>())
@@ -2874,7 +2874,7 @@ mod tests {
     #[tokio::test]
     async fn test_merge_insert_updates_indices() {
         let test_dataset = async || {
-            let mut dataset = lance_datagen::gen()
+            let mut dataset = lance_datagen::gen_batch()
                 .col("id", array::step::<UInt32Type>())
                 .col("value", array::step::<UInt32Type>())
                 .col("other_value", array::step::<UInt32Type>())
@@ -2969,7 +2969,7 @@ mod tests {
 
         let (dataset, _) = merge_insert
             .execute_reader(
-                lance_datagen::gen()
+                lance_datagen::gen_batch()
                     .col("id", array::step_custom::<UInt32Type>(50, 1))
                     .col("value", array::step_custom::<UInt32Type>(50, 1))
                     .col("other_value", array::step_custom::<UInt32Type>(50, 1))
@@ -2997,7 +2997,7 @@ mod tests {
 
         let (dataset, _) = merge_insert
             .execute_reader(
-                lance_datagen::gen()
+                lance_datagen::gen_batch()
                     .col("id", array::step_custom::<UInt32Type>(50, 1))
                     .col("value", array::step_custom::<UInt32Type>(50, 1))
                     .into_df_stream(RowCount::from(40), BatchCount::from(1)),
@@ -3029,7 +3029,7 @@ mod tests {
 
         let (dataset, _) = merge_insert
             .execute_reader(
-                lance_datagen::gen()
+                lance_datagen::gen_batch()
                     .col("id", array::step_custom::<UInt32Type>(10, 1))
                     .col("value", array::step_custom::<UInt32Type>(10, 1))
                     .into_df_stream(RowCount::from(80), BatchCount::from(1)),
@@ -3132,7 +3132,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_plan_upsert() {
-        let data = lance_datagen::gen()
+        let data = lance_datagen::gen_batch()
             .with_seed(Seed::from(1))
             .col("value", array::step::<UInt32Type>())
             .col("key", array::rand_pseudo_uuid_hex());
@@ -3151,7 +3151,7 @@ mod tests {
                 .unwrap();
 
         // Create new data for upsert
-        let new_data = lance_datagen::gen()
+        let new_data = lance_datagen::gen_batch()
             .with_seed(Seed::from(2))
             .col("value", array::step::<UInt32Type>())
             .col("key", array::rand_pseudo_uuid_hex());
@@ -3184,7 +3184,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_fast_path_update_only() {
-        let data = lance_datagen::gen()
+        let data = lance_datagen::gen_batch()
             .with_seed(Seed::from(1))
             .col("value", array::step::<UInt32Type>())
             .col("key", array::rand_pseudo_uuid_hex());
@@ -3203,7 +3203,7 @@ mod tests {
                 .unwrap();
 
         // Create new data for update
-        let new_data = lance_datagen::gen()
+        let new_data = lance_datagen::gen_batch()
             .with_seed(Seed::from(2))
             .col("value", array::step::<UInt32Type>())
             .col("key", array::rand_pseudo_uuid_hex());
@@ -3230,7 +3230,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_fast_path_conditional_update() {
-        let data = lance_datagen::gen()
+        let data = lance_datagen::gen_batch()
             .with_seed(Seed::from(1))
             .col("value", array::step::<UInt32Type>())
             .col("key", array::rand_pseudo_uuid_hex());
@@ -3251,7 +3251,7 @@ mod tests {
         .unwrap();
 
         // Create new data for conditional update
-        let new_data = lance_datagen::gen()
+        let new_data = lance_datagen::gen_batch()
             .with_seed(Seed::from(2))
             .col("value", array::step::<UInt32Type>())
             .col("key", array::rand_pseudo_uuid_hex());
@@ -3283,7 +3283,7 @@ mod tests {
         let dataset_path = dataset_uri.to_str().unwrap();
 
         // Create initial dataset with auto cleanup interval of 1 version
-        let data = lance_datagen::gen()
+        let data = lance_datagen::gen_batch()
             .with_seed(Seed::from(1))
             .col("id", array::step::<UInt32Type>())
             .into_reader_rows(RowCount::from(100), BatchCount::from(1));
@@ -3316,7 +3316,7 @@ mod tests {
         clock.set_system_time(chrono::Duration::seconds(2));
 
         // First merge insert WITHOUT skip_auto_cleanup - should trigger cleanup
-        let new_data = lance_datagen::gen()
+        let new_data = lance_datagen::gen_batch()
             .with_seed(Seed::from(2))
             .col("id", array::step::<UInt32Type>())
             .into_df_stream(RowCount::from(50), BatchCount::from(1));
@@ -3337,7 +3337,7 @@ mod tests {
         clock.set_system_time(chrono::Duration::seconds(3));
 
         // Need to do another merge insert for cleanup to take effect since cleanup runs on the old dataset
-        let new_data_extra = lance_datagen::gen()
+        let new_data_extra = lance_datagen::gen_batch()
             .with_seed(Seed::from(4))
             .col("id", array::step::<UInt32Type>())
             .into_df_stream(RowCount::from(10), BatchCount::from(1));
@@ -3373,7 +3373,7 @@ mod tests {
         clock.set_system_time(chrono::Duration::seconds(4));
 
         // Second merge insert WITH skip_auto_cleanup - should NOT trigger cleanup
-        let new_data2 = lance_datagen::gen()
+        let new_data2 = lance_datagen::gen_batch()
             .with_seed(Seed::from(3))
             .col("id", array::step::<UInt32Type>())
             .into_df_stream(RowCount::from(30), BatchCount::from(1));
@@ -3409,7 +3409,7 @@ mod tests {
     #[tokio::test]
     async fn test_explain_plan() {
         // Set up test data using lance_datagen
-        let dataset = lance_datagen::gen()
+        let dataset = lance_datagen::gen_batch()
             .col("id", lance_datagen::array::step::<Int32Type>())
             .col("name", array::cycle_utf8_literals(&["a", "b", "c"]))
             .into_ram_dataset(FragmentCount::from(1), FragmentRowCount::from(3))
@@ -3455,7 +3455,7 @@ MergeInsert: on=[id], when_matched=UpdateAll, when_not_matched=InsertAll, when_n
     #[tokio::test]
     async fn test_analyze_plan() {
         // Set up test data using lance_datagen
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col("id", lance_datagen::array::step::<Int32Type>())
             .col("name", array::cycle_utf8_literals(&["a", "b", "c"]))
             .into_ram_dataset(FragmentCount::from(1), FragmentRowCount::from(3))

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1563,7 +1563,7 @@ mod tests {
     use arrow_array::{FixedSizeListArray, RecordBatch, RecordBatchIterator, StringArray};
     use arrow_schema::{Field, Schema};
     use lance_arrow::*;
-    use lance_datagen::r#gen;
+    use lance_datagen::gen_batch;
     use lance_datagen::{array, BatchCount, Dimension, RowCount};
     use lance_index::scalar::FullTextSearchQuery;
     use lance_index::vector::{
@@ -2388,7 +2388,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_remap_empty() {
-        let data = gen()
+        let data = gen_batch()
             .col("int", array::step::<Int32Type>())
             .col(
                 "vector",

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -562,7 +562,7 @@ mod tests {
     #[tokio::test]
     async fn test_advance_mem_wal_generation() {
         // Create a dataset with some data
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -707,7 +707,7 @@ mod tests {
     #[tokio::test]
     async fn test_append_new_entry_to_mem_wal() {
         // Create a dataset with some data
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -841,7 +841,7 @@ mod tests {
     #[tokio::test]
     async fn test_seal_mem_wal() {
         // Create a dataset with some data
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -1010,7 +1010,7 @@ mod tests {
     #[tokio::test]
     async fn test_flush_mem_wal() {
         // Create a dataset with some data
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -1118,7 +1118,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_mem_wal_owner() {
         // Create a dataset with some data
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -1279,7 +1279,7 @@ mod tests {
     #[tokio::test]
     async fn test_trim_mem_wal_index_with_reindex() {
         // Create a dataset with some data
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -1467,7 +1467,7 @@ mod tests {
     #[tokio::test]
     async fn test_trim_mem_wal_index_with_delta_index() {
         // Create a dataset with enough data for vector index clustering
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -1507,7 +1507,7 @@ mod tests {
             .unwrap();
 
         // Append new data files to the dataset (without rewriting existing files)
-        let new_data = lance_datagen::gen()
+        let new_data = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -1593,7 +1593,7 @@ mod tests {
     #[tokio::test]
     async fn test_flush_mem_wal_through_merge_insert() {
         // Create a dataset with some data
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -1644,7 +1644,7 @@ mod tests {
         );
 
         // Create new data for merge insert
-        let new_data = lance_datagen::gen()
+        let new_data = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -1820,7 +1820,7 @@ mod tests {
         );
 
         // Create merge insert that flushes generation 1
-        let new_data_valid = lance_datagen::gen()
+        let new_data_valid = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -1870,7 +1870,7 @@ mod tests {
     #[tokio::test]
     async fn test_replay_mem_wal_with_split_brain_writer() {
         // Create a dataset with some data
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -2018,7 +2018,7 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_mem_wal_replay_and_modifications() {
         // Create a dataset with some data
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -2128,7 +2128,7 @@ mod tests {
             .unwrap();
 
         // Create some data for the merge insert
-        let new_data = lance_datagen::gen()
+        let new_data = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -2172,7 +2172,7 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_mem_wal_append_and_merge_insert_flush() {
         // Create a dataset with some data
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -2252,7 +2252,7 @@ mod tests {
             .unwrap();
 
         // Create some data for the merge insert
-        let new_data = lance_datagen::gen()
+        let new_data = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -2322,7 +2322,7 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_mem_wal_advance_and_merge_insert_flush() {
         // Create a dataset with some data
-        let mut dataset = lance_datagen::gen()
+        let mut dataset = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),
@@ -2409,7 +2409,7 @@ mod tests {
             .unwrap();
 
         // Create some data for the merge insert
-        let new_data = lance_datagen::gen()
+        let new_data = lance_datagen::gen_batch()
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(128)),

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -1873,7 +1873,7 @@ mod tests {
     use itertools::Itertools;
     use lance_core::utils::address::RowAddress;
     use lance_core::ROW_ID;
-    use lance_datagen::{array, gen, ArrayGeneratorExt, Dimension, RowCount};
+    use lance_datagen::{array, gen_batch, ArrayGeneratorExt, Dimension, RowCount};
     use lance_index::metrics::NoOpMetricsCollector;
     use lance_index::vector::sq::builder::SQBuildParams;
     use lance_linalg::distance::l2_distance_batch;
@@ -2455,7 +2455,7 @@ mod tests {
         index_params.version(index_version);
 
         let nrows = 2_000;
-        let data = gen()
+        let data = gen_batch()
             .col(
                 "vec",
                 array::rand_vec::<Float32Type>(Dimension::from(test_case.dimension as u32)),
@@ -2509,7 +2509,7 @@ mod tests {
         // Generate random data with nulls
         let nrows = 2_000;
         let dims = 32;
-        let data = gen()
+        let data = gen_batch()
             .col(
                 "vec",
                 array::rand_vec::<Float32Type>(Dimension::from(dims as u32)).with_random_nulls(0.5),
@@ -2550,7 +2550,7 @@ mod tests {
         check_index(&dataset, num_non_null, dims).await;
 
         // Append more data
-        let data = gen()
+        let data = gen_batch()
             .col(
                 "vec",
                 array::rand_vec::<Float32Type>(Dimension::from(dims as u32)).with_random_nulls(0.5),

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -1881,7 +1881,7 @@ mod tests {
         generate_random_array, generate_random_array_with_range, generate_random_array_with_seed,
         generate_scaled_random_array, sample_without_replacement,
     };
-    use rand::{seq::SliceRandom, thread_rng};
+    use rand::{rng, seq::SliceRandom};
     use rstest::rstest;
     use tempfile::tempdir;
 
@@ -2183,7 +2183,7 @@ mod tests {
         if num_parts > ids.len() as u32 {
             panic!("Not enough ids to break into {num_parts} parts");
         }
-        let mut rng = thread_rng();
+        let mut rng = rng();
         ids.shuffle(&mut rng);
 
         let values_per_part = ids.len() / num_parts as usize;

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -680,7 +680,7 @@ mod tests {
     use lance_linalg::kernels::normalize_fsl;
     use lance_testing::datagen::{generate_random_array, generate_random_array_with_range};
     use object_store::path::Path;
-    use rand::distributions::uniform::SampleUniform;
+    use rand::distr::uniform::SampleUniform;
     use rstest::rstest;
     use tempfile::tempdir;
 

--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -296,7 +296,7 @@ fn random_ranges(
     byte_width: usize,
 ) -> impl Iterator<Item = std::ops::Range<u64>> + Send {
     let rows_per_batch = 1.max(block_size / byte_width);
-    let mut rng = SmallRng::from_entropy();
+    let mut rng = SmallRng::from_os_rng();
     let num_bins = num_rows.div_ceil(rows_per_batch);
 
     let bins_iter: Box<dyn Iterator<Item = usize> + Send> = if sample_size_hint * 5 >= num_rows {

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -37,7 +37,7 @@ use lance_table::format::{
 use lance_table::io::commit::{
     CommitConfig, CommitError, CommitHandler, ManifestLocation, ManifestNamingScheme,
 };
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 use snafu::location;
 
 use futures::future::Either;
@@ -561,7 +561,7 @@ pub(crate) async fn do_commit_detached_transaction(
     let mut backoff = Backoff::default();
     while backoff.attempt() < commit_config.num_retries {
         // Pick a random u64 with the highest bit set to indicate it is detached
-        let random_version = thread_rng().gen::<u64>() | DETACHED_VERSION_MASK;
+        let random_version = rng().random::<u64>() | DETACHED_VERSION_MASK;
 
         let (mut manifest, mut indices) = match transaction.operation {
             Operation::Restore { version } => {

--- a/rust/lance/src/io/commit/s3_test.rs
+++ b/rust/lance/src/io/commit/s3_test.rs
@@ -13,7 +13,7 @@ use crate::{
 use aws_config::{BehaviorVersion, ConfigLoader, Region, SdkConfig};
 use aws_sdk_s3::{config::Credentials, Client as S3Client};
 use futures::future::try_join_all;
-use lance_datagen::{array, gen, RowCount};
+use lance_datagen::{array, gen_batch, RowCount};
 
 const CONFIG: &[(&str, &str)] = &[
     ("access_key_id", "ACCESS_KEY"),
@@ -177,7 +177,7 @@ impl Drop for DynamoDBCommitTable {
 async fn test_concurrent_writers() {
     use crate::utils::test::IoTrackingStore;
 
-    let datagen = gen().col("values", array::step::<Int32Type>());
+    let datagen = gen_batch().col("values", array::step::<Int32Type>());
     let data = datagen.into_batch_rows(RowCount::from(100)).unwrap();
 
     let (io_stats_wrapper, io_stats) = IoTrackingStore::new_wrapper();
@@ -265,7 +265,7 @@ async fn test_ddb_open_iops() {
     let ddb_table = DynamoDBCommitTable::new("test-ddb-iops").await;
     let uri = format!("s3+ddb://{}/test?ddbTableName={}", bucket.0, ddb_table.0);
 
-    let datagen = gen().col("values", array::step::<Int32Type>());
+    let datagen = gen_batch().col("values", array::step::<Int32Type>());
     let data = datagen.into_batch_rows(RowCount::from(100)).unwrap();
 
     let (io_stats_wrapper, io_stats) = IoTrackingStore::new_wrapper();

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -1494,7 +1494,7 @@ mod tests {
     use arrow_array::{cast::AsArray, Array, UInt32Array};
     use itertools::Itertools;
     use lance_core::datatypes::OnMissing;
-    use lance_datagen::{array, r#gen, BatchCount, Dimension, RowCount};
+    use lance_datagen::{array, gen_batch, BatchCount, Dimension, RowCount};
     use lance_index::{
         optimize::OptimizeOptions,
         scalar::{expression::PlannerIndexExt, ScalarIndexParams},
@@ -1529,7 +1529,7 @@ mod tests {
         async fn new() -> Self {
             let tmp_path = tempfile::tempdir().unwrap();
 
-            let mut dataset = gen()
+            let mut dataset = gen_batch()
                 .col("fully_indexed", array::step::<UInt32Type>())
                 .col("partly_indexed", array::step::<UInt64Type>())
                 .col("not_indexed", array::step::<UInt32Type>())
@@ -1577,7 +1577,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            let new_data = gen()
+            let new_data = gen_batch()
                 .col("fully_indexed", array::step_custom::<UInt32Type>(200, 1))
                 .col("partly_indexed", array::step_custom::<UInt64Type>(200, 1))
                 .col("not_indexed", array::step_custom::<UInt32Type>(200, 1))
@@ -2115,7 +2115,7 @@ mod tests {
         // This test reproduces the issue from the Python test_limit_offset[stable] failure
         // Create a simple dataset with 10 rows (0-9)
         let tmp_path = tempfile::tempdir().unwrap();
-        let mut dataset = gen()
+        let mut dataset = gen_batch()
             .col("a", array::step::<UInt32Type>())
             .into_dataset(
                 tmp_path.path().to_str().unwrap(),

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -1058,7 +1058,7 @@ pub mod tests {
             .execute(0, Arc::new(TaskContext::default()))
             .unwrap();
 
-        let flat_input = lance_datagen::gen()
+        let flat_input = lance_datagen::gen_batch()
             .col(
                 "text",
                 lance_datagen::array::rand_utf8(ByteCount::from(10), false),

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -1493,7 +1493,7 @@ mod tests {
             let num_frags = 100;
             let frags_per_delta = num_frags / num_deltas;
 
-            let batches = lance_datagen::gen()
+            let batches = lance_datagen::gen_batch()
                 .col("vector", array::jitter_centroids(centroids.clone(), 0.0001))
                 .col("label", array::cycle::<UInt32Type>(Vec::from_iter(0..61)))
                 .col("userid", array::step::<UInt64Type>())

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -805,7 +805,7 @@ mod tests {
         scalar::ScalarValue,
     };
     use futures::TryStreamExt;
-    use lance_datagen::gen;
+    use lance_datagen::gen_batch;
     use lance_index::{
         scalar::{
             expression::{ScalarIndexExpr, ScalarIndexSearch},
@@ -832,7 +832,7 @@ mod tests {
         let test_dir = tempdir().unwrap();
         let test_uri = test_dir.path().to_str().unwrap();
 
-        let mut dataset = gen()
+        let mut dataset = gen_batch()
             .col("ordered", lance_datagen::array::step::<UInt64Type>())
             .into_dataset(
                 test_uri,

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -928,7 +928,7 @@ mod tests {
         let fixture = NoContextTestFixture::new();
         let arc_dasaset = Arc::new(fixture.dataset);
 
-        let input = lance_datagen::gen()
+        let input = lance_datagen::gen_batch()
             .col(ROW_ID, lance_datagen::array::step::<UInt64Type>())
             .into_df_exec(RowCount::from(50), BatchCount::from(2));
 

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -447,7 +447,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_replay() {
-        let data = lance_datagen::gen()
+        let data = lance_datagen::gen_batch()
             .col("x", array::step::<UInt32Type>())
             .into_reader_rows(RowCount::from(1024), BatchCount::from(16));
         let schema = data.schema();

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -701,7 +701,7 @@ impl NoContextTestFixture {
         runtime.block_on(async move {
             let tempdir = tempdir().unwrap();
             let tmppath = tempdir.path().to_str().unwrap();
-            let dataset = lance_datagen::gen()
+            let dataset = lance_datagen::gen_batch()
                 .col(
                     "text",
                     lance_datagen::array::rand_utf8(ByteCount::from(10), false),

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -84,7 +84,7 @@ impl TestDatasetGenerator {
     ///    consistent across fragments.
     ///
     pub async fn make_hostile(&self, uri: &str) -> Dataset {
-        let seed = self.seed.unwrap_or_else(|| rand::thread_rng().gen());
+        let seed = self.seed.unwrap_or_else(|| rand::rng().random());
         let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
         let schema = self.make_schema(&mut rng);
 
@@ -147,7 +147,7 @@ impl TestDatasetGenerator {
         let mut new_ids = field_ids.clone();
         // Add a hole
         if new_ids.len() > 2 {
-            let hole_pos = rng.gen_range(1..new_ids.len() - 1);
+            let hole_pos = rng.random_range(1..new_ids.len() - 1);
             for id in new_ids.iter_mut().skip(hole_pos) {
                 *id += 1;
             }
@@ -180,7 +180,7 @@ impl TestDatasetGenerator {
         let num_files = if batch.num_columns() == 1 {
             1
         } else {
-            rng.gen_range(min_num_files..=batch.num_columns())
+            rng.random_range(min_num_files..=batch.num_columns())
         };
 
         // Randomly assign top level fields to files.
@@ -863,7 +863,7 @@ mod tests {
         let data = vec![RecordBatch::new_empty(arrow_schema.clone())];
 
         let generator = TestDatasetGenerator::new(data, data_storage_version);
-        let schema = generator.make_schema(&mut rand::thread_rng());
+        let schema = generator.make_schema(&mut rand::rng());
 
         let roundtripped_schema = ArrowSchema::from(&schema);
         assert_eq!(&roundtripped_schema, arrow_schema.as_ref());
@@ -920,7 +920,7 @@ mod tests {
         .unwrap();
 
         let generator = TestDatasetGenerator::new(vec![data.clone()], data_storage_version);
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         for _ in 1..50 {
             let schema = generator.make_schema(&mut rng);
             let fragment = generator


### PR DESCRIPTION
- upgrades `rand` to `0.9.1`
- replace `gen` with `genn` as `gen` will be keyword of Rust