### PR TITLE
feat(python): expose search_filter in scanner

### DIFF
--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -61,6 +61,7 @@ from .fragment import (
     RowIdMeta as RowIdMeta,
 )
 from .indices import IndexDescription as IndexDescription
+from .lance import PySearchFilter
 from .optimize import (
     Compaction as Compaction,
 )
@@ -223,6 +224,7 @@ class _Dataset:
         columns: Optional[List[str]] = None,
         columns_with_transform: Optional[List[Tuple[str, str]]] = None,
         filter: Optional[str] = None,
+        search_filter: Optional[PySearchFilter] = None,
         prefilter: Optional[bool] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None,

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -4273,3 +4273,122 @@ def test_describe_indices(tmp_path):
     indices = ds.describe_indices()
     for index in indices:
         assert index.num_rows_indexed == 50
+
+
+def test_vector_filter_fts_search(tmp_path):
+    # Create test data
+    ids = list(range(1, 301))
+    vectors = [[float(i)] * 4 for i in ids]
+
+    # Create text data:
+    #   "text <i>" for ids 1-255, 299, 300,
+    #   "noop <i>" for 256-298,
+    texts = []
+    for i in ids:
+        if i <= 255:
+            texts.append(f"text {i}")
+        elif i <= 298:
+            texts.append(f"noop {i}")
+        else:
+            texts.append(f"text {i}")
+
+    categories = []
+    for i in ids:
+        if i % 3 == 1:
+            categories.append("literature")
+        elif i % 3 == 2:
+            categories.append("science")
+        else:
+            categories.append("geography")
+
+    table = pa.table(
+        {
+            "id": ids,
+            "vector": pa.array(vectors, type=pa.list_(pa.float32(), 4)),
+            "text": texts,
+            "category": categories,
+        }
+    )
+
+    # Write dataset and create indices
+    ds = lance.write_dataset(table, tmp_path)
+
+    ds = ds.create_index(
+        "vector",
+        index_type="IVF_PQ",
+        num_partitions=2,
+        num_sub_vectors=4,
+    )
+    ds.create_scalar_index("text", index_type="INVERTED", with_position=True)
+
+    # Create vector_query
+    vector_query = {
+        "column": "vector",
+        "q": np.array([300, 300, 300, 300], dtype=np.float32),
+        "k": 5,
+        "minimum_nprobes": 20,
+        "use_index": True,
+    }
+
+    # Case 1: search with prefilter=true, query_filter=vector([300,300,300,300])
+    scanner = ds.scanner(
+        prefilter=False, nearest=vector_query, filter=MatchQuery("text", "text")
+    )
+    result = scanner.to_table()
+    assert [300, 299] == result["id"].to_pylist()
+
+    # Case 2: search with prefilter=true, search_filter=match("text"),
+    #         filter="category='geography'"
+    scanner = ds.scanner(
+        prefilter=True,
+        nearest=vector_query,
+        filter={
+            "expr_filter": "category='geography'",
+            "search_filter": MatchQuery("text", "text"),
+        },
+    )
+    result = scanner.to_table()
+    assert [300, 255, 252, 249, 246] == result["id"].to_pylist()
+
+    # Case 3: search with prefilter=false, search_filter=match("text")
+    scanner = ds.scanner(
+        prefilter=False,
+        nearest=vector_query,
+        filter=MatchQuery("text", "text"),
+    )
+    result = scanner.to_table()
+    assert [300, 299] == result["id"].to_pylist()
+
+    # Case 4: search with prefilter=false, search_filter=match("text"),
+    #       filter="category='geography'"
+    scanner = ds.scanner(
+        prefilter=False,
+        nearest=vector_query,
+        filter={
+            "expr_filter": "category='geography'",
+            "search_filter": MatchQuery("text", "text"),
+        },
+    )
+    result = scanner.to_table()
+    assert [300] == result["id"].to_pylist()
+
+    # Case 5: search with prefilter=false, search_filter=phrase("text")
+    scanner = ds.scanner(
+        prefilter=False,
+        nearest=vector_query,
+        filter=PhraseQuery("text", "text"),
+    )
+    result = scanner.to_table()
+    assert [299, 300] == result["id"].to_pylist()
+
+    # Case 6: search with prefilter=false, search_filter=phrase("text")
+    scanner = ds.scanner(
+        prefilter=False,
+        nearest=vector_query,
+        filter={
+            "expr_filter": "category='geography'",
+            "search_filter": PhraseQuery("text", "text"),
+        },
+    )
+    result = scanner.to_table()
+    assert [300] == result["id"].to_pylist()

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -43,7 +43,7 @@ use dataset::io_stats::IoStats;
 use dataset::optimize::{
     PyCompaction, PyCompactionMetrics, PyCompactionPlan, PyCompactionTask, PyRewriteResult,
 };
-use dataset::{DatasetBasePath, MergeInsertBuilder, PyFullTextQuery};
+use dataset::{DatasetBasePath, MergeInsertBuilder, PyFullTextQuery, PySearchFilter};
 use env_logger::{Builder, Env};
 use file::{
     stable_version, LanceBufferDescriptor, LanceColumnMetadata, LanceFileMetadata, LanceFileReader,
@@ -276,6 +276,7 @@ fn lance(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<TraceGuard>()?;
     m.add_class::<schema::LanceSchema>()?;
     m.add_class::<PyFullTextQuery>()?;
+    m.add_class::<PySearchFilter>()?;
     m.add_class::<namespace::PyDirectoryNamespace>()?;
     m.add_class::<namespace::PyRestNamespace>()?;
     m.add_class::<namespace::PyRestAdapter>()?;


### PR DESCRIPTION
Adding python api to support using fts as a filter for vector search, or using vector_query as a filter for fts search. Related to https://github.com/lance-format/lance/pull/4928.