### PR TITLE
feat(python)!: unify Python CreateIndex api with Rust implementation

### DIFF
--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -5370,6 +5370,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-build 0.11.9",
  "pyo3",
+ "roaring",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -57,6 +57,7 @@ pyo3 = { version = "0.24.1", features = [
 ] }
 tokio = { version = "1.23", features = ["rt-multi-thread"] }
 uuid = "1.3.0"
+roaring = "0.10.1"
 serde_json = "1"
 serde = "1.0.197"
 serde_yaml = "0.9.34"

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3256,13 +3256,17 @@ class ExecuteResult(TypedDict):
     num_deleted_rows: int
 
 
-class Index(TypedDict):
-    name: str
-    type: str
+@dataclass
+class Index:
+    """Represents an index in the dataset."""
+
     uuid: str
-    fields: List[str]
-    version: int
+    name: str
+    fields: List[int]
+    dataset_version: int
     fragment_ids: Set[int]
+    index_version: int
+    created_at: Optional[datetime] = None
 
 
 class AutoCleanupConfig(TypedDict):
@@ -3612,13 +3616,8 @@ class LanceOperation:
         Operation that creates an index on the dataset.
         """
 
-        uuid: str
-        name: str
-        fields: List[int]
-        dataset_version: int
-        fragment_ids: Set[int]
-        index_version: int
-        created_at: Optional[datetime] = None
+        new_indices: List[Index]
+        removed_indices: List[Index]
 
     @dataclass
     class DataReplacementGroup:

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -12,12 +12,87 @@ use pyo3::exceptions::PyValueError;
 use pyo3::types::PySet;
 use pyo3::{intern, prelude::*};
 use pyo3::{Bound, FromPyObject, PyAny, PyResult, Python};
+use roaring::RoaringBitmap;
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::schema::LanceSchema;
 use crate::utils::{class_name, export_vec, extract_vec, PyLance};
+
+// Add Index bindings
+impl FromPyObject<'_> for PyLance<Index> {
+    fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
+        let uuid = ob.getattr("uuid")?.to_string();
+        let name = ob.getattr("name")?.extract()?;
+        let fields = ob.getattr("fields")?.extract()?;
+        let dataset_version = ob.getattr("dataset_version")?.extract()?;
+        let index_version = ob.getattr("index_version")?.extract()?;
+        let fragment_ids = ob.getattr("fragment_ids")?;
+        let created_at = ob.getattr("created_at")?.extract()?;
+
+        let fragment_ids_ref: &Bound<'_, PySet> = fragment_ids.downcast()?;
+        let fragment_bitmap = Some(
+            fragment_ids_ref
+                .into_iter()
+                .map(|id| id.extract::<u32>())
+                .collect::<PyResult<RoaringBitmap>>()?,
+        );
+
+        Ok(Self(Index {
+            uuid: Uuid::parse_str(&uuid).map_err(|e| PyValueError::new_err(e.to_string()))?,
+            name,
+            fields,
+            dataset_version,
+            fragment_bitmap,
+            index_details: None,
+            index_version,
+            created_at,
+        }))
+    }
+}
+
+impl<'py> IntoPyObject<'py> for PyLance<&Index> {
+    type Target = PyAny;
+    type Output = Bound<'py, Self::Target>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        let namespace = py
+            .import(intern!(py, "lance"))
+            .expect("Failed to import lance module");
+
+        let uuid = self.0.uuid.to_string();
+        let name = &self.0.name;
+        let fields = &self.0.fields;
+        let dataset_version = self.0.dataset_version;
+        let index_version = self.0.index_version;
+        let fragment_ids = self.0.fragment_bitmap.as_ref().map_or_else(
+            || PySet::empty(py).unwrap(),
+            |bitmap| {
+                let set = PySet::empty(py).unwrap();
+                for id in bitmap.iter() {
+                    set.add(id).unwrap();
+                }
+                set
+            },
+        );
+        let created_at = self.0.created_at;
+
+        let cls = namespace
+            .getattr("Index")
+            .expect("Failed to get Index class");
+        cls.call1((
+            uuid,
+            name.clone(),
+            fields.clone(),
+            dataset_version,
+            fragment_ids,
+            index_version,
+            created_at,
+        ))
+    }
+}
 
 impl FromPyObject<'_> for PyLance<DataReplacementGroup> {
     fn extract_bound(ob: &Bound<'_, PyAny>) -> PyResult<Self> {
@@ -127,37 +202,15 @@ impl FromPyObject<'_> for PyLance<Operation> {
                 Ok(Self(op))
             }
             "CreateIndex" => {
-                let uuid = ob.getattr("uuid")?.to_string();
-                let name = ob.getattr("name")?.extract()?;
-                let fields = ob.getattr("fields")?.extract()?;
-                let dataset_version = ob.getattr("dataset_version")?.extract()?;
-                let index_version = ob.getattr("index_version")?.extract()?;
-                let fragment_ids = ob.getattr("fragment_ids")?;
-                let created_at = ob.getattr("created_at")?.extract()?;
-                let fragment_ids_ref: &Bound<'_, PySet> = fragment_ids.downcast()?;
-                let fragment_ids = fragment_ids_ref
-                    .into_iter()
-                    .map(|id| id.extract())
-                    .collect::<PyResult<Vec<u32>>>()?;
-                let fragment_bitmap = Some(fragment_ids.into_iter().collect());
+                let new_indices_py = ob.getattr("new_indices")?;
+                let removed_indices_py = ob.getattr("removed_indices")?;
 
-                let new_indices = vec![Index {
-                    uuid: Uuid::parse_str(&uuid)
-                        .map_err(|e| PyValueError::new_err(e.to_string()))?,
-                    name,
-                    fields,
-                    dataset_version,
-                    fragment_bitmap,
-                    // TODO: we should use lance::dataset::Dataset::commit_existing_index once
-                    // we have a way to determine index details from an existing index.
-                    index_details: None,
-                    index_version,
-                    created_at,
-                }];
+                let new_indices = extract_vec(&new_indices_py)?;
+                let removed_indices = extract_vec(&removed_indices_py)?;
 
                 let op = Operation::CreateIndex {
-                    removed_indices: Vec::new(),
                     new_indices,
+                    removed_indices,
                 };
                 Ok(Self(op))
             }
@@ -285,52 +338,16 @@ impl<'py> IntoPyObject<'py> for PyLance<&Operation> {
                 cls.call1((groups_py, rewritten_indices_py))
             }
             Operation::CreateIndex {
-                ref new_indices, ..
+                ref new_indices,
+                ref removed_indices,
             } => {
-                if let Some(index) = new_indices.first() {
-                    let uuid = index.uuid.to_string();
-                    let name = &index.name;
-                    let fields = &index.fields;
-                    let dataset_version = index.dataset_version;
-                    let index_version = index.index_version;
-                    let fragment_ids = index.fragment_bitmap.as_ref().map_or_else(
-                        || PySet::empty(py).unwrap(),
-                        |bitmap| {
-                            let set = PySet::empty(py).unwrap();
-                            for id in bitmap.iter() {
-                                set.add(id).unwrap();
-                            }
-                            set
-                        },
-                    );
-                    let created_at = index.created_at;
+                let new_indices_py = export_vec(py, new_indices.as_slice())?;
+                let removed_indices_py = export_vec(py, removed_indices.as_slice())?;
 
-                    let cls = namespace
-                        .getattr("CreateIndex")
-                        .expect("Failed to get CreateIndex class");
-                    cls.call1((
-                        uuid,
-                        name,
-                        fields,
-                        dataset_version,
-                        fragment_ids,
-                        index_version,
-                        created_at,
-                    ))
-                } else {
-                    let cls = namespace
-                        .getattr("CreateIndex")
-                        .expect("Failed to get CreateIndex class");
-                    cls.call1((
-                        "",
-                        "",
-                        Vec::<i32>::new(),
-                        0,
-                        PySet::empty(py).unwrap(),
-                        0,
-                        None::<Option<i64>>,
-                    ))
-                }
+                let cls = namespace
+                    .getattr("CreateIndex")
+                    .expect("Failed to get CreateIndex class");
+                cls.call1((new_indices_py, removed_indices_py))
             }
             Operation::Project { ref schema } => {
                 let schema_py = LanceSchema(schema.clone());


### PR DESCRIPTION
BREAKING CHANGE: the `CreateIndex` operation in Python now takes a list of indices instead of representing a single index

closes https://github.com/lancedb/lance/issues/4390

This commit refactors the Python CreateIndex class to match the Rust implementation structure, enabling consistent API across languages.

- Updated CreateIndex class to use new_indices and removed_indices fields
- Enhanced Index class from TypedDict to dataclass
- Simplified pyo3 bindings
- Updated test cases to use new API structure