### PR TITLE
fix: trait Array has been sealed in arrow new version

### DIFF
--- a/python/src/arrow.rs
+++ b/python/src/arrow.rs
@@ -76,7 +76,8 @@ pub fn bfloat16_array<'py>(
     values: Vec<Option<f32>>,
     py: Python<'py>,
 ) -> PyResult<Bound<'py, PyAny>> {
-    let array = BFloat16Array::from_iter(values.into_iter().map(|v| v.map(bf16::from_f32)));
+    let array =
+        BFloat16Array::from_iter(values.into_iter().map(|v| v.map(bf16::from_f32))).into_inner();
 
     // Create a record batch with a single column and an annotated schema
     let field = Field::new("bfloat16", DataType::FixedSizeBinary(2), true).with_metadata(

--- a/rust/lance-index/src/vector/bq/builder.rs
+++ b/rust/lance-index/src/vector/bq/builder.rs
@@ -58,7 +58,7 @@ impl RabitQuantizer {
 
         let rotate_mat = match T::FLOAT_TYPE {
             FloatType::Float16 | FloatType::Float32 | FloatType::Float64 => {
-                let rotate_mat = T::ArrayType::from(rotate_mat);
+                let rotate_mat = <T::ArrayType as FloatArray<T>>::from_values(rotate_mat);
                 FixedSizeListArray::try_new_from_values(rotate_mat, code_dim).unwrap()
             }
             _ => unimplemented!("RabitQ does not support data type: {:?}", T::FLOAT_TYPE),

--- a/rust/lance-linalg/benches/dot.rs
+++ b/rust/lance-linalg/benches/dot.rs
@@ -39,7 +39,7 @@ where
     let type_name = std::any::type_name::<T::Native>();
     c.bench_function(format!("Dot({type_name}, arrow_artiy)").as_str(), |b| {
         b.iter(|| {
-            T::ArrayType::from(
+            <T::ArrayType as FloatArray<T>>::from_values(
                 target
                     .as_slice()
                     .chunks(DIMENSION)

--- a/rust/lance-testing/src/datagen.rs
+++ b/rust/lance-testing/src/datagen.rs
@@ -209,10 +209,8 @@ where
 {
     let mut rng = StdRng::from_seed(seed);
 
-    T::ArrayType::from(
-        repeat_with(|| T::Native::from_f32(rng.random::<f32>()).unwrap())
-            .take(n)
-            .collect::<Vec<_>>(),
+    <T::ArrayType as lance_arrow::FloatArray<T>>::from_iter_values(
+        repeat_with(|| T::Native::from_f32(rng.random::<f32>()).unwrap()).take(n),
     )
 }
 


### PR DESCRIPTION
Arrow 57.2 has changed `Array` trait into sealed, this PR provides a workaround.

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**