### PR TITLE
perf: cache global BM25 idf per query

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -328,8 +328,8 @@ impl InvertedIndex {
                 let mut score = 0.0;
                 for (term_index, freq) in freqs.into_iter() {
                     debug_assert!((term_index as usize) < idf_by_position.len());
-                    score += idf_by_position[term_index as usize]
-                        * scorer.doc_weight(freq, doc_length);
+                    score +=
+                        idf_by_position[term_index as usize] * scorer.doc_weight(freq, doc_length);
                 }
                 if candidates.len() < limit {
                     candidates.push(Reverse(ScoredDoc::new(row_id, score)));


### PR DESCRIPTION
this could avoid scanning all partitions for scoring each token, helpful when we have many partitions and long query