### PR TITLE
ci: fix version inconsistency and pytorch deprecation warning

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -92,6 +92,11 @@ replace = 'lance-namespace = {{ version = "={new_version}"'
 
 [[tool.bumpversion.files]]
 filename = "Cargo.toml"
+search = 'lance-namespace-datafusion = {{ version = "={current_version}"'
+replace = 'lance-namespace-datafusion = {{ version = "={new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "Cargo.toml"
 search = 'lance-namespace-impls = {{ version = "={current_version}"'
 replace = 'lance-namespace-impls = {{ version = "={new_version}"'
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5183,7 +5183,7 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-datafusion"
-version = "2.0.0-beta.9"
+version = "2.1.0-beta.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/python/python/lance/torch/distance.py
+++ b/python/python/lance/torch/distance.py
@@ -1,11 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
-
+import warnings
 from typing import Optional, Tuple
 
-from lance.dependencies import torch
-from lance.log import LOGGER
+# Suppress torch.jit.script deprecation warning in PyTorch 2.10+
+# TODO: migrate to torch.compile when feasible
+warnings.filterwarnings(
+    "ignore",
+    message=r".*torch\.jit\.script.*deprecated.*",
+    category=DeprecationWarning,
+)
+
+from lance.dependencies import torch  # noqa: E402
+from lance.log import LOGGER  # noqa: E402
 
 __all__ = [
     "pairwise_cosine",


### PR DESCRIPTION
https://github.com/lance-format/lance/actions/runs/21189464705/job/60952409705

https://github.com/lance-format/lance/actions/runs/21190703617/job/60956265092

For pytorch, first give this quick fix to let CI continue to work, actual fix is needed to use `torch.compile`