### PR TITLE
feat: build Linux wheels with debug symbols for GitHub releases

### DIFF
--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -18,10 +18,6 @@ inputs:
     description: "The manylinux version to build for"
     required: false
     default: "2_17"
-  upload_debug_wheel:
-    description: "Upload debug wheels as artifacts"
-    required: false
-    default: "false"
 runs:
   using: "composite"
   steps:
@@ -77,24 +73,3 @@ runs:
             && curl -L https://github.com/protocolbuffers/protobuf/releases/download/v24.4/protoc-24.4-linux-aarch_64.zip > /tmp/protoc.zip \
             && unzip /tmp/protoc.zip -d /usr/local \
             && rm /tmp/protoc.zip
-    - name: Upload debug wheels as artifacts
-      if: ${{ inputs.upload_debug_wheel == 'true' }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: debug-wheels-linux-${{ inputs.manylinux }}-${{ inputs.arm-build == 'true' && 'arm64' || 'x86_64' }}
-        path: python/target/wheels/*.whl
-        retention-days: 90
-    - name: Upload debug wheels to release
-      if: ${{ inputs.upload_debug_wheel == 'true' && github.event_name == 'release' }}
-      uses: softprops/action-gh-release@v1
-      with:
-        files: python/target/wheels/*.whl
-        fail_on_unmatched_files: false
-    - name: Strip wheels for PyPI
-      if: ${{ inputs.upload_debug_wheel == 'true' }}
-      shell: bash
-      run: |
-        # Fix permissions on wheel files created in container
-        sudo chown -R $(id -u):$(id -g) python/target/wheels/
-        chmod +x ci/strip_wheel.sh
-        ci/strip_wheel.sh python/target/wheels/*.whl

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -73,7 +73,26 @@ jobs:
         args: "--release ${{ matrix.config.extra_args }}"
         arm-build: ${{ matrix.config.platform == 'aarch64' }}
         manylinux: ${{ matrix.config.manylinux }}
-        upload_debug_wheel: "true"
+    - name: Upload debug wheels to release
+      if: github.event_name == 'release'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: python/target/wheels/*.whl
+        fail_on_unmatched_files: false
+    - name: Upload debug wheels as artifacts
+      if: github.event_name != 'release'
+      uses: actions/upload-artifact@v4
+      with:
+        name: debug-wheels-linux-${{ matrix.config.manylinux }}-${{ matrix.config.platform }}
+        path: python/target/wheels/*.whl
+        retention-days: 90
+    - name: Strip wheels for PyPI
+      shell: bash
+      run: |
+        # Fix permissions on wheel files created in container
+        sudo chown -R $(id -u):$(id -g) python/target/wheels/
+        chmod +x ci/strip_wheel.sh
+        ci/strip_wheel.sh python/target/wheels/*.whl
     - uses: ./.github/workflows/upload_wheel
       if: github.event_name == 'release'
       with:


### PR DESCRIPTION
Build wheels with debug symbols and upload them as GitHub artifacts and release assets, while stripping symbols before PyPI upload. This provides debug wheels for troubleshooting without increasing PyPI package size.

## Changes
- Remove `--strip` flag from Linux wheel builds
- Add script to strip debug symbols from wheels post-build
- Upload debug wheels as GitHub artifacts (90 day retention)
- Attach debug wheels to GitHub releases
- Strip wheels before uploading to PyPI


🤖 Generated with [Claude Code](https://claude.ai/code)