### PR TITLE
fix: propagate span in filtered read

### DIFF
--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -31,7 +31,6 @@ use lance_core::utils::deletion::DeletionVector;
 use lance_core::utils::futures::FinallyStreamExt;
 use lance_core::utils::mask::RowIdMask;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
-use lance_core::utils::tracing::StreamTracingExt;
 use lance_core::{datatypes::Projection, Error, Result};
 use lance_datafusion::planner::Planner;
 use lance_datafusion::utils::{


### PR DESCRIPTION
Right now tracing context is lost when we run `read_fragment`, even though it would be useful to see what is going on inside.