### PR TITLE
feat: implement large read io split in format 2.1

### DIFF
--- a/python/src/file.rs
+++ b/python/src/file.rs
@@ -438,7 +438,7 @@ impl LanceFileReader {
         }
 
         let inner = FileReader::try_open_with_file_metadata(
-            Arc::new(LanceEncodingsIo(file.clone())),
+            Arc::new(LanceEncodingsIo::new(file.clone())),
             path,
             base_projection,
             Arc::<DecoderPlugins>::default(),

--- a/rust/lance-file/src/v2/io.rs
+++ b/rust/lance-file/src/v2/io.rs
@@ -5,15 +5,91 @@ use futures::{future::BoxFuture, FutureExt};
 use lance_encoding::EncodingsIo;
 use lance_io::scheduler::FileScheduler;
 
+use super::reader::DEFAULT_READ_CHUNK_SIZE;
+
 #[derive(Debug)]
-pub struct LanceEncodingsIo(pub FileScheduler);
+pub struct LanceEncodingsIo {
+    scheduler: FileScheduler,
+    /// Size of chunks when reading large pages
+    read_chunk_size: u64,
+}
+
+impl LanceEncodingsIo {
+    pub fn new(scheduler: FileScheduler) -> Self {
+        Self {
+            scheduler,
+            read_chunk_size: DEFAULT_READ_CHUNK_SIZE,
+        }
+    }
+
+    pub fn with_read_chunk_size(mut self, read_chunk_size: u64) -> Self {
+        self.read_chunk_size = read_chunk_size;
+        self
+    }
+}
 
 impl EncodingsIo for LanceEncodingsIo {
     fn submit_request(
         &self,
-        range: Vec<std::ops::Range<u64>>,
+        ranges: Vec<std::ops::Range<u64>>,
         priority: u64,
     ) -> BoxFuture<'static, lance_core::Result<Vec<bytes::Bytes>>> {
-        self.0.submit_request(range, priority).boxed()
+        let mut split_ranges = Vec::new();
+        let mut split_indices = Vec::new(); // Track which original range each split came from
+
+        // Split large ranges into smaller chunks
+        //
+        // TODO: consider read_chunk_size before submitting requests.
+        for (idx, range) in ranges.iter().enumerate() {
+            let range_size = range.end - range.start;
+
+            if range_size > self.read_chunk_size {
+                let num_chunks = range_size.div_ceil(self.read_chunk_size);
+                let chunk_size = range_size / num_chunks;
+
+                for i in 0..num_chunks {
+                    let start = range.start + i * chunk_size;
+                    let end = if i == num_chunks - 1 {
+                        range.end // Last chunk gets any remaining bytes
+                    } else {
+                        start + chunk_size
+                    };
+                    split_ranges.push(start..end);
+                    split_indices.push(idx);
+                }
+            } else {
+                split_ranges.push(range.clone());
+                split_indices.push(idx);
+            }
+        }
+
+        let fut = self.scheduler.submit_request(split_ranges, priority);
+
+        async move {
+            let split_results = fut.await?;
+            let mut results = vec![Vec::new(); ranges.len()];
+
+            for (split_result, &orig_idx) in split_results.iter().zip(split_indices.iter()) {
+                results[orig_idx].push(split_result.clone());
+            }
+
+            Ok(results
+                .into_iter()
+                .map(|chunks| {
+                    if chunks.len() == 1 {
+                        chunks.into_iter().next().unwrap()
+                    } else {
+                        // Concatenate multiple chunks
+                        let total_size: usize = chunks.iter().map(|c| c.len()).sum();
+                        let mut combined = Vec::with_capacity(total_size);
+                        for chunk in chunks {
+                            combined.extend_from_slice(&chunk);
+                        }
+                        bytes::Bytes::from(combined)
+                    }
+                })
+                .collect())
+        }
+        .boxed()
     }
 }

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -320,7 +320,7 @@ impl ReaderProjection {
 #[derive(Clone, Debug)]
 pub struct FileReaderOptions {
     pub decoder_config: DecoderConfig,
-    /// Size of chunks when reading large pages. Pages larger than this 
+    /// Size of chunks when reading large pages. Pages larger than this
     /// will be read in multiple chunks to control memory usage.
     /// Default: 8MB (DEFAULT_READ_CHUNK_SIZE)
     pub read_chunk_size: u64,
@@ -777,11 +777,11 @@ impl FileReader {
     ) -> Result<Self> {
         let file_metadata = Arc::new(Self::read_all_metadata(&scheduler).await?);
         let path = scheduler.reader().path().clone();
-        
+
         // Create LanceEncodingsIo with read chunk size from options
-        let encodings_io = LanceEncodingsIo::new(scheduler)
-            .with_read_chunk_size(options.read_chunk_size);
-        
+        let encodings_io =
+            LanceEncodingsIo::new(scheduler).with_read_chunk_size(options.read_chunk_size);
+
         Self::try_open_with_file_metadata(
             Arc::new(encodings_io),
             path,

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -42,7 +42,9 @@ use crate::format::MAGIC;
 /// Pages buffers are aligned to 64 bytes
 pub(crate) const PAGE_BUFFER_ALIGNMENT: usize = 64;
 const PAD_BUFFER: [u8; PAGE_BUFFER_ALIGNMENT] = [72; PAGE_BUFFER_ALIGNMENT];
-const MAX_PAGE_BYTES: usize = 32 * 1024 * 1024;
+// In 2.1+, we allow larger pages and split them on read instead of write
+// This avoids empty pages and small pages issues from write-time splitting
+const MAX_PAGE_BYTES: usize = 128 * 1024 * 1024; // 128MB default, was 32MB
 const ENV_LANCE_FILE_WRITER_MAX_PAGE_BYTES: &str = "LANCE_FILE_WRITER_MAX_PAGE_BYTES";
 
 #[derive(Debug, Clone, Default)]
@@ -1380,5 +1382,99 @@ mod tests {
             "status column should use RLE encoding due to metadata threshold, but got: {}",
             status_encoding
         );
+    }
+
+    #[tokio::test]
+    async fn test_large_page_split_on_read() {
+        use arrow_array::Array;
+        use futures::TryStreamExt;
+        use lance_encoding::decoder::FilterExpression;
+        use lance_io::ReadBatchParams;
+        
+        // Test that large pages written with relaxed limits can be split during read
+        
+        let arrow_field = ArrowField::new("data", DataType::Binary, false);
+        let arrow_schema = ArrowSchema::new(vec![arrow_field]);
+        let lance_schema = LanceSchema::try_from(&arrow_schema).unwrap();
+
+        // Create a large binary value (40MB) to trigger large page creation
+        let large_value = vec![42u8; 40 * 1024 * 1024];
+        let array = arrow_array::BinaryArray::from(vec![
+            Some(large_value.as_slice()),
+            Some(b"small value"),
+        ]);
+        let batch = RecordBatch::try_new(
+            Arc::new(arrow_schema),
+            vec![Arc::new(array)],
+        ).unwrap();
+
+        // Write with relaxed page size limit (128MB)
+        let options = FileWriterOptions {
+            max_page_bytes: Some(128 * 1024 * 1024),
+            format_version: Some(LanceFileVersion::V2_1),
+            ..Default::default()
+        };
+
+        let fs = FsFixture::default();
+        let path = fs.tmp_path.child("large_page_test.lance");
+
+        let mut writer = FileWriter::try_new(
+            fs.object_store.create(&path).await.unwrap(),
+            lance_schema.clone(),
+            options,
+        ).unwrap();
+
+        writer.write_batch(&batch).await.unwrap();
+        let num_rows = writer.finish().await.unwrap();
+        assert_eq!(num_rows, 2);
+
+        // Read back with split configuration
+        let file_scheduler = fs.scheduler
+            .open_file(&path, &CachedFileSize::unknown())
+            .await
+            .unwrap();
+
+        // Configure reader to split pages larger than 10MB into chunks
+        let reader_options = FileReaderOptions {
+            read_chunk_size: 10 * 1024 * 1024,  // 10MB chunks
+            ..Default::default()
+        };
+
+        let file_reader = FileReader::try_open(
+            file_scheduler,
+            None,
+            Arc::<DecoderPlugins>::default(),
+            &LanceCache::no_cache(),
+            reader_options,
+        )
+        .await
+        .unwrap();
+
+        // Read the data back
+        let stream = file_reader
+            .read_stream(
+                ReadBatchParams::RangeFull,
+                1024,
+                10,  // batch_readahead
+                FilterExpression::no_filter(),
+            )
+            .unwrap();
+
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        assert_eq!(batches.len(), 1);
+        
+        // Verify the data is correctly read despite splitting
+        let read_array = batches[0].column(0);
+        let read_binary = read_array
+            .as_any()
+            .downcast_ref::<arrow_array::BinaryArray>()
+            .unwrap();
+        
+        assert_eq!(read_binary.len(), 2);
+        assert_eq!(read_binary.value(0).len(), 40 * 1024 * 1024);
+        assert_eq!(read_binary.value(1), b"small value");
+        
+        // Verify first value matches what we wrote
+        assert!(read_binary.value(0).iter().all(|&b| b == 42u8));
     }
 }

--- a/rust/lance/benches/take.rs
+++ b/rust/lance/benches/take.rs
@@ -238,7 +238,7 @@ async fn create_file_reader(dataset: &Dataset, file_path: &Path) -> FileReader {
     let file_metadata = FileReader::read_all_metadata(&file).await.unwrap();
 
     FileReader::try_open_with_file_metadata(
-        Arc::new(LanceEncodingsIo(file.clone())),
+        Arc::new(LanceEncodingsIo::new(file.clone())),
         file_path.clone(),
         None,
         Arc::<DecoderPlugins>::default(),

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -418,7 +418,7 @@ mod v2_adapter {
                 let scheduler = self.file_scheduler.with_priority(op_priority);
                 Arc::new(
                     self.reader
-                        .with_scheduler(Arc::new(LanceEncodingsIo(scheduler))),
+                        .with_scheduler(Arc::new(LanceEncodingsIo::new(scheduler))),
                 )
             } else {
                 self.reader.clone()
@@ -952,7 +952,7 @@ impl FileFragment {
             let metadata_cache = self.dataset.metadata_cache.file_metadata_cache(&path);
             let reader = Arc::new(
                 v2::reader::FileReader::try_open_with_file_metadata(
-                    Arc::new(LanceEncodingsIo(file_scheduler.clone())),
+                    Arc::new(LanceEncodingsIo::new(file_scheduler.clone())),
                     path,
                     None,
                     Arc::<DecoderPlugins>::default(),


### PR DESCRIPTION
This PR will implement large read IO splitting in format 2.1. 

In the future, we can implement new improvements such as enhanced I/O split logic and transforming read I/O into a stream, as a follow-up enhancement.

---

closes https://github.com/lancedb/lance/issues/3788