### PR TITLE
fix: add children information when convert DataType::FixedSizeList to Lance field

### DIFF
--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -995,6 +995,7 @@ impl TryFrom<&ArrowField> for Field {
                 .map(|f| Self::try_from(f.as_ref()))
                 .collect::<Result<_>>()?,
             DataType::List(item) => vec![Self::try_from(item.as_ref())?],
+            DataType::FixedSizeList(item, _) => vec![Self::try_from(item.as_ref())?],
             DataType::LargeList(item) => vec![Self::try_from(item.as_ref())?],
             _ => vec![],
         };


### PR DESCRIPTION
If Arrow field is:

```
Field { name: "randFloat3", data_type: FixedSizeList(Field { name: "element", data_type: Float32, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} }, 3), nullable: true, dict_id: 0, dict_is_ordered: false, metadata: {"arrow.fixed-size-list.size": "3"} }
```

then the converted Lance field is:

```
Field { name: "randFloat3", id: 2, parent_id: -1, logical_type: LogicalType("fixed_size_list:float:3"), metadata: {"arrow.fixed-size-list.size": "3"}, encoding: Some(Plain), nullable: true, children: [], dictionary: None, unenforced_primary_key: false }
```
The child's type information is missed.

Related issue https://github.com/lance-format/lance-spark/issues/138