### PR TITLE
test: add coverage for large string variant in PrefixPlusCounterGenerator

### DIFF
--- a/rust/lance-datagen/src/generator.rs
+++ b/rust/lance-datagen/src/generator.rs
@@ -3032,7 +3032,7 @@ mod tests {
             *genn.generate(RowCount::from(3), &mut rng).unwrap(),
             arrow_array::StringArray::from_iter_values(["user_0", "user_1", "user_2"])
         );
-        
+
         let mut genn = array::utf8_prefix_plus_counter("user_", true);
         assert_eq!(
             *genn.generate(RowCount::from(3), &mut rng).unwrap(),


### PR DESCRIPTION
test: add coverage for large string variant in PrefixPlusCounterGenerator

The existing test only covered the is_large=false case. This commit adds
test coverage for the is_large=true branch that generates LargeStringArray,
bringing the test coverage to 100% for this generator.

Fixes the codecov report showing missing coverage on line 1080 in
rust/lance-datagen/src/generator.rs.