### PR TITLE
fix(java)!: correct spelling of addFiledStatistics to addFieldStatistics

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -1551,7 +1551,7 @@ fn inner_get_data_statistics<'local>(
         )?;
         env.call_method(
             &data_stats,
-            "addFiledStatistics",
+            "addFieldStatistics",
             "(Lorg/lance/ipc/FieldStatistics;)V",
             &[JValue::Object(&filed_jobj)],
         )?;

--- a/java/src/main/java/org/lance/ipc/DataStatistics.java
+++ b/java/src/main/java/org/lance/ipc/DataStatistics.java
@@ -27,7 +27,7 @@ public class DataStatistics implements Serializable {
   }
 
   // used for rust to add field statistics
-  public void addFiledStatistics(FieldStatistics fieldStatistics) {
+  public void addFieldStatistics(FieldStatistics fieldStatistics) {
     fields.add(fieldStatistics);
   }
 


### PR DESCRIPTION
BREAKING CHANGE: It modifies the name of a public method of `DataStatistics` class.