### PR TITLE
feat: add dynamic header middleware support for rest namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2986,7 +2986,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3225,7 +3225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4198,7 +4198,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4523,7 +4523,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4618,7 +4618,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5246,10 +5246,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a21b43fe2a373896727b97927adedd2683d2907683f294f62cf8815fbf6a01"
+version = "0.4.5"
 dependencies = [
+ "async-trait",
  "reqwest",
  "serde",
  "serde_json",
@@ -6007,7 +6006,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7112,7 +7111,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.35",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -7149,9 +7148,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7743,7 +7742,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8778,7 +8777,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9691,7 +9690,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ lance-io = { version = "=2.0.0-beta.5", path = "./rust/lance-io", default-featur
 lance-linalg = { version = "=2.0.0-beta.5", path = "./rust/lance-linalg" }
 lance-namespace = { version = "=2.0.0-beta.5", path = "./rust/lance-namespace" }
 lance-namespace-impls = { version = "=2.0.0-beta.5", path = "./rust/lance-namespace-impls" }
-lance-namespace-reqwest-client = "0.3.1"
+lance-namespace-reqwest-client = { path = "../lance-namespace/rust/lance-namespace-reqwest-client" }
 lance-table = { version = "=2.0.0-beta.5", path = "./rust/lance-table" }
 lance-test-macros = { version = "=2.0.0-beta.5", path = "./rust/lance-test-macros" }
 lance-testing = { version = "=2.0.0-beta.5", path = "./rust/lance-testing" }

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -4302,10 +4302,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a21b43fe2a373896727b97927adedd2683d2907683f294f62cf8815fbf6a01"
+version = "0.4.5"
 dependencies = [
+ "async-trait",
  "reqwest",
  "serde",
  "serde_json",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4640,10 +4640,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00a21b43fe2a373896727b97927adedd2683d2907683f294f62cf8815fbf6a01"
+version = "0.4.5"
 dependencies = [
+ "async-trait",
  "reqwest",
  "serde",
  "serde_json",

--- a/rust/lance-io/src/object_store/storage_options.rs
+++ b/rust/lance-io/src/object_store/storage_options.rs
@@ -115,6 +115,7 @@ impl StorageOptionsProvider for LanceNamespaceStorageOptionsProvider {
             id: Some(self.table_id.clone()),
             version: None,
             with_table_uri: None,
+            ..Default::default()
         };
 
         let response = self

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -934,6 +934,7 @@ impl LanceNamespace for DirectoryNamespace {
                     schema: Some(Box::new(json_schema)),
                     storage_options,
                     stats: None,
+                    ..Default::default()
                 })
             }
             Err(err) => {
@@ -960,6 +961,7 @@ impl LanceNamespace for DirectoryNamespace {
                         schema: None,
                         storage_options,
                         stats: None,
+                        ..Default::default()
                     })
                 } else {
                     Err(Error::Namespace {
@@ -1156,7 +1158,6 @@ impl LanceNamespace for DirectoryNamespace {
         Ok(CreateEmptyTableResponse {
             transaction_id: None,
             location: Some(table_uri),
-            properties: None,
             storage_options: self.storage_options.clone(),
         })
     }
@@ -1987,6 +1988,7 @@ mod tests {
             id: Some(vec![]),
             page_token: None,
             limit: None,
+            ..Default::default()
         };
         let result = namespace.list_namespaces(list_req).await;
         assert!(result.is_ok());
@@ -2020,6 +2022,7 @@ mod tests {
             id: Some(vec!["parent".to_string()]),
             page_token: None,
             limit: None,
+            ..Default::default()
         };
         let result = namespace.list_namespaces(list_req).await;
         assert!(result.is_ok());
@@ -2033,6 +2036,7 @@ mod tests {
             id: Some(vec![]),
             page_token: None,
             limit: None,
+            ..Default::default()
         };
         let result = namespace.list_namespaces(list_req).await;
         assert!(result.is_ok());
@@ -2065,6 +2069,7 @@ mod tests {
             id: Some(vec!["test_ns".to_string()]),
             page_token: None,
             limit: None,
+            ..Default::default()
         };
         let result = namespace.list_tables(list_req).await;
         assert!(result.is_ok());
@@ -2113,6 +2118,7 @@ mod tests {
             id: Some(vec!["test_ns".to_string()]),
             page_token: None,
             limit: None,
+            ..Default::default()
         };
         let result = namespace.list_tables(list_req).await;
         assert!(result.is_ok());
@@ -2248,6 +2254,7 @@ mod tests {
         // Describe namespace and verify properties
         let describe_req = DescribeNamespaceRequest {
             id: Some(vec!["test_ns".to_string()]),
+            ..Default::default()
         };
         let result = namespace.describe_namespace(describe_req).await;
         assert!(result.is_ok());
@@ -2326,6 +2333,7 @@ mod tests {
             id: Some(vec!["ns1".to_string()]),
             page_token: None,
             limit: None,
+            ..Default::default()
         };
         let result = namespace.list_tables(list_req).await.unwrap();
         assert_eq!(result.tables.len(), 1);
@@ -2335,6 +2343,7 @@ mod tests {
             id: Some(vec!["ns2".to_string()]),
             page_token: None,
             limit: None,
+            ..Default::default()
         };
         let result = namespace.list_tables(list_req).await.unwrap();
         assert_eq!(result.tables.len(), 1);

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -1113,6 +1113,7 @@ impl LanceNamespace for ManifestNamespace {
                             schema: Some(Box::new(json_schema)),
                             storage_options: self.storage_options.clone(),
                             stats: None,
+                            ..Default::default()
                         })
                     }
                     Err(_) => {
@@ -1126,6 +1127,7 @@ impl LanceNamespace for ManifestNamespace {
                             schema: None,
                             storage_options: self.storage_options.clone(),
                             stats: None,
+                            ..Default::default()
                         })
                     }
                 }
@@ -1624,7 +1626,6 @@ impl LanceNamespace for ManifestNamespace {
         Ok(CreateEmptyTableResponse {
             transaction_id: None,
             location: Some(table_uri),
-            properties: None,
             storage_options: self.storage_options.clone(),
         })
     }
@@ -2172,6 +2173,7 @@ mod tests {
         // Verify namespace exists
         let exists_req = NamespaceExistsRequest {
             id: Some(vec!["ns1".to_string()]),
+            ..Default::default()
         };
         let result = dir_namespace.namespace_exists(exists_req).await;
         assert!(result.is_ok(), "Namespace should exist");
@@ -2181,6 +2183,7 @@ mod tests {
             id: Some(vec![]),
             page_token: None,
             limit: None,
+            ..Default::default()
         };
         let result = dir_namespace.list_namespaces(list_req).await;
         assert!(result.is_ok());
@@ -2225,6 +2228,7 @@ mod tests {
         // Verify nested namespace exists
         let exists_req = NamespaceExistsRequest {
             id: Some(vec!["parent".to_string(), "child".to_string()]),
+            ..Default::default()
         };
         let result = dir_namespace.namespace_exists(exists_req).await;
         assert!(result.is_ok(), "Nested namespace should exist");
@@ -2234,6 +2238,7 @@ mod tests {
             id: Some(vec!["parent".to_string()]),
             page_token: None,
             limit: None,
+            ..Default::default()
         };
         let result = dir_namespace.list_namespaces(list_req).await;
         assert!(result.is_ok());
@@ -2301,6 +2306,7 @@ mod tests {
         // Verify namespace no longer exists
         let exists_req = NamespaceExistsRequest {
             id: Some(vec!["ns1".to_string()]),
+            ..Default::default()
         };
         let result = dir_namespace.namespace_exists(exists_req).await;
         assert!(result.is_err(), "Namespace should not exist after drop");
@@ -2379,6 +2385,7 @@ mod tests {
             id: Some(vec!["ns1".to_string()]),
             page_token: None,
             limit: None,
+            ..Default::default()
         };
         let result = dir_namespace.list_tables(list_req).await;
         assert!(result.is_ok());
@@ -2415,6 +2422,7 @@ mod tests {
         // Describe the namespace
         let describe_req = DescribeNamespaceRequest {
             id: Some(vec!["ns1".to_string()]),
+            ..Default::default()
         };
         let result = dir_namespace.describe_namespace(describe_req).await;
         assert!(

--- a/rust/lance-namespace-impls/src/lib.rs
+++ b/rust/lance-namespace-impls/src/lib.rs
@@ -104,7 +104,7 @@ pub use credentials::azure::{AzureCredentialVendor, AzureCredentialVendorConfig}
 pub use credentials::azure_props;
 
 #[cfg(feature = "rest")]
-pub use rest::{RestNamespace, RestNamespaceBuilder};
+pub use rest::{HeaderProvider, RestNamespace, RestNamespaceBuilder, StaticHeaderProvider};
 
 #[cfg(feature = "rest-adapter")]
 pub use rest_adapter::{RestAdapter, RestAdapterConfig, RestAdapterHandle};

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -823,7 +823,7 @@ impl Dataset {
                 let request = CreateEmptyTableRequest {
                     id: Some(table_id.clone()),
                     location: None,
-                    properties: None,
+                    ..Default::default()
                 };
                 let response =
                     namespace
@@ -872,6 +872,7 @@ impl Dataset {
                     id: Some(table_id.clone()),
                     version: None,
                     with_table_uri: None,
+                    ..Default::default()
                 };
                 let response =
                     namespace

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -138,6 +138,7 @@ impl DatasetBuilder {
             id: Some(table_id.clone()),
             version: None,
             with_table_uri: None,
+            ..Default::default()
         };
 
         let response = namespace


### PR DESCRIPTION
Paired with https://github.com/lance-format/lance-namespace/pull/298.

# Changes
- Support dynamic header middlewares for namespace clients. Previously this was possible with something like:
```python
class CustomRestNamespaceConfig(RestNamespaceConfig):
    def __init__(self, properties: Dict[str, str]):
        super().__init__(properties)
        self.e2e = init_e2e_client()
        self.token = None
        self.expiration = 0


    def additional_headers(self) -> Dict[str, str]:
        if self.token is None or time.time() > self.expiration - 60:
            response = self.e2e.get_token()
            self.token = response.token
            self.expiration = response.expires_at_epoch_time
        return {"x-forwarded-authentication": self.token}


class CustomRestNamespace(LanceRestNamespace):
    def __init__(self, **kwargs):
        configuration = Configuration()
        (crt, pkey) = getClientKeystore()
        configuration.cert_file = crt
        configuration.key_file = pkey
        configuration.ssl_ca_cert = getClientTruststore()
        configuration.assert_hostname = False

        configuration.retries = Retry(total=MAX_RETRIES, backoff_factor=HTTP_BACKOFF_FACTOR)
        configuration.host = kwargs["uri"]

        self.api_client = ApiClient(configuration)
        self.namespace_api = NamespaceApi(self.api_client)
        self.table_api = TableApi(self.api_client)
        self.transaction_api = TransactionApi(self.api_client)
        self.config = CustomRestNamespaceConfig(kwargs)


    def namespace_id(self) -> str:
        return "customlance"
```

With https://github.com/lance-format/lance/commit/c73c3dccf77aba67ae35c1b9d357857cc93aaf71, this behavior was broken as the namespace client pattern was switched to builder and the additional_headers pass-through fields were removed. The idea here is now:

```python
  class CustomBdpLanceRestNamespace(LanceRestNamespace):
      def __init__(self, **kwargs):
          configuration = Configuration()
          (crt, pkey) = getClientKeystore()
          configuration.cert_file = crt
          configuration.key_file = pkey
          configuration.ssl_ca_cert = getClientTruststore()
          configuration.assert_hostname = False
          configuration.retries = Retry(total=MAX_RETRIES, backoff_factor=HTTP_BACKOFF_FACTOR)
          configuration.host = kwargs["uri"]

          # Token state (closure captures these)
          e2e = init_e2e_client()
          token_cache = {"token": None, "expiration": 0}

          def get_headers():
              if token_cache["token"] is None or time.time() > token_cache["expiration"] - 60:
                  response = e2e.get_token()
                  token_cache["token"] = response.token
                  token_cache["expiration"] = response.expires_at_epoch_time
              return {"x-forwarded-authentication": token_cache["token"]}

          # Set the header provider
          configuration.header_provider = get_headers

          self.api_client = ApiClient(configuration)
          self.namespace_api = NamespaceApi(self.api_client)
          self.table_api = TableApi(self.api_client)
          self.transaction_api = TransactionApi(self.api_client)

      def namespace_id(self) -> str:
          return "customlance"
```

This allows for background propagation of the headers without needing to pass-through the "additionalHeaders" fields in all the API callsites.

# Alternatives considered
1. Plumb through the additional_headers param to the rust namespace implementation, then simply pass through headers in rest.rs using the header_provider.