### PR TITLE
chore: fix various typos in the index spec and add sbbf details

### DIFF
--- a/docs/src/format/table/index/index.md
+++ b/docs/src/format/table/index/index.md
@@ -2,9 +2,9 @@
 
 Lance supports three main categories of indices to accelerate data access:
 
-1. **[Scalar Indices](scalar/index.md)** - Traditional indices for accelerating various database query patterns
-2. **[Vector Indices](vector/index.md)** - Specialized indices for vector search
-3. **[System Indices](system/index.md)** - Auxiliary indices for accelerating internal system operations
+1. **Scalar Indices** - Traditional indices for accelerating various database query patterns
+2. **Vector Indices** - Specialized indices for vector search
+3. **System Indices** - Auxiliary indices for accelerating internal system operations
 
 ## Index Section in Manifest
 
@@ -28,19 +28,21 @@ Index section stores a list of index metadata:
 
 ### Index ID, Name and Delta Indices
 
-Each index has a unique UUID. Multiple indexes of different IDs can share the same name.
-When this happens, these indexes are called **Delta Indices** because they together forms a complete index.
+Each index has a unique UUID. Multiple indices of different IDs can share the same name.
+When this happens, these indices are called **Delta Indices** because they together forms a complete index.
 Delta indices are typically used when the index is updated incrementally to avoid full rebuild.
+The Lance SDK provides functions for users to choose when to create delta indices,
+and when to merge them back into a single index.
 
-## Index Coverage and Fragment Bitmap
+### Index Coverage and Fragment Bitmap
 
 An index records the fragments it covers using a bitmap of the `uint32` fragment IDs, 
 so that during query planning phase, Lance can generate a split plan to leverage index for covered fragments,
 and perform scan for uncovered fragments and merge the results.
 
-## Index Remap and Row Address
+### Index Remap and Row Address
 
-In general, indexes describe how to find a row address based on some value of a column.
+In general, indices describe how to find a row address based on some value of a column.
 For example, a B-tree index can be used to find the row address of a specific value in a sorted array.
 
 When compaction happens, because the row address has changed and some delete markers are removed, the index needs to be updated accordingly.
@@ -52,11 +54,11 @@ For more details, see [Fragment Reuse Index](fragment_reuse_index.md)
 
 Using stable row ID to replace row address for index is a work in progress.
 The main benefit is that remap is not needed, and an update only needs to invaludate the index if related column data has changed.
-The tradeoff is that it requires an additional IOPS to translate row ID to row address.
-We are still working on evaluating the performance impact of this change.
-
+The tradeoff is that it requires an additional index search to translate a stable row ID to the physical row address.
+We are still working on evaluating the performance impact of this change before making it more widely used.
 
 ## Index Storage
 
 The content of each index is stored at `_indices/{UUID}` directory under the dataset directory.
-The actual content stored depends on the index type.
+We call this location the **index directory**.
+The actual content stored in the index directory depends on the index type.

--- a/docs/src/format/table/index/index.md
+++ b/docs/src/format/table/index/index.md
@@ -29,7 +29,7 @@ Index section stores a list of index metadata:
 ### Index ID, Name and Delta Indices
 
 Each index has a unique UUID. Multiple indices of different IDs can share the same name.
-When this happens, these indices are called **Delta Indices** because they together forms a complete index.
+When this happens, these indices are called **Delta Indices** because they together form a complete index.
 Delta indices are typically used when the index is updated incrementally to avoid full rebuild.
 The Lance SDK provides functions for users to choose when to create delta indices,
 and when to merge them back into a single index.
@@ -37,7 +37,7 @@ and when to merge them back into a single index.
 ### Index Coverage and Fragment Bitmap
 
 An index records the fragments it covers using a bitmap of the `uint32` fragment IDs, 
-so that during query planning phase, Lance can generate a split plan to leverage index for covered fragments,
+so that during the query planning phase, Lance can generate a split plan to leverage the index for covered fragments,
 and perform scan for uncovered fragments and merge the results.
 
 ### Index Remap and Row Address
@@ -46,14 +46,14 @@ In general, indices describe how to find a row address based on some value of a 
 For example, a B-tree index can be used to find the row address of a specific value in a sorted array.
 
 When compaction happens, because the row address has changed and some delete markers are removed, the index needs to be updated accordingly.
-This update is fast because it's a pure mapping operation to delete some values or change the old row address to new row address.
+This update is fast because it's a pure mapping operation to delete some values or change the old row address to the new row address.
 We call this process **Index Remap**.
-For more details, see [Fragment Reuse Index](fragment_reuse_index.md)
+For more details, see [Fragment Reuse Index](system/frag_reuse.md)
 
 ### Stable Row ID for Index
 
-Using stable row ID to replace row address for index is a work in progress.
-The main benefit is that remap is not needed, and an update only needs to invaludate the index if related column data has changed.
+Using a stable row ID to replace the row address for an index is a work in progress.
+The main benefit is that remap is not needed, and an update only needs to invalidate the index if related column data has changed.
 The tradeoff is that it requires an additional index search to translate a stable row ID to the physical row address.
 We are still working on evaluating the performance impact of this change before making it more widely used.
 

--- a/docs/src/format/table/index/scalar/bloom_filter.md
+++ b/docs/src/format/table/index/scalar/bloom_filter.md
@@ -33,6 +33,53 @@ The bloom filter index stores zone-based bloom filters in a single file:
 | `bloomfilter_item`        | String | Expected number of items per zone (default: "8192")         |
 | `bloomfilter_probability` | String | False positive probability (default: "0.00057", ~1 in 1754) |
 
+## Bloom Filter Spec
+
+The bloom filter index uses a Split Block Bloom Filter (SBBF) implementation,
+which is optimized for SIMD operations.
+
+### SBBF Structure
+
+The SBBF divides the bit array into blocks of 256 bits, where each block consists of 8 contiguous 32-bit words.
+This structure enables efficient SIMD operations and cache-friendly memory access patterns.
+The block layout is the following:
+
+- **Block size**: 256 bits (32 bytes)
+- **Words per block**: 8 × 32-bit integers
+- **Minimum filter size**: 32 bytes (1 block)
+- **Maximum filter size**: 128 MiB
+
+### Hashing Mechanism
+
+The SBBF uses xxHash64 with seed=0 for primary hashing, combined with a salt-based secondary hashing scheme:
+
+1. **Primary hash**: xxHash64(value) → 64-bit hash
+2. **Block selection**: Upper 32 bits determine which block to use
+3. **Bit selection**: Lower 32 bits combined with 8 salt values set 8 bits in the block
+
+#### Salt Values
+
+```
+SALT = [0x47b6137b, 0x44974d91, 0x8824ad5b, 0xa2b7289d,
+        0x705495c7, 0x2df1424b, 0x9efc4947, 0x5c6bfb31]
+```
+
+Each salt value generates one bit position within the block, ensuring uniform distribution.
+
+### Filter Sizing Algorithm
+
+The SBBF automatically determines optimal filter size based on:
+- **NDV** (Number of Distinct Values): Expected unique items
+- **FPP** (False Positive Probability): Target error rate
+
+The implementation uses binary search to find the minimum log₂(bytes) that achieves the desired FPP,
+using Putze et al.'s cache-efficient bloom filter formula.
+
+### False Positive Probability Convergence
+
+The implementation uses up to 750 iterations of Poisson distribution calculations to ensure accurate FPP estimation,
+particularly for dense filters where NDV approaches filter capacity.
+
 ## Accelerated Queries
 
 The bloom filter index provides inexact results for the following query types:

--- a/docs/src/format/table/index/scalar/btree.md
+++ b/docs/src/format/table/index/scalar/btree.md
@@ -54,5 +54,5 @@ The BTree index provides exact results for the following query types:
 |------------|---------------------------|-----------------------------------------------------------------------------|
 | **Equals** | `column = value`          | BTree lookup to find relevant pages, then search within sub-indices         |
 | **Range**  | `column BETWEEN a AND b`  | BTree traversal for pages overlapping the range, then search each sub-index |
-| **IsIn**   | `column IN (v1, v2, ...)` | Multiple BTree lookups, unions results from all matching sub-indices        |
+| **IsIn**   | `column IN (v1, v2, ...)` | Multiple BTree lookups, union results from all matching sub-indices         |
 | **IsNull** | `column IS NULL`          | Returns rows from all pages where null_count > 0                            |

--- a/docs/src/format/table/index/scalar/fts.md
+++ b/docs/src/format/table/index/scalar/fts.md
@@ -134,8 +134,7 @@ Arabic, Danish, Dutch, English, Finnish, French, German, Greek, Hungarian, Itali
 Lance SDKs provide dedicated full text search APIs to leverage the FTS index capabilities. 
 These APIs support complex query types beyond simple token matching, 
 enabling sophisticated text search operations.
-
-### Supported Query Types
+Here are the query types enabled by the FTS index:
 
 | Query Type          | Description                                                                              | Example Usage                                        | Result Type |
 |---------------------|------------------------------------------------------------------------------------------|------------------------------------------------------|-------------|

--- a/docs/src/format/table/index/system/frag_reuse.md
+++ b/docs/src/format/table/index/system/frag_reuse.md
@@ -7,14 +7,14 @@ When data modifications happen against a Lance table,
 it could trigger compaction and index optimization at the same time to improve data layout and index coverage.
 By default, compaction will remap all indices at the same time to prevent read regression.
 This means both compaction and index optimization could modify the same index and cause one process to fail.
-Typically, the compaction would fail because it has to modify all indexes and takes longer,
+Typically, the compaction would fail because it has to modify all indices and takes longer,
 resulting in table layout degrading over time.
 
 Fragment Reuse Index allows a compaction to defer the index remap process.
 Suppose a compaction removes fragments A and B and produced C.
 At query runtime, it reuses the old fragments A and B by 
 updating the row addresses related to A and B in the index to the latest ones in C.
-Because indexes are typically cached in memory after initial load,
+Because indices are typically cached in memory after initial load,
 the in-memory index is up to date after the fragment reuse application process.
 
 ## Index Details
@@ -23,14 +23,13 @@ the in-memory index is up to date after the fragment reuse application process.
 %%% proto.message.FragmentReuseIndexDetails %%%
 ```
 
-
 ## Expected Use Pattern
 
-Fragment Reuse Index is created if user defers index remap in compaction.
+Fragment Reuse Index should be created if user defers index remap in compaction.
 The index accumulates a new **reuse version** every time a compaction is executed.
 
-As long as all the scalar and vector indexes are created after the specific reuse version,
-that means the indices are caught up and reuse version can be trimmed.
+As long as all the scalar and vector indices are created after the specific reuse version,
+the indices are all caught up and the specific reuse version can be trimmed.
 
 It is expected that user schedules additional process to trim the index periodically
 to keep the list of reuse version in control.

--- a/docs/src/format/table/index/system/frag_reuse.md
+++ b/docs/src/format/table/index/system/frag_reuse.md
@@ -11,7 +11,7 @@ Typically, the compaction would fail because it has to modify all indices and ta
 resulting in table layout degrading over time.
 
 Fragment Reuse Index allows a compaction to defer the index remap process.
-Suppose a compaction removes fragments A and B and produced C.
+Suppose a compaction removes fragments A and B and produces C.
 At query runtime, it reuses the old fragments A and B by 
 updating the row addresses related to A and B in the index to the latest ones in C.
 Because indices are typically cached in memory after initial load,
@@ -25,11 +25,11 @@ the in-memory index is up to date after the fragment reuse application process.
 
 ## Expected Use Pattern
 
-Fragment Reuse Index should be created if user defers index remap in compaction.
+Fragment Reuse Index should be created if the user defers index remap in compaction.
 The index accumulates a new **reuse version** every time a compaction is executed.
 
 As long as all the scalar and vector indices are created after the specific reuse version,
 the indices are all caught up and the specific reuse version can be trimmed.
 
-It is expected that user schedules additional process to trim the index periodically
-to keep the list of reuse version in control.
+It is expected that the user schedules an additional process to trim the index periodically
+to keep the list of reuse versions in control.

--- a/docs/src/format/table/index/system/memwal.md
+++ b/docs/src/format/table/index/system/memwal.md
@@ -22,6 +22,6 @@ It is expected that:
 
 1. there is exactly one writer for each region, guaranteed by optimistic update of the owner_id
 2. each writer updates the MemWAL index after a successful write to WAL and MemTable
-3. a new writer always finds unsealed MemWALs and perform replay before accepting new writes
+3. a new writer always finds unsealed MemWALs and performs replay before accepting new writes
 4. background processes are responsible for merging flushed MemWALs to the main Lance table, and making index up to date.
 5. a MemWAL-aware reader is able to merge results of MemTables in the MemWALs with results in the base Lance table. 

--- a/docs/src/format/table/index/vector/index.md
+++ b/docs/src/format/table/index/vector/index.md
@@ -10,9 +10,10 @@ Lance splits each vector index into 3 parts - clustering, sub-index and quantiza
 
 ### Clustering
 
-Lance uses Inverted File (IVF) as the primary clustering mechanism.
-IVF partitions the dataset into clusters using k-means clustering. 
-Each cluster (partition) contains vectors that are similar to the cluster centroid.
+Clustering divides all the vectors into different disjoint clusters (a.k.a. partitions).
+Lance currently supports using Inverted File (IVF) as the primary clustering mechanism.
+IVF partitions the vectors into clusters using k-means clustering algorithm. 
+Each cluster contains vectors that are similar to the cluster centroid.
 During search, only the most relevant clusters are examined, dramatically reducing search time.
 IVF can be combined with any sub-index type and quantization method.
 
@@ -65,7 +66,7 @@ The index file stores the search structure with graph or flat organization.
 The Arrow schema of the Lance file varies depending on the sub-index type used.
 
 !!! note
-All partitions are stored in the same file, and partitions must be written in order.
+    All partitions are stored in the same file, and partitions must be written in order.
 
 ##### FLAT
 
@@ -86,11 +87,12 @@ HNSW (Hierarchical Navigable Small World) indices provide fast approximate searc
 | `_distance`   | list<float32> | false    | Distances to neighbors |
 
 !!! note
-HNSW consists of multiple levels, and all levels must be written in order starting from level 0.
+    HNSW consists of multiple levels, and all levels must be written in order starting from level 0.
 
 #### Arrow Schema Metadata
 
-The index file contains metadata in its Arrow schema metadata to describe the index configuration and structure:
+The index file contains metadata in its Arrow schema metadata to describe the index configuration and structure.
+Here are the metadata keys and their corresponding values:
 
 ##### "lance:index"
 
@@ -154,8 +156,8 @@ It is stored as a Lance file named `auxiliary.idx` within the index directory.
 Since the auxiliary file stores the actual (quantized) vectors,
 the Arrow schema of the Lance file varies depending on the quantization method used.
 
-!!!note
-All partitions are stored in the same file, and partitions must be written in order.
+!!! note
+    All partitions are stored in the same file, and partitions must be written in order.
 
 ##### FLAT
 
@@ -186,7 +188,8 @@ Compresses vectors using scalar quantization for moderate memory savings:
 
 #### Arrow Schema Metadata
 
-The auxiliary file also contains metadata in its Arrow schema metadata for vector storage configuration:
+The auxiliary file also contains metadata in its Arrow schema metadata for vector storage configuration.
+Here are the metadata keys and their corresponding values:
 
 ##### "distance_type"
 The distance metric used to compute similarity between vectors (e.g., "l2", "cosine", "dot").
@@ -235,7 +238,8 @@ in the auxiliary file's global buffer for efficient access:
 
 ### Appendix 1: Example IVF_PQ Format
 
-This example shows how an `IVF_PQ` index is physically laid out. Assume vectors have dimension 128, PQ uses 16 subquantizers (m=16) with 256 codewords per subvector (ksub=256), and distance type is "l2".
+This example shows how an `IVF_PQ` index is physically laid out. Assume vectors have dimension 128, 
+PQ uses 16 subquantizers (m=16) with 256 codewords per subvector (ksub=256), and distance type is "l2".
 
 #### Index File
 
@@ -270,7 +274,7 @@ pa.schema([
 
 ### Appendix 2: Accessing Index File with Python
 
-The following example demonstrates how to read and parse the global buffer from Lance index files using Python:
+The following example demonstrates how to read and parse different components in the Lance index files using Python:
 
 ```python
 import pyarrow as pa

--- a/docs/src/format/table/index/vector/index.md
+++ b/docs/src/format/table/index/vector/index.md
@@ -12,7 +12,7 @@ Lance splits each vector index into 3 parts - clustering, sub-index and quantiza
 
 Clustering divides all the vectors into different disjoint clusters (a.k.a. partitions).
 Lance currently supports using Inverted File (IVF) as the primary clustering mechanism.
-IVF partitions the vectors into clusters using k-means clustering algorithm. 
+IVF partitions the vectors into clusters using the k-means clustering algorithm. 
 Each cluster contains vectors that are similar to the cluster centroid.
 During search, only the most relevant clusters are examined, dramatically reducing search time.
 IVF can be combined with any sub-index type and quantization method.
@@ -49,7 +49,7 @@ Here are the commonly used combinations:
 
 The Lance vector index format has gone through 3 versions so far.
 This document currently only records version 3 which is the latest version.
-The specific version of the vector index is recorded in the `index_version` field of the generic index metadata.
+The specific version of the vector index is recorded in the `index_version` field of the generic [index metadata](../index.md#index-metadata).
 
 ## Storage Layout (V3)
 

--- a/docs/src/format/table/index/vector/index.md
+++ b/docs/src/format/table/index/vector/index.md
@@ -238,8 +238,8 @@ in the auxiliary file's global buffer for efficient access:
 
 ### Appendix 1: Example IVF_PQ Format
 
-This example shows how an `IVF_PQ` index is physically laid out. Assume vectors have dimension 128, 
-PQ uses 16 subquantizers (m=16) with 256 codewords per subvector (ksub=256), and distance type is "l2".
+This example shows how an `IVF_PQ` index is physically laid out. Assume vectors have dimension 128,
+PQ uses 16 num_sub_vectors (m=16) with 8 num_bits per subvector, and distance type is "l2".
 
 #### Index File
 


### PR DESCRIPTION
- Make sure we are clear that the sub-sections under "Arrow schema metadata" in vector index refers to metadata keys
- Use "indices" consistently across the docs
- Fix broken links
- Fix notes indentation
- Fix typos in various sentences and add more information if necessary
- Add bffs information in bloom filter
- Ran grammar fix through claude code