### PR TITLE
fix: remove imports that are not needed

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -441,8 +441,6 @@ class LanceDataset(pa.dataset.Dataset):
 
         # Handle deprecation warning for index_cache_size
         if index_cache_size is not None:
-            import warnings
-
             warnings.warn(
                 "The 'index_cache_size' parameter is deprecated. "
                 "Use 'index_cache_size_bytes' instead. "
@@ -5663,8 +5661,6 @@ def write_dataset(
                     response = namespace.declare_table(declare_request)
                 except (UnsupportedOperationError, NotImplementedError):
                     # Fall back to deprecated create_empty_table
-                    import warnings
-
                     warnings.warn(
                         "create_empty_table is deprecated, use declare_table instead. "
                         "Support will be removed in 3.0.0.",
@@ -5677,8 +5673,6 @@ def write_dataset(
                     response = namespace.create_empty_table(fallback_request)
             else:
                 # Namespace doesn't have declare_table, fall back to create_empty_table
-                import warnings
-
                 warnings.warn(
                     "create_empty_table is deprecated, use declare_table instead. "
                     "Support will be removed in 3.0.0.",


### PR DESCRIPTION
There is already an `import warnings` at the top of the file.  Having the import inside the if branches actually causes errors because if you have something like this...

```
import warnings

def some_function():
  if something:
    import warnings
  warnings.warn("blah")
```

You will get an error because the inner import creates a function-local variable named `warnings` which is undefined when the function starts and you will get an `UnboundLocalError`.  This is currently causing the benchmarks to fail.

