### PR TITLE
feat: build type-aware index for JSON

### DIFF
--- a/rust/lance-datafusion/src/udf.rs
+++ b/rust/lance-datafusion/src/udf.rs
@@ -17,6 +17,7 @@ pub fn register_functions(ctx: &SessionContext) {
     ctx.register_udf(CONTAINS_TOKENS_UDF.clone());
     // JSON functions
     ctx.register_udf(json::json_extract_udf());
+    ctx.register_udf(json::json_extract_with_type_udf());
     ctx.register_udf(json::json_exists_udf());
     ctx.register_udf(json::json_get_udf());
     ctx.register_udf(json::json_get_string_udf());

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -7,8 +7,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use arrow_schema::{DataType, Field};
+use arrow_array::{Array, LargeBinaryArray, RecordBatch, StructArray, UInt8Array};
+use arrow_schema::{DataType, Field, Field as ArrowField, Schema};
 use async_trait::async_trait;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::{
     execution::SendableRecordBatchStream,
     physical_plan::{projection::ProjectionExec, ExecutionPlan},
@@ -20,7 +22,9 @@ use datafusion_physical_expr::{
     PhysicalExpr, ScalarFunctionExpr,
 };
 use deepsize::DeepSizeOf;
+use futures::StreamExt;
 use lance_datafusion::exec::{get_session_context, LanceExecutionOptions, OneShotExec};
+use lance_datafusion::udf::json::JsonbType;
 use prost::Message;
 use roaring::RoaringBitmap;
 use serde::{Deserialize, Serialize};
@@ -363,38 +367,322 @@ impl JsonIndexPlugin {
         Ok(self.registry.lock().unwrap().as_ref().expect_ok()?.clone())
     }
 
-    fn extract_json(
+    /// Extract JSON with type information using the new UDF
+    async fn extract_json_with_type_info(
         data: SendableRecordBatchStream,
         path: String,
-    ) -> Result<SendableRecordBatchStream> {
+    ) -> Result<(SendableRecordBatchStream, DataType)> {
         let input = Arc::new(OneShotExec::new(data));
         let input_schema = input.schema();
         let value_column_idx = input_schema
             .column_with_name(VALUE_COLUMN_NAME)
             .expect_ok()?
             .0;
-        // TODO: We should just copy over all non-value columns, not cherry-pick row id
         let row_id_column_idx = input_schema.column_with_name(ROW_ID).expect_ok()?.0;
+
+        // Call json_extract_with_type UDF
         let exprs = vec![
             (
                 Arc::new(ScalarFunctionExpr::try_new(
-                    Arc::new(lance_datafusion::udf::json::json_extract_udf()),
+                    Arc::new(lance_datafusion::udf::json::json_extract_with_type_udf()),
                     vec![
                         Arc::new(Column::new(VALUE_COLUMN_NAME, value_column_idx)),
                         Arc::new(Literal::new(ScalarValue::Utf8(Some(path)))),
                     ],
                     &input_schema,
                 )?) as Arc<dyn PhysicalExpr>,
-                VALUE_COLUMN_NAME.to_string(),
+                "json_result".to_string(),
             ),
             (
                 Arc::new(Column::new(ROW_ID, row_id_column_idx)) as Arc<dyn PhysicalExpr>,
                 ROW_ID.to_string(),
             ),
         ];
+
         let project = ProjectionExec::try_new(exprs, input)?;
         let ctx = get_session_context(&LanceExecutionOptions::default());
-        project.execute(0, ctx.task_ctx()).map_err(Error::from)
+        let mut stream = project.execute(0, ctx.task_ctx())?;
+
+        // Collect batches and determine type from first non-null value
+        let mut all_batches = Vec::new();
+        let mut inferred_type: Option<DataType> = None;
+
+        while let Some(batch_result) = stream.next().await {
+            let batch = batch_result?;
+
+            // Determine type from first non-null value if not yet set
+            if inferred_type.is_none() {
+                if let Some(json_result_column) = batch.column_by_name("json_result") {
+                    if let Some(struct_array) =
+                        json_result_column.as_any().downcast_ref::<StructArray>()
+                    {
+                        if let Some(type_array) = struct_array.column_by_name("type_tag") {
+                            if let Some(uint8_array) =
+                                type_array.as_any().downcast_ref::<UInt8Array>()
+                            {
+                                // Find first non-null value to determine type
+                                for i in 0..uint8_array.len() {
+                                    if !uint8_array.is_null(i) {
+                                        let type_tag = uint8_array.value(i);
+                                        let jsonb_type =
+                                            JsonbType::from_u8(type_tag).ok_or_else(|| {
+                                                Error::InvalidInput {
+                                                    source: format!(
+                                                        "Invalid type tag: {}",
+                                                        type_tag
+                                                    )
+                                                    .into(),
+                                                    location: location!(),
+                                                }
+                                            })?;
+
+                                        // Map JsonbType to Arrow DataType
+                                        inferred_type = Some(match jsonb_type {
+                                            JsonbType::Null => continue, // Skip null values
+                                            JsonbType::Boolean => DataType::Boolean,
+                                            JsonbType::Int64 => DataType::Int64,
+                                            JsonbType::Float64 => DataType::Float64,
+                                            JsonbType::String => DataType::Utf8,
+                                            JsonbType::Array => DataType::LargeBinary,
+                                            JsonbType::Object => DataType::LargeBinary,
+                                        });
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            all_batches.push(batch);
+        }
+
+        // If no type was inferred (all nulls), default to String
+        let inferred_type = inferred_type.unwrap_or(DataType::Utf8);
+
+        // Recreate stream from collected batches
+        let schema =
+            all_batches
+                .first()
+                .map(|b| b.schema())
+                .ok_or_else(|| Error::InvalidInput {
+                    source: "No batches in stream".into(),
+                    location: location!(),
+                })?;
+
+        let recreated_stream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::iter(all_batches.into_iter().map(Ok)),
+        )) as SendableRecordBatchStream;
+
+        Ok((recreated_stream, inferred_type))
+    }
+
+    /// Convert the stream with JSONB values and type tags to properly typed values
+    async fn convert_stream_by_type(
+        data: SendableRecordBatchStream,
+        target_type: DataType,
+    ) -> Result<SendableRecordBatchStream> {
+        let input = Arc::new(OneShotExec::new(data));
+        let _input_schema = input.schema();
+        let ctx = get_session_context(&LanceExecutionOptions::default());
+        let mut stream = input.execute(0, ctx.task_ctx())?;
+
+        let mut converted_batches = Vec::new();
+
+        while let Some(batch_result) = stream.next().await {
+            let batch = batch_result?;
+
+            // Extract the struct column containing value and type_tag
+            let json_result_column =
+                batch
+                    .column_by_name("json_result")
+                    .ok_or_else(|| Error::InvalidInput {
+                        source: "Missing json_result column".into(),
+                        location: location!(),
+                    })?;
+
+            let struct_array = json_result_column
+                .as_any()
+                .downcast_ref::<StructArray>()
+                .ok_or_else(|| Error::InvalidInput {
+                    source: "json_result is not a struct".into(),
+                    location: location!(),
+                })?;
+
+            let value_array =
+                struct_array
+                    .column_by_name("value")
+                    .ok_or_else(|| Error::InvalidInput {
+                        source: "Missing value column in struct".into(),
+                        location: location!(),
+                    })?;
+
+            let binary_array = value_array
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .ok_or_else(|| Error::InvalidInput {
+                    source: "value is not LargeBinary".into(),
+                    location: location!(),
+                })?;
+
+            // Convert based on target type using serde deserialization
+            let converted_array: Arc<dyn Array> = match target_type {
+                DataType::Boolean => {
+                    let mut builder =
+                        arrow_array::builder::BooleanBuilder::with_capacity(binary_array.len());
+                    for i in 0..binary_array.len() {
+                        if binary_array.is_null(i) {
+                            builder.append_null();
+                        } else if let Some(bytes) = binary_array.value(i).into() {
+                            let raw_jsonb = jsonb::RawJsonb::new(bytes);
+                            // Try to deserialize directly to bool
+                            match jsonb::from_raw_jsonb::<bool>(&raw_jsonb) {
+                                Ok(bool_val) => builder.append_value(bool_val),
+                                Err(e) => {
+                                    return Err(Error::InvalidInput {
+                                        source: format!(
+                                            "Failed to deserialize JSONB to bool at index {}: {}",
+                                            i, e
+                                        )
+                                        .into(),
+                                        location: location!(),
+                                    });
+                                }
+                            }
+                        } else {
+                            builder.append_null();
+                        }
+                    }
+                    Arc::new(builder.finish())
+                }
+                DataType::Int64 => {
+                    let mut builder =
+                        arrow_array::builder::Int64Builder::with_capacity(binary_array.len());
+                    for i in 0..binary_array.len() {
+                        if binary_array.is_null(i) {
+                            builder.append_null();
+                        } else if let Some(bytes) = binary_array.value(i).into() {
+                            let raw_jsonb = jsonb::RawJsonb::new(bytes);
+                            // Try to deserialize directly to i64
+                            match jsonb::from_raw_jsonb::<i64>(&raw_jsonb) {
+                                Ok(int_val) => builder.append_value(int_val),
+                                Err(e) => {
+                                    return Err(Error::InvalidInput {
+                                        source: format!(
+                                            "Failed to deserialize JSONB to i64 at index {}: {}",
+                                            i, e
+                                        )
+                                        .into(),
+                                        location: location!(),
+                                    });
+                                }
+                            }
+                        } else {
+                            builder.append_null();
+                        }
+                    }
+                    Arc::new(builder.finish())
+                }
+                DataType::Float64 => {
+                    let mut builder =
+                        arrow_array::builder::Float64Builder::with_capacity(binary_array.len());
+                    for i in 0..binary_array.len() {
+                        if binary_array.is_null(i) {
+                            builder.append_null();
+                        } else if let Some(bytes) = binary_array.value(i).into() {
+                            let raw_jsonb = jsonb::RawJsonb::new(bytes);
+                            // Try to deserialize directly to f64 (serde handles int->float conversion)
+                            match jsonb::from_raw_jsonb::<f64>(&raw_jsonb) {
+                                Ok(float_val) => builder.append_value(float_val),
+                                Err(e) => {
+                                    return Err(Error::InvalidInput {
+                                        source: format!(
+                                            "Failed to deserialize JSONB to f64 at index {}: {}",
+                                            i, e
+                                        )
+                                        .into(),
+                                        location: location!(),
+                                    });
+                                }
+                            }
+                        } else {
+                            builder.append_null();
+                        }
+                    }
+                    Arc::new(builder.finish())
+                }
+                DataType::Utf8 => {
+                    let mut builder = arrow_array::builder::StringBuilder::with_capacity(
+                        binary_array.len(),
+                        1024,
+                    );
+                    for i in 0..binary_array.len() {
+                        if binary_array.is_null(i) {
+                            builder.append_null();
+                        } else if let Some(bytes) = binary_array.value(i).into() {
+                            let raw_jsonb = jsonb::RawJsonb::new(bytes);
+                            // Try to deserialize to String, or use to_string() for any type
+                            match jsonb::from_raw_jsonb::<String>(&raw_jsonb) {
+                                Ok(str_val) => builder.append_value(&str_val),
+                                Err(_) => {
+                                    // For non-string types, convert to string representation
+                                    builder.append_value(raw_jsonb.to_string());
+                                }
+                            }
+                        } else {
+                            builder.append_null();
+                        }
+                    }
+                    Arc::new(builder.finish())
+                }
+                DataType::LargeBinary => {
+                    // Keep as binary for array/object types
+                    value_array.clone()
+                }
+                _ => {
+                    return Err(Error::InvalidInput {
+                        source: format!("Unsupported target type: {:?}", target_type).into(),
+                        location: location!(),
+                    });
+                }
+            };
+
+            // Get row_id column
+            let row_id_column = batch
+                .column_by_name(ROW_ID)
+                .ok_or_else(|| Error::InvalidInput {
+                    source: "Missing row_id column".into(),
+                    location: location!(),
+                })?
+                .clone();
+
+            // Create new batch with converted values
+            let new_schema = Arc::new(Schema::new(vec![
+                ArrowField::new(VALUE_COLUMN_NAME, target_type.clone(), true),
+                ArrowField::new(ROW_ID, DataType::UInt64, false),
+            ]));
+
+            let new_batch =
+                RecordBatch::try_new(new_schema.clone(), vec![converted_array, row_id_column])?;
+
+            converted_batches.push(new_batch);
+        }
+
+        // Create stream from converted batches
+        let schema = converted_batches
+            .first()
+            .map(|b| b.schema())
+            .ok_or_else(|| Error::InvalidInput {
+                source: "No batches to convert".into(),
+                location: location!(),
+            })?;
+
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::iter(converted_batches.into_iter().map(Ok)),
+        )))
     }
 }
 
@@ -412,8 +700,7 @@ impl ScalarIndexPlugin for JsonIndexPlugin {
             });
         }
 
-        // TODO: How do we determine the target type?
-        // TODO: How do we extract to a specific type?  Maybe try_cast?
+        // Initially use Utf8, will be refined during training with type inference
         let target_type = DataType::Utf8;
 
         let params = serde_json::from_str::<JsonIndexParameters>(params)?;
@@ -470,11 +757,31 @@ impl ScalarIndexPlugin for JsonIndexPlugin {
             .downcast::<JsonTrainingRequest>()
             .unwrap();
         let path = request.parameters.path.clone();
+
+        // Extract JSON with type information
+        let (data_stream, inferred_type) =
+            Self::extract_json_with_type_info(data, path.clone()).await?;
+
+        // Convert the stream to properly typed values based on inferred type
+        let converted_stream =
+            Self::convert_stream_by_type(data_stream, inferred_type.clone()).await?;
+
+        // Update the target request with inferred type
         let registry = self.registry()?;
         let target_plugin = registry.get_plugin_by_name(&request.parameters.target_index_type)?;
-        let data = Self::extract_json(data, path.clone())?;
+
+        // Create a new training request with the inferred type
+        let target_request = target_plugin.new_training_request(
+            request
+                .parameters
+                .target_index_parameters
+                .as_deref()
+                .unwrap_or("{}"),
+            &Field::new("", inferred_type, true),
+        )?;
+
         let target_index = target_plugin
-            .train_index(data, index_store, request.target_request)
+            .train_index(converted_stream, index_store, target_request)
             .await?;
 
         let index_details = crate::pb::JsonIndexDetails {
@@ -502,5 +809,151 @@ impl ScalarIndexPlugin for JsonIndexPlugin {
             .load_index(index_store, target_details, frag_reuse_index, cache)
             .await?;
         Ok(Arc::new(JsonIndex::new(target_index, json_details.path)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{ArrayRef, RecordBatch};
+    use arrow_schema::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    // Note: The old test_detect_json_value_type test has been removed as we now use
+    // JSONB's inherent type information instead of string-based type detection
+
+    #[tokio::test]
+    async fn test_json_extract_with_type_info() {
+        use arrow_array::{LargeBinaryArray, UInt64Array};
+        use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+        use futures::stream;
+
+        // Create test JSONB data
+        let json_data = vec![
+            r#"{"name": "Alice", "age": 30, "active": true}"#,
+            r#"{"name": "Bob", "age": 25, "active": false}"#,
+            r#"{"name": "Charlie", "age": 35, "active": true}"#,
+        ];
+
+        // Convert JSON strings to JSONB binary format
+        let mut jsonb_values = Vec::new();
+        for json_str in &json_data {
+            let owned_jsonb: jsonb::OwnedJsonb = json_str.parse().unwrap();
+            jsonb_values.push(Some(owned_jsonb.to_vec()));
+        }
+
+        // Create test batch with JSONB data
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(VALUE_COLUMN_NAME, DataType::LargeBinary, true),
+            Field::new(ROW_ID, DataType::UInt64, false),
+        ]));
+
+        let jsonb_array = LargeBinaryArray::from(
+            jsonb_values
+                .iter()
+                .map(|v| v.as_deref())
+                .collect::<Vec<_>>(),
+        );
+        let row_ids = UInt64Array::from(vec![1, 2, 3]);
+
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(jsonb_array) as ArrayRef,
+                Arc::new(row_ids) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            stream::iter(vec![Ok(batch)]),
+        )) as SendableRecordBatchStream;
+
+        // Test type inference for integer field
+        let (_result_stream, inferred_type) =
+            JsonIndexPlugin::extract_json_with_type_info(stream, "$.age".to_string())
+                .await
+                .unwrap();
+
+        assert_eq!(inferred_type, DataType::Int64);
+
+        // Create new test stream for boolean field
+        let batch2 = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(LargeBinaryArray::from(vec![
+                    json_data[0]
+                        .parse::<jsonb::OwnedJsonb>()
+                        .ok()
+                        .map(|j| j.to_vec())
+                        .as_deref(),
+                    json_data[1]
+                        .parse::<jsonb::OwnedJsonb>()
+                        .ok()
+                        .map(|j| j.to_vec())
+                        .as_deref(),
+                    json_data[2]
+                        .parse::<jsonb::OwnedJsonb>()
+                        .ok()
+                        .map(|j| j.to_vec())
+                        .as_deref(),
+                ])) as ArrayRef,
+                Arc::new(UInt64Array::from(vec![1, 2, 3])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        let stream2 = Box::pin(RecordBatchStreamAdapter::new(
+            schema.clone(),
+            stream::iter(vec![Ok(batch2)]),
+        )) as SendableRecordBatchStream;
+
+        // Test type inference for boolean field
+        let (_, inferred_type) =
+            JsonIndexPlugin::extract_json_with_type_info(stream2, "$.active".to_string())
+                .await
+                .unwrap();
+
+        assert_eq!(inferred_type, DataType::Boolean);
+
+        // Create test stream for string field
+        let batch3 = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(LargeBinaryArray::from(vec![
+                    json_data[0]
+                        .parse::<jsonb::OwnedJsonb>()
+                        .ok()
+                        .map(|j| j.to_vec())
+                        .as_deref(),
+                    json_data[1]
+                        .parse::<jsonb::OwnedJsonb>()
+                        .ok()
+                        .map(|j| j.to_vec())
+                        .as_deref(),
+                    json_data[2]
+                        .parse::<jsonb::OwnedJsonb>()
+                        .ok()
+                        .map(|j| j.to_vec())
+                        .as_deref(),
+                ])) as ArrayRef,
+                Arc::new(UInt64Array::from(vec![1, 2, 3])) as ArrayRef,
+            ],
+        )
+        .unwrap();
+
+        let stream3 = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::iter(vec![Ok(batch3)]),
+        )) as SendableRecordBatchStream;
+
+        // Test type inference for string field
+        let (_, inferred_type) =
+            JsonIndexPlugin::extract_json_with_type_info(stream3, "$.name".to_string())
+                .await
+                .unwrap();
+
+        assert_eq!(inferred_type, DataType::Utf8);
     }
 }


### PR DESCRIPTION
This PR will fix https://github.com/lancedb/lance/issues/4625

To make the best use of the JSONB format, I added a new UDF that extracts JSONB as its raw value along with its type tag. This way, there's no need to first convert the JSONB value to a JSON string and then back to the desired type.

---

**This PR was primarily authored with Claude Code using Opus 4.1 and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**