### PR TITLE
refactor!: deprecate mac x86 support

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -97,8 +97,6 @@ jobs:
       matrix:
         python-minor-version: ["9"]
         config:
-          - target: x86_64-apple-darwin
-            runner: macos-14
           - target: aarch64-apple-darwin
             runner: warp-macos-14-arm64-6x
     env:
@@ -134,7 +132,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: pylance-debug-macosx_${{ matrix.config.target == 'x86_64-apple-darwin' && 'x86_64' || 'arm64' }}
+          name: pylance-debug-macosx_arm64
           path: python/target/wheels/*.whl
           retention-days: 90
       - uses: ./.github/workflows/upload_wheel

--- a/rust/lance-linalg/build.rs
+++ b/rust/lance-linalg/build.rs
@@ -15,9 +15,8 @@ fn main() -> Result<(), String> {
         println!("cargo:rustc-cfg=feature=\"nightly\"");
     }
 
-    // Let clippy know about our custom cfg attributes
+    // Let clippy know about our custom cfg attribute
     println!("cargo::rustc-check-cfg=cfg(kernel_support, values(\"avx512\"))");
-    println!("cargo::rustc-check-cfg=cfg(kernel_support_dist_table, values(\"avx512\"))");
 
     println!("cargo:rerun-if-changed=src/simd/f16.c");
     println!("cargo:rerun-if-changed=src/simd/dist_table.c");
@@ -62,9 +61,7 @@ fn main() -> Result<(), String> {
                 err
             );
         } else {
-            // Use a separate cfg flag for dist_table to avoid symbol mismatch
-            // when f16 build succeeds but dist_table build fails (or vice versa)
-            println!("cargo:rustc-cfg=kernel_support_dist_table=\"avx512\"");
+            println!("cargo:rustc-cfg=kernel_support=\"avx512\"");
         };
         // Build a version with AVX
         // While GCC doesn't have support for _Float16 until GCC 12, clang

--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -35,7 +35,7 @@ pub fn sum_4bit_dist_table(
     debug_assert!(n.is_multiple_of(BATCH_SIZE));
 
     match *SIMD_SUPPORT {
-        #[cfg(all(kernel_support_dist_table = "avx512", target_arch = "x86_64"))]
+        #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
         SimdSupport::Avx512 | SimdSupport::Avx512FP16 => unsafe {
             for i in (0..n).step_by(BATCH_SIZE) {
                 let codes = &codes[i * code_len..(i + BATCH_SIZE) * code_len];
@@ -162,7 +162,7 @@ unsafe fn sum_dist_table_32bytes_batch_avx2(codes: &[u8], dist_table: &[u8], dis
 // We implement the AVX512 version in C because AVX512 is not stable yet in Rust,
 // implement it in Rust once we upgrade rust to 1.89.0.
 extern "C" {
-    #[cfg(all(kernel_support_dist_table = "avx512", target_arch = "x86_64"))]
+    #[cfg(all(kernel_support = "avx512", target_arch = "x86_64"))]
     pub fn sum_4bit_dist_table_32bytes_batch_avx512(
         codes: *const u8,
         code_length: usize,


### PR DESCRIPTION
We have very low download stats for mac x86, and also latest github runners for mac are all arm, so it makes sense at this point to deprecate x86 support in general.

We also revert #5379 since it is no longer needed.