### PR TITLE
fix: allow storage options provider without expires_at_millis

### DIFF
--- a/java/src/main/java/org/lance/namespace/LanceNamespaceStorageOptionsProvider.java
+++ b/java/src/main/java/org/lance/namespace/LanceNamespaceStorageOptionsProvider.java
@@ -73,11 +73,13 @@ public class LanceNamespaceStorageOptionsProvider implements StorageOptionsProvi
   /**
    * Fetch credentials from the namespace.
    *
-   * <p>This calls namespace.describeTable() to get the latest credentials and their expiration
-   * time.
+   * <p>This calls namespace.describeTable() to get the latest credentials and optionally their
+   * expiration time.
    *
-   * @return Flat map of string key-value pairs containing credentials and expires_at_millis
-   * @throws RuntimeException if the namespace doesn't return storage credentials or expiration time
+   * @return Flat map of string key-value pairs containing credentials. May optionally include
+   *     expires_at_millis. If expires_at_millis is not provided, credentials are treated as
+   *     non-expiring and will not be automatically refreshed.
+   * @throws RuntimeException if the namespace doesn't return storage credentials
    */
   @Override
   public Map<String, String> fetchStorageOptions() {
@@ -96,14 +98,9 @@ public class LanceNamespaceStorageOptionsProvider implements StorageOptionsProvi
               + "Ensure the namespace supports credential vending.");
     }
 
-    // Verify expires_at_millis is present
-    if (!storageOptions.containsKey("expires_at_millis")) {
-      throw new RuntimeException(
-          "Namespace storage_options missing 'expires_at_millis'. "
-              + "Credential refresh will not work properly.");
-    }
-
     // Return storage_options directly - it's already a flat Map<String, String>
+    // Note: expires_at_millis is optional. If not provided, credentials are treated
+    // as non-expiring and will not be automatically refreshed.
     return storageOptions;
   }
 

--- a/python/python/lance/namespace.py
+++ b/python/python/lance/namespace.py
@@ -448,18 +448,20 @@ class LanceNamespaceStorageOptionsProvider(StorageOptionsProvider):
         """Fetch storage options from the namespace.
 
         This calls namespace.describe_table() to get the latest storage options
-        and their expiration time.
+        and optionally their expiration time.
 
         Returns
         -------
         Dict[str, str]
-            Flat dictionary of string key-value pairs containing storage options
-            and expires_at_millis
+            Flat dictionary of string key-value pairs containing storage options.
+            May optionally include expires_at_millis. If expires_at_millis is not
+            provided, credentials are treated as non-expiring and will not be
+            automatically refreshed.
 
         Raises
         ------
         RuntimeError
-            If the namespace doesn't return storage options or expiration time
+            If the namespace doesn't return storage options
         """
         request = DescribeTableRequest(id=self._table_id, version=None)
         response = self._namespace.describe_table(request)
@@ -470,14 +472,9 @@ class LanceNamespaceStorageOptionsProvider(StorageOptionsProvider):
                 "Ensure the namespace supports storage options providing."
             )
 
-        # Verify expires_at_millis is present
-        if "expires_at_millis" not in storage_options:
-            raise RuntimeError(
-                "Namespace storage_options missing 'expires_at_millis'. "
-                "Storage options refresh will not work properly."
-            )
-
         # Return the storage_options directly - it's already a flat Map<String, String>
+        # Note: expires_at_millis is optional. If not provided, credentials are treated
+        # as non-expiring and will not be automatically refreshed.
         return storage_options
 
     def provider_id(self) -> str:


### PR DESCRIPTION
Mainly for test use cases, it might be possible to return a credential that never expires, and currently we just block the use case which is unnecessary.

Also ensure that when user explicitly sets an AwsCredentialProvider in rust, it is respected instead of getting only the initial credentials and later being overwritten by the DynamicStorageOptionsCredentialProvider.