### PR TITLE
feat: allow configure temp dir size for datafusion exec

### DIFF
--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -289,6 +289,7 @@ pub type ExecutionStatsCallback = Arc<dyn Fn(&ExecutionSummaryCounts) + Send + S
 pub struct LanceExecutionOptions {
     pub use_spilling: bool,
     pub mem_pool_size: Option<u64>,
+    pub max_temp_directory_size: Option<u64>,
     pub batch_size: Option<usize>,
     pub target_partition: Option<usize>,
     pub execution_stats_callback: Option<ExecutionStatsCallback>,
@@ -300,6 +301,7 @@ impl std::fmt::Debug for LanceExecutionOptions {
         f.debug_struct("LanceExecutionOptions")
             .field("use_spilling", &self.use_spilling)
             .field("mem_pool_size", &self.mem_pool_size)
+            .field("max_temp_directory_size", &self.max_temp_directory_size)
             .field("batch_size", &self.batch_size)
             .field("target_partition", &self.target_partition)
             .field("skip_logging", &self.skip_logging)
@@ -312,6 +314,7 @@ impl std::fmt::Debug for LanceExecutionOptions {
 }
 
 const DEFAULT_LANCE_MEM_POOL_SIZE: u64 = 100 * 1024 * 1024;
+const DEFAULT_LANCE_MAX_TEMP_DIRECTORY_SIZE: u64 = 100 * 1024 * 1024 * 1024; // 100GB
 
 impl LanceExecutionOptions {
     pub fn mem_pool_size(&self) -> u64 {
@@ -325,6 +328,23 @@ impl LanceExecutionOptions {
                     }
                 })
                 .unwrap_or(DEFAULT_LANCE_MEM_POOL_SIZE)
+        })
+    }
+
+    pub fn max_temp_directory_size(&self) -> u64 {
+        self.max_temp_directory_size.unwrap_or_else(|| {
+            std::env::var("LANCE_MAX_TEMP_DIRECTORY_SIZE")
+                .map(|s| match s.parse::<u64>() {
+                    Ok(v) => v,
+                    Err(e) => {
+                        warn!(
+                            "Failed to parse LANCE_MAX_TEMP_DIRECTORY_SIZE: {}, using default",
+                            e
+                        );
+                        DEFAULT_LANCE_MAX_TEMP_DIRECTORY_SIZE
+                    }
+                })
+                .unwrap_or(DEFAULT_LANCE_MAX_TEMP_DIRECTORY_SIZE)
         })
     }
 
@@ -348,8 +368,10 @@ pub fn new_session_context(options: &LanceExecutionOptions) -> SessionContext {
         session_config = session_config.with_target_partitions(target_partition);
     }
     if options.use_spilling() {
+        let disk_manager_builder = DiskManagerBuilder::default()
+            .with_max_temp_directory_size(options.max_temp_directory_size());
         runtime_env_builder = runtime_env_builder
-            .with_disk_manager_builder(DiskManagerBuilder::default())
+            .with_disk_manager_builder(disk_manager_builder)
             .with_memory_pool(Arc::new(FairSpillPool::new(
                 options.mem_pool_size() as usize
             )));
@@ -373,7 +395,9 @@ static DEFAULT_SESSION_CONTEXT_WITH_SPILLING: LazyLock<SessionContext> = LazyLoc
 });
 
 pub fn get_session_context(options: &LanceExecutionOptions) -> SessionContext {
-    if options.mem_pool_size() == DEFAULT_LANCE_MEM_POOL_SIZE && options.target_partition.is_none()
+    if options.mem_pool_size() == DEFAULT_LANCE_MEM_POOL_SIZE
+        && options.max_temp_directory_size() == DEFAULT_LANCE_MAX_TEMP_DIRECTORY_SIZE
+        && options.target_partition.is_none()
     {
         return if options.use_spilling() {
             DEFAULT_SESSION_CONTEXT_WITH_SPILLING.clone()


### PR DESCRIPTION
user hit error:

```
Operation failed: Query Execution error: Execution error: LanceError(IO): Resources exhausted: The used disk space 
during the spilling process has exceeded the allowable limit of 100.0 GB. Try increasing the `max_temp_directory_size` in 
the disk manager configuration., /home/runner/work/lance/lance/rust/lance-datafusion/src/chunker.rs:49:46, 
/home/runner/work/lance/lance/rust/lance-index/src/scalar/btree.rs:1418:29
```