### PR TITLE
feat: allow using opendal to access s3, azblob and gcs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1239,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,6 +1368,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,6 +1484,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1676,6 +1715,15 @@ dependencies = [
  "libc",
  "rand 0.9.1",
  "regex",
+]
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
 ]
 
 [[package]]
@@ -2559,6 +2607,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,6 +2761,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2731,10 +2799,10 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
- "der",
+ "der 0.6.1",
  "elliptic-curve",
  "rfc6979",
- "signature",
+ "signature 1.6.4",
 ]
 
 [[package]]
@@ -2751,12 +2819,12 @@ checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint 0.4.9",
- "der",
+ "der 0.6.1",
  "digest",
  "ff",
  "generic-array",
  "group",
- "pkcs8",
+ "pkcs8 0.9.0",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
@@ -3888,6 +3956,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4097,6 +4175,21 @@ dependencies = [
  "ryu",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -4684,6 +4777,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -5350,6 +5446,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5550,6 +5663,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "crc32c",
  "futures",
  "getrandom 0.2.16",
  "http 1.3.1",
@@ -5562,6 +5676,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "uuid",
 ]
@@ -5632,6 +5747,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -5796,6 +5921,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5921,13 +6075,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der 0.7.10",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki 0.7.3",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
- "der",
- "spki",
+ "der 0.6.1",
+ "spki 0.6.0",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "pkcs5",
+ "rand_core 0.6.4",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -6620,15 +6812,20 @@ dependencies = [
  "hmac",
  "home",
  "http 1.3.1",
+ "jsonwebtoken",
  "log",
  "once_cell",
  "percent-encoding",
+ "quick-xml 0.37.5",
  "rand 0.8.5",
  "reqwest",
+ "rsa",
+ "rust-ini",
  "serde",
  "serde_json",
  "sha1",
  "sha2",
+ "tokio",
 ]
 
 [[package]]
@@ -6730,6 +6927,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sha2",
+ "signature 2.2.0",
+ "spki 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rstest"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6757,6 +6975,17 @@ dependencies = [
  "rustc_version",
  "syn 2.0.101",
  "unicode-ident",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+ "trim-in-place",
 ]
 
 [[package]]
@@ -6949,6 +7178,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7003,6 +7241,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7019,9 +7268,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
  "base16ct",
- "der",
+ "der 0.6.1",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.9.0",
  "subtle",
  "zeroize",
 ]
@@ -7224,10 +7473,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -7308,13 +7579,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -8233,6 +8520,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
 
 [[package]]
 name = "try-lock"

--- a/deny.toml
+++ b/deny.toml
@@ -85,6 +85,7 @@ ignore = [
     { id = "RUSTSEC-2024-0370", reason = "`proc-macro-error` is used by jieba-rs via include-flate" },
     { id = "RUSTSEC-2024-0436", reason = "`paste` is used by datafusion" },
     { id = "RUSTSEC-2025-0052", reason = "`async-std` is used by tfrecord" },
+    { id = "RUSTSEC-2023-0071", reason = "`rsa` is used by opendal via reqsign" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -72,6 +72,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1081,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1202,15 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -1323,6 +1349,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1403,6 +1438,16 @@ checksum = "8f10f8c9340e31fc120ff885fcdb54a0b48e474bbd77cab557f0c30a3e569402"
 dependencies = [
  "parse-zoneinfo",
  "phf_codegen",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1561,6 +1606,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32c"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a47af21622d091a8f0fb295b88bc886ac74efcc613efc19f5d0b21de5c89e47"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "crc32fast"
@@ -2393,6 +2447,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2475,6 +2540,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -3475,6 +3549,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3664,6 +3748,21 @@ dependencies = [
  "ryu",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -4091,6 +4190,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lazycell"
@@ -4679,6 +4781,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+dependencies = [
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4835,6 +4954,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "crc32c",
  "futures",
  "getrandom 0.2.16",
  "http 1.3.1",
@@ -4847,6 +4967,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "uuid",
 ]
@@ -4879,6 +5000,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -5032,6 +5163,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5154,6 +5314,44 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs5"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e847e2c91a18bfa887dd028ec33f2fe6f25db77db3619024764914affe8b69a6"
+dependencies = [
+ "aes",
+ "cbc",
+ "der",
+ "pbkdf2",
+ "scrypt",
+ "sha2",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "pkcs5",
+ "rand_core 0.6.4",
+ "spki",
 ]
 
 [[package]]
@@ -5854,15 +6052,20 @@ dependencies = [
  "hmac",
  "home",
  "http 1.3.1",
+ "jsonwebtoken",
  "log",
  "once_cell",
  "percent-encoding",
+ "quick-xml",
  "rand 0.8.5",
  "reqwest",
+ "rsa",
+ "rust-ini",
  "serde",
  "serde_json",
  "sha1",
  "sha2",
+ "tokio",
 ]
 
 [[package]]
@@ -5936,6 +6139,38 @@ checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+ "trim-in-place",
 ]
 
 [[package]]
@@ -6116,6 +6351,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6168,6 +6412,17 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "sct"
@@ -6367,10 +6622,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -6434,6 +6711,22 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -7128,6 +7421,12 @@ dependencies = [
  "tracing-core",
  "tracing-log",
 ]
+
+[[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
 
 [[package]]
 name = "try-lock"

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -65,9 +65,9 @@ harness = false
 [features]
 default = ["aws", "azure", "gcp"]
 gcs-test = []
-gcp = ["object_store/gcp"]
-aws = ["object_store/aws", "dep:aws-config", "dep:aws-credential-types"]
-azure = ["object_store/azure"]
+gcp = ["object_store/gcp", "dep:opendal", "opendal/services-gcs", "dep:object_store_opendal"]
+aws = ["object_store/aws", "dep:aws-config", "dep:aws-credential-types", "dep:opendal", "opendal/services-s3", "dep:object_store_opendal"]
+azure = ["object_store/azure", "dep:opendal", "opendal/services-azblob", "dep:object_store_opendal"]
 oss = ["dep:opendal", "opendal/services-oss", "dep:object_store_opendal"]
 
 [lints]

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -10,6 +10,10 @@ use std::{
     time::{Duration, SystemTime},
 };
 
+use object_store::ObjectStore as OSObjectStore;
+use object_store_opendal::OpendalStore;
+use opendal::{services::S3, Operator};
+
 use aws_config::default_provider::credentials::DefaultCredentialsChain;
 use aws_credential_types::provider::ProvideCredentials;
 use object_store::{
@@ -33,6 +37,91 @@ use lance_core::error::{Error, Result};
 #[derive(Default, Debug)]
 pub struct AwsStoreProvider;
 
+impl AwsStoreProvider {
+    async fn build_amazon_s3_store(
+        &self,
+        base_path: &mut Url,
+        params: &ObjectStoreParams,
+        storage_options: &StorageOptions,
+        is_s3_express: bool,
+    ) -> Result<Arc<dyn OSObjectStore>> {
+        let max_retries = storage_options.client_max_retries();
+        let retry_timeout = storage_options.client_retry_timeout();
+        let retry_config = RetryConfig {
+            backoff: Default::default(),
+            max_retries,
+            retry_timeout: Duration::from_secs(retry_timeout),
+        };
+
+        let mut s3_storage_options = storage_options.as_s3_options();
+        let region = resolve_s3_region(base_path, &s3_storage_options).await?;
+        let (aws_creds, region) = build_aws_credential(
+            params.s3_credentials_refresh_offset,
+            params.aws_credentials.clone(),
+            Some(&s3_storage_options),
+            region,
+        )
+        .await?;
+
+        // Set S3Express flag if detected
+        if is_s3_express {
+            s3_storage_options.insert(AmazonS3ConfigKey::S3Express, true.to_string());
+        }
+
+        // before creating the OSObjectStore we need to rewrite the url to drop ddb related parts
+        base_path.set_scheme("s3").unwrap();
+        base_path.set_query(None);
+
+        // we can't use parse_url_opts here because we need to manually set the credentials provider
+        let mut builder = AmazonS3Builder::new();
+        for (key, value) in s3_storage_options {
+            builder = builder.with_config(key, value);
+        }
+        builder = builder
+            .with_url(base_path.as_ref())
+            .with_credentials(aws_creds)
+            .with_retry(retry_config)
+            .with_region(region);
+
+        Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
+    }
+
+    async fn build_opendal_s3_store(
+        &self,
+        base_path: &Url,
+        storage_options: &StorageOptions,
+    ) -> Result<Arc<dyn OSObjectStore>> {
+        let bucket = base_path
+            .host_str()
+            .ok_or_else(|| Error::invalid_input("S3 URL must contain bucket name", location!()))?
+            .to_string();
+
+        let prefix = base_path.path().trim_start_matches('/').to_string();
+
+        // Start with all storage options as the config map
+        // OpenDAL will handle environment variables through its default credentials chain
+        let mut config_map: HashMap<String, String> = storage_options.0.clone();
+
+        // Set required OpenDAL configuration
+        config_map.insert("bucket".to_string(), bucket);
+
+        if !prefix.is_empty() {
+            config_map.insert("root".to_string(), format!("/{}", prefix));
+        }
+
+        let operator = Operator::from_iter::<S3>(config_map)
+            .map_err(|e| {
+                Error::invalid_input(
+                    format!("Failed to create S3 operator: {:?}", e),
+                    location!(),
+                )
+            })?
+            .finish();
+
+        Ok(Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>)
+    }
+}
+
 #[async_trait::async_trait]
 impl ObjectStoreProvider for AwsStoreProvider {
     async fn new_store(
@@ -43,58 +132,33 @@ impl ObjectStoreProvider for AwsStoreProvider {
         let block_size = params.block_size.unwrap_or(DEFAULT_CLOUD_BLOCK_SIZE);
         let mut storage_options =
             StorageOptions(params.storage_options.clone().unwrap_or_default());
+        storage_options.with_env_s3();
         let download_retry_count = storage_options.download_retry_count();
 
-        let max_retries = storage_options.client_max_retries();
-        let retry_timeout = storage_options.client_retry_timeout();
-        let retry_config = RetryConfig {
-            backoff: Default::default(),
-            max_retries,
-            retry_timeout: Duration::from_secs(retry_timeout),
-        };
+        let use_opendal = storage_options
+            .0
+            .get("use_opendal")
+            .map(|v| v == "true")
+            .unwrap_or(false);
 
-        storage_options.with_env_s3();
+        // Determine S3 Express and constant size upload parts before building the store
+        let is_s3_express = check_s3_express(&base_path, &storage_options);
 
-        let mut storage_options = storage_options.as_s3_options();
-        let region = resolve_s3_region(&base_path, &storage_options).await?;
-        let (aws_creds, region) = build_aws_credential(
-            params.s3_credentials_refresh_offset,
-            params.aws_credentials.clone(),
-            Some(&storage_options),
-            region,
-        )
-        .await?;
-
-        // This will be default in next version of object store.
-        // https://github.com/apache/arrow-rs/pull/7181
-        // We can do this when we upgrade to 0.12.
-        storage_options
-            .entry(AmazonS3ConfigKey::ConditionalPut)
-            .or_insert_with(|| "etag".to_string());
-
-        // Cloudflare does not support varying part sizes.
         let use_constant_size_upload_parts = storage_options
-            .get(&AmazonS3ConfigKey::Endpoint)
+            .0
+            .get("aws_endpoint")
             .map(|endpoint| endpoint.contains("r2.cloudflarestorage.com"))
             .unwrap_or(false);
 
-        let is_s3_express = check_s3_express(&base_path, &mut storage_options);
-
-        // before creating the OSObjectStore we need to rewrite the url to drop ddb related parts
-        base_path.set_scheme("s3").unwrap();
-        base_path.set_query(None);
-
-        // we can't use parse_url_opts here because we need to manually set the credentials provider
-        let mut builder = AmazonS3Builder::new();
-        for (key, value) in storage_options {
-            builder = builder.with_config(key, value);
-        }
-        builder = builder
-            .with_url(base_path.as_ref())
-            .with_credentials(aws_creds)
-            .with_retry(retry_config)
-            .with_region(region);
-        let inner = Arc::new(builder.build()?);
+        let inner = if use_opendal {
+            // Use OpenDAL implementation
+            self.build_opendal_s3_store(&base_path, &storage_options)
+                .await?
+        } else {
+            // Use default Amazon S3 implementation
+            self.build_amazon_s3_store(&mut base_path, params, &storage_options, is_s3_express)
+                .await?
+        };
 
         Ok(ObjectStore {
             inner,
@@ -109,18 +173,14 @@ impl ObjectStoreProvider for AwsStoreProvider {
     }
 }
 
-/// Check if the storage is S3 Express, update object storage options along the way
-fn check_s3_express(url: &Url, storage_options: &mut HashMap<AmazonS3ConfigKey, String>) -> bool {
-    if matches!(storage_options.get(&AmazonS3ConfigKey::S3Express), Some(val) if val == "true") {
-        return true;
-    }
-
-    if url.authority().ends_with("--x-s3") {
-        storage_options.insert(AmazonS3ConfigKey::S3Express, true.to_string());
-        return true;
-    }
-
-    false
+/// Check if the storage is S3 Express
+fn check_s3_express(url: &Url, storage_options: &StorageOptions) -> bool {
+    storage_options
+        .0
+        .get("s3_express")
+        .map(|v| v == "true")
+        .unwrap_or(false)
+        || url.authority().ends_with("--x-s3")
 }
 
 /// Figure out the S3 region of the bucket.
@@ -437,37 +497,52 @@ mod tests {
         let cases = [
             (
                 "s3://bucket/path/to/file",
-                HashMap::from([(AmazonS3ConfigKey::S3Express, "true".into())]),
+                HashMap::from([("s3_express".to_string(), "true".to_string())]),
                 true,
             ),
             (
                 "s3://bucket/path/to/file",
-                HashMap::from([(AmazonS3ConfigKey::S3Express, "false".into())]),
+                HashMap::from([("s3_express".to_string(), "false".to_string())]),
                 false,
             ),
             ("s3://bucket/path/to/file", HashMap::from([]), false),
             (
                 "s3://bucket--x-s3/path/to/file",
-                HashMap::from([(AmazonS3ConfigKey::S3Express, "true".into())]),
+                HashMap::from([("s3_express".to_string(), "true".to_string())]),
                 true,
             ),
             (
                 "s3://bucket--x-s3/path/to/file",
-                HashMap::from([(AmazonS3ConfigKey::S3Express, "false".into())]),
-                true,
+                HashMap::from([("s3_express".to_string(), "false".to_string())]),
+                true, // URL takes precedence
             ),
             ("s3://bucket--x-s3/path/to/file", HashMap::from([]), true),
         ];
 
-        for (uri, mut configs, expected) in cases {
+        for (uri, storage_map, expected) in cases {
             let url = Url::parse(uri).unwrap();
-            let is_s3_express = check_s3_express(&url, &mut configs);
+            let storage_options = StorageOptions(storage_map);
+            let is_s3_express = check_s3_express(&url, &storage_options);
             assert_eq!(is_s3_express, expected);
-            if is_s3_express {
-                assert!(configs
-                    .get(&AmazonS3ConfigKey::S3Express)
-                    .is_some_and(|opt| opt == "true"));
-            }
         }
+    }
+
+    #[tokio::test]
+    async fn test_use_opendal_flag() {
+        let provider = AwsStoreProvider;
+        let url = Url::parse("s3://test-bucket/path").unwrap();
+        let params_with_flag = ObjectStoreParams {
+            storage_options: Some(HashMap::from([
+                ("use_opendal".to_string(), "true".to_string()),
+                ("region".to_string(), "us-west-2".to_string()),
+            ])),
+            ..Default::default()
+        };
+
+        let store = provider
+            .new_store(url.clone(), &params_with_flag)
+            .await
+            .unwrap();
+        assert_eq!(store.scheme, "s3");
     }
 }

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -3,6 +3,11 @@
 
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
+use object_store::ObjectStore as OSObjectStore;
+use object_store_opendal::OpendalStore;
+use opendal::{services::Azblob, Operator};
+use snafu::location;
+
 use object_store::{
     azure::{AzureConfigKey, MicrosoftAzureBuilder},
     RetryConfig,
@@ -13,19 +18,54 @@ use crate::object_store::{
     ObjectStore, ObjectStoreParams, ObjectStoreProvider, StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE,
     DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE,
 };
-use lance_core::error::Result;
+use lance_core::error::{Error, Result};
 
 #[derive(Default, Debug)]
 pub struct AzureBlobStoreProvider;
 
-#[async_trait::async_trait]
-impl ObjectStoreProvider for AzureBlobStoreProvider {
-    async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
-        let block_size = params.block_size.unwrap_or(DEFAULT_CLOUD_BLOCK_SIZE);
-        let mut storage_options =
-            StorageOptions(params.storage_options.clone().unwrap_or_default());
-        let download_retry_count = storage_options.download_retry_count();
+impl AzureBlobStoreProvider {
+    async fn build_opendal_azure_store(
+        &self,
+        base_path: &Url,
+        storage_options: &StorageOptions,
+    ) -> Result<Arc<dyn OSObjectStore>> {
+        let container = base_path
+            .host_str()
+            .ok_or_else(|| {
+                Error::invalid_input("Azure URL must contain container name", location!())
+            })?
+            .to_string();
 
+        let prefix = base_path.path().trim_start_matches('/').to_string();
+
+        // Start with all storage options as the config map
+        // OpenDAL will handle environment variables through its default credentials chain
+        let mut config_map: HashMap<String, String> = storage_options.0.clone();
+
+        // Set required OpenDAL configuration
+        config_map.insert("container".to_string(), container);
+
+        if !prefix.is_empty() {
+            config_map.insert("root".to_string(), format!("/{}", prefix));
+        }
+
+        let operator = Operator::from_iter::<Azblob>(config_map)
+            .map_err(|e| {
+                Error::invalid_input(
+                    format!("Failed to create Azure Blob operator: {:?}", e),
+                    location!(),
+                )
+            })?
+            .finish();
+
+        Ok(Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>)
+    }
+
+    async fn build_microsoft_azure_store(
+        &self,
+        base_path: &Url,
+        storage_options: &StorageOptions,
+    ) -> Result<Arc<dyn OSObjectStore>> {
         let max_retries = storage_options.client_max_retries();
         let retry_timeout = storage_options.client_retry_timeout();
         let retry_config = RetryConfig {
@@ -34,14 +74,39 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
             retry_timeout: Duration::from_secs(retry_timeout),
         };
 
-        storage_options.with_env_azure();
         let mut builder = MicrosoftAzureBuilder::new()
             .with_url(base_path.as_ref())
             .with_retry(retry_config);
         for (key, value) in storage_options.as_azure_options() {
             builder = builder.with_config(key, value);
         }
-        let inner = Arc::new(builder.build()?);
+
+        Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStoreProvider for AzureBlobStoreProvider {
+    async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
+        let block_size = params.block_size.unwrap_or(DEFAULT_CLOUD_BLOCK_SIZE);
+        let mut storage_options =
+            StorageOptions(params.storage_options.clone().unwrap_or_default());
+        storage_options.with_env_azure();
+        let download_retry_count = storage_options.download_retry_count();
+
+        let use_opendal = storage_options
+            .0
+            .get("use_opendal")
+            .map(|v| v.as_str() == "true")
+            .unwrap_or(false);
+
+        let inner = if use_opendal {
+            self.build_opendal_azure_store(&base_path, &storage_options)
+                .await?
+        } else {
+            self.build_microsoft_azure_store(&base_path, &storage_options)
+                .await?
+        };
 
         Ok(ObjectStore {
             inner,
@@ -86,6 +151,8 @@ impl StorageOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::object_store::ObjectStoreParams;
+    use std::collections::HashMap;
 
     #[test]
     fn test_azure_store_path() {
@@ -95,5 +162,29 @@ mod tests {
         let path = provider.extract_path(&url).unwrap();
         let expected_path = object_store::path::Path::from("path/to/file");
         assert_eq!(path, expected_path);
+    }
+
+    #[tokio::test]
+    async fn test_use_opendal_flag() {
+        let provider = AzureBlobStoreProvider;
+        let url = Url::parse("az://test-container/path").unwrap();
+        let params_with_flag = ObjectStoreParams {
+            storage_options: Some(HashMap::from([
+                ("use_opendal".to_string(), "true".to_string()),
+                ("account_name".to_string(), "test_account".to_string()),
+                (
+                    "endpoint".to_string(),
+                    "https://test_account.blob.core.windows.net".to_string(),
+                ),
+                ("account_key".to_string(), "12345=".to_string()),
+            ])),
+            ..Default::default()
+        };
+
+        let store = provider
+            .new_store(url.clone(), &params_with_flag)
+            .await
+            .unwrap();
+        assert_eq!(store.scheme, "az");
     }
 }

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -3,6 +3,11 @@
 
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
+use object_store::ObjectStore as OSObjectStore;
+use object_store_opendal::OpendalStore;
+use opendal::{services::Gcs, Operator};
+use snafu::location;
+
 use object_store::{
     gcp::{GcpCredential, GoogleCloudStorageBuilder, GoogleConfigKey},
     RetryConfig, StaticCredentialProvider,
@@ -13,19 +18,52 @@ use crate::object_store::{
     ObjectStore, ObjectStoreParams, ObjectStoreProvider, StorageOptions, DEFAULT_CLOUD_BLOCK_SIZE,
     DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE,
 };
-use lance_core::error::Result;
+use lance_core::error::{Error, Result};
 
 #[derive(Default, Debug)]
 pub struct GcsStoreProvider;
 
-#[async_trait::async_trait]
-impl ObjectStoreProvider for GcsStoreProvider {
-    async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
-        let block_size = params.block_size.unwrap_or(DEFAULT_CLOUD_BLOCK_SIZE);
-        let mut storage_options =
-            StorageOptions(params.storage_options.clone().unwrap_or_default());
-        let download_retry_count = storage_options.download_retry_count();
+impl GcsStoreProvider {
+    async fn build_opendal_gcs_store(
+        &self,
+        base_path: &Url,
+        storage_options: &StorageOptions,
+    ) -> Result<Arc<dyn OSObjectStore>> {
+        let bucket = base_path
+            .host_str()
+            .ok_or_else(|| Error::invalid_input("GCS URL must contain bucket name", location!()))?
+            .to_string();
 
+        let prefix = base_path.path().trim_start_matches('/').to_string();
+
+        // Start with all storage options as the config map
+        // OpenDAL will handle environment variables through its default credentials chain
+        let mut config_map: HashMap<String, String> = storage_options.0.clone();
+
+        // Set required OpenDAL configuration
+        config_map.insert("bucket".to_string(), bucket);
+
+        if !prefix.is_empty() {
+            config_map.insert("root".to_string(), format!("/{}", prefix));
+        }
+
+        let operator = Operator::from_iter::<Gcs>(config_map)
+            .map_err(|e| {
+                Error::invalid_input(
+                    format!("Failed to create GCS operator: {:?}", e),
+                    location!(),
+                )
+            })?
+            .finish();
+
+        Ok(Arc::new(OpendalStore::new(operator)) as Arc<dyn OSObjectStore>)
+    }
+
+    async fn build_google_cloud_store(
+        &self,
+        base_path: &Url,
+        storage_options: &StorageOptions,
+    ) -> Result<Arc<dyn OSObjectStore>> {
         let max_retries = storage_options.client_max_retries();
         let retry_timeout = storage_options.client_retry_timeout();
         let retry_config = RetryConfig {
@@ -34,7 +72,6 @@ impl ObjectStoreProvider for GcsStoreProvider {
             retry_timeout: Duration::from_secs(retry_timeout),
         };
 
-        storage_options.with_env_gcs();
         let mut builder = GoogleCloudStorageBuilder::new()
             .with_url(base_path.as_ref())
             .with_retry(retry_config);
@@ -49,7 +86,33 @@ impl ObjectStoreProvider for GcsStoreProvider {
             let credential_provider = Arc::new(StaticCredentialProvider::new(credential)) as _;
             builder = builder.with_credentials(credential_provider);
         }
-        let inner = Arc::new(builder.build()?);
+
+        Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStoreProvider for GcsStoreProvider {
+    async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
+        let block_size = params.block_size.unwrap_or(DEFAULT_CLOUD_BLOCK_SIZE);
+        let mut storage_options =
+            StorageOptions(params.storage_options.clone().unwrap_or_default());
+        storage_options.with_env_gcs();
+        let download_retry_count = storage_options.download_retry_count();
+
+        let use_opendal = storage_options
+            .0
+            .get("use_opendal")
+            .map(|v| v.as_str() == "true")
+            .unwrap_or(false);
+
+        let inner = if use_opendal {
+            self.build_opendal_gcs_store(&base_path, &storage_options)
+                .await?
+        } else {
+            self.build_google_cloud_store(&base_path, &storage_options)
+                .await?
+        };
 
         Ok(ObjectStore {
             inner,
@@ -101,6 +164,8 @@ impl StorageOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::object_store::ObjectStoreParams;
+    use std::collections::HashMap;
 
     #[test]
     fn test_gcs_store_path() {
@@ -110,5 +175,27 @@ mod tests {
         let path = provider.extract_path(&url).unwrap();
         let expected_path = object_store::path::Path::from("path/to/file");
         assert_eq!(path, expected_path);
+    }
+
+    #[tokio::test]
+    async fn test_use_opendal_flag() {
+        let provider = GcsStoreProvider;
+        let url = Url::parse("gs://test-bucket/path").unwrap();
+        let params_with_flag = ObjectStoreParams {
+            storage_options: Some(HashMap::from([
+                ("use_opendal".to_string(), "true".to_string()),
+                (
+                    "service_account".to_string(),
+                    "test@example.iam.gserviceaccount.com".to_string(),
+                ),
+            ])),
+            ..Default::default()
+        };
+
+        let store = provider
+            .new_store(url.clone(), &params_with_flag)
+            .await
+            .unwrap();
+        assert_eq!(store.scheme, "gs");
     }
 }


### PR DESCRIPTION
User can set `use_opendal=true` storage option to enable this route. Any storage option will be passed to OpenDAL as is to initialize its operator.

Related to: https://github.com/apache/arrow-rs-object-store/issues/472