### PR TITLE
feat(java): add deleteRows for Fragment

### DIFF
--- a/java/core/src/main/java/com/lancedb/lance/Fragment.java
+++ b/java/core/src/main/java/com/lancedb/lance/Fragment.java
@@ -101,6 +101,20 @@ public class Fragment {
         dataset.allocator());
   }
 
+  /**
+   * Delete rows by row indexes.
+   *
+   * @param rowIndexes The row indexes to delete.
+   * @return The fragment metadata after deletion. If all rows are deleted, return Null. Otherwise,
+   *     returns a new fragment with the updated deletion vector.
+   */
+  public FragmentMetadata deleteRows(List<Integer> rowIndexes) {
+    return nativeDeleteRows(dataset, fragmentMetadata.getId(), rowIndexes);
+  }
+
+  private static native FragmentMetadata nativeDeleteRows(
+      Dataset dataset, int fragmentId, List<Integer> rowIndexes);
+
   private native int countRowsNative(Dataset dataset, long fragmentId);
 
   public int getId() {

--- a/java/core/src/main/java/com/lancedb/lance/RowAddress.java
+++ b/java/core/src/main/java/com/lancedb/lance/RowAddress.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lancedb.lance;
+
+public class RowAddress {
+
+  public static int rowIndex(long rowAddress) {
+    return (int) (rowAddress & 0xFFFFFFFFL);
+  }
+}

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1628,7 +1628,7 @@ impl FileFragment {
         self.write_deletions(deletion_vector).await
     }
 
-    pub(crate) async fn extend_deletions(
+    pub async fn extend_deletions(
         self,
         new_deletions: impl IntoIterator<Item = u32>,
     ) -> Result<Option<Self>> {


### PR DESCRIPTION
This PR adds a method for Dataset to delete some rows (identified by _rowaddr list) from a specific Fragment.

This method will be used in Spark MOR update. The updated old rows are deleted from the Fragment using Deletion Vector. And updated new rows are written in new Fragments. In commit stage, Update transaction operation is committed on the Dataset to apply updation.