### PR TITLE
chore: clean up the temporary directory after the example is completed

### DIFF
--- a/rust/examples/src/write_read_ds.rs
+++ b/rust/examples/src/write_read_ds.rs
@@ -7,10 +7,10 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::{RecordBatch, RecordBatchIterator};
 use futures::StreamExt;
 use lance::dataset::{WriteMode, WriteParams};
-use lance::Dataset;
-use std::sync::Arc;
 use lance::io::ObjectStore;
+use lance::Dataset;
 use lance_core::utils::tempfile::TempStrDir;
+use std::sync::Arc;
 
 // Writes sample dataset to the given path
 async fn write_dataset(data_path: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -73,7 +73,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         write_dataset(data_path).await?;
         read_dataset(data_path).await?;
         Ok(())
-    }.await;
+    }
+    .await;
 
     if let Err(e) = clean_resources(data_path).await {
         eprintln!("Failed to clean resources: {:?}", e);


### PR DESCRIPTION
chore for `rust/examples/src/write_read_ds.rs`
Clean up the temporary directory after the example is completed

Before
<img width="371" height="386" alt="截屏2025-10-09 12 43 06" src="https://github.com/user-attachments/assets/dedaa2a5-bc1a-4602-a01e-0a2c52273f22" />

After
<img width="397" height="428" alt="截屏2025-10-09 12 43 45" src="https://github.com/user-attachments/assets/a25e97d3-3916-417c-bc09-f001cf6b53da" />
