### PR TITLE
feat(java): Expose additional Operation::Update fields to bindings

### DIFF
--- a/java/lance-jni/src/traits.rs
+++ b/java/lance-jni/src/traits.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use jni::objects::{JIntArray, JMap, JObject, JString, JValue, JValueGen};
+use jni::objects::{JIntArray, JLongArray, JMap, JObject, JString, JValue, JValueGen};
 use jni::JNIEnv;
 
 use crate::error::Result;
@@ -191,6 +191,15 @@ impl IntoJava for JLance<Vec<i32>> {
     }
 }
 
+impl IntoJava for JLance<Vec<u32>> {
+    fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
+        let arr = env.new_long_array(self.0.len() as i32)?;
+        let res: Vec<i64> = self.0.iter().map(|val| *val as i64).collect();
+        env.set_long_array_region(&arr, 0, &res)?;
+        Ok(arr.into())
+    }
+}
+
 impl IntoJava for JLance<usize> {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
         Ok(env.new_object("java/lang/Long", "(J)V", &[JValueGen::Long(self.0 as i64)])?)
@@ -245,6 +254,16 @@ impl FromJObjectWithEnv<Vec<i32>> for JIntArray<'_> {
         Ok(ret)
     }
 }
+
+impl FromJObjectWithEnv<Vec<u32>> for JLongArray<'_> {
+    fn extract_object(&self, env: &mut JNIEnv<'_>) -> Result<Vec<u32>> {
+        let len = env.get_array_length(self)?;
+        let mut ret: Vec<i64> = vec![0; len as usize];
+        env.get_long_array_region(self, 0, ret.as_mut_slice())?;
+        Ok(ret.into_iter().map(|val| val as u32).collect())
+    }
+}
+
 
 impl FromJObjectWithEnv<i32> for JObject<'_> {
     fn extract_object(&self, env: &mut JNIEnv<'_>) -> Result<i32> {

--- a/java/lance-jni/src/traits.rs
+++ b/java/lance-jni/src/traits.rs
@@ -264,7 +264,6 @@ impl FromJObjectWithEnv<Vec<u32>> for JLongArray<'_> {
     }
 }
 
-
 impl FromJObjectWithEnv<i32> for JObject<'_> {
     fn extract_object(&self, env: &mut JNIEnv<'_>) -> Result<i32> {
         let ret = env.call_method(self, "intValue", "()I", &[])?.i()?;

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -13,11 +13,11 @@ use crate::JNIEnvExt;
 use arrow::datatypes::Schema;
 use arrow_schema::ffi::FFI_ArrowSchema;
 use chrono::DateTime;
-use jni::objects::{JByteArray, JMap, JObject, JString, JValue};
+use jni::objects::{JByteArray, JLongArray, JMap, JObject, JString, JValue, JValueGen};
 use jni::sys::jbyte;
 use jni::JNIEnv;
 use lance::dataset::transaction::{
-    DataReplacementGroup, Operation, RewriteGroup, RewrittenIndex, Transaction, TransactionBuilder,
+    DataReplacementGroup, Operation, RewriteGroup, RewrittenIndex, Transaction, TransactionBuilder, UpdateMode,
 };
 use lance::table::format::{Fragment, Index};
 use lance_core::datatypes::Schema as LanceSchema;
@@ -170,6 +170,25 @@ impl IntoJava for &Index {
     }
 }
 
+impl IntoJava for &UpdateMode {
+    fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
+        let name = match self {
+            UpdateMode::RewriteRows => "RewriteRows",
+            UpdateMode::RewriteColumns => "RewriteColumns",
+        };
+        let update_mode_type_class = "com/lancedb/lance/operation/Update$UpdateMode";
+        env.get_static_field(
+            update_mode_type_class,
+            name,
+            format!("L{};", update_mode_type_class),
+        )?
+        .l()
+        .map_err(|e| {
+            Error::runtime_error(format!("failed to get {}: {}", update_mode_type_class, e))
+        })
+    }
+}
+
 impl FromJObjectWithEnv<RewriteGroup> for JObject<'_> {
     fn extract_object(&self, env: &mut JNIEnv<'_>) -> Result<RewriteGroup> {
         let old_fragments: Vec<Fragment> =
@@ -294,6 +313,21 @@ impl FromJObjectWithEnv<DataReplacementGroup> for JObject<'_> {
             .extract_object(env)?;
 
         Ok(DataReplacementGroup(fragment_id, new_file))
+    }
+}
+
+impl FromJObjectWithEnv<UpdateMode> for JObject<'_> {
+    fn extract_object(&self, env: &mut JNIEnv<'_>) -> Result<UpdateMode> {
+        let s = env
+            .call_method(self, "toString", "()Ljava/lang/String;", &[])?
+            .l()?;
+        let s: String = env.get_string(&JString::from(s))?.into();
+        let t = if s == "RewriteRows" {
+            UpdateMode::RewriteRows
+        } else {
+            UpdateMode::RewriteColumns
+        };
+        Ok(t)
     }
 }
 
@@ -462,10 +496,10 @@ fn convert_to_java_operation_inner<'local>(
             removed_fragment_ids,
             updated_fragments,
             new_fragments,
-            fields_modified: _,
+            fields_modified,
             mem_wal_to_merge: _,
-            fields_for_preserving_frag_bitmap: _,
-            update_mode: _,
+            fields_for_preserving_frag_bitmap,
+            update_mode,
         } => {
             let removed_ids: Vec<JLance<i64>> = removed_fragment_ids
                 .iter()
@@ -474,14 +508,30 @@ fn convert_to_java_operation_inner<'local>(
             let removed_fragment_ids_obj = export_vec(env, &removed_ids)?;
             let updated_fragments_obj = export_vec(env, &updated_fragments)?;
             let new_fragments_obj = export_vec(env, &new_fragments)?;
-
+            let fields_modified = JLance(fields_modified.clone()).into_java(env)?;
+            let fields_for_preserving_frag_bitmap = JLance(fields_for_preserving_frag_bitmap.clone()).into_java(env)?;
+            let update_mode =     match update_mode {
+                Some(update_mode) => update_mode.into_java(env),
+                None => Ok(JObject::null()),
+            }?;
+            let update_mode_optional = env
+                .call_static_method(
+                    "java/util/Optional",
+                    "ofNullable",
+                    "(Ljava/lang/Object;)Ljava/util/Optional;",
+                    &[JValue::Object(&update_mode)],
+                )?
+                .l()?;
             Ok(env.new_object(
                 "com/lancedb/lance/operation/Update",
-                "(Ljava/util/List;Ljava/util/List;Ljava/util/List;)V",
+                "(Ljava/util/List;Ljava/util/List;Ljava/util/List;[J[JLjava/util/Optional;)V",
                 &[
                     JValue::Object(&removed_fragment_ids_obj),
                     JValue::Object(&updated_fragments_obj),
                     JValue::Object(&new_fragments_obj),
+                    JValueGen::Object(&fields_modified),
+                    JValueGen::Object(&fields_for_preserving_frag_bitmap),
+                    JValue::Object(&update_mode_optional),
                 ],
             )?)
         }
@@ -883,14 +933,24 @@ fn convert_to_rust_operation(
                     fragment.extract_object(env)
                 })?;
 
+            let fields_modified = env.call_method(java_operation, "fieldsModified", "()[J", &[])?.l()?;
+            let fields_modified = JLongArray::from(fields_modified).extract_object(env)?;
+
+            let fields_for_preserving_frag_bitmap = env.call_method(java_operation, "fieldsForRreservingFragBitmap", "()[J", &[])?.l()?;
+            let fields_for_preserving_frag_bitmap = JLongArray::from(fields_for_preserving_frag_bitmap).extract_object(env)?;
+
+            let update_mode: Option<UpdateMode> = env.get_optional_from_method(java_operation, "updateMode", |env, update_mode| {
+                    update_mode.extract_object(env)
+                })?;
+
             Operation::Update {
                 removed_fragment_ids,
                 updated_fragments,
                 new_fragments,
-                fields_modified: vec![],
+                fields_modified: fields_modified,
                 mem_wal_to_merge: None,
-                update_mode: None,
-                fields_for_preserving_frag_bitmap: vec![],
+                fields_for_preserving_frag_bitmap: fields_for_preserving_frag_bitmap,
+                update_mode: update_mode,
             }
         }
         "DataReplacement" => {

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -510,7 +510,7 @@ fn convert_to_java_operation_inner<'local>(
             let new_fragments_obj = export_vec(env, &new_fragments)?;
             let fields_modified = JLance(fields_modified.clone()).into_java(env)?;
             let fields_for_preserving_frag_bitmap = JLance(fields_for_preserving_frag_bitmap.clone()).into_java(env)?;
-            let update_mode =     match update_mode {
+            let update_mode = match update_mode {
                 Some(update_mode) => update_mode.into_java(env),
                 None => Ok(JObject::null()),
             }?;
@@ -936,7 +936,7 @@ fn convert_to_rust_operation(
             let fields_modified = env.call_method(java_operation, "fieldsModified", "()[J", &[])?.l()?;
             let fields_modified = JLongArray::from(fields_modified).extract_object(env)?;
 
-            let fields_for_preserving_frag_bitmap = env.call_method(java_operation, "fieldsForRreservingFragBitmap", "()[J", &[])?.l()?;
+            let fields_for_preserving_frag_bitmap = env.call_method(java_operation, "fieldsForPreservingFragBitmap", "()[J", &[])?.l()?;
             let fields_for_preserving_frag_bitmap = JLongArray::from(fields_for_preserving_frag_bitmap).extract_object(env)?;
 
             let update_mode: Option<UpdateMode> = env.get_optional_from_method(java_operation, "updateMode", |env, update_mode| {

--- a/java/src/main/java/com/lancedb/lance/operation/Update.java
+++ b/java/src/main/java/com/lancedb/lance/operation/Update.java
@@ -17,22 +17,33 @@ import com.lancedb.lance.FragmentMetadata;
 
 import com.google.common.base.MoreObjects;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class Update implements Operation {
   private final List<Long> removedFragmentIds;
   private final List<FragmentMetadata> updatedFragments;
   private final List<FragmentMetadata> newFragments;
+  private final long[] fieldsModified;
+  private final long[] fieldsForRreservingFragBitmap;
+  private final Optional<UpdateMode> updateMode;
 
   private Update(
       List<Long> removedFragmentIds,
       List<FragmentMetadata> updatedFragments,
-      List<FragmentMetadata> newFragments) {
+      List<FragmentMetadata> newFragments,
+      long[] fieldsModified,
+      long[] fieldsForRreservingFragBitmap,
+      Optional<UpdateMode> updateMode) {
     this.removedFragmentIds = removedFragmentIds;
     this.updatedFragments = updatedFragments;
     this.newFragments = newFragments;
+    this.fieldsModified = fieldsModified;
+    this.fieldsForRreservingFragBitmap = fieldsForRreservingFragBitmap;
+    this.updateMode = updateMode;
   }
 
   public static Builder builder() {
@@ -51,6 +62,18 @@ public class Update implements Operation {
     return newFragments;
   }
 
+  public long[] fieldsModified() {
+    return fieldsModified;
+  }
+
+  public long[] fieldsForRreservingFragBitmap() {
+    return fieldsForRreservingFragBitmap;
+  }
+
+  public Optional<UpdateMode> updateMode() {
+    return updateMode;
+  }
+
   @Override
   public String name() {
     return "Update";
@@ -61,6 +84,9 @@ public class Update implements Operation {
         .add("removedFragmentIds", removedFragmentIds)
         .add("updatedFragments", updatedFragments)
         .add("newFragments", newFragments)
+        .add("fieldsModified", fieldsModified)
+        .add("fieldsForRreservingFragBitmap", fieldsForRreservingFragBitmap)
+        .add("updateMode", updateMode)
         .toString();
   }
 
@@ -71,13 +97,24 @@ public class Update implements Operation {
     Update that = (Update) o;
     return Objects.equals(removedFragmentIds, that.removedFragmentIds)
         && Objects.equals(updatedFragments, that.updatedFragments)
-        && Objects.equals(newFragments, that.newFragments);
+        && Objects.equals(newFragments, that.newFragments)
+        && Arrays.equals(fieldsModified, that.fieldsModified)
+        && Arrays.equals(fieldsForRreservingFragBitmap, that.fieldsForRreservingFragBitmap)
+        && Objects.equals(updateMode, that.updateMode);
+  }
+
+  public enum UpdateMode {
+    RewriteRows,
+    RewriteColumns;
   }
 
   public static class Builder {
     private List<Long> removedFragmentIds = Collections.emptyList();
     private List<FragmentMetadata> updatedFragments = Collections.emptyList();
     private List<FragmentMetadata> newFragments = Collections.emptyList();
+    private long[] fieldsModified = new long[0];
+    private long[] fieldsForRreservingFragBitmap = new long[0];
+    private Optional<UpdateMode> updateMode = Optional.empty();
 
     private Builder() {}
 
@@ -96,8 +133,29 @@ public class Update implements Operation {
       return this;
     }
 
+    public Builder fieldsModified(long[] fieldsModified) {
+      this.fieldsModified = fieldsModified;
+      return this;
+    }
+
+    public Builder fieldsForRreservingFragBitmap(long[] fieldsForRreservingFragBitmap) {
+      this.fieldsForRreservingFragBitmap = fieldsForRreservingFragBitmap;
+      return this;
+    }
+
+    public Builder updateMode(Optional<UpdateMode> updateMode) {
+      this.updateMode = updateMode;
+      return this;
+    }
+
     public Update build() {
-      return new Update(removedFragmentIds, updatedFragments, newFragments);
+      return new Update(
+          removedFragmentIds,
+          updatedFragments,
+          newFragments,
+          fieldsModified,
+          fieldsForRreservingFragBitmap,
+          updateMode);
     }
   }
 }

--- a/java/src/main/java/com/lancedb/lance/operation/Update.java
+++ b/java/src/main/java/com/lancedb/lance/operation/Update.java
@@ -28,7 +28,7 @@ public class Update implements Operation {
   private final List<FragmentMetadata> updatedFragments;
   private final List<FragmentMetadata> newFragments;
   private final long[] fieldsModified;
-  private final long[] fieldsForRreservingFragBitmap;
+  private final long[] fieldsForPreservingFragBitmap;
   private final Optional<UpdateMode> updateMode;
 
   private Update(
@@ -36,13 +36,13 @@ public class Update implements Operation {
       List<FragmentMetadata> updatedFragments,
       List<FragmentMetadata> newFragments,
       long[] fieldsModified,
-      long[] fieldsForRreservingFragBitmap,
+      long[] fieldsForPreservingFragBitmap,
       Optional<UpdateMode> updateMode) {
     this.removedFragmentIds = removedFragmentIds;
     this.updatedFragments = updatedFragments;
     this.newFragments = newFragments;
     this.fieldsModified = fieldsModified;
-    this.fieldsForRreservingFragBitmap = fieldsForRreservingFragBitmap;
+    this.fieldsForPreservingFragBitmap = fieldsForPreservingFragBitmap;
     this.updateMode = updateMode;
   }
 
@@ -66,8 +66,8 @@ public class Update implements Operation {
     return fieldsModified;
   }
 
-  public long[] fieldsForRreservingFragBitmap() {
-    return fieldsForRreservingFragBitmap;
+  public long[] fieldsForPreservingFragBitmap() {
+    return fieldsForPreservingFragBitmap;
   }
 
   public Optional<UpdateMode> updateMode() {
@@ -85,7 +85,7 @@ public class Update implements Operation {
         .add("updatedFragments", updatedFragments)
         .add("newFragments", newFragments)
         .add("fieldsModified", fieldsModified)
-        .add("fieldsForRreservingFragBitmap", fieldsForRreservingFragBitmap)
+        .add("fieldsForPreservingFragBitmap", fieldsForPreservingFragBitmap)
         .add("updateMode", updateMode)
         .toString();
   }
@@ -99,7 +99,7 @@ public class Update implements Operation {
         && Objects.equals(updatedFragments, that.updatedFragments)
         && Objects.equals(newFragments, that.newFragments)
         && Arrays.equals(fieldsModified, that.fieldsModified)
-        && Arrays.equals(fieldsForRreservingFragBitmap, that.fieldsForRreservingFragBitmap)
+        && Arrays.equals(fieldsForPreservingFragBitmap, that.fieldsForPreservingFragBitmap)
         && Objects.equals(updateMode, that.updateMode);
   }
 
@@ -113,7 +113,7 @@ public class Update implements Operation {
     private List<FragmentMetadata> updatedFragments = Collections.emptyList();
     private List<FragmentMetadata> newFragments = Collections.emptyList();
     private long[] fieldsModified = new long[0];
-    private long[] fieldsForRreservingFragBitmap = new long[0];
+    private long[] fieldsForPreservingFragBitmap = new long[0];
     private Optional<UpdateMode> updateMode = Optional.empty();
 
     private Builder() {}
@@ -138,8 +138,8 @@ public class Update implements Operation {
       return this;
     }
 
-    public Builder fieldsForRreservingFragBitmap(long[] fieldsForRreservingFragBitmap) {
-      this.fieldsForRreservingFragBitmap = fieldsForRreservingFragBitmap;
+    public Builder fieldsForPreservingFragBitmap(long[] fieldsForPreservingFragBitmap) {
+      this.fieldsForPreservingFragBitmap = fieldsForPreservingFragBitmap;
       return this;
     }
 
@@ -154,7 +154,7 @@ public class Update implements Operation {
           updatedFragments,
           newFragments,
           fieldsModified,
-          fieldsForRreservingFragBitmap,
+          fieldsForPreservingFragBitmap,
           updateMode);
     }
   }

--- a/java/src/test/java/com/lancedb/lance/operation/UpdateTest.java
+++ b/java/src/test/java/com/lancedb/lance/operation/UpdateTest.java
@@ -17,6 +17,7 @@ import com.lancedb.lance.Dataset;
 import com.lancedb.lance.FragmentMetadata;
 import com.lancedb.lance.TestUtils;
 import com.lancedb.lance.Transaction;
+import com.lancedb.lance.operation.Update.UpdateMode;
 
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -77,6 +79,7 @@ public class UpdateTest extends OperationTestBase {
                           Collections.singletonList(
                               Long.valueOf(dataset.getFragments().get(0).getId())))
                       .newFragments(Collections.singletonList(newFragment))
+                      .updateMode(Optional.of(UpdateMode.RewriteRows))
                       .build())
               .build();
 
@@ -86,6 +89,10 @@ public class UpdateTest extends OperationTestBase {
         assertEquals(rowCount, dataset.countRows());
 
         Transaction txn = dataset.readTransaction().orElse(null);
+        Update commit = (Update) transaction.operation();
+        Update read = (Update) txn.operation();
+        System.out.println(String.format("operation equals: %s", read.equals(commit)));
+        assertEquals(commit, read);
         assertEquals(transaction, txn);
       }
     }

--- a/java/src/test/java/com/lancedb/lance/operation/UpdateTest.java
+++ b/java/src/test/java/com/lancedb/lance/operation/UpdateTest.java
@@ -89,10 +89,6 @@ public class UpdateTest extends OperationTestBase {
         assertEquals(rowCount, dataset.countRows());
 
         Transaction txn = dataset.readTransaction().orElse(null);
-        Update commit = (Update) transaction.operation();
-        Update read = (Update) txn.operation();
-        System.out.println(String.format("operation equals: %s", read.equals(commit)));
-        assertEquals(commit, read);
         assertEquals(transaction, txn);
       }
     }


### PR DESCRIPTION
This PR enhances the Java bindings for Operation::Update as a follow-up to #4589.

While #4589 introduced new fields to the Rust Operation::Update struct, the Java bindings were still missing support not only for those new fields but also for the existing `fields_modified field`, which is crucial for handling column modifications.

Specifically, it adds support for the following fields:

```rust
  Update {
      // ...
      /// The fields that have been modified
      fields_modified: Vec<u32>,
      // 👇 New fields from #4589
      /// The fields that used to judge whether to preserve the new frag's id into
      /// the frag bitmap of the specified indices.
      fields_for_preserving_frag_bitmap: Vec<u32>,
      /// The mode of update
      update_mode: Option<UpdateMode>,
  }
```