### PR TITLE
chore: remove lancedb in github discussion links and java pom file

### DIFF
--- a/ci/create_rc_discussion.sh
+++ b/ci/create_rc_discussion.sh
@@ -55,7 +55,7 @@ if [ -n "$RELEASE_BRANCH" ]; then
 fi
 
 DISCUSSION_BODY="${DISCUSSION_BODY}
-- **Release Notes**: https://github.com/lancedb/lance/releases/tag/${RC_TAG}
+- **Release Notes**: https://github.com/lance-format/lance/releases/tag/${RC_TAG}
 
 ### Testing Instructions
 
@@ -78,7 +78,7 @@ Add to your \`pom.xml\`:
 Add to your \`Cargo.toml\`:
 \`\`\`toml
 [dependencies]
-lance = { version = \"=${RC_VERSION}\", git = \"https://github.com/lancedb/lance\", tag = \"${RC_TAG}\" }
+lance = { version = \"=${RC_VERSION}\", git = \"https://github.com/lance-format/lance\", tag = \"${RC_TAG}\" }
 \`\`\`
 
 ### Voting Instructions

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
 
     <description>Lance Format Java API</description>
-    <url>http://lancedb.com/</url>
+    <url>https://lance.org/</url>
 
     <developers>
         <developer>


### PR DESCRIPTION
Cherry pick of https://github.com/lance-format/lance/pull/5394 to release/v1.0