### PR TITLE
perf: use heap to maintain topk results

### DIFF
--- a/rust/lance-index/src/vector/flat/index.rs
+++ b/rust/lance-index/src/vector/flat/index.rs
@@ -4,7 +4,7 @@
 //! Flat Vector Index.
 //!
 
-use std::collections::HashMap;
+use std::collections::{BinaryHeap, HashMap};
 use std::sync::Arc;
 
 use arrow::array::AsArray;
@@ -88,48 +88,85 @@ impl IvfSubIndex for FlatIndex {
         metrics: &dyn MetricsCollector,
     ) -> Result<RecordBatch> {
         let is_range_query = params.lower_bound.is_some() || params.upper_bound.is_some();
+        let row_ids = storage.row_ids();
         let dist_calc = storage.dist_calculator(query);
+        let mut res = BinaryHeap::with_capacity(k);
         metrics.record_comparisons(storage.len());
 
-        let res = match prefilter.is_empty() {
+        match prefilter.is_empty() {
             true => {
-                let iter = dist_calc
-                    .distance_all(k)
-                    .into_iter()
-                    .zip(0..storage.len() as u32)
-                    .map(|(dist, id)| OrderedNode::new(id, dist.into()));
+                let dists = dist_calc.distance_all(k);
+
                 if is_range_query {
-                    let lower_bound = params.lower_bound.unwrap_or(f32::MIN);
-                    let upper_bound = params.upper_bound.unwrap_or(f32::MAX);
-                    iter.filter(|r| lower_bound <= r.dist.0 && r.dist.0 < upper_bound)
-                        .sorted_unstable()
+                    let lower_bound = params.lower_bound.unwrap_or(f32::MIN).into();
+                    let upper_bound = params.upper_bound.unwrap_or(f32::MAX).into();
+
+                    for (&row_id, dist) in row_ids.zip(dists) {
+                        let dist = dist.into();
+                        if dist < lower_bound || dist >= upper_bound {
+                            continue;
+                        }
+                        if res.len() < k {
+                            res.push(OrderedNode::new(row_id, dist));
+                        } else if res.peek().unwrap().dist > dist {
+                            res.pop();
+                            res.push(OrderedNode::new(row_id, dist));
+                        }
+                    }
                 } else {
-                    iter.sorted_unstable()
+                    for (&row_id, dist) in row_ids.zip(dists) {
+                        let dist = dist.into();
+                        if res.len() < k {
+                            res.push(OrderedNode::new(row_id, dist));
+                        } else if res.peek().unwrap().dist > dist {
+                            res.pop();
+                            res.push(OrderedNode::new(row_id, dist));
+                        }
+                    }
                 }
             }
             false => {
                 let row_id_mask = prefilter.mask();
-                let iter = (0..storage.len())
-                    .filter(|&id| row_id_mask.selected(storage.row_id(id as u32)))
-                    .map(|id| OrderedNode {
-                        id: id as u32,
-                        dist: OrderedFloat(dist_calc.distance(id as u32)),
-                    });
                 if is_range_query {
-                    let lower_bound = params.lower_bound.unwrap_or(f32::MIN);
-                    let upper_bound = params.upper_bound.unwrap_or(f32::MAX);
-                    iter.filter(|r| lower_bound <= r.dist.0 && r.dist.0 < upper_bound)
-                        .sorted_unstable()
+                    let lower_bound = params.lower_bound.unwrap_or(f32::MIN).into();
+                    let upper_bound = params.upper_bound.unwrap_or(f32::MAX).into();
+                    for (id, &row_id) in row_ids.enumerate() {
+                        if !row_id_mask.selected(row_id) {
+                            continue;
+                        }
+                        let dist = dist_calc.distance(id as u32).into();
+                        if dist < lower_bound || dist >= upper_bound {
+                            continue;
+                        }
+
+                        if res.len() < k {
+                            res.push(OrderedNode::new(row_id, dist));
+                        } else if res.peek().unwrap().dist > dist {
+                            res.pop();
+                            res.push(OrderedNode::new(row_id, dist));
+                        }
+                    }
                 } else {
-                    iter.sorted_unstable()
+                    for (id, &row_id) in row_ids.enumerate() {
+                        if !row_id_mask.selected(row_id) {
+                            continue;
+                        }
+
+                        let dist = dist_calc.distance(id as u32).into();
+                        if res.len() < k {
+                            res.push(OrderedNode::new(row_id, dist));
+                        } else if res.peek().unwrap().dist > dist {
+                            res.pop();
+                            res.push(OrderedNode::new(row_id, dist));
+                        }
+                    }
                 }
             }
         };
 
-        let (row_ids, dists): (Vec<_>, Vec<_>) = res
-            .take(k)
-            .map(|r| (storage.row_id(r.id), r.dist.0))
-            .unzip();
+        // we don't need to sort the results by distances here
+        // because there's a SortExec node in the query plan which sorts the results from all partitions
+        let (row_ids, dists): (Vec<_>, Vec<_>) = res.into_iter().map(|r| (r.id, r.dist.0)).unzip();
         let (row_ids, dists) = (UInt64Array::from(row_ids), Float32Array::from(dists));
 
         Ok(RecordBatch::try_new(

--- a/rust/lance-index/src/vector/flat/index.rs
+++ b/rust/lance-index/src/vector/flat/index.rs
@@ -11,7 +11,6 @@ use arrow::array::AsArray;
 use arrow_array::{Array, ArrayRef, Float32Array, RecordBatch, UInt64Array};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use deepsize::DeepSizeOf;
-use itertools::Itertools;
 use lance_core::{Error, Result, ROW_ID_FIELD};
 use lance_file::reader::FileReader;
 use lance_linalg::distance::DistanceType;
@@ -22,7 +21,7 @@ use crate::{
     metrics::MetricsCollector,
     prefilter::PreFilter,
     vector::{
-        graph::{OrderedFloat, OrderedNode},
+        graph::OrderedNode,
         quantizer::{Quantization, QuantizationType, Quantizer, QuantizerMetadata},
         storage::{DistCalculator, VectorStore},
         v3::subindex::IvfSubIndex,

--- a/rust/lance-index/src/vector/graph.rs
+++ b/rust/lance-index/src/vector/graph.rs
@@ -94,37 +94,40 @@ impl From<OrderedFloat> for f32 {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, DeepSizeOf)]
-pub struct OrderedNode {
-    pub id: u32,
+pub struct OrderedNode<T = u32>
+where
+    T: PartialEq + Eq,
+{
+    pub id: T,
     pub dist: OrderedFloat,
 }
 
-impl OrderedNode {
-    pub fn new(id: u32, dist: OrderedFloat) -> Self {
+impl<T: PartialEq + Eq> OrderedNode<T> {
+    pub fn new(id: T, dist: OrderedFloat) -> Self {
         Self { id, dist }
     }
 }
 
-impl PartialOrd for OrderedNode {
+impl<T: PartialEq + Eq> PartialOrd for OrderedNode<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.dist.cmp(&other.dist))
     }
 }
 
-impl Ord for OrderedNode {
+impl<T: PartialEq + Eq> Ord for OrderedNode<T> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.dist.cmp(&other.dist)
     }
 }
 
-impl From<(OrderedFloat, u32)> for OrderedNode {
-    fn from((dist, id): (OrderedFloat, u32)) -> Self {
+impl<T: PartialEq + Eq> From<(OrderedFloat, T)> for OrderedNode<T> {
+    fn from((dist, id): (OrderedFloat, T)) -> Self {
         Self { id, dist }
     }
 }
 
-impl From<OrderedNode> for (OrderedFloat, u32) {
-    fn from(node: OrderedNode) -> Self {
+impl<T: PartialEq + Eq> From<OrderedNode<T>> for (OrderedFloat, T) {
+    fn from(node: OrderedNode<T>) -> Self {
         (node.dist, node.id)
     }
 }


### PR DESCRIPTION
for partition with ~8K rows, the ANN index takes only 39.356µs to calculate the distances, but sorting the candidates by distances takes 132.739µs, it's even worse with larger partition, so use heap to reduce the overhead, which takes only 10.018µs