### PR TITLE
ci: remove not needed actions on our self-hosted runner

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -152,14 +152,6 @@ jobs:
       CC: clang
       CXX: clang++
     steps:
-      # Remove not needed tools from runner
-      - uses: easimon/maximize-build-space@v10
-        with:
-          remove-dotnet: true
-          remove-android: true
-          remove-haskell: true
-          remove-codeql: true
-          remove-docker-images: true
       - uses: actions/checkout@v4
       # Remote cargo.lock to force a fresh build
       - name: Remove Cargo.lock


### PR DESCRIPTION
This action is not needed since we are on our self-hosted runner.

---

**This PR was primarily authored with Codex using GPT-5-Codex and then hand-reviewed by me. I AM responsible for every change made in this PR. I aimed to keep it aligned with our goals, though I may have missed minor issues. Please flag anything that feels off, I'll fix it quickly.**