### PR TITLE
feat: allow reading the _rowoffset

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -2858,6 +2858,16 @@ def test_scan_count_rows(tmp_path: Path):
     assert dataset.count_rows(filter=pa_ds.field("a") < 20) == 20
 
 
+def test_with_row_offset(tmp_path: Path):
+    base_dir = tmp_path / "dataset"
+    df = pd.DataFrame({"a": range(100)})
+    dataset = lance.write_dataset(df, base_dir, max_rows_per_file=25)
+
+    tbl = dataset.scanner(columns=[], with_row_offset=True).to_table()
+    tbl = tbl.combine_chunks()
+    assert tbl == pa.table({"_rowoffset": pa.array(range(100), pa.uint64())})
+
+
 def test_scanner_schemas(tmp_path: Path):
     base_dir = tmp_path / "dataset"
     df = pd.DataFrame({"a": range(50), "s": [f"s-{i}" for i in range(50)]})

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -624,7 +624,7 @@ impl Dataset {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature=(columns=None, columns_with_transform=None, filter=None, prefilter=None, limit=None, offset=None, nearest=None, batch_size=None, io_buffer_size=None, batch_readahead=None, fragment_readahead=None, scan_in_order=None, fragments=None, with_row_id=None, with_row_address=None, use_stats=None, substrait_filter=None, fast_search=None, full_text_query=None, late_materialization=None, use_scalar_index=None, include_deleted_rows=None, scan_stats_callback=None, strict_batch_size=None, order_by=None))]
+    #[pyo3(signature=(columns=None, columns_with_transform=None, filter=None, prefilter=None, limit=None, offset=None, nearest=None, batch_size=None, io_buffer_size=None, batch_readahead=None, fragment_readahead=None, scan_in_order=None, fragments=None, with_row_id=None, with_row_address=None, with_row_offset=None,use_stats=None, substrait_filter=None, fast_search=None, full_text_query=None, late_materialization=None, use_scalar_index=None, include_deleted_rows=None, scan_stats_callback=None, strict_batch_size=None, order_by=None))]
     fn scanner(
         self_: PyRef<'_, Self>,
         columns: Option<Vec<String>>,
@@ -642,6 +642,7 @@ impl Dataset {
         fragments: Option<Vec<FileFragment>>,
         with_row_id: Option<bool>,
         with_row_address: Option<bool>,
+        with_row_offset: Option<bool>,
         use_stats: Option<bool>,
         substrait_filter: Option<Vec<u8>>,
         fast_search: Option<bool>,
@@ -661,6 +662,10 @@ impl Dataset {
 
         if with_row_address.unwrap_or(false) {
             scanner.with_row_address();
+        }
+
+        if with_row_offset.unwrap_or(false) {
+            scanner.with_row_offset();
         }
 
         match (columns, columns_with_transform) {
@@ -2117,6 +2122,13 @@ impl SqlQueryBuilder {
     fn with_row_addr(&self, with_row_addr: bool) -> Self {
         Self {
             builder: self.builder.clone().with_row_addr(with_row_addr),
+        }
+    }
+
+    #[pyo3(signature = (with_row_offset))]
+    fn with_row_offset(&self, with_row_offset: bool) -> Self {
+        Self {
+            builder: self.builder.clone().with_row_offset(with_row_offset),
         }
     }
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -376,13 +376,19 @@ struct FFILanceTableProvider {
     dataset: Arc<::lance::Dataset>,
     with_row_id: bool,
     with_row_addr: bool,
+    with_row_offset: bool,
 }
 
 #[pymethods]
 impl FFILanceTableProvider {
     #[new]
-    #[pyo3(signature = (dataset, *, with_row_id = false, with_row_addr = false))]
-    fn new(dataset: &Bound<'_, PyAny>, with_row_id: bool, with_row_addr: bool) -> PyResult<Self> {
+    #[pyo3(signature = (dataset, *, with_row_id = false, with_row_addr = false, with_row_offset = false))]
+    fn new(
+        dataset: &Bound<'_, PyAny>,
+        with_row_id: bool,
+        with_row_addr: bool,
+        with_row_offset: bool,
+    ) -> PyResult<Self> {
         let py = dataset.py();
         let dataset = dataset.getattr("_ds")?.extract::<Py<Dataset>>()?;
         let dataset_ref = &dataset.bind(py).borrow().ds;
@@ -392,6 +398,7 @@ impl FFILanceTableProvider {
             dataset: dataset_ref.clone(),
             with_row_id,
             with_row_addr,
+            with_row_offset,
         })
     }
 
@@ -404,6 +411,7 @@ impl FFILanceTableProvider {
             self.dataset.clone(),
             self.with_row_id,
             self.with_row_addr,
+            self.with_row_offset,
         ));
 
         let ffi_provider =

--- a/rust/lance/src/datafusion/dataframe.rs
+++ b/rust/lance/src/datafusion/dataframe.rs
@@ -18,7 +18,7 @@ use datafusion::{
     physical_plan::{streaming::PartitionStream, ExecutionPlan, SendableRecordBatchStream},
 };
 use lance_arrow::SchemaExt;
-use lance_core::{ROW_ADDR_FIELD, ROW_ID_FIELD};
+use lance_core::{ROW_ADDR_FIELD, ROW_ID_FIELD, ROW_OFFSET_FIELD};
 
 use crate::Dataset;
 
@@ -28,23 +28,31 @@ pub struct LanceTableProvider {
     full_schema: Arc<Schema>,
     row_id_idx: Option<usize>,
     row_addr_idx: Option<usize>,
+    row_offset_idx: Option<usize>,
     ordered: bool,
 }
 
 impl LanceTableProvider {
-    pub fn new(dataset: Arc<Dataset>, with_row_id: bool, with_row_addr: bool) -> Self {
-        Self::new_with_ordering(dataset, with_row_id, with_row_addr, true)
+    pub fn new(
+        dataset: Arc<Dataset>,
+        with_row_id: bool,
+        with_row_addr: bool,
+        with_row_offset: bool,
+    ) -> Self {
+        Self::new_with_ordering(dataset, with_row_id, with_row_addr, with_row_offset, true)
     }
 
     pub fn new_with_ordering(
         dataset: Arc<Dataset>,
         with_row_id: bool,
         with_row_addr: bool,
+        with_row_offset: bool,
         ordered: bool,
     ) -> Self {
         let mut full_schema = Schema::from(dataset.schema());
         let mut row_id_idx = None;
         let mut row_addr_idx = None;
+        let mut row_offset_idx = None;
         if with_row_id {
             full_schema = full_schema.try_with_column(ROW_ID_FIELD.clone()).unwrap();
             row_id_idx = Some(full_schema.fields.len() - 1);
@@ -53,11 +61,18 @@ impl LanceTableProvider {
             full_schema = full_schema.try_with_column(ROW_ADDR_FIELD.clone()).unwrap();
             row_addr_idx = Some(full_schema.fields.len() - 1);
         }
+        if with_row_offset {
+            full_schema = full_schema
+                .try_with_column(ROW_OFFSET_FIELD.clone())
+                .unwrap();
+            row_offset_idx = Some(full_schema.fields.len() - 1);
+        }
         Self {
             dataset,
             full_schema: Arc::new(full_schema),
             row_id_idx,
             row_addr_idx,
+            row_offset_idx,
             ordered,
         }
     }
@@ -96,6 +111,8 @@ impl TableProvider for LanceTableProvider {
                         scan.with_row_id();
                     } else if Some(*field_idx) == self.row_addr_idx {
                         scan.with_row_address();
+                    } else if Some(*field_idx) == self.row_offset_idx {
+                        scan.with_row_offset();
                     } else {
                         columns.push(self.full_schema.field(*field_idx).name());
                     }
@@ -148,6 +165,7 @@ pub trait SessionContextExt {
         dataset: Arc<Dataset>,
         with_row_id: bool,
         with_row_addr: bool,
+        with_row_offset: bool,
     ) -> datafusion::common::Result<DataFrame>;
     /// Creates a DataFrame for reading a Lance dataset without ordering
     fn read_lance_unordered(
@@ -155,6 +173,7 @@ pub trait SessionContextExt {
         dataset: Arc<Dataset>,
         with_row_id: bool,
         with_row_addr: bool,
+        with_row_offset: bool,
     ) -> datafusion::common::Result<DataFrame>;
     /// Creates a DataFrame for reading a stream of data
     ///
@@ -207,11 +226,13 @@ impl SessionContextExt for SessionContext {
         dataset: Arc<Dataset>,
         with_row_id: bool,
         with_row_addr: bool,
+        with_row_offset: bool,
     ) -> datafusion::common::Result<DataFrame> {
         self.read_table(Arc::new(LanceTableProvider::new(
             dataset,
             with_row_id,
             with_row_addr,
+            with_row_offset,
         )))
     }
 
@@ -220,11 +241,13 @@ impl SessionContextExt for SessionContext {
         dataset: Arc<Dataset>,
         with_row_id: bool,
         with_row_addr: bool,
+        with_row_offset: bool,
     ) -> datafusion::common::Result<DataFrame> {
         self.read_table(Arc::new(LanceTableProvider::new_with_ordering(
             dataset,
             with_row_id,
             with_row_addr,
+            with_row_offset,
             false,
         )))
     }
@@ -276,7 +299,7 @@ pub mod tests {
 
         ctx.register_table(
             "foo",
-            Arc::new(LanceTableProvider::new(Arc::new(data), true, true)),
+            Arc::new(LanceTableProvider::new(Arc::new(data), true, true, true)),
         )
         .unwrap();
 

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -697,7 +697,7 @@ impl MergeInsertJob {
 
         match self.check_compatible_schema(&schema)? {
             SchemaComparison::FullCompatible => {
-                let existing = session_ctx.read_lance(self.dataset.clone(), true, false)?;
+                let existing = session_ctx.read_lance(self.dataset.clone(), true, false, false)?;
                 // We need to rename the columns from the target table so that they don't conflict with the source table
                 let existing = Self::prefix_columns(existing, "target_");
                 let joined =
@@ -705,7 +705,7 @@ impl MergeInsertJob {
                 Ok(joined.execute_stream().await?)
             }
             SchemaComparison::Subschema => {
-                let existing = session_ctx.read_lance(self.dataset.clone(), true, true)?;
+                let existing = session_ctx.read_lance(self.dataset.clone(), true, true, false)?;
                 let columns = schema
                     .field_names()
                     .iter()
@@ -1231,7 +1231,7 @@ impl MergeInsertJob {
         //       indexed vs non-indexed cases. That should be handled by optimizer rules.
         let session_config = SessionConfig::default();
         let session_ctx = SessionContext::new_with_config(session_config);
-        let scan = session_ctx.read_lance_unordered(self.dataset.clone(), false, true)?;
+        let scan = session_ctx.read_lance_unordered(self.dataset.clone(), false, true, false)?;
         let on_cols = self
             .params
             .on

--- a/rust/lance/src/io/exec.rs
+++ b/rust/lance/src/io/exec.rs
@@ -27,7 +27,7 @@ pub use lance_index::scalar::expression::FilterPlan;
 pub use optimizer::get_physical_optimizer;
 pub use projection::project;
 pub use pushdown_scan::{LancePushdownScanExec, ScanConfig};
-pub use rowids::AddRowAddrExec;
+pub use rowids::{AddRowAddrExec, AddRowOffsetExec};
 pub use scan::{LanceScanConfig, LanceScanExec};
 pub use take::TakeExec;
 pub use utils::PreFilterSource;

--- a/rust/lance/src/io/exec/rowids.rs
+++ b/rust/lance/src/io/exec/rowids.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
+use std::u64;
 
 use arrow_array::{cast::AsArray, types::UInt64Type, Array, ArrayRef, RecordBatch, UInt64Array};
 use arrow_schema::{Schema, SchemaRef};
@@ -12,10 +14,18 @@ use datafusion::execution::SendableRecordBatchStream;
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use datafusion_physical_expr::EquivalenceProperties;
+use datafusion_physical_plan::execution_plan::CardinalityEffect;
 use datafusion_physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion_physical_plan::Statistics;
 use futures::{StreamExt, TryStreamExt};
-use lance_core::{ROW_ADDR_FIELD, ROW_ID};
+use lance_core::utils::address::RowAddress;
+use lance_core::utils::deletion::DeletionVector;
+use lance_core::{
+    Error as LanceError, Result as LanceResult, ROW_ADDR, ROW_ADDR_FIELD, ROW_ID, ROW_OFFSET,
+    ROW_OFFSET_FIELD,
+};
 use lance_table::rowids::RowIdIndex;
+use snafu::location;
 
 use crate::dataset::rowids::get_row_id_index;
 use crate::utils::future::SharedPrerequisite;
@@ -319,6 +329,233 @@ impl ExecutionPlan for AddRowAddrExec {
 
     fn properties(&self) -> &PlanProperties {
         &self.properties
+    }
+}
+
+#[derive(Debug)]
+struct FragInfo {
+    // The dataset offset of the first row in the fragment
+    row_offset: u64,
+    // The key is the cumulative row offset in the fragment, the value is the number of rows deleted so far
+    deletion_vector: Option<Arc<DeletionVector>>,
+}
+
+/// Add a `_rowoffset` column to a stream of record batches that have a `_rowaddr` column.
+///
+/// The row offset is the number of rows between the current row and the first row in the dataset.
+#[derive(Clone, Debug)]
+pub struct AddRowOffsetExec {
+    input: Arc<dyn ExecutionPlan>,
+    row_addr_pos: usize,
+    frag_id_to_offset: Arc<HashMap<u32, FragInfo>>,
+    properties: PlanProperties,
+}
+
+impl AddRowOffsetExec {
+    fn internal_new(
+        input: Arc<dyn ExecutionPlan>,
+        frag_id_to_offset: Arc<HashMap<u32, FragInfo>>,
+    ) -> LanceResult<Self> {
+        let input_schema = input.schema();
+        let row_addr_pos = input_schema
+            .index_of(ROW_ADDR)
+            .map_err(|_| LanceError::Internal {
+                message: format!("Input plan does not have a {} column", ROW_ADDR),
+                location: location!(),
+            })?;
+
+        if input_schema.field_with_name(ROW_OFFSET).is_ok() {
+            return Err(LanceError::Internal {
+                message: format!("Input plan already has a {} column", ROW_OFFSET),
+                location: location!(),
+            });
+        }
+
+        let mut fields = input.schema().fields().iter().cloned().collect::<Vec<_>>();
+        fields.push(Arc::new(ROW_OFFSET_FIELD.clone()));
+        let schema = Arc::new(Schema::new_with_metadata(
+            fields,
+            input.schema().metadata().clone(),
+        ));
+
+        let new_eq_props = EquivalenceProperties::new(schema.clone())
+            .extend(input.properties().eq_properties.clone());
+        let properties = input.properties().clone().with_eq_properties(new_eq_props);
+
+        Ok(Self {
+            input,
+            row_addr_pos,
+            frag_id_to_offset,
+            properties,
+        })
+    }
+
+    pub async fn try_new(
+        input: Arc<dyn ExecutionPlan>,
+        dataset: Arc<Dataset>,
+    ) -> LanceResult<Self> {
+        let mut frag_id_to_offset = HashMap::new();
+        let mut row_offset = 0;
+        for frag in dataset.get_fragments() {
+            let deletion_vector = frag.get_deletion_vector().await?;
+            frag_id_to_offset.insert(
+                frag.id() as u32,
+                FragInfo {
+                    row_offset,
+                    deletion_vector,
+                },
+            );
+            // Should be sync in most cases
+            row_offset += frag.count_rows(None).await? as u64;
+        }
+
+        Self::internal_new(input, Arc::new(frag_id_to_offset))
+    }
+
+    // A dummy placeholder to use in emergency when we can't find the fragment info (better than panic)
+    const DUMMY_FRAG_INFO: FragInfo = FragInfo {
+        row_offset: u64::MAX - u32::MAX as u64,
+        deletion_vector: None,
+    };
+
+    fn compute_row_offsets(
+        row_addr: &ArrayRef,
+        frag_id_to_offset: &HashMap<u32, FragInfo>,
+    ) -> Result<ArrayRef> {
+        let row_addr_values = row_addr.as_primitive::<UInt64Type>().values();
+        let mut row_offsets = Vec::with_capacity(row_addr_values.len());
+
+        let mut last_frag_id = u32::MAX;
+        let mut last_frag_offset = 0;
+        let mut last_frag_delete_count = 0;
+        let mut dv_iter = None;
+
+        for addr in row_addr_values {
+            let addr = RowAddress::new_from_u64(*addr);
+            let frag_id = addr.fragment_id();
+            if frag_id != last_frag_id {
+                last_frag_id = frag_id;
+                let frag_info = frag_id_to_offset
+                    .get(&frag_id)
+                    .unwrap_or(&Self::DUMMY_FRAG_INFO);
+                last_frag_offset = frag_info.row_offset;
+                last_frag_delete_count = 0;
+                dv_iter = frag_info
+                    .deletion_vector
+                    .as_ref()
+                    .map(|dv| dv.to_sorted_iter().peekable());
+            }
+
+            let row_offset = addr.row_offset();
+            if let Some(dv_iter) = &mut dv_iter {
+                while dv_iter.peek().is_some() {
+                    if *dv_iter.peek().unwrap() < row_offset {
+                        dv_iter.next();
+                        last_frag_delete_count += 1;
+                    } else {
+                        break;
+                    }
+                }
+                row_offsets
+                    .push(last_frag_offset + row_offset as u64 - last_frag_delete_count as u64);
+            } else {
+                row_offsets.push(last_frag_offset + row_offset as u64);
+            }
+        }
+
+        Ok(Arc::new(UInt64Array::from(row_offsets)))
+    }
+}
+
+impl DisplayAs for AddRowOffsetExec {
+    fn fmt_as(
+        &self,
+        _format_type: DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        write!(f, "AddRowOffsetExec")
+    }
+}
+
+impl ExecutionPlan for AddRowOffsetExec {
+    fn name(&self) -> &str {
+        "AddRowOffsetExec"
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn properties(&self) -> &PlanProperties {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        vec![true]
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+        self.input.partition_statistics(partition)
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        true
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::Equal
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            Err(DataFusionError::Internal(
+                "AddRowOffsetExec: invalid number of children".into(),
+            ))
+        } else {
+            Ok(Arc::new(Self::internal_new(
+                children.into_iter().next().unwrap(),
+                self.frag_id_to_offset.clone(),
+            )?))
+        }
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion::execution::TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let input_stream = self.input.execute(partition, context)?;
+        let schema = self.schema();
+        let row_addr_pos = self.row_addr_pos;
+        let frag_id_to_offset = self.frag_id_to_offset.clone();
+        let stream = input_stream.then(move |batch| {
+            let schema = schema.clone();
+            let row_addr_pos = row_addr_pos;
+            let frag_id_to_offset = frag_id_to_offset.clone();
+            async move {
+                let batch = batch?;
+                let row_addr = batch.column(row_addr_pos);
+                let row_offsets = Self::compute_row_offsets(row_addr, frag_id_to_offset.as_ref())?;
+                let mut columns = batch.columns().to_vec();
+                columns.push(Arc::new(row_offsets));
+                Ok(RecordBatch::try_new(schema.clone(), columns)?)
+            }
+        });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            stream,
+        )))
     }
 }
 


### PR DESCRIPTION
The row offset (_rowoffset) is similar to the row id and the row address but slightly different.  The row offset is always a number from 0 to len(dataset).

The row offset is highly unstable (it can change from rows being deleted or from compaction, updates, or anything else that modifies a dataset) but it has one useful property.  The user does not need to query the list of available row offset up front for sampling purposes.  This makes it useful in some cases for sampling a dataset.