### PR TITLE
fix: handle NULL elements in LABEL_LIST index results and explain_plan

### DIFF
--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -2055,9 +2055,9 @@ def test_label_list_index_array_contains(tmp_path: Path):
 
 
 def test_label_list_index_null_element_match(tmp_path: Path):
-    """Ensure LABEL_LIST index keeps scan semantics when lists contain NULLs."""
+    """Covers NULL elements inside non-NULL lists (list itself is never NULL)."""
     tbl = pa.table(
-        {"labels": [["foo", None], ["foo"], ["bar", None], ["bar"], None, []]}
+        {"labels": [["foo", None], ["foo"], ["bar", None], [None], ["bar"], []]}
     )
     dataset = lance.write_dataset(tbl, tmp_path / "dataset")
 
@@ -2065,10 +2065,62 @@ def test_label_list_index_null_element_match(tmp_path: Path):
         "array_has_any(labels, ['foo'])",
         "array_has_all(labels, ['foo'])",
         "array_contains(labels, 'foo')",
-        # TODO(issue #5904): Enable after fixing NOT filters with NULL lists/elements
+        "NOT array_has_any(labels, ['foo'])",
+        "NOT array_has_all(labels, ['foo'])",
+        "NOT array_contains(labels, 'foo')",
+    ]
+    expected = {
+        f: dataset.to_table(filter=f).column("labels").to_pylist() for f in filters
+    }
+
+    dataset.create_scalar_index("labels", index_type="LABEL_LIST")
+
+    actual = {
+        f: dataset.to_table(filter=f).column("labels").to_pylist() for f in filters
+    }
+    assert actual == expected
+
+
+def test_label_list_index_null_list_match(tmp_path: Path):
+    """Covers NULL lists (list itself is NULL, elements are not NULL)."""
+    tbl = pa.table({"labels": [["foo"], ["bar"], None, []]})
+    dataset = lance.write_dataset(tbl, tmp_path / "dataset")
+
+    filters = [
+        "array_has_any(labels, ['foo'])",
+        "array_has_all(labels, ['foo'])",
+        "array_contains(labels, 'foo')",
+        # TODO(issue #5904): Enable after fixing NOT filters with whole-list NULLs
         # "NOT array_has_any(labels, ['foo'])",
         # "NOT array_has_all(labels, ['foo'])",
         # "NOT array_contains(labels, 'foo')",
+    ]
+    expected = {
+        f: dataset.to_table(filter=f).column("labels").to_pylist() for f in filters
+    }
+
+    dataset.create_scalar_index("labels", index_type="LABEL_LIST")
+
+    actual = {
+        f: dataset.to_table(filter=f).column("labels").to_pylist() for f in filters
+    }
+    assert actual == expected
+
+
+def test_label_list_index_null_literal_filters(tmp_path: Path):
+    """Ensure filters with NULL literal needles produce consistent results with scan."""
+    tbl = pa.table(
+        {"labels": [["foo", None], ["bar", None], [None], ["foo"], ["bar"], []]}
+    )
+    dataset = lance.write_dataset(tbl, tmp_path / "dataset")
+
+    filters = [
+        "array_has_any(labels, [NULL])",
+        "array_has_all(labels, [NULL])",
+        "array_contains(labels, NULL)",
+        "NOT array_has_any(labels, [NULL])",
+        "NOT array_has_all(labels, [NULL])",
+        "NOT array_contains(labels, NULL)",
     ]
     expected = {
         f: dataset.to_table(filter=f).column("labels").to_pylist() for f in filters

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -546,12 +546,7 @@ impl ScalarIndex for BitmapIndex {
             }
         };
 
-        let mut null_rows = null_row_ids.unwrap_or_default();
-        if !null_rows.is_empty() {
-            // A row can be both TRUE and NULL after list flattening; treat it as TRUE.
-            null_rows -= &row_ids;
-        }
-        let selection = NullableRowAddrSet::new(row_ids, null_rows);
+        let selection = NullableRowAddrSet::new(row_ids, null_row_ids.unwrap_or_default());
         Ok(SearchResult::Exact(selection))
     }
 

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -1551,7 +1551,7 @@ pub mod tests {
 
         // Test: Search for lists containing value 1
         // Row 0: [1, 2] - contains 1 → TRUE
-        // Row 1: [3, null] - has null item, unknown if it matches → NULL
+        // Row 1: [3, null] - null elements are ignored → FALSE
         // Row 2: [4] - doesn't contain 1 → FALSE
         let query = LabelListQuery::HasAnyLabel(vec![ScalarValue::UInt8(Some(1))]);
         let result = index.search(&query, &NoOpMetricsCollector).await.unwrap();
@@ -1570,17 +1570,9 @@ pub mod tests {
                     "Should find row 0 where list contains 1"
                 );
 
-                let null_row_ids = row_ids.null_rows();
                 assert!(
-                    !null_row_ids.is_empty(),
-                    "null_row_ids should not be empty - row 1 has null item"
-                );
-                let null_rows: Vec<u64> =
-                    null_row_ids.row_addrs().unwrap().map(u64::from).collect();
-                assert_eq!(
-                    null_rows,
-                    vec![1],
-                    "Should report row 1 as null because it contains a null item"
+                    row_ids.null_rows().is_empty(),
+                    "null_row_ids should be empty when null elements are ignored"
                 );
             }
             _ => panic!("Expected Exact search result"),


### PR DESCRIPTION
closes #5682

changes:
- Treat element-level NULLs in LABEL_LIST as non-matches so array_has_any/array_has_all return TRUE/FALSE when the list itself is non-NULL.
- Allow nullable list literals in `LabelListQuery::to_expr` to prevent `explain_plan()` panics.
- Add Python tests covering element-level NULLs, list-level NULLs, NULL-literal filters and explain behavior.