### PR TITLE
perf: use LRU cache for session contexts in get_session_context

### DIFF
--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -946,8 +946,12 @@ impl ExecutionPlan for StrictBatchSizeExec {
 mod tests {
     use super::*;
 
+    // Serialize cache tests since they share global state
+    static CACHE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn test_session_context_cache() {
+        let _lock = CACHE_TEST_LOCK.lock().unwrap();
         let cache = get_session_cache();
 
         // Clear any existing entries from other tests
@@ -983,6 +987,7 @@ mod tests {
 
     #[test]
     fn test_session_context_cache_lru_eviction() {
+        let _lock = CACHE_TEST_LOCK.lock().unwrap();
         let cache = get_session_cache();
 
         // Clear any existing entries from other tests


### PR DESCRIPTION
## Motivation

We have a performance issue when `LANCE_MEM_POOL_SIZE`: when this is set (to something different than the default), the current cache always misses here:

https://github.com/lance-format/lance/blob/445dd5bfe7b0111fd8e146163393e825e5995679/rust/lance-datafusion/src/exec.rs#L398-L410

## Summary
- Replace static `LazyLock` session contexts with LRU cache (size 4)
- Cache key uses resolved configuration values (after env var lookup)
- Fixes cache misses when `LANCE_MEM_POOL_SIZE` env var is set

## Test plan
- [x] `cargo test -p lance-datafusion` passes
- [x] `cargo clippy -p lance-datafusion` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)