### PR TITLE
perf: improve FTS performance for long query

### DIFF
--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -480,13 +480,12 @@ impl<'a, S: Scorer> Wand<'a, S> {
             }
 
             // move all postings to this doc id
-            self.move_preceding(pivot, doc_id);
-            if self.postings.is_empty() {
-                // no more postings, so we can stop
-                break;
-            } else if self.postings[0].doc().map(|d| d.doc_id()) != Some(doc_id) {
-                // this doc is not in the postings, so we can skip it
-                continue;
+            if !self.check_pivot_aligned(pivot, doc_id) {
+                if self.postings.is_empty() {
+                    break;
+                } else {
+                    continue;
+                }
             }
 
             pivot = 0;

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -5789,7 +5789,7 @@ mod tests {
             .try_into_batch()
             .await
             .unwrap();
-        assert_eq!(result.num_rows(), 5);
+        assert_eq!(result.num_rows(), 5, "{:?}", result);
         let ids = result["id"].as_primitive::<UInt64Type>().values();
         assert!(ids.contains(&0));
         assert!(ids.contains(&1));


### PR DESCRIPTION
this improves WAND perf in case of the query consists of many tokens:
- use bubble sort when the algo only needs to advance single iterator
- move less posting iterators when evaluate the documents if there are many iterators are at the same doc id