### PR TITLE
fix(java): align version type from i32 to u64

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -125,7 +125,7 @@ impl BlockingDataset {
     #[allow(clippy::too_many_arguments)]
     pub fn open(
         uri: &str,
-        version: Option<i32>,
+        version: Option<u64>,
         block_size: Option<i32>,
         index_cache_size_bytes: i64,
         metadata_cache_size_bytes: i64,
@@ -165,7 +165,7 @@ impl BlockingDataset {
         let mut builder = DatasetBuilder::from_uri(uri).with_read_params(params);
 
         if let Some(ver) = version {
-            builder = builder.with_version(ver as u64);
+            builder = builder.with_version(ver);
         }
 
         if let Some(serialized_manifest) = serialized_manifest {
@@ -1038,7 +1038,7 @@ pub extern "system" fn Java_org_lance_Dataset_openNative<'local>(
     mut env: JNIEnv<'local>,
     _obj: JObject,
     path: JString,
-    version_obj: JObject,    // Optional<Integer>
+    version_obj: JObject,    // Optional<Long>
     block_size_obj: JObject, // Optional<Integer>
     index_cache_size_bytes: jlong,
     metadata_cache_size_bytes: jlong,
@@ -1066,7 +1066,7 @@ pub extern "system" fn Java_org_lance_Dataset_openNative<'local>(
 fn inner_open_native<'local>(
     env: &mut JNIEnv<'local>,
     path: JString,
-    version_obj: JObject,    // Optional<Integer>
+    version_obj: JObject,    // Optional<Long>
     block_size_obj: JObject, // Optional<Integer>
     index_cache_size_bytes: jlong,
     metadata_cache_size_bytes: jlong,
@@ -1075,7 +1075,7 @@ fn inner_open_native<'local>(
     storage_options_provider_obj: JObject, // Optional<StorageOptionsProvider>
 ) -> Result<JObject<'local>> {
     let path_str: String = path.extract(env)?;
-    let version = env.get_int_opt(&version_obj)?;
+    let version = env.get_u64_opt(&version_obj)?;
     let block_size = env.get_int_opt(&block_size_obj)?;
     let jmap = JMap::from_env(env, &storage_options_obj)?;
     let storage_options = to_rust_map(env, &jmap)?;

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -341,7 +341,7 @@ public class Dataset implements Closeable {
 
   private static native Dataset openNative(
       String path,
-      Optional<Integer> version,
+      Optional<Long> version,
       Optional<Integer> blockSize,
       long indexCacheSize,
       long metadataCacheSizeBytes,

--- a/java/src/main/java/org/lance/ReadOptions.java
+++ b/java/src/main/java/org/lance/ReadOptions.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 /** Read options for reading from a dataset. */
 public class ReadOptions {
 
-  private final Optional<Integer> version;
+  private final Optional<Long> version;
   private final Optional<Integer> blockSize;
   private final long indexCacheSizeBytes;
   private final long metadataCacheSizeBytes;
@@ -43,7 +43,7 @@ public class ReadOptions {
     this.storageOptionsProvider = builder.storageOptionsProvider;
   }
 
-  public Optional<Integer> getVersion() {
+  public Optional<Long> getVersion() {
     return version;
   }
 
@@ -87,7 +87,7 @@ public class ReadOptions {
 
   public static class Builder {
 
-    private Optional<Integer> version = Optional.empty();
+    private Optional<Long> version = Optional.empty();
     private Optional<Integer> blockSize = Optional.empty();
     private long indexCacheSizeBytes = 6 * 1024 * 1024 * 1024; // Default to 6 GiB like Rust
     private long metadataCacheSizeBytes = 1024 * 1024 * 1024; // Default to 1 GiB like Rust
@@ -101,7 +101,7 @@ public class ReadOptions {
      * @param version the version of the dataset
      * @return this builder
      */
-    public Builder setVersion(int version) {
+    public Builder setVersion(long version) {
       this.version = Optional.of(version);
       return this;
     }


### PR DESCRIPTION
This should be a mistake introduced long long ago