### PR TITLE
fix: populate all fields from ExecutionSummaryCounts to  ScannerStats

### DIFF
--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -527,10 +527,17 @@ class PyFullTextQuery:
     ) -> PyFullTextQuery: ...
 
 class ScanStatistics:
+    """Statistics about a scan operation."""
+
     iops: int
+    requests: int
     bytes_read: int
     indices_loaded: int
     parts_loaded: int
+    index_comparisons: int
+    all_counts: Dict[
+        str, int
+    ]  # Additional metrics for debugging purposes. Subject to change.
 
 __version__: str
 language_model_home: Callable[[], str]

--- a/python/src/scanner.rs
+++ b/python/src/scanner.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::pyarrow::*;
@@ -54,21 +55,31 @@ pub struct ScanStatistics {
     /// Number of IO operations performed.  This may be slightly higher than
     /// the actual number due to coalesced I/O
     pub iops: usize,
+    /// Number of requests made to the storage layer
+    pub requests: usize,
     /// Number of bytes read from disk
     pub bytes_read: usize,
     /// Number of indices loaded
     pub indices_loaded: usize,
     /// Number of index partitions loaded
     pub parts_loaded: usize,
+    /// Number of index comparisons performed
+    pub index_comparisons: usize,
+    /// Additional metrics for more detailed statistics. These are subject to change in the future
+    /// and should only be used for debugging purposes.
+    pub all_counts: HashMap<String, usize>,
 }
 
 impl ScanStatistics {
     pub fn from_lance(stats: &ExecutionSummaryCounts) -> Self {
         Self {
             iops: stats.iops,
+            requests: stats.requests,
             bytes_read: stats.bytes_read,
             indices_loaded: stats.indices_loaded,
             parts_loaded: stats.parts_loaded,
+            index_comparisons: stats.index_comparisons,
+            all_counts: stats.all_counts.clone(),
         }
     }
 }
@@ -77,8 +88,8 @@ impl ScanStatistics {
 impl ScanStatistics {
     fn __repr__(&self) -> String {
         format!(
-            "ScanStatistics(iops={}, bytes_read={}, indices_loaded={}, parts_loaded={})",
-            self.iops, self.bytes_read, self.indices_loaded, self.parts_loaded
+            "ScanStatistics(iops={}, requests={}, bytes_read={}, indices_loaded={}, parts_loaded={}, index_comparisons={}, all_counts={:?})",
+            self.iops, self.requests, self.bytes_read, self.indices_loaded, self.parts_loaded, self.index_comparisons, self.all_counts
         )
     }
 }


### PR DESCRIPTION
Python API ScannerStats was missing some fields from ExecutionSummaryCounts, This PR populate them for the scan fallback

`scan_stats_callback (Callable[[ScanStatistics], None], default None) – A callback function that will be called with the scan statistics after the scan is complete. Errors raised by the callback will be logged but not re-raised.`

https://lancedb.github.io/lance-python-doc/all-modules.html#lance.dataset.LanceDataset.scanner

For the added UT i can see


`ScanStatistics(iops=3, requests=3, bytes_read=3649, indices_loaded=0, parts_loaded=0, index_comparisons=0, all_counts={"ranges_scanned": 1, "rows_scanned": 100, "fragments_scanned": 1})`
