### PR TITLE
fix: infer multivector sampling rows

### DIFF
--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -542,7 +542,9 @@ mod tests {
             .await
             .unwrap();
 
-        let training_data = maybe_sample_training_data(&dataset, "mv", 1000).await.unwrap();
+        let training_data = maybe_sample_training_data(&dataset, "mv", 1000)
+            .await
+            .unwrap();
         assert_eq!(training_data.len(), 1000);
     }
 


### PR DESCRIPTION
Replace fixed 1030 assumption when sampling multivector rows for index training by inferring vectors-per-row from a non-null example. Fall back to n=1030 if no non-empty value is found. Adds unit tests for inferred n and fallback behavior.