### PR TITLE
perf: materialize the tokens after WAND done

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -276,9 +276,7 @@ impl InvertedIndex {
                     let mut tokens_by_position = vec![String::new(); postings.len()];
                     for posting in &postings {
                         let idx = posting.term_index() as usize;
-                        if idx < tokens_by_position.len() {
-                            tokens_by_position[idx] = posting.token().to_owned();
-                        }
+                        tokens_by_position[idx] = posting.token().to_owned();
                     }
                     let params = params.clone();
                     let mask = mask.clone();

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -371,11 +371,7 @@ impl<'a, S: Scorer> Wand<'a, S> {
             _ => {}
         }
 
-        let mut candidates = if limit <= BLOCK_SIZE * 10 {
-            BinaryHeap::with_capacity(limit)
-        } else {
-            BinaryHeap::new()
-        };
+        let mut candidates = BinaryHeap::with_capacity(std::cmp::min(limit, BLOCK_SIZE * 10));
         let mut num_comparisons = 0;
         while let Some((pivot, doc)) = self.next()? {
             if let Some(cur_doc) = self.cur_doc {


### PR DESCRIPTION
this avoids copying tokens for each candidate during WAND search, these small strings could lead high memory usage if we have many partitions and the queries are with large limit.

verified on a 1M dataset
before:
Peak RSS delta: 497.09 MiB

after:
Peak RSS delta: 222.34 MiB

this also improves the FTS performance by ~10% for such queries