### PR TITLE
fix: parallelize bitmap partition loading in IsIn expressions

### DIFF
--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -442,7 +442,7 @@ impl ScalarIndex for BitmapIndex {
                         let this = self.clone();
                         async move { this.load_bitmap(&key, None).await }
                     }))
-                    .buffered(get_num_compute_intensive_cpus())
+                    .buffer_unordered(get_num_compute_intensive_cpus())
                     .try_collect()
                     .await?;
 
@@ -480,7 +480,7 @@ impl ScalarIndex for BitmapIndex {
                         let this = self.clone();
                         async move { this.load_bitmap(&key, None).await }
                     }))
-                    .buffered(get_num_compute_intensive_cpus())
+                    .buffer_unordered(get_num_compute_intensive_cpus())
                     .try_collect()
                     .await?;
 


### PR DESCRIPTION
Prior to this commit an IsIn query on a bitmap index would load partitions in serial order. On high latency connections, queries with large IsIn lists can get very slow. This commit changes the partition loading to be parallelized over the number of CPUs, similar to btree.