### PR TITLE
fix: flaky test test_ann_prefilter for HNSW

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -5811,6 +5811,7 @@ mod test {
         scan.filter("filterable > 5").unwrap();
         scan.nearest("vector", query_key.as_ref(), 1).unwrap();
         scan.minimum_nprobes(100);
+        scan.ef(100);
         scan.with_row_id();
 
         let batches = scan


### PR DESCRIPTION
this test searches for top1 which could lead to greedy search for HNSW, fix it by setting `ef` 