### PR TITLE
feat: use single session context in dataset sql

### DIFF
--- a/java/core/src/test/java/com/lancedb/lance/SqlQueryTest.java
+++ b/java/core/src/test/java/com/lancedb/lance/SqlQueryTest.java
@@ -55,7 +55,7 @@ public class SqlQueryTest {
   @Test
   public void testToRecordBatches() throws IOException {
     // Test normal query
-    ArrowReader reader = dataset.sql("select * from " + NAME).tableName(NAME).intoBatchRecords();
+    ArrowReader reader = dataset.sql("select * from {{DATASET}}").intoBatchRecords();
     Assertions.assertEquals(
         "Schema<id: Int(32, true), name: Utf8>",
         reader.getVectorSchemaRoot().getSchema().toString());
@@ -73,18 +73,14 @@ public class SqlQueryTest {
     reader.close();
 
     // Test agg query
-    reader = dataset.sql("select sum(id) from " + NAME).tableName(NAME).intoBatchRecords();
-    Assertions.assertEquals(
-        "Schema<sum(sqlquery_test_dataset.id): Int(64, true)>",
-        reader.getVectorSchemaRoot().getSchema().toString());
+    reader = dataset.sql("select sum(id) from {{DATASET}}").intoBatchRecords();
     Assertions.assertTrue(reader.loadNextBatch());
     long sum = (Long) reader.getVectorSchemaRoot().getVector(0).getObject(0);
     Assertions.assertEquals(sum, 780);
     reader.close();
 
     // Test empty result
-    reader =
-        dataset.sql("select * from " + NAME + " where id < 0").tableName(NAME).intoBatchRecords();
+    reader = dataset.sql("select * from {{DATASET}} where id < 0").intoBatchRecords();
     Assertions.assertEquals(
         "Schema<id: Int(32, true), name: Utf8>",
         reader.getVectorSchemaRoot().getSchema().toString());
@@ -98,8 +94,7 @@ public class SqlQueryTest {
     // Test withRowId and rowAddr
     reader =
         dataset
-            .sql("select id, name, _rowid, _rowaddr from " + NAME)
-            .tableName(NAME)
+            .sql("select id, name, _rowid, _rowaddr from {{DATASET}}")
             .withRowId(true)
             .withRowAddr(true)
             .intoBatchRecords();

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -3166,7 +3166,15 @@ class SqlQueryBuilder:
 
     def table_name(self, table_name: str) -> "SqlQueryBuilder":
         """
-        Set the table name for the query.
+        Set table name for the dataset, so that you can run SQL queries
+        against it. In most cases, we should not directly set the table_name.
+        Instead, use {{DATASET}} as a placeholder for the table name.
+
+        Example
+        >>> sql = 'SELECT * FROM {{DATASET}} WHERE age > 20'
+
+        If you must set a table name, try to use a name that is unlikely to
+        conflict, otherwise we may encounter a 'table already exists' error.
 
         Parameters
         ----------

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -3761,17 +3761,14 @@ def test_dataset_sql(tmp_path: Path):
     table = pa.table({"id": [1, 2, 3], "value": ["a", "b", "c"]})
     ds = lance.write_dataset(table, tmp_path / "test")
 
-    query = ds.sql("SELECT * FROM test WHERE id > 1").table_name("test").build()
+    query = ds.sql("SELECT * FROM {{DATASET}} WHERE id > 1").build()
 
     result = query.to_batch_records()
     expected = pa.table({"id": [2, 3], "value": ["b", "c"]})
     assert pa.Table.from_batches(result) == expected
 
     stream_result = (
-        ds.sql("SELECT value FROM test WHERE id = 1")
-        .table_name("test")
-        .build()
-        .to_stream_reader()
+        ds.sql("SELECT value FROM {{DATASET}} WHERE id = 1").build().to_stream_reader()
     )
     batches = list(stream_result)
     assert len(batches) == 1
@@ -3779,7 +3776,7 @@ def test_dataset_sql(tmp_path: Path):
 
     complex_query = ds.sql("""
                            SELECT id as user_id, UPPER(value) as val
-                           FROM dataset
+                           FROM {{DATASET}}
                            WHERE id BETWEEN 1 AND 3
                            """).build()
     complex_result = complex_query.to_batch_records()


### PR DESCRIPTION
This is related to https://github.com/lancedb/lance/pull/4420#pullrequestreview-3116559468. We should use single session context for better performance.

The single session context causes a register table conflicts error. Regardless of whether we use the session context or the session state to register tables, we encounter this error because registered tables are shared. To address this problem, I introduced a table placeholder {{DATASET}}. In most cases, users should not set the table name manually but instead use the placeholder in their SQL queries, something like 'SELECT * FROM {{DATASET}}'. The SqlQueryBuilder will generate a unique table name for each query, and deregister the table after query is done. However, if users can confidently ensure that the table name will not conflict, they can manually set the table name.

There is another approach to solve this issue, which allows users to freely set table names without requiring the use of placeholders. In this approach, we first parse the SQL into an AST, traverse the AST to find all user-defined table names, and replace them with table names that include a UUID suffix. Then, we generate a logical plan from the modified AST and execute it, followed by deregistering the table. What do you think?  @westonpace @jackye1995 @yanghua 

