### PR TITLE
perf: move cpu heavy fst building into blocking threads

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -50,6 +50,7 @@ use lance_core::{Error, Result, ROW_ID, ROW_ID_FIELD};
 use roaring::RoaringBitmap;
 use snafu::location;
 use std::sync::LazyLock;
+use tokio::task::spawn_blocking;
 use tracing::{info, instrument};
 
 use super::{
@@ -840,31 +841,41 @@ impl TokenSet {
     }
 
     pub async fn load(reader: Arc<dyn IndexReader>) -> Result<Self> {
-        let mut next_id = 0;
-        let mut total_length = 0;
-        let mut tokens = fst::MapBuilder::memory();
-
         let batch = reader.read_range(0..reader.num_rows(), None).await?;
-        let token_col = batch[TOKEN_COL].as_string::<i32>();
-        let token_id_col = batch[TOKEN_ID_COL].as_primitive::<datatypes::UInt32Type>();
 
-        for (token, &token_id) in token_col.iter().zip(token_id_col.values().iter()) {
-            let token = token.ok_or(Error::Index {
-                message: "found null token in token set".to_owned(),
-                location: location!(),
-            })?;
-            next_id = next_id.max(token_id + 1);
-            total_length += token.len();
-            tokens
-                .insert(token, token_id as u64)
-                .map_err(|e| Error::Index {
-                    message: format!("failed to insert token {}: {}", token, e),
+        let (tokens, next_id, total_length) = spawn_blocking(move || {
+            let mut next_id = 0;
+            let mut total_length = 0;
+            let mut tokens = fst::MapBuilder::memory();
+
+            let token_col = batch[TOKEN_COL].as_string::<i32>();
+            let token_id_col = batch[TOKEN_ID_COL].as_primitive::<datatypes::UInt32Type>();
+
+            for (token, &token_id) in token_col.iter().zip(token_id_col.values().iter()) {
+                let token = token.ok_or(Error::Index {
+                    message: "found null token in token set".to_owned(),
                     location: location!(),
                 })?;
-        }
+                next_id = next_id.max(token_id + 1);
+                total_length += token.len();
+                tokens
+                    .insert(token, token_id as u64)
+                    .map_err(|e| Error::Index {
+                        message: format!("failed to insert token {}: {}", token, e),
+                        location: location!(),
+                    })?;
+            }
+
+            Ok::<_, Error>((tokens.into_map(), next_id, total_length))
+        })
+        .await
+        .map_err(|err| Error::Execution {
+            message: format!("failed to spawn blocking task: {}", err),
+            location: location!(),
+        })??;
 
         Ok(Self {
-            tokens: TokenMap::Fst(tokens.into_map()),
+            tokens: TokenMap::Fst(tokens),
             next_id,
             total_length,
         })


### PR DESCRIPTION
`fst` took longer to build and compile than we expected. Moving CPU-heavy fst tasks to blocking threads can prevent them from occupying our IO threads.

My test on a 40M dataset from Wikipedia on GCS shows that this change can improve the P99 of FTS over **38.5%**.

Before:

```shell
- open(ms): mean=81.60, p95=114.56, p99=120.58, min=59.96, max=122.09
- search(ms): mean=7807.53, p95=8044.16, p99=8062.43, min=7643.53, max=8067.00
- total(ms): mean=7889.13, p95=8155.86, p99=8182.45, min=7703.49, max=8189.09
- wall-clock(s): 40.01
```

After:

```shell
- open(ms): mean=95.85, p95=138.47, p99=148.06, min=75.59, max=150.46
- search(ms): mean=4632.34, p95=4910.30, p99=4955.11, min=4434.44, max=4966.32
- total(ms): mean=4728.19, p95=5012.80, p99=5048.02, min=4510.04, max=5056.83
- wall-clock(s): 24.20
```

Flamegraph before:

<img width="2037" height="647" alt="image" src="https://github.com/user-attachments/assets/042a39a4-5d12-49cf-8b1d-93f51f63e0a3" />

Flamegraph after:

<img width="2042" height="770" alt="image" src="https://github.com/user-attachments/assets/052c3e78-2f32-481c-badf-baf611358c2a" />
