### PR TITLE
fix: avoid column name collision in merge_insert by using __action

### DIFF
--- a/rust/lance/src/dataset/write/merge_insert/logical_plan.rs
+++ b/rust/lance/src/dataset/write/merge_insert/logical_plan.rs
@@ -15,7 +15,7 @@ use std::{cmp::Ordering, sync::Arc};
 
 use crate::{dataset::write::merge_insert::exec::FullSchemaMergeInsertExec, Dataset};
 
-use super::MergeInsertParams;
+use super::{MergeInsertParams, MERGE_ACTION_COLUMN};
 
 /// Logical plan node for merge insert write.
 ///
@@ -23,7 +23,7 @@ use super::MergeInsertParams;
 /// * `source.{col1, col2, ...}` - columns from the source relation
 /// * `target.{col1, col2, ...}` - columns from the target relation
 /// * `target._rowaddr` - special column to locate existing rows in the target
-/// * `action` - unqualified column that describes the action to perform.
+/// * `__action` - unqualified column that describes the action to perform.
 ///   See [`super::assign_action::merge_insert_action`]
 ///
 /// Output is empty.
@@ -145,7 +145,7 @@ impl UserDefinedLogicalNodeCore for MergeInsertWriteNode {
     fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
         // Going to need:
         // * all columns from the `source` relation
-        // * `action` column (unqualified)
+        // * `__action` column (unqualified)
         // * `target._rowaddr` column specifically
 
         let input_schema = self.input.schema();
@@ -161,8 +161,8 @@ impl UserDefinedLogicalNodeCore for MergeInsertWriteNode {
                     true
                 }
 
-                // Include unqualified columns like "action" - tells us what operation to perform
-                None if field.name() == "action" => true,
+                // Include unqualified columns like "__action" - tells us what operation to perform
+                None if field.name() == MERGE_ACTION_COLUMN => true,
 
                 // Skip other target columns (target.value, target.key, target._rowid) - not needed for write
                 _ => false,


### PR DESCRIPTION
## Summary
- Changes internal column name from `action` to `__action` to avoid collisions with user columns
- Follows Lance's convention of using underscore prefixes for internal columns (like `_rowaddr`)

## Test plan
- [x] Added test `test_merge_insert_with_action_column` that reproduces issue #4498
- [x] All existing merge_insert tests pass
- [x] Linting and formatting complete

Fixes #4498

🤖 Generated with [Claude Code](https://claude.ai/code)