### PR TITLE
docs: in dataset.rs, fix comment for get_fragments

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1821,8 +1821,6 @@ impl Dataset {
     }
 
     /// Get fragments.
-    ///
-    /// If `filter` is provided, only fragments with the given name will be returned.
     pub fn get_fragments(&self) -> Vec<FileFragment> {
         let dataset = Arc::new(self.clone());
         self.manifest


### PR DESCRIPTION
In rust/lance/src/dataset.rs, a comment for Dataset.get_fragments talks about a 'filter' parameter that doesn't actually exist. Remove this comment.