### PR TITLE
fix: fix the deduplicated prefix in the opendal s3 store root setting

### DIFF
--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -107,7 +107,7 @@ impl AwsStoreProvider {
         config_map.insert("bucket".to_string(), bucket);
 
         if !prefix.is_empty() {
-            config_map.insert("root".to_string(), format!("/{}", prefix));
+            config_map.insert("root".to_string(), "/".to_string());
         }
 
         let operator = Operator::from_iter::<S3>(config_map)


### PR DESCRIPTION
When using OpenDAL S3 as the object store, I encountered the same issue as with OpenDAL OSS object store: duplication of root prefixes (see https://github.com/lancedb/lance/issues/4423).
Reference the pull request https://github.com/lancedb/lance/pull/4424 for the fix.