### PR TITLE
chore: clean up the residual FTS hardcode for index

### DIFF
--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1800,7 +1800,7 @@ impl Dataset {
             "ZONEMAP" => IndexType::ZoneMap,
             "BLOOMFILTER" => IndexType::BloomFilter,
             "LABEL_LIST" => IndexType::LabelList,
-            "INVERTED" | "FTS" => IndexType::Inverted,
+            "INVERTED" => IndexType::Inverted,
             "IVF_FLAT" | "IVF_PQ" | "IVF_SQ" | "IVF_RQ" | "IVF_HNSW_FLAT" | "IVF_HNSW_PQ"
             | "IVF_HNSW_SQ" => IndexType::Vector,
             _ => {
@@ -1853,7 +1853,7 @@ impl Dataset {
                     params: Some(config.config.clone()),
                 })
             }
-            "INVERTED" | "FTS" => {
+            "INVERTED" => {
                 let mut params = InvertedIndexParams::default();
                 if let Some(kwargs) = kwargs {
                     if let Some(with_position) = kwargs.get_item("with_position")? {


### PR DESCRIPTION
Before,  there were two names that mapped to the FTX index they are `INVERTED`, `FTS`.  At some time, the code has been refactored only to use `INVERTED`. But there are still some residual `FTS` hardcodes that need to be cleaned.