### PR TITLE
docs: clarify v2.2 nested drop rollback risk

### DIFF
--- a/docs/src/guide/data_evolution.md
+++ b/docs/src/guide/data_evolution.md
@@ -153,14 +153,14 @@ print(dataset.schema)
 # id: int64
 ```
 
+Starting with Lance file format `2.2`, nested sub-column removal is supported for
+nested types (for example `people.item.city` on `list<struct<...>>`), instead of
+being limited to `struct` only.
+
 To actually remove the data from disk, the files must be rewritten to remove the
 columns and then the old files must be deleted. This can be done using
 `lance.dataset.DatasetOptimizer.compact_files()` followed by
 `lance.LanceDataset.cleanup_old_versions()`.
-
-Starting with Lance file format `2.2`, nested sub-column removal is supported for
-nested types (for example `people.item.city` on `list<struct<...>>`), instead of
-being limited to `struct` only.
 
 !!! warning
 


### PR DESCRIPTION

- add a warning that `drop_columns` is metadata-only but data can become unrecoverable after `compact_files` + `cleanup_old_versions`
- add operational guidance for rollback windows (tag/snapshot, delayed cleanup, validation before aggressive cleanup)

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.3-codex`) and fully reviewed and edited by me. I take full responsibility for all changes.**
