### PR TITLE
feat: add `use_index` option for merge insert

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -208,6 +208,27 @@ class MergeInsertBuilder(_MergeInsertBuilder):
         """
         return super(MergeInsertBuilder, self).retry_timeout(timeout)
 
+    def use_index(self, use_index: bool) -> "MergeInsertBuilder":
+        """
+        Controls whether to use indices for the merge operation.
+
+        When set to False, forces a full table scan even if an index exists on
+        the join key. This can be useful for benchmarking or when the optimizer
+        chooses a suboptimal path.
+
+        Parameters
+        ----------
+        use_index : bool
+            If True (default), uses an index if available. If False, forces a
+            full table scan.
+
+        Returns
+        -------
+        MergeInsertBuilder
+            The builder instance for method chaining.
+        """
+        return super(MergeInsertBuilder, self).use_index(use_index)
+
     def explain_plan(
         self, schema: Optional[pa.Schema] = None, verbose: bool = False
     ) -> str:

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -213,6 +213,11 @@ impl MergeInsertBuilder {
         Ok(slf)
     }
 
+    pub fn use_index(mut slf: PyRefMut<'_, Self>, use_index: bool) -> PyResult<PyRefMut<'_, Self>> {
+        slf.builder.use_index(use_index);
+        Ok(slf)
+    }
+
     pub fn execute(&mut self, new_data: &Bound<PyAny>) -> PyResult<PyObject> {
         let py = new_data.py();
         let new_data = convert_reader(new_data)?;


### PR DESCRIPTION
Closes #4631

## Summary

Add an option to not use an index for merge insert operations. Useful as an escape hatch when optimizer not choosing the best path. Also useful for benchmarking and comparing code paths.

## Implementation

- Add `use_index: bool` field to `MergeInsertParams` (default: true)
- Add `use_index()` method to `MergeInsertBuilder` 
- Update `create_joined_stream()` to respect the `use_index` parameter
- Update `can_use_create_plan()` to consider `use_index` when determining fast path eligibility
- Add Python bindings and documentation
- Add comprehensive tests for both Rust and Python

## Test plan

- [x] Added Rust test `test_merge_insert_use_index` verifying explain_plan behavior and execution
- [x] Added Python test `test_merge_insert_use_index` with similar verification
- [x] All existing merge_insert tests still pass
- [x] Code formatting and linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)