### PR TITLE
fix: update CachedFileMetadata version API to V2.0

### DIFF
--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -122,6 +122,7 @@ impl CachedFileMetadata {
     pub fn version(&self) -> LanceFileVersion {
         match (self.major_version, self.minor_version) {
             (0, 3) => LanceFileVersion::V2_0,
+            (2, 0) => LanceFileVersion::V2_0,
             (2, 1) => LanceFileVersion::V2_1,
             (2, 2) => LanceFileVersion::V2_2,
             _ => panic!(


### PR DESCRIPTION
Consistent with [`version.rs#`](https://github.com/lance-format/lance/blob/2e21599fd6887b1649e0359f92b12362ce04031f/rust/lance-encoding/src/version.rs#L58) **(2, 0) => Ok(Self::V2_0),**

```
    pub fn try_from_major_minor(major: u32, minor: u32) -> Result<Self> {
        match (major, minor) {
            (0, 0) => Ok(Self::Legacy),
            (0, 1) => Ok(Self::Legacy),
            (0, 2) => Ok(Self::Legacy),
            (0, 3) => Ok(Self::V2_0),
            (2, 0) => Ok(Self::V2_0),
            (2, 1) => Ok(Self::V2_1),
            (2, 2) => Ok(Self::V2_2),
            _ => Err(Error::InvalidInput {
                source: format!("Unknown Lance storage version: {}.{}", major, minor).into(),
                location: location!(),
            }),
        }
    }
```