### PR TITLE
fix: clarify column names in missing column errors

### DIFF
--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -964,20 +964,20 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
         //   Stream<(parttitions, index uuid)>
         let per_index_stream = input_stream
             .and_then(move |batch| {
-                let part_id_col = batch.column_by_name(PART_ID_COLUMN).expect(&format!(
-                    "ANNSubIndexExec: input missing {} column",
-                    PART_ID_COLUMN
-                ));
+                let part_id_col = batch.column_by_name(PART_ID_COLUMN).unwrap_or_else(|| {
+                    panic!("ANNSubIndexExec: input missing {} column", PART_ID_COLUMN)
+                });
                 let part_id_arr = part_id_col.as_list::<i32>().clone();
-                let dist_q_c_col = batch.column_by_name(DIST_Q_C_COLUMN).expect(&format!(
-                    "ANNSubIndexExec: input missing {} column",
-                    DIST_Q_C_COLUMN
-                ));
+                let dist_q_c_col = batch.column_by_name(DIST_Q_C_COLUMN).unwrap_or_else(|| {
+                    panic!("ANNSubIndexExec: input missing {} column", DIST_Q_C_COLUMN)
+                });
                 let dist_q_c_arr = dist_q_c_col.as_list::<i32>().clone();
-                let index_uuid_col = batch.column_by_name(INDEX_UUID_COLUMN).expect(&format!(
-                    "ANNSubIndexExec: input missing {} column",
-                    INDEX_UUID_COLUMN
-                ));
+                let index_uuid_col = batch.column_by_name(INDEX_UUID_COLUMN).unwrap_or_else(|| {
+                    panic!(
+                        "ANNSubIndexExec: input missing {} column",
+                        INDEX_UUID_COLUMN
+                    )
+                });
                 let index_uuid = index_uuid_col.as_string::<i32>().clone();
 
                 let plan: Vec<DataFusionResult<(_, _, _)>> = part_id_arr


### PR DESCRIPTION
Prior to this commit we could fail to find expected internal columns in KNN execution and display an unprefixed name to the user. This is confusing because there's no visual indicator that the column is internal (indicated by prefixing with _ typically). This commit changes the error to display the real column name instead.