### PR TITLE
fix: avoid unnecessary get_fragments calling during plan compaction

### DIFF
--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -471,14 +471,12 @@ pub async fn plan_compaction(
 ) -> Result<CompactionPlan> {
     // get_fragments should be returning fragments in sorted order (by id)
     // and fragment ids should be unique
+    let fragments = dataset.get_fragments();
     debug_assert!(
-        dataset
-            .get_fragments()
-            .windows(2)
-            .all(|w| w[0].id() < w[1].id()),
+        fragments.windows(2).all(|w| w[0].id() < w[1].id()),
         "fragments in manifest are not sorted"
     );
-    let mut fragment_metrics = futures::stream::iter(dataset.get_fragments())
+    let mut fragment_metrics = futures::stream::iter(fragments)
         .map(|fragment| async move {
             match collect_metrics(&fragment).await {
                 Ok(metrics) => Ok((fragment.metadata, metrics)),


### PR DESCRIPTION
Avoid unnecessary get_fragments calling during plan compaction

get_fragments involves deep copying of dataset and fragment, which is pretty heavy.