### PR TITLE
test: use cheaper builds for profiling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,6 +9,11 @@ debug = true
 codegen-units = 16
 lto = "thin"
 
+[profile.bench]
+inherits = "release"
+lto = "thin"
+codegen-units = 16
+
 [target.x86_64-unknown-linux-gnu]
 rustflags = ["-C", "target-cpu=haswell", "-C", "target-feature=+avx2,+fma,+f16c"]
 


### PR DESCRIPTION
Running `cargo bench` is incredibly expensive, especially in higher level crates like `lance`.  Since we aren't actually creating release builds and more interested in trends and investigation (we aren't doing any comparative benchmarking at this level) I think it is ok to use a slightly less optimized profile for building.