### PR TITLE
fix: do not modify Lance schema when projecting system columns

### DIFF
--- a/rust/lance-core/src/datatypes/schema.rs
+++ b/rust/lance-core/src/datatypes/schema.rs
@@ -259,10 +259,6 @@ impl Schema {
                 } else {
                     candidates.push(projected_field)
                 }
-            } else if first == ROW_ID {
-                candidates.push(Field::try_from(ROW_ID_FIELD.clone())?);
-            } else if first == ROW_ADDR {
-                candidates.push(Field::try_from(ROW_ADDR_FIELD.clone())?);
             } else if err_on_missing && first != ROW_ID && first != ROW_ADDR {
                 return Err(Error::Schema {
                     message: format!("Column {} does not exist", col.as_ref()),
@@ -435,10 +431,6 @@ impl Schema {
 
             if let Some(self_field) = self.field(&field.name) {
                 new_fields.push(self_field.project_by_field(field, on_type_mismatch)?);
-            } else if field.name == ROW_ID {
-                new_fields.push(Field::try_from(ROW_ID_FIELD.clone())?);
-            } else if field.name == ROW_ADDR {
-                new_fields.push(Field::try_from(ROW_ADDR_FIELD.clone())?);
             } else if matches!(on_missing, OnMissing::Error) {
                 return Err(Error::Schema {
                     message: format!("Field {} not found", field.name),

--- a/rust/lance-core/src/lib.rs
+++ b/rust/lance-core/src/lib.rs
@@ -42,3 +42,19 @@ pub static ROW_LAST_UPDATED_AT_VERSION_FIELD: LazyLock<ArrowField> =
 /// Row created at version field.
 pub static ROW_CREATED_AT_VERSION_FIELD: LazyLock<ArrowField> =
     LazyLock::new(|| ArrowField::new(ROW_CREATED_AT_VERSION, DataType::UInt64, true));
+
+/// Check if a column name is a system column.
+///
+/// System columns are virtual columns that are computed at read time and don't
+/// exist in the physical data files. They include:
+/// - `_rowid`: The row ID
+/// - `_rowaddr`: The row address
+/// - `_rowoffset`: The row offset
+/// - `_row_last_updated_at_version`: The version when the row was last updated
+/// - `_row_created_at_version`: The version when the row was created
+pub fn is_system_column(column_name: &str) -> bool {
+    matches!(
+        column_name,
+        ROW_ID | ROW_ADDR | ROW_OFFSET | ROW_LAST_UPDATED_AT_VERSION | ROW_CREATED_AT_VERSION
+    )
+}


### PR DESCRIPTION
Because `Schema::project_by_schema` is public API, adding system columns to it and use it in projection in #4794 was breaking some use cases. 