### PR TITLE
chore(io): remove shellexpand and use std::env::home_dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5198,7 +5198,6 @@ dependencies = [
  "rand 0.9.2",
  "rstest 0.23.0",
  "serde",
- "shellexpand",
  "snafu",
  "tempfile",
  "test-log",
@@ -8163,15 +8162,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "shellexpand"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
-dependencies = [
- "dirs 6.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,6 @@ rustc_version = "0.4"
 serde = { version = "^1" }
 serde_json = { version = "1" }
 semver = "1.0"
-shellexpand = "3.0"
 slatedb = "0.3"
 snafu = "0.8"
 strum = "0.26"

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -40,7 +40,6 @@ log.workspace = true
 pin-project.workspace = true
 prost.workspace = true
 serde.workspace = true
-shellexpand.workspace = true
 snafu.workspace = true
 tokio.workspace = true
 tracing.workspace = true


### PR DESCRIPTION
## Summary

- remove `shellexpand` from workspace and `lance-io` dependencies
- replace tilde expansion in `lance-io` with `std::env::home_dir`-based logic
- keep support for `~` and `~/...` paths (plus `~\\...` on Windows)
- update lockfile to drop `shellexpand`

## Validation

- `cargo check -p lance-io`
- `cargo test -p lance-io test_tilde_expansion -- --nocapture`
