### PR TITLE
fix: don't create an empty chunk when values are evenly divisible

### DIFF
--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -3487,6 +3487,7 @@ impl PrimitiveStructuralEncoder {
         let mut values_counter = 0;
         for (chunk_idx, chunk) in chunks.iter().enumerate() {
             let chunk_num_values = chunk.num_values(values_counter, num_elements);
+            debug_assert!(chunk_num_values > 0);
             values_counter += chunk_num_values;
             let chunk_levels = if chunk_idx < chunks.len() - 1 {
                 levels.slice_next(chunk_num_values as usize)

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -69,6 +69,7 @@ fn chunk_offsets<N: OffsetSizeTrait>(
             (num_values_in_this_chunk + 1) * byte_width + chunk_bytes.to_usize().unwrap();
 
         let padded_chunk_size = this_chunk_size.next_multiple_of(alignment);
+        debug_assert!(padded_chunk_size > 0);
 
         let this_chunk_bytes_start_offset = (num_values_in_this_chunk + 1) * byte_width;
         chunks_info.push(ChunkInfo {

--- a/rust/lance-encoding/src/encodings/physical/bitpacking.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpacking.rs
@@ -74,6 +74,7 @@ impl InlineBitpacking {
     fn bitpack_chunked<T: ArrowNativeType + BitPacking>(
         data: FixedWidthDataBlock,
     ) -> MiniBlockCompressed {
+        debug_assert!(data.num_values > 0);
         let data_buffer = data.data.borrow_to_typed_slice::<T>();
         let data_buffer = data_buffer.as_ref();
 

--- a/rust/lance-encoding/src/encodings/physical/byte_stream_split.rs
+++ b/rust/lance-encoding/src/encodings/physical/byte_stream_split.rs
@@ -157,6 +157,7 @@ impl MiniBlockCompressor for ByteStreamSplitEncoder {
                         chunk_size.ilog2() as u8
                     };
 
+                    debug_assert!(chunk_bytes > 0);
                     chunks.push(MiniBlockChunk {
                         buffer_sizes: vec![chunk_bytes as u16],
                         log_num_values,


### PR DESCRIPTION
If we had, for example, 1024 values, we were creating a chunk with 1024 values and a chunk with 0 values.  There is no reason for the empty chunk.  We were getting away with it in some cases but fuzz testing revealed a case where it caused a bug.