### PR TITLE
refactor: remove owned LanceBuffer to eliminate runtime try_clone checks

### DIFF
--- a/rust/lance-encoding/benches/buffer.rs
+++ b/rust/lance-encoding/benches/buffer.rs
@@ -27,7 +27,7 @@ fn bench_zip(c: &mut Criterion) {
             b.iter(move || {
                 let buffers = buffers
                     .iter_mut()
-                    .map(|(buf, bits_per_value)| (buf.borrow_and_clone(), *bits_per_value))
+                    .map(|(buf, bits_per_value)| (buf.clone(), *bits_per_value))
                     .collect::<Vec<_>>();
                 black_box(LanceBuffer::zip_into_one(buffers, num_values as u64).unwrap());
             })
@@ -51,7 +51,7 @@ fn bench_zip(c: &mut Criterion) {
             b.iter(move || {
                 let buffers = buffers
                     .iter_mut()
-                    .map(|(buf, bits_per_value)| (buf.borrow_and_clone(), *bits_per_value))
+                    .map(|(buf, bits_per_value)| (buf.clone(), *bits_per_value))
                     .collect::<Vec<_>>();
                 black_box(LanceBuffer::zip_into_one(buffers, num_values as u64).unwrap());
             })

--- a/rust/lance-encoding/benches/buffer.rs
+++ b/rust/lance-encoding/benches/buffer.rs
@@ -19,8 +19,8 @@ fn bench_zip(c: &mut Criterion) {
                 (0..num_values * 2).map(|_| rand::random::<u8>()).collect();
             let random_ints: Vec<u8> = (0..num_values * 4).map(|_| rand::random::<u8>()).collect();
             let mut buffers = vec![
-                (LanceBuffer::Owned(random_shorts), 16),
-                (LanceBuffer::Owned(random_ints), 32),
+                (LanceBuffer::from(random_shorts), 16),
+                (LanceBuffer::from(random_ints), 32),
             ];
             let buffers = &mut buffers;
 
@@ -42,9 +42,9 @@ fn bench_zip(c: &mut Criterion) {
             let random_shorts3: Vec<u8> =
                 (0..num_values * 2).map(|_| rand::random::<u8>()).collect();
             let mut buffers = vec![
-                (LanceBuffer::Owned(random_shorts1), 16),
-                (LanceBuffer::Owned(random_shorts2), 16),
-                (LanceBuffer::Owned(random_shorts3), 16),
+                (LanceBuffer::from(random_shorts1), 16),
+                (LanceBuffer::from(random_shorts2), 16),
+                (LanceBuffer::from(random_shorts3), 16),
             ];
             let buffers = &mut buffers;
 

--- a/rust/lance-encoding/src/buffer.rs
+++ b/rust/lance-encoding/src/buffer.rs
@@ -9,7 +9,7 @@ use arrow_buffer::{ArrowNativeType, Buffer, MutableBuffer, ScalarBuffer};
 use lance_core::{utils::bit::is_pwr_two, Error, Result};
 use snafu::location;
 
-/// A copy-on-write byte buffer
+/// A copy-on-write byte buffer.
 ///
 /// It wraps arrow_buffer::Buffer which provides:
 /// - Cheap cloning (reference counted)

--- a/rust/lance-encoding/src/buffer.rs
+++ b/rust/lance-encoding/src/buffer.rs
@@ -6,98 +6,45 @@
 use std::{ops::Deref, panic::RefUnwindSafe, ptr::NonNull, sync::Arc};
 
 use arrow_buffer::{ArrowNativeType, Buffer, MutableBuffer, ScalarBuffer};
-use itertools::Either;
-use snafu::location;
 
-use lance_core::{utils::bit::is_pwr_two, Error, Result};
+use lance_core::{utils::bit::is_pwr_two, Result};
 
-/// A copy-on-write byte buffer
+/// A copy-on-write byte buffer backed by Arrow Buffer
 ///
-/// It can be created from read-only buffers (e.g. bytes::Bytes or arrow_buffer::Buffer), e.g. "borrowed"
-/// or from writeable buffers (e.g. Vec<u8>), e.g. "owned"
+/// It wraps arrow_buffer::Buffer which provides:
+/// - Cheap cloning (reference counted)
+/// - Zero-copy slicing
+/// - Automatic memory alignment
 ///
-/// The buffer can switch to borrowed mode without a copy of the data
-///
-/// LanceBuffer does not implement Clone because doing could potentially silently trigger a copy of the data
-/// and we want to make sure that the user is aware of this operation.
-///
-/// If you need to clone a LanceBuffer you can use borrow_and_clone() which will make sure that the buffer
-/// is in borrowed mode before cloning.  This is a zero copy operation (but requires &mut self).
-pub enum LanceBuffer {
-    Borrowed(Buffer),
-    Owned(Vec<u8>),
-}
-
-// Compares equality of the buffers, ignoring owned / unowned status
-impl PartialEq for LanceBuffer {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Borrowed(l0), Self::Borrowed(r0)) => l0 == r0,
-            (Self::Owned(l0), Self::Owned(r0)) => l0 == r0,
-            (Self::Borrowed(l0), Self::Owned(r0)) => l0.as_slice() == r0.as_slice(),
-            (Self::Owned(l0), Self::Borrowed(r0)) => l0.as_slice() == r0.as_slice(),
-        }
-    }
-}
-
-impl Eq for LanceBuffer {}
-
-impl std::fmt::Debug for LanceBuffer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let preview = if self.len() > 10 {
-            format!("0x{}...", hex::encode_upper(&self[..10]))
-        } else {
-            format!("0x{}", hex::encode_upper(self.as_ref()))
-        };
-        match self {
-            Self::Borrowed(buffer) => write!(
-                f,
-                "LanceBuffer::Borrowed(bytes={} #bytes={})",
-                preview,
-                buffer.len()
-            ),
-            Self::Owned(buffer) => {
-                write!(
-                    f,
-                    "LanceBuffer::Owned(bytes={} #bytes={})",
-                    preview,
-                    buffer.len()
-                )
-            }
-        }
-    }
-}
+/// LanceBuffer is designed to be used in situations where you might need to
+/// pass around byte buffers efficiently without worrying about ownership.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LanceBuffer(Buffer);
 
 impl LanceBuffer {
-    /// Convert into a mutable buffer.  If this is a borrowed buffer, the data will be copied.
+    /// Convert into a Vec<u8>, will copy the data
     pub fn into_owned(self) -> Vec<u8> {
-        match self {
-            Self::Borrowed(buffer) => buffer.to_vec(),
-            Self::Owned(buffer) => buffer,
-        }
+        self.0.to_vec()
     }
 
-    /// Convert into an Arrow buffer.  Never copies data.
+    /// Convert into an Arrow buffer. Never copies data.
     pub fn into_buffer(self) -> Buffer {
-        match self {
-            Self::Borrowed(buffer) => buffer,
-            Self::Owned(buffer) => Buffer::from_vec(buffer),
-        }
+        self.0
     }
 
-    /// Returns an owned buffer of the given size with all bits set to 0
+    /// Returns a buffer of the given size with all bits set to 0
     pub fn all_unset(len: usize) -> Self {
-        Self::Owned(vec![0; len])
+        Self(Buffer::from_vec(vec![0; len]))
     }
 
-    /// Returns an owned buffer of the given size with all bits set to 1
+    /// Returns a buffer of the given size with all bits set to 1
     pub fn all_set(len: usize) -> Self {
-        Self::Owned(vec![0xff; len])
+        Self(Buffer::from_vec(vec![0xff; len]))
     }
 
     /// Creates an empty buffer
     pub fn empty() -> Self {
-        Self::Owned(Vec::new())
+        Self(Buffer::from_vec(Vec::<u8>::new()))
     }
 
     /// Converts the buffer into a hex string
@@ -114,7 +61,7 @@ impl LanceBuffer {
         for buffer in buffers {
             data.extend_from_slice(buffer.as_ref());
         }
-        Self::Owned(data)
+        Self(Buffer::from_vec(data))
     }
 
     /// Converts the buffer into a hex string, inserting a space
@@ -139,7 +86,7 @@ impl LanceBuffer {
     /// sure we can safely reinterpret the buffer.
     ///
     /// If the buffer is properly aligned this will be zero-copy.  If not, a copy
-    /// will be made and an owned buffer returned.
+    /// will be made.
     ///
     /// If `bytes_per_value` is not a power of two, then we assume the buffer is
     /// never going to be reinterpret into another type and we can safely
@@ -150,12 +97,12 @@ impl LanceBuffer {
             // The original buffer is not aligned, cannot zero-copy
             let mut buf = Vec::with_capacity(bytes.len());
             buf.extend_from_slice(&bytes);
-            Self::Owned(buf)
+            Self(Buffer::from_vec(buf))
         } else {
             // The original buffer is aligned, can zero-copy
             // SAFETY: the alignment is correct we can make this conversion
             unsafe {
-                Self::Borrowed(Buffer::from_custom_allocation(
+                Self(Buffer::from_custom_allocation(
                     NonNull::new(bytes.as_ptr() as _).expect("should be a valid pointer"),
                     bytes.len(),
                     Arc::new(bytes),
@@ -166,92 +113,51 @@ impl LanceBuffer {
 
     /// Convert a buffer into a bytes::Bytes object
     pub fn into_bytes(self) -> bytes::Bytes {
-        match self {
-            Self::Owned(buf) => buf.into(),
-            Self::Borrowed(buf) => buf.into_vec::<u8>().unwrap().into(),
-        }
+        self.0.into_vec::<u8>().unwrap().into()
     }
 
-    /// Convert into a borrowed buffer, this is a zero-copy operation
-    ///
-    /// This is often called before cloning the buffer
+    /// Convert into a borrowed buffer, this is now a no-op since all buffers are borrowed
     pub fn into_borrowed(self) -> Self {
-        match self {
-            Self::Borrowed(_) => self,
-            Self::Owned(buffer) => Self::Borrowed(Buffer::from_vec(buffer)),
-        }
+        self
     }
 
     /// Creates an owned copy of the buffer, will always involve a full copy of the bytes
     pub fn to_owned(&self) -> Self {
-        match self {
-            Self::Borrowed(buffer) => Self::Owned(buffer.to_vec()),
-            Self::Owned(buffer) => Self::Owned(buffer.clone()),
-        }
+        Self(Buffer::from_vec(self.0.to_vec()))
     }
 
-    /// Creates a clone of the buffer but also puts the buffer into borrowed mode
+    /// Creates a clone of the buffer (cheap, reference counted)
     ///
-    /// This is a zero-copy operation
+    /// This method exists for backwards compatibility but now just calls clone()
     pub fn borrow_and_clone(&mut self) -> Self {
-        match self {
-            Self::Borrowed(buffer) => Self::Borrowed(buffer.clone()),
-            Self::Owned(buffer) => {
-                let buf_data = std::mem::take(buffer);
-                let buffer = Buffer::from_vec(buf_data);
-                *self = Self::Borrowed(buffer.clone());
-                Self::Borrowed(buffer)
-            }
-        }
+        self.clone()
     }
 
-    /// Clones the buffer but fails if the buffer is in owned mode
+    /// Clones the buffer (always cheap, reference counted)
+    ///
+    /// This method exists for backwards compatibility
     pub fn try_clone(&self) -> Result<Self> {
-        match self {
-            Self::Borrowed(buffer) => Ok(Self::Borrowed(buffer.clone())),
-            Self::Owned(_) => Err(Error::Internal {
-                message: "try_clone called on an owned buffer".to_string(),
-                location: location!(),
-            }),
-        }
+        Ok(self.clone())
     }
 
     /// Make an owned copy of the buffer (always does a copy of the data)
     pub fn deep_copy(&self) -> Self {
-        match self {
-            Self::Borrowed(buffer) => Self::Owned(buffer.to_vec()),
-            Self::Owned(buffer) => Self::Owned(buffer.clone()),
-        }
+        Self(Buffer::from_vec(self.0.to_vec()))
     }
 
     /// Reinterprets a Vec<T> as a LanceBuffer
-    ///
-    /// Note that this creates a borrowed buffer.  It is not possible to safely
-    /// reinterpret a Vec<T> into a Vec<u8> in rust due to this constraint from
-    /// [`Vec::from_raw_parts`]:
-    ///
-    /// > `T` needs to have the same alignment as what `ptr` was allocated with.
-    /// > (`T` having a less strict alignment is not sufficient, the alignment really
-    /// > needs to be equal to satisfy the [`dealloc`] requirement that memory must be
-    /// > allocated and deallocated with the same layout.)
-    ///
-    /// However, we can safely reinterpret Vec<T> into &[u8] which is what happens here.
     pub fn reinterpret_vec<T: ArrowNativeType>(vec: Vec<T>) -> Self {
-        Self::Borrowed(Buffer::from_vec(vec))
+        Self(Buffer::from_vec(vec))
     }
 
     /// Reinterprets Arc<[T]> as a LanceBuffer
-    ///
-    /// This is similar to [`Self::reinterpret_vec`] but for Arc<[T]> instead of Vec<T>
-    ///
-    /// The same alignment constraints apply
     pub fn reinterpret_slice<T: ArrowNativeType + RefUnwindSafe>(arc: Arc<[T]>) -> Self {
         let slice = arc.as_ref();
         let data = NonNull::new(slice.as_ptr() as _).unwrap_or(NonNull::dangling());
         let len = std::mem::size_of_val(slice);
         // SAFETY: the ptr will be valid for len items if the Arc<[T]> is valid
         let buffer = unsafe { Buffer::from_custom_allocation(data, len, Arc::new(arc)) };
-        Self::Borrowed(buffer)
+        Self(buffer)
     }
 
     /// Reinterprets a LanceBuffer into a Vec<T>
@@ -270,7 +176,7 @@ impl LanceBuffer {
         }
 
         if is_aligned {
-            ScalarBuffer::<T>::from(self.borrow_and_clone().into_buffer())
+            ScalarBuffer::<T>::from(self.clone().into_buffer())
         } else {
             let num_values = self.len() / std::mem::size_of::<T>();
             let vec = Vec::<T>::with_capacity(num_values);
@@ -298,13 +204,16 @@ impl LanceBuffer {
             data.extend_from_slice(buffer.as_ref());
         }
 
-        Self::Owned(data)
+        Self(Buffer::from_vec(data))
     }
 
     /// Zips multiple buffers into a single buffer, consuming the input buffers
     ///
     /// Unlike concat_into_one this "zips" the buffers, interleaving the values
     pub fn zip_into_one(buffers: Vec<(Self, u64)>, num_values: u64) -> Result<Self> {
+        use lance_core::Error;
+        use snafu::location;
+        
         let bytes_per_value = buffers.iter().map(|(_, bits_per_value)| {
             if bits_per_value % 8 == 0 {
                 Ok(bits_per_value / 8)
@@ -334,15 +243,15 @@ impl LanceBuffer {
             }
         }
 
-        Ok(Self::Owned(zipped))
+        Ok(Self(Buffer::from_vec(zipped)))
     }
 
     /// Create a LanceBuffer from a slice
     ///
-    /// This is NOT a zero-copy operation.  We can't even create a borrowed buffer because
+    /// This is NOT a zero-copy operation.  We can't create a borrowed buffer because
     /// we have no way of extending the lifetime of the slice.
     pub fn copy_slice(slice: &[u8]) -> Self {
-        Self::Owned(slice.to_vec())
+        Self(Buffer::from_vec(slice.to_vec()))
     }
 
     /// Create a LanceBuffer from an array (fixed-size slice)
@@ -350,15 +259,12 @@ impl LanceBuffer {
     /// This is NOT a zero-copy operation.  The slice memory could be on the stack and
     /// thus we can't forget it.
     pub fn copy_array<const N: usize>(array: [u8; N]) -> Self {
-        Self::Owned(Vec::from(array))
+        Self(Buffer::from_vec(Vec::from(array)))
     }
 
     #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
-        match self {
-            Self::Borrowed(buffer) => buffer.len(),
-            Self::Owned(buffer) => buffer.len(),
-        }
+        self.0.len()
     }
 
     /// Returns a new [LanceBuffer] that is a slice of this buffer starting at `offset`,
@@ -366,17 +272,13 @@ impl LanceBuffer {
     /// Doing so allows the same memory region to be shared between lance buffers.
     /// # Panics
     /// Panics if `(offset + length)` is larger than the existing length.
-    /// If the buffer is owned this method will require a copy.
     pub fn slice_with_length(&self, offset: usize, length: usize) -> Self {
         let original_buffer_len = self.len();
         assert!(
             offset.saturating_add(length) <= original_buffer_len,
             "the offset + length of the sliced Buffer cannot exceed the existing length"
         );
-        match self {
-            Self::Borrowed(buffer) => Self::Borrowed(buffer.slice_with_length(offset, length)),
-            Self::Owned(buffer) => Self::Owned(buffer[offset..offset + length].to_vec()),
-        }
+        Self(self.0.slice_with_length(offset, length))
     }
 
     // Backport of https://github.com/apache/arrow-rs/pull/6707
@@ -398,30 +300,26 @@ impl LanceBuffer {
     /// Unlike `slice_with_length`, this method allows for slicing at a bit level but always
     /// requires a copy of the data (unless offset is byte-aligned)
     ///
-    /// This method also converts to a borrowed buffer for convenience, but that could be optimized
-    /// away in the future if needed.
-    ///
     /// This method performs the bit slice using the Arrow convention of *bitwise* little-endian
     ///
     /// This means, given the bit buffer 0bABCDEFGH_HIJKLMNOP and the slice starting at bit 3 and
     /// with length 8, the result will be 0bNOPABCDE
     pub fn bit_slice_le_with_length(&mut self, offset: usize, length: usize) -> Self {
-        let Self::Borrowed(borrowed) = self.borrow_and_clone() else {
-            unreachable!()
-        };
         // Use this and remove backport once we upgrade to arrow-rs 54
-        // let sliced = borrowed.bit_slice(offset, length);
-        let sliced = Self::arrow_bit_slice(&borrowed, offset, length);
-        Self::Borrowed(sliced)
+        // let sliced = self.0.bit_slice(offset, length);
+        let sliced = Self::arrow_bit_slice(&self.0, offset, length);
+        Self(sliced)
+    }
+
+    /// Get a pointer to the underlying data
+    pub fn as_ptr(&self) -> *const u8 {
+        self.0.as_ptr()
     }
 }
 
 impl AsRef<[u8]> for LanceBuffer {
     fn as_ref(&self) -> &[u8] {
-        match self {
-            Self::Borrowed(buffer) => buffer.as_slice(),
-            Self::Owned(buffer) => buffer.as_slice(),
-        }
+        self.0.as_slice()
     }
 }
 
@@ -437,24 +335,24 @@ impl Deref for LanceBuffer {
 
 impl From<Vec<u8>> for LanceBuffer {
     fn from(buffer: Vec<u8>) -> Self {
-        Self::Owned(buffer)
+        Self(Buffer::from_vec(buffer))
     }
 }
 
 impl From<Buffer> for LanceBuffer {
     fn from(buffer: Buffer) -> Self {
-        Self::Borrowed(buffer)
+        Self(buffer)
     }
 }
 
 // An iterator that keeps a clone of a borrowed LanceBuffer so we
 // can have a 'static lifetime
-pub struct BorrowedBufferIter {
-    buffer: arrow_buffer::Buffer,
+pub struct LanceBufferIter {
+    buffer: Buffer,
     index: usize,
 }
 
-impl Iterator for BorrowedBufferIter {
+impl Iterator for LanceBufferIter {
     type Item = u8;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -471,12 +369,12 @@ impl Iterator for BorrowedBufferIter {
 
 impl IntoIterator for LanceBuffer {
     type Item = u8;
-    type IntoIter = Either<std::vec::IntoIter<u8>, BorrowedBufferIter>;
+    type IntoIter = LanceBufferIter;
 
     fn into_iter(self) -> Self::IntoIter {
-        match self {
-            Self::Borrowed(buffer) => Either::Right(BorrowedBufferIter { buffer, index: 0 }),
-            Self::Owned(buffer) => Either::Left(buffer.into_iter()),
+        LanceBufferIter {
+            buffer: self.0,
+            index: 0,
         }
     }
 }
@@ -489,8 +387,8 @@ mod tests {
 
     #[test]
     fn test_eq() {
-        let buf = LanceBuffer::Borrowed(Buffer::from_vec(vec![1_u8, 2, 3]));
-        let buf2 = LanceBuffer::Owned(vec![1, 2, 3]);
+        let buf = LanceBuffer::from(Buffer::from_vec(vec![1_u8, 2, 3]));
+        let buf2 = LanceBuffer::from(vec![1, 2, 3]);
         assert_eq!(buf, buf2);
     }
 
@@ -503,7 +401,7 @@ mod tests {
         expected.extend_from_slice(&1_u32.to_ne_bytes());
         expected.extend_from_slice(&2_u32.to_ne_bytes());
         expected.extend_from_slice(&3_u32.to_ne_bytes());
-        let expected = LanceBuffer::Owned(expected);
+        let expected = LanceBuffer::from(expected);
 
         assert_eq!(expected, buf);
         assert_eq!(buf.borrow_to_typed_slice::<u32>().as_ref(), vec![1, 2, 3]);
@@ -511,11 +409,11 @@ mod tests {
 
     #[test]
     fn test_concat() {
-        let buf1 = LanceBuffer::Owned(vec![1_u8, 2, 3]);
-        let buf2 = LanceBuffer::Owned(vec![4_u8, 5, 6]);
-        let buf3 = LanceBuffer::Owned(vec![7_u8, 8, 9]);
+        let buf1 = LanceBuffer::from(vec![1_u8, 2, 3]);
+        let buf2 = LanceBuffer::from(vec![4_u8, 5, 6]);
+        let buf3 = LanceBuffer::from(vec![7_u8, 8, 9]);
 
-        let expected = LanceBuffer::Owned(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        let expected = LanceBuffer::from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
         assert_eq!(
             expected,
             LanceBuffer::concat_into_one(vec![buf1, buf2, buf3])
@@ -527,7 +425,7 @@ mod tests {
             LanceBuffer::concat_into_one(vec![empty])
         );
 
-        let expected = LanceBuffer::Owned(vec![1, 2, 3]);
+        let expected = LanceBuffer::from(vec![1, 2, 3]);
         assert_eq!(
             expected,
             LanceBuffer::concat_into_one(vec![expected.deep_copy(), LanceBuffer::empty()])
@@ -536,7 +434,7 @@ mod tests {
 
     #[test]
     fn test_zip() {
-        let buf1 = LanceBuffer::Owned(vec![1_u8, 2, 3]);
+        let buf1 = LanceBuffer::from(vec![1_u8, 2, 3]);
         let buf2 = LanceBuffer::reinterpret_vec(vec![1_u16, 2, 3]);
         let buf3 = LanceBuffer::reinterpret_vec(vec![1_u32, 2, 3]);
 
@@ -550,21 +448,21 @@ mod tests {
             expected.extend_from_slice(&(i as u16).to_ne_bytes());
             expected.extend_from_slice(&(i as u32).to_ne_bytes());
         }
-        let expected = LanceBuffer::Owned(expected);
+        let expected = LanceBuffer::from(expected);
 
         assert_eq!(expected, zipped);
     }
 
     #[test]
     fn test_hex() {
-        let buf = LanceBuffer::Owned(vec![1, 2, 15, 20]);
+        let buf = LanceBuffer::from(vec![1, 2, 15, 20]);
         assert_eq!("01020F14", buf.as_hex());
     }
 
     #[test]
     #[should_panic]
     fn test_to_typed_slice_invalid() {
-        let mut buf = LanceBuffer::Owned(vec![0, 1, 2]);
+        let mut buf = LanceBuffer::from(vec![0, 1, 2]);
         buf.borrow_to_typed_slice::<u16>();
     }
 
@@ -572,7 +470,7 @@ mod tests {
     fn test_to_typed_slice() {
         // Buffer is aligned, no copy will be made, both calls
         // should get same ptr
-        let mut buf = LanceBuffer::Owned(vec![0, 1]);
+        let mut buf = LanceBuffer::from(vec![0, 1]);
         let borrow = buf.borrow_to_typed_slice::<u16>();
         let view_ptr = borrow.as_ref().as_ptr();
         let borrow2 = buf.borrow_to_typed_slice::<u16>();
@@ -594,7 +492,7 @@ mod tests {
 
     #[test]
     fn test_bit_slice_le() {
-        let mut buf = LanceBuffer::Owned(vec![0x0F, 0x0B]);
+        let mut buf = LanceBuffer::from(vec![0x0F, 0x0B]);
 
         // Keep in mind that validity buffers are *bitwise* little-endian
         assert_eq!(buf.bit_slice_le_with_length(0, 4).as_ref(), &[0x0F]);
@@ -603,5 +501,15 @@ mod tests {
         assert_eq!(buf.bit_slice_le_with_length(0, 8).as_ref(), &[0x0F]);
         assert_eq!(buf.bit_slice_le_with_length(4, 8).as_ref(), &[0xB0]);
         assert_eq!(buf.bit_slice_le_with_length(4, 12).as_ref(), &[0xB0, 0x00]);
+    }
+
+    #[test]
+    fn test_clone() {
+        let buf = LanceBuffer::from(vec![1, 2, 3]);
+        let cloned = buf.clone();
+        assert_eq!(buf, cloned);
+        
+        // Clone should be cheap (reference counted)
+        assert_eq!(buf.as_ptr(), cloned.as_ptr());
     }
 }

--- a/rust/lance-encoding/src/buffer.rs
+++ b/rust/lance-encoding/src/buffer.rs
@@ -22,11 +22,6 @@ use snafu::location;
 pub struct LanceBuffer(Buffer);
 
 impl LanceBuffer {
-    /// Convert into a Vec<u8>, will copy the data
-    pub fn into_owned(self) -> Vec<u8> {
-        self.0.to_vec()
-    }
-
     /// Convert into an Arrow buffer. Never copies data.
     pub fn into_buffer(self) -> Buffer {
         self.0
@@ -114,6 +109,8 @@ impl LanceBuffer {
     }
 
     /// Convert a buffer into a bytes::Bytes object
+    ///
+    /// This convert is zero cost.
     pub fn into_bytes(self) -> bytes::Bytes {
         self.0.into_vec::<u8>().unwrap().into()
     }

--- a/rust/lance-encoding/src/buffer.rs
+++ b/rust/lance-encoding/src/buffer.rs
@@ -213,7 +213,7 @@ impl LanceBuffer {
     pub fn zip_into_one(buffers: Vec<(Self, u64)>, num_values: u64) -> Result<Self> {
         use lance_core::Error;
         use snafu::location;
-        
+
         let bytes_per_value = buffers.iter().map(|(_, bits_per_value)| {
             if bits_per_value % 8 == 0 {
                 Ok(bits_per_value / 8)
@@ -501,15 +501,5 @@ mod tests {
         assert_eq!(buf.bit_slice_le_with_length(0, 8).as_ref(), &[0x0F]);
         assert_eq!(buf.bit_slice_le_with_length(4, 8).as_ref(), &[0xB0]);
         assert_eq!(buf.bit_slice_le_with_length(4, 12).as_ref(), &[0xB0, 0x00]);
-    }
-
-    #[test]
-    fn test_clone() {
-        let buf = LanceBuffer::from(vec![1, 2, 3]);
-        let cloned = buf.clone();
-        assert_eq!(buf, cloned);
-        
-        // Clone should be cheap (reference counted)
-        assert_eq!(buf.as_ptr(), cloned.as_ptr());
     }
 }

--- a/rust/lance-encoding/src/buffer.rs
+++ b/rust/lance-encoding/src/buffer.rs
@@ -9,7 +9,7 @@ use arrow_buffer::{ArrowNativeType, Buffer, MutableBuffer, ScalarBuffer};
 use lance_core::{utils::bit::is_pwr_two, Error, Result};
 use snafu::location;
 
-/// A copy-on-write byte buffer backed by Arrow Buffer
+/// A copy-on-write byte buffer
 ///
 /// It wraps arrow_buffer::Buffer which provides:
 /// - Cheap cloning (reference counted)

--- a/rust/lance-encoding/src/data.rs
+++ b/rust/lance-encoding/src/data.rs
@@ -40,7 +40,7 @@ use crate::{
 /// Note: this data block should not be used for future work.  It will be deprecated
 /// in the 2.1 version of the format where nullability will be handled by the structural
 /// encoders.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AllNullDataBlock {
     /// The number of values represented by this block
     pub num_values: u64,
@@ -53,18 +53,6 @@ impl AllNullDataBlock {
 
     fn into_buffers(self) -> Vec<LanceBuffer> {
         vec![]
-    }
-
-    fn borrow_and_clone(&mut self) -> Self {
-        Self {
-            num_values: self.num_values,
-        }
-    }
-
-    fn try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            num_values: self.num_values,
-        })
     }
 }
 
@@ -100,7 +88,7 @@ impl PartialEq for BlockInfo {
 /// Note: this data block should not be used for future work.  It will be deprecated
 /// in the 2.1 version of the format where nullability will be handled by the structural
 /// encoders.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NullableDataBlock {
     /// The underlying data
     pub data: Box<DataBlock>,
@@ -128,29 +116,13 @@ impl NullableDataBlock {
         buffers
     }
 
-    fn borrow_and_clone(&mut self) -> Self {
-        Self {
-            data: Box::new(self.data.borrow_and_clone()),
-            nulls: self.nulls.borrow_and_clone(),
-            block_info: self.block_info.clone(),
-        }
-    }
-
-    fn try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            data: Box::new(self.data.try_clone()?),
-            nulls: self.nulls.try_clone()?,
-            block_info: self.block_info.clone(),
-        })
-    }
-
     pub fn data_size(&self) -> u64 {
         self.data.data_size() + self.nulls.len() as u64
     }
 }
 
 /// A block representing the same constant value repeated many times
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct ConstantDataBlock {
     /// Data buffer containing the value
     pub data: LanceBuffer,
@@ -169,16 +141,9 @@ impl ConstantDataBlock {
         todo!()
     }
 
-    pub fn borrow_and_clone(&mut self) -> Self {
-        Self {
-            data: self.data.borrow_and_clone(),
-            num_values: self.num_values,
-        }
-    }
-
     pub fn try_clone(&self) -> Result<Self> {
         Ok(Self {
-            data: self.data.try_clone()?,
+            data: self.data.clone(),
             num_values: self.num_values,
         })
     }
@@ -189,7 +154,7 @@ impl ConstantDataBlock {
 }
 
 /// A data block for a single buffer of data where each element has a fixed number of bits
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct FixedWidthDataBlock {
     /// The data buffer
     pub data: LanceBuffer,
@@ -229,18 +194,9 @@ impl FixedWidthDataBlock {
         vec![self.data]
     }
 
-    pub fn borrow_and_clone(&mut self) -> Self {
-        Self {
-            data: self.data.borrow_and_clone(),
-            bits_per_value: self.bits_per_value,
-            num_values: self.num_values,
-            block_info: self.block_info.clone(),
-        }
-    }
-
     pub fn try_clone(&self) -> Result<Self> {
         Ok(Self {
-            data: self.data.try_clone()?,
+            data: self.data.clone(),
             bits_per_value: self.bits_per_value,
             num_values: self.num_values,
             block_info: self.block_info.clone(),
@@ -272,7 +228,7 @@ impl<T: OffsetSizeTrait> DataBlockBuilderImpl for VariableWidthDataBlockBuilder<
         let block = data_block.as_variable_width_ref().unwrap();
         assert!(block.bits_per_offset == T::get_byte_width() as u8 * 8);
 
-        let offsets: ScalarBuffer<T> = block.offsets.try_clone().unwrap().borrow_to_typed_slice();
+        let offsets: ScalarBuffer<T> = block.offsets.clone().borrow_to_typed_slice();
 
         let start_offset = offsets[selection.start as usize];
         let end_offset = offsets[selection.end as usize];
@@ -427,7 +383,7 @@ impl DataBlockBuilderImpl for StructDataBlockBuilder {
     }
 }
 /// A data block to represent a fixed size list
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FixedSizeListBlock {
     /// The child data block
     pub child: Box<DataBlock>,
@@ -436,20 +392,6 @@ pub struct FixedSizeListBlock {
 }
 
 impl FixedSizeListBlock {
-    fn borrow_and_clone(&mut self) -> Self {
-        Self {
-            child: Box::new(self.child.borrow_and_clone()),
-            dimension: self.dimension,
-        }
-    }
-
-    fn try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            child: Box::new(self.child.try_clone()?),
-            dimension: self.dimension,
-        })
-    }
-
     pub fn num_values(&self) -> u64 {
         self.child.num_values() / self.dimension
     }
@@ -482,7 +424,7 @@ impl FixedSizeListBlock {
     pub fn flatten_as_fixed(&mut self) -> FixedWidthDataBlock {
         match self.child.as_mut() {
             DataBlock::FixedSizeList(fsl) => fsl.flatten_as_fixed(),
-            DataBlock::FixedWidth(fw) => fw.borrow_and_clone(),
+            DataBlock::FixedWidth(fw) => fw.clone(),
             _ => panic!("Expected FixedSizeList or FixedWidth data block"),
         }
     }
@@ -582,7 +524,7 @@ impl DataBlockBuilderImpl for NullableDataBlockBuilder {
     fn append(&mut self, data_block: &DataBlock, selection: Range<u64>) {
         let nullable = data_block.as_nullable_ref().unwrap();
         let bool_buf = BooleanBuffer::new(
-            nullable.nulls.try_clone().unwrap().into_buffer(),
+            nullable.nulls.clone().into_buffer(),
             selection.start as usize,
             (selection.end - selection.start) as usize,
         );
@@ -603,7 +545,7 @@ impl DataBlockBuilderImpl for NullableDataBlockBuilder {
 /// A data block with no regular structure.  There is no available spot to attach
 /// validity / repdef information and it cannot be converted to Arrow without being
 /// decoded
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OpaqueBlock {
     pub buffers: Vec<LanceBuffer>,
     pub num_values: u64,
@@ -611,37 +553,13 @@ pub struct OpaqueBlock {
 }
 
 impl OpaqueBlock {
-    fn borrow_and_clone(&mut self) -> Self {
-        Self {
-            buffers: self
-                .buffers
-                .iter_mut()
-                .map(|b| b.borrow_and_clone())
-                .collect(),
-            num_values: self.num_values,
-            block_info: self.block_info.clone(),
-        }
-    }
-
-    fn try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            buffers: self
-                .buffers
-                .iter()
-                .map(|b| b.try_clone())
-                .collect::<Result<_>>()?,
-            num_values: self.num_values,
-            block_info: self.block_info.clone(),
-        })
-    }
-
     pub fn data_size(&self) -> u64 {
         self.buffers.iter().map(|b| b.len() as u64).sum()
     }
 }
 
 /// A data block for variable-width data (e.g. strings, packed rows, etc.)
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VariableWidthBlock {
     /// The data buffer
     pub data: LanceBuffer,
@@ -677,28 +595,8 @@ impl VariableWidthBlock {
         vec![self.offsets, self.data]
     }
 
-    fn borrow_and_clone(&mut self) -> Self {
-        Self {
-            data: self.data.borrow_and_clone(),
-            offsets: self.offsets.borrow_and_clone(),
-            bits_per_offset: self.bits_per_offset,
-            num_values: self.num_values,
-            block_info: self.block_info.clone(),
-        }
-    }
-
-    fn try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            data: self.data.try_clone()?,
-            offsets: self.offsets.try_clone()?,
-            bits_per_offset: self.bits_per_offset,
-            num_values: self.num_values,
-            block_info: self.block_info.clone(),
-        })
-    }
-
     pub fn offsets_as_block(&mut self) -> DataBlock {
-        let offsets = self.offsets.borrow_and_clone();
+        let offsets = self.offsets.clone();
         DataBlock::FixedWidth(FixedWidthDataBlock {
             data: offsets,
             bits_per_value: self.bits_per_offset as u64,
@@ -713,7 +611,7 @@ impl VariableWidthBlock {
 }
 
 /// A data block representing a struct
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StructDataBlock {
     /// The child arrays
     pub children: Vec<DataBlock>,
@@ -776,30 +674,6 @@ impl StructDataBlock {
             .collect()
     }
 
-    fn borrow_and_clone(&mut self) -> Self {
-        Self {
-            children: self
-                .children
-                .iter_mut()
-                .map(|c| c.borrow_and_clone())
-                .collect(),
-            block_info: self.block_info.clone(),
-            validity: self.validity.clone(),
-        }
-    }
-
-    fn try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            children: self
-                .children
-                .iter()
-                .map(|c| c.try_clone())
-                .collect::<Result<_>>()?,
-            block_info: self.block_info.clone(),
-            validity: self.validity.clone(),
-        })
-    }
-
     pub fn data_size(&self) -> u64 {
         self.children
             .iter()
@@ -809,7 +683,7 @@ impl StructDataBlock {
 }
 
 /// A data block for dictionary encoded data
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct DictionaryDataBlock {
     /// The indices buffer
     pub indices: FixedWidthDataBlock,
@@ -849,20 +723,6 @@ impl DictionaryDataBlock {
         buffers.extend(self.dictionary.into_buffers());
         buffers
     }
-
-    fn borrow_and_clone(&mut self) -> Self {
-        Self {
-            indices: self.indices.borrow_and_clone(),
-            dictionary: Box::new(self.dictionary.borrow_and_clone()),
-        }
-    }
-
-    fn try_clone(&self) -> Result<Self> {
-        Ok(Self {
-            indices: self.indices.try_clone()?,
-            dictionary: Box::new(self.dictionary.try_clone()?),
-        })
-    }
 }
 
 /// A DataBlock is a collection of buffers that represents an "array" of data in very generic terms
@@ -879,7 +739,7 @@ impl DictionaryDataBlock {
 ///
 /// In addition, a DataBlock can be created from an Arrow array or arrays.  This is not a zero-copy
 /// operation as some normalization may be required.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum DataBlock {
     Empty(),
     Constant(ConstantDataBlock),
@@ -935,21 +795,6 @@ impl DataBlock {
     ///
     /// This is a zero-copy operation but requires a mutable reference to self and, afterwards,
     /// all buffers will be in Borrowed mode.
-    pub fn borrow_and_clone(&mut self) -> Self {
-        match self {
-            Self::Empty() => Self::Empty(),
-            Self::Constant(inner) => Self::Constant(inner.borrow_and_clone()),
-            Self::AllNull(inner) => Self::AllNull(inner.borrow_and_clone()),
-            Self::Nullable(inner) => Self::Nullable(inner.borrow_and_clone()),
-            Self::FixedWidth(inner) => Self::FixedWidth(inner.borrow_and_clone()),
-            Self::FixedSizeList(inner) => Self::FixedSizeList(inner.borrow_and_clone()),
-            Self::VariableWidth(inner) => Self::VariableWidth(inner.borrow_and_clone()),
-            Self::Struct(inner) => Self::Struct(inner.borrow_and_clone()),
-            Self::Dictionary(inner) => Self::Dictionary(inner.borrow_and_clone()),
-            Self::Opaque(inner) => Self::Opaque(inner.borrow_and_clone()),
-        }
-    }
-
     /// Try and clone the block
     ///
     /// This will fail if any buffers are in owned mode.  You can call borrow_and_clone() to
@@ -957,15 +802,15 @@ impl DataBlock {
     pub fn try_clone(&self) -> Result<Self> {
         match self {
             Self::Empty() => Ok(Self::Empty()),
-            Self::Constant(inner) => Ok(Self::Constant(inner.try_clone()?)),
-            Self::AllNull(inner) => Ok(Self::AllNull(inner.try_clone()?)),
-            Self::Nullable(inner) => Ok(Self::Nullable(inner.try_clone()?)),
-            Self::FixedWidth(inner) => Ok(Self::FixedWidth(inner.try_clone()?)),
-            Self::FixedSizeList(inner) => Ok(Self::FixedSizeList(inner.try_clone()?)),
-            Self::VariableWidth(inner) => Ok(Self::VariableWidth(inner.try_clone()?)),
-            Self::Struct(inner) => Ok(Self::Struct(inner.try_clone()?)),
-            Self::Dictionary(inner) => Ok(Self::Dictionary(inner.try_clone()?)),
-            Self::Opaque(inner) => Ok(Self::Opaque(inner.try_clone()?)),
+            Self::Constant(inner) => Ok(Self::Constant(inner.clone())),
+            Self::AllNull(inner) => Ok(Self::AllNull(inner.clone())),
+            Self::Nullable(inner) => Ok(Self::Nullable(inner.clone())),
+            Self::FixedWidth(inner) => Ok(Self::FixedWidth(inner.clone())),
+            Self::FixedSizeList(inner) => Ok(Self::FixedSizeList(inner.clone())),
+            Self::VariableWidth(inner) => Ok(Self::VariableWidth(inner.clone())),
+            Self::Struct(inner) => Ok(Self::Struct(inner.clone())),
+            Self::Dictionary(inner) => Ok(Self::Dictionary(inner.clone())),
+            Self::Opaque(inner) => Ok(Self::Opaque(inner.clone())),
         }
     }
 

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -99,7 +99,8 @@ impl FieldEncoder for BlobStructuralEncoder {
                     sizes.push(0);
                 } else {
                     // Add data to external buffers
-                    let position = external_buffers.add_buffer(LanceBuffer::from(Buffer::from(value)));
+                    let position =
+                        external_buffers.add_buffer(LanceBuffer::from(Buffer::from(value)));
                     positions.push(position);
                     sizes.push(value.len() as u64);
                 }

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -4,6 +4,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use arrow_array::{cast::AsArray, Array, ArrayRef, StructArray, UInt64Array};
+use arrow_buffer::Buffer;
 use arrow_schema::{DataType, Field as ArrowField, Fields};
 use futures::future::BoxFuture;
 use lance_core::{datatypes::Field, Error, Result};
@@ -98,7 +99,7 @@ impl FieldEncoder for BlobStructuralEncoder {
                     sizes.push(0);
                 } else {
                     // Add data to external buffers
-                    let position = external_buffers.add_buffer(LanceBuffer::Borrowed(value.into()));
+                    let position = external_buffers.add_buffer(LanceBuffer::from(Buffer::from(value)));
                     positions.push(position);
                     sizes.push(value.len() as u64);
                 }

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -2439,8 +2439,8 @@ impl VariableFullZipDecoder {
         };
         self.rep = ScalarBuffer::from(rep);
         self.def = ScalarBuffer::from(def);
-        self.data = LanceBuffer::Owned(unzipped_data);
-        self.offsets = LanceBuffer::Owned(offsets_data);
+        self.data = LanceBuffer::from(unzipped_data);
+        self.offsets = LanceBuffer::from(offsets_data);
     }
 }
 
@@ -2622,7 +2622,7 @@ impl DecodePageTask for FixedFullZipDecodeTask {
                 }
 
                 // Finally, we decompress the values and add them to our output buffer
-                let values_buf = LanceBuffer::Owned(values);
+                let values_buf = LanceBuffer::from(values);
                 let fixed_data = FixedWidthDataBlock {
                     bits_per_value: self.bytes_per_value as u64 * 8,
                     block_info: BlockInfo::new(),
@@ -3367,8 +3367,8 @@ impl PrimitiveStructuralEncoder {
             meta_buffer.extend_from_slice(&metadata.to_le_bytes());
         }
 
-        let data_buffer = LanceBuffer::Owned(data_buffer);
-        let metadata_buffer = LanceBuffer::Owned(meta_buffer);
+        let data_buffer = LanceBuffer::from(data_buffer);
+        let metadata_buffer = LanceBuffer::from(meta_buffer);
 
         SerializedMiniBlockPage {
             num_buffers: miniblocks.data.len() as u64,
@@ -3730,12 +3730,12 @@ impl PrimitiveStructuralEncoder {
             rep_index_builder.append(zipped_data.len() as u64);
         }
 
-        let zipped_data = LanceBuffer::Owned(zipped_data);
+        let zipped_data = LanceBuffer::from(zipped_data);
         let rep_index = rep_index_builder.into_data();
         let rep_index = if rep_index.is_empty() {
             None
         } else {
-            Some(LanceBuffer::Owned(rep_index))
+            Some(LanceBuffer::from(rep_index))
         };
         SerializedFullZip {
             values: zipped_data,
@@ -3826,10 +3826,10 @@ impl PrimitiveStructuralEncoder {
             rep_index_builder.append(buf.len() as u64);
         }
 
-        let zipped_data = LanceBuffer::Owned(buf);
+        let zipped_data = LanceBuffer::from(buf);
         let rep_index = rep_index_builder.into_data();
         debug_assert!(!rep_index.is_empty());
-        let rep_index = Some(LanceBuffer::Owned(rep_index));
+        let rep_index = Some(LanceBuffer::from(rep_index));
         SerializedFullZip {
             values: zipped_data,
             repetition_index: rep_index,

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -145,7 +145,7 @@ impl DecodeMiniBlockTask {
         num_levels: u16,
     ) -> Result<ScalarBuffer<u16>> {
         let rep = rep_decompressor.decompress(levels, num_levels as u64)?;
-        let mut rep = rep.as_fixed_width().unwrap();
+        let rep = rep.as_fixed_width().unwrap();
         debug_assert_eq!(rep.num_values, num_levels as u64);
         debug_assert_eq!(rep.bits_per_value, 16);
         Ok(rep.data.borrow_to_typed_slice::<u16>())
@@ -555,7 +555,7 @@ impl DecodePageTask for DecodeMiniBlockTask {
             let mut data_builder = DataBlockBuilder::with_capacity_estimate(estimated_size_bytes);
 
             // if dictionary encoding is applied, decode indices based on their actual bit width
-            if let DataBlock::FixedWidth(mut fixed_width_data_block) = data {
+            if let DataBlock::FixedWidth(fixed_width_data_block) = data {
                 match fixed_width_data_block.bits_per_value {
                     32 => {
                         let indices = fixed_width_data_block.data.borrow_to_typed_slice::<i32>();
@@ -613,7 +613,7 @@ impl Clone for LoadedChunk {
     fn clone(&self) -> Self {
         Self {
             // Safe as we always create borrowed buffers here
-            data: self.data.try_clone().unwrap(),
+            data: self.data.clone(),
             items_in_chunk: self.items_in_chunk,
             byte_range: self.byte_range.clone(),
             chunk_idx: self.chunk_idx,
@@ -765,7 +765,7 @@ impl StructuralPageScheduler for ComplexAllNullScheduler {
 
             let rep = if has_rep {
                 let rep = data_iter.next().unwrap();
-                let mut rep = LanceBuffer::from_bytes(rep, 2);
+                let rep = LanceBuffer::from_bytes(rep, 2);
                 let rep = rep.borrow_to_typed_slice::<u16>();
                 Some(rep)
             } else {
@@ -774,7 +774,7 @@ impl StructuralPageScheduler for ComplexAllNullScheduler {
 
             let def = if has_def {
                 let def = data_iter.next().unwrap();
-                let mut def = LanceBuffer::from_bytes(def, 2);
+                let def = LanceBuffer::from_bytes(def, 2);
                 let def = def.borrow_to_typed_slice::<u16>();
                 Some(def)
             } else {
@@ -1051,7 +1051,7 @@ impl MiniBlockRepIndex {
     /// Returns an empty index if no bytes are provided.
     pub fn decode_from_bytes(rep_bytes: &[u8], stride: usize) -> Self {
         // Convert bytes to u64 slice, handling alignment automatically
-        let mut buffer = crate::buffer::LanceBuffer::from(rep_bytes.to_vec());
+        let buffer = crate::buffer::LanceBuffer::from(rep_bytes.to_vec());
         let u64_slice = buffer.borrow_to_typed_slice::<u64>();
         let n = u64_slice.len() / stride;
 
@@ -1523,7 +1523,7 @@ impl StructuralPageScheduler for MiniBlockScheduler {
 
             // Parse the metadata and build the chunk meta
             assert!(meta_bytes.len() % 2 == 0);
-            let mut bytes = LanceBuffer::from_bytes(meta_bytes, 2);
+            let bytes = LanceBuffer::from_bytes(meta_bytes, 2);
             let words = bytes.borrow_to_typed_slice::<u16>();
             let words = words.as_ref();
 
@@ -2456,7 +2456,7 @@ impl StructuralPageDecoder for VariableFullZipDecoder {
         //
         // So either we pay for a copy to normalize the offsets or we just return the entire data buffer
         // which is slightly cheaper.
-        let data = self.data.borrow_and_clone();
+        let data = self.data.clone();
 
         let offset_start = self.offset_starts[start];
         let offset_end = self.offset_starts[end] + (self.bits_per_offset as usize / 8);
@@ -3396,9 +3396,9 @@ impl PrimitiveStructuralEncoder {
         };
         // Make the levels into a FixedWidth data block
         let num_levels = levels.num_levels() as u64;
-        let mut levels_buf = levels.all_levels().try_clone().unwrap();
+        let levels_buf = levels.all_levels().clone();
         let levels_block = DataBlock::FixedWidth(FixedWidthDataBlock {
-            data: levels_buf.borrow_and_clone(),
+            data: levels_buf,
             bits_per_value: 16,
             num_values: num_levels,
             block_info: BlockInfo::new(),
@@ -3413,7 +3413,7 @@ impl PrimitiveStructuralEncoder {
         for (chunk_idx, chunk) in chunks.iter().enumerate() {
             let chunk_num_values = chunk.num_values(values_counter, num_elements);
             values_counter += chunk_num_values;
-            let mut chunk_levels = if chunk_idx < chunks.len() - 1 {
+            let chunk_levels = if chunk_idx < chunks.len() - 1 {
                 levels.slice_next(chunk_num_values as usize)
             } else {
                 levels.slice_rest()
@@ -3582,7 +3582,7 @@ impl PrimitiveStructuralEncoder {
 
         let (rep_index, rep_index_depth) =
             match compressed_rep.as_mut().and_then(|cr| cr.rep_index.as_mut()) {
-                Some(rep_index) => (Some(rep_index.borrow_and_clone()), 1),
+                Some(rep_index) => (Some(rep_index.clone()), 1),
                 None => (None, 0),
             };
 
@@ -3661,7 +3661,7 @@ impl PrimitiveStructuralEncoder {
                 num_items,
             );
 
-            if let Some(mut rep_index) = rep_index {
+            if let Some(rep_index) = rep_index {
                 let view = rep_index.borrow_to_typed_slice::<u64>();
                 let total = view.chunks_exact(2).map(|c| c[0]).sum::<u64>();
                 debug_assert_eq!(total, num_rows);
@@ -3747,7 +3747,7 @@ impl PrimitiveStructuralEncoder {
     //
     // In addition, we create a second buffer, the repetition index
     fn serialize_full_zip_variable(
-        mut variable: VariableWidthBlock,
+        variable: VariableWidthBlock,
         mut repdef: ControlWordIterator,
         num_items: u64,
     ) -> SerializedFullZip {

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -272,7 +272,7 @@ impl MiniBlockDecompressor for BinaryMiniBlockDecompressor {
                 .collect::<Vec<u64>>();
 
             Ok(DataBlock::VariableWidth(VariableWidthBlock {
-                data: LanceBuffer::Owned(
+                data: LanceBuffer::from(
                     data[offsets[0] as usize..offsets[num_values as usize] as usize].to_vec(),
                 ),
                 offsets: LanceBuffer::reinterpret_vec(result_offsets),
@@ -293,7 +293,7 @@ impl MiniBlockDecompressor for BinaryMiniBlockDecompressor {
                 .collect::<Vec<u32>>();
 
             Ok(DataBlock::VariableWidth(VariableWidthBlock {
-                data: LanceBuffer::Owned(
+                data: LanceBuffer::from(
                     data[offsets[0] as usize..offsets[num_values as usize] as usize].to_vec(),
                 ),
                 offsets: LanceBuffer::reinterpret_vec(result_offsets),
@@ -353,7 +353,7 @@ impl BlockCompressor for VariableEncoder {
 
                         // store bytes
                         output.extend_from_slice(&variable_width_data.data);
-                        Ok(LanceBuffer::Owned(output))
+                        Ok(LanceBuffer::from(output))
                     }
                     64 => {
                         let offsets = variable_width_data.offsets.borrow_to_typed_slice::<u64>();
@@ -382,7 +382,7 @@ impl BlockCompressor for VariableEncoder {
 
                         // store bytes
                         output.extend_from_slice(&variable_width_data.data);
-                        Ok(LanceBuffer::Owned(output))
+                        Ok(LanceBuffer::from(output))
                     }
                     _ => {
                         panic!("BinaryBlockEncoder does not work with {} bits per offset VariableWidth DataBlock.",

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -169,10 +169,7 @@ impl BinaryMiniBlockEncoder {
     // put binary data into chunks, every chunk is less than or equal to `AIM_MINICHUNK_SIZE`.
     // In each chunk, offsets are put first then followed by binary bytes data, each chunk is padded to 8 bytes.
     // the offsets in the chunk points to the bytes offset in this chunk.
-    fn chunk_data(
-        &self,
-        mut data: VariableWidthBlock,
-    ) -> (MiniBlockCompressed, CompressiveEncoding) {
+    fn chunk_data(&self, data: VariableWidthBlock) -> (MiniBlockCompressed, CompressiveEncoding) {
         // TODO: Support compression of offsets
         // TODO: Support general compression of data
         match data.bits_per_offset {
@@ -257,7 +254,7 @@ impl MiniBlockDecompressor for BinaryMiniBlockDecompressor {
     // `num_values` <= number of values in the chunk.
     fn decompress(&self, data: Vec<LanceBuffer>, num_values: u64) -> Result<DataBlock> {
         assert_eq!(data.len(), 1);
-        let mut data = data.into_iter().next().unwrap();
+        let data = data.into_iter().next().unwrap();
 
         if self.bits_per_offset == 64 {
             // offset and at least one value

--- a/rust/lance-encoding/src/encodings/physical/bitpacking.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpacking.rs
@@ -70,7 +70,7 @@ impl InlineBitpacking {
     ///
     /// Each chunk has the compressed bit width stored inline in the chunk itself.
     fn bitpack_chunked<T: ArrowNativeType + BitPacking>(
-        mut data: FixedWidthDataBlock,
+        data: FixedWidthDataBlock,
     ) -> MiniBlockCompressed {
         let data_buffer = data.data.borrow_to_typed_slice::<T>();
         let data_buffer = data_buffer.as_ref();
@@ -272,7 +272,7 @@ impl BlockDecompressor for InlineBitpacking {
 /// 1024 values because that's what the bitpacking primitives expect.  They just don't
 /// have a unique bit width for each chunk.
 fn bitpack_out_of_line<T: ArrowNativeType + BitPacking>(
-    mut data: FixedWidthDataBlock,
+    data: FixedWidthDataBlock,
     bit_width: usize,
 ) -> LanceBuffer {
     let data_buffer = data.data.borrow_to_typed_slice::<T>();
@@ -330,7 +330,7 @@ fn bitpack_out_of_line<T: ArrowNativeType + BitPacking>(
 
 /// Unpacks a FixedWidthDataBlock that has been bitpacked with a constant bit width
 fn unpack_out_of_line<T: ArrowNativeType + BitPacking>(
-    mut data: FixedWidthDataBlock,
+    data: FixedWidthDataBlock,
     num_values: usize,
     bits_per_value: usize,
 ) -> FixedWidthDataBlock {

--- a/rust/lance-encoding/src/encodings/physical/block.rs
+++ b/rust/lance-encoding/src/encodings/physical/block.rs
@@ -418,7 +418,7 @@ impl CompressedBufferEncoder {
 impl PerValueCompressor for CompressedBufferEncoder {
     fn compress(&self, data: DataBlock) -> Result<(PerValueDataBlock, CompressiveEncoding)> {
         let data_type = data.name();
-        let mut data = data.as_variable_width().ok_or(Error::Internal {
+        let data = data.as_variable_width().ok_or(Error::Internal {
             message: format!(
                 "Attempt to use CompressedBufferEncoder on data of type {}",
                 data_type
@@ -466,7 +466,7 @@ impl PerValueCompressor for CompressedBufferEncoder {
 }
 
 impl VariablePerValueDecompressor for CompressedBufferEncoder {
-    fn decompress(&self, mut data: VariableWidthBlock) -> Result<DataBlock> {
+    fn decompress(&self, data: VariableWidthBlock) -> Result<DataBlock> {
         let data_bytes = &data.data;
         let mut decompressed = Vec::with_capacity(data_bytes.len() * 2);
 

--- a/rust/lance-encoding/src/encodings/physical/constant.rs
+++ b/rust/lance-encoding/src/encodings/physical/constant.rs
@@ -19,16 +19,14 @@ pub struct ConstantDecompressor {
 
 impl ConstantDecompressor {
     pub fn new(scalar: LanceBuffer) -> Self {
-        Self {
-            scalar: scalar.into_borrowed(),
-        }
+        Self { scalar }
     }
 }
 
 impl BlockDecompressor for ConstantDecompressor {
     fn decompress(&self, _data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
         Ok(DataBlock::Constant(ConstantDataBlock {
-            data: self.scalar.try_clone().unwrap(),
+            data: self.scalar.clone(),
             num_values,
         }))
     }

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -42,7 +42,7 @@ struct FsstCompressed {
 impl FsstCompressed {
     fn fsst_compress(data: DataBlock) -> Result<Self> {
         match data {
-            DataBlock::VariableWidth(mut variable_width) => {
+            DataBlock::VariableWidth(variable_width) => {
                 match variable_width.bits_per_offset {
                     32 => {
                         let offsets = variable_width.offsets.borrow_to_typed_slice::<i32>();
@@ -198,7 +198,7 @@ impl FsstPerValueDecompressor {
 impl VariablePerValueDecompressor for FsstPerValueDecompressor {
     fn decompress(&self, data: VariableWidthBlock) -> Result<DataBlock> {
         // Step 1. Run inner decompressor
-        let mut compressed_variable_data = self
+        let compressed_variable_data = self
             .inner_decompressor
             .decompress(data)?
             .as_variable_width()
@@ -300,12 +300,12 @@ impl MiniBlockDecompressor for FsstMiniBlockDecompressor {
         // Step 1. decompress data use `BinaryMiniBlockDecompressor`
         // Extract the bits_per_offset from the binary encoding
         let compressed_data_block = self.inner_decompressor.decompress(data, num_values)?;
-        let DataBlock::VariableWidth(mut compressed_data_block) = compressed_data_block else {
+        let DataBlock::VariableWidth(compressed_data_block) = compressed_data_block else {
             panic!("BinaryMiniBlockDecompressor should output VariableWidth DataBlock")
         };
 
         // Step 2. FSST decompress
-        let bytes = compressed_data_block.data.borrow_and_clone();
+        let bytes = &compressed_data_block.data;
         let (decompress_bytes_buf, decompress_offset_buf) =
             if compressed_data_block.bits_per_offset == 64 {
                 let offsets = compressed_data_block.offsets.borrow_to_typed_slice::<i64>();

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -232,7 +232,7 @@ impl VariablePerValueDecompressor for FsstPerValueDecompressor {
                 decompress_offset_buf.truncate((num_values + 1) as usize);
 
                 Ok(DataBlock::VariableWidth(VariableWidthBlock {
-                    data: LanceBuffer::Owned(decompress_bytes_buf),
+                    data: LanceBuffer::from(decompress_bytes_buf),
                     offsets: LanceBuffer::reinterpret_vec(decompress_offset_buf),
                     bits_per_offset: 32,
                     num_values,
@@ -262,7 +262,7 @@ impl VariablePerValueDecompressor for FsstPerValueDecompressor {
                 decompress_offset_buf.truncate((num_values + 1) as usize);
 
                 Ok(DataBlock::VariableWidth(VariableWidthBlock {
-                    data: LanceBuffer::Owned(decompress_bytes_buf),
+                    data: LanceBuffer::from(decompress_bytes_buf),
                     offsets: LanceBuffer::reinterpret_vec(decompress_offset_buf),
                     bits_per_offset: 64,
                     num_values,
@@ -356,7 +356,7 @@ impl MiniBlockDecompressor for FsstMiniBlockDecompressor {
             };
 
         Ok(DataBlock::VariableWidth(VariableWidthBlock {
-            data: LanceBuffer::Owned(decompress_bytes_buf),
+            data: LanceBuffer::from(decompress_bytes_buf),
             offsets: decompress_offset_buf,
             bits_per_offset: compressed_data_block.bits_per_offset,
             num_values,

--- a/rust/lance-encoding/src/encodings/physical/packed.rs
+++ b/rust/lance-encoding/src/encodings/physical/packed.rs
@@ -53,7 +53,7 @@ fn struct_data_block_to_fixed_width_data_block(
 
     DataBlock::FixedWidth(FixedWidthDataBlock {
         bits_per_value: bits_per_values.iter().copied().sum(),
-        data: LanceBuffer::Owned(output),
+        data: LanceBuffer::from(output),
         num_values,
         block_info: BlockInfo::default(),
     })
@@ -151,7 +151,7 @@ impl MiniBlockDecompressor for PackedStructFixedWidthMiniBlockDecompressor {
             }
 
             let child = DataBlock::FixedWidth(FixedWidthDataBlock {
-                data: LanceBuffer::Owned(child_buf),
+                data: LanceBuffer::from(child_buf),
                 bits_per_value: self.bits_per_values[i],
                 num_values,
                 block_info: BlockInfo::default(),

--- a/rust/lance-encoding/src/encodings/physical/rle.rs
+++ b/rust/lance-encoding/src/encodings/physical/rle.rs
@@ -161,8 +161,8 @@ impl RleMiniBlockEncoder {
         // Return exactly two buffers: values and lengths
         Ok((
             vec![
-                LanceBuffer::Owned(all_values),
-                LanceBuffer::Owned(all_lengths),
+                LanceBuffer::from(all_values),
+                LanceBuffer::from(all_lengths),
             ],
             chunks,
         ))
@@ -398,7 +398,7 @@ impl RleMiniBlockDecompressor {
         if num_values == 0 {
             return Ok(DataBlock::FixedWidth(FixedWidthDataBlock {
                 bits_per_value: self.bits_per_value,
-                data: LanceBuffer::Owned(vec![]),
+                data: LanceBuffer::from(vec![]),
                 num_values: 0,
                 block_info: BlockInfo::default(),
             }));
@@ -424,7 +424,7 @@ impl RleMiniBlockDecompressor {
 
         Ok(DataBlock::FixedWidth(FixedWidthDataBlock {
             bits_per_value: self.bits_per_value,
-            data: LanceBuffer::Owned(decoded_data),
+            data: LanceBuffer::from(decoded_data),
             num_values,
             block_info: BlockInfo::default(),
         }))
@@ -605,7 +605,7 @@ mod tests {
 
         let block = DataBlock::FixedWidth(FixedWidthDataBlock {
             bits_per_value,
-            data: LanceBuffer::Owned(bytes),
+            data: LanceBuffer::from(bytes),
             num_values: data.len() as u64,
             block_info: BlockInfo::default(),
         });
@@ -662,15 +662,15 @@ mod tests {
     #[should_panic(expected = "RLE decompressor expects exactly 2 buffers")]
     fn test_invalid_buffer_count() {
         let decompressor = RleMiniBlockDecompressor::new(32);
-        let _ = decompressor.decompress(vec![LanceBuffer::Owned(vec![1, 2, 3, 4])], 10);
+        let _ = decompressor.decompress(vec![LanceBuffer::from(vec![1, 2, 3, 4])], 10);
     }
 
     #[test]
     #[should_panic(expected = "Inconsistent RLE buffers")]
     fn test_buffer_consistency() {
         let decompressor = RleMiniBlockDecompressor::new(32);
-        let values = LanceBuffer::Owned(vec![1, 0, 0, 0]); // 1 i32 value
-        let lengths = LanceBuffer::Owned(vec![5, 10]); // 2 lengths - mismatch!
+        let values = LanceBuffer::from(vec![1, 0, 0, 0]); // 1 i32 value
+        let lengths = LanceBuffer::from(vec![5, 10]); // 2 lengths - mismatch!
         let _ = decompressor.decompress(vec![values, lengths], 15);
     }
 
@@ -681,7 +681,7 @@ mod tests {
         // Test empty block
         let empty_block = DataBlock::FixedWidth(FixedWidthDataBlock {
             bits_per_value: 32,
-            data: LanceBuffer::Owned(vec![]),
+            data: LanceBuffer::from(vec![]),
             num_values: 0,
             block_info: BlockInfo::default(),
         });
@@ -893,7 +893,7 @@ mod tests {
 
         let block = DataBlock::FixedWidth(FixedWidthDataBlock {
             bits_per_value: 32,
-            data: LanceBuffer::Owned(bytes),
+            data: LanceBuffer::from(bytes),
             num_values: num_values as u64,
             block_info: BlockInfo::default(),
         });

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -150,8 +150,7 @@ impl ValueEncoder {
             num_values *= layer.dimension as usize;
             if let Some(validity) = &layer.validity {
                 let validity_slice = validity
-                    .try_clone()
-                    .unwrap()
+                    .clone()
                     .bit_slice_le_with_length(row_offset, num_values);
                 validity_buffers[buffer_counter].extend_from_slice(&validity_slice);
                 buffer_sizes.push(validity_slice.len() as u16);

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -248,7 +248,7 @@ impl ValueEncoder {
         // Finally, add the data buffer
         let buffers = validity_buffers
             .into_iter()
-            .map(LanceBuffer::Owned)
+            .map(LanceBuffer::from)
             .chain(std::iter::once(data.data))
             .collect::<Vec<_>>();
 
@@ -415,7 +415,7 @@ impl ValueEncoder {
             zipped.extend_from_slice(&data_slice[start..end]);
         }
 
-        let zipped = LanceBuffer::Owned(zipped);
+        let zipped = LanceBuffer::from(zipped);
         let data = PerValueDataBlock::Fixed(FixedWidthDataBlock {
             bits_per_value: bytes_per_row as u64 * 8,
             num_values,
@@ -671,14 +671,14 @@ impl ValueDecompressor {
         let mut block = DataBlock::FixedWidth(FixedWidthDataBlock {
             bits_per_value: self.bits_per_value,
             num_values: num_items as u64,
-            data: LanceBuffer::Owned(data_buffer),
+            data: LanceBuffer::from(data_buffer),
             block_info: BlockInfo::new(),
         });
 
         let mut validity_bufs = buffer_builders
             .into_iter()
             .rev()
-            .map(|mut b| LanceBuffer::Borrowed(b.buffer.finish().into_inner()));
+            .map(|mut b| LanceBuffer::from(b.buffer.finish().into_inner()));
         for layer in self.layers.iter().rev() {
             if layer.has_validity {
                 let nullable = NullableDataBlock {

--- a/rust/lance-encoding/src/previous/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/blob.rs
@@ -311,7 +311,7 @@ impl BlobFieldEncoder {
                 let size = end - start;
                 if size > 0 {
                     let val = data.slice_with_length(start as usize, size as usize);
-                    let position = external_buffers.add_buffer(LanceBuffer::Borrowed(val));
+                    let position = external_buffers.add_buffer(LanceBuffer::from(val));
                     positions.push(position);
                     sizes.push(size);
                 } else {

--- a/rust/lance-encoding/src/previous/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/binary.rs
@@ -491,7 +491,7 @@ impl ArrayEncoder for BinaryEncoder {
         if let Some(buffer_compressor) = &self.buffer_compressor {
             let mut compressed_data = Vec::with_capacity(data.data.len());
             buffer_compressor.compress(&data.data, &mut compressed_data)?;
-            data.data = LanceBuffer::Owned(compressed_data);
+            data.data = LanceBuffer::from(compressed_data);
         }
 
         let data = DataBlock::VariableWidth(VariableWidthBlock {

--- a/rust/lance-encoding/src/previous/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/binary.rs
@@ -389,7 +389,7 @@ impl BinaryEncoder {
 // Zero offset is removed from the start of the offsets array
 // The indices array is computed across all arrays in the vector
 fn get_indices_from_string_arrays(
-    mut offsets: LanceBuffer,
+    offsets: LanceBuffer,
     bits_per_offset: u8,
     nulls: Option<LanceBuffer>,
     num_rows: usize,

--- a/rust/lance-encoding/src/previous/encodings/physical/bitpack.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/bitpack.rs
@@ -298,7 +298,7 @@ impl ArrayEncoder for BitpackedForNonNegArrayEncoder {
                 let encoding = ProtobufUtils::basic_all_null_encoding();
                 Ok(EncodedArray { data, encoding })
             }
-            DataBlock::FixedWidth(mut unpacked) => {
+            DataBlock::FixedWidth(unpacked) => {
                 match data_type {
                     DataType::UInt8 | DataType::Int8 => encode_fixed_width!(self, unpacked, u8, buffer_index),
                     DataType::UInt16 | DataType::Int16 => encode_fixed_width!(self, unpacked, u16, buffer_index),
@@ -318,7 +318,7 @@ impl ArrayEncoder for BitpackedForNonNegArrayEncoder {
                 );
                 let encoded_values: EncodedArray;
                 match *nullable.data {
-                    DataBlock::FixedWidth(mut unpacked) => {
+                    DataBlock::FixedWidth(unpacked) => {
                         match data_type {
                             DataType::UInt8 | DataType::Int8 => encoded_values = encode_fixed_width!(self, unpacked, u8, buffer_index)?,
                             DataType::UInt16 | DataType::Int16 => encoded_values = encode_fixed_width!(self, unpacked, u16, buffer_index)?,

--- a/rust/lance-encoding/src/previous/encodings/physical/bitpack.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/bitpack.rs
@@ -729,7 +729,7 @@ impl ArrayEncoder for BitpackedArrayEncoder {
 
         let packed = DataBlock::FixedWidth(FixedWidthDataBlock {
             bits_per_value: self.num_bits,
-            data: LanceBuffer::Owned(dst_buffer),
+            data: LanceBuffer::from(dst_buffer),
             num_values: unpacked.num_values,
             block_info: BlockInfo::new(),
         });

--- a/rust/lance-encoding/src/previous/encodings/physical/dictionary.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/dictionary.rs
@@ -251,7 +251,7 @@ impl ArrayEncoder for AlreadyDictionaryEncoder {
                 DictionaryDataBlock {
                     indices: FixedWidthDataBlock {
                         bits_per_value: key_type.byte_width() as u64 * 8,
-                        data: LanceBuffer::Borrowed(indices.buffers()[0].clone()),
+                        data: LanceBuffer::from(indices.buffers()[0].clone()),
                         num_values: all_null.num_values,
                         block_info: BlockInfo::new(),
                     },

--- a/rust/lance-encoding/src/previous/encodings/physical/dictionary.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/dictionary.rs
@@ -121,7 +121,7 @@ impl PageScheduler for DictionaryPageScheduler {
 
                 let decoded_dict = items_decoder
                     .decode(0, num_dictionary_items as u64)?
-                    .borrow_and_clone();
+                    .clone();
 
                 let indices_decoder = indices_page_decoder.await?;
 
@@ -148,7 +148,7 @@ impl PrimitivePageDecoder for DirectDictionaryPageDecoder {
             .decode(rows_to_skip, num_rows)?
             .as_fixed_width()
             .unwrap();
-        let dict = self.decoded_dict.try_clone()?;
+        let dict = self.decoded_dict.clone();
         Ok(DataBlock::Dictionary(DictionaryDataBlock {
             indices,
             dictionary: Box::new(dict),

--- a/rust/lance-encoding/src/previous/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/fsst.rs
@@ -165,7 +165,7 @@ impl ArrayEncoder for FsstArrayEncoder {
         )?;
 
         let dest_offset = LanceBuffer::reinterpret_vec(dest_offsets);
-        let dest_values = LanceBuffer::Owned(dest_values);
+        let dest_values = LanceBuffer::from(dest_values);
         let dest_data = DataBlock::VariableWidth(VariableWidthBlock {
             bits_per_offset: 32,
             data: dest_values,

--- a/rust/lance-encoding/src/previous/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/fsst.rs
@@ -43,7 +43,7 @@ impl PageScheduler for FsstPageScheduler {
         let inner_decoder = self
             .inner_scheduler
             .schedule_ranges(ranges, scheduler, top_level_row);
-        let symbol_table = self.symbol_table.try_clone().unwrap();
+        let symbol_table = self.symbol_table.clone();
 
         async move {
             let inner_decoder = inner_decoder.await?;
@@ -138,7 +138,7 @@ impl ArrayEncoder for FsstArrayEncoder {
         data_type: &DataType,
         buffer_index: &mut u32,
     ) -> lance_core::Result<EncodedArray> {
-        let (mut data, nulls) = match data {
+        let (data, nulls) = match data {
             DataBlock::Nullable(nullable) => {
                 let data = nullable.data.as_variable_width().unwrap();
                 (data, Some(nullable.nulls))


### PR DESCRIPTION
This PR removes the owned LanceBuffer to eliminate runtime `try_clone` checks.

We observed numerous instances in recent user environments where buffers were reused but not properly aligned, leading to frequent occurrences of owned LanceBuffers. Unfortunately, many `try_clone` checks went unverified, and we had been assuming they were borrowed buffers.

Rather than attempting to fix all the unchecked owned buffers, we reconsidered whether retaining these owned buffers is worthwhile. In practice, they have never provided tangible benefits in real-world use cases.

Therefore, we have decided to remove the owned LanceBuffer concept entirely, eliminating the need for runtime `try_clone` checks. This change simplifies the codebase and makes it significantly easier to maintain.

cc @westonpace, should this PR be marked as breaking change? `LanceBuffer` seems only used in `lance-encoding`.