### PR TITLE
docs: fix and improve the description about row id

### DIFF
--- a/docs/src/format/table/row_id_lineage.md
+++ b/docs/src/format/table/row_id_lineage.md
@@ -62,9 +62,9 @@ Row IDs are assigned using a monotonically increasing `next_row_id` counter stor
 2. Writer assigns row IDs sequentially starting from `next_row_id` for new rows
 3. Writer updates `next_row_id` in the new manifest to `next_row_id + num_new_rows`
 4. If commit fails due to conflict, writer rebases:
-    - Re-reads the new `next_row_id` from the latest version
-    - Reassigns row IDs to new rows using the updated counter
-    - Retries commit
+   - Re-reads the new `next_row_id` from the latest version
+   - Reassigns row IDs to new rows using the updated counter
+   - Retries commit
 
 This protocol mirrors fragment ID assignment and ensures row IDs are unique across all table versions.
 


### PR DESCRIPTION
There are some misunderstood for users about the `row ID` in the doc. See: https://github.com/lance-format/lance/discussions/4935#discussioncomment-15093473 

This PR tries to correct and improve it.