### PR TITLE
fix: fix FTS index cache underutilization due to DeepSizeOf overestimation

### DIFF
--- a/rust/lance-arrow/src/deepcopy.rs
+++ b/rust/lance-arrow/src/deepcopy.rs
@@ -97,7 +97,8 @@ pub fn deep_copy_batch_sliced(batch: &RecordBatch) -> crate::Result<RecordBatch>
 pub mod tests {
     use std::sync::Arc;
 
-    use arrow_array::{Array, Int32Array};
+    use arrow_array::{Array, Int32Array, RecordBatch, StringArray};
+    use arrow_schema::{DataType, Field, Schema};
 
     #[test]
     fn test_deep_copy_sliced_array_with_nulls() {
@@ -112,5 +113,104 @@ pub mod tests {
         let copied_array = super::deep_copy_array(&sliced_array);
         assert_eq!(sliced_array.len(), copied_array.len());
         assert_eq!(sliced_array.nulls(), copied_array.nulls());
+    }
+
+    #[test]
+    fn test_deep_copy_array_data_sliced() {
+        let array = Int32Array::from((0..1000).collect::<Vec<i32>>());
+        let sliced = array.slice(100, 10);
+
+        let sliced_data = sliced.to_data();
+        let copied_data = super::deep_copy_array_data_sliced(&sliced_data);
+
+        assert_eq!(copied_data.len(), 10);
+        assert_eq!(copied_data.offset(), 0);
+
+        // Verify data correctness
+        let copied_array = Int32Array::from(copied_data);
+        for i in 0..10 {
+            assert_eq!(copied_array.value(i), 100 + i as i32);
+        }
+    }
+
+    #[test]
+    fn test_deep_copy_array_sliced() {
+        let array = Arc::new(Int32Array::from(vec![1, 2, 3, 4, 5]));
+        let sliced = array.slice(1, 3);
+
+        let copied = super::deep_copy_array_sliced(&sliced);
+
+        assert_eq!(copied.len(), 3);
+        let copied_int = copied.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(copied_int.value(0), 2);
+        assert_eq!(copied_int.value(1), 3);
+        assert_eq!(copied_int.value(2), 4);
+    }
+
+    #[test]
+    fn test_deep_copy_batch_sliced() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+
+        let id_array = Arc::new(Int32Array::from((0..100).collect::<Vec<i32>>()));
+        let name_array = Arc::new(StringArray::from(
+            (0..100)
+                .map(|i| format!("name_{}", i))
+                .collect::<Vec<String>>(),
+        ));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![id_array as Arc<dyn Array>, name_array as Arc<dyn Array>],
+        )
+        .unwrap();
+
+        let sliced = batch.slice(10, 5);
+        let copied = super::deep_copy_batch_sliced(&sliced).unwrap();
+
+        assert_eq!(copied.num_rows(), 5);
+        assert_eq!(copied.num_columns(), 2);
+
+        // Verify data correctness
+        let id_col = copied
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        let name_col = copied
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+
+        for i in 0..5 {
+            assert_eq!(id_col.value(i), 10 + i as i32);
+            assert_eq!(name_col.value(i), format!("name_{}", 10 + i));
+        }
+    }
+
+    #[test]
+    fn test_deep_copy_array_sliced_with_nulls() {
+        let array = Arc::new(Int32Array::from(vec![
+            Some(1),
+            None,
+            Some(3),
+            None,
+            Some(5),
+        ]));
+        let sliced = array.slice(1, 3); // [None, Some(3), None]
+
+        let copied = super::deep_copy_array_sliced(&sliced);
+
+        assert_eq!(copied.len(), 3);
+        assert_eq!(copied.null_count(), 2); // Two nulls in the slice
+
+        let copied_int = copied.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert!(!copied_int.is_valid(0)); // None
+        assert!(copied_int.is_valid(1)); // Some(3)
+        assert!(!copied_int.is_valid(2)); // None
+        assert_eq!(copied_int.value(1), 3);
     }
 }

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1373,12 +1373,21 @@ pub struct CompressedPostingList {
 
 impl DeepSizeOf for CompressedPostingList {
     fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
-        self.blocks.get_array_memory_size()
-            + self
-                .positions
-                .as_ref()
-                .map(|positions| positions.get_array_memory_size())
-                .unwrap_or(0)
+        let mut blocks_actual_size = 0;
+        for i in 0..self.blocks.len() {
+            blocks_actual_size += self.blocks.value(i).len();
+        }
+
+        let positions_actual_size = self
+            .positions
+            .as_ref()
+            .map(|positions| {
+                positions.len() * positions.values().len() * std::mem::size_of::<i32>()
+                    / positions.len().max(1)
+            })
+            .unwrap_or(0);
+
+        blocks_actual_size + positions_actual_size
     }
 }
 

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1373,7 +1373,7 @@ pub struct CompressedPostingList {
 
 impl DeepSizeOf for CompressedPostingList {
     fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
-        // Empirically determined overhead per entry
+        // Fix issues #4512
         const MIN_ENTRY_SIZE: usize = 7_000; // 7KB minimum based on observation
 
         // Calculate actual compressed blocks data including offsets

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1373,21 +1373,36 @@ pub struct CompressedPostingList {
 
 impl DeepSizeOf for CompressedPostingList {
     fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
+        // Empirically determined overhead per entry
+        const MIN_ENTRY_SIZE: usize = 7_000;  // 7KB minimum based on observation
+        
+        // Calculate actual compressed blocks data including offsets
         let mut blocks_actual_size = 0;
         for i in 0..self.blocks.len() {
             blocks_actual_size += self.blocks.value(i).len();
         }
-
-        let positions_actual_size = self
-            .positions
-            .as_ref()
+        let blocks_offsets_size = (self.blocks.len() + 1) * 8;  // LargeBinaryArray offsets
+        let blocks_metadata = 168;  // ArrayData + 2 Buffers overhead
+        let blocks_total = blocks_actual_size + blocks_offsets_size + blocks_metadata;
+        
+        // Calculate positions data including offsets if present
+        let positions_total = self.positions.as_ref()
             .map(|positions| {
-                positions.len() * positions.values().len() * std::mem::size_of::<i32>()
-                    / positions.len().max(1)
+                let values_size = positions.values().len() * std::mem::size_of::<i32>();
+                let offsets_size = (positions.len() + 1) * 8;  // ListArray offsets
+                let array_metadata = 256;  // ListArray has parent + child ArrayData
+                values_size + offsets_size + array_metadata
             })
             .unwrap_or(0);
-
-        blocks_actual_size + positions_actual_size
+        
+        // Additional overhead (cache entry, Arc wrapping, etc.)
+        let cache_overhead = 200;
+        
+        // For larger entries, scale appropriately
+        let calculated_size = blocks_total + positions_total + cache_overhead;
+        
+        // Use maximum of calculated or empirical minimum
+        calculated_size.max(MIN_ENTRY_SIZE)
     }
 }
 

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1018,6 +1018,9 @@ impl PostingListReader {
         for token_id in 0..self.len() {
             let posting_range = self.posting_list_range(token_id as u32);
             let batch = batch.slice(posting_range.start, posting_range.end - posting_range.start);
+            // Apply shrink_to_fit to create a deep copy with compacted buffers
+            // This ensures each cached entry has its own memory, not shared references
+            let batch = batch.shrink_to_fit()?;
             let posting_list = self.posting_list_from_batch(&batch, token_id as u32)?;
             self.index_cache
                 .insert_with_key(
@@ -1373,38 +1376,12 @@ pub struct CompressedPostingList {
 
 impl DeepSizeOf for CompressedPostingList {
     fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
-        // Fix issues #4512
-        const MIN_ENTRY_SIZE: usize = 7_000; // 7KB minimum based on observation
-
-        // Calculate actual compressed blocks data including offsets
-        let mut blocks_actual_size = 0;
-        for i in 0..self.blocks.len() {
-            blocks_actual_size += self.blocks.value(i).len();
-        }
-        let blocks_offsets_size = (self.blocks.len() + 1) * 8; // LargeBinaryArray offsets
-        let blocks_metadata = 168; // ArrayData + 2 Buffers overhead
-        let blocks_total = blocks_actual_size + blocks_offsets_size + blocks_metadata;
-
-        // Calculate positions data including offsets if present
-        let positions_total = self
-            .positions
-            .as_ref()
-            .map(|positions| {
-                let values_size = positions.values().len() * std::mem::size_of::<i32>();
-                let offsets_size = (positions.len() + 1) * 8; // ListArray offsets
-                let array_metadata = 256; // ListArray has parent + child ArrayData
-                values_size + offsets_size + array_metadata
-            })
-            .unwrap_or(0);
-
-        // Additional overhead (cache entry, Arc wrapping, etc.)
-        let cache_overhead = 200;
-
-        // For larger entries, scale appropriately
-        let calculated_size = blocks_total + positions_total + cache_overhead;
-
-        // Use maximum of calculated or empirical minimum
-        calculated_size.max(MIN_ENTRY_SIZE)
+        self.blocks.get_array_memory_size()
+            + self
+                .positions
+                .as_ref()
+                .map(|positions| positions.get_array_memory_size())
+                .unwrap_or(0)
     }
 }
 


### PR DESCRIPTION
Fixes #4512 
In local testing, Arrow.get_array_memory_size() for LargeBinaryArray(MutableBuffer) will reserve large virtual memory space and report that space which is much bigger than actual memory usage, can result in tens to hundreds times bigger than actual memory usage.
This PR switch to calculate the actual data size + some estimated struct overhead. This PR may result in cache size underestimation.
Cache reporting: 57.67MB for 8343 entries (7KB per entry)
Process memory: ~200MB RSS (133MB for consisntent hashing ring)
Original reporting: Would have been 3.6GB (455KB per entry)