### PR TITLE
perf: build fp16kernels with NEON support on iOS

### DIFF
--- a/rust/lance-linalg/build.rs
+++ b/rust/lance-linalg/build.rs
@@ -37,6 +37,10 @@ fn main() -> Result<(), String> {
     if target_arch == "aarch64" && target_os == "macos" {
         // Build a version with NEON
         build_f16_with_flags("neon", &["-mtune=apple-m1"]).unwrap();
+    } else if target_arch == "aarch64" && target_os == "ios" {
+        // Build version with NEON
+        // A13 bionic is the earliest supported iOS SOC
+        build_f16_with_flags("neon", &["-mtune=apple-a13"]).unwrap();
     } else if target_arch == "aarch64" && target_os == "linux" {
         // Build a version with NEON
         build_f16_with_flags("neon", &["-march=armv8.2-a+fp16"]).unwrap();


### PR DESCRIPTION
This PR also adds support for `mtune=apple-a13` when building lance-linalg for iOS, which is the earliest supported iOS architecture at time of writing.

This is pulled out of https://github.com/lance-format/lance/pull/5866 after the initial bug was fixed in https://github.com/lance-format/lance/pull/5747 and lancedb updated to Lance 2.x