### PR TITLE
feat!: add storage options to wrapping object store

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -139,7 +139,15 @@ impl std::fmt::Display for ObjectStore {
 }
 
 pub trait WrappingObjectStore: std::fmt::Debug + Send + Sync {
-    fn wrap(&self, original: Arc<dyn OSObjectStore>) -> Arc<dyn OSObjectStore>;
+    /// Wrap an object store with additional functionality
+    ///
+    /// The storage_options contain namespace information (e.g., azure_storage_account_name)
+    /// that wrappers may need for proper isolation
+    fn wrap(
+        &self,
+        original: Arc<dyn OSObjectStore>,
+        storage_options: Option<&HashMap<String, String>>,
+    ) -> Arc<dyn OSObjectStore>;
 }
 
 #[derive(Debug, Clone)]
@@ -158,10 +166,14 @@ impl ChainedWrappingObjectStore {
 }
 
 impl WrappingObjectStore for ChainedWrappingObjectStore {
-    fn wrap(&self, original: Arc<dyn OSObjectStore>) -> Arc<dyn OSObjectStore> {
+    fn wrap(
+        &self,
+        original: Arc<dyn OSObjectStore>,
+        storage_options: Option<&HashMap<String, String>>,
+    ) -> Arc<dyn OSObjectStore> {
         self.wrappers
             .iter()
-            .fold(original, |acc, wrapper| wrapper.wrap(acc))
+            .fold(original, |acc, wrapper| wrapper.wrap(acc, storage_options))
     }
 }
 
@@ -323,7 +335,7 @@ impl ObjectStore {
         if let Some((store, path)) = params.object_store.as_ref() {
             let mut inner = store.clone();
             if let Some(wrapper) = params.object_store_wrapper.as_ref() {
-                inner = wrapper.wrap(inner);
+                inner = wrapper.wrap(inner, params.storage_options.as_ref());
             }
             let store = Self {
                 inner,
@@ -686,12 +698,13 @@ impl ObjectStore {
         list_is_lexically_ordered: bool,
         io_parallelism: usize,
         download_retry_count: usize,
+        storage_options: Option<&HashMap<String, String>>,
     ) -> Self {
         let scheme = location.scheme();
         let block_size = block_size.unwrap_or_else(|| infer_block_size(scheme));
 
         let store = match wrapper {
-            Some(wrapper) => wrapper.wrap(store),
+            Some(wrapper) => wrapper.wrap(store, storage_options),
             None => store,
         };
 
@@ -926,7 +939,11 @@ mod tests {
     }
 
     impl WrappingObjectStore for TestWrapper {
-        fn wrap(&self, _original: Arc<dyn OSObjectStore>) -> Arc<dyn OSObjectStore> {
+        fn wrap(
+            &self,
+            _original: Arc<dyn OSObjectStore>,
+            _storage_options: Option<&HashMap<String, String>>,
+        ) -> Arc<dyn OSObjectStore> {
             self.called.store(true, Ordering::Relaxed);
 
             // return a mocked value so we can check if the final store is the one we expect

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -40,6 +40,25 @@ pub trait ObjectStoreProvider: std::fmt::Debug + Sync + Send {
             Error::invalid_input(format!("Invalid path in URL: {}", url.path()), location!())
         })
     }
+
+    /// Generate a cache URL for this provider.
+    ///
+    /// Providers can override this to implement custom cache key generation
+    /// that takes into account provider-specific requirements like namespace
+    /// isolation.
+    fn cache_url(&self, url: &Url, _params: &ObjectStoreParams) -> String {
+        if ["file", "file-object-store", "memory"].contains(&url.scheme()) {
+            // For file URLs, cache the URL without the path.
+            // The path can be different for different object stores,
+            // but we want to cache the object store itself.
+            format!("{}://", url.scheme())
+        } else {
+            // Bucket is parsed as domain, so drop the path.
+            let mut url = url.clone();
+            url.set_path("");
+            url.to_string()
+        }
+    }
 }
 
 /// A registry of object store providers.
@@ -68,28 +87,6 @@ pub struct ObjectStoreRegistry {
     // cache itself doesn't keep them alive if no object store is actually using
     // it.
     active_stores: RwLock<HashMap<(String, ObjectStoreParams), Weak<ObjectStore>>>,
-}
-
-/// Convert a URL to a cache key.
-///
-/// We truncate to the first path segment. This should capture
-/// buckets and prefixes. We keep URL params since those might be
-/// important.
-///
-/// * s3://bucket/path?param=value -> s3://bucket/path?param=value
-/// * file:///path/to/file -> file:///
-fn cache_url(url: &Url) -> String {
-    if ["file", "file-object-store", "memory"].contains(&url.scheme()) {
-        // For file URLs, we want to cache the URL without the path.
-        // This is because the path can be different for different
-        // object stores, but we want to cache the object store itself.
-        format!("{}://", url.scheme())
-    } else {
-        // Bucket is parsed as domain, so we just drop the path.
-        let mut url = url.clone();
-        url.set_path("");
-        url.to_string()
-    }
 }
 
 impl ObjectStoreRegistry {
@@ -154,7 +151,17 @@ impl ObjectStoreRegistry {
         base_path: Url,
         params: &ObjectStoreParams,
     ) -> Result<Arc<ObjectStore>> {
-        let cache_path = cache_url(&base_path);
+        let scheme = base_path.scheme();
+        let Some(provider) = self.get_provider(scheme) else {
+            let mut message = format!("No object store provider found for scheme: '{}'", scheme);
+            if let Ok(providers) = self.providers.read() {
+                let valid_schemes = providers.keys().cloned().collect::<Vec<_>>().join(", ");
+                message.push_str(&format!("\nValid schemes: {}", valid_schemes));
+            }
+            return Err(Error::invalid_input(message, location!()));
+        };
+
+        let cache_path = provider.cache_url(&base_path, params);
         let cache_key = (cache_path, params.clone());
 
         // Check if we have a cached store for this base path and params
@@ -185,22 +192,12 @@ impl ObjectStoreRegistry {
             }
         }
 
-        let scheme = base_path.scheme();
-        let Some(provider) = self.get_provider(scheme) else {
-            let mut message = format!("No object store provider found for scheme: '{}'", scheme);
-            if let Ok(providers) = self.providers.read() {
-                let valid_schemes = providers.keys().cloned().collect::<Vec<_>>().join(", ");
-                message.push_str(&format!("\nValid schemes: {}", valid_schemes));
-            }
-
-            return Err(Error::invalid_input(message, location!()));
-        };
         let mut store = provider.new_store(base_path, params).await?;
 
         store.inner = store.inner.traced();
 
         if let Some(wrapper) = &params.object_store_wrapper {
-            store.inner = wrapper.wrap(store.inner);
+            store.inner = wrapper.wrap(store.inner, params.storage_options.as_ref());
         }
 
         let store = Arc::new(store);
@@ -267,6 +264,24 @@ mod tests {
 
     #[test]
     fn test_cache_url() {
+        // Test the default cache_url implementation using a dummy provider
+        #[derive(Debug)]
+        struct DummyProvider;
+
+        #[async_trait::async_trait]
+        impl ObjectStoreProvider for DummyProvider {
+            async fn new_store(
+                &self,
+                _base_path: Url,
+                _params: &ObjectStoreParams,
+            ) -> Result<ObjectStore> {
+                unreachable!("This test doesn't create stores")
+            }
+        }
+
+        let provider = DummyProvider;
+        let params = ObjectStoreParams::default();
+
         let cases = [
             ("s3://bucket/path?param=value", "s3://bucket?param=value"),
             ("file:///path/to/file", "file://"),
@@ -280,7 +295,7 @@ mod tests {
 
         for (url, expected_cache_url) in cases {
             let url = Url::parse(url).unwrap();
-            let cache_url = cache_url(&url);
+            let cache_url = provider.cache_url(&url, &params);
             assert_eq!(cache_url, expected_cache_url);
         }
     }

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -46,7 +46,7 @@ pub trait ObjectStoreProvider: std::fmt::Debug + Sync + Send {
     /// Providers can override this to implement custom cache key generation
     /// that takes into account provider-specific requirements like namespace
     /// isolation.
-    fn cache_url(&self, url: &Url, _params: &ObjectStoreParams) -> String {
+    fn cache_url(&self, url: &Url) -> String {
         if ["file", "file-object-store", "memory"].contains(&url.scheme()) {
             // For file URLs, cache the URL without the path.
             // The path can be different for different object stores,
@@ -161,7 +161,7 @@ impl ObjectStoreRegistry {
             return Err(Error::invalid_input(message, location!()));
         };
 
-        let cache_path = provider.cache_url(&base_path, params);
+        let cache_path = provider.cache_url(&base_path);
         let cache_key = (cache_path, params.clone());
 
         // Check if we have a cached store for this base path and params
@@ -280,8 +280,6 @@ mod tests {
         }
 
         let provider = DummyProvider;
-        let params = ObjectStoreParams::default();
-
         let cases = [
             ("s3://bucket/path?param=value", "s3://bucket?param=value"),
             ("file:///path/to/file", "file://"),
@@ -295,7 +293,7 @@ mod tests {
 
         for (url, expected_cache_url) in cases {
             let url = Url::parse(url).unwrap();
-            let cache_url = provider.cache_url(&url, &params);
+            let cache_url = provider.cache_url(&url);
             assert_eq!(cache_url, expected_cache_url);
         }
     }

--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -1118,6 +1118,7 @@ mod tests {
             false,
             1,
             DEFAULT_DOWNLOAD_RETRY_COUNT,
+            None,
         ));
 
         let config = SchedulerConfig {
@@ -1207,6 +1208,7 @@ mod tests {
             false,
             1,
             DEFAULT_DOWNLOAD_RETRY_COUNT,
+            None,
         ));
 
         let config = SchedulerConfig {

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -271,6 +271,7 @@ impl DatasetBuilder {
                     // cloud-like
                     DEFAULT_CLOUD_IO_PARALLELISM,
                     download_retry_count,
+                    None, // No storage_options available here
                 )),
                 Path::from(store.1.path()),
                 commit_handler,

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -576,6 +576,7 @@ mod tests {
         fn wrap(
             &self,
             original: Arc<dyn object_store::ObjectStore>,
+            _storage_options: Option<&std::collections::HashMap<String, String>>,
         ) -> Arc<dyn object_store::ObjectStore> {
             Arc::new(ProxyObjectStore::new(original, self.policy.clone()))
         }

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -325,7 +325,11 @@ impl StatsHolder {
 }
 
 impl WrappingObjectStore for StatsHolder {
-    fn wrap(&self, target: Arc<dyn ObjectStore>) -> Arc<dyn ObjectStore> {
+    fn wrap(
+        &self,
+        target: Arc<dyn ObjectStore>,
+        _storage_options: Option<&std::collections::HashMap<String, String>>,
+    ) -> Arc<dyn ObjectStore> {
         Arc::new(IoTrackingStore {
             target,
             stats: self.0.clone(),

--- a/rust/lance/src/utils/test/throttle_store.rs
+++ b/rust/lance/src/utils/test/throttle_store.rs
@@ -15,7 +15,11 @@ pub struct ThrottledStoreWrapper {
 }
 
 impl WrappingObjectStore for ThrottledStoreWrapper {
-    fn wrap(&self, original: Arc<dyn ObjectStore>) -> Arc<dyn ObjectStore> {
+    fn wrap(
+        &self,
+        original: Arc<dyn ObjectStore>,
+        _storage_options: Option<&std::collections::HashMap<String, String>>,
+    ) -> Arc<dyn ObjectStore> {
         let throttle_store = ThrottledStore::new(original, self.config);
         Arc::new(throttle_store)
     }


### PR DESCRIPTION
Adds storage options to the wrap method of the WrappingObjectStore trait. This information may be necessary for the configuration of some kinds of object stores - for instance caching stores may care about azure storage account names.

Also exposes the cache_key trait method of ObjectStorageProvider, to enable custom storage providers to define their own methods of constructing keys.