### PR TITLE
fix: reduce verbosity of errors due to string conversion

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -1372,8 +1372,7 @@ impl PostingListReader {
                 let batch = self.posting_batch(token_id, false).await?;
                 self.posting_list_from_batch(&batch, token_id)
             })
-            .await
-            .map_err(|e| Error::io(e.to_string(), location!()))?
+            .await?
             .as_ref()
             .clone();
 

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -240,7 +240,7 @@ impl NGramPostingListReader {
                     )
                     .await?;
                 NGramPostingList::try_from_batch(batch, self.frag_reuse_index.clone())
-        }).await.map_err(|e| Error::io(e.to_string(), location!()))
+        }).await
     }
 }
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -4008,9 +4008,7 @@ impl Stream for DatasetRecordBatchStream {
         let mut this = self.project();
         let _guard = this.span.enter();
         match this.exec_node.poll_next_unpin(cx) {
-            Poll::Ready(result) => {
-                Poll::Ready(result.map(|r| r.map_err(|e| Error::io(e.to_string(), location!()))))
-            }
+            Poll::Ready(result) => Poll::Ready(result.map(|r| Ok(r?))),
             Poll::Pending => Poll::Pending,
         }
     }

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -300,7 +300,7 @@ impl UpdateJob {
             .map(|res| match res {
                 Ok(Ok(batch)) => Ok(batch),
                 Ok(Err(err)) => Err(err),
-                Err(e) => Err(DataFusionError::Execution(e.to_string())),
+                Err(e) => Err(DataFusionError::ExecutionJoin(Box::new(e))),
             });
         let stream = RecordBatchStreamAdapter::new(schema, stream);
 

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -233,7 +233,7 @@ impl ExecutionPlan for KNNVectorDistanceExec {
                 async move {
                     let batch = compute_distance(key, dt, &column, batch?)
                         .await
-                        .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+                        .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
                     let distances = batch[DIST_COL].as_primitive::<Float32Type>();
                     let mask = BooleanArray::from_iter(
@@ -242,7 +242,7 @@ impl ExecutionPlan for KNNVectorDistanceExec {
                             .map(|v| Some(v.map(|v| !v.is_nan()).unwrap_or(false))),
                     );
                     arrow::compute::filter_record_batch(&batch, &mask)
-                        .map_err(|e| DataFusionError::Execution(e.to_string()))
+                        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
                 }
             })
             .buffer_unordered(get_num_compute_intensive_cpus());

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -353,7 +353,7 @@ impl FragmentScanner {
                     .map(|res| match res {
                         Ok(Ok(batch)) => Ok(batch),
                         Ok(Err(err)) => Err(err),
-                        Err(err) => Err(DataFusionError::Execution(err.to_string())),
+                        Err(join_err) => Err(DataFusionError::ExecutionJoin(Box::new(join_err))),
                     })
             });
 


### PR DESCRIPTION
* Eliminates cases where we needlessly convert errors to strings.
* Uses `DataFusionError::ExecutionJoin()` when appropriate.