### PR TITLE
feat: add traces for file level IO

### DIFF
--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -473,7 +473,7 @@ impl IoTask {
 
     async fn run(self) {
         let file_path = self.reader.path().to_string();
-        let num_bytes = self.num_bytes();    
+        let num_bytes = self.num_bytes();
         let bytes = if self.to_read.start == self.to_read.end {
             Ok(Bytes::new())
         } else {
@@ -488,8 +488,8 @@ impl IoTask {
                 })
                 .await
                 .map_err(Error::from)
-        };    
-        // Emit per-file I/O trace event only when tracing is enabled    
+        };
+        // Emit per-file I/O trace event only when tracing is enabled
         tracing::trace!(
             file = file_path,
             bytes_read = num_bytes,
@@ -497,7 +497,7 @@ impl IoTask {
             range_start = self.to_read.start,
             range_end = self.to_read.end,
             "File I/O completed"
-        );        
+        );
         IOPS_QUOTA.release();
         (self.when_done)(bytes);
     }


### PR DESCRIPTION
A trace per file access will be very useful to analyze the access pattern (_indices vs _manifest vs _data)