### PR TITLE
ci: crates.io auth token is not long enough for us

### DIFF
--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -55,10 +55,12 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y protobuf-compiler libssl-dev
-      - uses: rust-lang/crates-io-auth-action@v1
-        id: auth
+      # Wait until https://github.com/rust-lang/crates-io-auth-action/issues/51 fixed
+      # - uses: rust-lang/crates-io-auth-action@v1
+      #   id: auth
       - uses: albertlockett/publish-crates@v2.2
         with:
-          registry-token: ${{ steps.auth.outputs.token }}
+          # registry-token: ${{ steps.auth.outputs.token }}
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           args: "--all-features"
           path: .


### PR DESCRIPTION
As mentioned in https://github.com/rust-lang/crates-io-auth-action/issues/51, the token expires after 30 minutes, which is insufficient for our needs. Let's revert this change and wait for a more suitable solution.