### PR TITLE
fix: correct underestimate of Bloom filter epsilon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4610,6 +4610,7 @@ dependencies = [
  "lance-linalg",
  "lance-table",
  "lance-testing",
+ "libm",
  "lindera",
  "lindera-tantivy",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ hyperloglogplus = { version = "0.4.1", features = ["const-loop"] }
 itertools = "0.13"
 jieba-rs = { version = "0.8.1", default-features = false }
 jsonb = { version = "0.5.3", default-features = false, features = ["databend"]}
+libm = "0.2.15"
 log = "0.4"
 mockall = { version = "0.13.1" }
 mock_instant = { version = "0.3.1", features = ["sync"] }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4118,6 +4118,7 @@ dependencies = [
  "lance-io",
  "lance-linalg",
  "lance-table",
+ "libm",
  "lindera",
  "lindera-tantivy",
  "log",

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -41,6 +41,7 @@ lance-file.workspace = true
 lance-io.workspace = true
 lance-linalg.workspace = true
 lance-table.workspace = true
+libm.workspace = true
 log.workspace = true
 num-traits.workspace = true
 object_store.workspace = true


### PR DESCRIPTION
Since split block bloom filters were added to Parquet from Impala, a bug was found and fixed regarding an underestimate of the false positive probability. Because the number of keys in each block is not identical, some blocks have higher fals positive probabilities and some lower. There is no closed-form formula for this, but there is an iterative way to calculate it. This patch adds that.

Fixes #4730.