### PR TITLE
refactor: remove unecessary parens

### DIFF
--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -2500,7 +2500,7 @@ pub mod array {
         let dist = Uniform::new(start_ticks, end_ticks).unwrap();
 
         let data_type = data_type.clone();
-        let sample_fn = move |rng: &mut _| (dist.sample(rng));
+        let sample_fn = move |rng: &mut _| dist.sample(rng);
         let width = data_type
             .primitive_width()
             .map(|width| ByteCount::from(width as u64))

--- a/rust/lance/src/datafusion/logical_plan.rs
+++ b/rust/lance/src/datafusion/logical_plan.rs
@@ -65,7 +65,7 @@ impl TableProvider for Dataset {
             schema_ref.clone()
         };
 
-        let scan_range = limit.map(|l| (0..l as u64));
+        let scan_range = limit.map(|l| 0..l as u64);
         let plan: Arc<dyn ExecutionPlan> =
             scanner.scan(false, false, false, scan_range, projections.into());
 

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -419,7 +419,7 @@ impl FilteredReadStream {
         let io_parallelism = dataset.object_store.io_parallelism();
         let fragment_readahead = options
             .fragment_readahead
-            .unwrap_or_else(|| ((*DEFAULT_FRAGMENT_READAHEAD).unwrap_or(io_parallelism * 2)))
+            .unwrap_or_else(|| (*DEFAULT_FRAGMENT_READAHEAD).unwrap_or(io_parallelism * 2))
             .max(1);
 
         let fragments = options


### PR DESCRIPTION
Remove unecessary parens that cause warnings.