### PR TITLE
feat(java): extends WriteParams in java with `enable_stable_row_ids` option

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -271,11 +271,12 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiSchema<'local
     _obj: JObject,
     arrow_schema_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,   // Optional<Integer>
-    max_rows_per_group: JObject,  // Optional<Integer>
-    max_bytes_per_file: JObject,  // Optional<Long>
-    mode: JObject,                // Optional<String>
-    storage_options_obj: JObject, // Map<String, String>
+    max_rows_per_file: JObject,        // Optional<Integer>
+    max_rows_per_group: JObject,       // Optional<Integer>
+    max_bytes_per_file: JObject,       // Optional<Long>
+    mode: JObject,                     // Optional<String>
+    enable_move_stable_rowid: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,      // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -287,6 +288,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiSchema<'local
             max_rows_per_group,
             max_bytes_per_file,
             mode,
+            enable_move_stable_rowid,
             storage_options_obj
         )
     )
@@ -297,11 +299,12 @@ fn inner_create_with_ffi_schema<'local>(
     env: &mut JNIEnv<'local>,
     arrow_schema_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,   // Optional<Integer>
-    max_rows_per_group: JObject,  // Optional<Integer>
-    max_bytes_per_file: JObject,  // Optional<Long>
-    mode: JObject,                // Optional<String>
-    storage_options_obj: JObject, // Map<String, String>
+    max_rows_per_file: JObject,        // Optional<Integer>
+    max_rows_per_group: JObject,       // Optional<Integer>
+    max_bytes_per_file: JObject,       // Optional<Long>
+    mode: JObject,                     // Optional<String>
+    enable_move_stable_rowid: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,      // Map<String, String>
 ) -> Result<JObject<'local>> {
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
     let c_schema = unsafe { FFI_ArrowSchema::from_raw(c_schema_ptr) };
@@ -315,6 +318,7 @@ fn inner_create_with_ffi_schema<'local>(
         max_rows_per_group,
         max_bytes_per_file,
         mode,
+        enable_move_stable_rowid,
         storage_options_obj,
         reader,
     )
@@ -340,11 +344,12 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiStream<'local
     _obj: JObject,
     arrow_array_stream_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,   // Optional<Integer>
-    max_rows_per_group: JObject,  // Optional<Integer>
-    max_bytes_per_file: JObject,  // Optional<Long>
-    mode: JObject,                // Optional<String>
-    storage_options_obj: JObject, // Map<String, String>
+    max_rows_per_file: JObject,        // Optional<Integer>
+    max_rows_per_group: JObject,       // Optional<Integer>
+    max_bytes_per_file: JObject,       // Optional<Long>
+    mode: JObject,                     // Optional<String>
+    enable_move_stable_rowid: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,      // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -356,6 +361,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiStream<'local
             max_rows_per_group,
             max_bytes_per_file,
             mode,
+            enable_move_stable_rowid,
             storage_options_obj
         )
     )
@@ -366,11 +372,12 @@ fn inner_create_with_ffi_stream<'local>(
     env: &mut JNIEnv<'local>,
     arrow_array_stream_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,   // Optional<Integer>
-    max_rows_per_group: JObject,  // Optional<Integer>
-    max_bytes_per_file: JObject,  // Optional<Long>
-    mode: JObject,                // Optional<String>
-    storage_options_obj: JObject, // Map<String, String>
+    max_rows_per_file: JObject,        // Optional<Integer>
+    max_rows_per_group: JObject,       // Optional<Integer>
+    max_bytes_per_file: JObject,       // Optional<Long>
+    mode: JObject,                     // Optional<String>
+    enable_move_stable_rowid: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,      // Map<String, String>
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
@@ -381,6 +388,7 @@ fn inner_create_with_ffi_stream<'local>(
         max_rows_per_group,
         max_bytes_per_file,
         mode,
+        enable_move_stable_rowid,
         storage_options_obj,
         reader,
     )
@@ -394,6 +402,7 @@ fn create_dataset<'local>(
     max_rows_per_group: JObject,
     max_bytes_per_file: JObject,
     mode: JObject,
+    enable_move_stable_rowid: JObject,
     storage_options_obj: JObject,
     reader: impl RecordBatchReader + Send + 'static,
 ) -> Result<JObject<'local>> {
@@ -405,6 +414,7 @@ fn create_dataset<'local>(
         &max_rows_per_group,
         &max_bytes_per_file,
         &mode,
+        &enable_move_stable_rowid,
         &storage_options_obj,
     )?;
 

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -271,12 +271,12 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiSchema<'local
     _obj: JObject,
     arrow_schema_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,        // Optional<Integer>
-    max_rows_per_group: JObject,       // Optional<Integer>
-    max_bytes_per_file: JObject,       // Optional<Long>
-    mode: JObject,                     // Optional<String>
-    enable_move_stable_rowid: JObject, // Optional<Boolean>
-    storage_options_obj: JObject,      // Map<String, String>
+    max_rows_per_file: JObject,     // Optional<Integer>
+    max_rows_per_group: JObject,    // Optional<Integer>
+    max_bytes_per_file: JObject,    // Optional<Long>
+    mode: JObject,                  // Optional<String>
+    enable_stable_row_ids: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,   // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -288,7 +288,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiSchema<'local
             max_rows_per_group,
             max_bytes_per_file,
             mode,
-            enable_move_stable_rowid,
+            enable_stable_row_ids,
             storage_options_obj
         )
     )
@@ -299,12 +299,12 @@ fn inner_create_with_ffi_schema<'local>(
     env: &mut JNIEnv<'local>,
     arrow_schema_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,        // Optional<Integer>
-    max_rows_per_group: JObject,       // Optional<Integer>
-    max_bytes_per_file: JObject,       // Optional<Long>
-    mode: JObject,                     // Optional<String>
-    enable_move_stable_rowid: JObject, // Optional<Boolean>
-    storage_options_obj: JObject,      // Map<String, String>
+    max_rows_per_file: JObject,     // Optional<Integer>
+    max_rows_per_group: JObject,    // Optional<Integer>
+    max_bytes_per_file: JObject,    // Optional<Long>
+    mode: JObject,                  // Optional<String>
+    enable_stable_row_ids: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,   // Map<String, String>
 ) -> Result<JObject<'local>> {
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
     let c_schema = unsafe { FFI_ArrowSchema::from_raw(c_schema_ptr) };
@@ -318,7 +318,7 @@ fn inner_create_with_ffi_schema<'local>(
         max_rows_per_group,
         max_bytes_per_file,
         mode,
-        enable_move_stable_rowid,
+        enable_stable_row_ids,
         storage_options_obj,
         reader,
     )
@@ -344,12 +344,12 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiStream<'local
     _obj: JObject,
     arrow_array_stream_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,        // Optional<Integer>
-    max_rows_per_group: JObject,       // Optional<Integer>
-    max_bytes_per_file: JObject,       // Optional<Long>
-    mode: JObject,                     // Optional<String>
-    enable_move_stable_rowid: JObject, // Optional<Boolean>
-    storage_options_obj: JObject,      // Map<String, String>
+    max_rows_per_file: JObject,     // Optional<Integer>
+    max_rows_per_group: JObject,    // Optional<Integer>
+    max_bytes_per_file: JObject,    // Optional<Long>
+    mode: JObject,                  // Optional<String>
+    enable_stable_row_ids: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,   // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -361,7 +361,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_createWithFfiStream<'local
             max_rows_per_group,
             max_bytes_per_file,
             mode,
-            enable_move_stable_rowid,
+            enable_stable_row_ids,
             storage_options_obj
         )
     )
@@ -372,12 +372,12 @@ fn inner_create_with_ffi_stream<'local>(
     env: &mut JNIEnv<'local>,
     arrow_array_stream_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,        // Optional<Integer>
-    max_rows_per_group: JObject,       // Optional<Integer>
-    max_bytes_per_file: JObject,       // Optional<Long>
-    mode: JObject,                     // Optional<String>
-    enable_move_stable_rowid: JObject, // Optional<Boolean>
-    storage_options_obj: JObject,      // Map<String, String>
+    max_rows_per_file: JObject,     // Optional<Integer>
+    max_rows_per_group: JObject,    // Optional<Integer>
+    max_bytes_per_file: JObject,    // Optional<Long>
+    mode: JObject,                  // Optional<String>
+    enable_stable_row_ids: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,   // Map<String, String>
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
@@ -388,7 +388,7 @@ fn inner_create_with_ffi_stream<'local>(
         max_rows_per_group,
         max_bytes_per_file,
         mode,
-        enable_move_stable_rowid,
+        enable_stable_row_ids,
         storage_options_obj,
         reader,
     )
@@ -402,7 +402,7 @@ fn create_dataset<'local>(
     max_rows_per_group: JObject,
     max_bytes_per_file: JObject,
     mode: JObject,
-    enable_move_stable_rowid: JObject,
+    enable_stable_row_ids: JObject,
     storage_options_obj: JObject,
     reader: impl RecordBatchReader + Send + 'static,
 ) -> Result<JObject<'local>> {
@@ -414,7 +414,7 @@ fn create_dataset<'local>(
         &max_rows_per_group,
         &max_bytes_per_file,
         &mode,
-        &enable_move_stable_rowid,
+        &enable_stable_row_ids,
         &storage_options_obj,
     )?;
 

--- a/java/lance-jni/src/ffi.rs
+++ b/java/lance-jni/src/ffi.rs
@@ -53,6 +53,9 @@ pub trait JNIEnvExt {
     /// Get Option<u64> from Java Optional<Long>.
     fn get_u64_opt(&mut self, obj: &JObject) -> Result<Option<u64>>;
 
+    /// Get Option<bool> from Java Optional<Boolean>.
+    fn get_boolean_opt(&mut self, obj: &JObject) -> Result<Option<bool>>;
+
     /// Get Option<&[u8]> from Java Optional<ByteBuffer>.
     fn get_bytes_opt(&mut self, obj: &JObject) -> Result<Option<&[u8]>>;
 
@@ -197,6 +200,16 @@ impl JNIEnvExt for JNIEnv<'_> {
             let long_obj = env.call_method(java_long_obj, "longValue", "()J", &[])?;
             let long_value = long_obj.j()?;
             Ok(long_value)
+        })
+    }
+
+    fn get_boolean_opt(&mut self, obj: &JObject) -> Result<Option<bool>> {
+        self.get_optional(obj, |env, inner_obj| {
+            let java_obj_gen = env.call_method(inner_obj, "get", "()Ljava/lang/Object;", &[])?;
+            let java_boolean_obj = java_obj_gen.l()?;
+            let boolean_obj = env.call_method(java_boolean_obj, "booleanValue", "()Z", &[])?;
+            let boolean_value = boolean_obj.z()?;
+            Ok(boolean_value)
         })
     }
 

--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -76,12 +76,12 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiArray<'local
     dataset_uri: JString,
     arrow_array_addr: jlong,
     arrow_schema_addr: jlong,
-    max_rows_per_file: JObject,        // Optional<Integer>
-    max_rows_per_group: JObject,       // Optional<Integer>
-    max_bytes_per_file: JObject,       // Optional<Long>
-    mode: JObject,                     // Optional<String>
-    enable_move_stable_rowid: JObject, // Optional<Boolean>
-    storage_options_obj: JObject,      // Map<String, String>
+    max_rows_per_file: JObject,     // Optional<Integer>
+    max_rows_per_group: JObject,    // Optional<Integer>
+    max_bytes_per_file: JObject,    // Optional<Long>
+    mode: JObject,                  // Optional<String>
+    enable_stable_row_ids: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,   // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw_with_return!(
         env,
@@ -94,7 +94,7 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiArray<'local
             max_rows_per_group,
             max_bytes_per_file,
             mode,
-            enable_move_stable_rowid,
+            enable_stable_row_ids,
             storage_options_obj
         ),
         JObject::default()
@@ -107,12 +107,12 @@ fn inner_create_with_ffi_array<'local>(
     dataset_uri: JString,
     arrow_array_addr: jlong,
     arrow_schema_addr: jlong,
-    max_rows_per_file: JObject,        // Optional<Integer>
-    max_rows_per_group: JObject,       // Optional<Integer>
-    max_bytes_per_file: JObject,       // Optional<Long>
-    mode: JObject,                     // Optional<String>
-    enable_move_stable_rowid: JObject, // Optional<Boolean>
-    storage_options_obj: JObject,      // Map<String, String>
+    max_rows_per_file: JObject,     // Optional<Integer>
+    max_rows_per_group: JObject,    // Optional<Integer>
+    max_bytes_per_file: JObject,    // Optional<Long>
+    mode: JObject,                  // Optional<String>
+    enable_stable_row_ids: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,   // Map<String, String>
 ) -> Result<JObject<'local>> {
     let c_array_ptr = arrow_array_addr as *mut FFI_ArrowArray;
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
@@ -134,7 +134,7 @@ fn inner_create_with_ffi_array<'local>(
         max_rows_per_group,
         max_bytes_per_file,
         mode,
-        enable_move_stable_rowid,
+        enable_stable_row_ids,
         storage_options_obj,
         reader,
     )
@@ -146,12 +146,12 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiStream<'a>(
     _obj: JObject,
     dataset_uri: JString,
     arrow_array_stream_addr: jlong,
-    max_rows_per_file: JObject,        // Optional<Integer>
-    max_rows_per_group: JObject,       // Optional<Integer>
-    max_bytes_per_file: JObject,       // Optional<Long>
-    mode: JObject,                     // Optional<String>
-    enable_move_stable_rowid: JObject, // Optional<Boolean>
-    storage_options_obj: JObject,      // Map<String, String>
+    max_rows_per_file: JObject,     // Optional<Integer>
+    max_rows_per_group: JObject,    // Optional<Integer>
+    max_bytes_per_file: JObject,    // Optional<Long>
+    mode: JObject,                  // Optional<String>
+    enable_stable_row_ids: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,   // Map<String, String>
 ) -> JObject<'a> {
     ok_or_throw_with_return!(
         env,
@@ -163,7 +163,7 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiStream<'a>(
             max_rows_per_group,
             max_bytes_per_file,
             mode,
-            enable_move_stable_rowid,
+            enable_stable_row_ids,
             storage_options_obj
         ),
         JObject::null()
@@ -175,12 +175,12 @@ fn inner_create_with_ffi_stream<'local>(
     env: &mut JNIEnv<'local>,
     dataset_uri: JString,
     arrow_array_stream_addr: jlong,
-    max_rows_per_file: JObject,        // Optional<Integer>
-    max_rows_per_group: JObject,       // Optional<Integer>
-    max_bytes_per_file: JObject,       // Optional<Long>
-    mode: JObject,                     // Optional<String>
-    enable_move_stable_rowid: JObject, // Optional<Boolean>
-    storage_options_obj: JObject,      // Map<String, String>
+    max_rows_per_file: JObject,     // Optional<Integer>
+    max_rows_per_group: JObject,    // Optional<Integer>
+    max_bytes_per_file: JObject,    // Optional<Long>
+    mode: JObject,                  // Optional<String>
+    enable_stable_row_ids: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,   // Map<String, String>
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
@@ -192,7 +192,7 @@ fn inner_create_with_ffi_stream<'local>(
         max_rows_per_group,
         max_bytes_per_file,
         mode,
-        enable_move_stable_rowid,
+        enable_stable_row_ids,
         storage_options_obj,
         reader,
     )
@@ -202,12 +202,12 @@ fn inner_create_with_ffi_stream<'local>(
 fn create_fragment<'a>(
     env: &mut JNIEnv<'a>,
     dataset_uri: JString,
-    max_rows_per_file: JObject,        // Optional<Integer>
-    max_rows_per_group: JObject,       // Optional<Integer>
-    max_bytes_per_file: JObject,       // Optional<Long>
-    mode: JObject,                     // Optional<String>
-    enable_move_stable_rowid: JObject, // Optional<Boolean>
-    storage_options_obj: JObject,      // Map<String, String>
+    max_rows_per_file: JObject,     // Optional<Integer>
+    max_rows_per_group: JObject,    // Optional<Integer>
+    max_bytes_per_file: JObject,    // Optional<Long>
+    mode: JObject,                  // Optional<String>
+    enable_stable_row_ids: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,   // Map<String, String>
     source: impl StreamingWriteSource,
 ) -> Result<JObject<'a>> {
     let path_str = dataset_uri.extract(env)?;
@@ -218,7 +218,7 @@ fn create_fragment<'a>(
         &max_rows_per_group,
         &max_bytes_per_file,
         &mode,
-        &enable_move_stable_rowid,
+        &enable_stable_row_ids,
         &storage_options_obj,
     )?;
     let fragments = RT.block_on(FileFragment::create_fragments(

--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -76,11 +76,12 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiArray<'local
     dataset_uri: JString,
     arrow_array_addr: jlong,
     arrow_schema_addr: jlong,
-    max_rows_per_file: JObject,   // Optional<Integer>
-    max_rows_per_group: JObject,  // Optional<Integer>
-    max_bytes_per_file: JObject,  // Optional<Long>
-    mode: JObject,                // Optional<String>
-    storage_options_obj: JObject, // Map<String, String>
+    max_rows_per_file: JObject,        // Optional<Integer>
+    max_rows_per_group: JObject,       // Optional<Integer>
+    max_bytes_per_file: JObject,       // Optional<Long>
+    mode: JObject,                     // Optional<String>
+    enable_move_stable_rowid: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,      // Map<String, String>
 ) -> JObject<'local> {
     ok_or_throw_with_return!(
         env,
@@ -93,6 +94,7 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiArray<'local
             max_rows_per_group,
             max_bytes_per_file,
             mode,
+            enable_move_stable_rowid,
             storage_options_obj
         ),
         JObject::default()
@@ -105,11 +107,12 @@ fn inner_create_with_ffi_array<'local>(
     dataset_uri: JString,
     arrow_array_addr: jlong,
     arrow_schema_addr: jlong,
-    max_rows_per_file: JObject,   // Optional<Integer>
-    max_rows_per_group: JObject,  // Optional<Integer>
-    max_bytes_per_file: JObject,  // Optional<Long>
-    mode: JObject,                // Optional<String>
-    storage_options_obj: JObject, // Map<String, String>
+    max_rows_per_file: JObject,        // Optional<Integer>
+    max_rows_per_group: JObject,       // Optional<Integer>
+    max_bytes_per_file: JObject,       // Optional<Long>
+    mode: JObject,                     // Optional<String>
+    enable_move_stable_rowid: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,      // Map<String, String>
 ) -> Result<JObject<'local>> {
     let c_array_ptr = arrow_array_addr as *mut FFI_ArrowArray;
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
@@ -131,6 +134,7 @@ fn inner_create_with_ffi_array<'local>(
         max_rows_per_group,
         max_bytes_per_file,
         mode,
+        enable_move_stable_rowid,
         storage_options_obj,
         reader,
     )
@@ -142,11 +146,12 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiStream<'a>(
     _obj: JObject,
     dataset_uri: JString,
     arrow_array_stream_addr: jlong,
-    max_rows_per_file: JObject,   // Optional<Integer>
-    max_rows_per_group: JObject,  // Optional<Integer>
-    max_bytes_per_file: JObject,  // Optional<Long>
-    mode: JObject,                // Optional<String>
-    storage_options_obj: JObject, // Map<String, String>
+    max_rows_per_file: JObject,        // Optional<Integer>
+    max_rows_per_group: JObject,       // Optional<Integer>
+    max_bytes_per_file: JObject,       // Optional<Long>
+    mode: JObject,                     // Optional<String>
+    enable_move_stable_rowid: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,      // Map<String, String>
 ) -> JObject<'a> {
     ok_or_throw_with_return!(
         env,
@@ -158,6 +163,7 @@ pub extern "system" fn Java_com_lancedb_lance_Fragment_createWithFfiStream<'a>(
             max_rows_per_group,
             max_bytes_per_file,
             mode,
+            enable_move_stable_rowid,
             storage_options_obj
         ),
         JObject::null()
@@ -169,11 +175,12 @@ fn inner_create_with_ffi_stream<'local>(
     env: &mut JNIEnv<'local>,
     dataset_uri: JString,
     arrow_array_stream_addr: jlong,
-    max_rows_per_file: JObject,   // Optional<Integer>
-    max_rows_per_group: JObject,  // Optional<Integer>
-    max_bytes_per_file: JObject,  // Optional<Long>
-    mode: JObject,                // Optional<String>
-    storage_options_obj: JObject, // Map<String, String>
+    max_rows_per_file: JObject,        // Optional<Integer>
+    max_rows_per_group: JObject,       // Optional<Integer>
+    max_bytes_per_file: JObject,       // Optional<Long>
+    mode: JObject,                     // Optional<String>
+    enable_move_stable_rowid: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,      // Map<String, String>
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
@@ -185,6 +192,7 @@ fn inner_create_with_ffi_stream<'local>(
         max_rows_per_group,
         max_bytes_per_file,
         mode,
+        enable_move_stable_rowid,
         storage_options_obj,
         reader,
     )
@@ -194,11 +202,12 @@ fn inner_create_with_ffi_stream<'local>(
 fn create_fragment<'a>(
     env: &mut JNIEnv<'a>,
     dataset_uri: JString,
-    max_rows_per_file: JObject,   // Optional<Integer>
-    max_rows_per_group: JObject,  // Optional<Integer>
-    max_bytes_per_file: JObject,  // Optional<Long>
-    mode: JObject,                // Optional<String>
-    storage_options_obj: JObject, // Map<String, String>
+    max_rows_per_file: JObject,        // Optional<Integer>
+    max_rows_per_group: JObject,       // Optional<Integer>
+    max_bytes_per_file: JObject,       // Optional<Long>
+    mode: JObject,                     // Optional<String>
+    enable_move_stable_rowid: JObject, // Optional<Boolean>
+    storage_options_obj: JObject,      // Map<String, String>
     source: impl StreamingWriteSource,
 ) -> Result<JObject<'a>> {
     let path_str = dataset_uri.extract(env)?;
@@ -209,6 +218,7 @@ fn create_fragment<'a>(
         &max_rows_per_group,
         &max_bytes_per_file,
         &mode,
+        &enable_move_stable_rowid,
         &storage_options_obj,
     )?;
     let fragments = RT.block_on(FileFragment::create_fragments(

--- a/java/lance-jni/src/utils.rs
+++ b/java/lance-jni/src/utils.rs
@@ -38,6 +38,7 @@ pub fn extract_write_params(
     max_rows_per_group: &JObject,
     max_bytes_per_file: &JObject,
     mode: &JObject,
+    enable_move_stable_rowid: &JObject,
     storage_options_obj: &JObject,
 ) -> Result<WriteParams> {
     let mut write_params = WriteParams::default();
@@ -53,6 +54,9 @@ pub fn extract_write_params(
     }
     if let Some(mode_val) = env.get_string_opt(mode)? {
         write_params.mode = WriteMode::try_from(mode_val.as_str())?;
+    }
+    if let Some(enable_move_stable_rowid_val) = env.get_boolean_opt(enable_move_stable_rowid)? {
+        write_params.enable_stable_row_ids = enable_move_stable_rowid_val;
     }
     // Java code always sets the data storage version to stable for now
     write_params.data_storage_version = Some(LanceFileVersion::Stable);

--- a/java/lance-jni/src/utils.rs
+++ b/java/lance-jni/src/utils.rs
@@ -38,7 +38,7 @@ pub fn extract_write_params(
     max_rows_per_group: &JObject,
     max_bytes_per_file: &JObject,
     mode: &JObject,
-    enable_move_stable_rowid: &JObject,
+    enable_stable_row_ids: &JObject,
     storage_options_obj: &JObject,
 ) -> Result<WriteParams> {
     let mut write_params = WriteParams::default();
@@ -55,8 +55,8 @@ pub fn extract_write_params(
     if let Some(mode_val) = env.get_string_opt(mode)? {
         write_params.mode = WriteMode::try_from(mode_val.as_str())?;
     }
-    if let Some(enable_move_stable_rowid_val) = env.get_boolean_opt(enable_move_stable_rowid)? {
-        write_params.enable_stable_row_ids = enable_move_stable_rowid_val;
+    if let Some(enable_stable_row_ids_val) = env.get_boolean_opt(enable_stable_row_ids)? {
+        write_params.enable_stable_row_ids = enable_stable_row_ids_val;
     }
     // Java code always sets the data storage version to stable for now
     write_params.data_storage_version = Some(LanceFileVersion::Stable);

--- a/java/src/main/java/com/lancedb/lance/Dataset.java
+++ b/java/src/main/java/com/lancedb/lance/Dataset.java
@@ -91,6 +91,7 @@ public class Dataset implements Closeable {
               params.getMaxRowsPerGroup(),
               params.getMaxBytesPerFile(),
               params.getMode(),
+              params.getEnableMoveStableRowId(),
               params.getStorageOptions());
       dataset.allocator = allocator;
       return dataset;
@@ -120,6 +121,7 @@ public class Dataset implements Closeable {
             params.getMaxRowsPerGroup(),
             params.getMaxBytesPerFile(),
             params.getMode(),
+            params.getEnableMoveStableRowId(),
             params.getStorageOptions());
     dataset.allocator = allocator;
     return dataset;
@@ -132,6 +134,7 @@ public class Dataset implements Closeable {
       Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile,
       Optional<String> mode,
+      Optional<Boolean> enableMoveStableRowId,
       Map<String, String> storageOptions);
 
   private static native Dataset createWithFfiStream(
@@ -141,6 +144,7 @@ public class Dataset implements Closeable {
       Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile,
       Optional<String> mode,
+      Optional<Boolean> enableMoveStableRowId,
       Map<String, String> storageOptions);
 
   /**

--- a/java/src/main/java/com/lancedb/lance/Dataset.java
+++ b/java/src/main/java/com/lancedb/lance/Dataset.java
@@ -91,7 +91,7 @@ public class Dataset implements Closeable {
               params.getMaxRowsPerGroup(),
               params.getMaxBytesPerFile(),
               params.getMode(),
-              params.getEnableMoveStableRowId(),
+              params.getEnableStableRowIds(),
               params.getStorageOptions());
       dataset.allocator = allocator;
       return dataset;
@@ -121,7 +121,7 @@ public class Dataset implements Closeable {
             params.getMaxRowsPerGroup(),
             params.getMaxBytesPerFile(),
             params.getMode(),
-            params.getEnableMoveStableRowId(),
+            params.getEnableStableRowIds(),
             params.getStorageOptions());
     dataset.allocator = allocator;
     return dataset;
@@ -134,7 +134,7 @@ public class Dataset implements Closeable {
       Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile,
       Optional<String> mode,
-      Optional<Boolean> enableMoveStableRowId,
+      Optional<Boolean> enableStableRowIds,
       Map<String, String> storageOptions);
 
   private static native Dataset createWithFfiStream(
@@ -144,7 +144,7 @@ public class Dataset implements Closeable {
       Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile,
       Optional<String> mode,
-      Optional<Boolean> enableMoveStableRowId,
+      Optional<Boolean> enableStableRowIds,
       Map<String, String> storageOptions);
 
   /**

--- a/java/src/main/java/com/lancedb/lance/Fragment.java
+++ b/java/src/main/java/com/lancedb/lance/Fragment.java
@@ -185,6 +185,7 @@ public class Fragment {
           params.getMaxRowsPerGroup(),
           params.getMaxBytesPerFile(),
           params.getMode(),
+          params.getEnableMoveStableRowId(),
           params.getStorageOptions());
     }
   }
@@ -209,6 +210,7 @@ public class Fragment {
         params.getMaxRowsPerGroup(),
         params.getMaxBytesPerFile(),
         params.getMode(),
+        params.getEnableMoveStableRowId(),
         params.getStorageOptions());
   }
 
@@ -225,6 +227,7 @@ public class Fragment {
       Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile,
       Optional<String> mode,
+      Optional<Boolean> enableMoveStableRowId,
       Map<String, String> storageOptions);
 
   /**
@@ -239,5 +242,6 @@ public class Fragment {
       Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile,
       Optional<String> mode,
+      Optional<Boolean> enableMoveStableRowId,
       Map<String, String> storageOptions);
 }

--- a/java/src/main/java/com/lancedb/lance/Fragment.java
+++ b/java/src/main/java/com/lancedb/lance/Fragment.java
@@ -185,7 +185,7 @@ public class Fragment {
           params.getMaxRowsPerGroup(),
           params.getMaxBytesPerFile(),
           params.getMode(),
-          params.getEnableMoveStableRowId(),
+          params.getEnableStableRowIds(),
           params.getStorageOptions());
     }
   }
@@ -210,7 +210,7 @@ public class Fragment {
         params.getMaxRowsPerGroup(),
         params.getMaxBytesPerFile(),
         params.getMode(),
-        params.getEnableMoveStableRowId(),
+        params.getEnableStableRowIds(),
         params.getStorageOptions());
   }
 
@@ -227,7 +227,7 @@ public class Fragment {
       Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile,
       Optional<String> mode,
-      Optional<Boolean> enableMoveStableRowId,
+      Optional<Boolean> enableStableRowIds,
       Map<String, String> storageOptions);
 
   /**
@@ -242,6 +242,6 @@ public class Fragment {
       Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile,
       Optional<String> mode,
-      Optional<Boolean> enableMoveStableRowId,
+      Optional<Boolean> enableStableRowIds,
       Map<String, String> storageOptions);
 }

--- a/java/src/main/java/com/lancedb/lance/WriteParams.java
+++ b/java/src/main/java/com/lancedb/lance/WriteParams.java
@@ -33,6 +33,7 @@ public class WriteParams {
   private final Optional<Integer> maxRowsPerGroup;
   private final Optional<Long> maxBytesPerFile;
   private final Optional<WriteMode> mode;
+  private final Optional<Boolean> enableMoveStableRowId;
   private Map<String, String> storageOptions = new HashMap<>();
 
   private WriteParams(
@@ -40,11 +41,13 @@ public class WriteParams {
       Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile,
       Optional<WriteMode> mode,
+      Optional<Boolean> enableMoveStableRowId,
       Map<String, String> storageOptions) {
     this.maxRowsPerFile = maxRowsPerFile;
     this.maxRowsPerGroup = maxRowsPerGroup;
     this.maxBytesPerFile = maxBytesPerFile;
     this.mode = mode;
+    this.enableMoveStableRowId = enableMoveStableRowId;
     this.storageOptions = storageOptions;
   }
 
@@ -69,6 +72,10 @@ public class WriteParams {
     return mode.map(Enum::name);
   }
 
+  public Optional<Boolean> getEnableMoveStableRowId() {
+    return enableMoveStableRowId;
+  }
+
   public Map<String, String> getStorageOptions() {
     return storageOptions;
   }
@@ -89,6 +96,7 @@ public class WriteParams {
     private Optional<Integer> maxRowsPerGroup = Optional.empty();
     private Optional<Long> maxBytesPerFile = Optional.empty();
     private Optional<WriteMode> mode = Optional.empty();
+    private Optional<Boolean> enableMoveStableRowId = Optional.empty();
     private Map<String, String> storageOptions = new HashMap<>();
 
     public Builder withMaxRowsPerFile(int maxRowsPerFile) {
@@ -116,9 +124,19 @@ public class WriteParams {
       return this;
     }
 
+    public Builder withEnableMoveStableRowId(boolean enableMoveStableRowId) {
+      this.enableMoveStableRowId = Optional.of(enableMoveStableRowId);
+      return this;
+    }
+
     public WriteParams build() {
       return new WriteParams(
-          maxRowsPerFile, maxRowsPerGroup, maxBytesPerFile, mode, storageOptions);
+          maxRowsPerFile,
+          maxRowsPerGroup,
+          maxBytesPerFile,
+          mode,
+          enableMoveStableRowId,
+          storageOptions);
     }
   }
 }

--- a/java/src/main/java/com/lancedb/lance/WriteParams.java
+++ b/java/src/main/java/com/lancedb/lance/WriteParams.java
@@ -33,7 +33,7 @@ public class WriteParams {
   private final Optional<Integer> maxRowsPerGroup;
   private final Optional<Long> maxBytesPerFile;
   private final Optional<WriteMode> mode;
-  private final Optional<Boolean> enableMoveStableRowId;
+  private final Optional<Boolean> enableStableRowIds;
   private Map<String, String> storageOptions = new HashMap<>();
 
   private WriteParams(
@@ -41,13 +41,13 @@ public class WriteParams {
       Optional<Integer> maxRowsPerGroup,
       Optional<Long> maxBytesPerFile,
       Optional<WriteMode> mode,
-      Optional<Boolean> enableMoveStableRowId,
+      Optional<Boolean> enableStableRowIds,
       Map<String, String> storageOptions) {
     this.maxRowsPerFile = maxRowsPerFile;
     this.maxRowsPerGroup = maxRowsPerGroup;
     this.maxBytesPerFile = maxBytesPerFile;
     this.mode = mode;
-    this.enableMoveStableRowId = enableMoveStableRowId;
+    this.enableStableRowIds = enableStableRowIds;
     this.storageOptions = storageOptions;
   }
 
@@ -72,8 +72,8 @@ public class WriteParams {
     return mode.map(Enum::name);
   }
 
-  public Optional<Boolean> getEnableMoveStableRowId() {
-    return enableMoveStableRowId;
+  public Optional<Boolean> getEnableStableRowIds() {
+    return enableStableRowIds;
   }
 
   public Map<String, String> getStorageOptions() {
@@ -96,7 +96,7 @@ public class WriteParams {
     private Optional<Integer> maxRowsPerGroup = Optional.empty();
     private Optional<Long> maxBytesPerFile = Optional.empty();
     private Optional<WriteMode> mode = Optional.empty();
-    private Optional<Boolean> enableMoveStableRowId = Optional.empty();
+    private Optional<Boolean> enableStableRowIds = Optional.empty();
     private Map<String, String> storageOptions = new HashMap<>();
 
     public Builder withMaxRowsPerFile(int maxRowsPerFile) {
@@ -124,8 +124,8 @@ public class WriteParams {
       return this;
     }
 
-    public Builder withEnableMoveStableRowId(boolean enableMoveStableRowId) {
-      this.enableMoveStableRowId = Optional.of(enableMoveStableRowId);
+    public Builder withEnableStableRowIds(boolean enableStableRowIds) {
+      this.enableStableRowIds = Optional.of(enableStableRowIds);
       return this;
     }
 
@@ -135,7 +135,7 @@ public class WriteParams {
           maxRowsPerGroup,
           maxBytesPerFile,
           mode,
-          enableMoveStableRowId,
+          enableStableRowIds,
           storageOptions);
     }
   }

--- a/java/src/test/java/com/lancedb/lance/DatasetTest.java
+++ b/java/src/test/java/com/lancedb/lance/DatasetTest.java
@@ -14,6 +14,7 @@
 package com.lancedb.lance;
 
 import com.lancedb.lance.ipc.LanceScanner;
+import com.lancedb.lance.ipc.ScanOptions;
 import com.lancedb.lance.operation.Append;
 import com.lancedb.lance.operation.Overwrite;
 import com.lancedb.lance.schema.ColumnAlteration;
@@ -26,6 +27,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.UInt8Vector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -43,6 +45,7 @@ import java.nio.channels.ClosedChannelException;
 import java.nio.file.Path;
 import java.time.Clock;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -960,6 +963,60 @@ public class DatasetTest {
           assertEquals(1, readTransaction.readVersion());
           assertNotNull(readTransaction.uuid());
           assertInstanceOf(Append.class, readTransaction.operation());
+        }
+      }
+    }
+  }
+
+  @Test
+  void testEnableMoveStableRowId(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("enable_move_stable_rowid").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      try (Dataset dataset =
+          testDataset.createDatasetWithWriteParams(
+              new WriteParams.Builder().withEnableMoveStableRowId(true).build())) {
+        // Step1: write two fragments
+        FragmentMetadata frag1 = testDataset.createNewFragment(10);
+        FragmentMetadata frag2 = testDataset.createNewFragment(10);
+
+        Transaction.Builder builder = new Transaction.Builder(dataset);
+        Append append = Append.builder().fragments(Arrays.asList(frag1, frag2)).build();
+        Transaction transaction = builder.operation(append).readVersion(dataset.version()).build();
+
+        // Step2: if move-stable-rowid is enabled, the rowids of new fragments should be
+        // consecutive.
+        try (Dataset newDataset = transaction.commit()) {
+          assertEquals(2, newDataset.version());
+
+          LanceScanner scanner =
+              newDataset.newScan(
+                  new ScanOptions.Builder()
+                      .withRowId(true)
+                      // load data in one batch
+                      .batchSize(20)
+                      .fragmentIds(Arrays.asList(0, 1))
+                      .build());
+
+          try (ArrowReader reader = scanner.scanBatches()) {
+            List<Long> rowIds = new ArrayList<>();
+            while (reader.loadNextBatch()) {
+              VectorSchemaRoot root = reader.getVectorSchemaRoot();
+              UInt8Vector rowidVec = (UInt8Vector) (root.getVector("_rowid"));
+              for (int i = 0; i < rowidVec.getValueCount(); i++) {
+                rowIds.add(rowidVec.get(i));
+              }
+            }
+
+            assertEquals(20, rowIds.size());
+
+            // rowids should be consecutive even across fragments
+            Collections.sort(rowIds);
+            for (int i = 0; i < rowIds.size() - 1; i++) {
+              assertEquals(rowIds.get(i) + 1, (long) rowIds.get(i + 1));
+            }
+          }
         }
       }
     }

--- a/java/src/test/java/com/lancedb/lance/DatasetTest.java
+++ b/java/src/test/java/com/lancedb/lance/DatasetTest.java
@@ -969,14 +969,14 @@ public class DatasetTest {
   }
 
   @Test
-  void testEnableMoveStableRowId(@TempDir Path tempDir) throws Exception {
-    String datasetPath = tempDir.resolve("enable_move_stable_rowid").toString();
+  void testEnableStableRowIds(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("enable_stable_row_ids").toString();
     try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
       TestUtils.SimpleTestDataset testDataset =
           new TestUtils.SimpleTestDataset(allocator, datasetPath);
       try (Dataset dataset =
           testDataset.createDatasetWithWriteParams(
-              new WriteParams.Builder().withEnableMoveStableRowId(true).build())) {
+              new WriteParams.Builder().withEnableStableRowIds(true).build())) {
         // Step1: write two fragments
         FragmentMetadata frag1 = testDataset.createNewFragment(10);
         FragmentMetadata frag2 = testDataset.createNewFragment(10);

--- a/java/src/test/java/com/lancedb/lance/TestUtils.java
+++ b/java/src/test/java/com/lancedb/lance/TestUtils.java
@@ -81,6 +81,10 @@ public class TestUtils {
       return dataset;
     }
 
+    public Dataset createDatasetWithWriteParams(WriteParams writeParams) {
+      return Dataset.create(allocator, datasetPath, getSchema(), writeParams);
+    }
+
     public FragmentMetadata createNewFragment(int rowCount) {
       List<FragmentMetadata> fragmentMetas = createNewFragment(rowCount, Integer.MAX_VALUE);
       assertEquals(1, fragmentMetas.size());


### PR DESCRIPTION
This PR is about to add `enable_stable_row_ids` option to Java API.

I notice that `stable_row_ids` is an important feature that has been introduced to Rust module. I believe that the java ecosystem also need this feature.