### PR TITLE
fix: index overestimates the posting list size

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1451,10 +1451,6 @@ impl PostingListReader {
 pub struct Positions(ListArray);
 
 impl DeepSizeOf for Positions {
-    fn deep_size_of(&self) -> usize {
-        self.0.get_array_memory_size()
-    }
-
     fn deep_size_of_children(&self, _context: &mut deepsize::Context) -> usize {
         self.0.get_buffer_memory_size()
     }
@@ -1619,7 +1615,7 @@ impl DeepSizeOf for PlainPostingList {
             + self
                 .positions
                 .as_ref()
-                .map(|positions| positions.get_array_memory_size())
+                .map(|positions| positions.get_buffer_memory_size())
                 .unwrap_or(0)
     }
 }


### PR DESCRIPTION
| len | array_bytes | buffer_bytes | abs_diff | ratio | 
| ---:| ---:| ---:| ---:| ---:| 
| 1 | 248 | 128 | 120 | 1.938 | 
| 8 | 312 | 192 | 120 | 1.625 | 
| 32 | 504 | 384 | 120 | 1.312 | 
| 128 | 568 | 448 | 120 | 1.268 | 

we double counted the fields' size and it overestimated the posting list size by 1.2x~2x for small ones