### PR TITLE
fix: don't log the 'experimental' warning if users are using 2.1

### DIFF
--- a/rust/lance-encoding/src/version.rs
+++ b/rust/lance-encoding/src/version.rs
@@ -14,13 +14,20 @@ pub const V2_FORMAT_2_2: &str = "2.2";
 /// Lance file version
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Ord, PartialOrd, strum::EnumIter)]
 pub enum LanceFileVersion {
-    // Note that Stable must come AFTER the stable version and Next must come AFTER the next version
-    // this way comparisons like x >= V2_0 will work the same if x is Stable or V2_0
+    // This is a little confusing but we rely on the following facts:
+    //
+    // Any version <= Next is stable
+    // The latest version before Stable is the default version for new datasets
+    // Any version >= Next is unstable
+    //
+    // As a result, 'Stable' is not the divider between stable and unstable (Next does this)
+    // but only serves to mark the default version for new datasets.
+    //
     /// The legacy (0.1) format
     Legacy,
     #[default]
     V2_0,
-    /// The latest stable release
+    /// The latest stable release (also the default version for new datasets)
     Stable,
     V2_1,
     /// The latest unstable release
@@ -36,6 +43,10 @@ impl LanceFileVersion {
             Self::Next => Self::V2_1,
             _ => *self,
         }
+    }
+
+    pub fn is_unstable(&self) -> bool {
+        self >= &Self::Next
     }
 
     pub fn try_from_major_minor(major: u32, minor: u32) -> Result<Self> {

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -142,7 +142,7 @@ impl FileWriter {
     /// If no data arrives and the writer is finished then the write will fail.
     pub fn new_lazy(object_writer: ObjectWriter, options: FileWriterOptions) -> Self {
         if let Some(format_version) = options.format_version {
-            if format_version > LanceFileVersion::Stable
+            if format_version.is_unstable()
                 && WARNED_ON_UNSTABLE_API
                     .compare_exchange(
                         false,
@@ -787,6 +787,7 @@ mod tests {
     use lance_encoding::decoder::DecoderPlugins;
     use lance_encoding::version::LanceFileVersion;
     use lance_io::object_store::ObjectStore;
+    use lance_io::object_writer::ObjectWriter;
     use lance_io::utils::CachedFileSize;
 
     #[tokio::test]

--- a/rust/lance-file/src/v2/writer.rs
+++ b/rust/lance-file/src/v2/writer.rs
@@ -787,7 +787,6 @@ mod tests {
     use lance_encoding::decoder::DecoderPlugins;
     use lance_encoding::version::LanceFileVersion;
     use lance_io::object_store::ObjectStore;
-    use lance_io::object_writer::ObjectWriter;
     use lance_io::utils::CachedFileSize;
 
     #[tokio::test]

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1900,7 +1900,8 @@ impl Dataset {
             .manifest()
             .data_storage_format
             .lance_file_version()
-            .unwrap()
+            .unwrap_or(LanceFileVersion::Legacy)
+            .resolve()
         {
             LanceFileVersion::Legacy => matches!(
                 datatype,
@@ -1911,9 +1912,7 @@ impl Dataset {
                     | DataType::FixedSizeBinary(_)
                     | DataType::FixedSizeList(_, _)
             ),
-            LanceFileVersion::V2_0 | LanceFileVersion::Stable => {
-                !matches!(datatype, DataType::Struct(..))
-            }
+            LanceFileVersion::V2_0 => !matches!(datatype, DataType::Struct(..)),
             _ => true,
         }
     }


### PR DESCRIPTION
2.1 is now stable but we never had to distinguish between "stable" and "default" before so our old warning logic was still printing a warning for users when the storage version is set to 2.1.