### PR TITLE
chore: remove redundant bench profile from lance-index crate

### DIFF
--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -99,9 +99,6 @@ pprof.workspace = true
 # docs.rs uses an older version of Ubuntu that does not have the necessary protoc version
 features = ["protoc"]
 
-[profile.bench]
-debug = true
-
 [[bench]]
 name = "find_partitions"
 harness = false


### PR DESCRIPTION
## Summary
- remove the crate-local `[profile.bench]` section from `lance-index` so Cargo no longer warns about ignored profiles

## Testing
- cargo check -p lance-index *(fails: missing protoc binaries in build environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f7a3662658832995d2a09bc46c0287