### PR TITLE
feat: add lance file version 2.2

### DIFF
--- a/rust/lance-encoding/src/version.rs
+++ b/rust/lance-encoding/src/version.rs
@@ -9,6 +9,7 @@ use snafu::location;
 pub const LEGACY_FORMAT_VERSION: &str = "0.1";
 pub const V2_FORMAT_2_0: &str = "2.0";
 pub const V2_FORMAT_2_1: &str = "2.1";
+pub const V2_FORMAT_2_2: &str = "2.2";
 
 /// Lance file version
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Ord, PartialOrd)]
@@ -24,6 +25,7 @@ pub enum LanceFileVersion {
     V2_1,
     /// The latest unstable release
     Next,
+    V2_2,
 }
 
 impl LanceFileVersion {
@@ -44,6 +46,7 @@ impl LanceFileVersion {
             (0, 3) => Ok(Self::V2_0),
             (2, 0) => Ok(Self::V2_0),
             (2, 1) => Ok(Self::V2_1),
+            (2, 2) => Ok(Self::V2_2),
             _ => Err(Error::InvalidInput {
                 source: format!("Unknown Lance storage version: {}.{}", major, minor).into(),
                 location: location!(),
@@ -56,6 +59,7 @@ impl LanceFileVersion {
             Self::Legacy => (0, 2),
             Self::V2_0 => (2, 0),
             Self::V2_1 => (2, 1),
+            Self::V2_2 => (2, 2),
             Self::Stable => self.resolve().to_numbers(),
             Self::Next => self.resolve().to_numbers(),
         }
@@ -71,6 +75,7 @@ impl std::fmt::Display for LanceFileVersion {
                 Self::Legacy => LEGACY_FORMAT_VERSION,
                 Self::V2_0 => V2_FORMAT_2_0,
                 Self::V2_1 => V2_FORMAT_2_1,
+                Self::V2_2 => V2_FORMAT_2_2,
                 Self::Stable => "stable",
                 Self::Next => "next",
             }
@@ -86,6 +91,7 @@ impl FromStr for LanceFileVersion {
             LEGACY_FORMAT_VERSION => Ok(Self::Legacy),
             V2_FORMAT_2_0 => Ok(Self::V2_0),
             V2_FORMAT_2_1 => Ok(Self::V2_1),
+            V2_FORMAT_2_2 => Ok(Self::V2_2),
             "stable" => Ok(Self::Stable),
             "legacy" => Ok(Self::Legacy),
             "next" => Ok(Self::Next),


### PR DESCRIPTION
This PR just added file version 2.2 without any pointer changes (neither `stable` nor `next`).

---

**This PR was primarily authored with Claude Code using Opus 4.1 and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**