### PR TITLE
test: lower recall requirement in remap case for PQ

### DIFF
--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1546,7 +1546,7 @@ mod tests {
         );
         test_index(params.clone(), nlist, recall_requirement, None).await;
         if distance_type == DistanceType::Cosine {
-            test_index_multivec(params.clone, nlist, recall_requirement).await;
+            test_index_multivec(params, nlist, recall_requirement).await;
         }
     }
 


### PR DESCRIPTION
PQ performs worse on farther vectors, so if we delete the many nearest vectors, the recall will be lower
This PR lowers the recall requirement in remap case for PQ, because it deletes half of the vectors