### PR TITLE
perf: remove tracing instrumentation from FTS hot paths

### DIFF
--- a/rust/lance-index/src/scalar/inverted/encoding.rs
+++ b/rust/lance-index/src/scalar/inverted/encoding.rs
@@ -9,7 +9,6 @@ use arrow::array::{ListBuilder, UInt32Builder};
 use arrow_array::{Array, ListArray};
 use bitpacking::{BitPacker, BitPacker4x};
 use lance_core::Result;
-use tracing::instrument;
 
 // we compress the posting list to multiple blocks of fixed number of elements (BLOCK_SIZE),
 // returns a LargeBinaryArray, where each binary is a compressed block (128 row ids + 128 frequencies)
@@ -217,7 +216,6 @@ pub fn read_num_positions(compressed: &arrow::array::LargeBinaryArray) -> u32 {
     u32::from_le_bytes(compressed.value(0).try_into().unwrap())
 }
 
-#[instrument(level = "info", name = "decompress_posting_block", skip_all)]
 pub fn decompress_posting_block(
     block: &[u8],
     buffer: &mut [u32; BLOCK_SIZE],
@@ -230,7 +228,6 @@ pub fn decompress_posting_block(
     decompress_block(&block[num_bytes..], buffer, frequencies);
 }
 
-#[instrument(level = "info", name = "decompress_posting_remainder", skip_all)]
 pub fn decompress_posting_remainder(
     block: &[u8],
     n: usize,

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -11,7 +11,6 @@ use arrow_array::{Array, UInt32Array};
 use arrow_schema::DataType;
 use lance_core::utils::mask::RowIdMask;
 use lance_core::Result;
-use tracing::instrument;
 
 use crate::metrics::MetricsCollector;
 
@@ -199,7 +198,6 @@ impl PostingIterator {
     }
 
     // move to the next doc id that is greater than or equal to least_id
-    #[instrument(level = "debug", name = "posting_iter_next", skip(self))]
     fn next(&mut self, least_id: u64) {
         match self.list {
             PostingList::Compressed(ref mut list) => {
@@ -455,7 +453,6 @@ impl<'a, S: Scorer> Wand<'a, S> {
 
     // find the first term that the sum of upper bound of all preceding terms and itself,
     // are greater than or equal to the threshold
-    #[instrument(level = "debug", skip_all)]
     fn find_pivot_term(&self) -> Option<usize> {
         if self.operator == Operator::And {
             // for AND query, we always require all terms to be present in the document,
@@ -486,7 +483,6 @@ impl<'a, S: Scorer> Wand<'a, S> {
 
     // pick the term that has the maximum upper bound and the current doc id is less than the given doc id
     // so that we can move the posting iterator to the next doc id that is possible to be candidate
-    #[instrument(level = "debug", skip_all)]
     fn move_term(&mut self, least_id: u64) {
         let picked = self.pick_term(least_id);
         self.postings[picked].next(least_id);

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -1791,7 +1791,7 @@ mod tests {
             assert_eq!(fragment1_rowaddrs.values()[0], 1u64 << 32); // fragment_id=1, local_offset=0
             assert_eq!(
                 fragment1_rowaddrs.values()[fragment1_rowaddrs.values().len() - 1],
-                8191 | 1u64 << 32
+                8191 | (1u64 << 32)
             );
 
             // Check fragment 2 _rowaddr values (should start from fragment_id=2)


### PR DESCRIPTION
## Summary

Remove #[instrument] macros from functions that are called millions/billions of times during Full-Text Search queries to eliminate significant telemetry overhead.

## Performance Impact

CPU profiling of FTS queries on a 600M row dataset showed ~80% of CPU time was spent on telemetry/tracing overhead. This PR removes instrumentation from the critical hot paths while keeping it on top-level functions.

## Changes

### Removed instrumentation from hot-path functions (called millions/billions of times):
- PostingIterator::next: Called billions of times when iterating through posting lists
- find_pivot_term: Called once per WAND iteration (tens of thousands to millions of times per query)
- move_term: Called frequently during document skipping operations
- decompress_posting_block/remainder: Called for every compressed block access

### Kept instrumentation on top-level functions (called once or few times):
- InvertedIndex::bm25_search: Top-level entry point, called once per query
- ScalarIndex::search: Top-level search interface
- InvertedPartition::bm25_search: Called once per partition
- posting_list: Called once per token in the query

## Expected Performance Improvement

Based on profiling data showing 80% overhead from these instrumentations, removing them should provide 4-5x performance improvement for FTS queries.

## Additional Changes
- Removed unused imports (tracing::instrument)
- Fixed clippy warning about operator precedence in zonemap.rs

## Testing
- cargo fmt --all passes
- cargo clippy --all --tests --benches -- -D warnings passes