### PR TITLE
fix: correctly handle OSS commit protocol to prevent data loss

### DIFF
--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -721,7 +721,7 @@ pub async fn commit_handler_from_url(
 
     match url.scheme() {
         "file" | "file-object-store" => Ok(local_handler),
-        "s3" | "gs" | "az" | "memory" => Ok(Arc::new(ConditionalPutCommitHandler)),
+        "s3" | "gs" | "az" | "memory" | "oss" => Ok(Arc::new(ConditionalPutCommitHandler)),
         #[cfg(not(feature = "dynamodb"))]
         "s3+ddb" => Err(Error::InvalidInput {
             source: "`s3+ddb://` scheme requires `dynamodb` feature to be enabled".into(),


### PR DESCRIPTION
Previously, OSS protocol was falling back to UnsafeCommitHandler which can lead to data loss during concurrent writes. This change ensures OSS uses the ConditionalPutCommitHandler which leverages the x-oss-forbid-overwrite header to provide proper concurrency control similar to other cloud storage protocols.

> ℹ️ **Note**: This is my first contribution to open source!  
> I'm excited to be part of the community 🙌  
> Please feel free to point out anything I can improve — I'm happy to learn and make changes!