### PR TITLE
fix: typo in optimize.pyi

### DIFF
--- a/python/python/lance/lance/optimize.pyi
+++ b/python/python/lance/lance/optimize.pyi
@@ -27,7 +27,7 @@ class CompactionMetrics:
 class RewriteResult:
     read_version: int
     metrics: CompactionMetrics
-    old_fragments: List["FragmentMetadata"]
+    original_fragments: List["FragmentMetadata"]
     new_fragments: List["FragmentMetadata"]
 
 class CompactionTask:


### PR DESCRIPTION
See https://github.com/lancedb/lance/blob/16bfffcde1d6a78af63d8e86b272423769cbf7c3/python/src/dataset/optimize.rs#L362