### PR TITLE
fix: fix decoder bugs in 2.1 list handling, expand test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,7 +1534,7 @@ version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -3502,6 +3502,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -4488,6 +4494,7 @@ dependencies = [
  "rand_xoshiro",
  "rstest",
  "snafu",
+ "strum 0.25.0",
  "tempfile",
  "test-log",
  "tokio",
@@ -4989,8 +4996,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "unicode-blocks",
  "unicode-normalization",
  "unicode-segmentation",
@@ -5937,7 +5944,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools 0.13.0",
  "prost 0.13.5",
  "prost-types 0.13.5",
@@ -6445,7 +6452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -6465,7 +6472,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7611,7 +7618,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -7747,11 +7754,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.1",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7760,7 +7789,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -7773,7 +7802,7 @@ version = "0.50.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1772d041c37cc7e6477733c76b2acf4ee36bd52b2ae4d9ea0ec9c87d003db32"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "prettyplease",
  "prost 0.13.5",
  "prost-build 0.13.5",
@@ -7795,7 +7824,7 @@ version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de6d24c270c6c672a86c183c3a8439ba46c1936f93cf7296aa692de3b0ff0228"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "pbjson",
  "pbjson-build",
  "pbjson-types",
@@ -8636,7 +8665,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d59ab345b6c0d8ae9500b9ff334a4c7c0d316c1c628dc55726b95887eb8dbd11"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "log",
  "proc-macro2",
  "quote",
@@ -8656,7 +8685,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741b7f1e2e1338c0bee5ad5a7d3a9bbd4e24c33765c08b7691810e68d879365d"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "log",
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,7 @@ serde = { version = "^1" }
 serde_json = { version = "1" }
 shellexpand = "3.0"
 snafu = "0.8"
+strum = "0.25"
 tantivy = { version = "0.24.1", features = ["stopwords"] }
 lindera = { version = "0.44.0" }
 lindera-tantivy = { version = "0.44.0" }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -4039,6 +4039,7 @@ dependencies = [
  "prost-types 0.13.5",
  "rand 0.9.1",
  "snafu",
+ "strum 0.25.0",
  "tokio",
  "tracing",
  "xxhash-rust",
@@ -4431,8 +4432,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "strum",
- "strum_macros",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "unicode-blocks",
  "unicode-normalization",
  "unicode-segmentation",
@@ -5629,8 +5630,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -5649,8 +5650,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5683,7 +5684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -5696,7 +5697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -6828,7 +6829,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -6933,11 +6934,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.3",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.1",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/rust/lance-encoding/Cargo.toml
+++ b/rust/lance-encoding/Cargo.toml
@@ -34,6 +34,7 @@ hyperloglogplus.workspace = true
 prost-types.workspace = true
 rand.workspace = true
 snafu.workspace = true
+strum = { workspace = true, features = ["derive"] }
 tokio.workspace = true
 tracing.workspace = true
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -401,7 +401,7 @@ pub struct ColumnInfoIter<'a> {
 
 impl<'a> ColumnInfoIter<'a> {
     pub fn new(column_infos: Vec<Arc<ColumnInfo>>, column_indices: &'a [u32]) -> Self {
-        let initial_pos = column_indices[0] as usize;
+        let initial_pos = column_indices.first().copied().unwrap_or(0) as usize;
         Self {
             column_infos,
             column_indices,
@@ -960,7 +960,7 @@ impl DecodeBatchScheduler {
             .metadata
             .insert("__lance_decoder_root".to_string(), "true".to_string());
 
-        if column_infos[0].is_structural() {
+        if column_infos.is_empty() || column_infos[0].is_structural() {
             let mut column_iter = ColumnInfoIter::new(column_infos.to_vec(), column_indices);
 
             let strategy = CoreFieldDecoderStrategy::from_decoder_config(decoder_config);

--- a/rust/lance-encoding/src/encoder.rs
+++ b/rust/lance-encoding/src/encoder.rs
@@ -275,9 +275,9 @@ pub trait FieldEncodingStrategy: Send + Sync + std::fmt::Debug {
 pub fn default_encoding_strategy(version: LanceFileVersion) -> Box<dyn FieldEncodingStrategy> {
     match version.resolve() {
         LanceFileVersion::Legacy => panic!(),
-        LanceFileVersion::V2_0 => {
-            Box::new(crate::previous::encoder::CoreFieldEncodingStrategy::default())
-        }
+        LanceFileVersion::V2_0 => Box::new(
+            crate::previous::encoder::CoreFieldEncodingStrategy::new(version),
+        ),
         _ => Box::new(StructuralEncodingStrategy::default()),
     }
 }

--- a/rust/lance-encoding/src/encodings/fuzz_tests.rs
+++ b/rust/lance-encoding/src/encodings/fuzz_tests.rs
@@ -271,7 +271,6 @@ proptest! {
                 .expect("Failed to generate test data");
 
             // Set up test cases
-            let version = LanceFileVersion::V2_1;
             let _field = config.to_field("test");
 
             let mut metadata = HashMap::new();
@@ -281,7 +280,7 @@ proptest! {
             }
 
             let test_cases = TestCases::default()
-                .with_file_version(version)
+                .with_min_file_version(LanceFileVersion::V2_1)
                 .with_batch_size(100)
                 .with_range(0..num_rows.min(500) as u64)
                 .with_indices(vec![0, num_rows as u64 / 2, (num_rows - 1) as u64]);
@@ -302,7 +301,7 @@ async fn test_edge_cases_single_value() {
     let single_int32 = Arc::new(Int32Array::from(vec![42])) as Arc<dyn Array>;
     let single_string = Arc::new(StringArray::from(vec!["test"])) as Arc<dyn Array>;
 
-    let test_cases = TestCases::default().with_file_version(LanceFileVersion::V2_1);
+    let test_cases = TestCases::default().with_min_file_version(LanceFileVersion::V2_1);
 
     check_round_trip_encoding_of_data(vec![single_int32], &test_cases, HashMap::new()).await;
 
@@ -318,7 +317,7 @@ async fn test_edge_cases_all_nulls() {
         vec![None, None, None] as Vec<Option<&str>>
     )) as Arc<dyn Array>;
 
-    let test_cases = TestCases::default().with_file_version(LanceFileVersion::V2_1);
+    let test_cases = TestCases::default().with_min_file_version(LanceFileVersion::V2_1);
 
     check_round_trip_encoding_of_data(vec![all_nulls_int32], &test_cases, HashMap::new()).await;
 
@@ -348,7 +347,7 @@ proptest! {
             let list_array = Arc::new(list_builder.finish()) as Arc<dyn Array>;
 
             let test_cases = TestCases::default()
-                .with_file_version(LanceFileVersion::V2_1)
+                .with_min_file_version(LanceFileVersion::V2_1)
                 .with_range(0..list_sizes.len().min(50) as u64);
 
             check_round_trip_encoding_of_data(
@@ -382,7 +381,7 @@ proptest! {
                 .expect("Failed to generate test data");
 
             let test_cases = TestCases::default()
-                .with_file_version(LanceFileVersion::V2_1);
+                .with_min_file_version(LanceFileVersion::V2_1);
 
             check_round_trip_encoding_of_data(
                 vec![test_data],
@@ -500,7 +499,7 @@ async fn test_all_valid_combinations() {
         let test_data =
             generate_test_data_for_config(&config, 100, 42).expect("Failed to generate test data");
 
-        let test_cases = TestCases::default().with_file_version(LanceFileVersion::V2_1);
+        let test_cases = TestCases::default().with_min_file_version(LanceFileVersion::V2_1);
 
         check_round_trip_encoding_of_data(vec![test_data], &test_cases, HashMap::new()).await;
     }

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -152,6 +152,7 @@ mod tests {
         compression::DefaultCompressionStrategy,
         encoder::{ColumnIndexSequence, EncodingOptions},
         testing::{check_round_trip_encoding_of_data, TestCases},
+        version::LanceFileVersion,
     };
     use arrow_array::LargeBinaryArray;
 
@@ -239,6 +240,12 @@ mod tests {
         ]));
 
         // Use the standard test harness
-        check_round_trip_encoding_of_data(vec![array], &TestCases::default(), blob_metadata).await;
+        check_round_trip_encoding_of_data(
+            vec![array],
+            // TODO (https://github.com/lancedb/lance/issues/4781)
+            &TestCases::default().with_max_file_version(LanceFileVersion::V2_0),
+            blob_metadata,
+        )
+        .await;
     }
 }

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -247,7 +247,7 @@ mod tests {
     use rstest::rstest;
 
     use crate::{
-        testing::{check_round_trip_encoding_of_data, check_round_trip_encoding_random, TestCases},
+        testing::{check_basic_random, check_round_trip_encoding_of_data, TestCases},
         version::LanceFileVersion,
     };
 
@@ -262,7 +262,6 @@ mod tests {
     #[rstest]
     #[test_log::test(tokio::test)]
     async fn test_list(
-        #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
         #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
         structural_encoding: &str,
     ) {
@@ -273,7 +272,7 @@ mod tests {
         );
         let field =
             Field::new("", make_list_type(DataType::Int32), true).with_metadata(field_metadata);
-        check_round_trip_encoding_random(field, version).await;
+        check_basic_random(field).await;
     }
 
     #[rstest]
@@ -290,26 +289,26 @@ mod tests {
         let field = Field::new("item", DataType::Int32, true).with_metadata(field_metadata);
         for _ in 0..5 {
             let field = Field::new("", make_list_type(field.data_type().clone()), true);
-            check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+            check_basic_random(field).await;
         }
     }
 
     #[test_log::test(tokio::test)]
     async fn test_large_list() {
         let field = Field::new("", make_large_list_type(DataType::Int32), true);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_nested_strings() {
         let field = Field::new("", make_list_type(DataType::Utf8), true);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_nested_list() {
         let field = Field::new("", make_list_type(make_list_type(DataType::Int32)), true);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -321,7 +320,7 @@ mod tests {
         )]));
 
         let field = Field::new("", make_list_type(struct_type), true);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -348,7 +347,6 @@ mod tests {
     #[rstest]
     #[test_log::test(tokio::test)]
     async fn test_simple_list(
-        #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
         #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
         structural_encoding: &str,
     ) {
@@ -371,8 +369,7 @@ mod tests {
             .with_range(0..3)
             .with_range(1..3)
             .with_indices(vec![1, 3])
-            .with_indices(vec![2])
-            .with_file_version(version);
+            .with_indices(vec![2]);
         check_round_trip_encoding_of_data(vec![Arc::new(list_array)], &test_cases, field_metadata)
             .await;
     }
@@ -420,7 +417,7 @@ mod tests {
             .with_range(5..7)
             .with_indices(vec![1, 6])
             .with_indices(vec![6])
-            .with_file_version(LanceFileVersion::V2_1);
+            .with_min_file_version(LanceFileVersion::V2_1);
         check_round_trip_encoding_of_data(vec![Arc::new(outer_list)], &test_cases, field_metadata)
             .await;
     }
@@ -451,7 +448,7 @@ mod tests {
             .with_range(1..3)
             .with_indices(vec![1, 3])
             .with_indices(vec![2])
-            .with_file_version(LanceFileVersion::V2_1);
+            .with_min_file_version(LanceFileVersion::V2_1);
         check_round_trip_encoding_of_data(vec![Arc::new(list_array)], &test_cases, field_metadata)
             .await;
     }
@@ -482,7 +479,7 @@ mod tests {
             .with_range(1..3)
             .with_indices(vec![1, 3])
             .with_indices(vec![2])
-            .with_file_version(LanceFileVersion::V2_1);
+            .with_min_file_version(LanceFileVersion::V2_1);
         check_round_trip_encoding_of_data(vec![Arc::new(list_array)], &test_cases, field_metadata)
             .await;
     }
@@ -514,7 +511,7 @@ mod tests {
             .with_range(1..2)
             .with_indices(vec![0])
             .with_indices(vec![1])
-            .with_file_version(LanceFileVersion::V2_1);
+            .with_min_file_version(LanceFileVersion::V2_1);
         check_round_trip_encoding_of_data(vec![Arc::new(list_array)], &test_cases, field_metadata)
             .await;
     }
@@ -537,7 +534,9 @@ mod tests {
             .with_range(1..3)
             .with_range(2..4)
             .with_indices(vec![1])
-            .with_indices(vec![2]);
+            .with_indices(vec![2])
+            // TODO (https://github.com/lancedb/lance/issues/4782)
+            .with_max_file_version(LanceFileVersion::V2_0);
         check_round_trip_encoding_of_data(
             vec![Arc::new(list_array)],
             &test_cases,
@@ -566,7 +565,7 @@ mod tests {
             .with_range(1..2)
             .with_indices(vec![1])
             .with_indices(vec![2])
-            .with_file_version(LanceFileVersion::V2_1);
+            .with_min_file_version(LanceFileVersion::V2_1);
         check_round_trip_encoding_of_data(
             vec![Arc::new(list_arr)],
             &test_cases,
@@ -605,7 +604,7 @@ mod tests {
             .with_range(1..2)
             .with_indices(vec![1])
             .with_indices(vec![2])
-            .with_file_version(LanceFileVersion::V2_1);
+            .with_min_file_version(LanceFileVersion::V2_1);
         check_round_trip_encoding_of_data(vec![Arc::new(list_arr)], &test_cases, field_metadata)
             .await;
     }
@@ -641,7 +640,7 @@ mod tests {
         );
 
         let test_cases = TestCases::default()
-            .with_file_version(LanceFileVersion::V2_1)
+            .with_min_file_version(LanceFileVersion::V2_1)
             .with_page_sizes(vec![100])
             .with_range(800..900);
         check_round_trip_encoding_of_data(
@@ -674,7 +673,6 @@ mod tests {
     #[rstest]
     #[test_log::test(tokio::test)]
     async fn test_empty_lists(
-        #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
         #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
         structural_encoding: &str,
     ) {
@@ -699,8 +697,7 @@ mod tests {
                 .with_indices(vec![1])
                 .with_indices(vec![0])
                 .with_indices(vec![2])
-                .with_indices(vec![0, 1])
-                .with_file_version(version);
+                .with_indices(vec![0, 1]);
             check_round_trip_encoding_of_data(
                 vec![list_array.clone()],
                 &test_cases,
@@ -727,10 +724,7 @@ mod tests {
         list_builder.append(true);
         let list_array = Arc::new(list_builder.finish());
 
-        let test_cases = TestCases::default()
-            .with_range(0..2)
-            .with_indices(vec![1])
-            .with_file_version(version);
+        let test_cases = TestCases::default().with_range(0..2).with_indices(vec![1]);
         check_round_trip_encoding_of_data(
             vec![list_array.clone()],
             &test_cases,
@@ -752,10 +746,7 @@ mod tests {
         list_builder.append(true);
         let list_array = Arc::new(list_builder.finish());
 
-        let test_cases = TestCases::default()
-            .with_range(0..2)
-            .with_indices(vec![1])
-            .with_file_version(version);
+        let test_cases = TestCases::default().with_range(0..2).with_indices(vec![1]);
         check_round_trip_encoding_of_data(
             vec![list_array.clone()],
             &test_cases,
@@ -775,10 +766,7 @@ mod tests {
         list_builder.append_null();
         let list_array = Arc::new(list_builder.finish());
 
-        let test_cases = TestCases::default()
-            .with_range(0..2)
-            .with_indices(vec![1])
-            .with_file_version(version);
+        let test_cases = TestCases::default().with_range(0..2).with_indices(vec![1]);
         check_round_trip_encoding_of_data(
             vec![list_array.clone()],
             &test_cases,
@@ -788,10 +776,6 @@ mod tests {
         let test_cases = test_cases.with_batch_size(1);
         check_round_trip_encoding_of_data(vec![list_array], &test_cases, field_metadata.clone())
             .await;
-
-        if version < LanceFileVersion::V2_1 {
-            return;
-        }
 
         // Scenario 4: All lists are null and inside a struct (only valid for 2.1 since 2.0 doesn't
         // support null structs)
@@ -816,7 +800,7 @@ mod tests {
         let test_cases = TestCases::default()
             .with_range(0..2)
             .with_indices(vec![1])
-            .with_file_version(version);
+            .with_min_file_version(LanceFileVersion::V2_1);
         check_round_trip_encoding_of_data(
             vec![struct_array.clone()],
             &test_cases,
@@ -838,16 +822,13 @@ mod tests {
         outer_list_builder.append_null();
         let list_array = Arc::new(outer_list_builder.finish());
 
-        let test_cases = TestCases::default().with_file_version(LanceFileVersion::V2_1);
+        let test_cases = TestCases::default().with_min_file_version(LanceFileVersion::V2_1);
         check_round_trip_encoding_of_data(vec![list_array], &test_cases, HashMap::new()).await;
     }
 
-    #[rstest]
     #[test_log::test(tokio::test)]
     #[ignore] // This test is quite slow in debug mode
-    async fn test_jumbo_list(
-        #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
-    ) {
+    async fn test_jumbo_list() {
         // This is an overflow test.  We have a list of lists where each list
         // has 1Mi items.  We encode 5000 of these lists and so we have over 4Gi in the
         // offsets range
@@ -862,9 +843,7 @@ mod tests {
         let arrs = vec![list_arr; 5000];
 
         // We can't validate because our validation relies on concatenating all input arrays
-        let test_cases = TestCases::default()
-            .without_validation()
-            .with_file_version(version);
+        let test_cases = TestCases::default().without_validation();
         check_round_trip_encoding_of_data(arrs, &test_cases, HashMap::new()).await;
     }
 
@@ -908,7 +887,7 @@ mod tests {
 
         // This should trigger the assertion failure at primitive.rs:1362
         // debug_assert!(rows_avail > 0)
-        let test_cases = TestCases::default().with_file_version(LanceFileVersion::V2_1);
+        let test_cases = TestCases::default().with_min_file_version(LanceFileVersion::V2_1);
 
         // The bug manifests when encoding this specific pattern
         // Expected: successful round-trip encoding

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     encoder::{EncodeTask, EncodedColumn, EncodedPage, FieldEncoder, OutOfLineBuffers},
     format::pb,
-    repdef::RepDefBuilder,
+    repdef::{CompositeRepDefUnraveler, RepDefBuilder},
 };
 use arrow_array::{cast::AsArray, Array, ArrayRef, StructArray};
 use arrow_schema::{DataType, Fields};
@@ -69,6 +69,7 @@ struct RepDefStructSchedulingJob<'a> {
     /// A min-heap whose key is the # of rows currently scheduled
     children: BinaryHeap<StructuralSchedulingJobWithStatus<'a>>,
     rows_scheduled: u64,
+    num_rows: u64,
 }
 
 impl<'a> RepDefStructSchedulingJob<'a> {
@@ -91,6 +92,7 @@ impl<'a> RepDefStructSchedulingJob<'a> {
         Self {
             children,
             rows_scheduled: 0,
+            num_rows,
         }
     }
 }
@@ -100,6 +102,18 @@ impl StructuralSchedulingJob for RepDefStructSchedulingJob<'_> {
         &mut self,
         mut context: &mut SchedulerContext,
     ) -> Result<Option<ScheduledScanLine>> {
+        if self.children.is_empty() {
+            // Special path for empty structs
+            if self.rows_scheduled == self.num_rows {
+                return Ok(None);
+            }
+            self.rows_scheduled = self.num_rows;
+            return Ok(Some(ScheduledScanLine {
+                decoders: Vec::new(),
+                rows_scheduled: self.num_rows,
+            }));
+        }
+
         let mut decoders = Vec::new();
         let old_rows_scheduled = self.rows_scheduled;
         // Schedule as many children as we need to until we have scheduled at least one
@@ -153,7 +167,6 @@ pub struct StructuralStructScheduler {
 
 impl StructuralStructScheduler {
     pub fn new(children: Vec<Box<dyn StructuralFieldScheduler>>, child_fields: Fields) -> Self {
-        debug_assert!(!children.is_empty());
         Self {
             children,
             child_fields,
@@ -284,6 +297,7 @@ impl StructuralFieldDecoder for StructuralStructDecoder {
             children: child_tasks,
             child_fields: self.child_fields.clone(),
             is_root: self.is_root,
+            num_rows,
         }))
     }
 
@@ -297,10 +311,18 @@ struct RepDefStructDecodeTask {
     children: Vec<Box<dyn StructuralDecodeArrayTask>>,
     child_fields: Fields,
     is_root: bool,
+    num_rows: u64,
 }
 
 impl StructuralDecodeArrayTask for RepDefStructDecodeTask {
     fn decode(self: Box<Self>) -> Result<DecodedArray> {
+        if self.children.is_empty() {
+            return Ok(DecodedArray {
+                array: Arc::new(StructArray::new_empty_fields(self.num_rows as usize, None)),
+                repdef: CompositeRepDefUnraveler::new(vec![]),
+            });
+        }
+
         let arrays = self
             .children
             .into_iter()
@@ -534,10 +556,9 @@ mod tests {
     };
     use arrow_buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
     use arrow_schema::{DataType, Field, Fields};
-    use rstest::rstest;
 
     use crate::{
-        testing::{check_round_trip_encoding_of_data, check_round_trip_encoding_random, TestCases},
+        testing::{check_basic_random, check_round_trip_encoding_of_data, TestCases},
         version::LanceFileVersion,
     };
 
@@ -548,7 +569,7 @@ mod tests {
             Field::new("b", DataType::Int32, false),
         ]));
         let field = Field::new("", data_type, false);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -598,7 +619,7 @@ mod tests {
             Some(rows_validity),
         );
 
-        let test_cases = TestCases::default().with_file_version(LanceFileVersion::V2_1);
+        let test_cases = TestCases::default().with_min_file_version(LanceFileVersion::V2_1);
 
         check_round_trip_encoding_of_data(vec![Arc::new(rows)], &test_cases, HashMap::new()).await;
     }
@@ -628,7 +649,7 @@ mod tests {
         );
         check_round_trip_encoding_of_data(
             vec![Arc::new(struct_array)],
-            &TestCases::default().with_file_version(LanceFileVersion::V2_1),
+            &TestCases::default().with_min_file_version(LanceFileVersion::V2_1),
             HashMap::new(),
         )
         .await;
@@ -659,17 +680,14 @@ mod tests {
         );
         check_round_trip_encoding_of_data(
             vec![Arc::new(struct_array)],
-            &TestCases::default().with_file_version(LanceFileVersion::V2_1),
+            &TestCases::default().with_min_file_version(LanceFileVersion::V2_1),
             HashMap::new(),
         )
         .await;
     }
 
-    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_struct_list(
-        #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
-    ) {
+    async fn test_struct_list() {
         let data_type = DataType::Struct(Fields::from(vec![
             Field::new(
                 "inner_list",
@@ -679,7 +697,7 @@ mod tests {
             Field::new("outer_int", DataType::Int32, true),
         ]));
         let field = Field::new("row", data_type, false);
-        check_round_trip_encoding_random(field, version).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -688,7 +706,7 @@ mod tests {
         // make sure we support that
         let data_type = DataType::Struct(Fields::from(Vec::<Field>::default()));
         let field = Field::new("row", data_type, false);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -710,7 +728,7 @@ mod tests {
             Field::new("outer_binary", DataType::Binary, true),
         ]));
         let field = Field::new("row", data_type, false);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/encodings/physical/bitpacking.rs
+++ b/rust/lance-encoding/src/encodings/physical/bitpacking.rs
@@ -502,7 +502,7 @@ mod test {
 
     #[test_log::test(tokio::test)]
     async fn test_miniblock_bitpack() {
-        let test_cases = TestCases::default().with_file_version(LanceFileVersion::V2_1);
+        let test_cases = TestCases::default().with_min_file_version(LanceFileVersion::V2_1);
 
         let arrays = vec![
             Arc::new(Int8Array::from(vec![100; 1024])) as Arc<dyn Array>,
@@ -541,7 +541,7 @@ mod test {
         // Test bitpacking encoding verification with varied small values that should trigger bitpacking
         let test_cases = TestCases::default()
             .with_expected_encoding("inline_bitpacking")
-            .with_file_version(LanceFileVersion::V2_1);
+            .with_min_file_version(LanceFileVersion::V2_1);
 
         // Generate data with varied small values to avoid RLE
         // Mix different values but keep them small to trigger bitpacking
@@ -565,7 +565,7 @@ mod test {
 
         let test_cases = TestCases::default()
             .with_expected_encoding("inline_bitpacking")
-            .with_file_version(LanceFileVersion::V2_1);
+            .with_min_file_version(LanceFileVersion::V2_1);
 
         // Build 2048 values: first 1024 all zeros (bit_width=0),
         // next 1024 small varied values to avoid RLE and trigger bitpacking.

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -381,7 +381,7 @@ mod tests {
     async fn test_fsst() {
         let test_cases = TestCases::default()
             .with_expected_encoding("fsst")
-            .with_file_version(LanceFileVersion::V2_1);
+            .with_min_file_version(LanceFileVersion::V2_1);
 
         // Generate data suitable for FSST (large strings, total size > 32KB)
         let arr = lance_datagen::gen_batch()

--- a/rust/lance-encoding/src/encodings/physical/rle.rs
+++ b/rust/lance-encoding/src/encodings/physical/rle.rs
@@ -952,7 +952,7 @@ mod tests {
 
         let test_cases = TestCases::default()
             .with_expected_encoding("rle")
-            .with_file_version(LanceFileVersion::V2_1);
+            .with_min_file_version(LanceFileVersion::V2_1);
 
         // Test both explicit metadata and automatic selection
         // 1. Test with explicit RLE threshold metadata (also disable BSS)

--- a/rust/lance-encoding/src/previous/encoder.rs
+++ b/rust/lance-encoding/src/previous/encoder.rs
@@ -114,19 +114,14 @@ pub struct CoreFieldEncodingStrategy {
     pub version: LanceFileVersion,
 }
 
-// For some reason clippy has a false negative and thinks this can be derived but
-// it can't because ArrayEncodingStrategy has no default implementation
-#[allow(clippy::derivable_impls)]
-impl Default for CoreFieldEncodingStrategy {
-    fn default() -> Self {
+impl CoreFieldEncodingStrategy {
+    pub fn new(version: LanceFileVersion) -> Self {
         Self {
-            array_encoding_strategy: Arc::<CoreArrayEncodingStrategy>::default(),
-            version: LanceFileVersion::default(),
+            array_encoding_strategy: Arc::new(CoreArrayEncodingStrategy::new(version)),
+            version,
         }
     }
-}
 
-impl CoreFieldEncodingStrategy {
     fn is_primitive_type(data_type: &DataType) -> bool {
         matches!(
             data_type,
@@ -272,7 +267,7 @@ impl FieldEncodingStrategy for CoreFieldEncodingStrategy {
 
 /// The core array encoding strategy is a set of basic encodings that
 /// are generally applicable in most scenarios.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct CoreArrayEncodingStrategy {
     pub version: LanceFileVersion,
 }
@@ -283,6 +278,12 @@ const BINARY_DATATYPES: [DataType; 4] = [
     DataType::Utf8,
     DataType::LargeUtf8,
 ];
+
+impl CoreArrayEncodingStrategy {
+    fn new(version: LanceFileVersion) -> Self {
+        Self { version }
+    }
+}
 
 impl CoreArrayEncodingStrategy {
     fn can_use_fsst(data_type: &DataType, data_size: u64, version: LanceFileVersion) -> bool {

--- a/rust/lance-encoding/src/previous/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/previous/encodings/logical/blob.rs
@@ -400,7 +400,7 @@ pub mod tests {
 
     use crate::{
         format::pb::column_encoding,
-        testing::{check_round_trip_encoding_of_data, check_round_trip_encoding_random, TestCases},
+        testing::{check_round_trip_encoding_of_data, check_specific_random, TestCases},
         version::LanceFileVersion,
     };
 
@@ -414,7 +414,9 @@ pub mod tests {
     #[test_log::test(tokio::test)]
     async fn test_blob() {
         let field = Field::new("", DataType::LargeBinary, false).with_metadata(BLOB_META.clone());
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        // TODO (https://github.com/lancedb/lance/issues/4781)
+        let test_cases = TestCases::default().with_max_file_version(LanceFileVersion::V2_0);
+        check_specific_random(field, test_cases).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -422,26 +424,32 @@ pub mod tests {
         let val1: &[u8] = &[1, 2, 3];
         let val2: &[u8] = &[7, 8, 9];
         let array = Arc::new(LargeBinaryArray::from(vec![Some(val1), None, Some(val2)]));
-        let test_cases = TestCases::default().with_verify_encoding(Arc::new(|cols| {
-            assert_eq!(cols.len(), 1);
-            let col = &cols[0];
-            assert!(matches!(
-                col.encoding.column_encoding.as_ref().unwrap(),
-                column_encoding::ColumnEncoding::Blob(_)
-            ));
-        }));
+        let test_cases = TestCases::default()
+            // TODO (https://github.com/lancedb/lance/issues/4781)
+            .with_max_file_version(LanceFileVersion::V2_0)
+            .with_verify_encoding(Arc::new(|cols| {
+                assert_eq!(cols.len(), 1);
+                let col = &cols[0];
+                assert!(matches!(
+                    col.encoding.column_encoding.as_ref().unwrap(),
+                    column_encoding::ColumnEncoding::Blob(_)
+                ));
+            }));
         // Use blob encoding if requested
         check_round_trip_encoding_of_data(vec![array.clone()], &test_cases, BLOB_META.clone())
             .await;
 
-        let test_cases = TestCases::default().with_verify_encoding(Arc::new(|cols| {
-            assert_eq!(cols.len(), 1);
-            let col = &cols[0];
-            assert!(!matches!(
-                col.encoding.column_encoding.as_ref().unwrap(),
-                column_encoding::ColumnEncoding::Blob(_)
-            ));
-        }));
+        let test_cases = TestCases::default()
+            // TODO (https://github.com/lancedb/lance/issues/4781)
+            .with_max_file_version(LanceFileVersion::V2_0)
+            .with_verify_encoding(Arc::new(|cols| {
+                assert_eq!(cols.len(), 1);
+                let col = &cols[0];
+                assert!(!matches!(
+                    col.encoding.column_encoding.as_ref().unwrap(),
+                    column_encoding::ColumnEncoding::Blob(_)
+                ));
+            }));
         // Don't use blob encoding if not requested
         check_round_trip_encoding_of_data(vec![array], &test_cases, Default::default()).await;
     }

--- a/rust/lance-encoding/src/previous/encodings/physical/bitmap.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/bitmap.rs
@@ -129,40 +129,30 @@ mod tests {
     use arrow_array::BooleanArray;
     use arrow_schema::{DataType, Field};
     use bytes::Bytes;
-    use rstest::rstest;
     use std::{collections::HashMap, sync::Arc};
 
     use crate::data::{DataBlock, FixedWidthDataBlock};
     use crate::decoder::PrimitivePageDecoder;
     use crate::previous::encodings::physical::bitmap::BitmapData;
-    use crate::testing::{
-        check_round_trip_encoding_of_data, check_round_trip_encoding_random, TestCases,
-    };
-    use crate::version::LanceFileVersion;
+    use crate::testing::{check_basic_random, check_round_trip_encoding_of_data, TestCases};
 
     use super::BitmapDecoder;
 
-    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_bitmap_boolean(
-        #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
-    ) {
+    async fn test_bitmap_boolean() {
         let field = Field::new("", DataType::Boolean, false);
-        check_round_trip_encoding_random(field, version).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_fsl_bitmap_boolean() {
         let field = Field::new("", DataType::Boolean, true);
         let field = Field::new("", DataType::FixedSizeList(Arc::new(field), 3), true);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_1).await;
+        check_basic_random(field).await;
     }
 
-    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_simple_boolean(
-        #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
-    ) {
+    async fn test_simple_boolean() {
         let array = BooleanArray::from(vec![
             Some(false),
             Some(true),
@@ -179,25 +169,20 @@ mod tests {
             .with_range(0..2)
             .with_range(0..3)
             .with_range(1..9)
-            .with_indices(vec![0, 1, 3, 4])
-            .with_file_version(version);
+            .with_indices(vec![0, 1, 3, 4]);
         check_round_trip_encoding_of_data(vec![Arc::new(array)], &test_cases, HashMap::default())
             .await;
     }
 
-    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_tiny_boolean(
-        #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
-    ) {
+    async fn test_tiny_boolean() {
         // Test case for a tiny boolean array that is technically smaller than 1 byte
         let array = BooleanArray::from(vec![Some(false), Some(true), None]);
 
         let test_cases = TestCases::default()
             .with_range(0..1)
             .with_range(1..3)
-            .with_indices(vec![0, 2])
-            .with_file_version(version);
+            .with_indices(vec![0, 2]);
         check_round_trip_encoding_of_data(vec![Arc::new(array)], &test_cases, HashMap::default())
             .await;
     }

--- a/rust/lance-encoding/src/previous/encodings/physical/bitpack.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/bitpack.rs
@@ -1153,7 +1153,7 @@ fn rows_in_buffer(
 pub mod test {
     use crate::{
         format::pb,
-        testing::{check_round_trip_encoding_generated, ArrayGeneratorProvider},
+        testing::{check_round_trip_encoding_generated, ArrayGeneratorProvider, TestCases},
         version::LanceFileVersion,
     };
 
@@ -1686,12 +1686,8 @@ pub mod test {
 
         for (data_type, array_gen_provider) in bitpacked_test_cases {
             let field = Field::new("", data_type.clone(), false);
-            check_round_trip_encoding_generated(
-                field,
-                array_gen_provider.copy(),
-                LanceFileVersion::V2_1,
-            )
-            .await;
+            let test_cases = TestCases::basic().with_min_file_version(LanceFileVersion::V2_1);
+            check_round_trip_encoding_generated(field, array_gen_provider.copy(), test_cases).await;
         }
     }
 }

--- a/rust/lance-encoding/src/previous/encodings/physical/dictionary.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/dictionary.rs
@@ -415,7 +415,9 @@ pub mod tests {
     use std::{collections::HashMap, sync::Arc, vec};
 
     use crate::{
-        testing::{check_round_trip_encoding_of_data, check_round_trip_encoding_random, TestCases},
+        testing::{
+            check_basic_random, check_round_trip_encoding_of_data, check_specific_random, TestCases,
+        },
         version::LanceFileVersion,
     };
 
@@ -448,25 +450,25 @@ pub mod tests {
     #[test_log::test(tokio::test)]
     async fn test_utf8() {
         let field = Field::new("", DataType::Utf8, false);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_binary() {
         let field = Field::new("", DataType::Binary, false);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_large_binary() {
         let field = Field::new("", DataType::LargeBinary, true);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_large_utf8() {
         let field = Field::new("", DataType::LargeUtf8, true);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -572,6 +574,8 @@ pub mod tests {
             DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
             false,
         );
-        check_round_trip_encoding_random(dict_field, LanceFileVersion::V2_0).await;
+        // TODO (https://github.com/lancedb/lance/issues/4782)
+        let test_cases = TestCases::default().with_max_file_version(LanceFileVersion::V2_0);
+        check_specific_random(dict_field, test_cases).await;
     }
 }

--- a/rust/lance-encoding/src/previous/encodings/physical/fixed_size_binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/fixed_size_binary.rs
@@ -176,34 +176,31 @@ mod tests {
     use crate::data::{DataBlock, FixedWidthDataBlock};
     use crate::decoder::PrimitivePageDecoder;
     use crate::previous::encodings::physical::fixed_size_binary::FixedSizeBinaryDecoder;
-    use crate::{
-        testing::{check_round_trip_encoding_of_data, check_round_trip_encoding_random, TestCases},
-        version::LanceFileVersion,
-    };
+    use crate::testing::{check_basic_random, check_round_trip_encoding_of_data, TestCases};
 
     #[test_log::test(tokio::test)]
     async fn test_fixed_size_utf8_binary() {
         let field = Field::new("", DataType::Utf8, false);
         // This test only generates fixed size binary arrays anyway
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_fixed_size_binary() {
         let field = Field::new("", DataType::Binary, false);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_fixed_size_large_binary() {
         let field = Field::new("", DataType::LargeBinary, true);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]
     async fn test_fixed_size_large_utf8() {
         let field = Field::new("", DataType::LargeUtf8, true);
-        check_round_trip_encoding_random(field, LanceFileVersion::V2_0).await;
+        check_basic_random(field).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/previous/encodings/physical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/fixed_size_list.rs
@@ -137,25 +137,21 @@ mod tests {
     use arrow_buffer::{BooleanBuffer, NullBuffer};
     use arrow_schema::{DataType, Field};
     use lance_datagen::{array, gen_array, ArrayGeneratorExt, RowCount};
-    use rstest::rstest;
 
     use crate::{
-        testing::{check_round_trip_encoding_of_data, check_round_trip_encoding_random, TestCases},
+        testing::{check_basic_random, check_round_trip_encoding_of_data, TestCases},
         version::LanceFileVersion,
     };
 
     const PRIMITIVE_TYPES: &[DataType] = &[DataType::Int8, DataType::Float32, DataType::Float64];
 
-    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_value_fsl_primitive(
-        #[values(LanceFileVersion::V2_0, LanceFileVersion::V2_1)] version: LanceFileVersion,
-    ) {
+    async fn test_value_fsl_primitive() {
         for data_type in PRIMITIVE_TYPES {
             let inner_field = Field::new("item", data_type.clone(), true);
             let data_type = DataType::FixedSizeList(Arc::new(inner_field), 16);
             let field = Field::new("", data_type, false);
-            check_round_trip_encoding_random(field, version).await;
+            check_basic_random(field).await;
         }
     }
 
@@ -186,7 +182,7 @@ mod tests {
             .with_indices(vec![0, 1, 2])
             .with_indices(vec![1])
             .with_indices(vec![2])
-            .with_file_version(LanceFileVersion::V2_1);
+            .with_min_file_version(LanceFileVersion::V2_1);
 
         check_round_trip_encoding_of_data(vec![list], &test_cases, HashMap::default()).await;
     }
@@ -213,7 +209,7 @@ mod tests {
             .with_indices(vec![0, 1, 2])
             .with_indices(vec![1])
             .with_indices(vec![2])
-            .with_file_version(LanceFileVersion::V2_1);
+            .with_min_file_version(LanceFileVersion::V2_1);
 
         check_round_trip_encoding_of_data(vec![list], &test_cases, HashMap::default()).await;
     }
@@ -264,7 +260,7 @@ mod tests {
             .with_range(1..3)
             .with_indices(vec![0, 1, 2])
             .with_indices(vec![2])
-            .with_file_version(LanceFileVersion::V2_1);
+            .with_min_file_version(LanceFileVersion::V2_1);
 
         check_round_trip_encoding_of_data(vec![outer_list], &test_cases, HashMap::default()).await;
     }

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -16,7 +16,7 @@ use arrow_schema::{DataType, Field, FieldRef, Schema, SortOptions};
 use arrow_select::concat::concat;
 use bytes::{Bytes, BytesMut};
 use futures::{future::BoxFuture, FutureExt, StreamExt};
-use log::{debug, trace};
+use log::{debug, info, trace};
 use tokio::sync::mpsc::{self, UnboundedSender};
 
 use lance_core::{utils::bit::pad_bytes, Result};
@@ -269,11 +269,16 @@ impl ArrayGeneratorProvider for RandomArrayGeneratorProvider {
 }
 
 /// Given a field this will test the round trip encoding and decoding of random data
-pub async fn check_round_trip_encoding_random(field: Field, version: LanceFileVersion) {
+pub async fn check_basic_random(field: Field) {
+    check_specific_random(field, TestCases::basic()).await;
+}
+
+pub async fn check_specific_random(field: Field, test_cases: TestCases) {
     let array_generator_provider = RandomArrayGeneratorProvider {
         field: field.clone(),
     };
-    check_round_trip_encoding_generated(field, Box::new(array_generator_provider), version).await;
+    check_round_trip_encoding_generated(field, Box::new(array_generator_provider), test_cases)
+        .await;
 }
 
 pub struct FnArrayGeneratorProvider<F: Fn() -> Box<dyn ArrayGenerator> + Clone + 'static> {
@@ -300,16 +305,23 @@ impl<F: Fn() -> Box<dyn ArrayGenerator> + Clone + 'static> ArrayGeneratorProvide
     }
 }
 
+pub async fn check_basic_generated(
+    field: Field,
+    array_generator_provider: Box<dyn ArrayGeneratorProvider>,
+) {
+    check_round_trip_encoding_generated(field, array_generator_provider, TestCases::basic()).await;
+}
+
 pub async fn check_round_trip_encoding_generated(
     field: Field,
     array_generator_provider: Box<dyn ArrayGeneratorProvider>,
-    version: LanceFileVersion,
+    test_cases: TestCases,
 ) {
     let lance_field = lance_core::datatypes::Field::try_from(&field).unwrap();
     for page_size in [4096, 1024 * 1024] {
         debug!("Testing random data with a page size of {}", page_size);
-        let encoding_strategy = default_encoding_strategy(version);
-        let encoder_factory = || {
+        let encoder_factory = |version: LanceFileVersion| {
+            let encoding_strategy = default_encoding_strategy(version);
             let mut column_index_seq = ColumnIndexSequence::default();
             let encoding_options = EncodingOptions {
                 max_page_bytes: MAX_PAGE_BYTES,
@@ -327,20 +339,31 @@ pub async fn check_round_trip_encoding_generated(
                 .unwrap()
         };
 
-        // let array_generator_provider = RandomArrayGeneratorProvider{field: field.clone()};
-        check_round_trip_field_encoding_random(
+        check_round_trip_random(
             encoder_factory,
             field.clone(),
             array_generator_provider.copy(),
-            version,
+            &test_cases,
         )
         .await
     }
 }
 
 fn supports_nulls(data_type: &DataType, version: LanceFileVersion) -> bool {
-    // 2.0 doesn't support nullability for structs
-    !(matches!(data_type, DataType::Struct(_)) && version == LanceFileVersion::V2_0)
+    if let DataType::Struct(fields) = data_type {
+        if version == LanceFileVersion::V2_0 {
+            // 2.0 doesn't support nullability for structs
+            false
+        } else if fields.is_empty() {
+            // Even in 2.1 we don't support nulls for struct if there are no children because
+            // we have no spot to stick the repdef info (there is no column)
+            false
+        } else {
+            true
+        }
+    } else {
+        true
+    }
 }
 
 type EncodingVerificationFn = dyn Fn(&[EncodedColumn]);
@@ -354,7 +377,8 @@ pub struct TestCases {
     skip_validation: bool,
     max_page_size: Option<u64>,
     page_sizes: Vec<u64>,
-    file_version: LanceFileVersion,
+    min_file_version: Option<LanceFileVersion>,
+    max_file_version: Option<LanceFileVersion>,
     verify_encoding: Option<Arc<EncodingVerificationFn>>,
     expected_encoding: Option<Vec<String>>,
 }
@@ -368,7 +392,8 @@ impl Default for TestCases {
             skip_validation: false,
             max_page_size: None,
             page_sizes: vec![4096, 1024 * 1024],
-            file_version: LanceFileVersion::default(),
+            min_file_version: None,
+            max_file_version: None,
             verify_encoding: None,
             expected_encoding: None,
         }
@@ -376,6 +401,21 @@ impl Default for TestCases {
 }
 
 impl TestCases {
+    pub fn basic() -> Self {
+        Self::default()
+            .with_range(0..500)
+            .with_range(100..1100)
+            .with_range(8000..8500)
+            .with_indices(vec![100])
+            .with_indices(vec![0])
+            .with_indices(vec![9999])
+            .with_indices(vec![100, 1100, 5000])
+            .with_indices(vec![1000, 2000, 3000])
+            .with_indices(vec![2000, 2001, 2002, 2003, 2004])
+            // Big take that spans multiple pages and generates multiple output batches
+            .with_indices((100..500).map(|i| i * 3).collect::<Vec<_>>())
+    }
+
     pub fn with_range(mut self, range: Range<u64>) -> Self {
         self.ranges.push(range);
         self
@@ -396,8 +436,13 @@ impl TestCases {
         self
     }
 
-    pub fn with_file_version(mut self, version: LanceFileVersion) -> Self {
-        self.file_version = version;
+    pub fn with_min_file_version(mut self, version: LanceFileVersion) -> Self {
+        self.min_file_version = Some(version);
+        self
+    }
+
+    pub fn with_max_file_version(mut self, version: LanceFileVersion) -> Self {
+        self.max_file_version = Some(version);
         self
     }
 
@@ -413,6 +458,24 @@ impl TestCases {
 
     fn get_max_page_size(&self) -> u64 {
         self.max_page_size.unwrap_or(MAX_PAGE_BYTES)
+    }
+
+    fn get_versions(&self) -> Vec<LanceFileVersion> {
+        LanceFileVersion::iter_non_legacy()
+            .filter(|v| {
+                if let Some(min_file_version) = &self.min_file_version {
+                    if v < min_file_version {
+                        return false;
+                    }
+                }
+                if let Some(max_file_version) = &self.max_file_version {
+                    if v > max_file_version {
+                        return false;
+                    }
+                }
+                true
+            })
+            .collect()
     }
 
     pub fn with_verify_encoding(mut self, verify_encoding: Arc<EncodingVerificationFn>) -> Self {
@@ -611,24 +674,31 @@ pub async fn check_round_trip_encoding_of_data(
     let mut field = Field::new("", example_data.data_type().clone(), true);
     field = field.with_metadata(metadata);
     let lance_field = lance_core::datatypes::Field::try_from(&field).unwrap();
-    for page_size in test_cases.page_sizes.iter() {
-        let encoding_strategy = default_encoding_strategy(test_cases.file_version);
-        let mut column_index_seq = ColumnIndexSequence::default();
-        let encoding_options = EncodingOptions {
-            cache_bytes_per_column: *page_size,
-            max_page_bytes: test_cases.get_max_page_size(),
-            keep_original_array: true,
-            buffer_alignment: MIN_PAGE_BUFFER_ALIGNMENT,
-        };
-        let encoder = encoding_strategy
-            .create_field_encoder(
-                encoding_strategy.as_ref(),
-                &lance_field,
-                &mut column_index_seq,
-                &encoding_options,
-            )
-            .unwrap();
-        check_round_trip_encoding_inner(encoder, &field, data.clone(), test_cases).await
+    for file_version in test_cases.get_versions() {
+        for page_size in test_cases.page_sizes.iter() {
+            let encoding_strategy = default_encoding_strategy(file_version);
+            let mut column_index_seq = ColumnIndexSequence::default();
+            let encoding_options = EncodingOptions {
+                cache_bytes_per_column: *page_size,
+                max_page_bytes: test_cases.get_max_page_size(),
+                keep_original_array: true,
+                buffer_alignment: MIN_PAGE_BUFFER_ALIGNMENT,
+            };
+            let encoder = encoding_strategy
+                .create_field_encoder(
+                    encoding_strategy.as_ref(),
+                    &lance_field,
+                    &mut column_index_seq,
+                    &encoding_options,
+                )
+                .unwrap();
+            info!(
+                "Testing round trip encoding of data with file version {} and page size {}",
+                file_version, page_size
+            );
+            check_round_trip_encoding_inner(encoder, &field, data.clone(), test_cases, file_version)
+                .await
+        }
     }
 }
 
@@ -697,8 +767,24 @@ async fn check_round_trip_encoding_inner(
     field: &Field,
     data: Vec<Arc<dyn Array>>,
     test_cases: &TestCases,
+    file_version: LanceFileVersion,
 ) {
     let mut writer = SimulatedWriter::new(encoder.num_columns());
+
+    let log_page = |encoded_page: &EncodedPage| {
+        debug!(
+            "Encoded page on column {} with {} rows and start row {} and buffer sizes [{}]",
+            encoded_page.column_idx,
+            encoded_page.num_rows,
+            encoded_page.row_number,
+            encoded_page
+                .data
+                .iter()
+                .map(|buf| buf.len().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    };
 
     let mut row_number = 0;
     for arr in &data {
@@ -719,9 +805,10 @@ async fn check_round_trip_encoding_inner(
         }
         for encode_task in encode_tasks {
             let encoded_page = encode_task.await.unwrap();
+            log_page(&encoded_page);
 
             // For V2.1, verify encoding in the page if expected
-            if test_cases.file_version >= LanceFileVersion::V2_1 {
+            if file_version >= LanceFileVersion::V2_1 {
                 if let Some(ref expected) = test_cases.expected_encoding {
                     verify_page_encoding(&encoded_page, expected, encoded_page.column_idx as usize)
                         .unwrap();
@@ -740,9 +827,10 @@ async fn check_round_trip_encoding_inner(
     }
     for task in encode_tasks {
         let encoded_page = task.await.unwrap();
+        log_page(&encoded_page);
 
         // For V2.1, verify encoding in the page if expected
-        if test_cases.file_version >= LanceFileVersion::V2_1 {
+        if file_version >= LanceFileVersion::V2_1 {
             if let Some(ref expected) = test_cases.expected_encoding {
                 verify_page_encoding(&encoded_page, expected, encoded_page.column_idx as usize)
                     .unwrap();
@@ -807,7 +895,7 @@ async fn check_round_trip_encoding_inner(
         Some(concat(&data.iter().map(|arr| arr.as_ref()).collect::<Vec<_>>()).unwrap())
     };
 
-    let is_structural_encoding = test_cases.file_version >= LanceFileVersion::V2_1;
+    let is_structural_encoding = file_version >= LanceFileVersion::V2_1;
 
     debug!("Testing full decode");
     let scheduler_copy = scheduler.clone();
@@ -925,74 +1013,42 @@ async fn check_round_trip_encoding_inner(
 const NUM_RANDOM_ROWS: u32 = 10000;
 
 /// Generates random data (parameterized by null rate, slicing, and # ingest batches)
-/// and tests with that.
-async fn check_round_trip_field_encoding_random(
-    encoder_factory: impl Fn() -> Box<dyn FieldEncoder>,
+/// and tests with that against default test cases.
+///
+/// To test specific test cases use the
+async fn check_round_trip_random(
+    encoder_factory: impl Fn(LanceFileVersion) -> Box<dyn FieldEncoder>,
     field: Field,
     array_generator_provider: Box<dyn ArrayGeneratorProvider>,
-    version: LanceFileVersion,
+    test_cases: &TestCases,
 ) {
     for null_rate in [None, Some(0.5), Some(1.0)] {
         for use_slicing in [false, true] {
-            if null_rate != Some(1.0) && matches!(field.data_type(), DataType::Null) {
-                continue;
-            }
-
-            let field = if null_rate.is_some() {
-                if !supports_nulls(field.data_type(), version) {
+            for file_version in test_cases.get_versions() {
+                if null_rate != Some(1.0) && matches!(field.data_type(), DataType::Null) {
                     continue;
                 }
-                field.clone().with_nullable(true)
-            } else {
-                field.clone().with_nullable(false)
-            };
 
-            let test_cases = TestCases::default()
-                .with_file_version(version)
-                .with_range(0..500)
-                .with_range(100..1100)
-                .with_range(8000..8500)
-                .with_indices(vec![100])
-                .with_indices(vec![0])
-                .with_indices(vec![9999])
-                .with_indices(vec![100, 1100, 5000])
-                .with_indices(vec![1000, 2000, 3000])
-                .with_indices(vec![2000, 2001, 2002, 2003, 2004])
-                // Big take that spans multiple pages and generates multiple output batches
-                .with_indices((100..500).map(|i| i * 3).collect::<Vec<_>>());
-
-            for num_ingest_batches in [1, 5, 10] {
-                let rows_per_batch = NUM_RANDOM_ROWS / num_ingest_batches;
-                let mut data = Vec::new();
-
-                // Test both ingesting one big array sliced into smaller arrays and smaller
-                // arrays independently generated.  These behave slightly differently.  For
-                // example, a list array sliced into smaller arrays will have arrays whose
-                // starting offset is not 0.
-                if use_slicing {
-                    let mut generator = gen_batch().anon_col(array_generator_provider.provide());
-                    if let Some(null_rate) = null_rate {
-                        // The null generator is the only generator that already inserts nulls
-                        // and attempting to do so again makes arrow-rs grumpy
-                        if !matches!(field.data_type(), DataType::Null) {
-                            generator.with_random_nulls(null_rate);
-                        }
+                let field = if null_rate.is_some() {
+                    if !supports_nulls(field.data_type(), file_version) {
+                        continue;
                     }
-                    let all_data = generator
-                        .into_batch_rows(RowCount::from(10000))
-                        .unwrap()
-                        .column(0)
-                        .clone();
-                    let mut offset = 0;
-                    for _ in 0..num_ingest_batches {
-                        data.push(all_data.slice(offset, rows_per_batch as usize));
-                        offset += rows_per_batch as usize;
-                    }
+                    field.clone().with_nullable(true)
                 } else {
-                    for i in 0..num_ingest_batches {
-                        let mut generator = gen_batch()
-                            .with_seed(Seed::from(i as u64))
-                            .anon_col(array_generator_provider.provide());
+                    field.clone().with_nullable(false)
+                };
+
+                for num_ingest_batches in [1, 5, 10] {
+                    let rows_per_batch = NUM_RANDOM_ROWS / num_ingest_batches;
+                    let mut data = Vec::new();
+
+                    // Test both ingesting one big array sliced into smaller arrays and smaller
+                    // arrays independently generated.  These behave slightly differently.  For
+                    // example, a list array sliced into smaller arrays will have arrays whose
+                    // starting offset is not 0.
+                    if use_slicing {
+                        let mut generator =
+                            gen_batch().anon_col(array_generator_provider.provide());
                         if let Some(null_rate) = null_rate {
                             // The null generator is the only generator that already inserts nulls
                             // and attempting to do so again makes arrow-rs grumpy
@@ -1000,24 +1056,55 @@ async fn check_round_trip_field_encoding_random(
                                 generator.with_random_nulls(null_rate);
                             }
                         }
-                        let arr = generator
-                            .into_batch_rows(RowCount::from(rows_per_batch as u64))
+                        let all_data = generator
+                            .into_batch_rows(RowCount::from(10000))
                             .unwrap()
                             .column(0)
                             .clone();
-                        data.push(arr);
+                        let mut offset = 0;
+                        for _ in 0..num_ingest_batches {
+                            data.push(all_data.slice(offset, rows_per_batch as usize));
+                            offset += rows_per_batch as usize;
+                        }
+                    } else {
+                        for i in 0..num_ingest_batches {
+                            let mut generator = gen_batch()
+                                .with_seed(Seed::from(i as u64))
+                                .anon_col(array_generator_provider.provide());
+                            if let Some(null_rate) = null_rate {
+                                // The null generator is the only generator that already inserts nulls
+                                // and attempting to do so again makes arrow-rs grumpy
+                                if !matches!(field.data_type(), DataType::Null) {
+                                    generator.with_random_nulls(null_rate);
+                                }
+                            }
+                            let arr = generator
+                                .into_batch_rows(RowCount::from(rows_per_batch as u64))
+                                .unwrap()
+                                .column(0)
+                                .clone();
+                            data.push(arr);
+                        }
                     }
-                }
 
-                debug!(
-                    "Testing with {} rows divided across {} batches for {} rows per batch with null_rate={:?} and use_slicing={}",
-                    NUM_RANDOM_ROWS,
-                    num_ingest_batches,
-                    rows_per_batch,
-                    null_rate,
-                    use_slicing
-                );
-                check_round_trip_encoding_inner(encoder_factory(), &field, data, &test_cases).await
+                    info!(
+                        "Testing version {} with {} rows divided across {} batches for {} rows per batch with null_rate={:?} and use_slicing={}",
+                        file_version,
+                        NUM_RANDOM_ROWS,
+                        num_ingest_batches,
+                        rows_per_batch,
+                        null_rate,
+                        use_slicing
+                    );
+                    check_round_trip_encoding_inner(
+                        encoder_factory(file_version),
+                        &field,
+                        data,
+                        test_cases,
+                        file_version,
+                    )
+                    .await
+                }
             }
         }
     }

--- a/rust/lance-encoding/src/version.rs
+++ b/rust/lance-encoding/src/version.rs
@@ -12,7 +12,7 @@ pub const V2_FORMAT_2_1: &str = "2.1";
 pub const V2_FORMAT_2_2: &str = "2.2";
 
 /// Lance file version
-#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Ord, PartialOrd)]
+#[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Ord, PartialOrd, strum::EnumIter)]
 pub enum LanceFileVersion {
     // Note that Stable must come AFTER the stable version and Next must come AFTER the next version
     // this way comparisons like x >= V2_0 will work the same if x is Stable or V2_0
@@ -63,6 +63,12 @@ impl LanceFileVersion {
             Self::Stable => self.resolve().to_numbers(),
             Self::Next => self.resolve().to_numbers(),
         }
+    }
+
+    pub fn iter_non_legacy() -> impl Iterator<Item = Self> {
+        use strum::IntoEnumIterator;
+
+        Self::iter().filter(|&v| v != Self::Stable && v != Self::Next && v != Self::Legacy)
     }
 }
 

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -383,7 +383,9 @@ impl FileWriter {
     /// flushed to the file (some data may be in the data cache or the I/O cache)
     pub async fn write_batch(&mut self, batch: &RecordBatch) -> Result<()> {
         debug!(
-            "write_batch called with {} bytes of data",
+            "write_batch called with {} rows, {} columns, and {} bytes of data",
+            batch.num_rows(),
+            batch.num_columns(),
             batch.get_array_memory_size()
         );
         self.ensure_initialized(batch)?;

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -494,14 +494,15 @@ mod tests {
     use super::*;
 
     fn sample_fragment() -> Fragment {
+        let (major_version, minor_version) = LanceFileVersion::Stable.to_numbers();
         Fragment {
             id: 0,
             files: vec![DataFile {
                 path: "file.lance".to_string(),
                 fields: vec![0],
                 column_indices: vec![0],
-                file_major_version: 2,
-                file_minor_version: 0,
+                file_major_version: major_version,
+                file_minor_version: minor_version,
                 file_size_bytes: CachedFileSize::new(100),
                 base_id: None,
             }],

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1127,7 +1127,7 @@ impl DatasetIndexInternalExt for Dataset {
                 .await
             }
 
-            (0, 3) => {
+            (0, 3) | (2, _) => {
                 let scheduler = ScanScheduler::new(
                     self.object_store.clone(),
                     SchedulerConfig::max_bandwidth(&self.object_store),

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1704,7 +1704,7 @@ mod tests {
                 "path1",
                 vec![0],
                 vec![0],
-                &LanceFileVersion::V2_0,
+                &LanceFileVersion::Stable,
                 NonZero::new(10),
             )
             .with_physical_rows(3);
@@ -1836,7 +1836,7 @@ mod tests {
                 "path1",
                 vec![0],
                 vec![0],
-                &LanceFileVersion::V2_0,
+                &LanceFileVersion::Stable,
                 NonZero::new(10),
             )
             .with_physical_rows(3);


### PR DESCRIPTION
This fixes various issues in the 2.1 list decoder.  In addition, I've reworked the test utilities slightly as a large number of tests were not running against 2.1.  This exposed several issues and some tests I've had to defer fixing for future PRs and I've created TODO's for those.