### PR TITLE
fix: fix deletion when using file-object-store://

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -1134,7 +1134,7 @@ mod tests {
             url.set_path(path.to_str().unwrap());
             url
         };
-        let (store, base) = ObjectStore::from_uri(&url.to_string()).await.unwrap();
+        let (store, base) = ObjectStore::from_uri(url.as_ref()).await.unwrap();
         store.remove_dir_all(base.child("foo")).await.unwrap();
 
         assert!(!path.join("foo").exists());


### PR DESCRIPTION
When using `file-object-store://`, we currently do not delete directories that are empty. This is because the other object stores (such as s3) don't need this. This PR fixes this to explicitly delete the empty directories when using `file-object-store://`.

This fixes a bug where tables appear to be undeletable when using `file-object-store://`

```
>>> db = lancedb.connect("file-object-store:///tmp/foo")
>>> table = db.create_table("my_table", schema=schema)
>>> db.table_names()
['my_table']
>>> db.drop_table("my_table")
>>> db.table_names()
['my_table']
```