### PR TITLE
feat: implement blob encoding for 2.1

### DIFF
--- a/protos/encodings_v2_1.proto
+++ b/protos/encodings_v2_1.proto
@@ -153,6 +153,21 @@ message AllNullLayout {
   repeated RepDefLayer layers = 5;
 }
 
+// A layout where large binary data is encoded externally and only
+// the descriptions (position + size) are placed in the page
+//
+// Repdef information is stored in the descriptions.  A description with a size of
+// 0 and a position of 0 is an empty value.  A description with a size of 0 and a
+// non-zero position is a null value and the position is the repdef value.
+message BlobLayout {
+  // The inner layout used to store the descriptions
+  PageLayout inner_layout = 1;
+  // The meaning of each repdef layer, used to interpret repdef buffers correctly
+  //
+  // The inner layout's repdef layers will always be 1 all valid item layer
+  repeated RepDefLayer layers = 2;
+}
+
 // Describes the structural encoding of a page
 message PageLayout {
   oneof layout {
@@ -162,6 +177,9 @@ message PageLayout {
     AllNullLayout all_null_layout = 2;
     // A layout used for pages where the data is large
     FullZipLayout full_zip_layout = 3;
+    // A layout where large binary data is encoded externally
+    // and only the descriptions are put in the page
+    BlobLayout blob_layout = 4;
   }
 }
 

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -34,13 +34,11 @@ pub static BLOB_DESC_FIELDS: LazyLock<Fields> = LazyLock::new(|| {
     ])
 });
 
-pub static BLOB_DESC_FIELD: LazyLock<ArrowField> = LazyLock::new(|| {
-    ArrowField::new(
-        "description",
-        DataType::Struct(BLOB_DESC_FIELDS.clone()),
-        true,
-    )
-});
+pub static BLOB_DESC_TYPE: LazyLock<DataType> =
+    LazyLock::new(|| DataType::Struct(BLOB_DESC_FIELDS.clone()));
+
+pub static BLOB_DESC_FIELD: LazyLock<ArrowField> =
+    LazyLock::new(|| ArrowField::new("description", BLOB_DESC_TYPE.clone(), true));
 
 pub static BLOB_DESC_LANCE_FIELD: LazyLock<Field> =
     LazyLock::new(|| Field::try_from(&*BLOB_DESC_FIELD).unwrap());

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -1032,29 +1032,29 @@ impl DecodeBatchScheduler {
         let mut root_job = maybe_root_job.unwrap();
         let mut num_rows_scheduled = 0;
         loop {
-            let maybe_next_scan_line = root_job.schedule_next(&mut context);
-            if let Err(err) = maybe_next_scan_line {
+            let maybe_next_scan_lines = root_job.schedule_next(&mut context);
+            if let Err(err) = maybe_next_scan_lines {
                 schedule_action(Err(err));
                 return;
             }
-            let next_scan_line = maybe_next_scan_line.unwrap();
-            match next_scan_line {
-                Some(next_scan_line) => {
-                    trace!(
-                        "Scheduled scan line of {} rows and {} decoders",
-                        next_scan_line.rows_scheduled,
-                        next_scan_line.decoders.len()
-                    );
-                    num_rows_scheduled += next_scan_line.rows_scheduled;
-                    if !schedule_action(Ok(DecoderMessage {
-                        scheduled_so_far: num_rows_scheduled,
-                        decoders: next_scan_line.decoders,
-                    })) {
-                        // Decoder has disconnected
-                        return;
-                    }
+            let next_scan_lines = maybe_next_scan_lines.unwrap();
+            if next_scan_lines.is_empty() {
+                return;
+            }
+            for next_scan_line in next_scan_lines {
+                trace!(
+                    "Scheduled scan line of {} rows and {} decoders",
+                    next_scan_line.rows_scheduled,
+                    next_scan_line.decoders.len()
+                );
+                num_rows_scheduled += next_scan_line.rows_scheduled;
+                if !schedule_action(Ok(DecoderMessage {
+                    scheduled_so_far: num_rows_scheduled,
+                    decoders: next_scan_line.decoders,
+                })) {
+                    // Decoder has disconnected
+                    return;
                 }
-                None => return,
             }
         }
     }
@@ -1419,7 +1419,7 @@ impl BatchDecodeStream {
 // Utility types to smooth out the differences between the 2.0 and 2.1 decoders so that
 // we can have a single implementation of the batch decode iterator
 enum RootDecoderMessage {
-    LoadedPage(LoadedPage),
+    LoadedPage(LoadedPageShard),
     LegacyPage(crate::previous::decoder::DecoderReady),
 }
 trait RootDecoderType {
@@ -1501,7 +1501,7 @@ impl<T: RootDecoderType> BatchDecodeIterator<T> {
     ///
     /// If the data is not available this will perform a *blocking* wait (put
     /// the current thread to sleep)
-    fn wait_for_page(&self, unloaded_page: UnloadedPage) -> Result<LoadedPage> {
+    fn wait_for_page(&self, unloaded_page: UnloadedPageShard) -> Result<LoadedPageShard> {
         match maybe_done(unloaded_page.0) {
             // Fast path, avoid all runtime shenanigans if the data is ready
             MaybeDone::Done(loaded_page) => loaded_page,
@@ -2308,9 +2308,9 @@ impl SchedulerContext {
     }
 }
 
-pub struct UnloadedPage(pub BoxFuture<'static, Result<LoadedPage>>);
+pub struct UnloadedPageShard(pub BoxFuture<'static, Result<LoadedPageShard>>);
 
-impl std::fmt::Debug for UnloadedPage {
+impl std::fmt::Debug for UnloadedPageShard {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("UnloadedPage").finish()
     }
@@ -2323,10 +2323,13 @@ pub struct ScheduledScanLine {
 }
 
 pub trait StructuralSchedulingJob: std::fmt::Debug {
-    fn schedule_next(
-        &mut self,
-        context: &mut SchedulerContext,
-    ) -> Result<Option<ScheduledScanLine>>;
+    /// Schedule the next batch of data
+    ///
+    /// Normally this equates to scheduling the next page of data into one task.  Very large pages
+    /// might be split into multiple scan lines.  Each scan line has one or more rows.
+    ///
+    /// If a scheduler ends early it may return an empty vector.
+    fn schedule_next(&mut self, context: &mut SchedulerContext) -> Result<Vec<ScheduledScanLine>>;
 }
 
 /// A filter expression to apply to the data
@@ -2433,7 +2436,7 @@ pub enum MessageType {
     // Starting in 2.1 we use a simpler scheme where the scheduling happens in priority
     // order and the message is an unloaded decoder.  These can be awaited, in order, and
     // the decoder does not have to worry about waiting for I/O.
-    UnloadedPage(UnloadedPage),
+    UnloadedPage(UnloadedPageShard),
 }
 
 impl MessageType {
@@ -2446,7 +2449,7 @@ impl MessageType {
         }
     }
 
-    pub fn into_structural(self) -> UnloadedPage {
+    pub fn into_structural(self) -> UnloadedPageShard {
         match self {
             Self::UnloadedPage(unloaded) => unloaded,
             Self::DecoderReady(_) => {
@@ -2487,7 +2490,7 @@ pub trait StructuralPageDecoder: std::fmt::Debug + Send {
 }
 
 #[derive(Debug)]
-pub struct LoadedPage {
+pub struct LoadedPageShard {
     // The decoder that is ready to be decoded
     pub decoder: Box<dyn StructuralPageDecoder>,
     // The path to the decoder, the first value is the column index
@@ -2509,7 +2512,6 @@ pub struct LoadedPage {
     // handled through indirect I/O at the moment and so they don't
     // need to be represented (yet)
     pub path: VecDeque<u32>,
-    pub page_index: usize,
 }
 
 pub struct DecodedArray {
@@ -2526,7 +2528,7 @@ pub trait StructuralFieldDecoder: std::fmt::Debug + Send {
     ///
     /// The default implementation does not expect children and returns
     /// an error.
-    fn accept_page(&mut self, _child: LoadedPage) -> Result<()>;
+    fn accept_page(&mut self, _child: LoadedPageShard) -> Result<()>;
     /// Creates a task to decode `num_rows` of data into an array
     fn drain(&mut self, num_rows: u64) -> Result<Box<dyn StructuralDecodeArrayTask>>;
     /// The data type of the decoded data

--- a/rust/lance-encoding/src/encodings/logical/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/blob.rs
@@ -6,16 +6,18 @@ use std::{collections::HashMap, sync::Arc};
 use arrow_array::{cast::AsArray, Array, ArrayRef, StructArray, UInt64Array};
 use arrow_buffer::Buffer;
 use arrow_schema::{DataType, Field as ArrowField, Fields};
-use futures::future::BoxFuture;
-use lance_core::{datatypes::Field, Error, Result};
+use futures::{future::BoxFuture, FutureExt};
+use lance_core::{datatypes::Field, error::LanceOptionExt, Error, Result};
 use snafu::location;
 
 use crate::{
     buffer::LanceBuffer,
     constants::PACKED_STRUCT_META_KEY,
-    encoder::{EncodeTask, EncodedColumn, FieldEncoder, OutOfLineBuffers},
+    decoder::PageEncoding,
+    encoder::{EncodeTask, EncodedColumn, EncodedPage, FieldEncoder, OutOfLineBuffers},
     encodings::logical::primitive::PrimitiveStructuralEncoder,
-    repdef::RepDefBuilder,
+    format::ProtobufUtils21,
+    repdef::{DefinitionInterpretation, RepDefBuilder},
 };
 
 /// Blob structural encoder - stores large binary data in external buffers
@@ -26,6 +28,8 @@ use crate::{
 pub struct BlobStructuralEncoder {
     // Encoder for the descriptors (position/size struct)
     descriptor_encoder: Box<dyn FieldEncoder>,
+    // Set when we first see data
+    def_meaning: Option<Arc<[DefinitionInterpretation]>>,
 }
 
 impl BlobStructuralEncoder {
@@ -60,7 +64,43 @@ impl BlobStructuralEncoder {
             Arc::new(HashMap::new()),
         )?);
 
-        Ok(Self { descriptor_encoder })
+        Ok(Self {
+            descriptor_encoder,
+            def_meaning: None,
+        })
+    }
+
+    fn wrap_tasks(
+        tasks: Vec<EncodeTask>,
+        def_meaning: Arc<[DefinitionInterpretation]>,
+    ) -> Vec<EncodeTask> {
+        tasks
+            .into_iter()
+            .map(|task| {
+                let def_meaning = def_meaning.clone();
+                task.then(|encoded_page| async move {
+                    let encoded_page = encoded_page?;
+
+                    let PageEncoding::Structural(inner_layout) = encoded_page.description else {
+                        return Err(Error::Internal {
+                            message: "Expected inner encoding to return structural layout"
+                                .to_string(),
+                            location: location!(),
+                        });
+                    };
+
+                    let wrapped = ProtobufUtils21::blob_layout(inner_layout, &def_meaning);
+                    Ok(EncodedPage {
+                        column_idx: encoded_page.column_idx,
+                        data: encoded_page.data,
+                        description: PageEncoding::Structural(wrapped),
+                        num_rows: encoded_page.num_rows,
+                        row_number: encoded_page.row_number,
+                    })
+                })
+                .boxed()
+            })
+            .collect::<Vec<_>>()
     }
 }
 
@@ -69,10 +109,16 @@ impl FieldEncoder for BlobStructuralEncoder {
         &mut self,
         array: ArrayRef,
         external_buffers: &mut OutOfLineBuffers,
-        repdef: RepDefBuilder,
+        mut repdef: RepDefBuilder,
         row_number: u64,
         num_rows: u64,
     ) -> Result<Vec<EncodeTask>> {
+        if let Some(validity) = array.nulls() {
+            repdef.add_validity_bitmap(validity.clone());
+        } else {
+            repdef.add_no_null(array.len());
+        }
+
         // Convert input array to LargeBinary
         let binary_array = array
             .as_binary_opt::<i64>()
@@ -81,15 +127,34 @@ impl FieldEncoder for BlobStructuralEncoder {
                 location: location!(),
             })?;
 
+        let repdef = RepDefBuilder::serialize(vec![repdef]);
+
+        let rep = repdef.repetition_levels.as_ref();
+        let def = repdef.definition_levels.as_ref();
+        let def_meaning: Arc<[DefinitionInterpretation]> = repdef.def_meaning.into();
+
+        if self.def_meaning.is_none() {
+            self.def_meaning = Some(def_meaning.clone());
+        } else {
+            debug_assert_eq!(self.def_meaning.as_ref().unwrap(), &def_meaning);
+        }
+
         // Collect positions and sizes
         let mut positions = Vec::with_capacity(binary_array.len());
         let mut sizes = Vec::with_capacity(binary_array.len());
 
         for i in 0..binary_array.len() {
             if binary_array.is_null(i) {
-                // Null values are handled in the structural layer
-                // We just need placeholders here
-                positions.push(0);
+                // Null values are smuggled into the positions array
+
+                // If we have null values we must have definition levels
+                let mut repdef = (def.expect_ok()?[i] as u64) << 16;
+                if let Some(rep) = rep {
+                    repdef += rep[i] as u64;
+                }
+
+                debug_assert_ne!(repdef, 0);
+                positions.push(repdef);
                 sizes.push(0);
             } else {
                 let value = binary_array.value(i);
@@ -116,21 +181,32 @@ impl FieldEncoder for BlobStructuralEncoder {
                 ArrowField::new("size", DataType::UInt64, false),
             ]),
             vec![position_array as ArrayRef, size_array as ArrayRef],
-            binary_array.nulls().cloned(), // Pass through null buffer
+            None, // Descriptors are never null
         ));
 
         // Delegate to descriptor encoder
-        self.descriptor_encoder.maybe_encode(
+        let encode_tasks = self.descriptor_encoder.maybe_encode(
             descriptor_array,
             external_buffers,
-            repdef,
+            RepDefBuilder::default(),
             row_number,
             num_rows,
-        )
+        )?;
+
+        Ok(Self::wrap_tasks(encode_tasks, def_meaning))
     }
 
     fn flush(&mut self, external_buffers: &mut OutOfLineBuffers) -> Result<Vec<EncodeTask>> {
-        self.descriptor_encoder.flush(external_buffers)
+        let encode_tasks = self.descriptor_encoder.flush(external_buffers)?;
+
+        // Use the cached def meaning.  If we haven't seen any data yet then we can just use a dummy
+        // value (not clear there would be any encode tasks in that case)
+        let def_meaning = self
+            .def_meaning
+            .clone()
+            .unwrap_or_else(|| Arc::new([DefinitionInterpretation::AllValidItem]));
+
+        Ok(Self::wrap_tasks(encode_tasks, def_meaning))
     }
 
     fn finish(
@@ -152,7 +228,6 @@ mod tests {
         compression::DefaultCompressionStrategy,
         encoder::{ColumnIndexSequence, EncodingOptions},
         testing::{check_round_trip_encoding_of_data, TestCases},
-        version::LanceFileVersion,
     };
     use arrow_array::LargeBinaryArray;
 
@@ -240,12 +315,6 @@ mod tests {
         ]));
 
         // Use the standard test harness
-        check_round_trip_encoding_of_data(
-            vec![array],
-            // TODO (https://github.com/lancedb/lance/issues/4781)
-            &TestCases::default().with_max_file_version(LanceFileVersion::V2_0),
-            blob_metadata,
-        )
-        .await;
+        check_round_trip_encoding_of_data(vec![array], &TestCases::default(), blob_metadata).await;
     }
 }

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -143,10 +143,7 @@ impl<'a> StructuralListSchedulingJob<'a> {
 }
 
 impl StructuralSchedulingJob for StructuralListSchedulingJob<'_> {
-    fn schedule_next(
-        &mut self,
-        context: &mut SchedulerContext,
-    ) -> Result<Option<ScheduledScanLine>> {
+    fn schedule_next(&mut self, context: &mut SchedulerContext) -> Result<Vec<ScheduledScanLine>> {
         self.child.schedule_next(context)
     }
 }
@@ -164,7 +161,7 @@ impl StructuralListDecoder {
 }
 
 impl StructuralFieldDecoder for StructuralListDecoder {
-    fn accept_page(&mut self, child: crate::decoder::LoadedPage) -> Result<()> {
+    fn accept_page(&mut self, child: crate::decoder::LoadedPageShard) -> Result<()> {
         self.child.accept_page(child)
     }
 

--- a/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/blob.rs
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Routines for decoding blob data
+//!
+//! The blob structural encoding is a structural encoding where the values (blobs) are stored
+//! out-of-line in the file.  The page contains the descriptions, encoded using some other layout.
+
+use std::{collections::VecDeque, ops::Range, sync::Arc};
+
+use arrow_array::{cast::AsArray, make_array, Array, UInt64Array};
+use bytes::Bytes;
+use futures::{future::BoxFuture, FutureExt};
+use snafu::location;
+
+use lance_core::{
+    cache::DeepSizeOf, datatypes::BLOB_DESC_TYPE, error::LanceOptionExt, Error, Result,
+};
+
+use crate::{
+    buffer::LanceBuffer,
+    data::{BlockInfo, DataBlock, VariableWidthBlock},
+    decoder::{DecodePageTask, DecodedPage, StructuralPageDecoder},
+    encodings::logical::primitive::{CachedPageData, PageLoadTask, StructuralPageScheduler},
+    repdef::{DefinitionInterpretation, RepDefUnraveler},
+    EncodingsIo,
+};
+
+/// How many bytes to target in each unloaded / loaded shard.  A larger value means
+/// we buffer more data in memory / make bigger requests to the I/O scheduler while
+/// a smaller value means more requests to the I/O scheduler.
+///
+/// This is probably a reasonable default for most cases.
+pub const TARGET_SHARD_SIZE: u64 = 32 * 1024 * 1024;
+
+struct BlobCacheableState {
+    positions: Arc<UInt64Array>,
+    sizes: Arc<UInt64Array>,
+    inner_state: Arc<dyn CachedPageData>,
+}
+
+impl DeepSizeOf for BlobCacheableState {
+    fn deep_size_of_children(&self, context: &mut lance_core::cache::Context) -> usize {
+        self.positions.get_array_memory_size()
+            + self.sizes.get_array_memory_size()
+            + self.inner_state.deep_size_of_children(context)
+    }
+}
+
+impl CachedPageData for BlobCacheableState {
+    fn as_arc_any(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync + 'static> {
+        self
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct BlobPageScheduler {
+    inner_scheduler: Box<dyn StructuralPageScheduler>,
+    row_number: u64,
+    num_rows: u64,
+    def_meaning: Arc<[DefinitionInterpretation]>,
+    positions: Option<Arc<UInt64Array>>,
+    sizes: Option<Arc<UInt64Array>>,
+}
+
+impl BlobPageScheduler {
+    pub fn new(
+        inner_scheduler: Box<dyn StructuralPageScheduler>,
+        row_number: u64,
+        num_rows: u64,
+        def_meaning: Arc<[DefinitionInterpretation]>,
+    ) -> Self {
+        Self {
+            inner_scheduler,
+            row_number,
+            num_rows,
+            def_meaning,
+            positions: None,
+            sizes: None,
+        }
+    }
+
+    fn create_page_load_task(
+        ranges_to_read: Vec<Range<u64>>,
+        mut loaded_blobs: Vec<LoadedBlob>,
+        first_row_number: u64,
+        io: &dyn EncodingsIo,
+        def_meaning: Arc<[DefinitionInterpretation]>,
+    ) -> Result<PageLoadTask> {
+        let num_rows = loaded_blobs.len() as u64;
+        let read_fut = io.submit_request(ranges_to_read, first_row_number);
+        let decoder_fut = async move {
+            let bytes = read_fut.await?;
+            let mut bytes_iter = bytes.into_iter();
+            for blob in loaded_blobs.iter_mut() {
+                if blob.def == 0 {
+                    blob.set_bytes(bytes_iter.next().expect_ok()?);
+                }
+            }
+            debug_assert!(bytes_iter.next().is_none());
+            Ok(Box::new(BlobPageDecoder::new(loaded_blobs, def_meaning))
+                as Box<dyn StructuralPageDecoder>)
+        }
+        .boxed();
+        Ok(PageLoadTask {
+            decoder_fut,
+            num_rows,
+        })
+    }
+}
+
+impl StructuralPageScheduler for BlobPageScheduler {
+    fn initialize<'a>(
+        &'a mut self,
+        io: &Arc<dyn EncodingsIo>,
+    ) -> BoxFuture<'a, Result<Arc<dyn CachedPageData>>> {
+        let io = io.clone();
+        let num_rows = self.num_rows;
+        async move {
+            let cached = self.inner_scheduler.initialize(&io).await?;
+            let mut desc_decoders = self.inner_scheduler.schedule_ranges(&[0..num_rows], &io)?;
+            if desc_decoders.len() != 1 {
+                // This can't happen yet today so being a little lazy but if it did happen we just
+                // need to concatenate the descriptions.  I'm guessing by then we might be doing something
+                // different than "load all descriptors in initialize" anyways.
+                return Err(Error::NotSupported {
+                    source: "Expected exactly one descriptor decoder".into(),
+                    location: location!(),
+                });
+            }
+            let desc_decoder_task = desc_decoders.pop().unwrap();
+            let mut desc_decoder = desc_decoder_task.decoder_fut.await?;
+
+            let descs = desc_decoder.drain(desc_decoder_task.num_rows)?;
+            let descs = descs.decode()?;
+            let descs = make_array(descs.data.into_arrow(BLOB_DESC_TYPE.clone(), true)?);
+            let descs = descs.as_struct();
+            let positions = Arc::new(
+                descs
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .unwrap()
+                    .clone(),
+            );
+            let sizes = Arc::new(
+                descs
+                    .column(1)
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .unwrap()
+                    .clone(),
+            );
+            self.positions = Some(positions.clone());
+            self.sizes = Some(sizes.clone());
+            let state = Arc::new(BlobCacheableState {
+                inner_state: cached,
+                positions,
+                sizes,
+            });
+            Ok(state as Arc<dyn CachedPageData>)
+        }
+        .boxed()
+    }
+
+    fn load(&mut self, data: &Arc<dyn CachedPageData>) {
+        let blob_state = data
+            .clone()
+            .as_arc_any()
+            .downcast::<BlobCacheableState>()
+            .unwrap();
+        self.positions = Some(blob_state.positions.clone());
+        self.sizes = Some(blob_state.sizes.clone());
+        self.inner_scheduler.load(&blob_state.inner_state);
+    }
+
+    fn schedule_ranges(
+        &self,
+        ranges: &[Range<u64>],
+        io: &Arc<dyn EncodingsIo>,
+    ) -> Result<Vec<PageLoadTask>> {
+        let num_rows: u64 = ranges.iter().map(|r| r.end - r.start).sum();
+
+        let positions = self.positions.as_ref().expect_ok()?;
+        let sizes = self.sizes.as_ref().expect_ok()?;
+
+        let mut page_load_tasks = Vec::new();
+        let mut bytes_so_far = 0;
+        let mut ranges_to_read = Vec::with_capacity(num_rows as usize);
+        let mut loaded_blobs = Vec::with_capacity(num_rows as usize);
+        let mut first_row_number = None;
+        for range in ranges {
+            for row in range.start..range.end {
+                if first_row_number.is_none() {
+                    first_row_number = Some(row + self.row_number);
+                }
+                let position = positions.value(row as usize);
+                let size = sizes.value(row as usize);
+
+                if size == 0 {
+                    let rep = (position & 0xFFFF) as u16;
+                    let def = ((position >> 16) & 0xFFFF) as u16;
+                    loaded_blobs.push(LoadedBlob::new(rep, def));
+                } else {
+                    loaded_blobs.push(LoadedBlob::new(0, 0));
+                    ranges_to_read.push(position..(position + size));
+                    bytes_so_far += size;
+                }
+
+                if bytes_so_far >= TARGET_SHARD_SIZE {
+                    let page_load_task = Self::create_page_load_task(
+                        std::mem::take(&mut ranges_to_read),
+                        std::mem::take(&mut loaded_blobs),
+                        first_row_number.unwrap(),
+                        io.as_ref(),
+                        self.def_meaning.clone(),
+                    )?;
+                    page_load_tasks.push(page_load_task);
+                    bytes_so_far = 0;
+                    first_row_number = None;
+                }
+            }
+        }
+        if !loaded_blobs.is_empty() {
+            let page_load_task = Self::create_page_load_task(
+                std::mem::take(&mut ranges_to_read),
+                std::mem::take(&mut loaded_blobs),
+                first_row_number.unwrap(),
+                io.as_ref(),
+                self.def_meaning.clone(),
+            )?;
+            page_load_tasks.push(page_load_task);
+        }
+
+        Ok(page_load_tasks)
+    }
+}
+
+#[derive(Debug)]
+struct LoadedBlob {
+    bytes: Option<Bytes>,
+    rep: u16,
+    def: u16,
+}
+
+impl LoadedBlob {
+    fn new(rep: u16, def: u16) -> Self {
+        Self {
+            bytes: None,
+            rep,
+            def,
+        }
+    }
+
+    fn set_bytes(&mut self, bytes: Bytes) {
+        self.bytes = Some(bytes);
+    }
+}
+
+#[derive(Debug)]
+struct BlobPageDecoder {
+    blobs: VecDeque<LoadedBlob>,
+    def_meaning: Arc<[DefinitionInterpretation]>,
+    num_rows: u64,
+}
+
+impl BlobPageDecoder {
+    fn new(blobs: Vec<LoadedBlob>, def_meaning: Arc<[DefinitionInterpretation]>) -> Self {
+        Self {
+            num_rows: blobs.len() as u64,
+            blobs: blobs.into_iter().collect(),
+            def_meaning,
+        }
+    }
+}
+
+impl StructuralPageDecoder for BlobPageDecoder {
+    fn drain(&mut self, num_rows: u64) -> Result<Box<dyn DecodePageTask>> {
+        let blobs = self.blobs.drain(0..num_rows as usize).collect::<Vec<_>>();
+        Ok(Box::new(BlobDecodePageTask::new(
+            blobs,
+            self.def_meaning.clone(),
+        )))
+    }
+
+    fn num_rows(&self) -> u64 {
+        self.num_rows
+    }
+}
+
+#[derive(Debug)]
+struct BlobDecodePageTask {
+    blobs: Vec<LoadedBlob>,
+    def_meaning: Arc<[DefinitionInterpretation]>,
+}
+
+impl BlobDecodePageTask {
+    fn new(blobs: Vec<LoadedBlob>, def_meaning: Arc<[DefinitionInterpretation]>) -> Self {
+        Self { blobs, def_meaning }
+    }
+}
+
+impl DecodePageTask for BlobDecodePageTask {
+    fn decode(self: Box<Self>) -> Result<DecodedPage> {
+        let num_values = self.blobs.len() as u64;
+        let num_bytes = self
+            .blobs
+            .iter()
+            .filter_map(|b| b.bytes.as_ref())
+            .map(|b| b.len())
+            .sum::<usize>();
+        let mut buffer = Vec::with_capacity(num_bytes);
+        let mut offsets = Vec::with_capacity(num_values as usize + 1);
+        let mut rep = Vec::with_capacity(num_values as usize);
+        let mut def = Vec::with_capacity(num_values as usize);
+        offsets.push(0_u64);
+        for blob in self.blobs {
+            rep.push(blob.rep);
+            def.push(blob.def);
+            if let Some(bytes) = blob.bytes {
+                offsets.push(offsets.last().unwrap() + bytes.len() as u64);
+                buffer.extend_from_slice(&bytes);
+            } else {
+                // Null / emptyvalue
+                offsets.push(*offsets.last().unwrap());
+            }
+        }
+        let offsets = LanceBuffer::reinterpret_vec(offsets);
+        let data = LanceBuffer::from(buffer);
+        let data_block = DataBlock::VariableWidth(VariableWidthBlock {
+            data,
+            offsets,
+            bits_per_offset: 64,
+            num_values,
+            block_info: BlockInfo::new(),
+        });
+
+        let rep = if rep.iter().any(|r| *r != 0) {
+            Some(rep)
+        } else {
+            None
+        };
+        let def = if self.def_meaning.len() > 1
+            || self.def_meaning[0] != DefinitionInterpretation::AllValidItem
+        {
+            Some(def)
+        } else {
+            None
+        };
+
+        Ok(DecodedPage {
+            data: data_block,
+            repdef: RepDefUnraveler::new(rep, def, self.def_meaning),
+        })
+    }
+}

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::{collections::BinaryHeap, ops::Range, sync::Arc};
+use std::{
+    collections::{BinaryHeap, VecDeque},
+    ops::Range,
+    sync::Arc,
+};
 
 use crate::{
     decoder::{
-        DecodedArray, FilterExpression, LoadedPage, NextDecodeTask, PageEncoding,
+        DecodedArray, FilterExpression, LoadedPageShard, NextDecodeTask, PageEncoding,
         ScheduledScanLine, SchedulerContext, StructuralDecodeArrayTask, StructuralFieldDecoder,
         StructuralFieldScheduler, StructuralSchedulingJob,
     },
@@ -35,6 +39,7 @@ struct StructuralSchedulingJobWithStatus<'a> {
     job: Box<dyn StructuralSchedulingJob + 'a>,
     rows_scheduled: u64,
     rows_remaining: u64,
+    ready_scan_lines: VecDeque<ScheduledScanLine>,
 }
 
 impl PartialEq for StructuralSchedulingJobWithStatus<'_> {
@@ -87,6 +92,7 @@ impl<'a> RepDefStructSchedulingJob<'a> {
                 job,
                 rows_scheduled: 0,
                 rows_remaining: num_rows,
+                ready_scan_lines: VecDeque::new(),
             })
             .collect::<BinaryHeap<_>>();
         Self {
@@ -101,17 +107,17 @@ impl StructuralSchedulingJob for RepDefStructSchedulingJob<'_> {
     fn schedule_next(
         &mut self,
         mut context: &mut SchedulerContext,
-    ) -> Result<Option<ScheduledScanLine>> {
+    ) -> Result<Vec<ScheduledScanLine>> {
         if self.children.is_empty() {
             // Special path for empty structs
             if self.rows_scheduled == self.num_rows {
-                return Ok(None);
+                return Ok(Vec::new());
             }
             self.rows_scheduled = self.num_rows;
-            return Ok(Some(ScheduledScanLine {
+            return Ok(vec![ScheduledScanLine {
                 decoders: Vec::new(),
                 rows_scheduled: self.num_rows,
-            }));
+            }]);
         }
 
         let mut decoders = Vec::new();
@@ -119,16 +125,22 @@ impl StructuralSchedulingJob for RepDefStructSchedulingJob<'_> {
         // Schedule as many children as we need to until we have scheduled at least one
         // complete row
         while old_rows_scheduled == self.rows_scheduled {
-            let mut next_child = self.children.pop().unwrap();
-            let scoped = context.push(next_child.col_name, next_child.col_idx);
-            let child_scan = next_child.job.schedule_next(scoped.context)?;
-            // next_child is the least-scheduled child and, if it's done, that
-            // means we are completely done.
-            if child_scan.is_none() {
-                return Ok(None);
+            if self.children.is_empty() {
+                // Early exit when schedulers are exhausted prematurely (TODO: does this still happen?)
+                return Ok(Vec::new());
             }
-            let child_scan = child_scan.unwrap();
-
+            let mut next_child = self.children.pop().unwrap();
+            if next_child.ready_scan_lines.is_empty() {
+                let scoped = context.push(next_child.col_name, next_child.col_idx);
+                let child_scans = next_child.job.schedule_next(scoped.context)?;
+                context = scoped.pop();
+                if child_scans.is_empty() {
+                    // Continue without pushing next_child back onto the heap (it is done)
+                    continue;
+                }
+                next_child.ready_scan_lines.extend(child_scans);
+            }
+            let child_scan = next_child.ready_scan_lines.pop_front().unwrap();
             trace!(
                 "Scheduled {} rows for child {}",
                 child_scan.rows_scheduled,
@@ -139,13 +151,12 @@ impl StructuralSchedulingJob for RepDefStructSchedulingJob<'_> {
             decoders.extend(child_scan.decoders);
             self.children.push(next_child);
             self.rows_scheduled = self.children.peek().unwrap().rows_scheduled;
-            context = scoped.pop();
         }
         let struct_rows_scheduled = self.rows_scheduled - old_rows_scheduled;
-        Ok(Some(ScheduledScanLine {
+        Ok(vec![ScheduledScanLine {
             decoders,
             rows_scheduled: struct_rows_scheduled,
-        }))
+        }])
     }
 }
 
@@ -279,7 +290,7 @@ impl StructuralStructDecoder {
 }
 
 impl StructuralFieldDecoder for StructuralStructDecoder {
-    fn accept_page(&mut self, mut child: LoadedPage) -> Result<()> {
+    fn accept_page(&mut self, mut child: LoadedPageShard) -> Result<()> {
         // children with empty path should not be delivered to this method
         let child_idx = child.path.pop_front().unwrap();
         // This decoder is intended for one of our children

--- a/rust/lance-encoding/src/format.rs
+++ b/rust/lance-encoding/src/format.rs
@@ -569,6 +569,23 @@ impl ProtobufUtils21 {
         )
     }
 
+    pub fn blob_layout(
+        inner_layout: pb21::PageLayout,
+        def_meaning: &[DefinitionInterpretation],
+    ) -> pb21::PageLayout {
+        pb21::PageLayout {
+            layout: Some(pb21::page_layout::Layout::BlobLayout(Box::new(
+                pb21::BlobLayout {
+                    inner_layout: Some(Box::new(inner_layout)),
+                    layers: def_meaning
+                        .iter()
+                        .map(|&def| Self::def_inter_to_repdef_layer(def))
+                        .collect(),
+                },
+            ))),
+        }
+    }
+
     pub fn all_null_layout(def_meaning: &[DefinitionInterpretation]) -> pb21::PageLayout {
         pb21::PageLayout {
             layout: Some(pb21::page_layout::Layout::AllNullLayout(

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -6,7 +6,9 @@ use std::{cmp::Ordering, collections::HashMap, ops::Range, sync::Arc};
 use crate::{
     decoder::DecoderConfig,
     encodings::physical::block::CompressionScheme,
-    format::pb21::{compressive_encoding::Compression, BufferCompression, CompressiveEncoding},
+    format::pb21::{
+        compressive_encoding::Compression, BufferCompression, CompressiveEncoding, PageLayout,
+    },
 };
 
 use arrow_array::{make_array, Array, StructArray, UInt64Array};
@@ -244,7 +246,10 @@ async fn test_decode(
                 }
             }
         }
-        offset += batch_size as usize;
+        offset += batch.num_rows();
+    }
+    if let Some(expected) = expected.as_ref() {
+        assert_eq!(offset, expected.len());
     }
 }
 
@@ -366,7 +371,7 @@ fn supports_nulls(data_type: &DataType, version: LanceFileVersion) -> bool {
     }
 }
 
-type EncodingVerificationFn = dyn Fn(&[EncodedColumn]);
+type EncodingVerificationFn = dyn Fn(&[EncodedColumn], &LanceFileVersion);
 
 // The default will just test the full read
 #[derive(Clone)]
@@ -483,9 +488,9 @@ impl TestCases {
         self
     }
 
-    fn verify_encoding(&self, encoding: &[EncodedColumn]) {
+    fn verify_encoding(&self, encoding: &[EncodedColumn], version: &LanceFileVersion) {
         if let Some(verify_encoding) = self.verify_encoding.as_ref() {
-            verify_encoding(encoding);
+            verify_encoding(encoding, version);
         }
     }
 
@@ -600,6 +605,39 @@ pub fn extract_array_encoding_chain(enc: &CompressiveEncoding) -> Vec<String> {
     chain
 }
 
+fn collect_page_encoding(layout: &PageLayout, actual_chain: &mut Vec<String>) -> Result<()> {
+    // Extract encodings from the page layout
+    use crate::format::pb21::page_layout::Layout;
+    if let Some(ref layout_type) = layout.layout {
+        match layout_type {
+            Layout::MiniBlockLayout(mini_block) => {
+                // Check value compression
+                if let Some(ref value_comp) = mini_block.value_compression {
+                    let chain = extract_array_encoding_chain(value_comp);
+                    actual_chain.extend(chain);
+                }
+            }
+            Layout::FullZipLayout(full_zip) => {
+                // Check value compression in full zip layout
+                if let Some(ref value_comp) = full_zip.value_compression {
+                    let chain = extract_array_encoding_chain(value_comp);
+                    actual_chain.extend(chain);
+                }
+            }
+            Layout::AllNullLayout(_) => {
+                // No value encoding for all null
+            }
+            Layout::BlobLayout(blob) => {
+                if let Some(inner_layout) = &blob.inner_layout {
+                    collect_page_encoding(inner_layout.as_ref(), actual_chain)?
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Verify that a single page contains the expected encoding
 fn verify_page_encoding(
     page: &EncodedPage,
@@ -614,29 +652,7 @@ fn verify_page_encoding(
 
     match &page.description {
         PageEncoding::Structural(layout) => {
-            // Extract encodings from the page layout
-            use crate::format::pb21::page_layout::Layout;
-            if let Some(ref layout_type) = layout.layout {
-                match layout_type {
-                    Layout::MiniBlockLayout(mini_block) => {
-                        // Check value compression
-                        if let Some(ref value_comp) = mini_block.value_compression {
-                            let chain = extract_array_encoding_chain(value_comp);
-                            actual_chain.extend(chain);
-                        }
-                    }
-                    Layout::FullZipLayout(full_zip) => {
-                        // Check value compression in full zip layout
-                        if let Some(ref value_comp) = full_zip.value_compression {
-                            let chain = extract_array_encoding_chain(value_comp);
-                            actual_chain.extend(chain);
-                        }
-                    }
-                    Layout::AllNullLayout(_) => {
-                        // No value encoding for all null
-                    }
-                }
-            }
+            collect_page_encoding(layout, &mut actual_chain)?;
         }
         PageEncoding::Legacy(_) => {
             // We don't need to care about legacy.
@@ -842,7 +858,7 @@ async fn check_round_trip_encoding_inner(
 
     let mut external_buffers = writer.new_external_buffers();
     let encoded_columns = encoder.finish(&mut external_buffers).await.unwrap();
-    test_cases.verify_encoding(&encoded_columns);
+    test_cases.verify_encoding(&encoded_columns, &file_version);
     for buffer in external_buffers.take_buffers() {
         writer.write_lance_buffer(buffer);
     }


### PR DESCRIPTION
This PR fully adds the blob encoding back into 2.1.  The PR is slightly lazy at the moment.  For scheduling we simply load the descriptions as part of the search cache in the initialization of the scheduler.  In the future we may not want to do that since it could be memory intensive.  We should instead spawn a new task to decode the descriptions via indirect I/O.  That can be saved for a follow-up however.