### PR TITLE
fix: circular reference in index caching leaks memory

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -54,6 +54,7 @@ tests = [
     "pillow",
     "pandas",
     "polars[pyarrow,pandas]",
+    "psutil",
     "pytest",
     # Workardound for https://github.com/lancedb/lance/issues/4472
     #

--- a/python/python/tests/test_memory_leaks.py
+++ b/python/python/tests/test_memory_leaks.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+from __future__ import annotations
+
+import gc
+import os
+from typing import Callable
+
+import lance
+import psutil
+import pyarrow as pa
+
+MiB = 1024 * 1024
+
+
+def get_memory_usage() -> int:
+    return psutil.Process(os.getpid()).memory_info().rss
+
+
+def assert_noleaks(
+    operation: Callable[[], None],
+    *,
+    iterations: int = 100,
+    warmup_iterations: int = 5,
+    threshold_mb: float = 1.0,
+    check_interval: int = 10,
+    leeway_factor: float = 2.0,  # optional jitter cushion
+) -> None:
+    """Check if an operation retains memory across repeated executions.
+
+    Args:
+        operation: A callable that performs the operation to test
+        iterations: Number of times to run the operation
+        warmup_iterations: Number of warmup runs before measuring
+        threshold_mb: Maximum allowed memory growth in MB
+        check_interval: How often to check memory during iterations
+        leeway_factor: Factor to multiply threshold for early bailout
+
+    Raises:
+        AssertionError: If memory leak is detected
+    """
+    if iterations <= 0:
+        raise ValueError("iterations must be > 0")
+    if check_interval <= 0:
+        raise ValueError("check_interval must be > 0")
+
+    for _ in range(warmup_iterations):
+        operation()
+    gc.collect()
+
+    baseline = get_memory_usage()
+
+    for i in range(iterations):
+        operation()
+
+        if i > 0 and i % check_interval == 0:
+            gc.collect()
+            current = get_memory_usage()
+            growth_mb = (current - baseline) / MiB
+            if growth_mb > threshold_mb * leeway_factor:
+                raise AssertionError(
+                    f"Possible leak: +{growth_mb:.2f} MiB after {i}/{iterations} "
+                    f"(threshold {threshold_mb:.2f} MiB; leeway x{leeway_factor}). "
+                    f"rss_base={baseline}, rss_now={current}"
+                )
+
+    gc.collect()
+    final = get_memory_usage()
+    total_mb = (final - baseline) / MiB
+
+    if total_mb > threshold_mb:
+        avg = total_mb / iterations
+        raise AssertionError(
+            f"Memory leak detected: +{total_mb:.2f} MiB over {iterations} iterations "
+            f"(threshold {threshold_mb:.2f} MiB; avg {avg:.4f} MiB/iter). "
+            f"rss_base={baseline}, rss_final={final}"
+        )
+
+
+class TestMemoryLeaks:
+    def test_index_statistics_no_leak(self, tmp_path) -> None:
+        dataset_path = str(tmp_path / "dataset")
+        data = pa.table({"id": [1]})
+        ds = lance.write_dataset(data, dataset_path)
+        ds.create_scalar_index("id", index_type="BTREE")
+
+        def access_index_stats() -> None:
+            d = lance.dataset(dataset_path)
+            for idx in d.list_indices():
+                if name := idx.get("name"):
+                    d.stats.index_stats(name)
+
+        assert_noleaks(
+            access_index_stats, iterations=1000, threshold_mb=2.0, check_interval=25
+        )

--- a/rust/lance-core/src/cache.rs
+++ b/rust/lance-core/src/cache.rs
@@ -466,7 +466,12 @@ impl WeakLanceCache {
         let cache = self.inner.upgrade()?;
         let key = self.get_key(key);
         if let Some(metadata) = cache.get(&(key, TypeId::of::<Arc<T>>())).await {
-            metadata.record.clone().downcast::<Arc<T>>().ok().map(|arc| arc.as_ref().clone())
+            metadata
+                .record
+                .clone()
+                .downcast::<Arc<T>>()
+                .ok()
+                .map(|arc| arc.as_ref().clone())
         } else {
             None
         }

--- a/rust/lance-core/src/cache.rs
+++ b/rust/lance-core/src/cache.rs
@@ -78,16 +78,6 @@ impl DeepSizeOf for LanceCache {
 }
 
 impl LanceCache {
-    /// Create from an existing Arc<Cache>
-    pub fn from_arc(cache: Arc<Cache<(String, TypeId), SizedRecord>>) -> Self {
-        Self {
-            cache,
-            prefix: String::new(),
-            hits: Arc::new(AtomicU64::new(0)),
-            misses: Arc::new(AtomicU64::new(0)),
-        }
-    }
-
     pub fn with_capacity(capacity: usize) -> Self {
         let cache = Cache::builder()
             .max_capacity(capacity as u64)

--- a/rust/lance-core/src/cache.rs
+++ b/rust/lance-core/src/cache.rs
@@ -123,11 +123,7 @@ impl LanceCache {
     pub fn with_key_prefix(&self, prefix: &str) -> Self {
         Self {
             cache: self.cache.clone(),
-            prefix: if self.prefix.is_empty() {
-                prefix.to_string()
-            } else {
-                format!("{}/{}", self.prefix, prefix)
-            },
+            prefix: format!("{}{}/", self.prefix, prefix),
             hits: self.hits.clone(),
             misses: self.misses.clone(),
         }
@@ -365,11 +361,7 @@ impl WeakLanceCache {
     pub fn with_key_prefix(&self, prefix: &str) -> Self {
         Self {
             inner: self.inner.clone(),
-            prefix: if self.prefix.is_empty() {
-                prefix.to_string()
-            } else {
-                format!("{}/{}", self.prefix, prefix)
-            },
+            prefix: format!("{}{}/", self.prefix, prefix),
         }
     }
 

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -2550,7 +2550,11 @@ pub async fn decode_batch(
     // polled twice.
 
     let io_scheduler = Arc::new(BufferScheduler::new(batch.data.clone())) as Arc<dyn EncodingsIo>;
-    let cache = cache.unwrap_or_else(|| Arc::new(LanceCache::with_capacity(128 * 1024 * 1024)));
+    let cache = if let Some(cache) = cache {
+        cache
+    } else {
+        Arc::new(lance_core::cache::LanceCache::with_capacity(128 * 1024 * 1024))
+    };
     let mut decode_scheduler = DecodeBatchScheduler::try_new(
         batch.schema.as_ref(),
         &batch.top_level_columns,

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -2553,7 +2553,9 @@ pub async fn decode_batch(
     let cache = if let Some(cache) = cache {
         cache
     } else {
-        Arc::new(lance_core::cache::LanceCache::with_capacity(128 * 1024 * 1024))
+        Arc::new(lance_core::cache::LanceCache::with_capacity(
+            128 * 1024 * 1024,
+        ))
     };
     let mut decode_scheduler = DecodeBatchScheduler::try_new(
         batch.schema.as_ref(),

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -5019,7 +5019,6 @@ mod tests {
     #[tokio::test]
     async fn test_fullzip_repetition_index_caching() {
         use crate::testing::SimulatedScheduler;
-        use lance_core::cache::LanceCache;
 
         // Simplified FixedPerValueDecompressor for testing
         #[derive(Debug)]
@@ -5058,7 +5057,7 @@ mod tests {
 
         let data = bytes::Bytes::from(full_data);
         let io = Arc::new(SimulatedScheduler::new(data));
-        let _cache = Arc::new(LanceCache::with_capacity(1024 * 1024));
+        let _cache = Arc::new(lance_core::cache::LanceCache::with_capacity(1024 * 1024));
 
         // Create FullZipScheduler with repetition index
         let mut scheduler = FullZipScheduler {

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -19,7 +19,7 @@ use futures::{future::BoxFuture, FutureExt, StreamExt};
 use log::{debug, trace};
 use tokio::sync::mpsc::{self, UnboundedSender};
 
-use lance_core::{cache::LanceCache, utils::bit::pad_bytes, Result};
+use lance_core::{utils::bit::pad_bytes, Result};
 use lance_datagen::{array, gen_batch, ArrayGenerator, RowCount, Seed};
 
 use crate::{
@@ -169,7 +169,7 @@ async fn test_decode(
     ) -> BoxFuture<'static, ()>,
 ) {
     let lance_schema = lance_core::datatypes::Schema::try_from(schema).unwrap();
-    let cache = Arc::new(LanceCache::with_capacity(128 * 1024 * 1024));
+    let cache = Arc::new(lance_core::cache::LanceCache::with_capacity(128 * 1024 * 1024));
     let column_indices = column_indices_from_schema(schema, is_structural_encoding);
     let decode_scheduler = DecodeBatchScheduler::try_new(
         &lance_schema,

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -169,7 +169,9 @@ async fn test_decode(
     ) -> BoxFuture<'static, ()>,
 ) {
     let lance_schema = lance_core::datatypes::Schema::try_from(schema).unwrap();
-    let cache = Arc::new(lance_core::cache::LanceCache::with_capacity(128 * 1024 * 1024));
+    let cache = Arc::new(lance_core::cache::LanceCache::with_capacity(
+        128 * 1024 * 1024,
+    ));
     let column_indices = column_indices_from_schema(schema, is_structural_encoding);
     let decode_scheduler = DecodeBatchScheduler::try_new(
         &lance_schema,

--- a/rust/lance-index/benches/inverted.rs
+++ b/rust/lance-index/benches/inverted.rs
@@ -78,7 +78,7 @@ fn bench_inverted(c: &mut Criterion) {
         })
     });
     let invert_index = rt
-        .block_on(InvertedIndex::load(store, None, LanceCache::no_cache()))
+        .block_on(InvertedIndex::load(store, None, &LanceCache::no_cache()))
         .unwrap();
 
     let params = FtsSearchParams::new().with_limit(Some(10));

--- a/rust/lance-index/benches/ngram.rs
+++ b/rust/lance-index/benches/ngram.rs
@@ -91,7 +91,7 @@ fn bench_ngram(c: &mut Criterion) {
         .measurement_time(Duration::from_secs(10));
     let details = prost_types::Any::from_msg(&pb::NGramIndexDetails::default()).unwrap();
     let index = rt
-        .block_on(NGramIndexPlugin.load_index(store, &details, None, LanceCache::no_cache()))
+        .block_on(NGramIndexPlugin.load_index(store, &details, None, &LanceCache::no_cache()))
         .unwrap();
     group.bench_function(format!("ngram_search({TOTAL})").as_str(), |b| {
         b.to_async(&rt).iter(|| async {

--- a/rust/lance-index/benches/zonemap.rs
+++ b/rust/lance-index/benches/zonemap.rs
@@ -88,7 +88,7 @@ fn bench_zonemap(c: &mut Criterion) {
         .measurement_time(Duration::from_secs(10));
     let details = prost_types::Any::from_msg(&pb::ZoneMapIndexDetails::default()).unwrap();
     let index = rt
-        .block_on(ZoneMapIndexPlugin.load_index(store, &details, None, LanceCache::no_cache()))
+        .block_on(ZoneMapIndexPlugin.load_index(store, &details, None, &LanceCache::no_cache()))
         .unwrap();
     group.bench_function(format!("zonemap_search({TOTAL})").as_str(), |b| {
         b.to_async(&rt).iter(|| async {

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -86,7 +86,7 @@ impl BitmapIndex {
     pub(crate) async fn load(
         store: Arc<dyn IndexStore>,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
-        _index_cache: LanceCache,
+        _index_cache: &LanceCache,
     ) -> Result<Arc<Self>> {
         let page_lookup_file = store.open_index_file(BITMAP_LOOKUP_NAME).await?;
         let total_rows = page_lookup_file.num_rows();
@@ -542,7 +542,7 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
         index_store: Arc<dyn IndexStore>,
         _index_details: &prost_types::Any,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
-        cache: LanceCache,
+        cache: &LanceCache,
     ) -> Result<Arc<dyn ScalarIndex>> {
         Ok(BitmapIndex::load(index_store, frag_reuse_index, cache).await? as Arc<dyn ScalarIndex>)
     }
@@ -636,7 +636,7 @@ pub mod tests {
 
         // Load the index using BitmapIndex::load
         tracing::info!("Loading index from disk...");
-        let loaded_index = BitmapIndex::load(Arc::new(test_store), None, LanceCache::no_cache())
+        let loaded_index = BitmapIndex::load(Arc::new(test_store), None, &LanceCache::no_cache())
             .await
             .expect("Failed to load bitmap index");
 
@@ -784,7 +784,7 @@ pub mod tests {
             .unwrap();
 
         // Reload and check
-        let reloaded_idx = BitmapIndex::load(test_store, None, LanceCache::no_cache())
+        let reloaded_idx = BitmapIndex::load(test_store, None, &LanceCache::no_cache())
             .await
             .expect("Failed to load bitmap index");
 

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -912,7 +912,7 @@ impl BTreeIndex {
             map,
             null_pages,
             store,
-            WeakLanceCache::from(&index_cache),
+            WeakLanceCache::from(index_cache),
             sub_index,
             batch_size,
             frag_reuse_index,

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -1757,9 +1757,7 @@ mod tests {
             .unwrap();
 
         let cache = lance_core::cache::LanceCache::with_capacity(100 * 1024 * 1024);
-        let index = BTreeIndex::load(test_store, None, cache)
-            .await
-            .unwrap();
+        let index = BTreeIndex::load(test_store, None, cache).await.unwrap();
 
         let query = SargableQuery::Equals(ScalarValue::Float32(Some(0.0)));
         let metrics = LocalMetricsCollector::default();

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -182,7 +182,7 @@ impl ScalarIndexPlugin for InvertedIndexPlugin {
         index_store: Arc<dyn IndexStore>,
         _index_details: &prost_types::Any,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
-        cache: LanceCache,
+        cache: &LanceCache,
     ) -> Result<Arc<dyn ScalarIndex>> {
         Ok(
             InvertedIndex::load(index_store, frag_reuse_index, cache).await?

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -557,7 +557,8 @@ impl InvertedPartition {
         let token_file = store.open_index_file(&token_file_path(id)).await?;
         let tokens = TokenSet::load(token_file).await?;
         let invert_list_file = store.open_index_file(&posting_file_path(id)).await?;
-        let inverted_list = PostingListReader::try_new(invert_list_file, index_cache.clone()).await?;
+        let inverted_list =
+            PostingListReader::try_new(invert_list_file, index_cache.clone()).await?;
         let docs_file = store.open_index_file(&doc_file_path(id)).await?;
         let docs = DocSet::load(docs_file, false, frag_reuse_index).await?;
         let fragments = docs.fragment_ids();

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -815,7 +815,7 @@ impl ScalarIndexPlugin for JsonIndexPlugin {
         index_store: Arc<dyn IndexStore>,
         index_details: &prost_types::Any,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
-        cache: LanceCache,
+        cache: &LanceCache,
     ) -> Result<Arc<dyn ScalarIndex>> {
         let registry = self.registry().unwrap();
         let json_details = crate::pb::JsonIndexDetails::decode(index_details.value.as_slice())?;

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -70,7 +70,7 @@ impl LabelListIndex {
     async fn load(
         store: Arc<dyn IndexStore>,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
-        index_cache: LanceCache,
+        index_cache: &LanceCache,
     ) -> Result<Arc<Self>> {
         BitmapIndex::load(store, frag_reuse_index, index_cache)
             .await
@@ -442,7 +442,7 @@ impl ScalarIndexPlugin for LabelListIndexPlugin {
         index_store: Arc<dyn IndexStore>,
         _index_details: &prost_types::Any,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
-        cache: LanceCache,
+        cache: &LanceCache,
     ) -> Result<Arc<dyn ScalarIndex>> {
         Ok(
             LabelListIndex::load(index_store, frag_reuse_index, cache).await?

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -394,7 +394,7 @@ pub mod tests {
                 index_store,
                 &default_details::<crate::pb::BTreeIndexDetails>(),
                 None,
-                LanceCache::no_cache(),
+                &LanceCache::no_cache(),
             )
             .await
             .unwrap();
@@ -459,7 +459,7 @@ pub mod tests {
                 index_store,
                 &default_details::<crate::pb::BTreeIndexDetails>(),
                 None,
-                LanceCache::no_cache(),
+                &LanceCache::no_cache(),
             )
             .await
             .unwrap();
@@ -486,7 +486,7 @@ pub mod tests {
                 updated_index_store,
                 &default_details::<crate::pb::BTreeIndexDetails>(),
                 None,
-                LanceCache::no_cache(),
+                &LanceCache::no_cache(),
             )
             .await
             .unwrap();
@@ -574,7 +574,7 @@ pub mod tests {
                 index_store,
                 &default_details::<crate::pb::BTreeIndexDetails>(),
                 None,
-                LanceCache::no_cache(),
+                &LanceCache::no_cache(),
             )
             .await
             .unwrap();
@@ -818,7 +818,7 @@ pub mod tests {
                     index_store,
                     &default_details::<crate::pb::BTreeIndexDetails>(),
                     None,
-                    LanceCache::no_cache(),
+                    &LanceCache::no_cache(),
                 )
                 .await
                 .unwrap();
@@ -877,7 +877,7 @@ pub mod tests {
                 index_store,
                 &default_details::<crate::pb::BTreeIndexDetails>(),
                 None,
-                LanceCache::no_cache(),
+                &LanceCache::no_cache(),
             )
             .await
             .unwrap();
@@ -954,7 +954,7 @@ pub mod tests {
         let data = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
         train_bitmap(&index_store, data).await;
 
-        let index = BitmapIndex::load(index_store, None, LanceCache::no_cache())
+        let index = BitmapIndex::load(index_store, None, &LanceCache::no_cache())
             .await
             .unwrap();
 
@@ -996,7 +996,7 @@ pub mod tests {
             .col(ROW_ID, array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(4096), BatchCount::from(100));
         train_bitmap(&index_store, data).await;
-        let index = BitmapIndex::load(index_store, None, LanceCache::no_cache())
+        let index = BitmapIndex::load(index_store, None, &LanceCache::no_cache())
             .await
             .unwrap();
 
@@ -1093,7 +1093,7 @@ pub mod tests {
         ]));
         let data = RecordBatchIterator::new(batches, schema);
         train_bitmap(&index_store, data).await;
-        let index = BitmapIndex::load(index_store, None, LanceCache::no_cache())
+        let index = BitmapIndex::load(index_store, None, &LanceCache::no_cache())
             .await
             .unwrap();
 
@@ -1281,7 +1281,7 @@ pub mod tests {
             .col(ROW_ID, array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(4096), BatchCount::from(1));
         train_bitmap(&index_store, data).await;
-        let index = BitmapIndex::load(index_store, None, LanceCache::no_cache())
+        let index = BitmapIndex::load(index_store, None, &LanceCache::no_cache())
             .await
             .unwrap();
 
@@ -1299,7 +1299,7 @@ pub mod tests {
             )
             .await
             .unwrap();
-        let updated_index = BitmapIndex::load(updated_index_store, None, LanceCache::no_cache())
+        let updated_index = BitmapIndex::load(updated_index_store, None, &LanceCache::no_cache())
             .await
             .unwrap();
 
@@ -1326,7 +1326,7 @@ pub mod tests {
             .col(ROW_ID, array::step::<UInt64Type>())
             .into_reader_rows(RowCount::from(50), BatchCount::from(1));
         train_bitmap(&index_store, data).await;
-        let index = BitmapIndex::load(index_store, None, LanceCache::no_cache())
+        let index = BitmapIndex::load(index_store, None, &LanceCache::no_cache())
             .await
             .unwrap();
 
@@ -1349,7 +1349,7 @@ pub mod tests {
             .remap(&mapping, remapped_store.as_ref())
             .await
             .unwrap();
-        let remapped_index = BitmapIndex::load(remapped_store, None, LanceCache::no_cache())
+        let remapped_index = BitmapIndex::load(remapped_store, None, &LanceCache::no_cache())
             .await
             .unwrap();
 
@@ -1441,7 +1441,7 @@ pub mod tests {
                         index_store,
                         &default_details::<crate::pb::LabelListIndexDetails>(),
                         None,
-                        LanceCache::no_cache(),
+                        &LanceCache::no_cache(),
                     )
                     .await
                     .unwrap();

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -345,7 +345,9 @@ pub mod tests {
                 .now_or_never()
                 .unwrap()
                 .unwrap();
-        let cache = Arc::new(lance_core::cache::LanceCache::with_capacity(128 * 1024 * 1024));
+        let cache = Arc::new(lance_core::cache::LanceCache::with_capacity(
+            128 * 1024 * 1024,
+        ));
         Arc::new(LanceIndexStore::new(object_store, test_path, cache))
     }
 

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -345,7 +345,7 @@ pub mod tests {
                 .now_or_never()
                 .unwrap()
                 .unwrap();
-        let cache = Arc::new(LanceCache::with_capacity(128 * 1024 * 1024));
+        let cache = Arc::new(lance_core::cache::LanceCache::with_capacity(128 * 1024 * 1024));
         Arc::new(LanceIndexStore::new(object_store, test_path, cache))
     }
 

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -313,7 +313,7 @@ impl NGramIndex {
         let posting_reader = Arc::new(NGramPostingListReader {
             reader: store.open_index_file(POSTINGS_FILENAME).await?,
             frag_reuse_index,
-            index_cache: WeakLanceCache::from(&index_cache),
+            index_cache: WeakLanceCache::from(index_cache),
         });
 
         Ok(Self {

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -292,7 +292,7 @@ impl NGramIndex {
     async fn from_store(
         store: Arc<dyn IndexStore>,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
-        index_cache: LanceCache,
+        index_cache: &LanceCache,
     ) -> Result<Self> {
         let tokens = store.open_index_file(POSTINGS_FILENAME).await?;
         let tokens = tokens
@@ -368,7 +368,7 @@ impl NGramIndex {
     async fn load(
         store: Arc<dyn IndexStore>,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
-        index_cache: LanceCache,
+        index_cache: &LanceCache,
     ) -> Result<Arc<Self>>
     where
         Self: Sized,
@@ -1298,7 +1298,7 @@ impl ScalarIndexPlugin for NGramIndexPlugin {
         index_store: Arc<dyn IndexStore>,
         _index_details: &prost_types::Any,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
-        cache: LanceCache,
+        cache: &LanceCache,
     ) -> Result<Arc<dyn ScalarIndex>> {
         Ok(NGramIndex::load(index_store, frag_reuse_index, cache).await? as Arc<dyn ScalarIndex>)
     }
@@ -1399,7 +1399,7 @@ mod tests {
             .unwrap();
 
         (
-            NGramIndex::from_store(Arc::new(test_store), None, LanceCache::no_cache())
+            NGramIndex::from_store(Arc::new(test_store), None, &LanceCache::no_cache())
                 .await
                 .unwrap(),
             tmpdir,
@@ -1601,7 +1601,7 @@ mod tests {
 
         index.update(data, test_store.as_ref()).await.unwrap();
 
-        let index = NGramIndex::from_store(test_store, None, LanceCache::no_cache())
+        let index = NGramIndex::from_store(test_store, None, &LanceCache::no_cache())
             .await
             .unwrap();
         assert_eq!(index.tokens.len(), 3);
@@ -1639,7 +1639,7 @@ mod tests {
         let remapping = HashMap::from([(2, Some(100)), (3, None), (4, Some(101))]);
         index.remap(&remapping, test_store.as_ref()).await.unwrap();
 
-        let index = NGramIndex::from_store(test_store, None, LanceCache::no_cache())
+        let index = NGramIndex::from_store(test_store, None, &LanceCache::no_cache())
             .await
             .unwrap();
         let row_ids = row_ids_in_index(&index).await;
@@ -1680,7 +1680,7 @@ mod tests {
 
         index.update(data, test_store.as_ref()).await.unwrap();
 
-        let index = NGramIndex::from_store(test_store, None, LanceCache::no_cache())
+        let index = NGramIndex::from_store(test_store, None, &LanceCache::no_cache())
             .await
             .unwrap();
         let row_ids = row_ids_in_index(&index).await;

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -31,7 +31,7 @@ use datafusion::execution::SendableRecordBatchStream;
 use deepsize::DeepSizeOf;
 use futures::{stream, FutureExt, Stream, StreamExt, TryStreamExt};
 use lance_arrow::iter_str_array;
-use lance_core::cache::{CacheKey, LanceCache};
+use lance_core::cache::{CacheKey, LanceCache, WeakLanceCache};
 use lance_core::error::LanceOptionExt;
 use lance_core::utils::address::RowAddress;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
@@ -207,7 +207,7 @@ impl NGramPostingList {
 struct NGramPostingListReader {
     reader: Arc<dyn IndexReader>,
     frag_reuse_index: Option<Arc<FragReuseIndex>>,
-    index_cache: LanceCache,
+    index_cache: WeakLanceCache,
 }
 
 impl DeepSizeOf for NGramPostingListReader {
@@ -313,7 +313,7 @@ impl NGramIndex {
         let posting_reader = Arc::new(NGramPostingListReader {
             reader: store.open_index_file(POSTINGS_FILENAME).await?,
             frag_reuse_index,
-            index_cache,
+            index_cache: WeakLanceCache::from(&index_cache),
         });
 
         Ok(Self {

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -148,7 +148,7 @@ pub trait ScalarIndexPlugin: Send + Sync + std::fmt::Debug {
         index_store: Arc<dyn IndexStore>,
         index_details: &prost_types::Any,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
-        cache: LanceCache,
+        cache: &LanceCache,
     ) -> Result<Arc<dyn ScalarIndex>>;
 
     /// Optional hook that plugins can use if they need to be aware of the registry

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -315,7 +315,7 @@ impl ZoneMapIndex {
     async fn load(
         store: Arc<dyn IndexStore>,
         fri: Option<Arc<FragReuseIndex>>,
-        index_cache: LanceCache,
+        index_cache: &LanceCache,
     ) -> Result<Arc<Self>>
     where
         Self: Sized,
@@ -344,7 +344,7 @@ impl ZoneMapIndex {
         data: RecordBatch,
         store: Arc<dyn IndexStore>,
         fri: Option<Arc<FragReuseIndex>>,
-        index_cache: LanceCache,
+        index_cache: &LanceCache,
         max_zonemap_size: u64,
     ) -> Result<Self> {
         // The RecordBatch should have columns: min, max, null_count
@@ -431,7 +431,7 @@ impl ZoneMapIndex {
                 max_zonemap_size,
                 store,
                 fri,
-                index_cache: WeakLanceCache::from(&index_cache),
+                index_cache: WeakLanceCache::from(index_cache),
             });
         }
 
@@ -460,7 +460,7 @@ impl ZoneMapIndex {
             max_zonemap_size,
             store,
             fri,
-            index_cache: WeakLanceCache::from(&index_cache),
+            index_cache: WeakLanceCache::from(index_cache),
         })
     }
 }
@@ -980,7 +980,7 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
         index_store: Arc<dyn IndexStore>,
         _index_details: &prost_types::Any,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
-        cache: LanceCache,
+        cache: &LanceCache,
     ) -> Result<Arc<dyn ScalarIndex>> {
         Ok(ZoneMapIndex::load(index_store, frag_reuse_index, cache).await? as Arc<dyn ScalarIndex>)
     }
@@ -1073,7 +1073,7 @@ mod tests {
         log::debug!("Successfully wrote the index file");
 
         // Read the index file back and check its contents
-        let index = ZoneMapIndex::load(test_store.clone(), None, LanceCache::no_cache())
+        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
             .await
             .expect("Failed to load ZoneMapIndex");
         assert_eq!(index.zones.len(), 0);
@@ -1117,7 +1117,7 @@ mod tests {
         log::debug!("Successfully wrote the index file");
 
         // Read the index file back and check its contents
-        let index = ZoneMapIndex::load(test_store.clone(), None, LanceCache::no_cache())
+        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
             .await
             .expect("Failed to load ZoneMapIndex");
         assert_eq!(index.zones.len(), 10);
@@ -1169,7 +1169,7 @@ mod tests {
             .unwrap();
 
         // Verify the updated index has more zones
-        let updated_index = ZoneMapIndex::load(test_store.clone(), None, LanceCache::no_cache())
+        let updated_index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
             .await
             .expect("Failed to load updated ZoneMapIndex");
 
@@ -1260,7 +1260,7 @@ mod tests {
         .unwrap();
 
         // Load the index
-        let index = ZoneMapIndex::load(test_store.clone(), None, LanceCache::no_cache())
+        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
             .await
             .expect("Failed to load ZoneMapIndex");
 
@@ -1476,7 +1476,7 @@ mod tests {
         assert_eq!(metadata.get(ZONEMAP_SIZE_META_KEY).unwrap(), "100");
 
         // Read the index file back and check its contents
-        let index = ZoneMapIndex::load(test_store.clone(), None, LanceCache::no_cache())
+        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
             .await
             .expect("Failed to load ZoneMapIndex");
         assert_eq!(index.zones.len(), 2);
@@ -1654,7 +1654,7 @@ mod tests {
         log::debug!("Successfully wrote the index file");
 
         // Read the index file back and check its contents
-        let index = ZoneMapIndex::load(test_store.clone(), None, LanceCache::no_cache())
+        let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
             .await
             .expect("Failed to load ZoneMapIndex");
         assert_eq!(index.zones.len(), 3);
@@ -1808,7 +1808,7 @@ mod tests {
             .unwrap();
 
             // Read the index file back and check its contents
-            let index = ZoneMapIndex::load(test_store.clone(), None, LanceCache::no_cache())
+            let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
                 .await
                 .expect("Failed to load ZoneMapIndex");
             assert_eq!(index.zones.len(), 5);
@@ -2006,7 +2006,7 @@ mod tests {
             .unwrap();
 
             // Read the index file back and check its contents
-            let index = ZoneMapIndex::load(test_store.clone(), None, LanceCache::no_cache())
+            let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
                 .await
                 .expect("Failed to load ZoneMapIndex");
             assert_eq!(index.zones.len(), 3);
@@ -2075,7 +2075,7 @@ mod tests {
             .unwrap();
 
             // Read the index file back and check its contents
-            let index = ZoneMapIndex::load(test_store.clone(), None, LanceCache::no_cache())
+            let index = ZoneMapIndex::load(test_store.clone(), None, &LanceCache::no_cache())
                 .await
                 .expect("Failed to load ZoneMapIndex");
             assert_eq!(index.zones.len(), 3);

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -21,7 +21,7 @@ use crate::{pb, Any};
 use datafusion::functions_aggregate::min_max::{MaxAccumulator, MinAccumulator};
 use datafusion_expr::Accumulator;
 use futures::TryStreamExt;
-use lance_core::cache::LanceCache;
+use lance_core::cache::{LanceCache, WeakLanceCache};
 use lance_core::ROW_ADDR;
 use lance_datafusion::chunker::chunk_concat_stream;
 use serde::{Deserialize, Serialize};
@@ -89,7 +89,7 @@ pub struct ZoneMapIndex {
     max_zonemap_size: u64,
     store: Arc<dyn IndexStore>,
     fri: Option<Arc<FragReuseIndex>>,
-    index_cache: LanceCache,
+    index_cache: WeakLanceCache,
 }
 
 impl std::fmt::Debug for ZoneMapIndex {
@@ -431,7 +431,7 @@ impl ZoneMapIndex {
                 max_zonemap_size,
                 store,
                 fri,
-                index_cache,
+                index_cache: WeakLanceCache::from(&index_cache),
             });
         }
 
@@ -460,7 +460,7 @@ impl ZoneMapIndex {
             max_zonemap_size,
             store,
             fri,
-            index_cache,
+            index_cache: WeakLanceCache::from(&index_cache),
         })
     }
 }

--- a/rust/lance-index/src/vector/ivf/shuffler.rs
+++ b/rust/lance-index/src/vector/ivf/shuffler.rs
@@ -511,7 +511,7 @@ impl IvfShuffler {
                 let file = scheduler
                     .open_file(&path, &CachedFileSize::unknown())
                     .await?;
-                let cache = LanceCache::with_capacity(128 * 1024 * 1024);
+                let cache = lance_core::cache::LanceCache::with_capacity(128 * 1024 * 1024);
 
                 let reader = Lancev2FileReader::try_open(
                     file,

--- a/rust/lance/benches/scalar_index.rs
+++ b/rust/lance/benches/scalar_index.rs
@@ -204,7 +204,7 @@ fn bench_warm_indexed(c: &mut Criterion) {
             fixture.index_store.clone(),
             &details,
             None,
-            LanceCache::no_cache(),
+            &LanceCache::no_cache(),
         ))
         .unwrap();
 

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -355,7 +355,7 @@ pub async fn open_scalar_index(
         .for_index(&uuid_str, frag_reuse_index.as_ref().map(|f| &f.uuid));
 
     plugin
-        .load_index(index_store, &index_details, frag_reuse_index, index_cache)
+        .load_index(index_store, &index_details, frag_reuse_index, &index_cache)
         .await
 }
 

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -35,7 +35,7 @@ use futures::{
 use io::write_hnsw_quantization_index_partitions;
 use lance_arrow::*;
 use lance_core::{
-    cache::{LanceCache, UnsizedCacheKey},
+    cache::{LanceCache, UnsizedCacheKey, WeakLanceCache},
     traits::DatasetTakeRows,
     utils::tracing::{IO_TYPE_LOAD_VECTOR_PART, TRACE_IO_EVENTS},
     Error, Result, ROW_ID_FIELD,
@@ -129,7 +129,7 @@ pub struct IVFIndex {
 
     pub metric_type: MetricType,
 
-    index_cache: LanceCache,
+    index_cache: WeakLanceCache,
 }
 
 impl DeepSizeOf for IVFIndex {
@@ -165,7 +165,7 @@ impl IVFIndex {
             sub_index,
             metric_type,
             partition_locks: PartitionLoadLock::new(num_partitions),
-            index_cache,
+            index_cache: WeakLanceCache::from(&index_cache),
         })
     }
 

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -23,7 +23,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use deepsize::DeepSizeOf;
 use futures::prelude::stream::{self, TryStreamExt};
 use lance_arrow::RecordBatchExt;
-use lance_core::cache::{CacheKey, LanceCache};
+use lance_core::cache::{CacheKey, LanceCache, WeakLanceCache};
 use lance_core::utils::tokio::spawn_cpu;
 use lance_core::utils::tracing::{IO_TYPE_LOAD_VECTOR_PART, TRACE_IO_EVENTS};
 use lance_core::{Error, Result, ROW_ID};
@@ -119,7 +119,7 @@ pub struct IVFIndex<S: IvfSubIndex + 'static, Q: Quantization + 'static> {
 
     distance_type: DistanceType,
 
-    index_cache: LanceCache,
+    index_cache: WeakLanceCache,
 
     _marker: PhantomData<(S, Q)>,
 }
@@ -226,7 +226,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             partition_locks: PartitionLoadLock::new(num_partitions),
             sub_index_metadata,
             distance_type,
-            index_cache,
+            index_cache: WeakLanceCache::from(&index_cache),
             _marker: PhantomData,
         })
     }

--- a/rust/lance/src/session.rs
+++ b/rust/lance/src/session.rs
@@ -95,28 +95,9 @@ impl Session {
         metadata_cache_size: usize,
         store_registry: Arc<ObjectStoreRegistry>,
     ) -> Self {
-        use lance_core::cache::SizedRecord;
-        use moka::future::Cache;
-
-        let index_cache_arc = Arc::new(
-            Cache::builder()
-                .max_capacity(index_cache_size as u64)
-                .weigher(|_, v: &SizedRecord| v.deep_size_of().try_into().unwrap_or(u32::MAX))
-                .support_invalidation_closures()
-                .build(),
-        );
-
-        let metadata_cache_arc = Arc::new(
-            Cache::builder()
-                .max_capacity(metadata_cache_size as u64)
-                .weigher(|_, v: &SizedRecord| v.deep_size_of().try_into().unwrap_or(u32::MAX))
-                .support_invalidation_closures()
-                .build(),
-        );
-
         Self {
-            index_cache: GlobalIndexCache(LanceCache::from_arc(index_cache_arc)),
-            metadata_cache: GlobalMetadataCache(LanceCache::from_arc(metadata_cache_arc)),
+            index_cache: GlobalIndexCache(LanceCache::with_capacity(index_cache_size)),
+            metadata_cache: GlobalMetadataCache(LanceCache::with_capacity(metadata_cache_size)),
             index_extensions: HashMap::new(),
             store_registry,
         }

--- a/rust/lance/src/session/caches.rs
+++ b/rust/lance/src/session/caches.rs
@@ -12,6 +12,7 @@
 
 use std::{borrow::Cow, ops::Deref};
 
+use deepsize::{Context, DeepSizeOf};
 use lance_core::{
     cache::{CacheKey, LanceCache},
     utils::{deletion::DeletionVector, mask::RowIdMask},
@@ -44,6 +45,12 @@ impl GlobalMetadataCache {
 impl Clone for GlobalMetadataCache {
     fn clone(&self) -> Self {
         Self(self.0.clone())
+    }
+}
+
+impl DeepSizeOf for GlobalMetadataCache {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.0.deep_size_of_children(context)
     }
 }
 

--- a/rust/lance/src/session/index_caches.rs
+++ b/rust/lance/src/session/index_caches.rs
@@ -43,6 +43,12 @@ impl Deref for GlobalIndexCache {
     }
 }
 
+impl DeepSizeOf for GlobalIndexCache {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.0.deep_size_of_children(context)
+    }
+}
+
 /// A type-safe wrapper around a LanceCache that enforces namespaces and keys
 /// for dataset-specific index data.
 pub struct DSIndexCache(pub(crate) LanceCache);


### PR DESCRIPTION
Prior to this commit, when a dataset loaded an index into its index cache, it would attach a strong reference to its index index cache to the index.

This resulted in a circular reference: the dataset's cache contained self-referential values. This prevented the cache from getting deallocated when the dataset was dropped, resulting in a leak if many datasets were opened over time.

This commit puts weak references to the cache on the indexes so the cycle is broken.