### PR TITLE
chore: build aws,azure,gcp,oss by default.

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -356,6 +356,9 @@
                                     <release>${rust.release.build}</release>
                                     <!-- Copy native libraries to target/classes for runtime access -->
                                     <copyTo>${project.build.directory}/classes/nativelib</copyTo>
+                                    <environmentVariables>
+                                        <CARGO_FEATURES>aws,azure,gcp,oss</CARGO_FEATURES>
+                                    </environmentVariables>
                                     <copyWithPlatformDir>true</copyWithPlatformDir>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
We should compile those storage backend in lance-io by default.