### PR TITLE
feat: add blob v2 schema

### DIFF
--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -43,6 +43,8 @@ pub const ARROW_EXT_META_KEY: &str = "ARROW:extension:metadata";
 /// Key used by lance to mark a field as a blob
 /// TODO: Use Arrow extension mechanism instead?
 pub const BLOB_META_KEY: &str = "lance-encoding:blob";
+/// Key used by Lance to record the blob column format version.
+pub const BLOB_VERSION_META_KEY: &str = "lance-encoding:blob-version";
 
 type Result<T> = std::result::Result<T, ArrowError>;
 

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -18,7 +18,9 @@ mod field;
 mod schema;
 
 use crate::{Error, Result};
-pub use field::{Encoding, Field, NullabilityComparison, OnTypeMismatch, SchemaCompareOptions};
+pub use field::{
+    BlobVersion, Encoding, Field, NullabilityComparison, OnTypeMismatch, SchemaCompareOptions,
+};
 pub use schema::{
     escape_field_path_for_project, format_field_path, parse_field_path, FieldRef, OnMissing,
     Projectable, Projection, Schema,
@@ -43,6 +45,32 @@ pub static BLOB_DESC_FIELD: LazyLock<ArrowField> = LazyLock::new(|| {
 
 pub static BLOB_DESC_LANCE_FIELD: LazyLock<Field> =
     LazyLock::new(|| Field::try_from(&*BLOB_DESC_FIELD).unwrap());
+
+pub static BLOB_V2_DESC_FIELDS: LazyLock<Fields> = LazyLock::new(|| {
+    Fields::from(vec![
+        ArrowField::new("kind", DataType::UInt8, false),
+        ArrowField::new("position", DataType::UInt64, true),
+        ArrowField::new("size", DataType::UInt64, true),
+        ArrowField::new("blob_id", DataType::UInt32, true),
+        ArrowField::new("blob_uri", DataType::Utf8, true),
+    ])
+});
+
+pub static BLOB_V2_DESC_TYPE: LazyLock<DataType> =
+    LazyLock::new(|| DataType::Struct(BLOB_V2_DESC_FIELDS.clone()));
+
+pub static BLOB_V2_DESC_FIELD: LazyLock<ArrowField> = LazyLock::new(|| {
+    ArrowField::new("description", BLOB_V2_DESC_TYPE.clone(), true).with_metadata(HashMap::from([
+        (lance_arrow::BLOB_META_KEY.to_string(), "true".to_string()),
+        (
+            lance_arrow::BLOB_VERSION_META_KEY.to_string(),
+            "2".to_string(),
+        ),
+    ]))
+});
+
+pub static BLOB_V2_DESC_LANCE_FIELD: LazyLock<Field> =
+    LazyLock::new(|| Field::try_from(&*BLOB_V2_DESC_FIELD).unwrap());
 
 /// LogicalType is a string presentation of arrow type.
 /// to be serialized into protobuf.

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -7,7 +7,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{Stream, StreamExt, TryStreamExt};
 use lance_core::datatypes::{
-    NullabilityComparison, OnMissing, OnTypeMismatch, SchemaCompareOptions,
+    BlobVersion, NullabilityComparison, OnMissing, OnTypeMismatch, SchemaCompareOptions,
 };
 use lance_core::error::LanceOptionExt;
 use lance_core::utils::tempfile::TempDir;
@@ -40,6 +40,14 @@ use super::progress::{NoopFragmentWriteProgress, WriteFragmentProgress};
 use super::transaction::Transaction;
 use super::utils::SchemaAdapter;
 use super::DATA_DIR;
+
+fn blob_version_for(storage_version: LanceFileVersion) -> BlobVersion {
+    if storage_version >= LanceFileVersion::V2_2 {
+        BlobVersion::V2
+    } else {
+        BlobVersion::V1
+    }
+}
 
 mod commit;
 pub mod delete;
@@ -580,7 +588,9 @@ pub async fn write_fragments_internal(
     // Make sure the max rows per group is not larger than the max rows per file
     params.max_rows_per_group = std::cmp::min(params.max_rows_per_group, params.max_rows_per_file);
 
-    let (schema, storage_version) = if let Some(dataset) = dataset {
+    let allow_blob_version_change =
+        dataset.is_none() || matches!(params.mode, WriteMode::Overwrite);
+    let (mut schema, storage_version) = if let Some(dataset) = dataset {
         match params.mode {
             WriteMode::Append | WriteMode::Create => {
                 // Append mode, so we need to check compatibility
@@ -626,6 +636,9 @@ pub async fn write_fragments_internal(
         // from the user or the default.
         (converted_schema, params.storage_version_or_default())
     };
+
+    let target_blob_version = blob_version_for(storage_version);
+    schema.apply_blob_version(target_blob_version, allow_blob_version_change)?;
 
     let fragments = do_write_fragments(
         object_store,


### PR DESCRIPTION
Part of https://github.com/lancedb/lance/issues/4947

This PR will add blob v2 shcema for lance so that we are ready to start writing new desc fields for blob.

The new schema is gated under file format version `2.2`.

---

**This PR was primarily authored with Codex using GPT-5-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**