### PR TITLE
fix(ci): use pull_request_target for fork PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
     # Optional: Only run on specific file changes
     # paths:


### PR DESCRIPTION
The `pull_request` event runs in the fork's context, which doesn't have
access to repository secrets. Switch to `pull_request_target` so the
workflow runs in the base repo context and can access `CLAUDE_CODE_OAUTH_TOKEN`.

This enables the Claude Code Review workflow to work on PRs from forks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)