### PR TITLE
feat: add serial commit

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -176,6 +176,7 @@ impl BlockingDataset {
             None,
             Default::default(),
             false, // TODO: support enable_v2_manifest_paths
+            false, // serial_commit
         ))?;
         Ok(Self { inner })
     }

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -1113,6 +1113,9 @@ impl Debug for ConditionalPutCommitHandler {
 pub struct CommitConfig {
     pub num_retries: u32,
     pub skip_auto_cleanup: bool,
+    /// When true, fail immediately if any concurrent transactions have been committed
+    /// since the read version of the transaction being committed.
+    pub serial_commit: bool,
     // TODO: add isolation_level
 }
 
@@ -1121,6 +1124,7 @@ impl Default for CommitConfig {
         Self {
             num_retries: 20,
             skip_auto_cleanup: false,
+            serial_commit: false,
         }
     }
 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1259,6 +1259,7 @@ impl Dataset {
         commit_handler: Option<Arc<dyn CommitHandler>>,
         session: Arc<Session>,
         enable_v2_manifest_paths: bool,
+        serial_commit: bool,
         detached: bool,
     ) -> Result<Self> {
         let read_version = read_version.map_or_else(
@@ -1277,7 +1278,8 @@ impl Dataset {
         let mut builder = CommitBuilder::new(base_uri)
             .enable_v2_manifest_paths(enable_v2_manifest_paths)
             .with_session(session)
-            .with_detached(detached);
+            .with_detached(detached)
+            .with_serial_commit(serial_commit);
 
         if let Some(store_params) = store_params {
             builder = builder.with_store_params(store_params);
@@ -1324,6 +1326,10 @@ impl Dataset {
     ///   dataset, use the [`Self::migrate_manifest_paths_v2`] method. WARNING: turning
     ///   this on will make the dataset unreadable for older versions of Lance
     ///   (prior to 0.17.0). Default is False.
+    /// * `serial_commit` - When true, the commit will fail if any transactions
+    ///   have been committed since `read_version`, enforcing strict serial ordering. When
+    ///   false (the default), the commit may be automatically rebased on concurrent updates.
+    #[allow(clippy::too_many_arguments)]
     pub async fn commit(
         dest: impl Into<WriteDestination<'_>>,
         operation: Operation,
@@ -1332,6 +1338,7 @@ impl Dataset {
         commit_handler: Option<Arc<dyn CommitHandler>>,
         session: Arc<Session>,
         enable_v2_manifest_paths: bool,
+        serial_commit: bool,
     ) -> Result<Self> {
         Self::do_commit(
             dest.into(),
@@ -1341,6 +1348,7 @@ impl Dataset {
             commit_handler,
             session,
             enable_v2_manifest_paths,
+            serial_commit,
             /*detached=*/ false,
         )
         .await
@@ -1371,6 +1379,7 @@ impl Dataset {
             commit_handler,
             session,
             enable_v2_manifest_paths,
+            /*serial_commit=*/ false,
             /*detached=*/ true,
         )
         .await

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -2868,6 +2868,7 @@ mod tests {
             None,
             Default::default(),
             true,
+            false,
         )
         .await
         .unwrap();
@@ -2941,6 +2942,7 @@ mod tests {
             None,
             Default::default(),
             true,
+            false,
         )
         .await
         .unwrap();
@@ -3400,10 +3402,18 @@ mod tests {
             initial_bases: None,
         };
 
-        let new_dataset =
-            Dataset::commit(test_uri, op, None, None, None, Default::default(), false)
-                .await
-                .unwrap();
+        let new_dataset = Dataset::commit(
+            test_uri,
+            op,
+            None,
+            None,
+            None,
+            Default::default(),
+            false,
+            false,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(new_dataset.count_rows(None).await.unwrap(), dataset_rows);
 
@@ -3510,10 +3520,18 @@ mod tests {
                 initial_bases: None,
             };
 
-            let dataset =
-                Dataset::commit(test_uri, op, None, None, None, Default::default(), false)
-                    .await
-                    .unwrap();
+            let dataset = Dataset::commit(
+                test_uri,
+                op,
+                None,
+                None,
+                None,
+                Default::default(),
+                false,
+                false,
+            )
+            .await
+            .unwrap();
 
             // We only kept the first fragment of 40 rows
             assert_eq!(
@@ -3750,6 +3768,7 @@ mod tests {
             None,
             Default::default(),
             false,
+            false,
         )
         .await?;
 
@@ -3884,6 +3903,7 @@ mod tests {
             None,
             None,
             Default::default(),
+            false,
             false,
         )
         .await

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -674,6 +674,7 @@ async fn test_datafile_replacement() {
         None,
         Arc::new(Default::default()),
         false,
+        false,
     )
     .await
     .unwrap();
@@ -702,6 +703,7 @@ async fn test_datafile_replacement() {
         None,
         None,
         Arc::new(Default::default()),
+        false,
         false,
     )
     .await
@@ -756,6 +758,7 @@ async fn test_datafile_replacement() {
         None,
         None,
         Arc::new(Default::default()),
+        false,
         false,
     )
     .await
@@ -820,6 +823,7 @@ async fn test_datafile_partial_replacement() {
         None,
         Arc::new(Default::default()),
         false,
+        false,
     )
     .await
     .unwrap();
@@ -872,6 +876,7 @@ async fn test_datafile_partial_replacement() {
         None,
         None,
         Arc::new(Default::default()),
+        false,
         false,
     )
     .await
@@ -927,6 +932,7 @@ async fn test_datafile_partial_replacement() {
         None,
         None,
         Arc::new(Default::default()),
+        false,
         false,
     )
     .await
@@ -1000,6 +1006,7 @@ async fn test_datafile_replacement_error() {
         None,
         Arc::new(Default::default()),
         false,
+        false,
     )
     .await
     .unwrap();
@@ -1031,6 +1038,7 @@ async fn test_datafile_replacement_error() {
         None,
         None,
         Arc::new(Default::default()),
+        false,
         false,
     )
     .await

--- a/rust/lance/src/dataset/tests/dataset_versioning.rs
+++ b/rust/lance/src/dataset/tests/dataset_versioning.rs
@@ -116,6 +116,7 @@ async fn test_v2_manifest_path_commit() {
         None,
         Default::default(),
         true, // enable_v2_manifest_paths
+        false,
     )
     .await
     .unwrap();

--- a/rust/lance/src/utils/test.rs
+++ b/rust/lance/src/utils/test.rs
@@ -124,6 +124,7 @@ impl TestDatasetGenerator {
             None,
             Default::default(),
             false,
+            false,
         )
         .await
         .unwrap()


### PR DESCRIPTION
Lance transaction is not strict serial isolation. Here is an example of write skew.

```
def write_skew():
    uri = './alice_and_bob.lance'
    table = pa.Table.from_batches([], schema=pa.schema([("fruit", pa.string())]))
    ds = lance.write_dataset(table, uri, enable_v2_manifest_paths=True, mode="append")
    read_version = ds.version

    # Transaction-1 starts. Add pear if there is no apple.
    txn_1 = None
    if ds.scanner(filter="fruit='apple'", limit=1).to_table().num_rows == 0:
        data = ["pear"]
        table = pa.table([data], schema=pa.schema([("fruit", pa.string())]))
        frag_meta = lance.fragment.LanceFragment.create(uri, table)
        txn_1 = lance.LanceOperation.Append([frag_meta])

    # Transaction-2 starts. Add apple if there is no pear.
    txn_2 = None
    if ds.scanner(filter="fruit='pear'", limit=1).to_table().num_rows == 0:
        data = ["apple"]
        table = pa.table([data], schema=pa.schema([("fruit", pa.string())]))
        frag_meta = lance.fragment.LanceFragment.create(uri, table)
        txn_2 = lance.LanceOperation.Append([frag_meta])

    # Task 1 commit.
    if txn_1 is not None:
        ds.commit(uri, read_version=read_version, operation=txn_1)

    # Task 2 commit.
    if txn_2 is not None:
        ds.commit(uri, read_version=read_version, operation=txn_2)

    # The count is 2, but what we want is either apple or pear.
    ds = lance.dataset(uri)
    print(ds.count_rows())
```

In partitioned namespace, we use a special lance table `__manifest` as meta store. When commit in cross-partitioned write, we need serial commit in `__manifest` to guarantee atomic commit.