### PR TITLE
perf: avoid per-iop clone of filename

### DIFF
--- a/rust/lance-io/src/scheduler.rs
+++ b/rust/lance-io/src/scheduler.rs
@@ -472,7 +472,7 @@ impl IoTask {
     }
 
     async fn run(self) {
-        let file_path = self.reader.path().to_string();
+        let file_path = self.reader.path().as_ref();
         let num_bytes = self.num_bytes();
         let bytes = if self.to_read.start == self.to_read.end {
             Ok(Bytes::new())


### PR DESCRIPTION
This is probably paranoid premature optimization but ¯\_(ツ)_/¯