### PR TITLE
Reduce allocs for bitmap index

### DIFF
--- a/python/python/tests/test_memory.py
+++ b/python/python/tests/test_memory.py
@@ -12,6 +12,27 @@ memtest = pytest.importorskip(
 )
 
 
+def test_bitmap_index_allocations(tmp_path: Path):
+    """Test that bitmap index creation doesn't cause excessive allocations.
+
+    This test creates ~100MB of int64 data and builds a bitmap index that reproduces https://github.com/lancedb/lance/issues/4047.
+    """
+    # 100MB of int64
+    num_values = 100 * 1024 * 1024 // 8
+    data = pa.table({"values": pa.array([i % 1000 for i in range(num_values)])})
+    dataset = lance.write_dataset(data, tmp_path / "dataset")
+
+    with memtest.track() as get_stats:
+        dataset.create_scalar_index("values", index_type="BITMAP")
+        stats = get_stats()
+
+    assert stats["total_allocations"] < 500_000, (
+        f"Bitmap index creation caused {stats['total_allocations']:,} allocations. "
+        "This may indicate a regression in allocation efficiency. "
+        "See https://github.com/lancedb/lance/issues/4047"
+    )
+
+
 def test_insert_memory(tmp_path: Path):
     def batch_generator():
         # 5MB batches -> 100MB total

--- a/rust/lance-core/src/utils/mask.rs
+++ b/rust/lance-core/src/utils/mask.rs
@@ -621,6 +621,47 @@ impl RowAddrTreeMap {
 
         Ok(Self { inner })
     }
+
+    /// Push a value that is greater than or equal to the current maximum.
+    ///
+    /// This is an O(1) operation when the value is greater than the current maximum.
+    /// Returns `true` if the value was added, `false` if it was already present
+    /// (which can only happen if value equals the current maximum).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the value is strictly less than the current maximum value within
+    /// the same fragment.
+    ///
+    /// ```rust
+    /// use lance_core::utils::mask::RowAddrTreeMap;
+    ///
+    /// let mut set = RowAddrTreeMap::new();
+    /// assert!(set.push(1));
+    /// assert!(set.push(2));
+    /// assert!(set.push(10));
+    /// assert!(set.contains(1));
+    /// assert!(set.contains(10));
+    /// ```
+    pub fn push(&mut self, value: u64) -> bool {
+        let fragment_id = (value >> 32) as u32;
+        let row_offset = value as u32;
+
+        match self.inner.get_mut(&fragment_id) {
+            None => {
+                let mut bitmap = RoaringBitmap::new();
+                bitmap.push(row_offset);
+                self.inner
+                    .insert(fragment_id, RowAddrSelection::Partial(bitmap));
+                true
+            }
+            Some(RowAddrSelection::Full) => {
+                // Fragment is already full, value is implicitly present
+                false
+            }
+            Some(RowAddrSelection::Partial(bitmap)) => bitmap.push(row_offset),
+        }
+    }
 }
 
 impl std::ops::BitOr<Self> for RowAddrTreeMap {
@@ -1370,6 +1411,45 @@ mod tests {
             assert!(map.contains(id), "Expected {} to be contained", id);
         }
         assert!(!map.contains(3));
+    }
+
+    #[test]
+    fn test_map_push() {
+        // Test pushing to empty map
+        let mut map = RowAddrTreeMap::default();
+        assert!(map.push(1));
+        assert!(map.push(2));
+        assert!(map.push(3));
+        assert!(map.contains(1));
+        assert!(map.contains(2));
+        assert!(map.contains(3));
+        assert!(!map.contains(0));
+
+        // Test pushing higher values
+        assert!(map.push(10));
+        assert!(map.push(20));
+        assert!(map.contains(10));
+        assert!(map.contains(20));
+
+        // Test pushing across fragment boundaries
+        let mut map2 = RowAddrTreeMap::default();
+        assert!(map2.push(1));
+        assert!(map2.push(2));
+        assert!(map2.push(1 << 32 | 5));
+        assert!(map2.push(1 << 32 | 10));
+        assert!(map2.contains(1));
+        assert!(map2.contains(2));
+        assert!(map2.contains(1 << 32 | 5));
+        assert!(map2.contains(1 << 32 | 10));
+    }
+
+    #[test]
+    fn test_map_push_to_full_fragment() {
+        // Test pushing to a full fragment (should return false)
+        let mut map = RowAddrTreeMap::default();
+        map.insert_fragment(0);
+        assert!(!map.push(1));
+        assert!(!map.push(2));
     }
 
     proptest::proptest! {

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -725,10 +725,11 @@ impl BitmapIndexPlugin {
 
             let row_id_column = row_ids.as_any().downcast_ref::<UInt64Array>().unwrap();
 
+            // Data arrives in row_address order, so row_ids are seen in ascending order.
             for i in 0..values.len() {
                 let row_id = row_id_column.value(i);
                 let key = ScalarValue::try_from_array(values.as_ref(), i)?;
-                state.entry(key.clone()).or_default().insert(row_id);
+                state.entry(key.clone()).or_default().push(row_id);
             }
         }
 


### PR DESCRIPTION
Attempts to address https://github.com/lance-format/lance/issues/5494. This improves runtime during bitmap index creation. I'm currently looking to see whether we can group by value, then construct a sorted range all-at-once with [from_sorted_iter](https://docs.rs/roaring/latest/roaring/bitmap/struct.RoaringBitmap.html#method.from_sorted_iter). Only problem with this is whether we might accumulate the same # of allocs doing a group by on these unique values. In this case, push() optimization will not be needed.

Roaring bitmaps support `RoaringBitmap::push` API where the successive calls to the method contain data in monotonically increasing order. This replaces expensive `RoaringBitmap::insert` being called which:
1. Does a [binary search](https://docs.rs/roaring/latest/src/roaring/bitmap/inherent.rs.html#187-197) to find the appropriate container.
2. Runs a linear`Vec::insert` on this container (need to shuffle items around).