### PR TITLE
fix: fix typo "blfoat16" -> "bfloat16" in datatypes.rs

### DIFF
--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -155,7 +155,7 @@ impl TryFrom<&DataType> for LogicalType {
             },
             DataType::FixedSizeList(field, len) => {
                 if is_bfloat16_field(field) {
-                    // Don't want to directly use `blfoat16`, in case a built-in type is added
+                    // Don't want to directly use `bfloat16`, in case a built-in type is added
                     // that isn't identical to our extension type.
                     format!("fixed_size_list:lance.bfloat16:{}", *len)
                 } else {


### PR DESCRIPTION
Fix typo "blfoat16" -> "bfloat16" in datatypes.rs