### PR TITLE
fix: open additional storage options provider related apis in lance dataset

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -2307,6 +2307,7 @@ class LanceDataset(pa.dataset.Dataset):
             storage_options=self.latest_storage_options(),
             storage_options_provider=self._storage_options_provider,
         )
+
     def checkout_version(
         self, version: int | str | Tuple[Optional[str], Optional[int]]
     ) -> "LanceDataset":


### PR DESCRIPTION
Backport of https://github.com/lance-format/lance/pull/5869

This PR backports the changes from the original PR to the release/v2.0 branch.
