### PR TITLE
ci: remove cached wheels before building

### DIFF
--- a/.github/workflows/build_linux_wheel/action.yml
+++ b/.github/workflows/build_linux_wheel/action.yml
@@ -25,6 +25,11 @@ runs:
       shell: bash
       run: |
         echo "ARM BUILD: ${{ inputs.arm-build }}"
+    - name: Clean old wheels
+      shell: bash
+      run: |
+        # Ensure no cached pylance wheels linger across cache restores
+        rm -f python/target/wheels/pylance-*.whl || true
     - name: Build x86_64 Manylinux2014 wheel
       if: ${{ inputs.arm-build == 'false' && inputs.manylinux == '2_17' }}
       uses: PyO3/maturin-action@v1


### PR DESCRIPTION
This PR will remove cached wheels before building to address CI broken like:

```shell
Processing ./target/wheels/pylance-1.1.0b1-cp39-abi3-manylinux_2_28_aarch64.whl
Processing ./target/wheels/pylance-1.1.0b2-cp39-abi3-manylinux_2_28_aarch64.whl (from pylance==1.1.0b2)
ERROR: Cannot install pylance 1.1.0b1 (from /runner/_work/lance/lance/python/target/wheels/pylance-1.1.0b1-cp39-abi3-manylinux_2_28_aarch64.whl) and pylance 1.1.0b2 (from /runner/_work/lance/lance/python/target/wheels/pylance-1.1.0b2-cp39-abi3-manylinux_2_28_aarch64.whl) because these package versions have conflicting dependencies.

The conflict is caused by:
The user requested pylance 1.1.0b1 (from /runner/_work/lance/lance/python/target/wheels/pylance-1.1.0b1-cp39-abi3-manylinux_2_28_aarch64.whl)
The user requested pylance 1.1.0b2 (from /runner/_work/lance/lance/python/target/wheels/pylance-1.1.0b2-cp39-abi3-manylinux_2_28_aarch64.whl)

Additionally, some packages in these conflicts have no matching distributions available for your environment:
pylance

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.1-codex-max`) and fully reviewed and edited by me. I take full responsibility for all changes.**