### PR TITLE
feat: add dictionary encoding for 64bit types like int64/double

### DIFF
--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -640,6 +640,9 @@ fn collect_page_encoding(layout: &PageLayout, actual_chain: &mut Vec<String>) ->
     if let Some(ref layout_type) = layout.layout {
         match layout_type {
             Layout::MiniBlockLayout(mini_block) => {
+                if mini_block.dictionary.is_some() {
+                    actual_chain.push("dictionary".to_string());
+                }
                 // Check value compression
                 if let Some(ref value_comp) = mini_block.value_compression {
                     let chain = extract_array_encoding_chain(value_comp);


### PR DESCRIPTION
This PR will introduce dictionary encoding for 64bit types like int64/double.


| Field | Parquet (bytes) | Lance 2.1 (bytes) | Lance 2.2 before (bytes) | Lance 2.2 after (bytes) | vs Parquet | vs Lance 2.1 | vs Lance 2.2 before |
|---|---:|---:|---:|---:|---:|---:|---:|
| `token_count` | 806,050 | 350,852 | 351,208 | 312,168 | -493,882 (-61.3%) | -38,684 (-11.0%) | -39,040 (-11.1%) |
| `score` | 254,145 | 1,438,596 | 1,438,952 | 164,048 | -90,097 (-35.5%) | -1,274,548 (-88.6%) | -1,274,904 (-88.6%) |

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**