### PR TITLE
refactor: cowardly refuse to use scalar indexes on expressions with null literals

### DIFF
--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -1710,26 +1710,19 @@ def test_null_handling(tmp_path: Path):
     )
     dataset = lance.write_dataset(tbl, tmp_path / "dataset")
 
-    def check(has_index: bool):
+    def check():
         assert dataset.to_table(filter="x IS NULL").num_rows == 1
         assert dataset.to_table(filter="x IS NOT NULL").num_rows == 3
         assert dataset.to_table(filter="x > 0").num_rows == 3
         assert dataset.to_table(filter="x < 5").num_rows == 3
         assert dataset.to_table(filter="x IN (1, 2)").num_rows == 2
-        # Note: there is a bit of discrepancy here.  Datafusion does not consider
-        # NULL==NULL when doing an IN operation due to classic SQL shenanigans.
-        # We should decide at some point which behavior we want and make this
-        # consistent.
-        if has_index:
-            assert dataset.to_table(filter="x IN (1, 2, NULL)").num_rows == 3
-        else:
-            assert dataset.to_table(filter="x IN (1, 2, NULL)").num_rows == 2
+        assert dataset.to_table(filter="x IN (1, 2, NULL)").num_rows == 2
 
-    check(False)
+    check()
     dataset.create_scalar_index("x", index_type="BITMAP")
-    check(True)
+    check()
     dataset.create_scalar_index("x", index_type="BTREE")
-    check(True)
+    check()
 
 
 def test_nan_handling(tmp_path: Path):

--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -1720,7 +1720,6 @@ mod tests {
         expected: Option<IndexedExpression>,
         optimize: bool,
     ) {
-        println!("Checking expression: {}", expr);
         let schema = Schema::new(vec![
             Field::new("color", DataType::Utf8, false),
             Field::new("size", DataType::Float32, false),


### PR DESCRIPTION
The current search logic with scalar indexes assumes that the list returned by a scalar index contains either:

* All the true rows and all other rows are false
* All the false rows and all other rows are true

This is a problem when dealing with nulls.  This is related to https://github.com/lancedb/lance/issues/4756

This PR doesn't fix #4756 however it does help avoid some areas where we are definitely likely to do the wrong thing.