### PR TITLE
fix: remove expensive clone in bitmap search

### DIFF
--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -438,10 +438,10 @@ impl ScalarIndex for BitmapIndex {
                 if keys.is_empty() {
                     RowAddrTreeMap::default()
                 } else {
-                    let bitmaps: Vec<_> = stream::iter(keys.into_iter().map(|key| {
-                        let this = self.clone();
-                        async move { this.load_bitmap(&key, None).await }
-                    }))
+                    let bitmaps: Vec<_> = stream::iter(
+                        keys.into_iter()
+                            .map(|key| async move { self.load_bitmap(&key, None).await }),
+                    )
                     .buffer_unordered(get_num_compute_intensive_cpus())
                     .try_collect()
                     .await?;
@@ -476,10 +476,10 @@ impl ScalarIndex for BitmapIndex {
                     RowAddrTreeMap::default()
                 } else {
                     // Load bitmaps in parallel
-                    let mut bitmaps: Vec<_> = stream::iter(keys.into_iter().map(|key| {
-                        let this = self.clone();
-                        async move { this.load_bitmap(&key, None).await }
-                    }))
+                    let mut bitmaps: Vec<_> = stream::iter(
+                        keys.into_iter()
+                            .map(|key| async move { self.load_bitmap(&key, None).await }),
+                    )
                     .buffer_unordered(get_num_compute_intensive_cpus())
                     .try_collect()
                     .await?;


### PR DESCRIPTION
https://github.com/lance-format/lance/commit/82df34342938a0ce36b08c1412b2fdef0e604009 parallelizes bitmap loading but it introduced a clone of the bitmap index.  Since this was a clone of the index itself and not just an arc clone it ended up being a very expensive deep clone, especially at scale.  It also led to unbounded memory usage since all clones needed to live at the same time and this could cause the search to crash.

Fortunately, these clones are not needed, so we can simply remove them.