### PR TITLE
feat: fallback to CPU if GPU accelerating is unavailable

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2797,6 +2797,10 @@ class LanceDataset(pa.dataset.Dataset):
                 accelerator="cuda"
             )
 
+        Note: GPU acceleration is currently supported only for the ``IVF_PQ`` index
+        type. Providing an accelerator for other index types will fall back to CPU
+        index building.
+
         References
         ----------
         * `Faiss Index <https://github.com/facebookresearch/faiss/wiki/Faiss-indexes>`_
@@ -2881,6 +2885,13 @@ class LanceDataset(pa.dataset.Dataset):
 
         # Handle timing for various parts of accelerated builds
         timers = {}
+        if accelerator is not None and index_type != "IVF_PQ":
+            LOGGER.warning(
+                "Index type %s does not support GPU acceleration; falling back to CPU",
+                index_type,
+            )
+            accelerator = None
+
         if accelerator is not None:
             from .vector import (
                 one_pass_assign_ivf_pq_on_accelerator,

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
+import logging
 import platform
 import random
 import string
@@ -459,6 +460,27 @@ def test_create_index_unsupported_accelerator(tmp_path):
             num_sub_vectors=16,
             accelerator="cuda:abc",
         )
+
+
+def test_create_index_accelerator_fallback(tmp_path, caplog):
+    tbl = create_table()
+    dataset = lance.write_dataset(tbl, tmp_path)
+
+    with caplog.at_level(logging.WARNING):
+        dataset = dataset.create_index(
+            "vector",
+            index_type="IVF_HNSW_SQ",
+            num_partitions=4,
+            accelerator="cuda",
+        )
+
+    indices = dataset.list_indices()
+    assert len(indices) == 1
+    assert indices[0]["type"] == "IVF_HNSW_SQ"
+    assert any(
+        "does not support GPU acceleration; falling back to CPU" in record.message
+        for record in caplog.records
+    )
 
 
 def test_use_index(dataset, tmp_path):


### PR DESCRIPTION
fix #5061 

## Summary
- fallback to CPU when an accelerator is passed to non-IVF_PQ indices
- document the limitation and add a warning-log regression test