### PR TITLE
chore: enable Maven auto-publish for Java artifacts

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -324,11 +324,12 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.4.0</version>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>ossrh</publishingServerId>
                             <tokenAuth>true</tokenAuth>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
## Summary
- Update central-publishing-maven-plugin from version 0.4.0 to 0.8.0
- Enable autoPublish to automatically release artifacts to Maven Central after successful staging

🤖 Generated with [Claude Code](https://claude.ai/code)