### PR TITLE
fix: let Java module use LanceFileVersion::Stable (#4558)

### DIFF
--- a/java/core/lance-jni/src/file_writer.rs
+++ b/java/core/lance-jni/src/file_writer.rs
@@ -98,7 +98,7 @@ fn inner_open<'local>(
         Result::Ok(FileWriter::new_lazy(
             obj_writer,
             FileWriterOptions {
-                format_version: Some(LanceFileVersion::V2_1),
+                format_version: Some(LanceFileVersion::Stable),
                 ..Default::default()
             },
         ))


### PR DESCRIPTION
It seems that the Java part is using different `LanceFileVersion` values.

In `java/core/lance-jni/src/utils.rs`, it uses `LanceFileVersion::Stable`.

In `java/core/lance-jni/src/file_writer.rs`, it uses `LanceFileVersion::V2_1`.

This change aims to unify the `LanceFileVersion` in the Java module to `Stable`.