### PR TITLE
ci: make sure changes in lance-namespace-impls doc is auto-updated

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -67,30 +67,11 @@ jobs:
       - name: Copy lance-namespace-impls docs
         run: |
           # Copy implementation specs to the integrations folder
-          cp lance-namespace-impls/docs/src/hive2.md docs/src/format/namespace/integrations/
-          cp lance-namespace-impls/docs/src/hive3.md docs/src/format/namespace/integrations/
-          cp lance-namespace-impls/docs/src/iceberg.md docs/src/format/namespace/integrations/
-          cp lance-namespace-impls/docs/src/polaris.md docs/src/format/namespace/integrations/
-          cp lance-namespace-impls/docs/src/unity.md docs/src/format/namespace/integrations/
-          cp lance-namespace-impls/docs/src/glue.md docs/src/format/namespace/integrations/
-          cp lance-namespace-impls/docs/src/gravitino.md docs/src/format/namespace/integrations/
-          cp lance-namespace-impls/docs/src/onelake.md docs/src/format/namespace/integrations/
-          cp lance-namespace-impls/docs/src/dataproc.md docs/src/format/namespace/integrations/
+          cp lance-namespace-impls/docs/src/*.md docs/src/format/namespace/integrations/
 
-          # Generate .pages for integrations (alphabetical order)
-          cat > docs/src/format/namespace/integrations/.pages << 'EOF'
-          nav:
-            - Apache Gravitino: gravitino.md
-            - Apache Hive MetaStore V2: hive2.md
-            - Apache Hive MetaStore V3: hive3.md
-            - Apache Iceberg REST Catalog: iceberg.md
-            - Apache Polaris: polaris.md
-            - AWS Glue: glue.md
-            - Google Dataproc: dataproc.md
-            - Microsoft OneLake: onelake.md
-            - Unity Catalog: unity.md
-            - Template for New Integrations: template.md
-          EOF
+          # Copy .pages from lance-namespace-impls and append template entry
+          cp lance-namespace-impls/docs/src/.pages docs/src/format/namespace/integrations/.pages
+          echo "  - Template for New Integrations: template.md" >> docs/src/format/namespace/integrations/.pages
       - name: Copy lance-spark docs
         run: |
           cp -r lance-spark/docs/src docs/src/integrations/spark


### PR DESCRIPTION
In previous change, we manually added each supported catalog integration, but that means every time we add a new one we still need to make a PR to lance, and that is inconvenient. This PR makes it simpler by having the nav `.pages` in the `lance-namespace-impls` repo and just add the template in the end, so we only need to update that repo for new catalog implementation supports.