### PR TITLE
fix: include base_id in DeletionFile serialization

### DIFF
--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -459,3 +459,50 @@ def test_fragment_metadata_pickle(tmp_path: Path, enable_stable_row_ids: bool):
     round_trip = pickle.loads(pickle.dumps(frag_meta))
 
     assert frag_meta == round_trip
+
+
+def test_deletion_file_with_base_id_serialization():
+    """Test that DeletionFile with base_id serializes correctly."""
+    from lance.fragment import DeletionFile, FragmentMetadata
+
+    # Create a DeletionFile with base_id
+    deletion_file = DeletionFile(
+        read_version=1,
+        id=123,
+        file_type='array',
+        num_deleted_rows=10,
+        base_id=456
+    )
+
+    # Verify the base_id is set
+    assert deletion_file.base_id == 456
+
+    # Test asdict includes base_id
+    deletion_dict = deletion_file.asdict()
+    assert 'base_id' in deletion_dict
+    assert deletion_dict['base_id'] == 456
+
+    # Create a FragmentMetadata with the deletion file
+    metadata = FragmentMetadata(
+        id=1,
+        files=[],
+        physical_rows=1000,
+        deletion_file=deletion_file
+    )
+
+    # Test pickle serialization/deserialization
+    pickled = pickle.dumps(metadata)
+    unpickled = pickle.loads(pickled)
+
+    # Verify the deletion file was correctly deserialized
+    assert unpickled.deletion_file is not None
+    assert unpickled.deletion_file.base_id == 456
+    assert unpickled == metadata
+
+    # Test JSON serialization/deserialization
+    json_data = metadata.to_json()
+    assert json_data['deletion_file']['base_id'] == 456
+
+    deserialized = FragmentMetadata.from_json(json.dumps(json_data))
+    assert deserialized.deletion_file is not None
+    assert deserialized.deletion_file.base_id == 456

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -467,11 +467,7 @@ def test_deletion_file_with_base_id_serialization():
 
     # Create a DeletionFile with base_id
     deletion_file = DeletionFile(
-        read_version=1,
-        id=123,
-        file_type='array',
-        num_deleted_rows=10,
-        base_id=456
+        read_version=1, id=123, file_type="array", num_deleted_rows=10, base_id=456
     )
 
     # Verify the base_id is set
@@ -479,15 +475,12 @@ def test_deletion_file_with_base_id_serialization():
 
     # Test asdict includes base_id
     deletion_dict = deletion_file.asdict()
-    assert 'base_id' in deletion_dict
-    assert deletion_dict['base_id'] == 456
+    assert "base_id" in deletion_dict
+    assert deletion_dict["base_id"] == 456
 
     # Create a FragmentMetadata with the deletion file
     metadata = FragmentMetadata(
-        id=1,
-        files=[],
-        physical_rows=1000,
-        deletion_file=deletion_file
+        id=1, files=[], physical_rows=1000, deletion_file=deletion_file
     )
 
     # Test pickle serialization/deserialization
@@ -501,7 +494,7 @@ def test_deletion_file_with_base_id_serialization():
 
     # Test JSON serialization/deserialization
     json_data = metadata.to_json()
-    assert json_data['deletion_file']['base_id'] == 456
+    assert json_data["deletion_file"]["base_id"] == 456
 
     deserialized = FragmentMetadata.from_json(json.dumps(json_data))
     assert deserialized.deletion_file is not None

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -469,6 +469,7 @@ impl PyDeletionFile {
             intern!(slf.py(), "num_deleted_rows"),
             slf.0.num_deleted_rows,
         )?;
+        dict.set_item(intern!(slf.py(), "base_id"), slf.0.base_id)?;
 
         Ok(dict)
     }


### PR DESCRIPTION
## Summary
- Fixed the missing `base_id` field in the `asdict` method of `PyDeletionFile` 
- Added comprehensive test coverage for DeletionFile serialization with base_id
- Resolves TypeError when deserializing FragmentMetadata objects containing a DeletionFile with base_id

## Problem
When attempting to serialize and deserialize a `FragmentMetadata` object with a `DeletionFile` that has a `base_id`, the deserialization fails with:
```
TypeError: DeletionFile.__new__() missing 1 required positional argument: 'base_id'
```

This occurs because the `asdict` method in `fragment.rs` (line 462) doesn't export the `base_id` parameter, which is required when reconstructing the `DeletionFile` object.

## Solution
Added `dict.set_item(intern!(slf.py(), "base_id"), slf.0.base_id)?;` to include the `base_id` field in the dictionary output of the `asdict` method.

## Testing
Added `test_deletion_file_with_base_id_serialization()` test that verifies:
- DeletionFile with base_id can be created
- The asdict method includes the base_id field  
- Pickle serialization/deserialization preserves base_id
- JSON serialization/deserialization preserves base_id

Fixes #4579