### PR TITLE
fix: blocking_take may hang on V2.0

### DIFF
--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -1516,7 +1516,7 @@ impl<T: RootDecoderType> BatchDecodeIterator<T> {
     /// Note that `scheduled_need` is cumulative.  E.g. this method
     /// should be called with 5, 10, 15 and not 5, 5, 5
     #[instrument(skip_all)]
-    fn wait_for_io(&mut self, scheduled_need: u64) -> Result<u64> {
+    fn wait_for_io(&mut self, scheduled_need: u64, to_take: u64) -> Result<u64> {
         while self.rows_scheduled < scheduled_need && !self.messages.is_empty() {
             let message = self.messages.pop_front().unwrap()?;
             self.rows_scheduled = message.scheduled_so_far;
@@ -1538,7 +1538,7 @@ impl<T: RootDecoderType> BatchDecodeIterator<T> {
             }
         }
 
-        let loaded_need = self.rows_drained + self.rows_per_batch as u64 - 1;
+        let loaded_need = self.rows_drained + to_take.min(self.rows_per_batch as u64) - 1;
 
         self.root_decoder
             .wait(loaded_need, &self.wait_for_io_runtime)?;
@@ -1568,7 +1568,7 @@ impl<T: RootDecoderType> BatchDecodeIterator<T> {
                 "Draining from scheduler (desire at least {} scheduled rows)",
                 desired_scheduled
             );
-            let actually_scheduled = self.wait_for_io(desired_scheduled)?;
+            let actually_scheduled = self.wait_for_io(desired_scheduled, to_take)?;
             if actually_scheduled < desired_scheduled {
                 let under_scheduled = desired_scheduled - actually_scheduled;
                 to_take -= under_scheduled;

--- a/rust/lance-file/src/v2/reader.rs
+++ b/rust/lance-file/src/v2/reader.rs
@@ -2014,10 +2014,13 @@ pub mod tests {
         assert_eq!(batches[0].num_rows(), total_rows);
     }
 
+    #[rstest]
     #[tokio::test]
-    async fn test_blocking_take() {
+    async fn test_blocking_take(
+        #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
+    ) {
         let fs = FsFixture::default();
-        let WrittenFile { data, schema, .. } = create_some_file(&fs, LanceFileVersion::V2_1).await;
+        let WrittenFile { data, schema, .. } = create_some_file(&fs, version).await;
         let total_rows = data.iter().map(|batch| batch.num_rows()).sum::<usize>();
 
         let file_scheduler = fs
@@ -2027,10 +2030,7 @@ pub mod tests {
             .unwrap();
         let file_reader = FileReader::try_open(
             file_scheduler.clone(),
-            Some(
-                ReaderProjection::from_column_names(LanceFileVersion::V2_1, &schema, &["score"])
-                    .unwrap(),
-            ),
+            Some(ReaderProjection::from_column_names(version, &schema, &["score"]).unwrap()),
             Arc::<DecoderPlugins>::default(),
             &test_cache(),
             FileReaderOptions::default(),


### PR DESCRIPTION
fix decoder wait_for_io when to_take is less than batch_size (#4538)