### PR TITLE
ci: fix accidentally reverted version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,7 +3384,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-array",
  "lance-datagen",
@@ -4660,7 +4660,7 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "all_asserts",
  "approx",
@@ -4751,7 +4751,7 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrayref",
  "paste",
@@ -4779,7 +4779,7 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4819,7 +4819,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4850,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4870,7 +4870,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4917,7 +4917,7 @@ dependencies = [
 
 [[package]]
 name = "lance-examples"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "all_asserts",
  "arrow",
@@ -4943,7 +4943,7 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4985,7 +4985,7 @@ dependencies = [
 
 [[package]]
 name = "lance-geo"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "datafusion",
  "geo-traits",
@@ -4999,7 +4999,7 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "approx",
  "arrow",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "approx",
  "arrow-array",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5160,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -5217,7 +5217,7 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -5263,7 +5263,7 @@ dependencies = [
 
 [[package]]
 name = "lance-test-macros"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5272,7 +5272,7 @@ dependencies = [
 
 [[package]]
 name = "lance-testing"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -5283,7 +5283,7 @@ dependencies = [
 
 [[package]]
 name = "lance-tools"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "clap",
  "lance-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "2"
 
 
 [workspace.package]
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 edition = "2021"
 authors = ["Lance Devs <dev@lance.org>"]
 license = "Apache-2.0"
@@ -50,23 +50,23 @@ rust-version = "1.82.0"
 
 [workspace.dependencies]
 libc = "0.2.176"
-lance = { version = "=2.0.0-beta.4", path = "./rust/lance", default-features = false }
-lance-arrow = { version = "=2.0.0-beta.4", path = "./rust/lance-arrow" }
-lance-core = { version = "=2.0.0-beta.4", path = "./rust/lance-core" }
-lance-datafusion = { version = "=2.0.0-beta.4", path = "./rust/lance-datafusion" }
-lance-datagen = { version = "=2.0.0-beta.4", path = "./rust/lance-datagen" }
-lance-encoding = { version = "=2.0.0-beta.4", path = "./rust/lance-encoding" }
-lance-file = { version = "=2.0.0-beta.4", path = "./rust/lance-file" }
-lance-geo = { version = "=2.0.0-beta.4", path = "./rust/lance-geo" }
-lance-index = { version = "=2.0.0-beta.4", path = "./rust/lance-index" }
-lance-io = { version = "=2.0.0-beta.4", path = "./rust/lance-io", default-features = false }
-lance-linalg = { version = "=2.0.0-beta.4", path = "./rust/lance-linalg" }
-lance-namespace = { version = "=2.0.0-beta.4", path = "./rust/lance-namespace" }
-lance-namespace-impls = { version = "=2.0.0-beta.4", path = "./rust/lance-namespace-impls" }
+lance = { version = "=2.0.0-beta.5", path = "./rust/lance", default-features = false }
+lance-arrow = { version = "=2.0.0-beta.5", path = "./rust/lance-arrow" }
+lance-core = { version = "=2.0.0-beta.5", path = "./rust/lance-core" }
+lance-datafusion = { version = "=2.0.0-beta.5", path = "./rust/lance-datafusion" }
+lance-datagen = { version = "=2.0.0-beta.5", path = "./rust/lance-datagen" }
+lance-encoding = { version = "=2.0.0-beta.5", path = "./rust/lance-encoding" }
+lance-file = { version = "=2.0.0-beta.5", path = "./rust/lance-file" }
+lance-geo = { version = "=2.0.0-beta.5", path = "./rust/lance-geo" }
+lance-index = { version = "=2.0.0-beta.5", path = "./rust/lance-index" }
+lance-io = { version = "=2.0.0-beta.5", path = "./rust/lance-io", default-features = false }
+lance-linalg = { version = "=2.0.0-beta.5", path = "./rust/lance-linalg" }
+lance-namespace = { version = "=2.0.0-beta.5", path = "./rust/lance-namespace" }
+lance-namespace-impls = { version = "=2.0.0-beta.5", path = "./rust/lance-namespace-impls" }
 lance-namespace-reqwest-client = { version = "=0.4.5" }
-lance-table = { version = "=2.0.0-beta.4", path = "./rust/lance-table" }
-lance-test-macros = { version = "=2.0.0-beta.4", path = "./rust/lance-test-macros" }
-lance-testing = { version = "=2.0.0-beta.4", path = "./rust/lance-testing" }
+lance-table = { version = "=2.0.0-beta.5", path = "./rust/lance-table" }
+lance-test-macros = { version = "=2.0.0-beta.5", path = "./rust/lance-test-macros" }
+lance-testing = { version = "=2.0.0-beta.5", path = "./rust/lance-testing" }
 approx = "0.5.1"
 # Note that this one does not include pyarrow
 arrow = { version = "57.0.0", optional = false, features = ["prettyprint"] }
@@ -91,7 +91,7 @@ half = { "version" = "2.1", default-features = false, features = [
     "num-traits",
     "std",
 ] }
-lance-bitpacking = { version = "=2.0.0-beta.4", path = "./rust/compression/bitpacking" }
+lance-bitpacking = { version = "=2.0.0-beta.5", path = "./rust/compression/bitpacking" }
 bitvec = "1"
 bytes = "1.4"
 byteorder = "1.5"
@@ -131,7 +131,7 @@ deepsize = "0.2.0"
 dirs = "6.0.0"
 either = "1.0"
 fst = { version = "0.4.7", features = ["levenshtein"] }
-fsst = { version = "=2.0.0-beta.4", path = "./rust/compression/fsst" }
+fsst = { version = "=2.0.0-beta.5", path = "./rust/compression/fsst" }
 futures = "0.3"
 geoarrow-array = "0.7"
 geoarrow-schema = "0.7"

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -2677,7 +2677,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-array",
  "rand 0.9.2",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrayref",
  "paste",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3980,7 +3980,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4017,7 +4017,7 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "lance-geo"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "datafusion",
  "geo-traits",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4118,6 +4118,7 @@ dependencies = [
  "roaring",
  "serde",
  "serde_json",
+ "smallvec",
  "snafu",
  "tantivy",
  "tempfile",
@@ -4129,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4202,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4218,7 +4219,7 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4230,7 +4231,7 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -4284,7 +4285,7 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -3046,7 +3046,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsst"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-array",
  "rand 0.9.2",
@@ -4236,7 +4236,7 @@ dependencies = [
 
 [[package]]
 name = "lance"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4320,7 +4320,7 @@ dependencies = [
 
 [[package]]
 name = "lance-bitpacking"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrayref",
  "paste",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "lance-core"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4366,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datafusion"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4397,7 +4397,7 @@ dependencies = [
 
 [[package]]
 name = "lance-datagen"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4415,7 +4415,7 @@ dependencies = [
 
 [[package]]
 name = "lance-encoding"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4452,7 +4452,7 @@ dependencies = [
 
 [[package]]
 name = "lance-file"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "lance-geo"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "datafusion",
  "geo-traits",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "lance-index"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "lance-io"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-arith",
@@ -4608,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "lance-linalg"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -4624,7 +4624,7 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4636,7 +4636,7 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-impls"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-ipc",
@@ -4690,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "lance-table"
-version = "2.0.0-beta.4"
+version = "2.0.0-beta.5"
 dependencies = [
  "arrow",
  "arrow-array",


### PR DESCRIPTION
Failing CI: https://github.com/lance-format/lance/actions/runs/20866107030/job/59957545595

The version was changed back to 2.0.0-beta.4 in a previous commit merge accidentally because it was not flagged as a merge conflict and the code still worked with old version.