### PR TITLE
chore: async-std has been discontinued

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,7 @@ on:
       - protos/**
       - .github/workflows/rust.yml
       - Cargo.toml
+      - Cargo.lock
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.typos.toml
+++ b/.typos.toml
@@ -9,6 +9,7 @@ terrestial = "terrestial"
 abd = "abd"
 afe = "afe"
 typ = "typ"
+flate = "flate"
 
 [files]
 extend-exclude = ["notebooks/*.ipynb"]

--- a/deny.toml
+++ b/deny.toml
@@ -82,7 +82,9 @@ ignore = [
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2021-0153", reason = "`encoding` is used by lindera" },
     { id = "RUSTSEC-2024-0384", reason = "`instant` is used by tantivy" },
+    { id = "RUSTSEC-2024-0370", reason = "`proc-macro-error` is used by jieba-rs via include-flate" },
     { id = "RUSTSEC-2024-0436", reason = "`paste` is used by datafusion" },
+    { id = "RUSTSEC-2025-0052", reason = "`async-std` is used by tfrecord" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
## Summary
This PR configures cargo-deny to ignore security advisories for unmaintained dependencies that are still needed for optional features.

## Changes
- Add RUSTSEC-2025-0052 to cargo-deny ignore list (async-std used by tfrecord for tensorflow support)
- Add RUSTSEC-2024-0370 to cargo-deny ignore list (proc-macro-error used by jieba-rs via include-flate)

## Context
The async-std crate has been discontinued and flagged as a security vulnerability. It's used by the tfrecord crate (v0.15.0) which provides tensorflow support. Rather than removing tensorflow functionality, we're acknowledging the advisory and keeping the feature available.

## Impact
- Fixes CI failure due to cargo-deny detecting security advisories
- Maintains tensorflow/tfrecord functionality
- Explicitly documents known security advisories in deny.toml

## Test plan
- [x] cargo-deny check advisories passes
- [x] Build succeeds with tensorflow feature
- [x] Python extension builds successfully

🤖 Generated with [Claude Code](https://claude.ai/code)