### PR TITLE
refactor: optimize MiniBlockRepIndex decode by decoding from bytes directly

### DIFF
--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -1023,24 +1023,17 @@ impl MiniBlockRepIndex {
     /// and no trailers, suitable for simple sequential data layouts.
     pub fn default_from_chunks(chunks: &[ChunkMeta]) -> Self {
         let mut blocks = Vec::with_capacity(chunks.len());
-        let mut chunk_has_preamble = false;
         let mut offset: u64 = 0;
 
         for c in chunks {
-            let ends = c.num_values;
-            let has_trailer = false;
-            let starts_including_trailer =
-                ends + (has_trailer as u64) - (chunk_has_preamble as u64);
-
             blocks.push(MiniBlockRepIndexBlock {
                 first_row: offset,
-                starts_including_trailer,
-                has_preamble: chunk_has_preamble,
-                has_trailer,
+                starts_including_trailer: c.num_values,
+                has_preamble: false,
+                has_trailer: false,
             });
 
-            chunk_has_preamble = has_trailer;
-            offset += starts_including_trailer;
+            offset += c.num_values;
         }
 
         Self { blocks }

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -1045,8 +1045,9 @@ impl MiniBlockRepIndex {
     /// where the first two values of each group represent ends_count and partial_count.
     /// Returns an empty index if no bytes are provided.
     pub fn decode_from_bytes(rep_bytes: &[u8], stride: usize) -> Self {
-        // Convert bytes to u64 slice using bytemuck for zero-copy conversion
-        let u64_slice: &[u64] = bytemuck::cast_slice(rep_bytes);
+        // Convert bytes to u64 slice, handling alignment automatically
+        let mut buffer = crate::buffer::LanceBuffer::from(rep_bytes.to_vec());
+        let u64_slice = buffer.borrow_to_typed_slice::<u64>();
         let n = u64_slice.len() / stride;
 
         let mut blocks = Vec::with_capacity(n);

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -1017,8 +1017,7 @@ impl DeepSizeOf for MiniBlockRepIndex {
 }
 
 impl MiniBlockRepIndex {
-    #[inline(never)]
-    pub fn decode_default_from_chunk_meta(chunks: &[ChunkMeta]) -> Self {
+    pub fn default_from_chunks(chunks: &[ChunkMeta]) -> Self {
         let mut blocks = Vec::with_capacity(chunks.len());
         let mut chunk_has_preamble = false;
         let mut offset: u64 = 0;
@@ -1033,7 +1032,7 @@ impl MiniBlockRepIndex {
                 first_row: offset,
                 starts_including_trailer,
                 has_preamble: chunk_has_preamble,
-                has_trailer: has_trailer,
+                has_trailer,
             });
 
             chunk_has_preamble = has_trailer;
@@ -1043,38 +1042,34 @@ impl MiniBlockRepIndex {
         Self { blocks }
     }
 
-    #[inline(never)]
-    pub fn decode_from_bytes_le(rep_bytes: &[u8], stride: usize, chunk_meta: &[ChunkMeta]) -> Self {
-        // 没有 repetition index 的情况，走默认路径
-        if rep_bytes.is_empty() {
-            return Self::decode_default_from_chunk_meta(chunk_meta);
-        }
-
-        assert!(stride >= 2, "rep stride must be >= 2 (ends, partial, ...)");
-        assert!(rep_bytes.len() % 8 == 0, "rep bytes must be multiples of 8");
-
-        let n64 = rep_bytes.len() / 8;
-        assert!(n64 % stride == 0, "rep length must be divisible by stride");
+    pub fn decode_from_bytes(rep_bytes: &[u8], stride: usize) -> Self {
+        let u64_size = std::mem::size_of::<u64>();
+        let n64 = rep_bytes.len() / u64_size;
         let n = n64 / stride;
 
         let mut blocks = Vec::with_capacity(n);
         let mut chunk_has_preamble = false;
         let mut offset: u64 = 0;
 
-        // 只取每个块的前两个值：ends_count 和 partial_count（小端）
+        // Extract first two values from each block: ends_count and partial_count
         for i in 0..n {
-            let base_u64 = i * stride;
-            let a = base_u64 * 8;
-            let b = a + 8;
-            let c = b + 8;
+            let base_offset = i * stride * u64_size;
+            let ends = {
+                let mut bytes = [0u8; 8];
+                bytes.copy_from_slice(&rep_bytes[base_offset..base_offset + u64_size]);
+                u64::from_le_bytes(bytes)
+            };
 
-            // 小端解释；多数存储格式（包括我们之前的实现）都是 LE。
-            // 若未来格式变了，只需把 from_le_bytes 换成 from_be_bytes。
-            let ends = u64::from_le_bytes(rep_bytes[a..b].try_into().unwrap());
-            let partial = u64::from_le_bytes(rep_bytes[b..c].try_into().unwrap());
+            let partial = {
+                let mut bytes = [0u8; 8];
+                bytes.copy_from_slice(
+                    &rep_bytes[base_offset + u64_size..base_offset + 2 * u64_size],
+                );
+                u64::from_le_bytes(bytes)
+            };
 
             let has_trailer = partial > 0;
-            // 分支转算术，便于编译器优化
+            // Convert branches to arithmetic for better compiler optimization
             let starts_including_trailer =
                 ends + (has_trailer as u64) - (chunk_has_preamble as u64);
 
@@ -1082,7 +1077,7 @@ impl MiniBlockRepIndex {
                 first_row: offset,
                 starts_including_trailer,
                 has_preamble: chunk_has_preamble,
-                has_trailer: has_trailer,
+                has_trailer,
             });
 
             chunk_has_preamble = has_trailer;
@@ -1598,32 +1593,12 @@ impl StructuralPageScheduler for MiniBlockScheduler {
             }
 
             // Build the repetition index
-            // let rep_index = if let Some(rep_index_data) = rep_index_bytes {
-            //     // If we have a repetition index then we use that
-            //     // TODO: Compress the repetition index :)
-            //     assert!(rep_index_data.len() % 8 == 0);
-            //     let mut repetition_index_vals = LanceBuffer::from_bytes(rep_index_data, 8);
-            //     let repetition_index_vals = repetition_index_vals.borrow_to_typed_slice::<u64>();
-            //     // Unflatten
-            //     repetition_index_vals
-            //         .as_ref()
-            //         .chunks_exact(self.repetition_index_depth as usize + 1)
-            //         .map(|c| c.to_vec())
-            //         .collect::<Vec<_>>()
-            // } else {
-            //     // Default rep index is just the number of items in each chunk
-            //     // with 0 partials/leftovers
-            //     chunk_meta
-            //         .iter()
-            //         .map(|c| vec![c.num_values, 0])
-            //         .collect::<Vec<_>>()
-            // };
-
             let rep_index = if let Some(rep_index_data) = rep_index_bytes {
+                assert!(rep_index_data.len() % 8 == 0);
                 let stride = self.repetition_index_depth as usize + 1;
-                MiniBlockRepIndex::decode_from_bytes_le(&rep_index_data, stride, &chunk_meta)
+                MiniBlockRepIndex::decode_from_bytes(&rep_index_data, stride)
             } else {
-                MiniBlockRepIndex::decode_default_from_chunk_meta(&chunk_meta)
+                MiniBlockRepIndex::default_from_chunks(&chunk_meta)
             };
 
             let mut page_meta = MiniBlockCacheableState {


### PR DESCRIPTION
`MiniBlockRepIndex::decode` used to be an allocation-heavy operation, creating numerous `Vec<Vec<u8>>` instances in memory only to drop them after parsing. The idea behind this PR is straightforward: decode the rep index directly from bytes without introducing any additional allocations.

## Before

```shell
Benchmarking V2_1 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take)
Benchmarking V2_1 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take): Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 16.7s, or reduce sample count to 20.
Benchmarking V2_1 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take): Collecting 100 samples in estimated 16.699 s (100 iterations)
Benchmarking V2_1 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take): Analyzing
V2_1 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take)
                        time:   [162.71 ms 163.23 ms 163.74 ms]
                        change: [+1.7266% +2.6730% +3.6496%] (p = 0.00 < 0.10)
                        Performance has regressed.
```

The `MiniBlockScheduler::initiate` only takes 45.3% of whole time.

<img width="3224" height="1126" alt="image" src="https://github.com/user-attachments/assets/d7e694db-1d2c-4fd7-b797-b7df614a8b2b" />


## After

```shell
Benchmarking V2_1 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take)
Benchmarking V2_1 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take): Warming up for 3.0000 s

Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 10.0s, or reduce sample count to 40.

Benchmarking V2_1 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take): Collecting 100 samples in estimated 10.034 s (100 iterations)
Benchmarking V2_1 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take): Analyzing
V2_1 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take)
                        time:   [92.341 ms 93.659 ms 94.998 ms]
                        change: [-43.446% -42.621% -41.718%] (p = 0.00 < 0.10)
                        Performance has improved.
```

The `MiniBlockScheduler::initiate` only takes 21.2% of whole time.

<img width="3622" height="1334" alt="image" src="https://github.com/user-attachments/assets/195c1e25-cf5d-4df8-a85f-c2c556413936" />

## Summary

This PR will make lance `2.1` 50% faster than before.

However we are still slower than 2.0, I will continute working on this.

```shell
Benchmarking V2_0 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take): Collecting 10 samples in V2_0 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take)
                        time:   [31.472 ms 31.659 ms 31.938 ms]
                        change: [-1.5902% -0.5624% +0.4912%] (p = 0.33 > 0.10)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

Benchmarking V2_1 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take): Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.4s or enable flat sampling.
Benchmarking V2_1 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take): Collecting 10 samples in V2_1 Single Random Take FileReader(1048577 file size, 1024 batches, 1000 rows per take)
                        time:   [87.263 ms 90.066 ms 94.046 ms]
                        change: [-6.6512% -2.6566% +2.7044%] (p = 0.32 > 0.10)
                        No change in performance detected.
```