### PR TITLE
docs: fix issues in HF integration docs

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -77,6 +77,12 @@ jobs:
           # Copy .pages from lance-namespace-impls and append template entry
           cp lance-namespace-impls/docs/src/.pages docs/src/format/namespace/integrations/.pages
           echo "  - Template for New Integrations: template.md" >> docs/src/format/namespace/integrations/.pages
+      - name: Copy lance-huggingface docs
+        run: |
+          cp -r lance-huggingface/docs/src docs/src/integrations/huggingface
+          cat >> docs/src/integrations/.pages << 'EOF'
+            - Huggingface: huggingface
+          EOF
       - name: Copy lance-spark docs
         run: |
           cp -r lance-spark/docs/src docs/src/integrations/spark
@@ -88,12 +94,6 @@ jobs:
           cp -r lance-ray/docs/src docs/src/integrations/ray
           cat >> docs/src/integrations/.pages << 'EOF'
             - Ray: ray
-          EOF
-      - name: Copy lance-huggingface docs
-        run: |
-          cp -r lance-huggingface/docs/src docs/src/integrations/huggingface
-          cat >> docs/src/integrations/.pages << 'EOF'
-            - Huggingface: huggingface
           EOF
       - name: Copy contributing docs
         run: |

--- a/docs/src/integrations/.pages
+++ b/docs/src/integrations/.pages
@@ -1,7 +1,6 @@
 nav:
   - Apache DataFusion: datafusion.md
   - DuckDB: duckdb.md
-  - Huggingface: huggingface.md
   - PostgreSQL: https://github.com/lancedb/pglance
   - PyTorch: pytorch.md
   - Tensorflow: tensorflow.md


### PR DESCRIPTION
- [x] This PR addresses the issues in sidebar organization for the Hugging Face integration. Now, the HF docs should appear in two pages and are more clearly visible in the page at first glance.
- [x] Remove redundant old sidebar link for `huggingface.md` (the doc source files come straight from the [lance-format/lance-huggingface](https://github.com/lance-format/lance-huggingface) repo)