### PR TITLE
fix: handle empty batches in dictionary decode helper

### DIFF
--- a/rust/lance-encoding/src/encodings/fuzz_tests.rs
+++ b/rust/lance-encoding/src/encodings/fuzz_tests.rs
@@ -392,6 +392,46 @@ proptest! {
     }
 }
 
+#[tokio::test]
+async fn test_list_dict_empty_batch() {
+    use arrow_array::builder::BinaryBuilder;
+    use arrow_array::builder::ListBuilder;
+
+    // Create a list with some values followed by empty/null lists
+    let mut list_builder = ListBuilder::new(BinaryBuilder::new());
+
+    // First 50 lists have values with LOW CARDINALITY to trigger dictionary encoding
+    // Only 5 unique values repeated many times (150 total values, 5 unique)
+    let values = [b"aaaaa", b"bbbbb", b"ccccc", b"ddddd", b"eeeee"];
+    for i in 0..50 {
+        // Each list has 3 values, cycling through the 5 unique values
+        list_builder.append_value([
+            Some(values[i % 5]),
+            Some(values[(i + 1) % 5]),
+            Some(values[(i + 2) % 5]),
+        ]);
+    }
+
+    // Next 50 lists are empty or null (no values)
+    for i in 0..50 {
+        if i % 2 == 0 {
+            list_builder.append_value(Vec::<Option<&[u8]>>::new()); // empty list
+        } else {
+            list_builder.append_null(); // null list
+        }
+    }
+
+    let list_array = Arc::new(list_builder.finish());
+
+    let test_cases = TestCases::default()
+        .with_min_file_version(LanceFileVersion::V2_1)
+        // Read only the empty/null lists (rows 50-99)
+        // This batch will have 0 underlying values
+        .with_range(50..100);
+
+    check_round_trip_encoding_of_data(vec![list_array], &test_cases, HashMap::new()).await;
+}
+
 // Test all valid combinations systematically (14 combinations)
 // Excludes FSL with Variable width types which are not supported
 #[tokio::test]


### PR DESCRIPTION
When working on https://github.com/lancedb/lance/pull/4972, I realized that Dictionary decoding failed when a batch contained only empty/null lists, resulting in zero indices to decode. Added guard in decode_helper to return AllNull(0) for this case.

Without the fix, we will see:

> DataBlockBuilder didn't see any data
> thread 'encodings::fuzz_tests::test_list_dict_empty_batch' panicked at rust/lance-encoding/src/data.rs:1631:36:
> DataBlockBuilder didn't see any data
> stack backtrace:
>    0: __rustc::rust_begin_unwind
>              at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/std/src/panicking.rs:697:5
>    1: core::panicking::panic_fmt
>              at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:75:14
>    2: core::panicking::panic_display
>              at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/panicking.rs:268:5
>    3: core::option::expect_failed
>              at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/option.rs:2139:5
>    4: core::option::Option<T>::expect
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/option.rs:964:21
>    5: lance_encoding::data::DataBlockBuilder::finish
>              at ./src/data.rs:1631:36
>    6: lance_encoding::data::DictionaryDataBlock::decode_helper
>              at ./src/data.rs:735:25
>    7: lance_encoding::data::DictionaryDataBlock::decode
>              at ./src/data.rs:742:24
>    8: lance_encoding::data::DictionaryDataBlock::into_arrow
>              at ./src/data.rs:781:18
>    9: lance_encoding::data::DataBlock::into_arrow
>              at ./src/data.rs:843:46
>   10: <lance_encoding::encodings::logical::primitive::StructuralCompositeDecodeArrayTask as lance_encoding::decoder::StructuralDecodeArrayTask>::decode
>              at ./src/encodings/logical/primitive.rs:3153:22
>   11: <lance_encoding::encodings::logical::list::StructuralListDecodeTask as lance_encoding::decoder::StructuralDecodeArrayTask>::decode
>              at ./src/encodings/logical/list.rs:198:66
>   12: <lance_encoding::encodings::logical::struct::RepDefStructDecodeTask as lance_encoding::decoder::StructuralDecodeArrayTask>::decode::{{closure}}
>              at ./src/encodings/logical/struct.rs:340:30
>   13: core::iter::adapters::map::map_try_fold::{{closure}}
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/iter/adapters/map.rs:95:28
>   14: <alloc::vec::into_iter::IntoIter<T,A> as core::iter::traits::iterator::Iterator>::try_fold
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/vec/into_iter.rs:351:25
>   15: <core::iter::adapters::map::Map<I,F> as core::iter::traits::iterator::Iterator>::try_fold
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/iter/adapters/map.rs:121:19
>   16: <core::iter::adapters::GenericShunt<I,R> as core::iter::traits::iterator::Iterator>::try_fold
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/iter/adapters/mod.rs:192:14
>   17: core::iter::traits::iterator::Iterator::try_for_each
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2487:14
>   18: <core::iter::adapters::GenericShunt<I,R> as core::iter::traits::iterator::Iterator>::next
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/iter/adapters/mod.rs:174:14
>   19: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/vec/spec_from_iter_nested.rs:25:41
>   20: <alloc::vec::Vec<T> as alloc::vec::spec_from_iter_nested::SpecFromIterNested<T,I>>::from_iter{{reify.shim}}
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/vec/spec_from_iter_nested.rs:19:5
>   21: alloc::vec::in_place_collect::<impl alloc::vec::spec_from_iter::SpecFromIter<T,I> for alloc::vec::Vec<T>>::from_iter
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/vec/in_place_collect.rs:246:9
>   22: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:3633:9
>   23: core::iter::traits::iterator::Iterator::collect
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2027:9
>   24: <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter::{{closure}}
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/result.rs:2054:51
>   25: core::iter::adapters::try_process
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/iter/adapters/mod.rs:160:17
>   26: <core::result::Result<V,E> as core::iter::traits::collect::FromIterator<core::result::Result<A,E>>>::from_iter
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/result.rs:2054:9
>   27: core::iter::traits::iterator::Iterator::collect
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/iter/traits/iterator.rs:2027:9
>   28: <lance_encoding::encodings::logical::struct::RepDefStructDecodeTask as lance_encoding::decoder::StructuralDecodeArrayTask>::decode
>              at ./src/encodings/logical/struct.rs:341:14
>   29: <alloc::boxed::Box<dyn lance_encoding::decoder::StructuralDecodeArrayTask> as lance_encoding::decoder::DecodeArrayTask>::decode
>              at ./src/decoder.rs:2418:9
>   30: lance_encoding::decoder::NextDecodeTask::into_batch
>              at ./src/decoder.rs:2440:36
>   31: lance_encoding::decoder::StructuralBatchDecodeStream::into_stream::{{closure}}::{{closure}}::{{closure}}::{{closure}}
>              at ./src/decoder.rs:1762:31
>   32: <core::pin::Pin<P> as core::future::future::Future>::poll
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
>   33: lance_encoding::testing::test_decode::{{closure}}
>              at ./src/testing.rs:210:32
>   34: lance_encoding::testing::check_round_trip_encoding_inner::{{closure}}
>              at ./src/testing.rs:969:10
>   35: lance_encoding::testing::check_round_trip_encoding_of_data::{{closure}}
>              at ./src/testing.rs:716:18
>   36: lance_encoding::encodings::fuzz_tests::test_list_dict_empty_batch::{{closure}}
>              at ./src/encodings/fuzz_tests.rs:335:86
>   37: <core::pin::Pin<P> as core::future::future::Future>::poll
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
>   38: <core::pin::Pin<P> as core::future::future::Future>::poll
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
>   39: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}::{{closure}}
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:742:70
>   40: tokio::task::coop::with_budget
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:167:5
>   41: tokio::task::coop::budget
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/task/coop/mod.rs:133:5
>   42: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:742:25
>   43: tokio::runtime::scheduler::current_thread::Context::enter
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:432:19
>   44: tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:741:44
>   45: tokio::runtime::scheduler::current_thread::CoreGuard::enter::{{closure}}
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:829:68
>   46: tokio::runtime::context::scoped::Scoped<T>::set
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/scoped.rs:40:9
>   47: tokio::runtime::context::set_scheduler::{{closure}}
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context.rs:176:38
>   48: std::thread::local::LocalKey<T>::try_with
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:315:12
>   49: std::thread::local::LocalKey<T>::with
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:279:20
>   50: tokio::runtime::context::set_scheduler
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context.rs:176:17
>   51: tokio::runtime::scheduler::current_thread::CoreGuard::enter
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:829:27
>   52: tokio::runtime::scheduler::current_thread::CoreGuard::block_on
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:729:24
>   53: tokio::runtime::scheduler::current_thread::CurrentThread::block_on::{{closure}}
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:200:33
>   54: tokio::runtime::context::runtime::enter_runtime
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/context/runtime.rs:65:16
>   55: tokio::runtime::scheduler::current_thread::CurrentThread::block_on
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/scheduler/current_thread/mod.rs:188:9
>   56: tokio::runtime::runtime::Runtime::block_on_inner
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/runtime.rs:356:52
>   57: tokio::runtime::runtime::Runtime::block_on
>              at /Users/yingjianwu/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.47.1/src/runtime/runtime.rs:330:18
>   58: lance_encoding::encodings::fuzz_tests::test_list_dict_empty_batch
>              at ./src/encodings/fuzz_tests.rs:335:91
>   59: lance_encoding::encodings::fuzz_tests::test_list_dict_empty_batch::{{closure}}
>              at ./src/encodings/fuzz_tests.rs:299:38
>   60: core::ops::function::FnOnce::call_once
>              at /Users/yingjianwu/.rustup/toolchains/1.90.0-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:253:5
>   61: core::ops::function::FnOnce::call_once
>              at /rustc/1159e78c4747b02ef996e55082b704c09b970588/library/core/src/ops/function.rs:253:5
> note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
> 
> error: test failed, to rerun pass `--lib`
> error: 1 target failed:
>     `--lib`
> 
> Process finished with exit code 101
> 