### PR TITLE
Java module can specify Lance file version, the same as Python API (#4558)

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -268,6 +268,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiSchema<'local
     max_bytes_per_file: JObject,    // Optional<Long>
     mode: JObject,                  // Optional<String>
     enable_stable_row_ids: JObject, // Optional<Boolean>
+    data_storage_version: JObject,  // Optional<String>
     storage_options_obj: JObject,   // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw!(
@@ -281,6 +282,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiSchema<'local
             max_bytes_per_file,
             mode,
             enable_stable_row_ids,
+            data_storage_version,
             storage_options_obj
         )
     )
@@ -296,6 +298,7 @@ fn inner_create_with_ffi_schema<'local>(
     max_bytes_per_file: JObject,    // Optional<Long>
     mode: JObject,                  // Optional<String>
     enable_stable_row_ids: JObject, // Optional<Boolean>
+    data_storage_version: JObject,  // Optional<String>
     storage_options_obj: JObject,   // Map<String, String>
 ) -> Result<JObject<'local>> {
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
@@ -311,6 +314,7 @@ fn inner_create_with_ffi_schema<'local>(
         max_bytes_per_file,
         mode,
         enable_stable_row_ids,
+        data_storage_version,
         storage_options_obj,
         reader,
     )
@@ -341,6 +345,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiStream<'local
     max_bytes_per_file: JObject,    // Optional<Long>
     mode: JObject,                  // Optional<String>
     enable_stable_row_ids: JObject, // Optional<Boolean>
+    data_storage_version: JObject,  // Optional<String>
     storage_options_obj: JObject,   // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw!(
@@ -354,6 +359,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiStream<'local
             max_bytes_per_file,
             mode,
             enable_stable_row_ids,
+            data_storage_version,
             storage_options_obj
         )
     )
@@ -369,6 +375,7 @@ fn inner_create_with_ffi_stream<'local>(
     max_bytes_per_file: JObject,    // Optional<Long>
     mode: JObject,                  // Optional<String>
     enable_stable_row_ids: JObject, // Optional<Boolean>
+    data_storage_version: JObject,  // Optional<String>
     storage_options_obj: JObject,   // Map<String, String>
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
@@ -381,6 +388,7 @@ fn inner_create_with_ffi_stream<'local>(
         max_bytes_per_file,
         mode,
         enable_stable_row_ids,
+        data_storage_version,
         storage_options_obj,
         reader,
     )
@@ -395,6 +403,7 @@ fn create_dataset<'local>(
     max_bytes_per_file: JObject,
     mode: JObject,
     enable_stable_row_ids: JObject,
+    data_storage_version: JObject,
     storage_options_obj: JObject,
     reader: impl RecordBatchReader + Send + 'static,
 ) -> Result<JObject<'local>> {
@@ -407,6 +416,7 @@ fn create_dataset<'local>(
         &max_bytes_per_file,
         &mode,
         &enable_stable_row_ids,
+        &data_storage_version,
         &storage_options_obj,
     )?;
 

--- a/java/lance-jni/src/file_writer.rs
+++ b/java/lance-jni/src/file_writer.rs
@@ -7,6 +7,7 @@ use crate::utils::to_rust_map;
 use crate::{
     error::{Error, Result},
     traits::IntoJava,
+    JNIEnvExt,
     RT,
 };
 use arrow::{
@@ -67,18 +68,21 @@ pub extern "system" fn Java_com_lancedb_lance_file_LanceFileWriter_openNative<'l
     mut env: JNIEnv<'local>,
     _writer_class: JObject,
     file_uri: JString,
+    data_storage_version: JObject, // Optional<String>
     storage_options_obj: JObject, // Map<String, String>
 ) -> JObject<'local> {
-    ok_or_throw!(env, inner_open(&mut env, file_uri, storage_options_obj))
+    ok_or_throw!(env, inner_open(&mut env, file_uri, data_storage_version, storage_options_obj))
 }
 
 fn inner_open<'local>(
     env: &mut JNIEnv<'local>,
     file_uri: JString,
+    data_storage_version: JObject,
     storage_options_obj: JObject,
 ) -> Result<JObject<'local>> {
     let file_uri_str: String = env.get_string(&file_uri)?.into();
     let jmap = JMap::from_env(env, &storage_options_obj)?;
+    let data_storage_version_opt = env.get_string_opt(&data_storage_version)?;
     let storage_options = to_rust_map(env, &jmap)?;
 
     let writer = RT.block_on(async move {
@@ -98,7 +102,9 @@ fn inner_open<'local>(
         Result::Ok(FileWriter::new_lazy(
             obj_writer,
             FileWriterOptions {
-                format_version: Some(LanceFileVersion::Stable),
+                format_version: data_storage_version_opt
+                    .map(|v| v.parse::<LanceFileVersion>())
+                    .transpose()?,
                 ..Default::default()
             },
         ))

--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -87,6 +87,7 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiArray<'local
     max_bytes_per_file: JObject,    // Optional<Long>
     mode: JObject,                  // Optional<String>
     enable_stable_row_ids: JObject, // Optional<Boolean>
+    data_storage_version: JObject,  // Optional<String>
     storage_options_obj: JObject,   // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw_with_return!(
@@ -101,6 +102,7 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiArray<'local
             max_bytes_per_file,
             mode,
             enable_stable_row_ids,
+            data_storage_version,
             storage_options_obj
         ),
         JObject::default()
@@ -118,6 +120,7 @@ fn inner_create_with_ffi_array<'local>(
     max_bytes_per_file: JObject,    // Optional<Long>
     mode: JObject,                  // Optional<String>
     enable_stable_row_ids: JObject, // Optional<Boolean>
+    data_storage_version: JObject,  // Optional<String>
     storage_options_obj: JObject,   // Map<String, String>
 ) -> Result<JObject<'local>> {
     let c_array_ptr = arrow_array_addr as *mut FFI_ArrowArray;
@@ -141,6 +144,7 @@ fn inner_create_with_ffi_array<'local>(
         max_bytes_per_file,
         mode,
         enable_stable_row_ids,
+        data_storage_version,
         storage_options_obj,
         reader,
     )
@@ -157,6 +161,7 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiStream<'a>(
     max_bytes_per_file: JObject,    // Optional<Long>
     mode: JObject,                  // Optional<String>
     enable_stable_row_ids: JObject, // Optional<Boolean>
+    data_storage_version: JObject,  // Optional<String>
     storage_options_obj: JObject,   // Map<String, String>
 ) -> JObject<'a> {
     ok_or_throw_with_return!(
@@ -170,6 +175,7 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiStream<'a>(
             max_bytes_per_file,
             mode,
             enable_stable_row_ids,
+            data_storage_version,
             storage_options_obj
         ),
         JObject::null()
@@ -186,6 +192,7 @@ fn inner_create_with_ffi_stream<'local>(
     max_bytes_per_file: JObject,    // Optional<Long>
     mode: JObject,                  // Optional<String>
     enable_stable_row_ids: JObject, // Optional<Boolean>
+    data_storage_version: JObject,  // Optional<String>
     storage_options_obj: JObject,   // Map<String, String>
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
@@ -199,6 +206,7 @@ fn inner_create_with_ffi_stream<'local>(
         max_bytes_per_file,
         mode,
         enable_stable_row_ids,
+        data_storage_version,
         storage_options_obj,
         reader,
     )
@@ -213,6 +221,7 @@ fn create_fragment<'a>(
     max_bytes_per_file: JObject,    // Optional<Long>
     mode: JObject,                  // Optional<String>
     enable_stable_row_ids: JObject, // Optional<Boolean>
+    data_storage_version: JObject,  // Optional<String>
     storage_options_obj: JObject,   // Map<String, String>
     source: impl StreamingWriteSource,
 ) -> Result<JObject<'a>> {
@@ -225,6 +234,7 @@ fn create_fragment<'a>(
         &max_bytes_per_file,
         &mode,
         &enable_stable_row_ids,
+        &data_storage_version,
         &storage_options_obj,
     )?;
     let fragments = RT.block_on(FileFragment::create_fragments(

--- a/java/lance-jni/src/utils.rs
+++ b/java/lance-jni/src/utils.rs
@@ -24,6 +24,7 @@ use crate::ffi::JNIEnvExt;
 
 use lance_index::vector::Query;
 use std::collections::HashMap;
+use std::str::FromStr;
 
 pub fn extract_storage_options(
     env: &mut JNIEnv,
@@ -41,6 +42,7 @@ pub fn extract_write_params(
     max_bytes_per_file: &JObject,
     mode: &JObject,
     enable_stable_row_ids: &JObject,
+    data_storage_version: &JObject,
     storage_options_obj: &JObject,
 ) -> Result<WriteParams> {
     let mut write_params = WriteParams::default();
@@ -60,8 +62,10 @@ pub fn extract_write_params(
     if let Some(enable_stable_row_ids_val) = env.get_boolean_opt(enable_stable_row_ids)? {
         write_params.enable_stable_row_ids = enable_stable_row_ids_val;
     }
-    // Java code always sets the data storage version to stable for now
-    write_params.data_storage_version = Some(LanceFileVersion::Stable);
+    if let Some(data_storage_version_val) = env.get_string_opt(data_storage_version)? {
+        write_params.data_storage_version =
+            Some(LanceFileVersion::from_str(data_storage_version_val.as_str())?);
+    }
     let storage_options: HashMap<String, String> =
         extract_storage_options(env, storage_options_obj)?;
 

--- a/java/src/main/java/com/lancedb/lance/Dataset.java
+++ b/java/src/main/java/com/lancedb/lance/Dataset.java
@@ -97,6 +97,7 @@ public class Dataset implements Closeable {
               params.getMaxBytesPerFile(),
               params.getMode(),
               params.getEnableStableRowIds(),
+              params.getDataStorageVersion(),
               params.getStorageOptions());
       dataset.allocator = allocator;
       return dataset;
@@ -127,6 +128,7 @@ public class Dataset implements Closeable {
             params.getMaxBytesPerFile(),
             params.getMode(),
             params.getEnableStableRowIds(),
+            params.getDataStorageVersion(),
             params.getStorageOptions());
     dataset.allocator = allocator;
     return dataset;
@@ -140,6 +142,7 @@ public class Dataset implements Closeable {
       Optional<Long> maxBytesPerFile,
       Optional<String> mode,
       Optional<Boolean> enableStableRowIds,
+      Optional<String> dataStorageVersion,
       Map<String, String> storageOptions);
 
   private static native Dataset createWithFfiStream(
@@ -150,6 +153,7 @@ public class Dataset implements Closeable {
       Optional<Long> maxBytesPerFile,
       Optional<String> mode,
       Optional<Boolean> enableStableRowIds,
+      Optional<String> dataStorageVersion,
       Map<String, String> storageOptions);
 
   /**

--- a/java/src/main/java/com/lancedb/lance/Fragment.java
+++ b/java/src/main/java/com/lancedb/lance/Fragment.java
@@ -224,6 +224,7 @@ public class Fragment {
           params.getMaxBytesPerFile(),
           params.getMode(),
           params.getEnableStableRowIds(),
+          params.getDataStorageVersion(),
           params.getStorageOptions());
     }
   }
@@ -249,6 +250,7 @@ public class Fragment {
         params.getMaxBytesPerFile(),
         params.getMode(),
         params.getEnableStableRowIds(),
+        params.getDataStorageVersion(),
         params.getStorageOptions());
   }
 
@@ -266,6 +268,7 @@ public class Fragment {
       Optional<Long> maxBytesPerFile,
       Optional<String> mode,
       Optional<Boolean> enableStableRowIds,
+      Optional<String> dataStorageVersion,
       Map<String, String> storageOptions);
 
   /**
@@ -281,5 +284,6 @@ public class Fragment {
       Optional<Long> maxBytesPerFile,
       Optional<String> mode,
       Optional<Boolean> enableStableRowIds,
+      Optional<String> dataStorageVersion,
       Map<String, String> storageOptions);
 }

--- a/java/src/main/java/com/lancedb/lance/WriteParams.java
+++ b/java/src/main/java/com/lancedb/lance/WriteParams.java
@@ -29,11 +29,21 @@ public class WriteParams {
     OVERWRITE
   }
 
+  public enum LanceFileVersion {
+    LEGACY,
+    V2_0,
+    STABLE,
+    V2_1,
+    NEXT,
+    V2_2,
+  }
+
   private final Optional<Integer> maxRowsPerFile;
   private final Optional<Integer> maxRowsPerGroup;
   private final Optional<Long> maxBytesPerFile;
   private final Optional<WriteMode> mode;
   private final Optional<Boolean> enableStableRowIds;
+  private final Optional<LanceFileVersion> dataStorageVersion;
   private Map<String, String> storageOptions = new HashMap<>();
 
   private WriteParams(
@@ -42,12 +52,14 @@ public class WriteParams {
       Optional<Long> maxBytesPerFile,
       Optional<WriteMode> mode,
       Optional<Boolean> enableStableRowIds,
+      Optional<LanceFileVersion> dataStorageVersion,
       Map<String, String> storageOptions) {
     this.maxRowsPerFile = maxRowsPerFile;
     this.maxRowsPerGroup = maxRowsPerGroup;
     this.maxBytesPerFile = maxBytesPerFile;
     this.mode = mode;
     this.enableStableRowIds = enableStableRowIds;
+    this.dataStorageVersion = dataStorageVersion;
     this.storageOptions = storageOptions;
   }
 
@@ -76,6 +88,10 @@ public class WriteParams {
     return enableStableRowIds;
   }
 
+  public Optional<String> getDataStorageVersion() {
+    return dataStorageVersion.map(Enum::name);
+  }
+
   public Map<String, String> getStorageOptions() {
     return storageOptions;
   }
@@ -87,6 +103,7 @@ public class WriteParams {
         .add("maxRowsPerGroup", maxRowsPerGroup.orElse(null))
         .add("maxBytesPerFile", maxBytesPerFile.orElse(null))
         .add("mode", mode.orElse(null))
+        .add("dataStorageVersion", dataStorageVersion.orElse(null))
         .toString();
   }
 
@@ -97,6 +114,7 @@ public class WriteParams {
     private Optional<Long> maxBytesPerFile = Optional.empty();
     private Optional<WriteMode> mode = Optional.empty();
     private Optional<Boolean> enableStableRowIds = Optional.empty();
+    private Optional<LanceFileVersion> dataStorageVersion = Optional.empty();
     private Map<String, String> storageOptions = new HashMap<>();
 
     public Builder withMaxRowsPerFile(int maxRowsPerFile) {
@@ -119,6 +137,11 @@ public class WriteParams {
       return this;
     }
 
+    public Builder withDataStorageVersion(LanceFileVersion dataStorageVersion) {
+      this.dataStorageVersion = Optional.of(dataStorageVersion);
+      return this;
+    }
+
     public Builder withStorageOptions(Map<String, String> storageOptions) {
       this.storageOptions = storageOptions;
       return this;
@@ -136,6 +159,7 @@ public class WriteParams {
           maxBytesPerFile,
           mode,
           enableStableRowIds,
+          dataStorageVersion,
           storageOptions);
     }
   }

--- a/java/src/main/java/com/lancedb/lance/file/LanceFileWriter.java
+++ b/java/src/main/java/com/lancedb/lance/file/LanceFileWriter.java
@@ -14,6 +14,7 @@
 package com.lancedb.lance.file;
 
 import com.lancedb.lance.JniLoader;
+import com.lancedb.lance.WriteParams;
 
 import org.apache.arrow.c.ArrowArray;
 import org.apache.arrow.c.ArrowSchema;
@@ -25,6 +26,7 @@ import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 
 public class LanceFileWriter implements AutoCloseable {
 
@@ -37,7 +39,8 @@ public class LanceFileWriter implements AutoCloseable {
   private DictionaryProvider dictionaryProvider;
 
   private static native LanceFileWriter openNative(
-      String fileUri, Map<String, String> storageOptions) throws IOException;
+      String fileUri, Optional<String> dataStorageVersion, Map<String, String> storageOptions)
+      throws IOException;
 
   private native void closeNative(long nativeLanceFileReaderHandle) throws IOException;
 
@@ -75,7 +78,27 @@ public class LanceFileWriter implements AutoCloseable {
       DictionaryProvider dictionaryProvider,
       Map<String, String> storageOptions)
       throws IOException {
-    LanceFileWriter writer = openNative(path, storageOptions);
+    return open(path, allocator, dictionaryProvider, Optional.empty(), storageOptions);
+  }
+
+  /**
+   * Open a LanceFileWriter to write to a given file URI
+   *
+   * @param path the URI of the file to write to
+   * @param allocator the BufferAllocator to use for the writer
+   * @param dictionaryProvider the DictionaryProvider to use for the writer
+   * @param dataStorageVersion the version of the data storage format to use
+   * @return a new LanceFileWriter
+   */
+  public static LanceFileWriter open(
+      String path,
+      BufferAllocator allocator,
+      DictionaryProvider dictionaryProvider,
+      Optional<WriteParams.LanceFileVersion> dataStorageVersion,
+      Map<String, String> storageOptions)
+      throws IOException {
+    Optional<String> dataStorageVersionStr = dataStorageVersion.map(Enum::name);
+    LanceFileWriter writer = openNative(path, dataStorageVersionStr, storageOptions);
     writer.allocator = allocator;
     writer.dictionaryProvider = dictionaryProvider;
     return writer;


### PR DESCRIPTION
This commit enables the Java module to specify the `file version`, and both the `Dataset` API and direct use of `file_writer` can specify it.

However, some additional tests still need to be added.