### PR TITLE
fix: panic when lance.auto_cleanup.interval is set to 0

### DIFF
--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -1460,7 +1460,11 @@ mod tests {
             "lance.auto_cleanup.retain_versions".to_string(),
             Some("1".to_string()),
         );
-        dataset.update_config(config_updates).replace().await.unwrap();
+        dataset
+            .update_config(config_updates)
+            .replace()
+            .await
+            .unwrap();
 
         fixture.overwrite_some_data().await.unwrap();
         fixture.overwrite_some_data().await.unwrap();
@@ -1470,7 +1474,6 @@ mod tests {
         fixture.overwrite_some_data().await.unwrap();
         check_num_files(&fixture, 2).await;
     }
-
 
     #[tokio::test]
     async fn cleanup_recent_verified_files() {


### PR DESCRIPTION
For now, when lance.auto_cleanup.interval is set to 0, dataset commits panic with a "division by zero" error:

```
thread 'dataset::cleanup::tests::test_auto_cleanup_interval_zero' panicked at rust/lance/src/dataset/cleanup.rs:672:12:
attempt to calculate the remainder with a divisor of zero
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

To fix the panic, we can interpret `lance.auto_cleanup.interval = 0` as triggering cleanup after each commit, which is equivalent to `lance.auto_cleanup.interval = 1`