### PR TITLE
docs: fix duplicate words in comments and error messages

### DIFF
--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -174,7 +174,7 @@ message Transaction {
     //          integrity guarantees provided by the storage backend.
     bool is_shallow = 1;
     // the reference name in the source dataset
-    // in most cases it should be the the branch or tag name in the source dataset
+    // in most cases it should be the branch or tag name in the source dataset
     optional string ref_name = 2;
     // the version of the source dataset for cloning
     uint64 ref_version = 3;

--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -1022,7 +1022,7 @@ impl ArrayGenerator for RandomBinaryGenerator {
 
 /// Generate a sequence of strings with a prefix and a counter
 ///
-/// For example, if the prefix is "user_" the the strings will be "user_0", "user_1", ...
+/// For example, if the prefix is "user_" the strings will be "user_0", "user_1", ...
 #[derive(Debug)]
 pub struct PrefixPlusCounterGenerator {
     prefix: String,
@@ -2598,7 +2598,7 @@ pub mod array {
 
     /// Creates a generator of strings with a prefix and a counter
     ///
-    /// For example, if the prefix is "user_" the the strings will be "user_0", "user_1", ...
+    /// For example, if the prefix is "user_" the strings will be "user_0", "user_1", ...
     pub fn utf8_prefix_plus_counter(
         prefix: impl Into<String>,
         is_large: bool,

--- a/rust/lance-encoding/src/previous/encodings/physical/bitpack.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/bitpack.rs
@@ -621,7 +621,7 @@ pub fn bitpack_params(arr: &dyn Array) -> Option<BitpackParams> {
     }
 }
 
-// Compute the number bits to to use for bitpacking generically.
+// Compute the number bits to use for bitpacking generically.
 // returns None if the array is empty or all nulls
 fn bitpack_params_for_type<T>(arr: &PrimitiveArray<T>) -> Option<BitpackParams>
 where

--- a/rust/lance-index/src/vector.rs
+++ b/rust/lance-index/src/vector.rs
@@ -86,7 +86,7 @@ pub struct Query {
     pub upper_bound: Option<f32>,
 
     /// The minimum number of probes to load and search.  More partitions
-    /// will only be loaded if we have not found k results, or the the algorithm
+    /// will only be loaded if we have not found k results, or the algorithm
     /// determines more partitions are needed to satisfy recall requirements.
     ///
     /// The planner will always search at least this many partitions. Defaults to 1.

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1563,7 +1563,7 @@ impl Scanner {
         if self.autoproject_scoring_columns {
             if self.nearest.is_some() && output_expr.iter().all(|(_, name)| name != DIST_COL) {
                 if self.explicit_projection {
-                    log::warn!("Deprecation warning, this behavior will change in the future. This search specified output columns but did not include `_distance`.  Currently the `_distance` column will be included.  In the future it will not.  Call `disable_scoring_autoprojection` to to adopt the future behavior and avoid this warning");
+                    log::warn!("Deprecation warning, this behavior will change in the future. This search specified output columns but did not include `_distance`.  Currently the `_distance` column will be included.  In the future it will not.  Call `disable_scoring_autoprojection` to adopt the future behavior and avoid this warning");
                 }
                 let vector_expr = expressions::col(DIST_COL, current_schema)?;
                 output_expr.push((vector_expr, DIST_COL.to_string()));

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -541,7 +541,7 @@ impl FragmentScanner {
             .project_by_schema(&self.projection.as_ref().into())
             .map_err(|err| Error::Internal {
                 message: format!(
-                    "Failed to to select schema {} from batch with schema {}\nInner error: {}",
+                    "Failed to select schema {} from batch with schema {}\nInner error: {}",
                     self.projection,
                     batch.schema(),
                     err


### PR DESCRIPTION
Fixed 7 instances of duplicate words:
- 'to to' → 'to' (3 occurrences)
- 'the the' → 'the' (4 occurrences)

This is a documentation/comment cleanup with no functional changes.