### PR TITLE
feat: add file list with sizes to IndexMetadata

### DIFF
--- a/protos/table.proto
+++ b/protos/table.proto
@@ -280,6 +280,19 @@ message IndexMetadata {
   // The base path index of the data file. Used when the file is imported or referred from another dataset.
   // Lance use it as key of the base_paths field in Manifest to determine the actual base path of the data file.
   optional uint32 base_id = 9;
+
+  // List of files and their sizes for this index segment.
+  // This enables skipping HEAD calls when opening indices and provides
+  // visibility into index storage size via describe_indices().
+  repeated IndexFile files = 10;
+}
+
+// Metadata about a single file within an index segment.
+message IndexFile {
+  // Path relative to the index directory (e.g., "index.idx", "auxiliary.idx")
+  string path = 1;
+  // Size of the file in bytes
+  uint64 size_bytes = 2;
 }
 
 // Index Section, containing a list of index metadata for one dataset version.

--- a/python/python/lance/lance/indices/__init__.pyi
+++ b/python/python/lance/lance/indices/__init__.pyi
@@ -57,6 +57,7 @@ class IndexSegmentDescription:
     fragment_ids: set[int]
     index_version: int
     created_at: Optional[datetime]
+    size_bytes: Optional[int]
 
     def __repr__(self) -> str: ...
 
@@ -69,5 +70,6 @@ class IndexDescription:
     field_names: list[str]
     segments: list[IndexSegmentDescription]
     details: dict
+    total_size_bytes: Optional[int]
 
     def __repr__(self) -> str: ...

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -481,11 +481,14 @@ pub struct PyIndexSegmentDescription {
     pub index_version: i32,
     /// The timestamp when the index segment was created
     pub created_at: Option<DateTime<Utc>>,
+    /// The total size in bytes of all files in this segment
+    /// (None for backward compatibility with indices created before file tracking)
+    pub size_bytes: Option<u64>,
 }
 
 impl PyIndexSegmentDescription {
     pub fn __repr__(&self) -> String {
-        format!("IndexSegmentDescription(uuid={}, dataset_version_at_last_update={}, fragment_ids={:?}, index_version={}, created_at={:?})", self.uuid, self.dataset_version_at_last_update, self.fragment_ids, self.index_version, self.created_at)
+        format!("IndexSegmentDescription(uuid={}, dataset_version_at_last_update={}, fragment_ids={:?}, index_version={}, created_at={:?}, size_bytes={:?})", self.uuid, self.dataset_version_at_last_update, self.fragment_ids, self.index_version, self.created_at, self.size_bytes)
     }
 }
 
@@ -507,6 +510,9 @@ pub struct PyIndexDescription {
     pub details: PyJson,
     /// The segments of the index
     pub segments: Vec<PyIndexSegmentDescription>,
+    /// The total size in bytes of all files across all segments
+    /// (None for backward compatibility with indices created before file tracking)
+    pub total_size_bytes: Option<u64>,
 }
 
 impl PyIndexDescription {
@@ -532,12 +538,14 @@ impl PyIndexDescription {
                     .as_ref()
                     .map(|bitmap| bitmap.iter().collect::<HashSet<_>>())
                     .unwrap_or_default();
+                let size_bytes = segment.total_size_bytes();
                 PyIndexSegmentDescription {
                     uuid: segment.uuid.to_string(),
                     dataset_version_at_last_update: segment.dataset_version,
                     fragment_ids,
                     index_version: segment.index_version,
                     created_at: segment.created_at,
+                    size_bytes,
                 }
             })
             .collect();
@@ -553,6 +561,7 @@ impl PyIndexDescription {
             type_url: index.type_url().to_string(),
             num_rows_indexed: index.rows_indexed(),
             details: PyJson(details),
+            total_size_bytes: index.total_size_bytes(),
         }
     }
 }
@@ -560,7 +569,7 @@ impl PyIndexDescription {
 #[pymethods]
 impl PyIndexDescription {
     pub fn __repr__(&self) -> String {
-        format!("IndexDescription(name={}, type_url={}, num_rows_indexed={}, fields={:?}, field_names={:?}, num_segments={})", self.name, self.type_url, self.num_rows_indexed, self.fields, self.field_names, self.segments.len())
+        format!("IndexDescription(name={}, type_url={}, num_rows_indexed={}, fields={:?}, field_names={:?}, num_segments={}, total_size_bytes={:?})", self.name, self.type_url, self.num_rows_indexed, self.fields, self.field_names, self.segments.len(), self.total_size_bytes)
     }
 }
 

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -54,6 +54,7 @@ impl FromPyObject<'_> for PyLance<IndexMetadata> {
             index_version,
             created_at,
             base_id,
+            files: None,
         }))
     }
 }

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -730,6 +730,15 @@ impl SearchResult {
     }
 }
 
+/// Metadata about a single file within an index segment.
+#[derive(Debug, Clone)]
+pub struct IndexFile {
+    /// Path relative to the index directory
+    pub path: String,
+    /// Size of the file in bytes
+    pub size_bytes: u64,
+}
+
 /// Brief information about an index that was created
 pub struct CreatedIndex {
     /// The details of the index that was created
@@ -741,6 +750,11 @@ pub struct CreatedIndex {
     ///
     /// This can be used to determine if a reader is able to load the index.
     pub index_version: u32,
+    /// List of files and their sizes for this index
+    ///
+    /// This enables skipping HEAD calls when opening indices and provides
+    /// visibility into index storage size via describe_indices().
+    pub files: Option<Vec<IndexFile>>,
 }
 
 /// The criteria that specifies how to update an index

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -580,6 +580,7 @@ impl ScalarIndex for BitmapIndex {
             index_details: prost_types::Any::from_msg(&pbold::BitmapIndexDetails::default())
                 .unwrap(),
             index_version: BITMAP_INDEX_VERSION,
+            files: None,
         })
     }
 
@@ -609,6 +610,7 @@ impl ScalarIndex for BitmapIndex {
             index_details: prost_types::Any::from_msg(&pbold::BitmapIndexDetails::default())
                 .unwrap(),
             index_version: BITMAP_INDEX_VERSION,
+            files: None,
         })
     }
 
@@ -803,6 +805,7 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
             index_details: prost_types::Any::from_msg(&pbold::BitmapIndexDetails::default())
                 .unwrap(),
             index_version: BITMAP_INDEX_VERSION,
+            files: None,
         })
     }
 

--- a/rust/lance-index/src/scalar/bloomfilter.rs
+++ b/rust/lance-index/src/scalar/bloomfilter.rs
@@ -510,6 +510,7 @@ impl ScalarIndex for BloomFilterIndex {
             index_details: prost_types::Any::from_msg(&pb::BloomFilterIndexDetails::default())
                 .unwrap(),
             index_version: BLOOMFILTER_INDEX_VERSION,
+            files: None,
         })
     }
 
@@ -1129,6 +1130,7 @@ impl ScalarIndexPlugin for BloomFilterIndexPlugin {
             index_details: prost_types::Any::from_msg(&pb::BloomFilterIndexDetails::default())
                 .unwrap(),
             index_version: BLOOMFILTER_INDEX_VERSION,
+            files: None,
         })
     }
 

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -1530,6 +1530,7 @@ impl ScalarIndex for BTreeIndex {
             index_details: prost_types::Any::from_msg(&pbold::BTreeIndexDetails::default())
                 .unwrap(),
             index_version: BTREE_INDEX_VERSION,
+            files: None,
         })
     }
 
@@ -1549,6 +1550,7 @@ impl ScalarIndex for BTreeIndex {
             index_details: prost_types::Any::from_msg(&pbold::BTreeIndexDetails::default())
                 .unwrap(),
             index_version: BTREE_INDEX_VERSION,
+            files: None,
         })
     }
 
@@ -2500,6 +2502,7 @@ impl ScalarIndexPlugin for BTreeIndexPlugin {
             index_details: prost_types::Any::from_msg(&pbold::BTreeIndexDetails::default())
                 .unwrap(),
             index_version: BTREE_INDEX_VERSION,
+            files: None,
         })
     }
 

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -67,6 +67,7 @@ impl InvertedIndexPlugin {
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&details).unwrap(),
             index_version: INVERTED_INDEX_VERSION,
+            files: None,
         })
     }
 

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -576,6 +576,7 @@ impl ScalarIndex for InvertedIndex {
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&details).unwrap(),
             index_version,
+            files: None,
         })
     }
 
@@ -597,6 +598,7 @@ impl ScalarIndex for InvertedIndex {
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&details).unwrap(),
             index_version,
+            files: None,
         })
     }
 

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -131,6 +131,7 @@ impl ScalarIndex for JsonIndex {
             index_details: prost_types::Any::from_msg(&json_details)?,
             // TODO: We should store the target index version in the details
             index_version: JSON_INDEX_VERSION,
+            files: None,
         })
     }
 
@@ -148,6 +149,7 @@ impl ScalarIndex for JsonIndex {
             index_details: prost_types::Any::from_msg(&json_details)?,
             // TODO: We should store the target index version in the details
             index_version: JSON_INDEX_VERSION,
+            files: None,
         })
     }
 
@@ -815,6 +817,7 @@ impl ScalarIndexPlugin for JsonIndexPlugin {
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&index_details)?,
             index_version: JSON_INDEX_VERSION,
+            files: None,
         })
     }
 

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -199,6 +199,7 @@ impl ScalarIndex for LabelListIndex {
             index_details: prost_types::Any::from_msg(&pbold::LabelListIndexDetails::default())
                 .unwrap(),
             index_version: LABEL_LIST_INDEX_VERSION,
+            files: None,
         })
     }
 
@@ -216,6 +217,7 @@ impl ScalarIndex for LabelListIndex {
             index_details: prost_types::Any::from_msg(&pbold::LabelListIndexDetails::default())
                 .unwrap(),
             index_version: LABEL_LIST_INDEX_VERSION,
+            files: None,
         })
     }
 
@@ -451,6 +453,7 @@ impl ScalarIndexPlugin for LabelListIndexPlugin {
             index_details: prost_types::Any::from_msg(&pbold::LabelListIndexDetails::default())
                 .unwrap(),
             index_version: LABEL_LIST_INDEX_VERSION,
+            files: None,
         })
     }
 

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -37,6 +37,9 @@ pub struct LanceIndexStore {
     index_dir: Path,
     metadata_cache: Arc<LanceCache>,
     scheduler: Arc<ScanScheduler>,
+    /// Cached file sizes (filename -> size in bytes)
+    /// When set, used to avoid HEAD calls when opening files
+    file_sizes: HashMap<String, u64>,
 }
 
 impl DeepSizeOf for LanceIndexStore {
@@ -63,7 +66,17 @@ impl LanceIndexStore {
             index_dir,
             metadata_cache,
             scheduler,
+            file_sizes: HashMap::new(),
         }
+    }
+
+    /// Set cached file sizes to avoid HEAD calls when opening files.
+    ///
+    /// The map should contain relative paths (e.g., "index.idx") as keys
+    /// and file sizes in bytes as values.
+    pub fn with_file_sizes(mut self, file_sizes: HashMap<String, u64>) -> Self {
+        self.file_sizes = file_sizes;
+        self
     }
 }
 
@@ -223,10 +236,13 @@ impl IndexStore for LanceIndexStore {
 
     async fn open_index_file(&self, name: &str) -> Result<Arc<dyn IndexReader>> {
         let path = self.index_dir.child(name);
-        let file_scheduler = self
-            .scheduler
-            .open_file(&path, &CachedFileSize::unknown())
-            .await?;
+        // Use cached file size if available, otherwise unknown (requires HEAD call)
+        let cached_size = self
+            .file_sizes
+            .get(name)
+            .map(|&size| CachedFileSize::new(size))
+            .unwrap_or_else(CachedFileSize::unknown);
+        let file_scheduler = self.scheduler.open_file(&path, &cached_size).await?;
         match current_reader::FileReader::try_open(
             file_scheduler,
             None,
@@ -295,6 +311,30 @@ impl IndexStore for LanceIndexStore {
     async fn delete_index_file(&self, name: &str) -> Result<()> {
         let path = self.index_dir.child(name);
         self.object_store.delete(&path).await
+    }
+}
+
+impl LanceIndexStore {
+    /// List all files in the index directory with their sizes.
+    ///
+    /// Returns a list of (relative_path, size_bytes) tuples.
+    pub async fn list_files_with_sizes(&self) -> Result<Vec<(String, u64)>> {
+        use futures::stream::StreamExt;
+
+        let mut files = Vec::new();
+        let mut stream = self.object_store.read_dir_all(&self.index_dir, None);
+        while let Some(meta) = stream.next().await {
+            let meta = meta?;
+            // Get relative path by stripping the index_dir prefix
+            let relative_path = meta
+                .location
+                .as_ref()
+                .strip_prefix(self.index_dir.as_ref())
+                .map(|s| s.trim_start_matches('/').to_string())
+                .unwrap_or_else(|| meta.location.filename().unwrap_or("").to_string());
+            files.push((relative_path, meta.size));
+        }
+        Ok(files)
     }
 }
 

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -515,6 +515,7 @@ impl ScalarIndex for NGramIndex {
             index_details: prost_types::Any::from_msg(&pbold::NGramIndexDetails::default())
                 .unwrap(),
             index_version: NGRAM_INDEX_VERSION,
+            files: None,
         })
     }
 
@@ -534,6 +535,7 @@ impl ScalarIndex for NGramIndex {
             index_details: prost_types::Any::from_msg(&pbold::NGramIndexDetails::default())
                 .unwrap(),
             index_version: NGRAM_INDEX_VERSION,
+            files: None,
         })
     }
 
@@ -1309,6 +1311,7 @@ impl ScalarIndexPlugin for NGramIndexPlugin {
             index_details: prost_types::Any::from_msg(&pbold::NGramIndexDetails::default())
                 .unwrap(),
             index_version: NGRAM_INDEX_VERSION,
+            files: None,
         })
     }
 

--- a/rust/lance-index/src/scalar/zonemap.rs
+++ b/rust/lance-index/src/scalar/zonemap.rs
@@ -585,6 +585,7 @@ impl ScalarIndex for ZoneMapIndex {
             index_details: prost_types::Any::from_msg(&pbold::ZoneMapIndexDetails::default())
                 .unwrap(),
             index_version: ZONEMAP_INDEX_VERSION,
+            files: None,
         })
     }
 
@@ -918,6 +919,7 @@ impl ScalarIndexPlugin for ZoneMapIndexPlugin {
             index_details: prost_types::Any::from_msg(&pbold::ZoneMapIndexDetails::default())
                 .unwrap(),
             index_version: ZONEMAP_INDEX_VERSION,
+            files: None,
         })
     }
 

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -116,6 +116,12 @@ pub trait IndexDescription: Send + Sync {
     /// plugin.  As a result, this method may fail if there is no plugin
     /// available for the index.
     fn details(&self) -> Result<String>;
+
+    /// Returns the total size in bytes of all files across all segments.
+    ///
+    /// Returns `None` if file size information is not available for any segment
+    /// (for backward compatibility with indices created before file tracking was added).
+    fn total_size_bytes(&self) -> Option<u64>;
 }
 
 // Extends Lance Dataset with secondary index.

--- a/rust/lance-table/src/format.rs
+++ b/rust/lance-table/src/format.rs
@@ -14,7 +14,7 @@ pub use crate::rowids::version::{
     RowDatasetVersionMeta, RowDatasetVersionRun, RowDatasetVersionSequence,
 };
 pub use fragment::*;
-pub use index::IndexMetadata;
+pub use index::{IndexFile, IndexMetadata};
 
 pub use manifest::{
     is_detached_version, BasePath, DataStorageFormat, Manifest, SelfDescribingFileReader,

--- a/rust/lance-table/src/format/index.rs
+++ b/rust/lance-table/src/format/index.rs
@@ -3,6 +3,7 @@
 
 //! Metadata for index
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
@@ -13,6 +14,15 @@ use uuid::Uuid;
 
 use super::pb;
 use lance_core::{Error, Result};
+
+/// Metadata about a single file within an index segment.
+#[derive(Debug, Clone, PartialEq, DeepSizeOf)]
+pub struct IndexFile {
+    /// Path relative to the index directory (e.g., "index.idx", "auxiliary.idx")
+    pub path: String,
+    /// Size of the file in bytes
+    pub size_bytes: u64,
+}
 
 /// Index metadata
 #[derive(Debug, Clone, PartialEq)]
@@ -57,6 +67,12 @@ pub struct IndexMetadata {
     /// The base path index of the index files. Used when the index is imported or referred from another dataset.
     /// Lance uses it as key of the base_paths field in Manifest to determine the actual base path of the index files.
     pub base_id: Option<u32>,
+
+    /// List of files and their sizes for this index segment.
+    /// This enables skipping HEAD calls when opening indices and provides
+    /// visibility into index storage size via describe_indices().
+    /// This is None for indices created before this field was added.
+    pub files: Option<Vec<IndexFile>>,
 }
 
 impl IndexMetadata {
@@ -66,6 +82,28 @@ impl IndexMetadata {
     ) -> Option<RoaringBitmap> {
         let fragment_bitmap = self.fragment_bitmap.as_ref()?;
         Some(fragment_bitmap & existing_fragments)
+    }
+
+    /// Returns a map of relative file paths to their sizes.
+    /// Returns an empty map if file information is not available.
+    pub fn file_size_map(&self) -> HashMap<String, u64> {
+        self.files
+            .as_ref()
+            .map(|files| {
+                files
+                    .iter()
+                    .map(|f| (f.path.clone(), f.size_bytes))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Returns the total size of all files in this index segment in bytes.
+    /// Returns None if file information is not available.
+    pub fn total_size_bytes(&self) -> Option<u64> {
+        self.files
+            .as_ref()
+            .map(|files| files.iter().map(|f| f.size_bytes).sum())
     }
 }
 
@@ -80,6 +118,7 @@ impl DeepSizeOf for IndexMetadata {
                 .as_ref()
                 .map(|fragment_bitmap| fragment_bitmap.serialized_size())
                 .unwrap_or(0)
+            + self.files.deep_size_of_children(context)
     }
 }
 
@@ -93,6 +132,21 @@ impl TryFrom<pb::IndexMetadata> for IndexMetadata {
             Some(RoaringBitmap::deserialize_from(
                 &mut proto.fragment_bitmap.as_slice(),
             )?)
+        };
+
+        let files = if proto.files.is_empty() {
+            None
+        } else {
+            Some(
+                proto
+                    .files
+                    .into_iter()
+                    .map(|f| IndexFile {
+                        path: f.path,
+                        size_bytes: f.size_bytes,
+                    })
+                    .collect(),
+            )
         };
 
         Ok(Self {
@@ -113,6 +167,7 @@ impl TryFrom<pb::IndexMetadata> for IndexMetadata {
                     .expect("Invalid timestamp in index metadata")
             }),
             base_id: proto.base_id,
+            files,
         })
     }
 }
@@ -129,6 +184,20 @@ impl From<&IndexMetadata> for pb::IndexMetadata {
             }
         }
 
+        let files = idx
+            .files
+            .as_ref()
+            .map(|files| {
+                files
+                    .iter()
+                    .map(|f| pb::IndexFile {
+                        path: f.path.clone(),
+                        size_bytes: f.size_bytes,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
         Self {
             uuid: Some((&idx.uuid).into()),
             name: idx.name.clone(),
@@ -142,6 +211,7 @@ impl From<&IndexMetadata> for pb::IndexMetadata {
             index_version: Some(idx.index_version),
             created_at: idx.created_at.map(|dt| dt.timestamp_millis() as u64),
             base_id: idx.base_id,
+            files,
         }
     }
 }

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -148,10 +148,8 @@ impl LanceIndexStoreExt for LanceIndexStore {
             .indice_files_dir(index)?
             .child(index.uuid.to_string());
         let cache = dataset.metadata_cache.file_metadata_cache(&index_dir);
-        Ok(Self::new(
-            dataset.object_store.clone(),
-            index_dir,
-            Arc::new(cache),
-        ))
+        let store = Self::new(dataset.object_store.clone(), index_dir, Arc::new(cache));
+        // Apply cached file sizes if available
+        Ok(store.with_file_sizes(index.file_size_map()))
     }
 }

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -284,6 +284,7 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                     index_version: curr_index_meta.index_version,
                     created_at: curr_index_meta.created_at,
                     base_id: None,
+                    files: curr_index_meta.files.clone(),
                 },
                 RemapResult::Remapped(remapped_index) => IndexMetadata {
                     uuid: remapped_index.new_id,
@@ -295,6 +296,8 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                     index_version: remapped_index.index_version as i32,
                     created_at: curr_index_meta.created_at,
                     base_id: None,
+                    // TODO: Capture file sizes after remapping
+                    files: None,
                 },
             };
 

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -3947,6 +3947,7 @@ mod tests {
             index_version: 1,
             created_at: None,
             base_id: None,
+            files: None,
         }
     }
 
@@ -3968,6 +3969,7 @@ mod tests {
             index_version: 1,
             created_at: None,
             base_id: None,
+            files: None,
         }
     }
 

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -360,6 +360,7 @@ pub(crate) async fn remap_index(
                 )
                 .unwrap(),
                 index_version: VECTOR_INDEX_VERSION,
+                files: None, // No file info for remapped indices
             }
         }
         _ => {
@@ -535,6 +536,18 @@ impl IndexDescription for IndexDescriptionImpl {
         plugin
             .details_as_json(&self.details.0)
             .map(|v| v.to_string())
+    }
+
+    fn total_size_bytes(&self) -> Option<u64> {
+        let mut total = 0u64;
+        for segment in &self.segments {
+            // If any segment is missing file info, return None for backward compatibility
+            let files = segment.files.as_ref()?;
+            for file in files {
+                total += file.size_bytes;
+            }
+        }
+        Some(total)
     }
 }
 
@@ -760,6 +773,7 @@ impl DatasetIndexExt for Dataset {
             index_version: 0,
             created_at: Some(chrono::Utc::now()),
             base_id: None, // New indices don't have base_id (they're not from shallow clone)
+            files: None,   // File info will be populated when index is created
         };
 
         let transaction = Transaction::new(
@@ -879,7 +893,8 @@ impl DatasetIndexExt for Dataset {
                 index_details: Some(Arc::new(res.new_index_details)),
                 index_version: res.new_index_version,
                 created_at: Some(chrono::Utc::now()),
-                base_id: None, // Mew merged index file locates in the cloned dataset.
+                base_id: None, // New merged index file locates in the cloned dataset.
+                files: res.files,
             };
             removed_indices.extend(res.removed_indices.iter().map(|&idx| idx.clone()));
             if deltas.len() > res.removed_indices.len() {
@@ -1373,9 +1388,12 @@ impl DatasetIndexInternalExt for Dataset {
                     self.object_store.clone(),
                     SchedulerConfig::max_bandwidth(&self.object_store),
                 );
-                let file = scheduler
-                    .open_file(&index_file, &CachedFileSize::unknown())
-                    .await?;
+                let file_sizes = index_meta.file_size_map();
+                let cached_size = file_sizes
+                    .get(INDEX_FILE_NAME)
+                    .map(|&size| CachedFileSize::new(size))
+                    .unwrap_or_else(CachedFileSize::unknown);
+                let file = scheduler.open_file(&index_file, &cached_size).await?;
                 let reader = lance_file::reader::FileReader::try_open(
                     file,
                     None,
@@ -5207,5 +5225,185 @@ mod tests {
             field_path2.contains('.'),
             "Field path should contain '.' for nested field"
         );
+    }
+
+    #[tokio::test]
+    async fn test_scalar_index_file_sizes_captured() {
+        // Test that file sizes are captured when creating a scalar index
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("values", DataType::Utf8, false),
+        ]));
+
+        let values = StringArray::from_iter_values(["hello", "world", "foo", "bar"]);
+        let record_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..4)),
+                Arc::new(values),
+            ],
+        )
+        .unwrap();
+
+        let reader =
+            RecordBatchIterator::new(vec![record_batch].into_iter().map(Ok), schema.clone());
+
+        let mut dataset = Dataset::write(reader, "memory://", None).await.unwrap();
+
+        // Create a scalar index
+        dataset
+            .create_index(
+                &["values"],
+                IndexType::Scalar,
+                Some("test_idx".to_string()),
+                &ScalarIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+
+        // Get index metadata and verify files are populated
+        let indices = dataset.load_indices().await.unwrap();
+        let test_index = indices.iter().find(|idx| idx.name == "test_idx").unwrap();
+
+        assert!(
+            test_index.files.is_some(),
+            "Index should have files populated"
+        );
+        let files = test_index.files.as_ref().unwrap();
+        assert!(!files.is_empty(), "Index should have at least one file");
+
+        // Verify each file has a positive size
+        for file in files {
+            assert!(
+                file.size_bytes > 0,
+                "File {} should have positive size",
+                file.path
+            );
+        }
+
+        // Verify total_size_bytes works
+        let total_size = test_index.total_size_bytes();
+        assert!(total_size.is_some(), "total_size_bytes should return Some");
+        assert!(total_size.unwrap() > 0, "Total size should be positive");
+    }
+
+    #[tokio::test]
+    async fn test_vector_index_file_sizes_captured() {
+        // Test that file sizes are captured when creating a vector index
+        let num_rows = 300;
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 4),
+                false,
+            ),
+        ]));
+
+        let float_arr = generate_random_array(4 * num_rows);
+        let vectors = FixedSizeListArray::try_new_from_values(float_arr, 4).unwrap();
+        let record_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..num_rows as i32)),
+                Arc::new(vectors),
+            ],
+        )
+        .unwrap();
+
+        let reader =
+            RecordBatchIterator::new(vec![record_batch].into_iter().map(Ok), schema.clone());
+
+        let mut dataset = Dataset::write(reader, "memory://", None).await.unwrap();
+
+        // Create vector index
+        let params = VectorIndexParams::ivf_pq(1, 8, 2, MetricType::L2, 2);
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some("test_vec_idx".to_string()),
+                &params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        // Get index metadata and verify files are populated
+        let indices = dataset.load_indices().await.unwrap();
+        let test_index = indices
+            .iter()
+            .find(|idx| idx.name == "test_vec_idx")
+            .unwrap();
+
+        assert!(
+            test_index.files.is_some(),
+            "Index should have files populated"
+        );
+        let files = test_index.files.as_ref().unwrap();
+        assert!(!files.is_empty(), "Index should have at least one file");
+
+        // Verify each file has a positive size
+        for file in files {
+            assert!(
+                file.size_bytes > 0,
+                "File {} should have positive size",
+                file.path
+            );
+        }
+
+        // Verify total_size_bytes works
+        let total_size = test_index.total_size_bytes();
+        assert!(total_size.is_some(), "total_size_bytes should return Some");
+        assert!(total_size.unwrap() > 0, "Total size should be positive");
+    }
+
+    #[tokio::test]
+    async fn test_describe_indices_total_size() {
+        // Test that describe_indices returns total_size_bytes
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("values", DataType::Utf8, false),
+        ]));
+
+        let values = StringArray::from_iter_values(["hello", "world", "foo", "bar"]);
+        let record_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..4)),
+                Arc::new(values),
+            ],
+        )
+        .unwrap();
+
+        let reader =
+            RecordBatchIterator::new(vec![record_batch].into_iter().map(Ok), schema.clone());
+
+        let mut dataset = Dataset::write(reader, "memory://", None).await.unwrap();
+
+        // Create a scalar index
+        dataset
+            .create_index(
+                &["values"],
+                IndexType::Scalar,
+                Some("test_idx".to_string()),
+                &ScalarIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+
+        // Use describe_indices to get index info
+        let descriptions = dataset.describe_indices(None).await.unwrap();
+        assert_eq!(descriptions.len(), 1);
+
+        let desc = &descriptions[0];
+        assert_eq!(desc.name(), "test_idx");
+
+        // Verify total_size_bytes is available
+        let total_size = desc.total_size_bytes();
+        assert!(total_size.is_some(), "total_size_bytes should be Some");
+        assert!(total_size.unwrap() > 0, "Total size should be positive");
     }
 }

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -29,6 +29,8 @@ pub struct IndexMergeResults<'a> {
     pub new_fragment_bitmap: RoaringBitmap,
     pub new_index_version: i32,
     pub new_index_details: prost_types::Any,
+    /// List of files and their sizes for the merged index
+    pub files: Option<Vec<lance_table::format::IndexFile>>,
 }
 
 /// Merge in-inflight unindexed data, with a specific number of previous indices
@@ -188,6 +190,7 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
                 CreatedIndex {
                     index_details: vector_index_details(),
                     index_version: VECTOR_INDEX_VERSION,
+                    files: None,
                 },
             ))
         }
@@ -211,6 +214,8 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
         new_fragment_bitmap: frag_bitmap,
         new_index_version: created_index.index_version as i32,
         new_index_details: created_index.index_details,
+        // TODO: Capture file sizes during merge
+        files: None,
     }))
 }
 

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -16,12 +16,16 @@ use crate::{
     Error, Result,
 };
 use futures::future::BoxFuture;
+use futures::StreamExt;
 use lance_index::{
     metrics::NoOpMetricsCollector,
     scalar::{inverted::tokenizer::InvertedIndexParams, ScalarIndexParams, LANCE_SCALAR_INDEX},
 };
-use lance_index::{scalar::CreatedIndex, IndexParams, IndexType, VECTOR_INDEX_VERSION};
+use lance_index::{
+    scalar::CreatedIndex, scalar::IndexFile, IndexParams, IndexType, VECTOR_INDEX_VERSION,
+};
 use lance_table::format::IndexMetadata;
+use object_store::path::Path;
 use snafu::location;
 use std::{future::IntoFuture, sync::Arc};
 use tracing::instrument;
@@ -293,9 +297,13 @@ impl<'a> CreateIndexBuilder<'a> {
                     )
                     .await?;
                 }
+                // Capture file sizes after vector index creation
+                let index_dir = self.dataset.indices_dir().child(index_id.to_string());
+                let files = list_index_files_with_sizes(self.dataset, &index_dir).await?;
                 CreatedIndex {
                     index_details: vector_index_details(),
                     index_version: VECTOR_INDEX_VERSION,
+                    files: Some(files),
                 }
             }
             // Can't use if let Some(...) here because it's not stable yet.
@@ -328,9 +336,13 @@ impl<'a> CreateIndexBuilder<'a> {
                 } else {
                     todo!("create empty vector index when train=false");
                 }
+                // Capture file sizes after vector index creation
+                let index_dir = self.dataset.indices_dir().child(index_id.to_string());
+                let files = list_index_files_with_sizes(self.dataset, &index_dir).await?;
                 CreatedIndex {
                     index_details: vector_index_details(),
                     index_version: VECTOR_INDEX_VERSION,
+                    files: Some(files),
                 }
             }
             (IndexType::FragmentReuse, _) => {
@@ -374,6 +386,15 @@ impl<'a> CreateIndexBuilder<'a> {
             index_version: created_index.index_version as i32,
             created_at: Some(chrono::Utc::now()),
             base_id: None,
+            files: created_index.files.map(|files| {
+                files
+                    .into_iter()
+                    .map(|f| lance_table::format::IndexFile {
+                        path: f.path,
+                        size_bytes: f.size_bytes,
+                    })
+                    .collect()
+            }),
         })
     }
 
@@ -395,6 +416,30 @@ impl<'a> CreateIndexBuilder<'a> {
 
         Ok(())
     }
+}
+
+/// List all files in an index directory with their sizes.
+async fn list_index_files_with_sizes(
+    dataset: &Dataset,
+    index_dir: &Path,
+) -> Result<Vec<IndexFile>> {
+    let mut files = Vec::new();
+    let mut stream = dataset.object_store.read_dir_all(index_dir, None);
+    while let Some(meta) = stream.next().await {
+        let meta = meta?;
+        // Get relative path by stripping the index_dir prefix
+        let relative_path = meta
+            .location
+            .as_ref()
+            .strip_prefix(index_dir.as_ref())
+            .map(|s| s.trim_start_matches('/').to_string())
+            .unwrap_or_else(|| meta.location.filename().unwrap_or("").to_string());
+        files.push(IndexFile {
+            path: relative_path,
+            size_bytes: meta.size,
+        });
+    }
+    Ok(files)
 }
 
 impl<'a> IntoFuture for CreateIndexBuilder<'a> {

--- a/rust/lance/src/index/frag_reuse.rs
+++ b/rust/lance/src/index/frag_reuse.rs
@@ -177,5 +177,7 @@ pub(crate) async fn build_frag_reuse_index_metadata(
         index_version: index_meta.map_or(0, |index_meta| index_meta.index_version),
         created_at: Some(chrono::Utc::now()),
         base_id: None,
+        // Fragment reuse index is inline (no files)
+        files: None,
     })
 }

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -558,6 +558,8 @@ pub(crate) fn new_mem_wal_index_meta(
         index_version: 0,
         created_at: Some(chrono::Utc::now()),
         base_id: None,
+        // Memory WAL index is inline (no files)
+        files: None,
     })
 }
 

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -286,9 +286,20 @@ pub(super) async fn build_scalar_index(
         preprocessed_data.unwrap()
     };
 
-    plugin
+    let mut created_index = plugin
         .train_index(training_data, &index_store, training_request, fragment_ids)
-        .await
+        .await?;
+
+    // Capture file sizes after index creation
+    let file_sizes = index_store.list_files_with_sizes().await?;
+    created_index.files = Some(
+        file_sizes
+            .into_iter()
+            .map(|(path, size_bytes)| lance_index::scalar::IndexFile { path, size_bytes })
+            .collect(),
+    );
+
+    Ok(created_index)
 }
 
 /// Fetches the scalar index plugin for a given index metadata
@@ -580,6 +591,7 @@ mod tests {
             index_version: 0,
             created_at: None,
             base_id: None,
+            files: None,
         }
     }
 

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -1181,6 +1181,8 @@ pub async fn initialize_vector_index(
         index_version: VECTOR_INDEX_VERSION as i32,
         created_at: Some(chrono::Utc::now()),
         base_id: None,
+        // TODO: Capture file sizes when adding vector index
+        files: None,
     };
 
     let transaction = Transaction::new(

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -2386,6 +2386,7 @@ mod tests {
             index_version: VECTOR_INDEX_VERSION as i32,
             created_at: Some(chrono::Utc::now()),
             base_id: None,
+            files: None,
         };
 
         // We need to commit this index to the dataset so that it can be found
@@ -2424,6 +2425,7 @@ mod tests {
             index_version: VECTOR_INDEX_VERSION as i32,
             created_at: None, // Test index, not setting timestamp
             base_id: None,
+            files: None,
         };
 
         let prefilter = Arc::new(DatasetPreFilter::new(dataset.clone(), &[index_meta], None));
@@ -2489,6 +2491,7 @@ mod tests {
             index_version: VECTOR_INDEX_VERSION as i32,
             created_at: Some(chrono::Utc::now()),
             base_id: None,
+            files: None,
         };
 
         // We need to commit this new index to the dataset so it can be found

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -2180,6 +2180,7 @@ mod tests {
             index_version: 0,
             created_at: None, // Test index, not setting timestamp
             base_id: None,
+            files: None,
         };
         let fragment0 = Fragment::new(0);
         let fragment1 = Fragment::new(1);


### PR DESCRIPTION
## Summary
- Add a new `files` field to `IndexMetadata` that stores a list of all files (with sizes) per index segment
- Use cached file sizes when opening indices to skip HEAD calls
- Expose total index size via `describe_indices()` and Python bindings

## Test plan
- [x] Added `test_index_file_sizes_captured` for scalar indices
- [x] Added `test_vector_index_file_sizes_captured` for vector indices
- [x] All existing index tests pass
- [ ] Manual testing with cloud storage to verify HEAD calls are reduced

Fixes #5226

🤖 Generated with [Claude Code](https://claude.com/claude-code)