### PR TITLE
ci: pin tersorflow version to bring macOS ARM CI back

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -55,7 +55,10 @@ tests = [
     "pandas",
     "polars[pyarrow,pandas]",
     "pytest",
-    "tensorflow",
+    # Workardound for https://github.com/lancedb/lance/issues/4472
+    #
+    # tensorflow is broken on 2.20.0 with macOS ARM.
+    "tensorflow==2.19.0",
     "tqdm",
     "datafusion",
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -58,7 +58,7 @@ tests = [
     # Workardound for https://github.com/lancedb/lance/issues/4472
     #
     # tensorflow is broken on 2.20.0 with macOS ARM.
-    "tensorflow==2.19.0",
+    "tensorflow<=2.19.0",
     "tqdm",
     "datafusion",
 ]


### PR DESCRIPTION
Part of https://github.com/lancedb/lance/issues/4472

I will remove it after ternsorflow have a fix.