### PR TITLE
perf!: remove shuffle buffer

### DIFF
--- a/rust/lance-index/src/vector/v3/shuffler.rs
+++ b/rust/lance-index/src/vector/v3/shuffler.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use arrow::{array::AsArray, compute::sort_to_indices};
 use arrow_array::{RecordBatch, UInt32Array};
 use arrow_schema::Schema;
-use futures::prelude::*;
+use futures::{future::try_join_all, prelude::*};
 use lance_arrow::{RecordBatchExt, SchemaExt};
 use lance_core::{
     cache::LanceCache,
@@ -160,12 +160,15 @@ impl Shuffler for IvfShuffler {
             let (shuffled, loss) = shuffled?;
             total_loss += loss;
 
-            for (part_id, batches) in shuffled.into_iter().enumerate() {
+            let mut futs = Vec::new();
+            for (part_id, (writer, batches)) in writers.iter_mut().zip(shuffled.iter()).enumerate()
+            {
                 if !batches.is_empty() {
                     partition_sizes[part_id] += batches.iter().map(|b| b.num_rows()).sum::<usize>();
-                    writers[part_id].write_batches(batches.iter()).await?;
+                    futs.push(writer.write_batches(batches.iter()));
                 }
             }
+            try_join_all(futs).await?;
         }
 
         // finish all writers


### PR DESCRIPTION
This removes a buffer in the shuffler that accumulated batches for batched writes to temporary storage. This was configured with a public buffer_size parameter hence the breaking change.

Previously, when we shuffled data we accumulated this many batches for each partition in memory and then flushed them all to disk at once. This may have been intended as an optimization in the original implementation of the shuffler, which supported external shuffling through arbitrary object storage. However, the shuffler was subsequently hardcoded to use local disk (where this kind of buffering serves no benefit) and even on remote object storage, we already have a layer of buffering in the storage writer.

Instead of buffering batches, just write them directly to the FileWriter. This results in much more predictable memory usage and also faster index builds.