### PR TITLE
fix: set JUnit dependency as test scope

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -94,6 +94,7 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.10.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This PR sets the JUnit dependency as test scope for the Java build.