### PR TITLE
ci: fix flaky test_read_btree_index_with_defer_index_remap

### DIFF
--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -3010,7 +3010,7 @@ mod tests {
 
         // Run compaction with deferred index remapping
         let options = CompactionOptions {
-            target_rows_per_fragment: 2_000,
+            target_rows_per_fragment: 50_000,
             defer_index_remap: true,
             ..Default::default()
         };


### PR DESCRIPTION
Closes https://github.com/lance-format/lance/issues/4925

The compaction number of rows was set too small, resulting in the process issuing too many concurrent fragment reservation commits at the same time and sometimes fail the test.