### PR TITLE
feat(index/fts): build fst at write time instead of read time

### DIFF
--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -80,6 +80,7 @@ pub struct InvertedIndexBuilder {
     pub(crate) partitions: Vec<u64>,
     new_partitions: Vec<u64>,
     fragment_mask: Option<u64>,
+    token_set_version: u32,
     _tmpdir: TempDir,
     local_store: Arc<dyn IndexStore>,
     src_store: Arc<dyn IndexStore>,
@@ -91,7 +92,13 @@ impl InvertedIndexBuilder {
     }
 
     pub fn new_with_fragment_mask(params: InvertedIndexParams, fragment_mask: Option<u64>) -> Self {
-        Self::from_existing_index(params, None, Vec::new(), fragment_mask)
+        Self::from_existing_index(
+            params,
+            None,
+            Vec::new(),
+            CURRENT_TOKEN_SET_VERSION,
+            fragment_mask,
+        )
     }
 
     /// Creates an InvertedIndexBuilder from existing index with fragment filtering.
@@ -104,6 +111,7 @@ impl InvertedIndexBuilder {
         params: InvertedIndexParams,
         store: Option<Arc<dyn IndexStore>>,
         partitions: Vec<u64>,
+        token_set_version: u32,
         fragment_mask: Option<u64>,
     ) -> Self {
         let tmpdir = tempdir().unwrap();
@@ -120,6 +128,7 @@ impl InvertedIndexBuilder {
             _tmpdir: tmpdir,
             local_store,
             src_store,
+            token_set_version,
             fragment_mask,
         }
     }
@@ -166,10 +175,17 @@ impl InvertedIndexBuilder {
             let receiver = receiver.clone();
             let id_alloc = id_alloc.clone();
             let fragment_mask = self.fragment_mask;
+            let token_set_version = self.token_set_version;
             let task = tokio::task::spawn(async move {
-                let mut worker =
-                    IndexWorker::new(store, tokenizer, with_position, id_alloc, fragment_mask)
-                        .await?;
+                let mut worker = IndexWorker::new(
+                    store,
+                    tokenizer,
+                    with_position,
+                    id_alloc,
+                    fragment_mask,
+                    token_set_version,
+                )
+                .await?;
                 while let Ok(batch) = receiver.recv().await {
                     worker.process_batch(batch).await?;
                 }
@@ -232,9 +248,14 @@ impl InvertedIndexBuilder {
         dest_store: &dyn IndexStore,
     ) -> Result<()> {
         for part in self.partitions.iter() {
-            let part =
-                InvertedPartition::load(src_store.clone(), *part, None, &LanceCache::no_cache())
-                    .await?;
+            let part = InvertedPartition::load(
+                src_store.clone(),
+                *part,
+                None,
+                &LanceCache::no_cache(),
+                self.token_set_version,
+            )
+            .await?;
             let mut builder = part.into_builder().await?;
             builder.remap(mapping).await?;
             builder.write(dest_store).await?;
@@ -254,6 +275,10 @@ impl InvertedIndexBuilder {
         let metadata = HashMap::from_iter(vec![
             ("partitions".to_owned(), serde_json::to_string(&partitions)?),
             ("params".to_owned(), serde_json::to_string(&self.params)?),
+            (
+                TOKEN_SET_VERSION_KEY.to_owned(),
+                serde_json::to_string(&self.token_set_version)?,
+            ),
         ]);
         let mut writer = dest_store
             .new_index_file(METADATA_FILE, Arc::new(Schema::empty()))
@@ -275,6 +300,10 @@ impl InvertedIndexBuilder {
         let metadata = HashMap::from_iter(vec![
             ("partitions".to_owned(), serde_json::to_string(&partitions)?),
             ("params".to_owned(), serde_json::to_string(&self.params)?),
+            (
+                TOKEN_SET_VERSION_KEY.to_owned(),
+                serde_json::to_string(&self.token_set_version)?,
+            ),
         ]);
         // Use partition ID to generate a unique temporary filename
         let file_name = part_metadata_file_path(partition);
@@ -290,13 +319,32 @@ impl InvertedIndexBuilder {
         let partitions = futures::future::try_join_all(
             self.partitions
                 .iter()
-                .map(|part| InvertedPartition::load(self.src_store.clone(), *part, None, &no_cache))
+                .map(|part| {
+                    InvertedPartition::load(
+                        self.src_store.clone(),
+                        *part,
+                        None,
+                        &no_cache,
+                        self.token_set_version,
+                    )
+                })
                 .chain(self.new_partitions.iter().map(|part| {
-                    InvertedPartition::load(self.local_store.clone(), *part, None, &no_cache)
+                    InvertedPartition::load(
+                        self.local_store.clone(),
+                        *part,
+                        None,
+                        &no_cache,
+                        self.token_set_version,
+                    )
                 })),
         )
         .await?;
-        let mut merger = SizeBasedMerger::new(dest_store, partitions, *LANCE_FTS_TARGET_SIZE << 20);
+        let mut merger = SizeBasedMerger::new(
+            dest_store,
+            partitions,
+            *LANCE_FTS_TARGET_SIZE << 20,
+            self.token_set_version,
+        );
         let partitions = merger.merge().await?;
 
         if self.fragment_mask.is_none() {
@@ -322,16 +370,18 @@ impl Default for InvertedIndexBuilder {
 pub struct InnerBuilder {
     id: u64,
     with_position: bool,
+    token_set_version: u32,
     pub(crate) tokens: TokenSet,
     pub(crate) posting_lists: Vec<PostingListBuilder>,
     pub(crate) docs: DocSet,
 }
 
 impl InnerBuilder {
-    pub fn new(id: u64, with_position: bool) -> Self {
+    pub fn new(id: u64, with_position: bool, token_set_version: u32) -> Self {
         Self {
             id,
             with_position,
+            token_set_version,
             tokens: TokenSet::default(),
             posting_lists: Vec::new(),
             docs: DocSet::default(),
@@ -448,7 +498,7 @@ impl InnerBuilder {
     async fn write_tokens(&mut self, store: &dyn IndexStore) -> Result<()> {
         log::info!("writing tokens of partition {}", self.id);
         let tokens = std::mem::take(&mut self.tokens);
-        let batch = tokens.to_batch()?;
+        let batch = tokens.to_versioned_batch(self.token_set_version)?;
         let mut writer = store
             .new_index_file(&token_file_path(self.id), batch.schema())
             .await?;
@@ -480,6 +530,7 @@ struct IndexWorker {
     estimated_size: u64,
     total_doc_length: usize,
     fragment_mask: Option<u64>,
+    token_set_version: u32,
 }
 
 impl IndexWorker {
@@ -489,6 +540,7 @@ impl IndexWorker {
         with_position: bool,
         id_alloc: Arc<AtomicU64>,
         fragment_mask: Option<u64>,
+        token_set_version: u32,
     ) -> Result<Self> {
         let schema = inverted_list_schema(with_position);
 
@@ -499,6 +551,7 @@ impl IndexWorker {
                 id_alloc.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                     | fragment_mask.unwrap_or(0),
                 with_position,
+                token_set_version,
             ),
             partitions: Vec::new(),
             id_alloc,
@@ -506,6 +559,7 @@ impl IndexWorker {
             estimated_size: 0,
             total_doc_length: 0,
             fragment_mask,
+            token_set_version,
         })
     }
 
@@ -586,6 +640,7 @@ impl IndexWorker {
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                     | self.fragment_mask.unwrap_or(0),
                 with_position,
+                self.token_set_version,
             ),
         );
         builder.write(self.store.as_ref()).await?;
@@ -831,6 +886,7 @@ async fn merge_metadata_files(
     // Collect all partition IDs and params
     let mut all_partitions = Vec::new();
     let mut params = None;
+    let mut token_set_version = None;
 
     for file_name in part_metadata_files {
         let reader = store.open_index_file(file_name).await?;
@@ -862,6 +918,20 @@ async fn merge_metadata_files(
                     }
                 })?,
             );
+        }
+
+        if token_set_version.is_none() {
+            if let Some(version_str) = metadata.get(TOKEN_SET_VERSION_KEY) {
+                token_set_version = Some(serde_json::from_str::<u32>(version_str).map_err(
+                    |e| Error::Index {
+                        message: format!(
+                            "failed to parse storage version from {}: {}",
+                            file_name, e
+                        ),
+                        location: location!(),
+                    },
+                )?);
+            }
         }
     }
 
@@ -937,7 +1007,14 @@ async fn merge_metadata_files(
     // Write merged metadata with remapped IDs
     let remapped_partitions: Vec<u64> = (0..id_mapping.len() as u64).collect();
     let params = params.unwrap_or_default();
-    let builder = InvertedIndexBuilder::new_with_fragment_mask(params, None);
+    let token_set_version = token_set_version.unwrap_or(TOKEN_SET_VERSION_V0);
+    let builder = InvertedIndexBuilder::from_existing_index(
+        params,
+        None,
+        remapped_partitions.clone(),
+        token_set_version,
+        None,
+    );
     builder
         .write_metadata(&*store, &remapped_partitions)
         .await?;

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -2576,6 +2576,10 @@ mod tests {
                 "params".to_owned(),
                 serde_json::to_string(&InvertedIndexParams::default()).unwrap(),
             ),
+            (
+                TOKEN_SET_VERSION_KEY.to_owned(),
+                serde_json::to_string(&CURRENT_TOKEN_SET_VERSION).unwrap(),
+            ),
         ]);
         let mut writer = store
             .new_index_file(METADATA_FILE, Arc::new(arrow_schema::Schema::empty()))

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -950,10 +950,6 @@ impl TokenSet {
     }
 
     async fn load_v0(reader: Arc<dyn IndexReader>) -> Result<Self> {
-        let mut next_id = 0;
-        let mut total_length = 0;
-        let mut tokens = fst::MapBuilder::memory();
-
         let batch = reader.read_range(0..reader.num_rows(), None).await?;
 
         let (tokens, next_id, total_length) = spawn_blocking(move || {

--- a/rust/lance-index/src/scalar/inverted/merger.rs
+++ b/rust/lance-index/src/scalar/inverted/merger.rs
@@ -29,6 +29,7 @@ pub struct SizeBasedMerger<'a> {
     input: Vec<InvertedPartition>,
     with_position: bool,
     target_size: u64,
+    token_set_version: u32,
     builder: InnerBuilder,
     partitions: Vec<u64>,
 }
@@ -42,6 +43,7 @@ impl<'a> SizeBasedMerger<'a> {
         dest_store: &'a dyn IndexStore,
         input: Vec<InvertedPartition>,
         target_size: u64,
+        token_set_version: u32,
     ) -> Self {
         let max_id = input.iter().map(|p| p.id()).max().unwrap_or(0);
         let with_position = input
@@ -54,7 +56,8 @@ impl<'a> SizeBasedMerger<'a> {
             input,
             with_position,
             target_size,
-            builder: InnerBuilder::new(max_id + 1, with_position),
+            token_set_version,
+            builder: InnerBuilder::new(max_id + 1, with_position, token_set_version),
             partitions: Vec::new(),
         }
     }
@@ -70,7 +73,11 @@ impl<'a> SizeBasedMerger<'a> {
                 start.elapsed()
             );
             self.partitions.push(self.builder.id());
-            self.builder = InnerBuilder::new(self.builder.id() + 1, self.with_position);
+            self.builder = InnerBuilder::new(
+                self.builder.id() + 1,
+                self.with_position,
+                self.token_set_version,
+            );
         }
         Ok(())
     }

--- a/rust/lance-index/src/scalar/inverted/merger.rs
+++ b/rust/lance-index/src/scalar/inverted/merger.rs
@@ -9,7 +9,7 @@ use crate::scalar::IndexStore;
 
 use super::{
     builder::{doc_file_path, posting_file_path, token_file_path, InnerBuilder, PositionRecorder},
-    InvertedPartition, PostingListBuilder,
+    InvertedPartition, PostingListBuilder, TokenSetFormat,
 };
 
 pub trait Merger {
@@ -29,7 +29,7 @@ pub struct SizeBasedMerger<'a> {
     input: Vec<InvertedPartition>,
     with_position: bool,
     target_size: u64,
-    token_set_version: u32,
+    token_set_format: TokenSetFormat,
     builder: InnerBuilder,
     partitions: Vec<u64>,
 }
@@ -43,7 +43,7 @@ impl<'a> SizeBasedMerger<'a> {
         dest_store: &'a dyn IndexStore,
         input: Vec<InvertedPartition>,
         target_size: u64,
-        token_set_version: u32,
+        token_set_format: TokenSetFormat,
     ) -> Self {
         let max_id = input.iter().map(|p| p.id()).max().unwrap_or(0);
         let with_position = input
@@ -56,8 +56,8 @@ impl<'a> SizeBasedMerger<'a> {
             input,
             with_position,
             target_size,
-            token_set_version,
-            builder: InnerBuilder::new(max_id + 1, with_position, token_set_version),
+            token_set_format,
+            builder: InnerBuilder::new(max_id + 1, with_position, token_set_format),
             partitions: Vec::new(),
         }
     }
@@ -76,7 +76,7 @@ impl<'a> SizeBasedMerger<'a> {
             self.builder = InnerBuilder::new(
                 self.builder.id() + 1,
                 self.with_position,
-                self.token_set_version,
+                self.token_set_format,
             );
         }
         Ok(())


### PR DESCRIPTION
We are now building the FST at write time instead of reading time, so the token set is constructed once during ingestion and only loaded during read operations. (Thank you @BubbleCal for this great idea!)

On a test with a 40M Wikipedia dataset, this change reduces the P95 latency by **32.3%**, from `5708.43 ms` to `3863.13 ms`.

The token set file's size reduced from `93.1 MB` to `46.2 MB`.

Before:

```shell
- open(ms): mean=84.96, p95=111.08, p99=113.98, min=69.28, max=114.70
- search(ms): mean=4993.26, p95=5708.43, p99=5778.55, min=4424.76, max=5796.08
- total(ms): mean=5078.22, p95=5814.05, p99=5891.44, min=4521.33, max=5910.78
- wall-clock(s): 25.98
```

<img width="2294" height="547" alt="image" src="https://github.com/user-attachments/assets/b36ac37c-c11b-4131-81e1-e470ea7bdc46" />


After:

```shell
- open(ms): mean=79.45, p95=107.79, p99=113.32, min=63.61, max=114.70
- search(ms): mean=3386.18, p95=3863.13, p99=3962.93, min=3115.72, max=3987.87
- total(ms): mean=3465.63, p95=3970.92, p99=4076.24, min=3183.25, max=4102.57
- wall-clock(s): 18.00
```

<img width="2297" height="783" alt="image" src="https://github.com/user-attachments/assets/02a4b3b1-8e5c-493b-be00-62c5b8bd9c3e" />

---

**This PR was primarily authored with Codex using GPT-5-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**