### PR TITLE
feat(java): simplify the use of optional in jni

### DIFF
--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -745,19 +745,7 @@ impl FromJObjectWithEnv<DataFile> for JObject<'_> {
 }
 
 fn get_base_id(env: &mut JNIEnv, obj: &JObject) -> Result<Option<u32>> {
-    let base_id = env
-        .call_method(obj, "getBaseId", "()Ljava/util/Optional;", &[])?
-        .l()?;
-
-    if env.call_method(&base_id, "isPresent", "()Z", &[])?.z()? {
-        let inner_value = env
-            .call_method(&base_id, "get", "()Ljava/lang/Object;", &[])?
-            .l()?;
-        let int_value = env.call_method(&inner_value, "intValue", "()I", &[])?.i()?;
-        Ok(Some(int_value as u32))
-    } else {
-        Ok(None)
-    }
+    env.get_optional_u32_from_method(obj, "getBaseId")
 }
 
 fn convert_to_java_integer<'local>(


### PR DESCRIPTION
This PR made the following changes:
- Unwrap java `Optional` inside `get_optional` , so the callback receives the unwrapped value instead of Optional<T> ; removes repeated get() boilerplate
- Fix `inner_shallow_clone` to correctly treat the closure input
- Replace `Optional` handling with `get_optional` to reduce duplication and improve readability