### PR TITLE
perf: optmize doc set loading

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -2219,11 +2219,14 @@ impl DocSet {
 
         let row_ids = row_id_col.values().to_vec();
         let num_tokens = num_tokens_col.values().to_vec();
-        let inv = row_ids
+        let mut inv: Vec<(u64, u32)> = row_ids
             .iter()
             .enumerate()
             .map(|(doc_id, row_id)| (*row_id, doc_id as u32))
             .collect();
+        if !row_ids.is_sorted() {
+            inv.sort_unstable_by_key(|entry| entry.0);
+        }
         let total_tokens = num_tokens.iter().map(|&x| x as u64).sum();
         Ok(Self {
             row_ids,

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -2200,14 +2200,13 @@ impl DocSet {
                     .collect();
                 let num_tokens = num_tokens_col.values().to_vec();
 
-                // build the inv
-                let inv = row_ids
+                // build the inv sorted by row_id for binary_search
+                let mut inv: Vec<(u64, u32)> = row_ids
                     .iter()
-                    .copied()
                     .enumerate()
-                    .sorted_unstable()
-                    .map(|(i, row_id)| (row_id, i as u32))
+                    .map(|(doc_id, row_id)| (*row_id, doc_id as u32))
                     .collect();
+                inv.sort_unstable_by_key(|entry| entry.0);
                 (row_ids, num_tokens, inv)
             }
         };

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -348,7 +348,6 @@ impl InvertedIndex {
                 tokens,
                 inverted_list,
                 docs,
-                fragments: Default::default(),
                 token_set_format: TokenSetFormat::Arrow,
             })],
         }))
@@ -606,7 +605,6 @@ pub struct InvertedPartition {
     pub(crate) tokens: TokenSet,
     pub(crate) inverted_list: Arc<PostingListReader>,
     pub(crate) docs: DocSet,
-    pub(crate) fragments: HashSet<u32>,
     token_set_format: TokenSetFormat,
 }
 
@@ -650,7 +648,6 @@ impl InvertedPartition {
         let inverted_list = PostingListReader::try_new(invert_list_file, index_cache).await?;
         let docs_file = store.open_index_file(&doc_file_path(id)).await?;
         let docs = DocSet::load(docs_file, false, frag_reuse_index).await?;
-        let fragments = docs.fragment_ids();
 
         Ok(Self {
             id,
@@ -658,7 +655,6 @@ impl InvertedPartition {
             tokens,
             inverted_list: Arc::new(inverted_list),
             docs,
-            fragments,
             token_set_format,
         })
     }
@@ -2102,13 +2098,6 @@ impl DocSet {
             }
         }
     }
-    pub fn fragment_ids(&self) -> HashSet<u32> {
-        self.row_ids
-            .iter()
-            .map(|row_id| (row_id >> 32) as u32)
-            .collect()
-    }
-
     pub fn total_tokens_num(&self) -> u64 {
         self.total_tokens
     }


### PR DESCRIPTION
This PR is another effort to optimize cold-start FTS queries. In this PR, I made the following changes:

- Remove unnecessary `fragment_ids` calculation. This implementation is not optimal (high hash conflicts) and there is no place that uses this set. It’s dead code.
- Refactor `DocSet::load` to avoid sorting row_ids when it is not needed.

Based on my test over a 40M Wikipedia dataset, this PR reduces the cold latency P95 by **18.7%**, from `3721.32 ms` to `2939.80 ms`.

Before:

```shell
- open(ms): mean=89.42, p95=111.35, p99=113.00, min=59.60, max=113.41
- search(ms): mean=3509.95, p95=3721.32, p99=3736.24, min=3213.37, max=3739.97
- total(ms): mean=3599.37, p95=3818.00, p99=3831.64, min=3272.97, max=3835.05
- wall-clock(s): 18.72
```

<img width="2289" height="782" alt="image" src="https://github.com/user-attachments/assets/11ddb99b-5759-4387-9aa1-69d42c5a91ee" />

 

After:

```shell
- open(ms): mean=82.63, p95=101.40, p99=104.23, min=69.31, max=104.94
- search(ms): mean=2822.02, p95=2939.80, p99=2954.77, min=2713.83, max=2958.51
- total(ms): mean=2904.65, p95=3024.94, p99=3041.57, min=2788.65, max=3045.73
- wall-clock(s): 15.22
```

<img width="2297" height="695" alt="image" src="https://github.com/user-attachments/assets/924efc75-3b13-4199-925c-3ddb453ac9f0" />


---

**This PR was primarily authored with Codex using GPT-5-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**