### PR TITLE
fix: properly skip fp16kernels if not enabled and allow building on ios

### DIFF
--- a/rust/lance-linalg/build.rs
+++ b/rust/lance-linalg/build.rs
@@ -34,9 +34,20 @@ fn main() -> Result<(), String> {
         return Ok(());
     }
 
+    if cfg!(not(feature = "fp16kernels")) {
+        println!(
+            "cargo:warning=fp16kernels feature is not enabled, skipping build of fp16 kernels"
+        );
+        return Ok(());
+    }
+
     if target_arch == "aarch64" && target_os == "macos" {
         // Build a version with NEON
         build_f16_with_flags("neon", &["-mtune=apple-m1"]).unwrap();
+    } else if target_arch == "aarch64" && target_os == "ios" {
+        // Build version with NEON
+        // A13 bionic is the earliest supported iOS SOC
+        build_f16_with_flags("neon", &["-mtune=apple-a13"]).unwrap();
     } else if target_arch == "aarch64" && target_os == "linux" {
         // Build a version with NEON
         build_f16_with_flags("neon", &["-march=armv8.2-a+fp16"]).unwrap();


### PR DESCRIPTION
Previously even if `fp16kernels` was disabled, the check would still fail and cause a build failure when trying to build lance-linalg.

The motivation was to enable building on `aarch64-apple-ios`. This PR also adds support for `mtune=apple-a13` when building for iOS, which is the earliest supported iOS architecture at time of writing.

This is intended for merge to the 1.0 branch of lance. Let me know if its preferable to PR it to main and backport the change after.