### PR TITLE
fix: too large data chunk generated by highly compressed yet nested data with RLE

### DIFF
--- a/rust/lance-encoding/src/encodings/physical/rle.rs
+++ b/rust/lance-encoding/src/encodings/physical/rle.rs
@@ -57,7 +57,6 @@ use crate::data::DataBlock;
 use crate::data::{BlockInfo, FixedWidthDataBlock};
 use crate::encodings::logical::primitive::miniblock::{
     MiniBlockChunk, MiniBlockCompressed, MiniBlockCompressor, MAX_MINIBLOCK_BYTES,
-    MAX_MINIBLOCK_VALUES,
 };
 use crate::format::{pb, ProtobufUtils};
 
@@ -199,7 +198,12 @@ impl RleMiniBlockEncoder {
         let data_slice = data.as_ref();
 
         let chunk_start = offset * type_size;
-        let max_by_count = MAX_MINIBLOCK_VALUES as usize;
+        // FIXME(xuanwo): we don't allow 4096 values as a workaround for https://github.com/lancedb/lance/issues/4429
+        // Since while rep/def takes 4B, 4Ki values will lead to the
+        // generated chunk buffer too large.MAX_MINIBLOCK_VALUES
+        //
+        // let max_by_count =  as usize;
+        let max_by_count = 2048usize;
         let max_values = values_remaining.min(max_by_count);
         let chunk_end = chunk_start + max_values * type_size;
 
@@ -527,6 +531,7 @@ mod tests {
     use super::*;
     use crate::compression::{CompressionStrategy, DefaultCompressionStrategy};
     use crate::data::DataBlock;
+    use crate::encodings::logical::primitive::miniblock::MAX_MINIBLOCK_VALUES;
     use arrow_array::Int32Array;
     use lance_core::datatypes::Field;
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -7231,8 +7231,10 @@ mod tests {
         let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
 
         // V2.1 format triggers miniblock encoding for narrow structs
-        let mut write_params = WriteParams::default();
-        write_params.data_storage_version = Some(lance_file::version::LanceFileVersion::V2_1);
+        let write_params = WriteParams {
+            data_storage_version: Some(lance_file::version::LanceFileVersion::V2_1),
+            ..Default::default()
+        };
 
         // Write dataset - this will panic with miniblock 16KB assertion
         let dataset = Dataset::write(reader, &test_uri, Some(write_params))


### PR DESCRIPTION
close https://github.com/lancedb/lance/issues/4429

---

As described in #4429, highly compressed yet nested data using RLE can produce data chunks that exceed our 16KiB threshold. This happens because our RLE encoding currently considers only the data buffer size and does not account for the size of REP/DEF markers, which can consume up to 4 bytes per value.

Ideally, we should include REP/DEF sizes in the calculation, but that would require significant changes. In this PR, I implemented a workaround to address the issue at the cost of a slightly lower compression ratio. A more comprehensive fix will follow after discussion.

This PR also includes a repro as part of our unit test to prevent regression of this bug.