### PR TITLE
fix: speed up generating ProjectionPlan for full schema

### DIFF
--- a/rust/lance-datafusion/src/projection.rs
+++ b/rust/lance-datafusion/src/projection.rs
@@ -212,7 +212,7 @@ impl ProjectionPlan {
         let requested_output_expr = physical_cols
             .into_iter()
             .map(|col_name| OutputColumn {
-                expr: datafusion::prelude::col(col_name),
+                expr: Expr::Column(Column::from_name(col_name)),
                 name: col_name.to_string(),
             })
             .collect();


### PR DESCRIPTION
In https://github.com/lancedb/lance/pull/4478 a change was introduced that added the `ProjectionPlan::full()` function. This will get the entire schema for a dataset and turn every column into a SQL expression in order to call `from_expressions`. This is causing us a significant performance hit when we have datasets that have very large schemas. Since we know for certain that this function is getting all of the columns, we should be able to short circuit the work being done in parsing strings to columns against the schema and instead jump straight to evaluating each column in the schema as an `Expr`.

Running one of our benchmarks (time in seconds):

- On commit 2b774a47 (before PR 4478): 0.4338
- On commit eeea03c2 (after PR 4478): 0.7486
- eeea03c2 with my update in this PR: 0.4274
