### PR TITLE
perf: introduce `assume` for generating better code

### DIFF
--- a/rust/lance-core/src/utils.rs
+++ b/rust/lance-core/src/utils.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 pub mod address;
+pub mod assume;
 pub mod backoff;
 pub mod bit;
 pub mod cpu;

--- a/rust/lance-core/src/utils/assume.rs
+++ b/rust/lance-core/src/utils/assume.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+/// A macro that combines debug_assert and std::hint::assert_unchecked for optimized assertions
+///
+/// In debug builds, this will perform a normal assertion check.
+/// In release builds, this will use hint::assert_unchecked which tells the compiler to assume
+/// the condition is true without actually checking it.
+///
+/// # Safety
+///
+/// This macro is unsafe in release builds since it uses hint::assert_unchecked.
+/// The caller must ensure the condition will always be true.
+#[macro_export]
+macro_rules! assume {
+    ($cond:expr) => {
+        debug_assert!($cond);
+        // SAFETY: The debug_assert ensures this is true in debug builds.
+        // In release builds, caller must ensure the condition holds.
+        unsafe { std::hint::assert_unchecked($cond); }
+    };
+    ($cond:expr, $($arg:tt)+) => {
+        debug_assert!($cond, $($arg)+);
+        // SAFETY: The debug_assert ensures this is true in debug builds.
+        // In release builds, caller must ensure the condition holds.
+        unsafe { std::hint::assert_unchecked($cond); }
+    };
+}
+
+/// A macro that combines debug_assert_eq and std::hint::assert_unchecked for optimized equality assertions
+///
+/// In debug builds, this will perform a normal equality assertion check.
+/// In release builds, this will use hint::assert_unchecked which tells the compiler to assume
+/// the values are equal without actually checking them.
+///
+/// # Safety
+///
+/// This macro is unsafe in release builds since it uses hint::assert_unchecked.
+/// The caller must ensure the values will always be equal.
+#[macro_export]
+macro_rules! assume_eq {
+    ($left:expr, $right:expr) => {
+        debug_assert_eq!($left, $right);
+        // SAFETY: The debug_assert ensures this is true in debug builds.
+        // In release builds, caller must ensure the values are equal.
+        unsafe { std::hint::assert_unchecked($left == $right); }
+    };
+    ($left:expr, $right:expr, $($arg:tt)+) => {
+        debug_assert_eq!($left, $right, $($arg)+);
+        // SAFETY: The debug_assert ensures this is true in debug builds.
+        // In release builds, caller must ensure the values are equal.
+        unsafe { std::hint::assert_unchecked($left == $right); }
+    };
+}

--- a/rust/lance-core/src/utils/assume.rs
+++ b/rust/lance-core/src/utils/assume.rs
@@ -27,28 +27,15 @@ macro_rules! assume {
     };
 }
 
-/// A macro that combines debug_assert_eq and std::hint::assert_unchecked for optimized equality assertions
-///
-/// In debug builds, this will perform a normal equality assertion check.
-/// In release builds, this will use hint::assert_unchecked which tells the compiler to assume
-/// the values are equal without actually checking them.
-///
-/// # Safety
-///
-/// This macro is unsafe in release builds since it uses hint::assert_unchecked.
-/// The caller must ensure the values will always be equal.
+/// Helper macro for equality assumptions.
 #[macro_export]
 macro_rules! assume_eq {
     ($left:expr, $right:expr) => {
         debug_assert_eq!($left, $right);
-        // SAFETY: The debug_assert ensures this is true in debug builds.
-        // In release builds, caller must ensure the values are equal.
         unsafe { std::hint::assert_unchecked($left == $right); }
     };
     ($left:expr, $right:expr, $($arg:tt)+) => {
         debug_assert_eq!($left, $right, $($arg)+);
-        // SAFETY: The debug_assert ensures this is true in debug builds.
-        // In release builds, caller must ensure the values are equal.
         unsafe { std::hint::assert_unchecked($left == $right); }
     };
 }

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -4,6 +4,7 @@
 use core::panic;
 use std::cmp::{max, min};
 
+use lance_core::assume_eq;
 use lance_linalg::distance::{dot_distance_batch, l2_distance_batch, Dot, L2};
 use lance_linalg::simd::u8::u8x16;
 use lance_linalg::simd::{Shuffle, SIMD};
@@ -129,6 +130,7 @@ pub(super) fn compute_pq_distance(
     for (sub_vec_idx, vec_indices) in code.chunks_exact(num_vectors).enumerate() {
         let dist_table =
             &distance_table[sub_vec_idx * NUM_CENTROIDS..(sub_vec_idx + 1) * NUM_CENTROIDS];
+        // assume_eq!(dist_table.len(), NUM_CENTROIDS);
         debug_assert_eq!(vec_indices.len(), distances.len());
         vec_indices
             .iter()

--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -130,8 +130,8 @@ pub(super) fn compute_pq_distance(
     for (sub_vec_idx, vec_indices) in code.chunks_exact(num_vectors).enumerate() {
         let dist_table =
             &distance_table[sub_vec_idx * NUM_CENTROIDS..(sub_vec_idx + 1) * NUM_CENTROIDS];
-        // assume_eq!(dist_table.len(), NUM_CENTROIDS);
-        debug_assert_eq!(vec_indices.len(), distances.len());
+        assume_eq!(dist_table.len(), NUM_CENTROIDS);
+        assume_eq!(vec_indices.len(), distances.len());
         vec_indices
             .iter()
             .zip(distances.iter_mut())

--- a/rust/lance-index/src/vector/pq/utils.rs
+++ b/rust/lance-index/src/vector/pq/utils.rs
@@ -4,7 +4,7 @@
 use arrow_array::{
     cast::AsArray, types::ArrowPrimitiveType, Array, FixedSizeListArray, PrimitiveArray,
 };
-use lance_core::{Error, Result};
+use lance_core::{assume, Error, Result};
 use snafu::location;
 
 /// Divide a 2D vector in [`T::Array`] to `m` sub-vectors.
@@ -62,7 +62,7 @@ pub fn get_sub_vector_centroids<const NUM_BITS: u32, T>(
     num_sub_vectors: usize,
     sub_vector_idx: usize,
 ) -> &[T] {
-    debug_assert!(
+    assume!(
         sub_vector_idx < num_sub_vectors,
         "sub_vector idx: {}, num_sub_vectors: {}",
         sub_vector_idx,

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -13,6 +13,7 @@ use arrow_array::{cast::AsArray, types::Float32Type, Array, FixedSizeListArray, 
 use arrow_schema::DataType;
 use half::{bf16, f16};
 use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray};
+use lance_core::assume_eq;
 #[cfg(feature = "fp16kernels")]
 use lance_core::utils::cpu::SimdSupport;
 use lance_core::utils::cpu::FP16_SIMD_SUPPORT;
@@ -218,8 +219,8 @@ pub fn dot_distance_batch<'a, T: Dot>(
     to: &'a [T],
     dimension: usize,
 ) -> Box<dyn Iterator<Item = f32> + 'a> {
-    debug_assert_eq!(from.len(), dimension);
-    debug_assert_eq!(to.len() % dimension, 0);
+    assume_eq!(from.len(), dimension);
+    assume_eq!(to.len() % dimension, 0);
     Box::new(to.chunks_exact(dimension).map(|v| dot_distance(from, v)))
 }
 

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -17,6 +17,7 @@ use arrow_array::{
 use arrow_schema::DataType;
 use half::{bf16, f16};
 use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray};
+use lance_core::assume_eq;
 #[cfg(feature = "fp16kernels")]
 use lance_core::utils::cpu::SimdSupport;
 use lance_core::utils::cpu::FP16_SIMD_SUPPORT;
@@ -195,8 +196,8 @@ pub fn l2_distance_batch<'a, T: L2>(
     to: &'a [T],
     dimension: usize,
 ) -> impl Iterator<Item = f32> + 'a {
-    debug_assert_eq!(from.len(), dimension);
-    debug_assert_eq!(to.len() % dimension, 0);
+    assume_eq!(from.len(), dimension);
+    assume_eq!(to.len() % dimension, 0);
 
     T::l2_batch(from, to, dimension)
 }


### PR DESCRIPTION
```
construct_dist_table: l2,PQ=96,DIM=1536
                        time:   [116.87 µs 117.06 µs 117.32 µs]
                        change: [-3.9662% -3.5804% -3.1590%] (p = 0.00 < 0.10)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

construct_dist_table: dot,PQ=96,DIM=1536
                        time:   [142.57 µs 142.76 µs 143.20 µs]
                        change: [-3.9276% -3.4103% -2.7466%] (p = 0.00 < 0.10)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

compute_distances: 16000,l2,PQ=96,DIM=1536
                        time:   [370.34 µs 370.98 µs 371.97 µs]
                        change: [-2.0826% -1.6790% -1.3494%] (p = 0.00 < 0.10)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

compute_distances: 16000,cosine,PQ=96,DIM=1536
                        time:   [390.10 µs 391.95 µs 393.27 µs]
                        change: [-4.2590% -2.2274% -0.8685%] (p = 0.02 < 0.10)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

compute_distances: 16000,dot,PQ=96,DIM=1536
                        time:   [391.99 µs 392.78 µs 393.77 µs]
                        change: [-2.2872% -1.8801% -1.4425%] (p = 0.00 < 0.10)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
```