### PR TITLE
ci: ignore rustls-pemfile warnings until upgrade

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -84,7 +84,8 @@ ignore = [
     { id = "RUSTSEC-2024-0370", reason = "`proc-macro-error` is used by jieba-rs via include-flate" },
     { id = "RUSTSEC-2024-0436", reason = "`paste` is used by datafusion" },
     { id = "RUSTSEC-2023-0071", reason = "`rsa` is used by opendal via reqsign" },
-    { id = "RUSTSEC-2025-0119", reason = "`number_prefix` used by hf-hub in examples" }
+    { id = "RUSTSEC-2025-0119", reason = "`number_prefix` used by hf-hub in examples" },
+    { id = "RUSTSEC-2025-0134", reason = "`rustls-pemfile` unmaintained; awaiting upstream object_store/hyper-rustls migration to rustls-pki-types" }
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.


### PR DESCRIPTION
Ignore this warning to wait for our upstream release.

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.1-codex-max`) and fully reviewed and edited by me. I take full responsibility for all changes.**