### PR TITLE
ci: fix warning message in CI

### DIFF
--- a/docs/src/integrations/datafusion.md
+++ b/docs/src/integrations/datafusion.md
@@ -127,7 +127,7 @@ ctx = SessionContext()
 table1 = FFILanceTableProvider(
     my_lance_dataset, with_row_id=True, with_row_addr=True
 )
-ctx.register_table_provider("table1", table1)
+ctx.register_table("table1", table1)
 ctx.table("table1")
 ctx.sql("SELECT * FROM table1 LIMIT 10")
 ```

--- a/python/python/tests/test_table_provider.py
+++ b/python/python/tests/test_table_provider.py
@@ -54,7 +54,7 @@ def test_table_loading():
         ffi_lance_table = FFILanceTableProvider(
             dataset, with_row_id=True, with_row_addr=True
         )
-        ctx.register_table_provider("ffi_lance_table", ffi_lance_table)
+        ctx.register_table("ffi_lance_table", ffi_lance_table)
         return ctx
 
     result = normalize(make_ctx().table("ffi_lance_table").collect())


### PR DESCRIPTION
This PR will fix warning message in CI

```shell
FAILED python/tests/test_table_provider.py::test_table_loading - DeprecationWarning: Use register_table() instead.
```

---

**This PR was primarily authored with Codex using GPT-5-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**