### PR TITLE
chore: add CODEOWNERS for spec files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# file specification
+protos/file*.proto @file-spec-team
+protos/encodings*.proto @file-spec-team
+docs/src/format/file/ @file-spec-team
+
+# table specification
+protos/table.proto @table-spec-team
+protos/rowids.proto @table-spec-team
+docs/src/format/table/ @table-spec-team
+
+# index specification
+protos/index.proto @index-spec-team
+protos/index_old.proto @index-spec-team
+docs/src/format/table/index/ @index-spec-team


### PR DESCRIPTION
Idea is we want to make sure people are notified when someone makes a PR with a spec change. This reduces the likelihood a spec change will sneak through without a vote.

My plan is to create three GitHub "teams": `file-spec-team`, `table-spec-team` and `index-spec-team`. I can add a few relevant PMC members to each, and we can update this easily over time.