### PR TITLE
test: add f16/f64 coverage to PQ distance table  benchmarks

### DIFF
--- a/rust/lance-index/benches/pq_dist_table.rs
+++ b/rust/lance-index/benches/pq_dist_table.rs
@@ -5,13 +5,13 @@
 
 use std::iter::repeat_n;
 
-use arrow_array::types::Float32Type;
+use arrow_array::types::{Float16Type, Float32Type, Float64Type};
 use arrow_array::{FixedSizeListArray, UInt8Array};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use lance_arrow::FixedSizeListArrayExt;
+use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray};
 use lance_index::vector::pq::distance::*;
 use lance_index::vector::pq::ProductQuantizer;
-use lance_linalg::distance::DistanceType;
+use lance_linalg::distance::{DistanceType, Dot, L2};
 use lance_testing::datagen::generate_random_array_with_seed;
 use rand::{prelude::StdRng, Rng, SeedableRng};
 
@@ -23,24 +23,35 @@ const PQ: usize = DIM / 8;
 const TOTAL: usize = 16 * 1000;
 
 fn construct_dist_table(c: &mut Criterion) {
-    let codebook = generate_random_array_with_seed::<Float32Type>(256 * DIM, [88; 32]);
-    let query = generate_random_array_with_seed::<Float32Type>(DIM, [32; 32]);
+    construct_dist_table_for_type::<Float16Type>(c, "f16");
+    construct_dist_table_for_type::<Float32Type>(c, "f32");
+    construct_dist_table_for_type::<Float64Type>(c, "f64");
+}
+
+fn construct_dist_table_for_type<T: ArrowFloatType>(c: &mut Criterion, type_name: &str)
+where
+    T::Native: L2 + Dot,
+    T::ArrayType: FloatArray<T>,
+{
+    let codebook = generate_random_array_with_seed::<T>(256 * DIM, [88; 32]);
+    let query = generate_random_array_with_seed::<T>(DIM, [32; 32]);
 
     c.bench_function(
         format!(
-            "construct_dist_table: {},PQ={},DIM={}",
+            "construct_dist_table: {},PQ={},DIM={},type={}",
             DistanceType::L2,
             PQ,
-            DIM
+            DIM,
+            type_name
         )
         .as_str(),
         |b| {
             b.iter(|| {
                 black_box(build_distance_table_l2(
-                    codebook.values(),
+                    codebook.as_slice(),
                     8,
                     PQ,
-                    query.values(),
+                    query.as_slice(),
                 ));
             })
         },
@@ -48,19 +59,20 @@ fn construct_dist_table(c: &mut Criterion) {
 
     c.bench_function(
         format!(
-            "construct_dist_table: {},PQ={},DIM={}",
+            "construct_dist_table: {},PQ={},DIM={},type={}",
             DistanceType::Dot,
             PQ,
-            DIM
+            DIM,
+            type_name
         )
         .as_str(),
         |b| {
             b.iter(|| {
                 black_box(build_distance_table_dot(
-                    codebook.values(),
+                    codebook.as_slice(),
                     8,
                     PQ,
-                    query.values(),
+                    query.as_slice(),
                 ));
             })
         },
@@ -68,23 +80,37 @@ fn construct_dist_table(c: &mut Criterion) {
 }
 
 fn compute_distances(c: &mut Criterion) {
-    let codebook = generate_random_array_with_seed::<Float32Type>(256 * DIM, [88; 32]);
-    let query = generate_random_array_with_seed::<Float32Type>(DIM, [32; 32]);
+    compute_distances_for_type::<Float16Type>(c, "f16");
+    compute_distances_for_type::<Float32Type>(c, "f32");
+    compute_distances_for_type::<Float64Type>(c, "f64");
+}
+
+fn compute_distances_for_type<T: ArrowFloatType>(c: &mut Criterion, type_name: &str)
+where
+    T::Native: L2 + Dot,
+    T::ArrayType: FloatArray<T>,
+{
+    let codebook = generate_random_array_with_seed::<T>(256 * DIM, [88; 32]);
+    let query = generate_random_array_with_seed::<T>(DIM, [32; 32]);
 
     let mut rnd = StdRng::from_seed([32; 32]);
     let code = UInt8Array::from_iter_values(repeat_n(rnd.random::<u8>(), TOTAL * PQ));
 
-    for dt in [DistanceType::L2, DistanceType::Cosine, DistanceType::Dot].iter() {
+    for dt in [DistanceType::L2, DistanceType::Cosine, DistanceType::Dot] {
         let pq = ProductQuantizer::new(
             PQ,
             8,
             DIM,
             FixedSizeListArray::try_new_from_values(codebook.clone(), DIM as i32).unwrap(),
-            *dt,
+            dt,
         );
 
         c.bench_function(
-            format!("compute_distances: {},{},PQ={},DIM={}", TOTAL, dt, PQ, DIM).as_str(),
+            format!(
+                "compute_distances: {},{},PQ={},DIM={},type={}",
+                TOTAL, dt, PQ, DIM, type_name
+            )
+            .as_str(),
             |b| {
                 b.iter(|| {
                     black_box(pq.compute_distances(&query, &code).unwrap());


### PR DESCRIPTION
closes #5478

Changes: 
* Add f16/f64 coverage to pq_dist_table and 4bitpq_dist_table benchmarks.