### PR TITLE
feat(memtest): add macos support

### DIFF
--- a/memtest/Makefile
+++ b/memtest/Makefile
@@ -1,8 +1,17 @@
 .PHONY: build test lint format clean
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+LIB_FILE := libmemtest.dylib
+PRELOAD_ENV := DYLD_INSERT_LIBRARIES
+else
+LIB_FILE := libmemtest.so
+PRELOAD_ENV := LD_PRELOAD
+endif
+
 build:
 	cargo build
-	cp target/debug/libmemtest.so python/memtest/
+	cp target/debug/$(LIB_FILE) python/memtest/
 	pip install -e .
 
 build-release:
@@ -11,7 +20,7 @@ build-release:
 	pip install -e .
 
 test:
-	LD_PRELOAD=./python/memtest/libmemtest.so pytest python/tests/ -v
+	$(PRELOAD_ENV)=./python/memtest/$(LIB_FILE) pytest python/tests/ -v
 
 lint:
 	cargo clippy -- -D warnings
@@ -27,3 +36,4 @@ clean:
 	find . -type d -name __pycache__ -exec rm -rf {} +
 	find . -type f -name "*.pyc" -delete
 	find . -type f -name "*.so" -delete
+	find . -type f -name "*.dylib" -delete

--- a/memtest/README.md
+++ b/memtest/README.md
@@ -16,6 +16,12 @@ To activate the memory tracking, you need to set the `LD_PRELOAD` environment va
 export LD_PRELOAD=$(lance-memtest)
 ```
 
+On macOS, use `DYLD_INSERT_LIBRARIES` instead:
+
+```shell
+export DYLD_INSERT_LIBRARIES=$(lance-memtest)
+```
+
 Then you can write Python code that tracks memory allocations:
 
 ```python

--- a/memtest/python/memtest/__main__.py
+++ b/memtest/python/memtest/__main__.py
@@ -1,7 +1,7 @@
 """CLI for lance-memtest."""
 
 import sys
-from memtest import get_library_path
+import memtest
 
 
 def main():
@@ -9,7 +9,7 @@ def main():
     args = sys.argv[1:]
 
     if not args or args[0] == "path":
-        lib_path = get_library_path()
+        lib_path = memtest.get_library_path()
         if lib_path is None:
             print(
                 "lance-memtest is not supported on this platform",
@@ -18,9 +18,15 @@ def main():
             return 1
         print(lib_path)
         return 0
+    if args[0] == "stats":
+        memtest.print_stats()
+        return 0
+    if args[0] == "reset":
+        memtest.reset_stats()
+        return 0
     else:
         print(f"Unknown command: {args[0]}", file=sys.stderr)
-        print("Usage: lance-memtest [path]", file=sys.stderr)
+        print("Usage: lance-memtest [path|stats|reset]", file=sys.stderr)
         return 1
 
 

--- a/memtest/python/tests/test_basic.py
+++ b/memtest/python/tests/test_basic.py
@@ -1,5 +1,6 @@
 """Basic tests for memtest functionality."""
 
+import platform
 import subprocess
 import sys
 
@@ -10,7 +11,10 @@ def test_get_library_path():
     """Test that we can get the library path."""
     lib_path = memtest.get_library_path()
     assert lib_path.exists()
-    assert lib_path.suffix == ".so"
+    if platform.system() == "Linux":
+        assert lib_path.suffix == ".so"
+    else:
+        assert lib_path.suffix == ".dylib"
 
 
 def test_get_stats():
@@ -110,7 +114,10 @@ def test_cli_path():
     )
 
     assert result.returncode == 0
-    assert ".so" in result.stdout
+    if platform.system() == "Linux":
+        assert ".so" in result.stdout
+    else:
+        assert ".dylib" in result.stdout
 
 
 def test_cli_stats():

--- a/memtest/python/tests/test_integration.py
+++ b/memtest/python/tests/test_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for memtest with real allocations."""
 
 import os
+import platform
 import subprocess
 import sys
 import tempfile
@@ -10,7 +11,7 @@ import memtest
 
 
 def test_preload_environment():
-    """Test that LD_PRELOAD works correctly."""
+    """Test that preloading works correctly."""
     lib_path = memtest.get_library_path()
 
     # Create a small Python script that uses memtest
@@ -36,7 +37,10 @@ assert stats['total_bytes_allocated'] > 0, "Should see bytes allocated"
 
     try:
         env = os.environ.copy()
-        env["LD_PRELOAD"] = str(lib_path)
+        if platform.system() == "Linux":
+            env["LD_PRELOAD"] = str(lib_path)
+        else:
+            env["DYLD_INSERT_LIBRARIES"] = str(lib_path)
 
         result = subprocess.run(
             [sys.executable, script_path],


### PR DESCRIPTION
This PR adds macOS support for the memtest tool, enabling it to run on macOS.

```shell
> cd memtest && DYLD_INSERT_LIBRARIES=./python/memtest/libmemtest.dylib ./.venv/bin/python -c "import memtest; memtest.print_stats()"

Memory Allocation Statistics:
  Total allocations:     5,128
  Total deallocations:   1,898
  Total bytes allocated: 12.6 MB
  Total bytes freed:     9.9 MB
  Current memory usage:  2.6 MB
  Peak memory usage:     2.8 MB
```

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**