### PR TITLE
perf: fallback to brute force FTS if filters matching fewer rows

### DIFF
--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -721,6 +721,38 @@ def test_fts_score(tmp_path):
     assert results["id"].to_pylist() == [3, 2, 1]
 
 
+def test_fts_with_filter(tmp_path):
+    data = pa.table(
+        {
+            "id": [1, 2, 3],
+            "text": ["lance database test", "full text search", "lance search text"],
+        }
+    )
+    ds = lance.write_dataset(data, tmp_path)
+    ds.create_scalar_index("id", "BTREE")
+    ds.create_scalar_index("text", "INVERTED")
+
+    results = ds.to_table(full_text_query="lance search text")
+    assert results.num_rows == 3
+    assert results["id"].to_pylist() == [3, 2, 1]
+
+    score_id1 = results.column("_score")[2].as_py()
+
+    results = ds.to_table(
+        full_text_query="lance search text",
+        filter="id <= 1",
+        prefilter=True,
+    )
+    assert results.num_rows == 1
+    assert results["id"].to_pylist() == [1]
+    assert results.column("_score")[0].as_py() == score_id1
+
+    plan = ds.scanner(
+        full_text_query="lance search text", filter="id <= 1", prefilter=True
+    ).analyze_plan()
+    assert "index_comparisons=1" in plan
+
+
 def test_fts_on_list(tmp_path):
     data = pa.table(
         {

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1885,6 +1885,7 @@ impl DocSet {
                     .iter()
                     .copied()
                     .enumerate()
+                    .sorted_unstable()
                     .map(|(i, row_id)| (row_id, i as u32))
                     .collect();
                 (row_ids, num_tokens, inv)

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -9,6 +9,7 @@ use arrow::array::AsArray;
 use arrow::datatypes::{Int32Type, UInt32Type};
 use arrow_array::{Array, UInt32Array};
 use arrow_schema::DataType;
+use lance_core::utils::address::RowAddress;
 use lance_core::utils::mask::RowIdMask;
 use lance_core::Result;
 
@@ -321,17 +322,30 @@ impl<'a, S: Scorer> Wand<'a, S> {
             return Ok(vec![]);
         }
 
+        let min_posting_length = self
+            .postings
+            .iter()
+            .map(|p| p.list.len())
+            .min()
+            .unwrap_or(0);
+        match (mask.max_len(), mask.iter_ids()) {
+            (Some(num_rows_matched), Some(row_ids))
+                if num_rows_matched <= min_posting_length as u64 =>
+            {
+                return self.flat_search(params, row_ids, metrics);
+            }
+            _ => {}
+        }
+
         let mut candidates = BinaryHeap::new();
         let mut num_comparisons = 0;
         while let Some((pivot, doc)) = self.next()? {
             self.cur_doc = Some(doc);
             num_comparisons += 1;
 
-            // if the doc is not located, we need to find the row id
             let row_id = match &doc {
                 DocInfo::Raw(doc) => {
                     // if the doc is not located, we need to find the row id
-                    // in the doc set. This is a bit slow, but it should be rare.
                     self.docs.row_id(doc.doc_id)
                 }
                 DocInfo::Located(doc) => doc.row_id,
@@ -365,6 +379,86 @@ impl<'a, S: Scorer> Wand<'a, S> {
                 self.threshold = candidates.peek().unwrap().0 .0.score.0 * params.wand_factor;
             }
             self.move_preceding(pivot, doc.doc_id() + 1);
+        }
+        metrics.record_comparisons(num_comparisons);
+
+        Ok(candidates
+            .into_sorted_vec()
+            .into_iter()
+            .map(|Reverse((doc, freqs, doc_length))| DocCandidate {
+                row_id: doc.row_id,
+                freqs,
+                doc_length,
+            })
+            .collect())
+    }
+
+    fn flat_search(
+        &mut self,
+        params: &FtsSearchParams,
+        row_ids: Box<dyn Iterator<Item = RowAddress> + '_>,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<Vec<DocCandidate>> {
+        let limit = params.limit.unwrap_or(usize::MAX);
+        if limit == 0 {
+            return Ok(vec![]);
+        }
+
+        let is_compressed = matches!(self.postings[0].list, PostingList::Compressed(_));
+
+        let mut num_comparisons = 0;
+        let mut candidates = BinaryHeap::new();
+        for row_addr in row_ids {
+            let row_id: u64 = row_addr.into();
+            let Some(doc_id) = self.docs.doc_id(row_id) else {
+                continue;
+            };
+
+            num_comparisons += 1;
+
+            // move all postings to this doc id
+            self.move_preceding(self.postings.len() - 1, doc_id);
+            if self.postings.is_empty() {
+                // no more postings, so we can stop
+                break;
+            } else if self.postings[0].doc().map(|d| d.doc_id()) != Some(doc_id) {
+                // this doc is not in the postings, so we can skip it
+                continue;
+            }
+
+            let mut pivot = 0;
+            while pivot + 1 < self.postings.len()
+                && self.postings[pivot + 1].doc().map(|d| d.doc_id()) == Some(doc_id)
+            {
+                pivot += 1;
+            }
+
+            // check positions
+            if params.phrase_slop.is_some()
+                && !self.check_positions(params.phrase_slop.unwrap() as i32)
+            {
+                continue;
+            }
+
+            // score the doc
+            let doc_length = match is_compressed {
+                true => self.docs.num_tokens(doc_id as u32),
+                false => self.docs.num_tokens_by_row_id(row_id),
+            };
+
+            let score = self.score(pivot, doc_length);
+            let freqs = self
+                .iter_token_freqs(pivot)
+                .map(|(token, freq)| (token.to_owned(), freq))
+                .collect();
+
+            if candidates.len() < limit {
+                candidates.push(Reverse((ScoredDoc::new(row_id, score), freqs, doc_length)));
+            } else if score > candidates.peek().unwrap().0 .0.score.0 {
+                candidates.pop();
+                candidates.push(Reverse((ScoredDoc::new(row_id, score), freqs, doc_length)));
+                self.threshold = candidates.peek().unwrap().0 .0.score.0 * params.wand_factor;
+            }
         }
         metrics.record_comparisons(num_comparisons);
 


### PR DESCRIPTION
if the filters match only a few rows, it may cause the WAND fails to filter out docs.
So we can evaluate only the matched rows, which would be much faster than running WAND first, this means to decompress at most `num_rows_matched * num_tokens` blocks