### PR TITLE
chore(java): refactor toString and Optional fields

### DIFF
--- a/java/core/lance-jni/src/blocking_dataset.rs
+++ b/java/core/lance-jni/src/blocking_dataset.rs
@@ -1249,40 +1249,32 @@ fn create_column_alteration(
     let path_jstring: JString = path_obj.into();
     let path: String = env.get_string(&path_jstring)?.into();
 
-    let rename_obj = env
-        .get_field(&column_alteration_jobj, "rename", "Ljava/util/Optional;")?
+    let rename = env
+        .call_method(
+            &column_alteration_jobj,
+            "getRename",
+            "()Ljava/util/Optional;",
+            &[],
+        )?
         .l()?;
-    let rename = if env.call_method(&rename_obj, "isPresent", "()Z", &[])?.z()? {
-        let jstring: JObject = env
-            .call_method(rename_obj, "get", "()Ljava/lang/Object;", &[])?
-            .l()?;
-        let jstring: JString = jstring.into();
-        let rename_str: String = env.get_string(&jstring)?.into(); // Intermediate variable
-        Some(rename_str)
-    } else {
-        None
-    };
-
-    let nullable_obj = env
-        .get_field(&column_alteration_jobj, "nullable", "Ljava/util/Optional;")?
+    let rename = env.get_string_opt(&rename)?;
+    let nullable = env
+        .call_method(
+            &column_alteration_jobj,
+            "getNullable",
+            "()Ljava/util/Optional;",
+            &[],
+        )?
         .l()?;
-    let nullable = if env
-        .call_method(&nullable_obj, "isPresent", "()Z", &[])?
-        .z()?
-    {
-        let nullable_value = env
-            .call_method(nullable_obj, "get", "()Ljava/lang/Object;", &[])?
-            .l()?;
-        Some(
-            env.call_method(nullable_value, "booleanValue", "()Z", &[])?
-                .z()?,
-        )
-    } else {
-        None
-    };
+    let nullable = env.get_bool_opt(&nullable)?;
 
     let data_type_obj = env
-        .get_field(&column_alteration_jobj, "dataType", "Ljava/util/Optional;")?
+        .call_method(
+            &column_alteration_jobj,
+            "getDataType",
+            "()Ljava/util/Optional;",
+            &[],
+        )?
         .l()?;
     let data_type = if env
         .call_method(&data_type_obj, "isPresent", "()Z", &[])?

--- a/java/core/src/main/java/com/lancedb/lance/FragmentMetadata.java
+++ b/java/core/src/main/java/com/lancedb/lance/FragmentMetadata.java
@@ -16,8 +16,7 @@ package com.lancedb.lance;
 import com.lancedb.lance.fragment.DataFile;
 import com.lancedb.lance.fragment.DeletionFile;
 import com.lancedb.lance.fragment.RowIdMeta;
-
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.io.Serializable;
 import java.util.List;
@@ -98,12 +97,12 @@ public class FragmentMetadata implements Serializable {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("id", id)
-        .append("physicalRows", physicalRows)
-        .append("files", files)
-        .append("deletionFile", deletionFile)
-        .append("rowIdMeta", rowIdMeta)
+    return ToStringHelper.of(this)
+        .add("id", id)
+        .add("physicalRows", physicalRows)
+        .add("files", files)
+        .add("deletionFile", deletionFile)
+        .add("rowIdMeta", rowIdMeta)
         .toString();
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/ReadOptions.java
+++ b/java/core/src/main/java/com/lancedb/lance/ReadOptions.java
@@ -13,7 +13,7 @@
  */
 package com.lancedb.lance;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,8 +22,8 @@ import java.util.Optional;
 /** Read options for reading from a dataset. */
 public class ReadOptions {
 
-  private final Optional<Integer> version;
-  private final Optional<Integer> blockSize;
+  private final Integer version;
+  private final Integer blockSize;
   private final long indexCacheSizeBytes;
   private final long metadataCacheSizeBytes;
   private final Map<String, String> storageOptions;
@@ -37,11 +37,11 @@ public class ReadOptions {
   }
 
   public Optional<Integer> getVersion() {
-    return version;
+    return Optional.ofNullable(version);
   }
 
   public Optional<Integer> getBlockSize() {
-    return blockSize;
+    return Optional.ofNullable(blockSize);
   }
 
   public long getIndexCacheSizeBytes() {
@@ -58,19 +58,19 @@ public class ReadOptions {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("version", version.orElse(null))
-        .append("blockSize", blockSize.orElse(null))
-        .append("indexCacheSizeBytes", indexCacheSizeBytes)
-        .append("metadataCacheSizeBytes", metadataCacheSizeBytes)
-        .append("storageOptions", storageOptions)
+    return ToStringHelper.of(this)
+        .add("version", version)
+        .add("blockSize", blockSize)
+        .add("indexCacheSizeBytes", indexCacheSizeBytes)
+        .add("metadataCacheSizeBytes", metadataCacheSizeBytes)
+        .add("storageOptions", storageOptions)
         .toString();
   }
 
   public static class Builder {
 
-    private Optional<Integer> version = Optional.empty();
-    private Optional<Integer> blockSize = Optional.empty();
+    private Integer version = null;
+    private Integer blockSize = null;
     private long indexCacheSizeBytes = 6 * 1024 * 1024 * 1024; // Default to 6 GiB like Rust
     private long metadataCacheSizeBytes = 1024 * 1024 * 1024; // Default to 1 GiB like Rust
     private Map<String, String> storageOptions = new HashMap<>();
@@ -82,7 +82,7 @@ public class ReadOptions {
      * @return this builder
      */
     public Builder setVersion(int version) {
-      this.version = Optional.of(version);
+      this.version = version;
       return this;
     }
 
@@ -94,7 +94,7 @@ public class ReadOptions {
      * @return this builder
      */
     public Builder setBlockSize(int blockSize) {
-      this.blockSize = Optional.of(blockSize);
+      this.blockSize = blockSize;
       return this;
     }
 

--- a/java/core/src/main/java/com/lancedb/lance/SqlQuery.java
+++ b/java/core/src/main/java/com/lancedb/lance/SqlQuery.java
@@ -23,8 +23,8 @@ import java.util.Optional;
 public class SqlQuery {
   private static final String DEFAULT_TABLE_NAME = "dataset";
 
-  private Dataset dataset;
-  private String sql;
+  private final Dataset dataset;
+  private final String sql;
   private String table = DEFAULT_TABLE_NAME;
   private boolean withRowId = false;
   private boolean withRowAddr = false;

--- a/java/core/src/main/java/com/lancedb/lance/Tag.java
+++ b/java/core/src/main/java/com/lancedb/lance/Tag.java
@@ -13,7 +13,7 @@
  */
 package com.lancedb.lance;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.util.Objects;
 
@@ -42,10 +42,10 @@ public class Tag {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("name", name)
-        .append("version", version)
-        .append("manifestSize", manifestSize)
+    return ToStringHelper.of(this)
+        .add("name", name)
+        .add("version", version)
+        .add("manifestSize", manifestSize)
         .toString();
   }
 

--- a/java/core/src/main/java/com/lancedb/lance/Transaction.java
+++ b/java/core/src/main/java/com/lancedb/lance/Transaction.java
@@ -14,6 +14,7 @@
 package com.lancedb.lance;
 
 import com.lancedb.lance.operation.Operation;
+import com.lancedb.lance.util.ToStringHelper;
 
 import org.apache.arrow.util.Preconditions;
 
@@ -95,9 +96,14 @@ public class Transaction {
 
   @Override
   public String toString() {
-    return String.format(
-        "Transaction{readVersion=%d, uuid='%s', operation=%s, blobOp=%s}",
-        readVersion, uuid, operation, blobOp);
+    return ToStringHelper.of(this)
+        .add("readVersion", readVersion)
+        .add("uuid", uuid)
+        .add("operation", operation)
+        .add("blobOp", blobOp)
+        .add("writeParams", writeParams)
+        .add("transactionProperties", transactionProperties)
+        .toString();
   }
 
   @Override

--- a/java/core/src/main/java/com/lancedb/lance/Version.java
+++ b/java/core/src/main/java/com/lancedb/lance/Version.java
@@ -13,7 +13,7 @@
  */
 package com.lancedb.lance;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.time.ZonedDateTime;
 import java.util.Objects;
@@ -45,10 +45,10 @@ public class Version {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("id", id)
-        .append("dataTime", dataTime)
-        .append("metadata", metadata)
+    return ToStringHelper.of(this)
+        .add("id", id)
+        .add("dataTime", dataTime)
+        .add("metadata", metadata)
         .toString();
   }
 

--- a/java/core/src/main/java/com/lancedb/lance/WriteParams.java
+++ b/java/core/src/main/java/com/lancedb/lance/WriteParams.java
@@ -13,7 +13,7 @@
  */
 package com.lancedb.lance;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,17 +29,17 @@ public class WriteParams {
     OVERWRITE
   }
 
-  private final Optional<Integer> maxRowsPerFile;
-  private final Optional<Integer> maxRowsPerGroup;
-  private final Optional<Long> maxBytesPerFile;
-  private final Optional<WriteMode> mode;
-  private Map<String, String> storageOptions = new HashMap<>();
+  private final Integer maxRowsPerFile;
+  private final Integer maxRowsPerGroup;
+  private final Long maxBytesPerFile;
+  private final WriteMode mode;
+  private final Map<String, String> storageOptions;
 
   private WriteParams(
-      Optional<Integer> maxRowsPerFile,
-      Optional<Integer> maxRowsPerGroup,
-      Optional<Long> maxBytesPerFile,
-      Optional<WriteMode> mode,
+      Integer maxRowsPerFile,
+      Integer maxRowsPerGroup,
+      Long maxBytesPerFile,
+      WriteMode mode,
       Map<String, String> storageOptions) {
     this.maxRowsPerFile = maxRowsPerFile;
     this.maxRowsPerGroup = maxRowsPerGroup;
@@ -49,15 +49,15 @@ public class WriteParams {
   }
 
   public Optional<Integer> getMaxRowsPerFile() {
-    return maxRowsPerFile;
+    return Optional.ofNullable(maxRowsPerFile);
   }
 
   public Optional<Integer> getMaxRowsPerGroup() {
-    return maxRowsPerGroup;
+    return Optional.ofNullable(maxRowsPerGroup);
   }
 
   public Optional<Long> getMaxBytesPerFile() {
-    return maxBytesPerFile;
+    return Optional.ofNullable(maxBytesPerFile);
   }
 
   /**
@@ -66,7 +66,7 @@ public class WriteParams {
    * @return mode
    */
   public Optional<String> getMode() {
-    return mode.map(Enum::name);
+    return Optional.ofNullable(mode).map(Enum::name);
   }
 
   public Map<String, String> getStorageOptions() {
@@ -75,39 +75,39 @@ public class WriteParams {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("maxRowsPerFile", maxRowsPerFile.orElse(null))
-        .append("maxRowsPerGroup", maxRowsPerGroup.orElse(null))
-        .append("maxBytesPerFile", maxBytesPerFile.orElse(null))
-        .append("mode", mode.orElse(null))
+    return ToStringHelper.of(this)
+        .add("maxRowsPerFile", maxRowsPerFile)
+        .add("maxRowsPerGroup", maxRowsPerGroup)
+        .add("maxBytesPerFile", maxBytesPerFile)
+        .add("mode", mode)
         .toString();
   }
 
   /** A builder of WriteParams. */
   public static class Builder {
-    private Optional<Integer> maxRowsPerFile = Optional.empty();
-    private Optional<Integer> maxRowsPerGroup = Optional.empty();
-    private Optional<Long> maxBytesPerFile = Optional.empty();
-    private Optional<WriteMode> mode = Optional.empty();
+    private Integer maxRowsPerFile;
+    private Integer maxRowsPerGroup;
+    private Long maxBytesPerFile;
+    private WriteMode mode;
     private Map<String, String> storageOptions = new HashMap<>();
 
     public Builder withMaxRowsPerFile(int maxRowsPerFile) {
-      this.maxRowsPerFile = Optional.of(maxRowsPerFile);
+      this.maxRowsPerFile = maxRowsPerFile;
       return this;
     }
 
     public Builder withMaxRowsPerGroup(int maxRowsPerGroup) {
-      this.maxRowsPerGroup = Optional.of(maxRowsPerGroup);
+      this.maxRowsPerGroup = maxRowsPerGroup;
       return this;
     }
 
     public Builder withMaxBytesPerFile(long maxBytesPerFile) {
-      this.maxBytesPerFile = Optional.of(maxBytesPerFile);
+      this.maxBytesPerFile = maxBytesPerFile;
       return this;
     }
 
     public Builder withMode(WriteMode mode) {
-      this.mode = Optional.of(mode);
+      this.mode = mode;
       return this;
     }
 

--- a/java/core/src/main/java/com/lancedb/lance/fragment/DataFile.java
+++ b/java/core/src/main/java/com/lancedb/lance/fragment/DataFile.java
@@ -13,7 +13,7 @@
  */
 package com.lancedb.lance.fragment;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -90,14 +90,14 @@ public class DataFile implements Serializable {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("path", path)
-        .append("fields", fields)
-        .append("columnIndices", columnIndices)
-        .append("fileMajorVersion", fileMajorVersion)
-        .append("fileMinorVersion", fileMinorVersion)
-        .append("fileSizeBytes", fileSizeBytes)
-        .append("baseId", baseId)
+    return ToStringHelper.of(this)
+        .add("path", path)
+        .add("fields", fields)
+        .add("columnIndices", columnIndices)
+        .add("fileMajorVersion", fileMajorVersion)
+        .add("fileMinorVersion", fileMinorVersion)
+        .add("fileSizeBytes", fileSizeBytes)
+        .add("baseId", baseId)
         .toString();
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/fragment/DeletionFile.java
+++ b/java/core/src/main/java/com/lancedb/lance/fragment/DeletionFile.java
@@ -13,7 +13,7 @@
  */
 package com.lancedb.lance.fragment;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -70,12 +70,12 @@ public class DeletionFile implements Serializable {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("id", id)
-        .append("readVersion", readVersion)
-        .append("numDeletedRows", numDeletedRows)
-        .append("fileType", fileType)
-        .append("baseId", baseId)
+    return ToStringHelper.of(this)
+        .add("id", id)
+        .add("readVersion", readVersion)
+        .add("numDeletedRows", numDeletedRows)
+        .add("fileType", fileType)
+        .add("baseId", baseId)
         .toString();
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/fragment/RowIdMeta.java
+++ b/java/core/src/main/java/com/lancedb/lance/fragment/RowIdMeta.java
@@ -13,7 +13,7 @@
  */
 package com.lancedb.lance.fragment;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -45,6 +45,6 @@ public class RowIdMeta implements Serializable {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this).append("metadata", metadata).toString();
+    return ToStringHelper.of(this).add("metadata", metadata).toString();
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/index/Index.java
+++ b/java/core/src/main/java/com/lancedb/lance/index/Index.java
@@ -13,7 +13,7 @@
  */
 package com.lancedb.lance.index;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -145,14 +145,14 @@ public class Index {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("uuid", uuid)
-        .append("fields", fields)
-        .append("name", name)
-        .append("datasetVersion", datasetVersion)
-        .append("indexVersion", indexVersion)
-        .append("createdAt", createdAt)
-        .append("baseId", baseId)
+    return ToStringHelper.of(this)
+        .add("uuid", uuid)
+        .add("fields", fields)
+        .add("name", name)
+        .add("datasetVersion", datasetVersion)
+        .add("indexVersion", indexVersion)
+        .add("createdAt", createdAt)
+        .add("baseId", baseId)
         .toString();
   }
 

--- a/java/core/src/main/java/com/lancedb/lance/index/IndexParams.java
+++ b/java/core/src/main/java/com/lancedb/lance/index/IndexParams.java
@@ -14,24 +14,23 @@
 package com.lancedb.lance.index;
 
 import com.lancedb.lance.index.vector.VectorIndexParams;
-
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.util.Optional;
 
 /** Parameters for creating an index. */
 public class IndexParams {
   private final DistanceType distanceType;
-  private final Optional<VectorIndexParams> vectorIndexParams;
+  private final VectorIndexParams vectorIndexParams;
 
-  private IndexParams(Builder builder) {
-    this.distanceType = builder.distanceType;
-    this.vectorIndexParams = builder.vectorIndexParams;
+  private IndexParams(DistanceType distanceType, VectorIndexParams vectorIndexParams) {
+    this.distanceType = distanceType;
+    this.vectorIndexParams = vectorIndexParams;
   }
 
   public static class Builder {
     private DistanceType distanceType = DistanceType.L2;
-    private Optional<VectorIndexParams> vectorIndexParams = Optional.empty();
+    private VectorIndexParams vectorIndexParams;
 
     public Builder() {}
 
@@ -53,12 +52,12 @@ public class IndexParams {
      * @return this builder
      */
     public Builder setVectorIndexParams(VectorIndexParams vectorIndexParams) {
-      this.vectorIndexParams = Optional.of(vectorIndexParams);
+      this.vectorIndexParams = vectorIndexParams;
       return this;
     }
 
     public IndexParams build() {
-      return new IndexParams(this);
+      return new IndexParams(distanceType, vectorIndexParams);
     }
   }
 
@@ -67,14 +66,14 @@ public class IndexParams {
   }
 
   public Optional<VectorIndexParams> getVectorIndexParams() {
-    return vectorIndexParams;
+    return Optional.ofNullable(vectorIndexParams);
   }
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("distanceType", distanceType)
-        .append("vectorIndexParams", vectorIndexParams.orElse(null))
+    return ToStringHelper.of(this)
+        .add("distanceType", distanceType)
+        .add("vectorIndexParams", vectorIndexParams)
         .toString();
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/index/vector/HnswBuildParams.java
+++ b/java/core/src/main/java/com/lancedb/lance/index/vector/HnswBuildParams.java
@@ -13,7 +13,7 @@
  */
 package com.lancedb.lance.index.vector;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.util.Optional;
 
@@ -25,7 +25,7 @@ public class HnswBuildParams {
   private final short maxLevel;
   private final int m;
   private final int efConstruction;
-  private final Optional<Integer> prefetchDistance;
+  private final Integer prefetchDistance;
 
   private HnswBuildParams(Builder builder) {
     this.maxLevel = builder.maxLevel;
@@ -38,7 +38,7 @@ public class HnswBuildParams {
     private short maxLevel = 7;
     private int m = 20;
     private int efConstruction = 150;
-    private Optional<Integer> prefetchDistance = Optional.of(2);
+    private Integer prefetchDistance = 2;
 
     /**
      * Create a new builder for HNSW index parameters. Each IVF partition will be built with an HNSW
@@ -78,7 +78,7 @@ public class HnswBuildParams {
      * @return Builder
      */
     public Builder setPrefetchDistance(Integer prefetchDistance) {
-      this.prefetchDistance = Optional.ofNullable(prefetchDistance);
+      this.prefetchDistance = prefetchDistance;
       return this;
     }
 
@@ -100,16 +100,16 @@ public class HnswBuildParams {
   }
 
   public Optional<Integer> getPrefetchDistance() {
-    return prefetchDistance;
+    return Optional.ofNullable(prefetchDistance);
   }
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("maxLevel", maxLevel)
-        .append("m", m)
-        .append("efConstruction", efConstruction)
-        .append("prefetchDistance", prefetchDistance.orElse(null))
+    return ToStringHelper.of(this)
+        .add("maxLevel", maxLevel)
+        .add("m", m)
+        .add("efConstruction", efConstruction)
+        .add("prefetchDistance", prefetchDistance)
         .toString();
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/index/vector/IvfBuildParams.java
+++ b/java/core/src/main/java/com/lancedb/lance/index/vector/IvfBuildParams.java
@@ -13,7 +13,7 @@
  */
 package com.lancedb.lance.index.vector;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 /**
  * Parameters for building an IVF index. Train IVF centroids for the given vector column. This will
@@ -156,13 +156,13 @@ public class IvfBuildParams {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("numPartitions", numPartitions)
-        .append("maxIters", maxIters)
-        .append("sampleRate", sampleRate)
-        .append("shufflePartitionBatches", shufflePartitionBatches)
-        .append("shufflePartitionConcurrency", shufflePartitionConcurrency)
-        .append("useResidual", useResidual)
+    return ToStringHelper.of(this)
+        .add("numPartitions", numPartitions)
+        .add("maxIters", maxIters)
+        .add("sampleRate", sampleRate)
+        .add("shufflePartitionBatches", shufflePartitionBatches)
+        .add("shufflePartitionConcurrency", shufflePartitionConcurrency)
+        .add("useResidual", useResidual)
         .toString();
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/index/vector/PQBuildParams.java
+++ b/java/core/src/main/java/com/lancedb/lance/index/vector/PQBuildParams.java
@@ -13,7 +13,7 @@
  */
 package com.lancedb.lance.index.vector;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 /**
  * Train a PQ model for a given column.
@@ -123,12 +123,12 @@ public class PQBuildParams {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("numSubVectors", numSubVectors)
-        .append("numBits", numBits)
-        .append("maxIters", maxIters)
-        .append("kmeansRedos", kmeansRedos)
-        .append("sampleRate", sampleRate)
+    return ToStringHelper.of(this)
+        .add("numSubVectors", numSubVectors)
+        .add("numBits", numBits)
+        .add("maxIters", maxIters)
+        .add("kmeansRedos", kmeansRedos)
+        .add("sampleRate", sampleRate)
         .toString();
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/index/vector/SQBuildParams.java
+++ b/java/core/src/main/java/com/lancedb/lance/index/vector/SQBuildParams.java
@@ -13,7 +13,7 @@
  */
 package com.lancedb.lance.index.vector;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 /** Parameters for using SQ quantizer. */
 public class SQBuildParams {
@@ -65,9 +65,6 @@ public class SQBuildParams {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("numBits", numBits)
-        .append("sampleRate", sampleRate)
-        .toString();
+    return ToStringHelper.of(this).add("numBits", numBits).add("sampleRate", sampleRate).toString();
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/index/vector/VectorIndexParams.java
+++ b/java/core/src/main/java/com/lancedb/lance/index/vector/VectorIndexParams.java
@@ -14,8 +14,7 @@
 package com.lancedb.lance.index.vector;
 
 import com.lancedb.lance.index.DistanceType;
-
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.util.Optional;
 
@@ -23,9 +22,9 @@ import java.util.Optional;
 public class VectorIndexParams {
   private final DistanceType distanceType;
   private final IvfBuildParams ivfParams;
-  private final Optional<PQBuildParams> pqParams;
-  private final Optional<HnswBuildParams> hnswParams;
-  private final Optional<SQBuildParams> sqParams;
+  private final PQBuildParams pqParams;
+  private final HnswBuildParams hnswParams;
+  private final SQBuildParams sqParams;
 
   private VectorIndexParams(Builder builder) {
     this.distanceType = builder.distanceType;
@@ -37,13 +36,13 @@ public class VectorIndexParams {
   }
 
   private void validate() {
-    if (pqParams.isPresent() && sqParams.isPresent()) {
+    if (pqParams != null && sqParams != null) {
       throw new IllegalArgumentException("PQ and SQ cannot coexist");
     }
-    if (hnswParams.isPresent() && !pqParams.isPresent() && !sqParams.isPresent()) {
+    if (hnswParams != null && pqParams == null && sqParams == null) {
       throw new IllegalArgumentException("HNSW must be combined with either PQ or SQ");
     }
-    if (sqParams.isPresent() && !hnswParams.isPresent()) {
+    if (sqParams != null && hnswParams == null) {
       throw new IllegalArgumentException("IVF + SQ is not supported");
     }
   }
@@ -144,9 +143,9 @@ public class VectorIndexParams {
   public static class Builder {
     private DistanceType distanceType = DistanceType.L2;
     private final IvfBuildParams ivfParams;
-    private Optional<PQBuildParams> pqParams = Optional.empty();
-    private Optional<HnswBuildParams> hnswParams = Optional.empty();
-    private Optional<SQBuildParams> sqParams = Optional.empty();
+    private PQBuildParams pqParams;
+    private HnswBuildParams hnswParams;
+    private SQBuildParams sqParams;
 
     /**
      * Create a new builder to create a vector index.
@@ -171,7 +170,7 @@ public class VectorIndexParams {
      * @return Builder
      */
     public Builder setPqParams(PQBuildParams pqParams) {
-      this.pqParams = Optional.of(pqParams);
+      this.pqParams = pqParams;
       return this;
     }
 
@@ -181,7 +180,7 @@ public class VectorIndexParams {
      * @return Builder
      */
     public Builder setHnswParams(HnswBuildParams hnswParams) {
-      this.hnswParams = Optional.of(hnswParams);
+      this.hnswParams = hnswParams;
       return this;
     }
 
@@ -190,7 +189,7 @@ public class VectorIndexParams {
      * @return Builder
      */
     public Builder setSqParams(SQBuildParams sqParams) {
-      this.sqParams = Optional.of(sqParams);
+      this.sqParams = sqParams;
       return this;
     }
 
@@ -208,25 +207,25 @@ public class VectorIndexParams {
   }
 
   public Optional<PQBuildParams> getPqParams() {
-    return pqParams;
+    return Optional.ofNullable(pqParams);
   }
 
   public Optional<HnswBuildParams> getHnswParams() {
-    return hnswParams;
+    return Optional.ofNullable(hnswParams);
   }
 
   public Optional<SQBuildParams> getSqParams() {
-    return sqParams;
+    return Optional.ofNullable(sqParams);
   }
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("distanceType", distanceType)
-        .append("ivfParams", ivfParams)
-        .append("pqParams", pqParams.orElse(null))
-        .append("hnswParams", hnswParams.orElse(null))
-        .append("sqParams", sqParams.orElse(null))
+    return ToStringHelper.of(this)
+        .add("distanceType", distanceType)
+        .add("ivfParams", ivfParams)
+        .add("pqParams", pqParams)
+        .add("hnswParams", hnswParams)
+        .add("sqParams", sqParams)
         .toString();
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/ipc/ColumnOrdering.java
+++ b/java/core/src/main/java/com/lancedb/lance/ipc/ColumnOrdering.java
@@ -13,6 +13,8 @@
  */
 package com.lancedb.lance.ipc;
 
+import com.lancedb.lance.util.ToStringHelper;
+
 import org.apache.arrow.util.Preconditions;
 
 import java.io.Serializable;
@@ -44,15 +46,11 @@ public class ColumnOrdering implements Serializable {
 
   @Override
   public String toString() {
-    return "ColumnOrdering{"
-        + "columnName='"
-        + columnName
-        + '\''
-        + ", nullFirst="
-        + nullFirst
-        + ", ascending="
-        + ascending
-        + '}';
+    return ToStringHelper.of(this)
+        .add("columnName", columnName)
+        .add("nullFirst", nullFirst)
+        .add("ascending", ascending)
+        .toString();
   }
 
   public static class Builder {

--- a/java/core/src/main/java/com/lancedb/lance/ipc/DataStatistics.java
+++ b/java/core/src/main/java/com/lancedb/lance/ipc/DataStatistics.java
@@ -13,6 +13,8 @@
  */
 package com.lancedb.lance.ipc;
 
+import com.lancedb.lance.util.ToStringHelper;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +42,6 @@ public class DataStatistics implements Serializable {
 
   @Override
   public String toString() {
-    return "DataStatistics{" + "fields=" + fields + '}';
+    return ToStringHelper.of(this).add("fields", fields).toString();
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/ipc/FieldStatistics.java
+++ b/java/core/src/main/java/com/lancedb/lance/ipc/FieldStatistics.java
@@ -13,6 +13,8 @@
  */
 package com.lancedb.lance.ipc;
 
+import com.lancedb.lance.util.ToStringHelper;
+
 import java.io.Serializable;
 
 public class FieldStatistics implements Serializable {
@@ -35,6 +37,6 @@ public class FieldStatistics implements Serializable {
 
   @Override
   public String toString() {
-    return "FieldStatistics{" + "id=" + id + ", dataSize=" + dataSize + '}';
+    return ToStringHelper.of(this).add("id", id).add("dataSize", dataSize).toString();
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/ipc/Query.java
+++ b/java/core/src/main/java/com/lancedb/lance/ipc/Query.java
@@ -14,9 +14,9 @@
 package com.lancedb.lance.ipc;
 
 import com.lancedb.lance.index.DistanceType;
+import com.lancedb.lance.util.ToStringHelper;
 
 import org.apache.arrow.util.Preconditions;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.util.Optional;
 
@@ -26,9 +26,9 @@ public class Query {
   private final float[] key;
   private final int k;
   private final int minimumNprobes;
-  private final Optional<Integer> maximumNprobes;
-  private final Optional<Integer> ef;
-  private final Optional<Integer> refineFactor;
+  private final Integer maximumNprobes;
+  private final Integer ef;
+  private final Integer refineFactor;
   private final DistanceType distanceType;
   private final boolean useIndex;
 
@@ -40,8 +40,7 @@ public class Query {
     Preconditions.checkArgument(
         builder.minimumNprobes > 0, "Minimum Nprobes must be greater than 0");
     Preconditions.checkArgument(
-        !builder.maximumNprobes.isPresent()
-            || builder.maximumNprobes.get() >= builder.minimumNprobes,
+        builder.maximumNprobes == null || builder.maximumNprobes >= builder.minimumNprobes,
         "Maximum Nprobes must be greater than minimum Nprobes");
     this.k = builder.k;
     this.minimumNprobes = builder.minimumNprobes;
@@ -69,15 +68,15 @@ public class Query {
   }
 
   public Optional<Integer> getMaximumNprobes() {
-    return maximumNprobes;
+    return Optional.of(maximumNprobes);
   }
 
   public Optional<Integer> getEf() {
-    return ef;
+    return Optional.of(ef);
   }
 
   public Optional<Integer> getRefineFactor() {
-    return refineFactor;
+    return Optional.of(refineFactor);
   }
 
   public String getDistanceType() {
@@ -90,16 +89,16 @@ public class Query {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("column", column)
-        .append("key", key)
-        .append("k", k)
-        .append("minimumNprobes", minimumNprobes)
-        .append("maximumNprobes", maximumNprobes.orElse(null))
-        .append("ef", ef.orElse(null))
-        .append("refineFactor", refineFactor.orElse(null))
-        .append("distanceType", distanceType)
-        .append("useIndex", useIndex)
+    return ToStringHelper.of(this)
+        .add("column", column)
+        .add("key", key)
+        .add("k", k)
+        .add("minimumNprobes", minimumNprobes)
+        .add("maximumNprobes", maximumNprobes)
+        .add("ef", ef)
+        .add("refineFactor", refineFactor)
+        .add("distanceType", distanceType)
+        .add("useIndex", useIndex)
         .toString();
   }
 
@@ -108,9 +107,9 @@ public class Query {
     private float[] key;
     private int k = 10;
     private int minimumNprobes = 20;
-    private Optional<Integer> maximumNprobes = Optional.empty();
-    private Optional<Integer> ef = Optional.empty();
-    private Optional<Integer> refineFactor = Optional.empty();
+    private Integer maximumNprobes;
+    private Integer ef;
+    private Integer refineFactor;
     private DistanceType distanceType = DistanceType.L2;
     private boolean useIndex = true;
 
@@ -158,7 +157,7 @@ public class Query {
      */
     public Builder setNprobes(int nprobes) {
       this.minimumNprobes = nprobes;
-      this.maximumNprobes = Optional.of(nprobes);
+      this.maximumNprobes = nprobes;
       return this;
     }
 
@@ -189,7 +188,7 @@ public class Query {
      * @return The Builder instance for method chaining.
      */
     public Builder setMaximumNprobes(int maximumNprobes) {
-      this.maximumNprobes = Optional.of(maximumNprobes);
+      this.maximumNprobes = maximumNprobes;
       return this;
     }
 
@@ -201,7 +200,7 @@ public class Query {
      * @return The Builder instance for method chaining.
      */
     public Builder setEf(int ef) {
-      this.ef = Optional.of(ef);
+      this.ef = ef;
       return this;
     }
 
@@ -212,7 +211,7 @@ public class Query {
      * @return The Builder instance for method chaining.
      */
     public Builder setRefineFactor(int refineFactor) {
-      this.refineFactor = Optional.of(refineFactor);
+      this.refineFactor = refineFactor;
       return this;
     }
 

--- a/java/core/src/main/java/com/lancedb/lance/ipc/ScanOptions.java
+++ b/java/core/src/main/java/com/lancedb/lance/ipc/ScanOptions.java
@@ -13,8 +13,9 @@
  */
 package com.lancedb.lance.ipc;
 
+import com.lancedb.lance.util.ToStringHelper;
+
 import org.apache.arrow.util.Preconditions;
-import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -22,18 +23,18 @@ import java.util.Optional;
 
 /** Lance scan options. */
 public class ScanOptions {
-  private final Optional<List<Integer>> fragmentIds;
-  private final Optional<Long> batchSize;
-  private final Optional<List<String>> columns;
-  private final Optional<String> filter;
-  private final Optional<ByteBuffer> substraitFilter;
-  private final Optional<Long> limit;
-  private final Optional<Long> offset;
-  private final Optional<Query> nearest;
+  private final List<Integer> fragmentIds;
+  private final Long batchSize;
+  private final List<String> columns;
+  private final String filter;
+  private final ByteBuffer substraitFilter;
+  private final Long limit;
+  private final Long offset;
+  private final Query nearest;
   private final boolean withRowId;
   private final boolean withRowAddress;
   private final int batchReadahead;
-  private final Optional<List<ColumnOrdering>> columnOrderings;
+  private final List<ColumnOrdering> columnOrderings;
 
   /**
    * Constructor for LanceScanOptions.
@@ -52,21 +53,21 @@ public class ScanOptions {
    * @param nearest (Optional) Nearest neighbor query.
    * @param batchReadahead Number of batches to read ahead.
    */
-  public ScanOptions(
-      Optional<List<Integer>> fragmentIds,
-      Optional<Long> batchSize,
-      Optional<List<String>> columns,
-      Optional<String> filter,
-      Optional<ByteBuffer> substraitFilter,
-      Optional<Long> limit,
-      Optional<Long> offset,
-      Optional<Query> nearest,
+  private ScanOptions(
+      List<Integer> fragmentIds,
+      Long batchSize,
+      List<String> columns,
+      String filter,
+      ByteBuffer substraitFilter,
+      Long limit,
+      Long offset,
+      Query nearest,
       boolean withRowId,
       boolean withRowAddress,
       int batchReadahead,
-      Optional<List<ColumnOrdering>> columnOrderings) {
+      List<ColumnOrdering> columnOrderings) {
     Preconditions.checkArgument(
-        !(filter.isPresent() && substraitFilter.isPresent()),
+        !(filter != null && substraitFilter != null),
         "cannot set both substrait filter and string filter");
     this.fragmentIds = fragmentIds;
     this.batchSize = batchSize;
@@ -88,7 +89,7 @@ public class ScanOptions {
    * @return Optional containing the fragment ids if specified, otherwise empty.
    */
   public Optional<List<Integer>> getFragmentIds() {
-    return fragmentIds;
+    return Optional.ofNullable(fragmentIds);
   }
 
   /**
@@ -97,7 +98,7 @@ public class ScanOptions {
    * @return Optional containing the batch size if specified, otherwise empty.
    */
   public Optional<Long> getBatchSize() {
-    return batchSize;
+    return Optional.ofNullable(batchSize);
   }
 
   /**
@@ -106,7 +107,7 @@ public class ScanOptions {
    * @return Optional containing the columns if specified, otherwise empty.
    */
   public Optional<List<String>> getColumns() {
-    return columns;
+    return Optional.ofNullable(columns);
   }
 
   /**
@@ -115,7 +116,7 @@ public class ScanOptions {
    * @return Optional containing the filter if specified, otherwise empty.
    */
   public Optional<String> getFilter() {
-    return filter;
+    return Optional.ofNullable(filter);
   }
 
   /**
@@ -124,7 +125,7 @@ public class ScanOptions {
    * @return Optional containing the substrait filter if specified, otherwise empty.
    */
   public Optional<ByteBuffer> getSubstraitFilter() {
-    return substraitFilter;
+    return Optional.ofNullable(substraitFilter);
   }
 
   /**
@@ -133,7 +134,7 @@ public class ScanOptions {
    * @return Optional containing the limit if specified, otherwise empty.
    */
   public Optional<Long> getLimit() {
-    return limit;
+    return Optional.ofNullable(limit);
   }
 
   /**
@@ -142,7 +143,7 @@ public class ScanOptions {
    * @return Optional containing the offset if specified, otherwise empty.
    */
   public Optional<Long> getOffset() {
-    return offset;
+    return Optional.ofNullable(offset);
   }
 
   /**
@@ -151,7 +152,7 @@ public class ScanOptions {
    * @return Optional containing the nearest neighbor query if specified, otherwise empty.
    */
   public Optional<Query> getNearest() {
-    return nearest;
+    return Optional.ofNullable(nearest);
   }
 
   /**
@@ -182,43 +183,43 @@ public class ScanOptions {
   }
 
   public Optional<List<ColumnOrdering>> getColumnOrderings() {
-    return columnOrderings;
+    return Optional.ofNullable(columnOrderings);
   }
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("fragmentIds", fragmentIds.orElse(null))
-        .append("batchSize", batchSize.orElse(null))
-        .append("columns", columns.orElse(null))
-        .append("filter", filter.orElse(null))
-        .append(
+    return ToStringHelper.of(this)
+        .add("fragmentIds", fragmentIds)
+        .add("batchSize", batchSize)
+        .add("columns", columns)
+        .add("filter", filter)
+        .add(
             "substraitFilter",
-            substraitFilter.map(buf -> "ByteBuffer[" + buf.remaining() + " bytes]").orElse(null))
-        .append("limit", limit.orElse(null))
-        .append("offset", offset.orElse(null))
-        .append("nearest", nearest.orElse(null))
-        .append("withRowId", withRowId)
-        .append("WithRowAddress", withRowAddress)
-        .append("batchReadahead", batchReadahead)
-        .append("columnOrdering", columnOrderings)
+            getSubstraitFilter().map(buf -> "ByteBuffer[" + buf.remaining() + " bytes]"))
+        .add("limit", limit)
+        .add("offset", offset)
+        .add("nearest", nearest)
+        .add("withRowId", withRowId)
+        .add("WithRowAddress", withRowAddress)
+        .add("batchReadahead", batchReadahead)
+        .add("columnOrdering", columnOrderings)
         .toString();
   }
 
   /** Builder for constructing LanceScanOptions. */
   public static class Builder {
-    private Optional<List<Integer>> fragmentIds = Optional.empty();
-    private Optional<Long> batchSize = Optional.empty();
-    private Optional<List<String>> columns = Optional.empty();
-    private Optional<String> filter = Optional.empty();
-    private Optional<ByteBuffer> substraitFilter = Optional.empty();
-    private Optional<Long> limit = Optional.empty();
-    private Optional<Long> offset = Optional.empty();
-    private Optional<Query> nearest = Optional.empty();
+    private List<Integer> fragmentIds;
+    private Long batchSize;
+    private List<String> columns;
+    private String filter;
+    private ByteBuffer substraitFilter;
+    private Long limit;
+    private Long offset;
+    private Query nearest;
     private boolean withRowId = false;
     private boolean withRowAddress = false;
     private int batchReadahead = 16;
-    private Optional<List<ColumnOrdering>> columnOrderings = Optional.empty();
+    private List<ColumnOrdering> columnOrderings;
 
     public Builder() {}
 
@@ -228,18 +229,18 @@ public class ScanOptions {
      * @param options another scan options
      */
     public Builder(ScanOptions options) {
-      this.fragmentIds = options.getFragmentIds();
-      this.batchSize = options.getBatchSize();
-      this.columns = options.getColumns();
-      this.filter = options.getFilter();
-      this.substraitFilter = options.getSubstraitFilter();
-      this.limit = options.getLimit();
-      this.offset = options.getOffset();
-      this.nearest = options.getNearest();
-      this.withRowId = options.isWithRowId();
-      this.withRowAddress = options.isWithRowAddress();
-      this.batchReadahead = options.getBatchReadahead();
-      this.columnOrderings = options.getColumnOrderings();
+      this.fragmentIds = options.fragmentIds;
+      this.batchSize = options.batchSize;
+      this.columns = options.columns;
+      this.filter = options.filter;
+      this.substraitFilter = options.substraitFilter;
+      this.limit = options.limit;
+      this.offset = options.offset;
+      this.nearest = options.nearest;
+      this.withRowId = options.withRowId;
+      this.withRowAddress = options.withRowAddress;
+      this.batchReadahead = options.batchReadahead;
+      this.columnOrderings = options.columnOrderings;
     }
 
     /**
@@ -249,7 +250,7 @@ public class ScanOptions {
      * @return Builder instance for method chaining.
      */
     public Builder fragmentIds(List<Integer> fragmentIds) {
-      this.fragmentIds = Optional.of(fragmentIds);
+      this.fragmentIds = fragmentIds;
       return this;
     }
 
@@ -260,7 +261,7 @@ public class ScanOptions {
      * @return Builder instance for method chaining.
      */
     public Builder batchSize(long batchSize) {
-      this.batchSize = Optional.of(batchSize);
+      this.batchSize = batchSize;
       return this;
     }
 
@@ -271,7 +272,7 @@ public class ScanOptions {
      * @return Builder instance for method chaining.
      */
     public Builder columns(List<String> columns) {
-      this.columns = Optional.of(columns);
+      this.columns = columns;
       return this;
     }
 
@@ -282,7 +283,7 @@ public class ScanOptions {
      * @return Builder instance for method chaining.
      */
     public Builder filter(String filter) {
-      this.filter = Optional.of(filter);
+      this.filter = filter;
       return this;
     }
 
@@ -293,7 +294,7 @@ public class ScanOptions {
      * @return Builder instance for method chaining.
      */
     public Builder substraitFilter(ByteBuffer substraitFilter) {
-      this.substraitFilter = Optional.of(substraitFilter);
+      this.substraitFilter = substraitFilter;
       return this;
     }
 
@@ -304,7 +305,7 @@ public class ScanOptions {
      * @return Builder instance for method chaining.
      */
     public Builder limit(long limit) {
-      this.limit = Optional.of(limit);
+      this.limit = limit;
       return this;
     }
 
@@ -315,7 +316,7 @@ public class ScanOptions {
      * @return Builder instance for method chaining.
      */
     public Builder offset(long offset) {
-      this.offset = Optional.of(offset);
+      this.offset = offset;
       return this;
     }
 
@@ -326,7 +327,7 @@ public class ScanOptions {
      * @return Builder instance for method chaining.
      */
     public Builder nearest(Query nearest) {
-      this.nearest = Optional.of(nearest);
+      this.nearest = nearest;
       return this;
     }
 
@@ -364,7 +365,7 @@ public class ScanOptions {
     }
 
     public Builder setColumnOrderings(List<ColumnOrdering> columnOrderings) {
-      this.columnOrderings = Optional.of(columnOrderings);
+      this.columnOrderings = columnOrderings;
       return this;
     }
 

--- a/java/core/src/main/java/com/lancedb/lance/operation/Append.java
+++ b/java/core/src/main/java/com/lancedb/lance/operation/Append.java
@@ -14,6 +14,7 @@
 package com.lancedb.lance.operation;
 
 import com.lancedb.lance.FragmentMetadata;
+import com.lancedb.lance.util.ToStringHelper;
 
 import org.apache.arrow.util.Preconditions;
 
@@ -49,7 +50,7 @@ public class Append implements Operation {
 
   @Override
   public String toString() {
-    return "Append{" + "fragments=" + fragments + '}';
+    return ToStringHelper.of(this).add("fragments", fragments).toString();
   }
 
   public static Builder builder() {

--- a/java/core/src/main/java/com/lancedb/lance/operation/DataReplacement.java
+++ b/java/core/src/main/java/com/lancedb/lance/operation/DataReplacement.java
@@ -14,6 +14,7 @@
 package com.lancedb.lance.operation;
 
 import com.lancedb.lance.fragment.DataFile;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.util.List;
 import java.util.Objects;
@@ -53,7 +54,7 @@ public class DataReplacement implements Operation {
 
   @Override
   public String toString() {
-    return "DataReplacement{" + "replacements=" + replacements + '}';
+    return ToStringHelper.of(this).add("replacements", replacements).toString();
   }
 
   @Override

--- a/java/core/src/main/java/com/lancedb/lance/operation/Delete.java
+++ b/java/core/src/main/java/com/lancedb/lance/operation/Delete.java
@@ -14,6 +14,7 @@
 package com.lancedb.lance.operation;
 
 import com.lancedb.lance.FragmentMetadata;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.util.Collections;
 import java.util.List;
@@ -21,9 +22,9 @@ import java.util.Objects;
 import java.util.Optional;
 
 public class Delete implements Operation {
-  private List<FragmentMetadata> updatedFragments;
-  private List<Long> deletedFragmentIds;
-  private String predicate;
+  private final List<FragmentMetadata> updatedFragments;
+  private final List<Long> deletedFragmentIds;
+  private final String predicate;
 
   private Delete(
       List<FragmentMetadata> updatedFragments, List<Long> deletedFragmentIds, String predicate) {
@@ -44,7 +45,7 @@ public class Delete implements Operation {
     return deletedFragmentIds;
   }
 
-  public Optional predicate() {
+  public Optional<String> predicate() {
     return Optional.ofNullable(predicate);
   }
 
@@ -54,9 +55,11 @@ public class Delete implements Operation {
   }
 
   public String toString() {
-    return String.format(
-        "Delete{updatedFragments=%s, deletedFragmentIds=%s, predicate=%s}",
-        updatedFragments, deletedFragmentIds, predicate);
+    return ToStringHelper.of(this)
+        .add("updatedFragments", updatedFragments)
+        .add("deletedFragmentIds", deletedFragmentIds)
+        .add("predicate", predicate)
+        .toString();
   }
 
   @Override

--- a/java/core/src/main/java/com/lancedb/lance/operation/Merge.java
+++ b/java/core/src/main/java/com/lancedb/lance/operation/Merge.java
@@ -14,6 +14,7 @@
 package com.lancedb.lance.operation;
 
 import com.lancedb.lance.FragmentMetadata;
+import com.lancedb.lance.util.ToStringHelper;
 
 import org.apache.arrow.vector.types.pojo.Schema;
 
@@ -45,7 +46,7 @@ public class Merge extends SchemaOperation {
 
   @Override
   public String toString() {
-    return "Merge{" + "fragments=" + fragments + ", schema=" + schema() + '}';
+    return ToStringHelper.of(this).add("fragments", fragments).add("schema", schema()).toString();
   }
 
   @Override

--- a/java/core/src/main/java/com/lancedb/lance/operation/Overwrite.java
+++ b/java/core/src/main/java/com/lancedb/lance/operation/Overwrite.java
@@ -14,6 +14,7 @@
 package com.lancedb.lance.operation;
 
 import com.lancedb.lance.FragmentMetadata;
+import com.lancedb.lance.util.ToStringHelper;
 
 import org.apache.arrow.vector.types.pojo.Schema;
 
@@ -57,14 +58,11 @@ public class Overwrite extends SchemaOperation {
 
   @Override
   public String toString() {
-    return "Overwrite{"
-        + "fragments="
-        + fragments
-        + ", schema="
-        + schema()
-        + ", configUpsertValues="
-        + configUpsertValues
-        + '}';
+    return ToStringHelper.of(this)
+        .add("fragments", fragments)
+        .add("schema", schema())
+        .add("configUpsertValues", configUpsertValues)
+        .toString();
   }
 
   @Override

--- a/java/core/src/main/java/com/lancedb/lance/operation/Project.java
+++ b/java/core/src/main/java/com/lancedb/lance/operation/Project.java
@@ -13,6 +13,8 @@
  */
 package com.lancedb.lance.operation;
 
+import com.lancedb.lance.util.ToStringHelper;
+
 import org.apache.arrow.vector.types.pojo.Schema;
 
 /**
@@ -33,7 +35,7 @@ public class Project extends SchemaOperation {
 
   @Override
   public String toString() {
-    return "Project{" + "schema=" + +'}';
+    return ToStringHelper.of(this).add("schema", schema()).toString();
   }
 
   public static Builder builder() {

--- a/java/core/src/main/java/com/lancedb/lance/operation/ReserveFragments.java
+++ b/java/core/src/main/java/com/lancedb/lance/operation/ReserveFragments.java
@@ -13,6 +13,8 @@
  */
 package com.lancedb.lance.operation;
 
+import com.lancedb.lance.util.ToStringHelper;
+
 /** ReserveFragments operation to reserve fragment IDs for future use. */
 public class ReserveFragments implements Operation {
   private final int numFragments;
@@ -37,7 +39,7 @@ public class ReserveFragments implements Operation {
 
   @Override
   public String toString() {
-    return "ReserveFragments{" + "numFragments=" + numFragments + '}';
+    return ToStringHelper.of(this).add("numFragments", numFragments).toString();
   }
 
   @Override

--- a/java/core/src/main/java/com/lancedb/lance/operation/Restore.java
+++ b/java/core/src/main/java/com/lancedb/lance/operation/Restore.java
@@ -13,6 +13,8 @@
  */
 package com.lancedb.lance.operation;
 
+import com.lancedb.lance.util.ToStringHelper;
+
 /** Restore operation to revert a dataset to a previous version. */
 public class Restore implements Operation {
   private final long version;
@@ -37,7 +39,7 @@ public class Restore implements Operation {
 
   @Override
   public String toString() {
-    return "Restore{" + "version=" + version + '}';
+    return ToStringHelper.of(this).add("version", version).toString();
   }
 
   @Override

--- a/java/core/src/main/java/com/lancedb/lance/operation/Rewrite.java
+++ b/java/core/src/main/java/com/lancedb/lance/operation/Rewrite.java
@@ -14,8 +14,7 @@
 package com.lancedb.lance.operation;
 
 import com.lancedb.lance.index.Index;
-
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -88,10 +87,10 @@ public class Rewrite implements Operation {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("groups", groups)
-        .append("rewrittenIndices", rewrittenIndices)
-        .append("fragReuseIndex", fragReuseIndex)
+    return ToStringHelper.of(this)
+        .add("groups", groups)
+        .add("rewrittenIndices", rewrittenIndices)
+        .add("fragReuseIndex", fragReuseIndex)
         .toString();
   }
 

--- a/java/core/src/main/java/com/lancedb/lance/operation/RewriteGroup.java
+++ b/java/core/src/main/java/com/lancedb/lance/operation/RewriteGroup.java
@@ -14,8 +14,7 @@
 package com.lancedb.lance.operation;
 
 import com.lancedb.lance.FragmentMetadata;
-
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.util.List;
 import java.util.Objects;
@@ -57,9 +56,9 @@ public class RewriteGroup {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this)
-        .append("oldFragments", oldFragments)
-        .append("newFragments", newFragments)
+    return ToStringHelper.of(this)
+        .add("oldFragments", oldFragments)
+        .add("newFragments", newFragments)
         .toString();
   }
 

--- a/java/core/src/main/java/com/lancedb/lance/operation/RewrittenIndex.java
+++ b/java/core/src/main/java/com/lancedb/lance/operation/RewrittenIndex.java
@@ -13,7 +13,7 @@
  */
 package com.lancedb.lance.operation;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -54,7 +54,7 @@ public class RewrittenIndex {
 
   @Override
   public String toString() {
-    return new ToStringBuilder(this).append("oldId", oldId).append("newId", newId).toString();
+    return ToStringHelper.of(this).add("oldId", oldId).add("newId", newId).toString();
   }
 
   public static Builder builder() {

--- a/java/core/src/main/java/com/lancedb/lance/operation/Update.java
+++ b/java/core/src/main/java/com/lancedb/lance/operation/Update.java
@@ -14,15 +14,16 @@
 package com.lancedb.lance.operation;
 
 import com.lancedb.lance.FragmentMetadata;
+import com.lancedb.lance.util.ToStringHelper;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 public class Update implements Operation {
-  private List<Long> removedFragmentIds;
-  private List<FragmentMetadata> updatedFragments;
-  private List<FragmentMetadata> newFragments;
+  private final List<Long> removedFragmentIds;
+  private final List<FragmentMetadata> updatedFragments;
+  private final List<FragmentMetadata> newFragments;
 
   private Update(
       List<Long> removedFragmentIds,
@@ -55,9 +56,11 @@ public class Update implements Operation {
   }
 
   public String toString() {
-    return String.format(
-        "Update{removedFragmentIds=%s, updatedFragments=%s, newFragments=%s}",
-        removedFragmentIds, updatedFragments, newFragments);
+    return ToStringHelper.of(this)
+        .add("removedFragmentIds", removedFragmentIds)
+        .add("updatedFragments", updatedFragments)
+        .add("newFragments", newFragments)
+        .toString();
   }
 
   @Override

--- a/java/core/src/main/java/com/lancedb/lance/operation/UpdateConfig.java
+++ b/java/core/src/main/java/com/lancedb/lance/operation/UpdateConfig.java
@@ -13,6 +13,8 @@
  */
 package com.lancedb.lance.operation;
 
+import com.lancedb.lance.util.ToStringHelper;
+
 import java.util.List;
 import java.util.Map;
 
@@ -61,16 +63,12 @@ public class UpdateConfig implements Operation {
 
   @Override
   public String toString() {
-    return "UpdateConfig{"
-        + "upsertValues="
-        + upsertValues
-        + ", deleteKeys="
-        + deleteKeys
-        + ", schemaMetadata="
-        + schemaMetadata
-        + ", fieldMetadata="
-        + fieldMetadata
-        + '}';
+    return ToStringHelper.of(this)
+        .add("upsertValues", upsertValues)
+        .add("deleteKeys", deleteKeys)
+        .add("schemaMetadata", schemaMetadata)
+        .add("fieldMetadata", fieldMetadata)
+        .toString();
   }
 
   public static Builder builder() {

--- a/java/core/src/main/java/com/lancedb/lance/schema/ColumnAlteration.java
+++ b/java/core/src/main/java/com/lancedb/lance/schema/ColumnAlteration.java
@@ -13,6 +13,9 @@
  */
 package com.lancedb.lance.schema;
 
+import com.lancedb.lance.util.ToStringHelper;
+
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 
 import java.util.Optional;
@@ -20,16 +23,16 @@ import java.util.Optional;
 /** Column alteration used to alter dataset columns. */
 public class ColumnAlteration {
 
-  private String path;
-  private Optional<String> rename;
-  private Optional<Boolean> nullable;
-  private Optional<ArrowType> dataType;
+  private final String path;
+  private final String rename;
+  private final Boolean nullable;
+  private final ArrowType dataType;
 
-  private ColumnAlteration(String path) {
+  private ColumnAlteration(String path, String rename, Boolean nullable, ArrowType dataType) {
     this.path = path;
-    this.rename = Optional.empty();
-    this.nullable = Optional.empty();
-    this.dataType = Optional.empty();
+    this.rename = rename;
+    this.nullable = nullable;
+    this.dataType = dataType;
   }
 
   public String getPath() {
@@ -37,41 +40,62 @@ public class ColumnAlteration {
   }
 
   public Optional<String> getRename() {
-    return rename;
+    return Optional.ofNullable(rename);
   }
 
   public Optional<Boolean> getNullable() {
-    return nullable;
+    return Optional.ofNullable(nullable);
   }
 
   public Optional<ArrowType> getDataType() {
-    return dataType;
+    return Optional.ofNullable(dataType);
+  }
+
+  @Override
+  public String toString() {
+    return ToStringHelper.of(this)
+        .add("path", path)
+        .add("rename", rename)
+        .add("nullable", nullable)
+        .add("dataType", dataType)
+        .toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
   }
 
   public static class Builder {
-    private final ColumnAlteration columnAlteration;
+
+    private String path;
+    private String rename;
+    private Boolean nullable;
+    private ArrowType dataType;
+
+    public Builder() {}
 
     public Builder(String path) {
-      this.columnAlteration = new ColumnAlteration(path);
+      this.path = path;
     }
 
     public Builder rename(String rename) {
-      this.columnAlteration.rename = Optional.of(rename);
+      this.rename = rename;
       return this;
     }
 
     public Builder nullable(boolean nullable) {
-      this.columnAlteration.nullable = Optional.of(nullable);
+      this.nullable = nullable;
       return this;
     }
 
     public Builder castTo(ArrowType dataType) {
-      this.columnAlteration.dataType = Optional.of(dataType);
+      this.dataType = dataType;
       return this;
     }
 
     public ColumnAlteration build() {
-      return columnAlteration;
+      Preconditions.checkArgument(path != null, "path is required");
+      return new ColumnAlteration(path, rename, nullable, dataType);
     }
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/schema/LanceField.java
+++ b/java/core/src/main/java/com/lancedb/lance/schema/LanceField.java
@@ -13,6 +13,8 @@
  */
 package com.lancedb.lance.schema;
 
+import com.lancedb.lance.util.ToStringHelper;
+
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -108,28 +110,17 @@ public class LanceField {
 
   @Override
   public String toString() {
-    return "LanceField{"
-        + "id="
-        + id
-        + ", parentId="
-        + parentId
-        + ", name='"
-        + name
-        + '\''
-        + ", nullable="
-        + nullable
-        + ", type="
-        + type
-        + ", storageType="
-        + storageType
-        + ", dictionaryEncoding="
-        + dictionaryEncoding
-        + ", metadata="
-        + metadata
-        + ", children="
-        + children
-        + ", isUnenforcedPrimaryKey="
-        + isUnenforcedPrimaryKey
-        + '}';
+    return ToStringHelper.of(this)
+        .add("id", id)
+        .add("parentId", parentId)
+        .add("name", name)
+        .add("nullable", nullable)
+        .add("type", type)
+        .add("storageType", storageType)
+        .add("dictionaryEncoding", dictionaryEncoding)
+        .add("metadata", metadata)
+        .add("children", children)
+        .add("isUnenforcedPrimaryKey", isUnenforcedPrimaryKey)
+        .toString();
   }
 }

--- a/java/core/src/main/java/com/lancedb/lance/schema/LanceSchema.java
+++ b/java/core/src/main/java/com/lancedb/lance/schema/LanceSchema.java
@@ -13,6 +13,8 @@
  */
 package com.lancedb.lance.schema;
 
+import com.lancedb.lance.util.ToStringHelper;
+
 import org.apache.arrow.vector.types.pojo.Schema;
 
 import java.util.Collections;
@@ -41,6 +43,10 @@ public class LanceSchema {
   public Schema asArrowSchema() {
     return new Schema(
         fields.stream().map(LanceField::asArrowField).collect(Collectors.toList()), metadata);
+  }
+
+  public String toString() {
+    return ToStringHelper.of(this).add("fields", fields).add("metadata", metadata).toString();
   }
 
   // Builder class for LanceSchema

--- a/java/core/src/main/java/com/lancedb/lance/schema/SqlExpressions.java
+++ b/java/core/src/main/java/com/lancedb/lance/schema/SqlExpressions.java
@@ -13,6 +13,8 @@
  */
 package com.lancedb.lance.schema;
 
+import com.lancedb.lance.util.ToStringHelper;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,6 +57,11 @@ public class SqlExpressions {
 
     public void setExpression(String expression) {
       this.expression = expression;
+    }
+
+    @Override
+    public String toString() {
+      return ToStringHelper.of(this).add("name", name).add("expression", expression).toString();
     }
   }
 

--- a/java/core/src/main/java/com/lancedb/lance/util/ToStringHelper.java
+++ b/java/core/src/main/java/com/lancedb/lance/util/ToStringHelper.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lancedb.lance.util;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
+
+/**
+ * A helper class for toString(). In case if we want to do some customization, we can change the
+ * style or use another library like guava.
+ */
+public class ToStringHelper {
+
+  private final ToStringBuilder builder;
+
+  private ToStringHelper(ToStringBuilder builder) {
+    this.builder = new ToStringBuilder(builder);
+  }
+
+  public static ToStringHelper of(Object obj) {
+    return new ToStringHelper(new ToStringBuilder(obj, SHORT_PREFIX_STYLE));
+  }
+
+  public ToStringHelper add(String key, Object value) {
+    builder.append(key, value);
+    return this;
+  }
+
+  public String toString() {
+    return builder.toString();
+  }
+}


### PR DESCRIPTION
TL;DR

1. ​​**Unify toString() style**​​: The toString() implementations were a little bit messy, so I unified them in this PR Currently, I used the original ToStringBuilder(create a until class to configure global style) but aligned it with Guava's style to facilitate future replacement if needed.

2. **​​Eliminate warnings for optional fields​​**: Avoid using Optional for fields entirely, as it is not a recommended practice in Java (unlike Rust). Instead, use Optional only in getter methods to prevent potential null-related warnings and maintain code clarity. **Note: didn't change any native interface using Optional**

3. **​​No interface changes​​**: This refactor ​​did not​​ modify any existing interfaces.

4. **Open to better solutions**​​: Feel free to suggest improvements. I’ll follow up after further discussion.