### PR TITLE
fix: remove unnecessary object store initialization

### DIFF
--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -201,15 +201,18 @@ impl<'a> CommitBuilder<'a> {
                     resolve_commit_handler(uri, self.commit_handler.clone(), &self.store_params)
                         .await?
                 };
-                let (object_store, base_path) =
-                if let Some(passed_store) = self.object_store {
-                    (passed_store, ObjectStore::extract_path_from_uri(session.store_registry(), uri)?)
+                let (object_store, base_path) = if let Some(passed_store) = self.object_store {
+                    (
+                        passed_store,
+                        ObjectStore::extract_path_from_uri(session.store_registry(), uri)?,
+                    )
                 } else {
                     ObjectStore::from_uri_and_params(
                         session.store_registry(),
                         uri,
                         &self.store_params.clone().unwrap_or_default(),
-                    ).await?
+                    )
+                    .await?
                 };
                 (object_store, base_path, commit_handler)
             }


### PR DESCRIPTION
When `self.object_store` exists, there is no need to perform the initialization operation of object_store again.