### PR TITLE
feat: add stats() method to ObjectStoreRegistry

### DIFF
--- a/rust/lance-file/src/reader.rs
+++ b/rust/lance-file/src/reader.rs
@@ -856,7 +856,7 @@ impl FileReader {
         &self,
         _projection: &ReaderProjection,
     ) -> Result<Vec<Arc<ColumnInfo>>> {
-        Ok(self.metadata.column_infos.to_vec())
+        Ok(self.metadata.column_infos.clone())
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/rust/lance-index/src/scalar/inverted/query.rs
+++ b/rust/lance-index/src/scalar/inverted/query.rs
@@ -794,7 +794,7 @@ pub fn collect_query_tokens(
                 continue;
             }
         }
-        tokens.push(token.text.to_owned());
+        tokens.push(token.text.clone());
     }
     Tokens::new(tokens, token_type)
 }
@@ -813,7 +813,7 @@ pub fn collect_doc_tokens(
                 continue;
             }
         }
-        tokens.push(token.text.to_owned());
+        tokens.push(token.text.clone());
     }
     Tokens::new(tokens, token_type)
 }

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -437,7 +437,10 @@ mod tests {
         for (params, (hits, misses, active)) in cases {
             stores.push(registry.get_store(url.clone(), params).await.unwrap());
             let s = registry.stats();
-            assert_eq!((s.hits, s.misses, s.active_stores), (*hits, *misses, *active));
+            assert_eq!(
+                (s.hits, s.misses, s.active_stores),
+                (*hits, *misses, *active)
+            );
         }
 
         // Same params returns same instance

--- a/rust/lance-tools/src/meta.rs
+++ b/rust/lance-tools/src/meta.rs
@@ -47,7 +47,7 @@ impl LanceToolFileMetadata {
             .open_file(&path, &CachedFileSize::unknown())
             .await?;
         let file_metadata = FileReader::read_all_metadata(&file_scheduler).await?;
-        let lance_tool_file_metadata = LanceToolFileMetadata { file_metadata };
+        let lance_tool_file_metadata = Self { file_metadata };
         Ok(lance_tool_file_metadata)
     }
 }


### PR DESCRIPTION
Adds a stats() method to ObjectStoreRegistry to show hit, miss, and active store counts. This will enable applications to monitor for unexpected spikes in cache misses (indicating storage handles are not reused, which is potentially costly).

Consuming applications can bring this condition on themselves by inadvertently adding dynamic data to storage_options, which is currently part of the cache key.