### PR TITLE
test: fix flaky commit iops test

### DIFF
--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -673,7 +673,7 @@ mod tests {
     #[tokio::test]
     #[rstest::rstest]
     async fn test_commit_conflict_iops(#[values(true, false)] use_cache: bool) {
-        let cache_size = if use_cache { 10_000 } else { 0 };
+        let cache_size = if use_cache { 1_000_000 } else { 0 };
         let session = Arc::new(Session::new(0, cache_size, Default::default()));
         let io_tracker = Arc::new(IOTracker::default());
         // We need throttled to correctly count num hops. Otherwise, memory store


### PR DESCRIPTION
The test checks the number of iops with and without a cache.  However, it sets the cache size to 10,000.  My guess is this was originally done when the cache size was a number of items.  Now it is being interpreted as 10KB.  Some of the transactions in the test are a few KB.  So the test actually always broke the cache limit.

The test was only flaky (and typically only failed on Windows) because moka does not evict immediately (if it did the test would fail every time).  So Windows, being slower, is more likely to give enough time for moka to run an eviction pass, which would cause an occasional failure.