### PR TITLE
feat: add support for already-dictionary to 2.1

### DIFF
--- a/rust/lance-encoding/src/compression.rs
+++ b/rust/lance-encoding/src/compression.rs
@@ -462,7 +462,7 @@ impl CompressionStrategy for DefaultCompressionStrategy {
 
     fn create_block_compressor(
         &self,
-        _field: &Field,
+        field: &Field,
         data: &DataBlock,
     ) -> Result<(Box<dyn BlockCompressor>, CompressiveEncoding)> {
         match data {
@@ -486,7 +486,11 @@ impl CompressionStrategy for DefaultCompressionStrategy {
                 );
                 Ok((encoder, encoding))
             }
-            _ => unreachable!(),
+            _ => todo!(
+                "block compressor for field {:?} and block type {:?}",
+                field,
+                data.name()
+            ),
         }
     }
 }

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -531,9 +531,7 @@ mod tests {
             .with_range(1..3)
             .with_range(2..4)
             .with_indices(vec![1])
-            .with_indices(vec![2])
-            // TODO (https://github.com/lancedb/lance/issues/4782)
-            .with_max_file_version(LanceFileVersion::V2_0);
+            .with_indices(vec![2]);
         check_round_trip_encoding_of_data(
             vec![Arc::new(list_array)],
             &test_cases,

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -17,6 +17,7 @@ use crate::{
         DICT_DIVISOR_META_KEY, STRUCTURAL_ENCODING_FULLZIP, STRUCTURAL_ENCODING_META_KEY,
         STRUCTURAL_ENCODING_MINIBLOCK,
     },
+    data::DictionaryDataBlock,
     encodings::logical::primitive::blob::BlobPageScheduler,
     format::{
         pb21::{self, compressive_encoding::Compression, CompressiveEncoding, PageLayout},
@@ -32,7 +33,7 @@ use lance_arrow::deepcopy::deep_copy_nulls;
 use lance_core::{
     cache::{CacheKey, Context, DeepSizeOf},
     error::{Error, LanceOptionExt},
-    utils::{bit::pad_bytes, hash::U8SliceKey},
+    utils::bit::pad_bytes,
 };
 use log::trace;
 use snafu::location;
@@ -81,6 +82,7 @@ use crate::{
 };
 
 pub mod blob;
+pub mod dict;
 pub mod fullzip;
 pub mod miniblock;
 
@@ -565,54 +567,25 @@ impl DecodePageTask for DecodeMiniBlockTask {
             data_builder.append(&values, item_range);
         }
 
-        let data = data_builder.finish();
+        let mut data = data_builder.finish();
 
         let unraveler = RepDefUnraveler::new(repbuf, defbuf, self.def_meaning.clone());
 
-        // if dictionary encoding is applied, do dictionary decode here.
         if let Some(dictionary) = &self.dictionary_data {
-            // assume the indices are uniformly distributed.
-            let estimated_size_bytes = dictionary.data_size()
-                * (data.num_values() + dictionary.num_values() - 1)
-                / dictionary.num_values();
-            let mut data_builder = DataBlockBuilder::with_capacity_estimate(estimated_size_bytes);
-
-            // if dictionary encoding is applied, decode indices based on their actual bit width
-            if let DataBlock::FixedWidth(fixed_width_data_block) = data {
-                match fixed_width_data_block.bits_per_value {
-                    32 => {
-                        let indices = fixed_width_data_block.data.borrow_to_typed_slice::<i32>();
-                        let indices = indices.as_ref();
-
-                        indices.iter().for_each(|&idx| {
-                            data_builder.append(dictionary, idx as u64..idx as u64 + 1);
-                        });
-                    }
-                    64 => {
-                        let indices = fixed_width_data_block.data.borrow_to_typed_slice::<i64>();
-                        let indices = indices.as_ref();
-
-                        indices.iter().for_each(|&idx| {
-                            data_builder.append(dictionary, idx as u64..idx as u64 + 1);
-                        });
-                    }
-                    _ => {
-                        return Err(lance_core::Error::Internal {
-                            message: format!(
-                                "Unsupported dictionary index bit width: {} bits",
-                                fixed_width_data_block.bits_per_value
-                            ),
-                            location: location!(),
-                        });
-                    }
-                }
-
-                let data = data_builder.finish();
-                return Ok(DecodedPage {
-                    data,
-                    repdef: unraveler,
+            // Don't decode here, that happens later (if needed)
+            let DataBlock::FixedWidth(indices) = data else {
+                return Err(lance_core::Error::Internal {
+                    message: format!(
+                        "Expected FixedWidth DataBlock for dictionary indices, got {:?}",
+                        data
+                    ),
+                    location: location!(),
                 });
-            }
+            };
+            data = DataBlock::Dictionary(DictionaryDataBlock::from_parts(
+                indices,
+                dictionary.as_ref().clone(),
+            ));
         }
 
         Ok(DecodedPage {
@@ -4092,170 +4065,6 @@ impl PrimitiveStructuralEncoder {
         })
     }
 
-    fn dictionary_encode(mut data_block: DataBlock) -> (DataBlock, DataBlock) {
-        let cardinality = data_block
-            .get_stat(Stat::Cardinality)
-            .unwrap()
-            .as_primitive::<UInt64Type>()
-            .value(0);
-        match data_block {
-            DataBlock::FixedWidth(ref mut fixed_width_data_block) => {
-                // Currently FixedWidth DataBlock with only bits_per_value 128 has cardinality
-                // TODO: a follow up PR to support `FixedWidth DataBlock with bits_per_value == 256`.
-                let mut map = HashMap::new();
-                let u128_slice = fixed_width_data_block.data.borrow_to_typed_slice::<u128>();
-                let u128_slice = u128_slice.as_ref();
-                let mut dictionary_buffer = Vec::with_capacity(cardinality as usize);
-                let mut indices_buffer =
-                    Vec::with_capacity(fixed_width_data_block.num_values as usize);
-                let mut curr_idx: i32 = 0;
-                u128_slice.iter().for_each(|&value| {
-                    let idx = *map.entry(value).or_insert_with(|| {
-                        dictionary_buffer.push(value);
-                        curr_idx += 1;
-                        curr_idx - 1
-                    });
-                    indices_buffer.push(idx);
-                });
-                let dictionary_data_block = DataBlock::FixedWidth(FixedWidthDataBlock {
-                    data: LanceBuffer::reinterpret_vec(dictionary_buffer),
-                    bits_per_value: 128,
-                    num_values: curr_idx as u64,
-                    block_info: BlockInfo::default(),
-                });
-                let mut indices_data_block = DataBlock::FixedWidth(FixedWidthDataBlock {
-                    data: LanceBuffer::reinterpret_vec(indices_buffer),
-                    bits_per_value: 32,
-                    num_values: fixed_width_data_block.num_values,
-                    block_info: BlockInfo::default(),
-                });
-                // Todo: if we decide to do eager statistics computing, wrap statistics computing
-                // in DataBlock constructor.
-                indices_data_block.compute_stat();
-
-                (indices_data_block, dictionary_data_block)
-            }
-            DataBlock::VariableWidth(ref mut variable_width_data_block) => {
-                match variable_width_data_block.bits_per_offset {
-                    32 => {
-                        let mut map = HashMap::new();
-                        let offsets = variable_width_data_block
-                            .offsets
-                            .borrow_to_typed_slice::<u32>();
-                        let offsets = offsets.as_ref();
-
-                        let max_len = variable_width_data_block.get_stat(Stat::MaxLength).expect(
-                            "VariableWidth DataBlock should have valid `Stat::DataSize` statistics",
-                        );
-                        let max_len = max_len.as_primitive::<UInt64Type>().value(0);
-
-                        let mut dictionary_buffer: Vec<u8> =
-                            Vec::with_capacity((max_len * cardinality) as usize);
-                        let mut dictionary_offsets_buffer = vec![0];
-                        let mut curr_idx = 0;
-                        let mut indices_buffer =
-                            Vec::with_capacity(variable_width_data_block.num_values as usize);
-
-                        offsets
-                            .iter()
-                            .zip(offsets.iter().skip(1))
-                            .for_each(|(&start, &end)| {
-                                let key =
-                                    &variable_width_data_block.data[start as usize..end as usize];
-                                let idx: i32 = *map.entry(U8SliceKey(key)).or_insert_with(|| {
-                                    dictionary_buffer.extend_from_slice(key);
-                                    dictionary_offsets_buffer.push(dictionary_buffer.len() as u32);
-                                    curr_idx += 1;
-                                    curr_idx - 1
-                                });
-                                indices_buffer.push(idx);
-                            });
-
-                        let dictionary_data_block = DataBlock::VariableWidth(VariableWidthBlock {
-                            data: LanceBuffer::reinterpret_vec(dictionary_buffer),
-                            offsets: LanceBuffer::reinterpret_vec(dictionary_offsets_buffer),
-                            bits_per_offset: 32,
-                            num_values: curr_idx as u64,
-                            block_info: BlockInfo::default(),
-                        });
-
-                        let mut indices_data_block = DataBlock::FixedWidth(FixedWidthDataBlock {
-                            data: LanceBuffer::reinterpret_vec(indices_buffer),
-                            bits_per_value: 32,
-                            num_values: variable_width_data_block.num_values,
-                            block_info: BlockInfo::default(),
-                        });
-                        // Todo: if we decide to do eager statistics computing, wrap statistics computing
-                        // in DataBlock constructor.
-                        indices_data_block.compute_stat();
-
-                        (indices_data_block, dictionary_data_block)
-                    }
-                    64 => {
-                        let mut map = HashMap::new();
-                        let offsets = variable_width_data_block
-                            .offsets
-                            .borrow_to_typed_slice::<u64>();
-                        let offsets = offsets.as_ref();
-
-                        let max_len = variable_width_data_block.get_stat(Stat::MaxLength).expect(
-                            "VariableWidth DataBlock should have valid `Stat::DataSize` statistics",
-                        );
-                        let max_len = max_len.as_primitive::<UInt64Type>().value(0);
-
-                        let mut dictionary_buffer: Vec<u8> =
-                            Vec::with_capacity((max_len * cardinality) as usize);
-                        let mut dictionary_offsets_buffer = vec![0];
-                        let mut curr_idx = 0;
-                        let mut indices_buffer =
-                            Vec::with_capacity(variable_width_data_block.num_values as usize);
-
-                        offsets
-                            .iter()
-                            .zip(offsets.iter().skip(1))
-                            .for_each(|(&start, &end)| {
-                                let key =
-                                    &variable_width_data_block.data[start as usize..end as usize];
-                                let idx: i64 = *map.entry(U8SliceKey(key)).or_insert_with(|| {
-                                    dictionary_buffer.extend_from_slice(key);
-                                    dictionary_offsets_buffer.push(dictionary_buffer.len() as u64);
-                                    curr_idx += 1;
-                                    curr_idx - 1
-                                });
-                                indices_buffer.push(idx);
-                            });
-
-                        let dictionary_data_block = DataBlock::VariableWidth(VariableWidthBlock {
-                            data: LanceBuffer::reinterpret_vec(dictionary_buffer),
-                            offsets: LanceBuffer::reinterpret_vec(dictionary_offsets_buffer),
-                            bits_per_offset: 64,
-                            num_values: curr_idx as u64,
-                            block_info: BlockInfo::default(),
-                        });
-
-                        let mut indices_data_block = DataBlock::FixedWidth(FixedWidthDataBlock {
-                            data: LanceBuffer::reinterpret_vec(indices_buffer),
-                            bits_per_value: 64,
-                            num_values: variable_width_data_block.num_values,
-                            block_info: BlockInfo::default(),
-                        });
-                        // Todo: if we decide to do eager statistics computing, wrap statistics computing
-                        // in DataBlock constructor.
-                        indices_data_block.compute_stat();
-
-                        (indices_data_block, dictionary_data_block)
-                    }
-                    _ => {
-                        unreachable!()
-                    }
-                }
-            }
-            _ => {
-                unreachable!("dictionary encode called with data block {:?}", data_block)
-            }
-        }
-    }
-
     fn should_dictionary_encode(data_block: &DataBlock, field: &Field) -> bool {
         // Don't dictionary encode tiny arrays
         let too_small = env::var("LANCE_ENCODING_DICT_TOO_SMALL")
@@ -4359,18 +4168,32 @@ impl PrimitiveStructuralEncoder {
                 }
             }
 
-            // The top-level validity is encoded in repdef so we can remove it.
-            let data_block = data_block.remove_outer_validity();
-
-
-            if Self::should_dictionary_encode(&data_block, &field) {
+            if let DataBlock::Dictionary(dict) = data_block {
+                log::debug!("Encoding column {} with {} items using dictionary encoding (already dictionary encoded)", column_idx, num_values);
+                let (mut indices_data_block, dictionary_data_block) = dict.into_parts();
+                // TODO: https://github.com/lancedb/lance/issues/4809
+                // If we compute stats on dictionary_data_block => panic.
+                // If we don't compute stats on indices_data_block => panic.
+                // This is messy.  Don't make me call compute_stat ever.
+                indices_data_block.compute_stat();
+                Self::encode_miniblock(
+                    column_idx,
+                    &field,
+                    compression_strategy.as_ref(),
+                    indices_data_block,
+                    repdefs,
+                    row_number,
+                    Some(dictionary_data_block),
+                    num_rows
+                )
+            } else if Self::should_dictionary_encode(&data_block, &field) {
                 log::debug!(
                     "Encoding column {} with {} items using dictionary encoding (mini-block layout)",
                     column_idx,
                     num_values
                 );
                 let (indices_data_block, dictionary_data_block) =
-                    Self::dictionary_encode(data_block);
+                    dict::dictionary_encode(data_block);
                 Self::encode_miniblock(
                     column_idx,
                     &field,
@@ -4421,28 +4244,37 @@ impl PrimitiveStructuralEncoder {
     }
 
     fn extract_validity_buf(
-        array: &dyn Array,
+        array: Arc<dyn Array>,
         repdef: &mut RepDefBuilder,
         keep_original_array: bool,
-    ) {
+    ) -> Result<Arc<dyn Array>> {
         if let Some(validity) = array.nulls() {
             if keep_original_array {
                 repdef.add_validity_bitmap(validity.clone());
             } else {
                 repdef.add_validity_bitmap(deep_copy_nulls(Some(validity)).unwrap());
             }
+            let data_no_nulls = array.to_data().into_builder().nulls(None).build()?;
+            Ok(make_array(data_no_nulls))
         } else {
             repdef.add_no_null(array.len());
+            Ok(array)
         }
     }
 
-    fn extract_validity(array: &dyn Array, repdef: &mut RepDefBuilder, keep_original_array: bool) {
+    fn extract_validity(
+        mut array: Arc<dyn Array>,
+        repdef: &mut RepDefBuilder,
+        keep_original_array: bool,
+    ) -> Result<Arc<dyn Array>> {
         match array.data_type() {
             DataType::Null => {
                 repdef.add_validity_bitmap(NullBuffer::new(BooleanBuffer::new_unset(array.len())));
+                Ok(array)
             }
             DataType::Dictionary(_, _) => {
-                unreachable!()
+                array = dict::normalize_dict_nulls(array)?;
+                Self::extract_validity_buf(array, repdef, keep_original_array)
             }
             // Extract our validity buf but NOT any child validity bufs. (they will be encoded in
             // as part of the values).  Note: for FSL we do not use repdef.add_fsl because we do
@@ -4467,7 +4299,7 @@ impl FieldEncoder for PrimitiveStructuralEncoder {
         row_number: u64,
         num_rows: u64,
     ) -> Result<Vec<EncodeTask>> {
-        Self::extract_validity(array.as_ref(), &mut repdef, self.keep_original_array);
+        let array = Self::extract_validity(array, &mut repdef, self.keep_original_array)?;
         self.accumulated_repdefs.push(repdef);
 
         if let Some((arrays, row_number, num_rows)) =

--- a/rust/lance-encoding/src/encodings/logical/primitive/dict.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive/dict.rs
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{collections::HashMap, sync::Arc};
+
+use arrow_array::{
+    cast::AsArray,
+    types::{
+        ArrowDictionaryKeyType, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type,
+        UInt64Type, UInt8Type,
+    },
+    Array, DictionaryArray, PrimitiveArray, UInt64Array,
+};
+use arrow_buffer::ArrowNativeType;
+use arrow_schema::DataType;
+use arrow_select::take::TakeOptions;
+use lance_core::{error::LanceOptionExt, utils::hash::U8SliceKey, Error, Result};
+use snafu::location;
+
+use crate::{
+    buffer::LanceBuffer,
+    data::{BlockInfo, DataBlock, FixedWidthDataBlock, VariableWidthBlock},
+    statistics::{ComputeStat, GetStat, Stat},
+};
+
+// Helper function for normalize_dict_nulls
+fn normalize_dict_nulls_impl<K: ArrowDictionaryKeyType>(
+    array: Arc<dyn Array>,
+) -> Result<Arc<dyn Array>> {
+    // TODO: Fast path when there is only one null index? (common case)
+
+    let dict_array = array.as_dictionary_opt::<K>().expect_ok()?;
+
+    if dict_array.values().null_count() == 0 {
+        return Ok(array);
+    }
+
+    let mut mapping = vec![None; dict_array.values().len()];
+    let mut skipped = 0;
+    let mut valid_indices = Vec::with_capacity(dict_array.values().len());
+    for (old_idx, is_valid) in dict_array.values().nulls().expect_ok()?.iter().enumerate() {
+        if is_valid {
+            // Should be safe since we are only decreasing K values (e.g. won't overflow u8 keys into u16)
+            mapping[old_idx] = Some(K::Native::from_usize(old_idx - skipped).expect_ok()?);
+            valid_indices.push(old_idx as u64);
+        } else {
+            skipped += 1;
+            mapping[old_idx] = None;
+        }
+    }
+
+    let mut keys_builder = PrimitiveArray::<K>::builder(dict_array.keys().len());
+    for key in dict_array.keys().iter() {
+        if let Some(key) = key {
+            if let Some(mapped) = mapping[key.to_usize().expect_ok()?] {
+                // Valid item
+                keys_builder.append_value(mapped);
+            } else {
+                // Null via values
+                keys_builder.append_null();
+            }
+        } else {
+            // Null via keys
+            keys_builder.append_null();
+        }
+    }
+    let keys = keys_builder.finish();
+
+    let valid_indices = UInt64Array::from(valid_indices);
+    let values = arrow_select::take::take(
+        dict_array.values(),
+        &valid_indices,
+        Some(TakeOptions {
+            check_bounds: false,
+        }),
+    )?;
+
+    Ok(Arc::new(DictionaryArray::new(keys, values)) as Arc<dyn Array>)
+}
+
+/// In Arrow a dictionary array can have nulls in two different places:
+/// 1. The keys can be null
+/// 2. The values can be null
+///
+/// We want to normalize this so that all nulls are in the keys.  This way we can store
+/// the nulls with the keys as rep-def values the same as any other array.
+pub fn normalize_dict_nulls(array: Arc<dyn Array>) -> Result<Arc<dyn Array>> {
+    match array.data_type() {
+        DataType::Dictionary(key_type, _) => match key_type.as_ref() {
+            DataType::UInt8 => normalize_dict_nulls_impl::<UInt8Type>(array),
+            DataType::UInt16 => normalize_dict_nulls_impl::<UInt16Type>(array),
+            DataType::UInt32 => normalize_dict_nulls_impl::<UInt32Type>(array),
+            DataType::UInt64 => normalize_dict_nulls_impl::<UInt64Type>(array),
+            DataType::Int8 => normalize_dict_nulls_impl::<Int8Type>(array),
+            DataType::Int16 => normalize_dict_nulls_impl::<Int16Type>(array),
+            DataType::Int32 => normalize_dict_nulls_impl::<Int32Type>(array),
+            DataType::Int64 => normalize_dict_nulls_impl::<Int64Type>(array),
+            _ => Err(Error::NotSupported {
+                source: format!("Unsupported dictionary key type: {}", key_type).into(),
+                location: location!(),
+            }),
+        },
+        _ => Err(Error::Internal {
+            message: format!("Data type is not a dictionary: {}", array.data_type()),
+            location: location!(),
+        }),
+    }
+}
+
+/// Dictionary encodes a data block
+///
+/// Currently only supported for some common cases (string / binary / u128)
+///
+/// Returns a block of indices (will always be a fixed width data block) and a block of dictionary
+pub fn dictionary_encode(mut data_block: DataBlock) -> (DataBlock, DataBlock) {
+    let cardinality = data_block
+        .get_stat(Stat::Cardinality)
+        .unwrap()
+        .as_primitive::<UInt64Type>()
+        .value(0);
+    match data_block {
+        DataBlock::FixedWidth(ref mut fixed_width_data_block) => {
+            // Currently FixedWidth DataBlock with only bits_per_value 128 has cardinality
+            // TODO: a follow up PR to support `FixedWidth DataBlock with bits_per_value == 256`.
+            let mut map = HashMap::new();
+            let u128_slice = fixed_width_data_block.data.borrow_to_typed_slice::<u128>();
+            let u128_slice = u128_slice.as_ref();
+            let mut dictionary_buffer = Vec::with_capacity(cardinality as usize);
+            let mut indices_buffer = Vec::with_capacity(fixed_width_data_block.num_values as usize);
+            let mut curr_idx: i32 = 0;
+            u128_slice.iter().for_each(|&value| {
+                let idx = *map.entry(value).or_insert_with(|| {
+                    dictionary_buffer.push(value);
+                    curr_idx += 1;
+                    curr_idx - 1
+                });
+                indices_buffer.push(idx);
+            });
+            let dictionary_data_block = DataBlock::FixedWidth(FixedWidthDataBlock {
+                data: LanceBuffer::reinterpret_vec(dictionary_buffer),
+                bits_per_value: 128,
+                num_values: curr_idx as u64,
+                block_info: BlockInfo::default(),
+            });
+            let mut indices_data_block = DataBlock::FixedWidth(FixedWidthDataBlock {
+                data: LanceBuffer::reinterpret_vec(indices_buffer),
+                bits_per_value: 32,
+                num_values: fixed_width_data_block.num_values,
+                block_info: BlockInfo::default(),
+            });
+            // Todo: if we decide to do eager statistics computing, wrap statistics computing
+            // in DataBlock constructor.
+            indices_data_block.compute_stat();
+
+            (indices_data_block, dictionary_data_block)
+        }
+        DataBlock::VariableWidth(ref mut variable_width_data_block) => {
+            match variable_width_data_block.bits_per_offset {
+                32 => {
+                    let mut map = HashMap::new();
+                    let offsets = variable_width_data_block
+                        .offsets
+                        .borrow_to_typed_slice::<u32>();
+                    let offsets = offsets.as_ref();
+
+                    let max_len = variable_width_data_block.get_stat(Stat::MaxLength).expect(
+                        "VariableWidth DataBlock should have valid `Stat::DataSize` statistics",
+                    );
+                    let max_len = max_len.as_primitive::<UInt64Type>().value(0);
+
+                    let mut dictionary_buffer: Vec<u8> =
+                        Vec::with_capacity((max_len * cardinality) as usize);
+                    let mut dictionary_offsets_buffer = vec![0];
+                    let mut curr_idx = 0;
+                    let mut indices_buffer =
+                        Vec::with_capacity(variable_width_data_block.num_values as usize);
+
+                    offsets
+                        .iter()
+                        .zip(offsets.iter().skip(1))
+                        .for_each(|(&start, &end)| {
+                            let key = &variable_width_data_block.data[start as usize..end as usize];
+                            let idx: i32 = *map.entry(U8SliceKey(key)).or_insert_with(|| {
+                                dictionary_buffer.extend_from_slice(key);
+                                dictionary_offsets_buffer.push(dictionary_buffer.len() as u32);
+                                curr_idx += 1;
+                                curr_idx - 1
+                            });
+                            indices_buffer.push(idx);
+                        });
+
+                    let dictionary_data_block = DataBlock::VariableWidth(VariableWidthBlock {
+                        data: LanceBuffer::reinterpret_vec(dictionary_buffer),
+                        offsets: LanceBuffer::reinterpret_vec(dictionary_offsets_buffer),
+                        bits_per_offset: 32,
+                        num_values: curr_idx as u64,
+                        block_info: BlockInfo::default(),
+                    });
+
+                    let mut indices_data_block = DataBlock::FixedWidth(FixedWidthDataBlock {
+                        data: LanceBuffer::reinterpret_vec(indices_buffer),
+                        bits_per_value: 32,
+                        num_values: variable_width_data_block.num_values,
+                        block_info: BlockInfo::default(),
+                    });
+                    // Todo: if we decide to do eager statistics computing, wrap statistics computing
+                    // in DataBlock constructor.
+                    indices_data_block.compute_stat();
+
+                    (indices_data_block, dictionary_data_block)
+                }
+                64 => {
+                    let mut map = HashMap::new();
+                    let offsets = variable_width_data_block
+                        .offsets
+                        .borrow_to_typed_slice::<u64>();
+                    let offsets = offsets.as_ref();
+
+                    let max_len = variable_width_data_block.get_stat(Stat::MaxLength).expect(
+                        "VariableWidth DataBlock should have valid `Stat::DataSize` statistics",
+                    );
+                    let max_len = max_len.as_primitive::<UInt64Type>().value(0);
+
+                    let mut dictionary_buffer: Vec<u8> =
+                        Vec::with_capacity((max_len * cardinality) as usize);
+                    let mut dictionary_offsets_buffer = vec![0];
+                    let mut curr_idx = 0;
+                    let mut indices_buffer =
+                        Vec::with_capacity(variable_width_data_block.num_values as usize);
+
+                    offsets
+                        .iter()
+                        .zip(offsets.iter().skip(1))
+                        .for_each(|(&start, &end)| {
+                            let key = &variable_width_data_block.data[start as usize..end as usize];
+                            let idx: i64 = *map.entry(U8SliceKey(key)).or_insert_with(|| {
+                                dictionary_buffer.extend_from_slice(key);
+                                dictionary_offsets_buffer.push(dictionary_buffer.len() as u64);
+                                curr_idx += 1;
+                                curr_idx - 1
+                            });
+                            indices_buffer.push(idx);
+                        });
+
+                    let dictionary_data_block = DataBlock::VariableWidth(VariableWidthBlock {
+                        data: LanceBuffer::reinterpret_vec(dictionary_buffer),
+                        offsets: LanceBuffer::reinterpret_vec(dictionary_offsets_buffer),
+                        bits_per_offset: 64,
+                        num_values: curr_idx as u64,
+                        block_info: BlockInfo::default(),
+                    });
+
+                    let mut indices_data_block = DataBlock::FixedWidth(FixedWidthDataBlock {
+                        data: LanceBuffer::reinterpret_vec(indices_buffer),
+                        bits_per_value: 64,
+                        num_values: variable_width_data_block.num_values,
+                        block_info: BlockInfo::default(),
+                    });
+                    // Todo: if we decide to do eager statistics computing, wrap statistics computing
+                    // in DataBlock constructor.
+                    indices_data_block.compute_stat();
+
+                    (indices_data_block, dictionary_data_block)
+                }
+                _ => {
+                    unreachable!()
+                }
+            }
+        }
+        _ => {
+            unreachable!("dictionary encode called with data block {:?}", data_block)
+        }
+    }
+}

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -10,7 +10,6 @@
 //! is needed in the encoding description.
 
 use arrow_array::OffsetSizeTrait;
-use bytemuck::cast_slice;
 use byteorder::{ByteOrder, LittleEndian};
 use core::panic;
 use snafu::location;
@@ -305,11 +304,11 @@ impl MiniBlockDecompressor for BinaryMiniBlockDecompressor {
 
 /// Most basic encoding for variable-width data which does no compression at all
 /// The DataBlock memory layout looks like below:
-/// ----------------------------------------------------------------------------------------
-/// | bits_per_offset | number of values  | bytes_start_offset | offsets data | bytes data
-/// ----------------------------------------------------------------------------------------
-/// |       1 byte    |<bits_per_offset>/8|<bits_per_offset>/8 |  offsets_len | dat_len
-/// ----------------------------------------------------------------------------------------
+///
+/// | bits_per_offset           | bytes_start_offset        | offsets data | bytes data |
+/// | ------------------------- | ------------------------- | ------------ | ---------- |
+/// | <bits_per_offset>/8 bytes | <bits_per_offset>/8 bytes | offsets_len  | data_len   |
+///
 /// It's used in VariableEncoder and BinaryBlockDecompressor
 ///
 #[derive(Debug, Default)]
@@ -319,35 +318,26 @@ impl BlockCompressor for VariableEncoder {
     fn compress(&self, mut data: DataBlock) -> Result<LanceBuffer> {
         match data {
             DataBlock::VariableWidth(ref mut variable_width_data) => {
-                let num_values: u64 = variable_width_data.num_values;
                 match variable_width_data.bits_per_offset {
                     32 => {
-                        let num_values: u32 = num_values
-            .try_into()
-            .expect("The Maximum number of values BinaryBlockEncoder can work with is u32::MAX");
-
                         let offsets = variable_width_data.offsets.borrow_to_typed_slice::<u32>();
                         let offsets = offsets.as_ref();
-                        // the first bit stores the bits_per_offset, the next 4 bytes store the number of values,
-                        // then 4 bytes for bytes_start_offset,
-                        // then offsets data, then bytes data.
-                        let bytes_start_offset = 1 + 4 + 4 + std::mem::size_of_val(offsets) as u32;
+                        // The first 4 bytes store the bits per offset, the next 4 bytes store the start
+                        // offset of the bytes data, then offsets data, then bytes data.
+                        let bytes_start_offset = 4 + 4 + std::mem::size_of_val(offsets) as u32;
 
                         let output_total_bytes =
                             bytes_start_offset as usize + variable_width_data.data.len();
                         let mut output: Vec<u8> = Vec::with_capacity(output_total_bytes);
 
                         // Store bit_per_offset info
-                        output.push(32_u8);
-
-                        // store `num_values` in the first 4 bytes of output buffer
-                        output.extend_from_slice(&(num_values).to_le_bytes());
+                        output.extend_from_slice(&(32_u32).to_le_bytes());
 
                         // store `bytes_start_offset` in the next 4 bytes of output buffer
                         output.extend_from_slice(&(bytes_start_offset).to_le_bytes());
 
                         // store offsets
-                        output.extend_from_slice(cast_slice(offsets));
+                        output.extend_from_slice(&variable_width_data.offsets);
 
                         // store bytes
                         output.extend_from_slice(&variable_width_data.data);
@@ -356,27 +346,22 @@ impl BlockCompressor for VariableEncoder {
                     64 => {
                         let offsets = variable_width_data.offsets.borrow_to_typed_slice::<u64>();
                         let offsets = offsets.as_ref();
-                        // the first bit stores the bits_per_offset, the next 8 bytes store the number of values,
-                        // then 8 bytes for bytes_start_offset,
-                        // then offsets data, then bytes data.
-
-                        let bytes_start_offset = 1 + 8 + 8 + std::mem::size_of_val(offsets) as u64;
+                        // The first 8 bytes store the bits per offset, the next 8 bytes store the start
+                        // offset of the bytes data, then offsets data, then bytes data.
+                        let bytes_start_offset = 8 + 8 + std::mem::size_of_val(offsets) as u64;
 
                         let output_total_bytes =
                             bytes_start_offset as usize + variable_width_data.data.len();
                         let mut output: Vec<u8> = Vec::with_capacity(output_total_bytes);
 
                         // Store bit_per_offset info
-                        output.push(64_u8);
-
-                        // store `num_values` in the first 8 bytes of output buffer
-                        output.extend_from_slice(&(num_values).to_le_bytes());
+                        output.extend_from_slice(&(64_u64).to_le_bytes());
 
                         // store `bytes_start_offset` in the next 8 bytes of output buffer
                         output.extend_from_slice(&(bytes_start_offset).to_le_bytes());
 
                         // store offsets
-                        output.extend_from_slice(cast_slice(offsets));
+                        output.extend_from_slice(&variable_width_data.offsets);
 
                         // store bytes
                         output.extend_from_slice(&variable_width_data.data);
@@ -423,61 +408,72 @@ pub struct BinaryBlockDecompressor {}
 
 impl BlockDecompressor for BinaryBlockDecompressor {
     fn decompress(&self, data: LanceBuffer, num_values: u64) -> Result<DataBlock> {
-        // The first byte contains bytes_per_offset info
-        let bits_per_offset = data[0];
-        match bits_per_offset {
-            32 => {
-                // the next 4 bytes in the BinaryBlock compressed buffer stores the num_values this block has.
-                let stored_num_values = LittleEndian::read_u32(&data[1..5]);
-                debug_assert_eq!(num_values, stored_num_values as u64);
+        // In older (not quite stable) versions we stored the bits per offset as a single byte and then the num_values
+        // as four bytes.  However, this led to alignment problems and was wasteful since we already store the num_values
+        // in higher layers.
+        //
+        // In the standard scheme we use 4 bytes for the bits per offset and 4 bytes for the bytes_start_offset and we
+        // rely on the passed in num_values to be correct.
 
-                // the next 4 bytes in the BinaryBlock compressed buffer stores the bytes_start_offset.
-                let bytes_start_offset = LittleEndian::read_u32(&data[5..9]);
-
-                // the next `bytes_start_offset - 9` stores the offsets.
-                let offsets = data.slice_with_length(9, bytes_start_offset as usize - 9);
-
-                // the rest are the binary bytes.
-                let data = data.slice_with_length(
-                    bytes_start_offset as usize,
-                    data.len() - bytes_start_offset as usize,
-                );
-
-                Ok(DataBlock::VariableWidth(VariableWidthBlock {
-                    data,
-                    offsets,
-                    bits_per_offset: 32,
-                    num_values,
-                    block_info: BlockInfo::new(),
-                }))
+        let (bits_per_offset, bytes_start_offset, offset_start) = if data[0] == 0 {
+            // Old scheme
+            let bits_per_offset = data[0];
+            match bits_per_offset {
+                32 => {
+                    debug_assert_eq!(LittleEndian::read_u32(&data[1..5]), num_values as u32);
+                    let bytes_start_offset = LittleEndian::read_u32(&data[5..9]);
+                    (bits_per_offset, bytes_start_offset as u64, 9)
+                }
+                64 => {
+                    debug_assert_eq!(LittleEndian::read_u64(&data[1..9]), num_values);
+                    let bytes_start_offset = LittleEndian::read_u64(&data[9..17]);
+                    (bits_per_offset, bytes_start_offset, 17)
+                }
+                _ => {
+                    return Err(Error::InvalidInput {
+                        source: format!("Unsupported bits_per_offset={}", bits_per_offset).into(),
+                        location: location!(),
+                    });
+                }
             }
-            64 => {
-                // the next 8 bytes in the BinaryBlock compressed buffer stores the num_values this block has.
-                let stored_num_values = LittleEndian::read_u64(&data[1..9]);
-                debug_assert_eq!(num_values, stored_num_values);
-
-                // the next 8 bytes in the BinaryBlock compressed buffer stores the bytes_start_offset.
-                let bytes_start_offset = LittleEndian::read_u64(&data[9..17]);
-
-                // the next `bytes_start_offset - 17` stores the offsets.
-                let offsets = data.slice_with_length(17, bytes_start_offset as usize - 17);
-
-                // the rest are the binary bytes.
-                let data = data.slice_with_length(
-                    bytes_start_offset as usize,
-                    data.len() - bytes_start_offset as usize,
-                );
-
-                Ok(DataBlock::VariableWidth(VariableWidthBlock {
-                    data,
-                    offsets,
-                    bits_per_offset: 64,
-                    num_values,
-                    block_info: BlockInfo::new(),
-                }))
+        } else {
+            // Standard scheme
+            let bits_per_offset = LittleEndian::read_u32(&data[0..4]) as u8;
+            match bits_per_offset {
+                32 => {
+                    let bytes_start_offset = LittleEndian::read_u32(&data[4..8]);
+                    (bits_per_offset, bytes_start_offset as u64, 8)
+                }
+                64 => {
+                    let bytes_start_offset = LittleEndian::read_u64(&data[8..16]);
+                    (bits_per_offset, bytes_start_offset, 16)
+                }
+                _ => {
+                    return Err(Error::InvalidInput {
+                        source: format!("Unsupported bits_per_offset={}", bits_per_offset).into(),
+                        location: location!(),
+                    });
+                }
             }
-            _ => panic!("Unsupported bits_per_offset={}", bits_per_offset),
-        }
+        };
+
+        // the next `bytes_start_offset - offset_start` stores the offsets.
+        let offsets =
+            data.slice_with_length(offset_start, bytes_start_offset as usize - offset_start);
+
+        // the rest are the binary bytes.
+        let data = data.slice_with_length(
+            bytes_start_offset as usize,
+            data.len() - bytes_start_offset as usize,
+        );
+
+        Ok(DataBlock::VariableWidth(VariableWidthBlock {
+            data,
+            offsets,
+            bits_per_offset,
+            num_values,
+            block_info: BlockInfo::new(),
+        }))
     }
 }
 


### PR DESCRIPTION
This is the case where data is already dictionary encoded and so we don't need to re-encode it and can just store it encoded.