### PR TITLE
feat: exposing option to provide a serialized manifest to the Java SDK

### DIFF
--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3381,7 +3381,6 @@ dependencies = [
  "lance-io",
  "lance-linalg",
  "lance-table",
- "libm",
  "log",
  "num-traits",
  "object_store",

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3381,6 +3381,7 @@ dependencies = [
  "lance-io",
  "lance-linalg",
  "lance-table",
+ "libm",
  "log",
  "num-traits",
  "object_store",

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -746,7 +746,7 @@ fn inner_open_native<'local>(
         index_cache_size_bytes,
         metadata_cache_size_bytes,
         storage_options,
-        serialized_manifest
+        serialized_manifest,
     )?;
     dataset.into_java(env)
 }

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -723,6 +723,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_openNative<'local>(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn inner_open_native<'local>(
     env: &mut JNIEnv<'local>,
     path: JString,

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -84,6 +84,7 @@ impl BlockingDataset {
         index_cache_size_bytes: i64,
         metadata_cache_size_bytes: i64,
         storage_options: HashMap<String, String>,
+        serialized_manifest: Option<&[u8]>,
     ) -> Result<Self> {
         let params = ReadParams {
             index_cache_size_bytes: index_cache_size_bytes as usize,
@@ -101,6 +102,10 @@ impl BlockingDataset {
             builder = builder.with_version(ver as u64);
         }
         builder = builder.with_storage_options(storage_options);
+
+        if let Some(serialized_manifest) = serialized_manifest {
+            builder = builder.with_serialized_manifest(serialized_manifest)?;
+        }
 
         let inner = RT.block_on(builder.load())?;
         Ok(Self { inner })
@@ -701,6 +706,7 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_openNative<'local>(
     index_cache_size_bytes: jlong,
     metadata_cache_size_bytes: jlong,
     storage_options_obj: JObject, // Map<String, String>
+    serialized_manifest: JObject, // Optional<ByteBuffer>
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -711,7 +717,8 @@ pub extern "system" fn Java_com_lancedb_lance_Dataset_openNative<'local>(
             block_size_obj,
             index_cache_size_bytes,
             metadata_cache_size_bytes,
-            storage_options_obj
+            storage_options_obj,
+            serialized_manifest
         )
     )
 }
@@ -724,12 +731,14 @@ fn inner_open_native<'local>(
     index_cache_size_bytes: jlong,
     metadata_cache_size_bytes: jlong,
     storage_options_obj: JObject, // Map<String, String>
+    serialized_manifest: JObject, // Optional<ByteBuffer>
 ) -> Result<JObject<'local>> {
     let path_str: String = path.extract(env)?;
     let version = env.get_int_opt(&version_obj)?;
     let block_size = env.get_int_opt(&block_size_obj)?;
     let jmap = JMap::from_env(env, &storage_options_obj)?;
     let storage_options = to_rust_map(env, &jmap)?;
+    let serialized_manifest = env.get_bytes_opt(&serialized_manifest)?;
     let dataset = BlockingDataset::open(
         &path_str,
         version,
@@ -737,6 +746,7 @@ fn inner_open_native<'local>(
         index_cache_size_bytes,
         metadata_cache_size_bytes,
         storage_options,
+        serialized_manifest
     )?;
     dataset.into_java(env)
 }

--- a/java/src/main/java/com/lancedb/lance/Dataset.java
+++ b/java/src/main/java/com/lancedb/lance/Dataset.java
@@ -38,6 +38,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
@@ -212,7 +213,8 @@ public class Dataset implements Closeable {
             options.getBlockSize(),
             options.getIndexCacheSizeBytes(),
             options.getMetadataCacheSizeBytes(),
-            options.getStorageOptions());
+            options.getStorageOptions(),
+            options.getSerializedManifest());
     dataset.allocator = allocator;
     dataset.selfManagedAllocator = selfManagedAllocator;
     return dataset;
@@ -224,7 +226,8 @@ public class Dataset implements Closeable {
       Optional<Integer> blockSize,
       long indexCacheSize,
       long metadataCacheSizeBytes,
-      Map<String, String> storageOptions);
+      Map<String, String> storageOptions,
+      Optional<ByteBuffer> serializedManifest);
 
   /**
    * Create a new version of dataset. Use {@link Transaction} instead

--- a/java/src/main/java/com/lancedb/lance/ReadOptions.java
+++ b/java/src/main/java/com/lancedb/lance/ReadOptions.java
@@ -15,6 +15,7 @@ package com.lancedb.lance;
 
 import com.google.common.base.MoreObjects;
 
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -26,6 +27,7 @@ public class ReadOptions {
   private final Optional<Integer> blockSize;
   private final long indexCacheSizeBytes;
   private final long metadataCacheSizeBytes;
+  private final Optional<ByteBuffer> serializedManifest;
   private final Map<String, String> storageOptions;
 
   private ReadOptions(Builder builder) {
@@ -34,6 +36,7 @@ public class ReadOptions {
     this.indexCacheSizeBytes = builder.indexCacheSizeBytes;
     this.metadataCacheSizeBytes = builder.metadataCacheSizeBytes;
     this.storageOptions = builder.storageOptions;
+    this.serializedManifest = builder.serializedManifest;
   }
 
   public Optional<Integer> getVersion() {
@@ -56,6 +59,10 @@ public class ReadOptions {
     return storageOptions;
   }
 
+  public Optional<ByteBuffer> getSerializedManifest() {
+    return serializedManifest;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -64,6 +71,9 @@ public class ReadOptions {
         .add("indexCacheSizeBytes", indexCacheSizeBytes)
         .add("metadataCacheSizeBytes", metadataCacheSizeBytes)
         .add("storageOptions", storageOptions)
+        .add(
+            "serializedManifest",
+            serializedManifest.map(buf -> "ByteBuffer[" + buf.remaining() + " bytes]").orElse(null))
         .toString();
   }
 
@@ -74,6 +84,7 @@ public class ReadOptions {
     private long indexCacheSizeBytes = 6 * 1024 * 1024 * 1024; // Default to 6 GiB like Rust
     private long metadataCacheSizeBytes = 1024 * 1024 * 1024; // Default to 1 GiB like Rust
     private Map<String, String> storageOptions = new HashMap<>();
+    private Optional<ByteBuffer> serializedManifest = Optional.empty();
 
     /**
      * Set the version of the dataset to read. If not set, read from latest version.
@@ -164,6 +175,18 @@ public class ReadOptions {
      */
     public Builder setStorageOptions(Map<String, String> storageOptions) {
       this.storageOptions = storageOptions;
+      return this;
+    }
+
+    /**
+     * Use a serialized manifest instead of loading it from the object store. This is common when
+     * transferring a dataset across IPC boundaries.
+     *
+     * @param serializedManifest the serialized manifest as a ByteBuffer
+     * @return this builder
+     */
+    public Builder setSerializedManifest(ByteBuffer serializedManifest) {
+      this.serializedManifest = Optional.of(serializedManifest);
       return this;
     }
 

--- a/java/src/test/java/com/lancedb/lance/DatasetTest.java
+++ b/java/src/test/java/com/lancedb/lance/DatasetTest.java
@@ -41,7 +41,9 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
 import java.time.ZonedDateTime;
@@ -55,6 +57,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -346,6 +349,39 @@ public class DatasetTest {
           () -> {
             Dataset.open(datasetPath, allocator);
           });
+    }
+  }
+
+  @Test
+  void testOpenSerializedManifest(@TempDir Path tempDir) throws IOException, URISyntaxException {
+    Path datasetPath = tempDir.resolve("serialized_manifest");
+    try (BufferAllocator allocator = new RootAllocator()) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath.toString());
+
+      try (Dataset dataset1 = testDataset.createEmptyDataset()) {
+        assertEquals(1, dataset1.version());
+        Path manifestPath = datasetPath.resolve("_versions");
+        Stream<Path> fileStream = Files.list(manifestPath);
+        assertEquals(1, fileStream.count());
+        Path filePath = manifestPath.resolve("1.manifest");
+        byte[] manifestBytes = Files.readAllBytes(filePath);
+        // Need to trim the magic number at end and message length at beginning
+        // https://github.com/lancedb/lance/blob/main/rust/lance-table/src/io/manifest.rs#L95-L96
+        byte[] trimmedManifest = Arrays.copyOfRange(manifestBytes, 4, manifestBytes.length - 16);
+        ByteBuffer manifestBuffer = ByteBuffer.allocateDirect(trimmedManifest.length);
+        manifestBuffer.put(trimmedManifest);
+        manifestBuffer.flip();
+        try (Dataset dataset2 = testDataset.write(1, 5)) {
+          assertEquals(2, dataset2.version());
+          assertEquals(2, dataset2.latestVersion());
+          // When reading from the serialized manifest, it shouldn't know about the second dataset
+          ReadOptions readOptions =
+              new ReadOptions.Builder().setSerializedManifest(manifestBuffer).build();
+          Dataset dataset1Manifest = Dataset.open(allocator, datasetPath.toString(), readOptions);
+          assertEquals(1, dataset1Manifest.version());
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Creates bindings for a user to provide a serialized manifest in the Java SDK (using the same methodology as the Python SDK)