### PR TITLE
fix: allow unused_unsafe for __cpuid to support both stable and nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,6 +85,8 @@ jobs:
       # Need up-to-date compilers for kernels
       CC: clang
       CXX: clang++
+      # Treat warnings as errors to catch issues early
+      RUSTFLAGS: "-D warnings"
     steps:
       - uses: actions/checkout@v4
       # pin the toolchain version to avoid surprises

--- a/rust/lance-core/src/utils/cpu.rs
+++ b/rust/lance-core/src/utils/cpu.rs
@@ -78,6 +78,8 @@ mod x86 {
         // EAX=7, ECX=0: Extended Features (includes AVX512)
         // More info on calling CPUID can be found here (section 1.4)
         // https://www.intel.com/content/dam/develop/external/us/en/documents/architecture-instruction-set-extensions-programming-reference.pdf
+        // __cpuid is safe in nightly but unsafe in stable, allow both
+        #[allow(unused_unsafe)]
         let ext_cpuid_result = unsafe { __cpuid(7) };
         check_flag(ext_cpuid_result.edx as usize, 23)
     }


### PR DESCRIPTION
In Rust nightly, __cpuid was changed to be a safe function, making the unsafe block unnecessary. This causes a warning that fails CI when -D warnings is set (e.g., via setup-rust-toolchain action).

Adding #[allow(unused_unsafe)] allows the code to compile without warnings on both stable (where unsafe is required) and nightly (where it's no longer needed).

Also add RUSTFLAGS="-D warnings" to the linux-build CI job to catch such issues early.

🤖 Generated with [Claude Code](https://claude.com/claude-code)