### PR TITLE
ci: fix bump version failed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ lance-io = { version = "=2.1.0-beta.0", path = "./rust/lance-io", default-featur
 lance-linalg = { version = "=2.1.0-beta.0", path = "./rust/lance-linalg" }
 lance-namespace = { version = "=2.1.0-beta.0", path = "./rust/lance-namespace" }
 lance-namespace-impls = { version = "=2.1.0-beta.0", path = "./rust/lance-namespace-impls" }
+lance-namespace-datafusion = { version = "=2.1.0-beta.0", path = "./rust/lance-namespace-datafusion" }
 lance-namespace-reqwest-client = { version = "=0.4.5" }
 lance-table = { version = "=2.1.0-beta.0", path = "./rust/lance-table" }
 lance-test-macros = { version = "=2.1.0-beta.0", path = "./rust/lance-test-macros" }


### PR DESCRIPTION
Publish beta failed because:
<img width="1586" height="426" alt="image" src="https://github.com/user-attachments/assets/677a3e4e-2568-463f-addb-322a8f08ba5d" />

We should add this pinned version