### PR TITLE
fix: refine SIMD support detection for AArch64 on iOS/tvOS

### DIFF
--- a/rust/lance-core/src/utils/cpu.rs
+++ b/rust/lance-core/src/utils/cpu.rs
@@ -16,7 +16,12 @@ pub enum SimdSupport {
 
 /// Support for FP16 SIMD operations
 pub static FP16_SIMD_SUPPORT: LazyLock<SimdSupport> = LazyLock::new(|| {
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", any(target_os = "ios", target_os = "tvos")))]
+    {
+        // AArch64 iOS/tvOS has NEON; fp16 arithmetic is available on modern targets.
+        SimdSupport::Neon
+    }
+    #[cfg(all(target_arch = "aarch64", not(any(target_os = "ios", target_os = "tvos"))))]
     {
         if aarch64::has_neon_f16_support() {
             SimdSupport::Neon

--- a/rust/lance-core/src/utils/cpu.rs
+++ b/rust/lance-core/src/utils/cpu.rs
@@ -21,7 +21,10 @@ pub static FP16_SIMD_SUPPORT: LazyLock<SimdSupport> = LazyLock::new(|| {
         // AArch64 iOS/tvOS has NEON; fp16 arithmetic is available on modern targets.
         SimdSupport::Neon
     }
-    #[cfg(all(target_arch = "aarch64", not(any(target_os = "ios", target_os = "tvos"))))]
+    #[cfg(all(
+        target_arch = "aarch64",
+        not(any(target_os = "ios", target_os = "tvos"))
+    ))]
     {
         if aarch64::has_neon_f16_support() {
             SimdSupport::Neon


### PR DESCRIPTION
This pull request updates the detection logic for FP16 SIMD support on AArch64 platforms in the `lance-core` crate. The main change is to ensure that on iOS and tvOS, NEON SIMD support is assumed for FP16 operations, while on other AArch64 platforms, runtime detection is still used.

Platform-specific SIMD detection:

* In `rust/lance-core/src/utils/cpu.rs`, the initialization of `FP16_SIMD_SUPPORT` now always assumes NEON support for FP16 on AArch64 iOS and tvOS platforms, while retaining runtime detection for other AArch64 targets.