### PR TITLE
chore: add buf.yaml

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,4 @@
+version: v2
+modules:
+  - path: protos
+    name: buf.build/lancedb/lance


### PR DESCRIPTION
Add a buf.yaml config to publish to Buf Schema Registry(BSR).