### PR TITLE
perf: do not instrument self in multipart upload

### DIFF
--- a/rust/lance-io/src/object_store/tracing.rs
+++ b/rust/lance-io/src/object_store/tracing.rs
@@ -31,12 +31,12 @@ impl MultipartUpload for TracedMultipartUpload {
         Box::pin(fut.instrument(write_span))
     }
 
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip_all)]
     async fn complete(&mut self) -> OSResult<PutResult> {
         self.target.complete().await
     }
 
-    #[instrument(level = "debug")]
+    #[instrument(level = "debug", skip_all)]
     async fn abort(&mut self) -> OSResult<()> {
         self.target.abort().await
     }


### PR DESCRIPTION
If we log `self` then it will log the object store which can be a lot of info (especially if it is a memory object store)