### PR TITLE
fix: fts flat search drops rows when avg_doc_length < 1.0

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -2538,7 +2538,7 @@ pub fn flat_bm25_search_stream(
                     token_docs.insert(token.clone(), token_nq);
                 }
                 MemBM25Scorer::new(
-                    index_bm25_scorer.avg_doc_length() as u64 * index_bm25_scorer.num_docs() as u64,
+                    index_bm25_scorer.total_tokens(),
                     index_bm25_scorer.num_docs(),
                     token_docs,
                 )

--- a/rust/lance-index/src/scalar/inverted/scorer.rs
+++ b/rust/lance-index/src/scalar/inverted/scorer.rs
@@ -57,7 +57,7 @@ impl MemBM25Scorer {
     }
 
     pub fn avg_doc_length(&self) -> f32 {
-        (self.total_tokens / self.num_docs as u64) as f32
+        self.total_tokens as f32 / self.num_docs as f32
     }
 
     pub fn num_docs_containing_token(&self, token: &str) -> usize {
@@ -71,6 +71,7 @@ impl MemBM25Scorer {
 pub struct IndexBM25Scorer<'a> {
     partitions: Vec<&'a InvertedPartition>,
     num_docs: usize,
+    total_tokens: u64,
     avg_doc_length: f32,
 }
 
@@ -86,6 +87,7 @@ impl<'a> IndexBM25Scorer<'a> {
         Self {
             partitions,
             num_docs,
+            total_tokens,
             avg_doc_length: avgdl,
         }
     }
@@ -94,8 +96,8 @@ impl<'a> IndexBM25Scorer<'a> {
         self.num_docs
     }
 
-    pub fn avg_doc_length(&self) -> f32 {
-        self.avg_doc_length
+    pub fn total_tokens(&self) -> u64 {
+        self.total_tokens
     }
 
     pub fn num_docs_containing_token(&self, token: &str) -> usize {


### PR DESCRIPTION
## Summary

- `MemBM25Scorer::avg_doc_length()` used integer division (`total_tokens / num_docs`), truncating values < 1.0 to 0. Changed to float division.
- `flat_bm25_search_stream` reconstructed `total_tokens` by casting the float avg back to `u64` (`avg_doc_length() as u64 * num_docs`), losing precision. Added `total_tokens()` accessor to `IndexBM25Scorer` to pass the exact value through.

Fixes #5871

## Test plan

- [x] New test `test_fts_unindexed_data_with_stop_words` — indexes 4 single-word rows (3 stop words) so `avg_doc_length = 0.25`, appends 10 unindexed rows, and asserts all 10 are returned by FTS query. Verified it fails without the fix (returns 7) and passes with it.
- [x] Existing `test_fts_unindexed_data` still passes
- [x] `lance-index` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)