### PR TITLE
feat: add a scalar index for JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4559,6 +4559,7 @@ dependencies = [
  "half",
  "itertools 0.13.0",
  "jieba-rs",
+ "jsonb",
  "lance-arrow",
  "lance-core",
  "lance-datafusion",

--- a/protos/index.proto
+++ b/protos/index.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package lance.index.pb;
 
+import "google/protobuf/any.proto";
+
 // The type of an index.
 enum IndexType {
   // Vector index
@@ -205,4 +207,8 @@ message InvertedIndexDetails {
   uint32 min_ngram_length = 9;
   uint32 max_ngram_length = 10;
   bool prefix_only = 11;
+}
+message JsonIndexDetails {
+  string path = 1;
+  google.protobuf.Any target_details = 2;
 }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4055,6 +4055,7 @@ dependencies = [
  "half",
  "itertools 0.13.0",
  "jieba-rs",
+ "jsonb",
  "lance-arrow",
  "lance-core",
  "lance-datafusion",

--- a/python/python/lance/indices.py
+++ b/python/python/lance/indices.py
@@ -2,13 +2,14 @@
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 import math
 import warnings
+from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 import pyarrow as pa
 
-from lance import LanceFragment
+from lance.fragment import LanceFragment
 from lance.file import LanceFileReader, LanceFileWriter
 
 from .lance import indices
@@ -632,3 +633,8 @@ class IndicesBuilder:
                 )
 
         return column
+
+@dataclass
+class IndexConfig:
+    index_type: str # The type of index to create (e.g. btree, zonemap, json)
+    parameters: dict # Parameters to configure the index

--- a/python/python/lance/lance/indices/__init__.pyi
+++ b/python/python/lance/lance/indices/__init__.pyi
@@ -14,6 +14,10 @@
 
 import pyarrow as pa
 
+class IndexConfig:
+    index_type: str,
+    config: str,
+
 def train_ivf_model(
     dataset,
     column: str,

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -83,6 +83,7 @@ use lance_table::io::commit::CommitHandler;
 use crate::error::PythonErrorExt;
 use crate::file::object_store_from_uri_or_path;
 use crate::fragment::FileFragment;
+use crate::indices::PyIndexConfig;
 use crate::scanner::ScanStatistics;
 use crate::schema::LanceSchema;
 use crate::session::Session;
@@ -1491,6 +1492,7 @@ impl Dataset {
             "IVF_FLAT" | "IVF_PQ" | "IVF_SQ" | "IVF_HNSW_FLAT" | "IVF_HNSW_PQ" | "IVF_HNSW_SQ" => {
                 IndexType::Vector
             }
+            "SCALAR" => IndexType::Scalar,
             _ => {
                 return Err(PyValueError::new_err(format!(
                     "Index type '{index_type}' is not supported."
@@ -1520,6 +1522,19 @@ impl Dataset {
                 index_type: "label_list".to_string(),
                 params: None,
             }),
+            "SCALAR" => {
+                let Some(kwargs) = kwargs else {
+                    return Err(PyValueError::new_err("SCALAR index type specified by no kwargs provided"));
+                };
+                let Some(config) = kwargs.get_item("config")? else {
+                    return Err(PyValueError::new_err("SCALAR index type specified by no `config` in kwargs"));
+                };
+                let config: PyIndexConfig = config.extract()?;
+                Box::new(ScalarIndexParams {
+                    index_type: config.index_type.clone(),
+                    params: Some(config.config.clone())
+                })
+            }
             "INVERTED" | "FTS" => {
                 let mut params = InvertedIndexParams::default();
                 if let Some(kwargs) = kwargs {

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -32,6 +32,25 @@ use lance::index::vector::ivf::write_ivf_pq_file_from_existing_index;
 use lance_index::DatasetIndexExt;
 use uuid::Uuid;
 
+#[pyclass(name = "IndexConfig", module = "lance.indices", get_all)]
+#[derive(Debug, Clone)]
+pub struct PyIndexConfig {
+    pub index_type: String,
+    pub config: String,
+}
+
+#[pymethods]
+impl PyIndexConfig {
+
+    #[new]
+    fn new(index_type: &str, config: &str) -> PyResult<Self> {
+        Ok(Self {
+            index_type: index_type.to_string(),
+            config: config.to_string()
+        })
+    }
+}
+
 #[pyclass(name = "IvfModel", module = "lance.indices")]
 #[derive(Debug, Clone)]
 pub struct PyIvfModel {
@@ -453,6 +472,7 @@ pub fn register_indices(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     indices.add_wrapped(wrap_pyfunction!(shuffle_transformed_vectors))?;
     indices.add_wrapped(wrap_pyfunction!(load_shuffled_vectors))?;
     indices.add_class::<PyIvfModel>()?;
+    indices.add_class::<PyIndexConfig>()?;
     indices.add_wrapped(wrap_pyfunction!(get_ivf_model))?;
     m.add_submodule(&indices)?;
     Ok(())

--- a/rust/lance-datafusion/src/udf.rs
+++ b/rust/lance-datafusion/src/udf.rs
@@ -10,7 +10,7 @@ use datafusion::prelude::SessionContext;
 use datafusion_functions::utils::make_scalar_function;
 use std::sync::{Arc, LazyLock};
 
-pub(crate) mod json;
+pub mod json;
 
 /// Register UDF functions to datafusion context.
 pub fn register_functions(ctx: &SessionContext) {

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -32,6 +32,7 @@ futures.workspace = true
 half.workspace = true
 itertools.workspace = true
 jieba-rs = { workspace = true, optional = true }
+jsonb.workspace = true
 lance-arrow.workspace = true
 lance-core.workspace = true
 lance-datafusion.workspace = true

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -34,6 +34,7 @@ pub mod btree;
 pub mod expression;
 pub mod flat;
 pub mod inverted;
+pub mod json;
 pub mod label_list;
 pub mod lance_format;
 pub mod ngram;

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -32,8 +32,7 @@ use crate::{
     scalar::{
         expression::SargableQueryParser,
         registry::{
-            DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering,
-            TrainingRequest, VALUE_COLUMN_NAME,
+            DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, VALUE_COLUMN_NAME
         },
         CreatedIndex, UpdateCriteria,
     },

--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -66,21 +66,40 @@ pub struct IndexedExpression {
 }
 
 pub trait ScalarQueryParser: std::fmt::Debug + Send + Sync {
+    /// Visit a between expression
+    /// 
+    /// Returns an IndexedExpression if the index can accelerate between expressions
     fn visit_between(
         &self,
         column: &str,
         low: &Bound<ScalarValue>,
         high: &Bound<ScalarValue>,
     ) -> Option<IndexedExpression>;
+    /// Visit an in list expression
+    /// 
+    /// Returns an IndexedExpression if the index can accelerate in list expressions
     fn visit_in_list(&self, column: &str, in_list: &[ScalarValue]) -> Option<IndexedExpression>;
+    /// Visit an is bool expression
+    /// 
+    /// Returns an IndexedExpression if the index can accelerate is bool expressions
     fn visit_is_bool(&self, column: &str, value: bool) -> Option<IndexedExpression>;
+    /// Visit an is null expression
+    /// 
+    /// Returns an IndexedExpression if the index can accelerate is null expressions
     fn visit_is_null(&self, column: &str) -> Option<IndexedExpression>;
+    /// Visit a comparison expression
+    /// 
+    /// Returns an IndexedExpression if the index can accelerate comparison expressions
     fn visit_comparison(
         &self,
         column: &str,
         value: &ScalarValue,
         op: &Operator,
     ) -> Option<IndexedExpression>;
+    /// Visit a scalar function expression
+    /// 
+    /// Returns an IndexedExpression if the index can accelerate the given scalar function.
+    /// For example, an ngram index can accelerate the contains function.
     fn visit_scalar_function(
         &self,
         column: &str,
@@ -88,6 +107,36 @@ pub trait ScalarQueryParser: std::fmt::Debug + Send + Sync {
         func: &ScalarUDF,
         args: &[Expr],
     ) -> Option<IndexedExpression>;
+
+    /// Visits a potential reference to a column
+    /// 
+    /// This function is a little different from the other visitors.  It is used to test if a potential
+    /// column reference is a reference the index handles.
+    /// 
+    /// Most indexes are designed to run on references to the indexed column.  For example, if a query
+    /// is "x = 7" and we have a scalar index on "x" then we apply the index to the "x" column reference.
+    /// 
+    /// However, some indexes are designed to run on projections of the indexed column.  For example,
+    /// if a query is "json_extract(json, '$.name') = 'books'" and we have a JSON index on the "json" column
+    /// then we apply the index to the projection of the "json" column.
+    /// 
+    /// This function is used to test if a potential column reference is a reference the index handles.
+    /// The default implementation matches column references but this can be overridden by indexes that
+    /// handle projections.
+    /// 
+    /// The function is also passed in the data type of the column and should return the data type of the
+    /// reference.  Normally this is the same as the input for a direct column reference and possibly something
+    /// different for a projection.  E.g. a JSON column (LargeBinary) might be projected to a string or float
+    /// 
+    /// Note: higher logic in the expression parser already limits references to either Expr::Column or Expr::ScalarFunction
+    /// where the first argument is an Expr::Column.  If your projection doesn't fit that mold then the
+    /// expression parser will need to be modified.
+    fn is_valid_reference(&self, func: &Expr, data_type: &DataType) -> Option<DataType> {
+        match func {
+            Expr::Column(_) => Some(data_type.clone()),
+            _ => None,
+        }
+    }
 }
 
 /// A generic parser that wraps multiple scalar query parsers
@@ -158,6 +207,17 @@ impl ScalarQueryParser for MultiQueryParser {
         self.parsers
             .iter()
             .find_map(|parser| parser.visit_scalar_function(column, data_type, func, args))
+    }
+    /// TODO(low-priority): This is maybe not quite right.  We should filter down the list of parsers based
+    /// on those that consider the reference valid.  Instead what we are doing is checking all parsers if any one
+    /// parser considers the reference valid.
+    /// 
+    /// This will be a problem if the user creates two indexes (e.g. btree and json) on the same column and those two
+    /// indexes have different reference schemes.
+    fn is_valid_reference(&self, func: &Expr, data_type: &DataType) -> Option<DataType> {
+        self.parsers
+            .iter()
+            .find_map(|parser| parser.is_valid_reference(func, data_type))
     }
 }
 
@@ -948,13 +1008,38 @@ fn maybe_column(expr: &Expr) -> Option<&str> {
 }
 
 // Extract a column from the expression, if it is a column, and we have an index for that column, or None
+//
+// There's two ways to get a column.  First, the obvious way, is a
+// simple column reference (e.g. x = 7).  Second, a more complex way,
+// is some kind of projection into a column (e.g. json_extract(json, '$.name')).
 fn maybe_indexed_column<'a, 'b>(
     expr: &'a Expr,
     index_info: &'b dyn IndexInformationProvider,
-) -> Option<(&'a str, &'b DataType, &'b dyn ScalarQueryParser)> {
-    let col = maybe_column(expr)?;
-    let data_type = index_info.get_index(col);
-    data_type.map(|(ty, parser)| (col, ty, parser))
+) -> Option<(&'a str, DataType, &'b dyn ScalarQueryParser)> {
+    match expr {
+        Expr::Column(col) => {
+            let col = col.name.as_str();
+            let (data_type, parser) = index_info.get_index(col)?;
+            if let Some(data_type) = parser.is_valid_reference(expr, &data_type) {
+                Some((col, data_type, parser))
+            } else {
+                None
+            }
+        },
+        Expr::ScalarFunction(udf) => {
+            if udf.args.is_empty() {
+                return None;
+            }
+            let col = maybe_column(&udf.args[0])?;
+            let (data_type, parser) = index_info.get_index(col)?;
+            if let Some(data_type) = parser.is_valid_reference(expr, &data_type) {
+                Some((col, data_type, parser))
+            } else {
+                None
+            }
+        },
+        _ => None,
+    }
 }
 
 // Extract a literal scalar value from an expression, if it is a literal, or None
@@ -1026,8 +1111,8 @@ fn visit_between(
     index_info: &dyn IndexInformationProvider,
 ) -> Option<IndexedExpression> {
     let (column, col_type, query_parser) = maybe_indexed_column(&between.expr, index_info)?;
-    let low = maybe_scalar(&between.low, col_type)?;
-    let high = maybe_scalar(&between.high, col_type)?;
+    let low = maybe_scalar(&between.low, &col_type)?;
+    let high = maybe_scalar(&between.high, &col_type)?;
 
     let indexed_expr =
         query_parser.visit_between(column, &Bound::Included(low), &Bound::Included(high))?;
@@ -1044,7 +1129,7 @@ fn visit_in_list(
     index_info: &dyn IndexInformationProvider,
 ) -> Option<IndexedExpression> {
     let (column, col_type, query_parser) = maybe_indexed_column(&in_list.expr, index_info)?;
-    let values = maybe_scalar_list(&in_list.list, col_type)?;
+    let values = maybe_scalar_list(&in_list.list, &col_type)?;
 
     let indexed_expr = query_parser.visit_in_list(column, &values)?;
 
@@ -1061,7 +1146,7 @@ fn visit_is_bool(
     value: bool,
 ) -> Option<IndexedExpression> {
     let (column, col_type, query_parser) = maybe_indexed_column(expr, index_info)?;
-    if *col_type != DataType::Boolean {
+    if col_type != DataType::Boolean {
         None
     } else {
         query_parser.visit_is_bool(column, value)
@@ -1074,7 +1159,7 @@ fn visit_column(
     index_info: &dyn IndexInformationProvider,
 ) -> Option<IndexedExpression> {
     let (column, col_type, query_parser) = maybe_indexed_column(col, index_info)?;
-    if *col_type != DataType::Boolean {
+    if col_type != DataType::Boolean {
         None
     } else {
         query_parser.visit_is_bool(column, true)
@@ -1110,7 +1195,7 @@ fn visit_comparison(
 ) -> Option<IndexedExpression> {
     let left_col = maybe_indexed_column(&expr.left, index_info);
     if let Some((column, col_type, query_parser)) = left_col {
-        let scalar = maybe_scalar(&expr.right, col_type)?;
+        let scalar = maybe_scalar(&expr.right, &col_type)?;
         query_parser.visit_comparison(column, &scalar, &expr.op)
     } else {
         // Datafusion's query simplifier will canonicalize expressions and so we shouldn't reach this case.  If, for some reason, we
@@ -1139,8 +1224,8 @@ fn maybe_range(
         return None;
     }
 
-    let left_value = maybe_scalar(&left_expr.right, dt)?;
-    let right_value = maybe_scalar(&right_expr.right, dt)?;
+    let left_value = maybe_scalar(&left_expr.right, &dt)?;
+    let right_value = maybe_scalar(&right_expr.right, &dt)?;
 
     let (low, high) = match (left_expr.op, right_expr.op) {
         // x >= a && x <= b
@@ -1248,7 +1333,7 @@ fn visit_scalar_fn(
         return None;
     }
     let (col, data_type, query_parser) = maybe_indexed_column(&scalar_fn.args[0], index_info)?;
-    query_parser.visit_scalar_function(col, data_type, &scalar_fn.func, &scalar_fn.args)
+    query_parser.visit_scalar_function(col, &data_type, &scalar_fn.func, &scalar_fn.args)
 }
 
 fn visit_node(
@@ -1418,10 +1503,12 @@ mod tests {
     use std::collections::HashMap;
 
     use arrow_schema::{Field, Schema};
-    use datafusion::prelude::SessionContext;
     use datafusion_common::{Column, DFSchema};
     use datafusion_expr::execution_props::ExecutionProps;
     use datafusion_expr::simplify::SimplifyContext;
+    use lance_datafusion::exec::{get_session_context, LanceExecutionOptions};
+
+    use crate::scalar::json::{JsonQuery, JsonQueryParser};
 
     use super::*;
 
@@ -1472,10 +1559,11 @@ mod tests {
             Field::new("aisle", DataType::UInt32, false),
             Field::new("on_sale", DataType::Boolean, false),
             Field::new("price", DataType::Float32, false),
+            Field::new("json", DataType::LargeBinary, false),
         ]);
         let df_schema: DFSchema = schema.try_into().unwrap();
 
-        let ctx = SessionContext::default();
+        let ctx = get_session_context(&LanceExecutionOptions::default());
         let state = ctx.state();
         let mut expr = state.create_logical_expr(expr, &df_schema).unwrap();
         if optimize {
@@ -1503,7 +1591,7 @@ mod tests {
         index_info: &dyn IndexInformationProvider,
         expr: &str,
         col: &str,
-        query: SargableQuery,
+        query: impl AnyQuery,
     ) {
         check(
             index_info,
@@ -1588,7 +1676,21 @@ mod tests {
                     Box::new(SargableQueryParser::new("price_idx".to_string(), false)),
                 ),
             ),
+            (
+                "json",
+                ColInfo::new(
+                    DataType::LargeBinary,
+                    Box::new(JsonQueryParser::new("$.name".to_string(), Box::new(SargableQueryParser::new("json_idx".to_string(), false)))),
+                ),
+            )
         ]);
+
+        check_simple(
+            &index_info,
+            "json_extract(json, '$.name') = 'foo'",
+            "json",
+            JsonQuery::new(Arc::new(SargableQuery::Equals(ScalarValue::Utf8(Some("foo".to_string())))), "$.name".to_string()),
+        );
 
         check_no_index(&index_info, "size BETWEEN 5 AND 10");
         // Cast case.  We will cast 5 (an int64) to Int16 and then coerce to UInt32

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -1,0 +1,469 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{
+    collections::HashMap, ops::Bound, sync::{Arc, Mutex}
+};
+
+use arrow_schema::{DataType, Field};
+use async_trait::async_trait;
+use datafusion::{
+    execution::SendableRecordBatchStream,
+    physical_plan::{projection::ProjectionExec, ExecutionPlan},
+};
+use datafusion_common::ScalarValue;
+use datafusion_expr::{Expr, Operator, ScalarUDF};
+use datafusion_physical_expr::{
+    expressions::{Column, Literal},
+    PhysicalExpr, ScalarFunctionExpr,
+};
+use deepsize::DeepSizeOf;
+use lance_datafusion::exec::{get_session_context, LanceExecutionOptions, OneShotExec};
+use prost::Message;
+use roaring::RoaringBitmap;
+use serde::{Deserialize, Serialize};
+use snafu::location;
+
+use lance_core::{cache::LanceCache, error::LanceOptionExt, Error, Result, ROW_ID};
+
+use crate::{
+    frag_reuse::FragReuseIndex, metrics::MetricsCollector, scalar::{
+        expression::{IndexedExpression, ScalarIndexExpr, ScalarIndexSearch, ScalarQueryParser}, registry::{
+            ScalarIndexPlugin, ScalarIndexPluginRegistry, TrainingCriteria, TrainingRequest,
+            VALUE_COLUMN_NAME,
+        }, AnyQuery, CreatedIndex, IndexStore, ScalarIndex, SearchResult, UpdateCriteria
+    }, Index, IndexType
+};
+
+const JSON_INDEX_VERSION: u32 = 0;
+
+/// A JSON index that indexes a field in a JSON column
+///
+/// The underlying index can be any other type of scalar index
+#[derive(Debug)]
+pub struct JsonIndex {
+    target_index: Arc<dyn ScalarIndex>,
+    path: String,
+}
+
+impl JsonIndex {
+    pub fn new(target_index: Arc<dyn ScalarIndex>, path: String) -> Self {
+        Self { target_index, path }
+    }
+}
+
+impl DeepSizeOf for JsonIndex {
+    fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
+        self.target_index.deep_size_of_children(context) + self.path.deep_size_of_children(context)
+    }
+}
+
+#[async_trait]
+impl Index for JsonIndex {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+        self
+    }
+
+    fn as_vector_index(self: Arc<Self>) -> Result<Arc<dyn crate::vector::VectorIndex>> {
+        unimplemented!()
+    }
+
+    fn index_type(&self) -> IndexType {
+        // TODO: This causes the index to appear as btree in list_indices call.  Need better logic
+        // in list_indices to use details instead of index_type.
+        IndexType::Scalar
+    }
+
+    async fn prewarm(&self) -> Result<()> {
+        self.target_index.prewarm().await
+    }
+
+    fn statistics(&self) -> Result<serde_json::Value> {
+        todo!()
+    }
+
+    async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {
+        self.target_index.calculate_included_frags().await
+    }
+}
+
+#[async_trait]
+impl ScalarIndex for JsonIndex {
+
+    async fn search(&self, query: &dyn AnyQuery, metrics: &dyn MetricsCollector) -> Result<SearchResult> {
+        let query = query.as_any().downcast_ref::<JsonQuery>().unwrap();
+        self.target_index.search(query.target_query.as_ref(), metrics).await
+    }
+
+    fn can_remap(&self) -> bool {
+        self.target_index.can_remap()
+    }
+
+    async fn remap(&self, mapping: &HashMap<u64, Option<u64>>, dest_store: &dyn IndexStore) -> Result<CreatedIndex> {
+        let target_created = self.target_index.remap(mapping, dest_store).await?;
+        let json_details = crate::pb::JsonIndexDetails {
+            path: self.path.clone(),
+            target_details: Some(target_created.index_details),
+        };
+        Ok(CreatedIndex {
+            index_details: prost_types::Any::from_msg(&json_details)?,
+            // TODO: We should store the target index version in the details
+            index_version: JSON_INDEX_VERSION,
+        })
+    }
+
+    async fn update(&self, new_data: SendableRecordBatchStream, dest_store: &dyn IndexStore) -> Result<CreatedIndex> {
+        let target_created = self.target_index.update(new_data, dest_store).await?;
+        let json_details = crate::pb::JsonIndexDetails {
+            path: self.path.clone(),
+            target_details: Some(target_created.index_details),
+        };
+        Ok(CreatedIndex {
+            index_details: prost_types::Any::from_msg(&json_details)?,
+            // TODO: We should store the target index version in the details
+            index_version: JSON_INDEX_VERSION,
+        })
+    }
+
+    fn update_criteria(&self) -> UpdateCriteria {
+        self.target_index.update_criteria()
+    }
+}
+
+/// Parameters for a [`JsonIndex`]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct JsonIndexParameters {
+    target_index_type: String,
+    target_index_parameters: Option<String>,
+    path: String,
+}
+
+// TODO: Do we really need to wrap the query or could we just return the target query directly?
+//
+// I think the only thing we really gain is a different format impl (e.g. it shows up as a json query
+// in the explain plan) but I don't know if that helps the user much.
+#[derive(Debug, Clone)]
+pub struct JsonQuery {
+    target_query: Arc<dyn AnyQuery>,
+    path: String,
+}
+
+impl JsonQuery {
+    pub fn new(target_query: Arc<dyn AnyQuery>, path: String) -> Self {
+        Self { target_query, path }
+    }
+}
+
+impl PartialEq for JsonQuery {
+    fn eq(&self, other: &Self) -> bool {
+        self.target_query.dyn_eq(other.target_query.as_ref()) && self.path == other.path
+    }
+}
+
+impl AnyQuery for JsonQuery {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    
+    fn format(&self, col: &str) -> String {
+        format!("Json({}->{})", self.target_query.format(col), self.path)
+    }
+    
+    fn to_expr(&self, _col: String) -> Expr {
+        todo!()
+    }
+    
+    fn dyn_eq(&self, other: &dyn AnyQuery) -> bool {
+        match other.as_any().downcast_ref::<Self>() {
+            Some(o) => self == o,
+            None => false,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct JsonQueryParser {
+    path: String,
+    target_parser: Box<dyn ScalarQueryParser>,
+}
+
+impl JsonQueryParser {
+    pub fn new(path: String, target_parser: Box<dyn ScalarQueryParser>) -> Self {
+        Self {
+            path,
+            target_parser,
+        }
+    }
+
+    fn wrap_search(&self, target_expr: IndexedExpression) -> IndexedExpression {
+        if let Some(scalar_query) = target_expr.scalar_query {
+            let scalar_query = match scalar_query {
+                ScalarIndexExpr::Query(ScalarIndexSearch { column, index_name, query, needs_recheck }) => {
+                    ScalarIndexExpr::Query(ScalarIndexSearch {
+                        column,
+                        index_name,
+                        query: Arc::new(JsonQuery::new(query, self.path.clone())),
+                        needs_recheck,
+                    })
+                }
+                // This code path should only be hit on leaf expr
+                _ => unreachable!(),
+            };
+            IndexedExpression {
+                scalar_query: Some(scalar_query),
+                refine_expr: target_expr.refine_expr,
+            }
+        } else {
+            target_expr
+        }
+    }
+}
+
+impl ScalarQueryParser for JsonQueryParser {
+    fn visit_between(
+        &self,
+        column: &str,
+        low: &Bound<ScalarValue>,
+        high: &Bound<ScalarValue>,
+    ) -> Option<IndexedExpression> {
+        self.target_parser.visit_between(column, &low, &high).map(|target_expr |self.wrap_search(target_expr))
+    }
+    fn visit_in_list(&self, column: &str, in_list: &[ScalarValue]) -> Option<IndexedExpression> {
+        self.target_parser.visit_in_list(column, &in_list).map(|target_expr| self.wrap_search(target_expr))
+    }
+    fn visit_is_bool(&self, column: &str, value: bool) -> Option<IndexedExpression> {
+        self.target_parser.visit_is_bool(column, value).map(|target_expr| self.wrap_search(target_expr))
+    }
+    fn visit_is_null(&self, column: &str) -> Option<IndexedExpression> {
+        self.target_parser.visit_is_null(column).map(|target_expr| self.wrap_search(target_expr))
+    }
+    fn visit_comparison(
+        &self,
+        column: &str,
+        value: &ScalarValue,
+        op: &Operator,
+    ) -> Option<IndexedExpression> {
+        self.target_parser.visit_comparison(column, &value, op).map(|target_expr| self.wrap_search(target_expr))
+    }
+    fn visit_scalar_function(
+        &self,
+        column: &str,
+        data_type: &DataType,
+        func: &ScalarUDF,
+        args: &[Expr],
+    ) -> Option<IndexedExpression> {
+        self.target_parser.visit_scalar_function(column, data_type, func, &args).map(|target_expr| self.wrap_search(target_expr))
+    }
+
+    fn is_valid_reference(&self, func: &Expr, _data_type: &DataType) -> Option<DataType> {
+        match func {
+            Expr::ScalarFunction(udf) => {
+                if udf.name() != "json_extract" {
+                    return None;
+                }
+                if udf.args.len() != 2 {
+                    return None;
+                }
+                // We already know index 0 is a column reference to the column so we just need to
+                // ensure that index 1 matches our path
+                match &udf.args[1] {
+                    Expr::Literal(ScalarValue::Utf8(Some(path)), _) => {
+                        if path == &self.path {
+                            // TODO: This may need to be flexible
+                            Some(DataType::Utf8)
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+pub struct JsonTrainingRequest {
+    parameters: JsonIndexParameters,
+    target_request: Box<dyn TrainingRequest>,
+}
+
+impl JsonTrainingRequest {
+    pub fn new(parameters: JsonIndexParameters, target_request: Box<dyn TrainingRequest>) -> Self {
+        Self {
+            parameters,
+            target_request,
+        }
+    }
+}
+
+impl TrainingRequest for JsonTrainingRequest {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn criteria(&self) -> &TrainingCriteria {
+        self.target_request.criteria()
+    }
+}
+
+/// Plugin implementation for a [`JsonIndex`]
+#[derive(Default)]
+pub struct JsonIndexPlugin {
+    registry: Mutex<Option<Arc<ScalarIndexPluginRegistry>>>,
+}
+
+impl std::fmt::Debug for JsonIndexPlugin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JsonIndexPlugin")
+    }
+}
+
+impl JsonIndexPlugin {
+    fn registry(&self) -> Result<Arc<ScalarIndexPluginRegistry>> {
+        Ok(self.registry.lock().unwrap().as_ref().expect_ok()?.clone())
+    }
+
+    fn extract_json(
+        data: SendableRecordBatchStream,
+        path: String,
+    ) -> Result<SendableRecordBatchStream> {
+        let input = Arc::new(OneShotExec::new(data));
+        let input_schema = input.schema().clone();
+        let value_column_idx = input_schema
+            .column_with_name(&VALUE_COLUMN_NAME)
+            .expect_ok()?
+            .0;
+        // TODO: We should just copy over all non-value columns, not cherry-pick row id
+        let row_id_column_idx = input_schema.column_with_name(ROW_ID).expect_ok()?.0;
+        let exprs = vec![
+            (
+                Arc::new(ScalarFunctionExpr::try_new(
+                    Arc::new(lance_datafusion::udf::json::json_extract_udf()),
+                    vec![
+                        Arc::new(Column::new(VALUE_COLUMN_NAME, value_column_idx)),
+                        Arc::new(Literal::new(ScalarValue::Utf8(Some(path)))),
+                    ],
+                    &input_schema,
+                )?) as Arc<dyn PhysicalExpr>,
+                VALUE_COLUMN_NAME.to_string(),
+            ),
+            (
+                Arc::new(Column::new(ROW_ID, row_id_column_idx)) as Arc<dyn PhysicalExpr>,
+                ROW_ID.to_string(),
+            ),
+        ];
+        let project = ProjectionExec::try_new(exprs, input)?;
+        let ctx = get_session_context(&LanceExecutionOptions::default());
+        project.execute(0, ctx.task_ctx()).map_err(Error::from)
+    }
+}
+
+#[async_trait]
+impl ScalarIndexPlugin for JsonIndexPlugin {
+    fn new_training_request(
+        &self,
+        params: &str,
+        field: &Field,
+    ) -> Result<Box<dyn TrainingRequest>> {
+        if !matches!(field.data_type(), DataType::Binary | DataType::LargeBinary) {
+            return Err(Error::InvalidInput {
+                source: "A JSON index can only be created on a Binary or LargeBinary field.".into(),
+                location: location!(),
+            });
+        }
+
+        // TODO: How do we determine the target type?
+        // TODO: How do we extract to a specific type?  Maybe try_cast?
+        let target_type = DataType::Utf8;
+
+        let params = serde_json::from_str::<JsonIndexParameters>(params)?;
+        let registry = self.registry()?;
+        let target_plugin = registry.get_plugin_by_name(&params.target_index_type)?;
+        let target_request = target_plugin.new_training_request(
+            &params
+                .target_index_parameters
+                .as_deref()
+                .unwrap_or("{}")
+                .to_string(),
+            &Field::new("", target_type, true),
+        )?;
+
+        Ok(Box::new(JsonTrainingRequest::new(params, target_request)))
+    }
+
+    fn provides_exact_answer(&self) -> bool {
+        // TODO: Need to lookup target plugin via details to figure this out correctly
+        true
+    }
+
+    fn attach_registry(&self, registry: Arc<ScalarIndexPluginRegistry>) {
+        let mut reg_ref = self.registry.lock().unwrap();
+        *reg_ref = Some(registry);
+    }
+
+    fn version(&self) -> u32 {
+        JSON_INDEX_VERSION
+    }
+
+    fn new_query_parser(
+        &self,
+        index_name: String,
+        index_details: &prost_types::Any,
+    ) -> Option<Box<dyn ScalarQueryParser>> {
+        // TODO: Allow return Result here
+        let registry = self.registry().unwrap();
+        let json_details = crate::pb::JsonIndexDetails::decode(index_details.value.as_slice()).unwrap();
+        let target_details = json_details.target_details.as_ref().expect_ok().unwrap();
+        let target_plugin = registry.get_plugin_by_details(target_details).unwrap();
+        // TODO: Use something like ${index_name}_${path} for the index name?  Don't have access to path here tho
+        let target_parser = target_plugin.new_query_parser(index_name.clone(), index_details)?;
+        Some(Box::new(JsonQueryParser::new(json_details.path.clone(), target_parser)) as Box<dyn ScalarQueryParser>)
+    }
+
+    async fn train_index(
+        &self,
+        data: SendableRecordBatchStream,
+        index_store: &dyn IndexStore,
+        request: Box<dyn TrainingRequest>,
+    ) -> Result<CreatedIndex> {
+        let request = (request as Box<dyn std::any::Any>)
+            .downcast::<JsonTrainingRequest>()
+            .unwrap();
+        let path = request.parameters.path.clone();
+        let registry = self.registry()?;
+        let target_plugin = registry.get_plugin_by_name(&request.parameters.target_index_type)?;
+        let data = Self::extract_json(data, path.clone())?;
+        let target_index = target_plugin
+            .train_index(data, index_store, request.target_request)
+            .await?;
+
+        let index_details = crate::pb::JsonIndexDetails {
+            path,
+            target_details: Some(target_index.index_details),
+        };
+        Ok(CreatedIndex {
+            index_details: prost_types::Any::from_msg(&index_details)?,
+            index_version: JSON_INDEX_VERSION,
+        })
+    }
+
+    async fn load_index(
+        &self,
+        index_store: Arc<dyn IndexStore>,
+        index_details: &prost_types::Any,
+        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        cache: LanceCache,
+    ) -> Result<Arc<dyn ScalarIndex>> {
+        let registry = self.registry().unwrap();
+        let json_details = crate::pb::JsonIndexDetails::decode(index_details.value.as_slice())?;
+        let target_details = json_details.target_details.as_ref().expect_ok()?;
+        let target_plugin = registry.get_plugin_by_details(target_details).unwrap();
+        let target_index = target_plugin.load_index(index_store, target_details, frag_reuse_index, cache).await?;
+        Ok(Arc::new(JsonIndex::new(target_index, json_details.path)))
+    }
+}

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -25,8 +25,7 @@ use crate::frag_reuse::FragReuseIndex;
 use crate::scalar::bitmap::BitmapIndexPlugin;
 use crate::scalar::expression::{LabelListQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
-    DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
-    VALUE_COLUMN_NAME,
+    DefaultTrainingRequest, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest, VALUE_COLUMN_NAME
 };
 use crate::scalar::{CreatedIndex, UpdateCriteria};
 use crate::{pb, Index, IndexType};

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -13,9 +13,7 @@ use crate::{
     frag_reuse::FragReuseIndex,
     pb,
     scalar::{
-        bitmap::BitmapIndexPlugin, btree::BTreeIndexPlugin, expression::ScalarQueryParser,
-        inverted::InvertedIndexPlugin, label_list::LabelListIndexPlugin, ngram::NGramIndexPlugin,
-        zonemap::ZoneMapIndexPlugin, CreatedIndex, IndexStore, ScalarIndex,
+        bitmap::BitmapIndexPlugin, btree::BTreeIndexPlugin, expression::ScalarQueryParser, inverted::InvertedIndexPlugin, json::JsonIndexPlugin, label_list::LabelListIndexPlugin, ngram::NGramIndexPlugin, zonemap::ZoneMapIndexPlugin, CreatedIndex, IndexStore, ScalarIndex
     },
 };
 
@@ -149,17 +147,14 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
         cache: LanceCache,
     ) -> Result<Arc<dyn ScalarIndex>>;
+
+    /// Optional hook that plugins can use if they need to be aware of the registry
+    fn attach_registry(&self, _registry: Arc<ScalarIndexPluginRegistry>) {}
 }
 
 /// A registry of scalar index plugins
 pub struct ScalarIndexPluginRegistry {
     plugins: HashMap<String, Box<dyn ScalarIndexPlugin>>,
-}
-
-impl Default for ScalarIndexPluginRegistry {
-    fn default() -> Self {
-        Self::with_default_plugins()
-    }
 }
 
 impl ScalarIndexPluginRegistry {
@@ -192,7 +187,7 @@ impl ScalarIndexPluginRegistry {
     }
 
     /// Create a registry with the default plugins
-    pub fn with_default_plugins() -> Self {
+    pub fn with_default_plugins() -> Arc<Self> {
         let mut registry = Self {
             plugins: HashMap::new(),
         };
@@ -202,6 +197,12 @@ impl ScalarIndexPluginRegistry {
         registry.add_plugin::<pb::NGramIndexDetails, NGramIndexPlugin>();
         registry.add_plugin::<pb::ZoneMapIndexDetails, ZoneMapIndexPlugin>();
         registry.add_plugin::<pb::InvertedIndexDetails, InvertedIndexPlugin>();
+        registry.add_plugin::<pb::JsonIndexDetails, JsonIndexPlugin>();
+
+        let registry = Arc::new(registry);
+        for plugin in registry.plugins.values() {
+            plugin.attach_registry(registry.clone());
+        }
 
         registry
     }

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -173,7 +173,7 @@ pub(crate) async fn load_training_data(
 }
 
 // TODO: Allow users to register their own plugins
-static SCALAR_INDEX_PLUGIN_REGISTRY: LazyLock<ScalarIndexPluginRegistry> =
+static SCALAR_INDEX_PLUGIN_REGISTRY: LazyLock<Arc<ScalarIndexPluginRegistry>> =
     LazyLock::new(ScalarIndexPluginRegistry::with_default_plugins);
 
 pub struct IndexDetails(pub Arc<prost_types::Any>);


### PR DESCRIPTION
Adds a scalar index for JSON columns by creating a scalar index on some sub-field in the JSON data.  Any scalar index type can be used as the underlying type.

This PR also introduces the ability to configure scalar indexes in a generic way.  It might be nice to eventually switch the Inverted index so that it can also be trained in this way (and then we don't need a special "create full text index" method) but that can be left for future work.

This PR also modifies the expression parsing slightly to introduce the idea that a query might match a direct column reference _or_ might match a projected column reference.  This could be useful in the future for things like indexes on struct fields, list items, image metadata, etc.