### PR TITLE
ci: run workflows also on release branch

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -2,8 +2,13 @@ name: Check docs
 
 on:
   push:
-    branches: ["main"]
+    branches:
+      - main
+      - release/**
   pull_request:
+    branches:
+      - main
+      - release/**
     paths:
       - docs/**
       - .github/workflows/docs-check.yml

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -4,6 +4,9 @@ on:
     # Trigger on published to include both stable and preview/beta releases
     types: [published]
   pull_request:
+    branches:
+      - main
+      - release/**
     paths:
       - .github/workflows/java-publish.yml
   workflow_dispatch:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
+    branches:
+      - main
+      - release/**
     paths:
       - java/**
       - rust/**

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -3,7 +3,11 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
+    branches:
+      - main
+      - release/**
     paths:
       - rust/**
       - python/**

--- a/.github/workflows/notebook.yml
+++ b/.github/workflows/notebook.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
+    branches:
+      - main
+      - release/**
     paths:
       - python/**
       - rust/**

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,6 +16,9 @@ on:
         default: true
         type: boolean
   pull_request:
+    branches:
+      - main
+      - release/**
     paths:
       - ".github/workflows/pypi-publish.yml"
       - ".github/workflows/build_linux_wheel/**"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
+    branches:
+      - main
+      - release/**
     paths:
       - Cargo.*
       - python/**

--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 9 * * *" # 9AM UTC = 2AM PST
   pull_request:
+    branches:
+      - main
+      - release/**
     paths:
       - ".github/workflows/rust-benchmark.yml"
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,11 @@ on:
   push:
     branches:
       - main
+      - release/**
   pull_request:
+    branches:
+      - main
+      - release/**
     paths:
       - rust/**
       - protos/**

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,5 +1,9 @@
 name: Typo checker
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - main
+      - release/**
 
 jobs:
   run:


### PR DESCRIPTION
Make sure all workflows are triggered properly when doing a patch against release branch

Patch of https://github.com/lance-format/lance/pull/5398 to release/v1.0