### PR TITLE
fix: backpatch bitmap search index loading parallelism

### DIFF
--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -438,10 +438,10 @@ impl ScalarIndex for BitmapIndex {
                 if keys.is_empty() {
                     RowIdTreeMap::default()
                 } else {
-                    let bitmaps: Vec<_> = stream::iter(keys.into_iter().map(|key| {
-                        let this = self.clone();
-                        async move { this.load_bitmap(&key, None).await }
-                    }))
+                    let bitmaps: Vec<_> = stream::iter(
+                        keys.into_iter()
+                            .map(|key| async move { self.load_bitmap(&key, None).await }),
+                    )
                     .buffer_unordered(get_num_compute_intensive_cpus())
                     .try_collect()
                     .await?;
@@ -476,10 +476,10 @@ impl ScalarIndex for BitmapIndex {
                     RowIdTreeMap::default()
                 } else {
                     // Load bitmaps in parallel
-                    let mut bitmaps: Vec<_> = stream::iter(keys.into_iter().map(|key| {
-                        let this = self.clone();
-                        async move { this.load_bitmap(&key, None).await }
-                    }))
+                    let mut bitmaps: Vec<_> = stream::iter(
+                        keys.into_iter()
+                            .map(|key| async move { self.load_bitmap(&key, None).await }),
+                    )
                     .buffer_unordered(get_num_compute_intensive_cpus())
                     .try_collect()
                     .await?;


### PR DESCRIPTION
This backpatches some improvements to bitmap index search to a previous hotfix release branch.