### PR TITLE
perf: reduce peak memory in nullable training data sampling

### DIFF
--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -298,8 +298,15 @@ pub async fn maybe_sample_training_data(
 
     let should_sample = num_rows > sample_size_hint;
     if should_sample {
-        sample_training_data(dataset, column, sample_size_hint, num_rows, vector_field, is_nullable)
-            .await
+        sample_training_data(
+            dataset,
+            column,
+            sample_size_hint,
+            num_rows,
+            vector_field,
+            is_nullable,
+        )
+        .await
     } else {
         // too small to require sampling
         let batch = scan_all_training_data(dataset, column, is_nullable).await?;
@@ -394,15 +401,24 @@ async fn sample_training_data(
 
     match vector_field.data_type() {
         DataType::FixedSizeList(_, _) if !is_nullable => {
-            sample_fsl_uniform(dataset, column, sample_size_hint, num_rows, byte_width, vector_field)
-                .await
+            sample_fsl_uniform(
+                dataset,
+                column,
+                sample_size_hint,
+                num_rows,
+                byte_width,
+                vector_field,
+            )
+            .await
         }
         DataType::FixedSizeList(_, _) => {
-            let scan = sample_training_data_scan(dataset, column, sample_size_hint, num_rows, byte_width)?;
+            let scan =
+                sample_training_data_scan(dataset, column, sample_size_hint, num_rows, byte_width)?;
             sample_nullable_fsl(column, sample_size_hint, byte_width, vector_field, scan).await
         }
         _ => {
-            let scan = sample_training_data_scan(dataset, column, sample_size_hint, num_rows, byte_width)?;
+            let scan =
+                sample_training_data_scan(dataset, column, sample_size_hint, num_rows, byte_width)?;
             sample_nullable_fallback(column, sample_size_hint, is_nullable, scan).await
         }
     }
@@ -857,7 +873,11 @@ mod tests {
         let dims: u32 = 8;
         let sample_size: usize = 500;
 
-        let col_gen = if nullable { vec_gen.with_random_nulls(0.5) } else { vec_gen };
+        let col_gen = if nullable {
+            vec_gen.with_random_nulls(0.5)
+        } else {
+            vec_gen
+        };
         let data = gen_batch()
             .col("vec", col_gen)
             .into_batch_rows(RowCount::from(nrows as u64))


### PR DESCRIPTION
When we sample data for IVF training we go down one of two paths, depending on whether the target column is nullable or not. For the not-nullable path, we use dataset.sample. For the nullable path, we do a block-level sampling of batches, then filter out all batches that contain all-null rows, and interleave the result into the output.

The interleaving step requires two copies of the filtered batches to be held in RAM.

This commit adds a specialization for the case of nullable fixed-length array columns. We now pre-size an output vector, and process the input scan as a stream. For each batch, we copy not-null values into the output vector, and drop the batch. This saves one copy of the filtered output and halves the memory consumption of the sampling step.