### PR TITLE
refactor: use the same path for dedicated and packed blob

### DIFF
--- a/rust/lance-core/src/utils/blob.rs
+++ b/rust/lance-core/src/utils/blob.rs
@@ -3,38 +3,25 @@
 
 use object_store::path::Path;
 
-/// Format a dedicated blob sidecar path for a data file.
+/// Format a blob sidecar path for a data file.
 ///
-/// Layout: `<base>/<data_file_key>/<blob_id>.raw`
+/// Layout: `<base>/<data_file_key>/<blob_id>.blob`
 /// - `base` is typically the dataset's data directory.
 /// - `data_file_key` is the stem of the data file (without extension).
-pub fn dedicated_blob_path(base: &Path, data_file_key: &str, blob_id: u32) -> Path {
-    let file_name = format!("{:08x}.raw", blob_id);
+/// - `blob_id` is the hex-encoded identifier assigned during write.
+pub fn blob_path(base: &Path, data_file_key: &str, blob_id: u32) -> Path {
+    let file_name = format!("{:08x}.blob", blob_id);
     base.child(data_file_key).child(file_name.as_str())
 }
 
-/// Format a packed blob sidecar path for a data file.
-///
-/// Layout: `<base>/<data_file_key>/<blob_id>.pack`
-pub fn pack_blob_path(base: &Path, data_file_key: &str, blob_id: u32) -> Path {
-    let file_name = format!("{:08x}.pack", blob_id);
-    base.child(data_file_key).child(file_name.as_str())
-}
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_dedicated_blob_path_formatting() {
+    fn test_blob_path_formatting() {
         let base = Path::from("base");
-        let path = dedicated_blob_path(&base, "deadbeef", 2);
-        assert_eq!(path.to_string(), "base/deadbeef/00000002.raw");
-    }
-
-    #[test]
-    fn test_pack_blob_path_formatting() {
-        let base = Path::from("base");
-        let path = pack_blob_path(&base, "cafebabe", 3);
-        assert_eq!(path.to_string(), "base/cafebabe/00000003.pack");
+        let path = blob_path(&base, "deadbeef", 2);
+        assert_eq!(path.to_string(), "base/deadbeef/00000002.blob");
     }
 }


### PR DESCRIPTION
I made this change to make it easier for us to perform compaction or GC, as all blob IDs will now refer to the same blob paths. This means that as long as we know the largest blob IDs, we can simply remove them all at once.

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.1-codex-max`) and fully reviewed and edited by me. I take full responsibility for all changes.**