### PR TITLE
docs: auto-build refactored namespace integrations doc

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -40,6 +40,11 @@ jobs:
         with:
           repository: lancedb/lance-ray
           path: lance-ray
+      - name: Checkout lance-namespace-impls
+        uses: actions/checkout@v4
+        with:
+          repository: lance-format/lance-namespace-impls
+          path: lance-namespace-impls
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
@@ -59,6 +64,33 @@ jobs:
             - Namespace Spec: namespace
           EOF
           cp docs/src/format/namespace/rest.yaml docs/src/rest.yaml
+      - name: Copy lance-namespace-impls docs
+        run: |
+          # Copy implementation specs to the integrations folder
+          cp lance-namespace-impls/docs/src/hive2.md docs/src/format/namespace/integrations/
+          cp lance-namespace-impls/docs/src/hive3.md docs/src/format/namespace/integrations/
+          cp lance-namespace-impls/docs/src/iceberg.md docs/src/format/namespace/integrations/
+          cp lance-namespace-impls/docs/src/polaris.md docs/src/format/namespace/integrations/
+          cp lance-namespace-impls/docs/src/unity.md docs/src/format/namespace/integrations/
+          cp lance-namespace-impls/docs/src/glue.md docs/src/format/namespace/integrations/
+          cp lance-namespace-impls/docs/src/gravitino.md docs/src/format/namespace/integrations/
+          cp lance-namespace-impls/docs/src/onelake.md docs/src/format/namespace/integrations/
+          cp lance-namespace-impls/docs/src/dataproc.md docs/src/format/namespace/integrations/
+
+          # Generate .pages for integrations (alphabetical order)
+          cat > docs/src/format/namespace/integrations/.pages << 'EOF'
+          nav:
+            - Apache Gravitino: gravitino.md
+            - Apache Hive MetaStore V2: hive2.md
+            - Apache Hive MetaStore V3: hive3.md
+            - Apache Iceberg REST Catalog: iceberg.md
+            - Apache Polaris: polaris.md
+            - AWS Glue: glue.md
+            - Google Dataproc: dataproc.md
+            - Microsoft OneLake: onelake.md
+            - Unity Catalog: unity.md
+            - Template for New Integrations: template.md
+          EOF
       - name: Copy lance-spark docs
         run: |
           cp -r lance-spark/docs/src docs/src/integrations/spark
@@ -86,6 +118,7 @@ jobs:
           cp lance-ray/CONTRIBUTING.md docs/src/community/project-specific/ray.md
           cp lance-spark/CONTRIBUTING.md docs/src/community/project-specific/spark.md
           cp lance-namespace/CONTRIBUTING.md docs/src/community/project-specific/namespace.md
+          cp lance-namespace-impls/CONTRIBUTING.md docs/src/community/project-specific/namespace-impls.md || true
 
           # Create .pages for project-specific
           cat > docs/src/community/project-specific/.pages << 'EOF'
@@ -93,6 +126,7 @@ jobs:
             - index.md
             - Lance: lance
             - Lance Namespace: namespace.md
+            - Lance Namespace Impls: namespace-impls.md
             - Lance Ray: ray.md
             - Lance Spark: spark.md
           EOF


### PR DESCRIPTION
Integrations are refactored to repo https://github.com/lance-format/lance-namespace-impls

Will be built to `https://lance.org/format/namespace/integrations`