### PR TITLE
ci: add workflow to listen to comments for benchmark requests

### DIFF
--- a/.github/workflows/benchmark-comment-trigger.yml
+++ b/.github/workflows/benchmark-comment-trigger.yml
@@ -39,7 +39,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.LANCE_BENCH_DISPATCH_TOKEN }}
-          repository: westonpace/lance-bench
+          repository: lancedb/lance-bench
           event-type: pr-comment
           client-payload: |
             {


### PR DESCRIPTION
I am working on a historical database of benchmark results at https://github.com/lancedb/lance-bench

I would like to be able to evaluate a PR to see if it improves performance or significantly regresses performance.  To do this I am following a pattern used in the Arrow project (and others).  By commenting `@bench-bot benchmark` a user (only users with write permission or PR authors) can trigger the lance-bench repo to run the lance benchmarks on the PR.  It will then compare the results with its historical record and decide if the PR's results are an improvement or regression.  It will then post that results diff back to the PR as a comment.

This PR adds the hook to listen for comments requesting benchmarks.  These comments are then forwarded to the lance-bench repository for further analysis.  For more details see https://github.com/lancedb/lance-bench/blob/main/.github/workflows/comment-monitor.yml