### PR TITLE
feat: short circuit SQL parsing

### DIFF
--- a/rust/lance-datafusion/src/planner.rs
+++ b/rust/lance-datafusion/src/planner.rs
@@ -839,6 +839,10 @@ impl Planner {
     /// Note: the returned expression must be passed through [optimize_filter()]
     /// before being passed to [create_physical_expr()].
     pub fn parse_expr(&self, expr: &str) -> Result<Expr> {
+        if let Ok(_) = self.schema.field_with_name(expr) {
+            return Ok(col(expr));
+        }
+
         let ast_expr = parse_sql_expr(expr)?;
         let expr = self.parse_sql_expr(&ast_expr)?;
         let schema = Schema::try_from(self.schema.as_ref())?;


### PR DESCRIPTION
This PR avoids a problem encountered when creating a scalar index on a column that had a name that was not easily parseable by the SQL parser. If we are getting a raw expression that matches a column name in the schema, then return it directly. 

More generally I wonder if we should be doing this sql parsing at all when we know we have columns. Should `ProjectionPlan::from_expressions` actually take in instead `columns: &[(impl AsRef<str>, &Expr)]` ?