### PR TITLE
feat: disable default features on internal use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ lance-index = { version = "=1.1.0-beta.2", path = "./rust/lance-index" }
 lance-io = { version = "=1.1.0-beta.2", path = "./rust/lance-io", default-features = false }
 lance-linalg = { version = "=1.1.0-beta.2", path = "./rust/lance-linalg" }
 lance-namespace = { version = "=1.1.0-beta.2", path = "./rust/lance-namespace" }
-lance-namespace-impls = { version = "=1.1.0-beta.2", path = "./rust/lance-namespace-impls", default-features = false }
+lance-namespace-impls = { version = "=1.1.0-beta.2", path = "./rust/lance-namespace-impls" }
 lance-namespace-reqwest-client = "0.0.18"
 lance-table = { version = "=1.1.0-beta.2", path = "./rust/lance-table" }
 lance-test-macros = { version = "=1.1.0-beta.2", path = "./rust/lance-test-macros" }

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -38,7 +38,7 @@ arrow-select = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 itertools = { workspace = true }
 futures = { workspace = true }
-lance = { workspace = true }
+lance = { workspace = true, features = ["aws", "azure", "gcp", "oss", "huggingface"] }
 lance-index = { workspace = true }
 lance-core = { workspace = true }
 lance-linalg = { workspace = true }

--- a/rust/lance-namespace-impls/Cargo.toml
+++ b/rust/lance-namespace-impls/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 rust-version.workspace = true
 
 [features]
-default = []
+default = ["dir-aws", "dir-azure", "dir-gcp", "dir-oss", "dir-huggingface"]
 rest = ["dep:reqwest"]
 rest-adapter = ["dep:axum", "dep:tower", "dep:tower-http", "dep:serde"]
 # Cloud storage features for directory implementation - align with lance-io
@@ -20,6 +20,7 @@ dir-gcp = ["lance-io/gcp", "lance/gcp"]
 dir-aws = ["lance-io/aws", "lance/aws"]
 dir-azure = ["lance-io/azure", "lance/azure"]
 dir-oss = ["lance-io/oss", "lance/oss"]
+dir-huggingface = ["lance-io/huggingface", "lance/huggingface"]
 
 [dependencies]
 lance-namespace.workspace = true


### PR DESCRIPTION
Part of https://github.com/lancedb/lancedb/issues/2771, continuing https://github.com/lancedb/lancedb/pull/2568.
`lance-namespace-impls` uses `lance` which pulled in default features (aws,gcp,azure,oss), which pulled `aws-*` crates into `lancedb` even when `lancedb` was used with `default-features = false`.


I don't have tests at hand, but it would probably be good to run `cargo tree -p lance -e no-build -e no-dev --no-default-features -i aws-config` in CI (maybe for each crate?) to avoid adding any dependency back by default in a future PR.