### PR TITLE
ci: don't use warp runners

### DIFF
--- a/.github/workflows/file_verification.yml
+++ b/.github/workflows/file_verification.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   run:
     timeout-minutes: 45
-    runs-on: warp-ubuntu-latest-x64-8x
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -180,7 +180,7 @@ jobs:
           if-no-files-found: error
   macos-arm64:
     name: Build on MacOS Arm64 and release
-    runs-on: warp-macos-14-arm64-6x
+    runs-on: macos-14
     timeout-minutes: 60
     needs:
       - linux-arm64

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -19,7 +19,7 @@ jobs:
 
   jumbo-tests:
     # jumbo tests need more resources
-    runs-on: warp-ubuntu-latest-x64-8x
+    runs-on: ubuntu-latest
     if: github.repository == 'lancedb/lance'
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -42,11 +42,11 @@ jobs:
           - platform: aarch64
             manylinux: "2_17"
             extra_args: ""
-            runner: warp-ubuntu-2404-arm64-4x
+            runner: ubuntu-24.04
           - platform: aarch64
             manylinux: "2_28"
             extra_args: "--features fp16kernels"
-            runner: warp-ubuntu-2404-arm64-4x
+            runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.config.runner }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -155,7 +155,7 @@ jobs:
 
   linux-arm:
     timeout-minutes: 45
-    runs-on: warp-ubuntu-2404-arm64-4x
+    runs-on: ubuntu-24.04-arm
     name: Python Linux 3.13 ARM
     defaults:
       run:

--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   Benchmark:
-    runs-on: warp-ubuntu-latest-arm64-8x
+    runs-on: ubuntu-latest-arm
     timeout-minutes: 120
     steps:
       - name: Apt-get

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -104,7 +104,7 @@ jobs:
           flags: unittests
           fail_ci_if_error: false
   linux-arm:
-    runs-on: warp-ubuntu-2404-arm64-4x
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 75
     steps:
       - uses: actions/checkout@v4
@@ -129,7 +129,7 @@ jobs:
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v protoc | sort | uniq | paste -s -d "," -`
           cargo test --profile ci --locked --features ${ALL_FEATURES}
   build-no-lock:
-    runs-on: warp-ubuntu-2404-x64-8x
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     env:
       # Need up-to-date compilers for kernels
@@ -150,7 +150,7 @@ jobs:
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v protoc | sort | uniq | paste -s -d "," -`
           cargo build --profile ci --benches --features ${ALL_FEATURES} --tests
   mac-build:
-    runs-on: warp-macos-14-arm64-6x
+    runs-on: macos-14
     timeout-minutes: 45
     strategy:
       matrix:
@@ -182,7 +182,7 @@ jobs:
         run: |
           cargo check --profile ci --benches --features fp16kernels,cli,dynamodb,substrait
   windows-build:
-    runs-on: warp-windows-latest-x64-4x
+    runs-on: windows-latest
     defaults:
       run:
         working-directory: rust


### PR DESCRIPTION
They aren't working in the new repo yet.