### PR TITLE
feat: add extended properties to manifest namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5208,6 +5208,7 @@ dependencies = [
  "lance-index",
  "lance-io",
  "lance-namespace",
+ "lance-namespace-reqwest-client",
  "log",
  "object_store",
  "rand 0.9.2",
@@ -5229,8 +5230,7 @@ dependencies = [
 [[package]]
 name = "lance-namespace-reqwest-client"
 version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2acdba67f84190067532fce07b51a435dd390d7cdc1129a05003e5cb3274cf0"
+source = "git+https://github.com/wojiaodoubao/lance-namespace?branch=rest-table-properties#a122997e5ed74122686c3a4bd228b839d0d025eb"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ lance-io = { version = "=2.0.0-beta.10", path = "./rust/lance-io", default-featu
 lance-linalg = { version = "=2.0.0-beta.10", path = "./rust/lance-linalg" }
 lance-namespace = { version = "=2.0.0-beta.10", path = "./rust/lance-namespace" }
 lance-namespace-impls = { version = "=2.0.0-beta.10", path = "./rust/lance-namespace-impls" }
-lance-namespace-reqwest-client = { version = "=0.4.5" }
+lance-namespace-reqwest-client = { git = "https://github.com/wojiaodoubao/lance-namespace", branch = "rest-table-properties" }
 lance-table = { version = "=2.0.0-beta.10", path = "./rust/lance-table" }
 lance-test-macros = { version = "=2.0.0-beta.10", path = "./rust/lance-test-macros" }
 lance-testing = { version = "=2.0.0-beta.10", path = "./rust/lance-testing" }

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3771,6 +3771,7 @@ dependencies = [
  "lance-index",
  "lance-io",
  "lance-namespace",
+ "lance-namespace-reqwest-client",
  "log",
  "object_store",
  "rand 0.9.2",
@@ -3787,8 +3788,7 @@ dependencies = [
 [[package]]
 name = "lance-namespace-reqwest-client"
 version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2acdba67f84190067532fce07b51a435dd390d7cdc1129a05003e5cb3274cf0"
+source = "git+https://github.com/wojiaodoubao/lance-namespace?branch=rest-table-properties#a122997e5ed74122686c3a4bd228b839d0d025eb"
 dependencies = [
  "reqwest",
  "serde",

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4294,6 +4294,7 @@ dependencies = [
  "lance-index",
  "lance-io",
  "lance-namespace",
+ "lance-namespace-reqwest-client",
  "log",
  "object_store",
  "rand 0.9.2",
@@ -4310,8 +4311,7 @@ dependencies = [
 [[package]]
 name = "lance-namespace-reqwest-client"
 version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2acdba67f84190067532fce07b51a435dd390d7cdc1129a05003e5cb3274cf0"
+source = "git+https://github.com/wojiaodoubao/lance-namespace?branch=rest-table-properties#a122997e5ed74122686c3a4bd228b839d0d025eb"
 dependencies = [
  "reqwest",
  "serde",

--- a/rust/lance-namespace-impls/Cargo.toml
+++ b/rust/lance-namespace-impls/Cargo.toml
@@ -29,6 +29,7 @@ credential-vendor-azure = ["dep:azure_core", "dep:azure_identity", "dep:azure_st
 [dependencies]
 lance-namespace.workspace = true
 lance-core.workspace = true
+lance-namespace-reqwest-client.workspace = true
 
 # REST implementation dependencies (optional, enabled by "rest" feature)
 reqwest = { version = "0.12", optional = true, default-features = false, features = [

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -8,6 +8,7 @@
 
 pub mod manifest;
 
+use crate::context::DynamicContextProvider;
 use arrow::record_batch::RecordBatchIterator;
 use arrow_ipc::reader::StreamReader;
 use async_trait::async_trait;
@@ -15,13 +16,7 @@ use bytes::Bytes;
 use lance::dataset::{Dataset, WriteParams};
 use lance::session::Session;
 use lance_io::object_store::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
-use object_store::path::Path;
-use object_store::{Error as ObjectStoreError, ObjectStore as OSObjectStore, PutMode, PutOptions};
-use std::collections::HashMap;
-use std::io::Cursor;
-use std::sync::Arc;
 
-use crate::context::DynamicContextProvider;
 use lance_namespace::models::{
     CreateEmptyTableRequest, CreateEmptyTableResponse, CreateNamespaceRequest,
     CreateNamespaceResponse, CreateTableRequest, CreateTableResponse, DeclareTableRequest,
@@ -30,6 +25,11 @@ use lance_namespace::models::{
     DropTableRequest, DropTableResponse, Identity, ListNamespacesRequest, ListNamespacesResponse,
     ListTablesRequest, ListTablesResponse, NamespaceExistsRequest, TableExistsRequest,
 };
+use object_store::path::Path;
+use object_store::{Error as ObjectStoreError, ObjectStore as OSObjectStore, PutMode, PutOptions};
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::sync::Arc;
 
 use lance_core::{box_error, Error, Result};
 use lance_namespace::schema::arrow_schema_to_json;

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -2872,6 +2872,7 @@ mod tests {
                 mode: Some("create".to_string()),
                 identity: None,
                 context: None,
+                properties: None,
             };
             let result = namespace.create_table(create_table_req, table_data).await;
             assert!(result.is_ok(), "Failed to create table: {:?}", result);

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -845,6 +845,7 @@ impl Dataset {
                             transaction_id: fallback_resp.transaction_id,
                             location: fallback_resp.location,
                             storage_options: fallback_resp.storage_options,
+                            properties: fallback_resp.properties,
                         }
                     }
                     Err(e) => {


### PR DESCRIPTION
This is a sub-task of the partitioned namespace, designed to introduce the concept of extended properties into the manifest namespace. The PartitionedNamespace will use extended properties to store partition fields.