### PR TITLE
chore(java): set the default file version to stable in java file api

### DIFF
--- a/java/core/lance-jni/src/file_writer.rs
+++ b/java/core/lance-jni/src/file_writer.rs
@@ -95,7 +95,7 @@ fn inner_open<'local>(
         Result::Ok(FileWriter::new_lazy(
             obj_writer,
             FileWriterOptions {
-                format_version: Some(LanceFileVersion::V2_1),
+                format_version: Some(LanceFileVersion::Stable),
                 ..Default::default()
             },
         ))


### PR DESCRIPTION
Since v2.1 is still unstable for production, we should set the default file version to stable for java file api (v2.0).
By the way, in python file api, the default file version is v2.0.

| Version        | Minimal Lance Version | Maximum Lance Version | Description                                                                                                                                  |
| -------------- | --------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
| 0.1            | Any                   | Any                   | This is the initial Lance format.                                                                                                            |
| 2.0            | 0.16.0                | Any                   | Rework of the Lance file format that removed row groups and introduced null support for lists, fixed size lists, and primitives              |
| 2.1 (unstable) | None                  | Any                   | Enhances integer and string compression, adds support for nulls in struct fields, and improves random access performance with nested fields. |
| legacy         | N/A                   | N/A                   | Alias for 0.1                                                                                                                                |
| stable         | N/A                   | N/A                   | Alias for the latest stable version (currently 2.0)                                                                                          |
| next           | N/A                   | N/A                   | Alias for the latest unstable version (currently 2.1)                                                                                        |