### PR TITLE
ci: fix python datafusion test

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -60,7 +60,7 @@ tests = [
     # Only test tensorflow on linux for now. We will deprecate tensorflow soon.
     "tensorflow; sys_platform == 'linux'",
     "tqdm",
-    "datafusion>=50.1<52",
+    "datafusion>=50.1,<52",
 ]
 dev = ["ruff==0.4.1", "pyright"]
 benchmarks = ["pytest-benchmark"]


### PR DESCRIPTION
Fixing error:

```
FAILED python/tests/test_table_provider.py::test_table_loading - ImportError: Incompatible libraries. DataFusion 52.0.0 introduced an incompatible signature change for table providers. Either downgrade DataFusion or upgrade your function library.
```