### PR TITLE
fix: spawn part load in fts training

### DIFF
--- a/rust/lance-index/src/scalar/inverted/merger.rs
+++ b/rust/lance-index/src/scalar/inverted/merger.rs
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use fst::Streamer;
-use lance_core::{cache::LanceCache, Error, Result};
+use futures::{stream, StreamExt, TryStreamExt};
+use lance_core::{cache::LanceCache, utils::tokio::get_num_compute_intensive_cpus, Error, Result};
 use snafu::location;
 use std::sync::Arc;
 
@@ -251,11 +252,22 @@ impl Merger for SizeBasedMerger<'_> {
         let start = std::time::Instant::now();
         let parts = std::mem::take(&mut self.input);
         let num_parts = parts.len();
+        let buffer_size = std::cmp::max(
+            1,
+            std::cmp::min(get_num_compute_intensive_cpus(), num_parts),
+        );
         let cache = LanceCache::no_cache();
         let token_set_format = self.token_set_format;
+        let mut stream = stream::iter(parts.into_iter().map(|part| {
+            let cache = cache.clone();
+            tokio::task::spawn(async move { part.load(&cache, token_set_format).await })
+        }))
+        .buffered(buffer_size);
 
-        for (idx, part) in parts.into_iter().enumerate() {
-            let part = part.load(&cache, token_set_format).await?;
+        let mut idx = 0;
+        while let Some(part) = stream.try_next().await? {
+            let part = part?;
+            idx += 1;
             self.merge_partition(part, &mut estimated_size).await?;
             self.progress
                 .stage_progress("merge_partitions", idx as u64)


### PR DESCRIPTION
When training an FTS index we load all of the partitions and merge them. The code was setup to load partitions in parallel. However, there was no spawn call so it wasn't actually loading anything in parallel. This lead to starvation on HEAD calls. The order of operations (everything was serialized) was something like...

Start load of part 1 file 1
Start load of part 2 file 1
...
Start load of part N file 1
Finish load and do CPU work to load file 1
Start load of part 1 file 2
Finish load and do CPU work to load file 2
...

The load request of part N file 1 would not get polled again until a lot of CPU work was done (to parse files 1-N-1). This resulted in the HEAD request being starved which looked like an S3 timeout.

This fix uses spawn.  I've tested it against 15M rows of fineweb data and ensured the RAM is still reasonably bounded even with parallel loading.