### PR TITLE
feat(cleanup): add more metrics to RemovalStats

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -2704,10 +2704,10 @@ fn inner_cleanup_with_policy<'local>(
         &[
             JValue::Long(stats.bytes_removed as i64),
             JValue::Long(stats.old_versions as i64),
-            JValue::Long(stats.removed_data_files as i64),
-            JValue::Long(stats.removed_transaction_files as i64),
-            JValue::Long(stats.removed_index_files as i64),
-            JValue::Long(stats.removed_deletion_files as i64),
+            JValue::Long(stats.data_files_removed as i64),
+            JValue::Long(stats.transaction_files_removed as i64),
+            JValue::Long(stats.index_files_removed as i64),
+            JValue::Long(stats.deletion_files_removed as i64),
         ],
     )?;
 

--- a/java/src/main/java/org/lance/cleanup/RemovalStats.java
+++ b/java/src/main/java/org/lance/cleanup/RemovalStats.java
@@ -17,10 +17,10 @@ package org.lance.cleanup;
 public class RemovalStats {
   private final long bytesRemoved;
   private final long oldVersions;
-  private final long removedDataFiles;
-  private final long removedTransactionFiles;
-  private final long removedIndexFiles;
-  private final long removedDeletionFiles;
+  private final long dataFilesRemoved;
+  private final long transactionFilesRemoved;
+  private final long indexFilesRemoved;
+  private final long deletionFilesRemoved;
 
   public RemovalStats(long bytesRemoved, long oldVersions) {
     this(bytesRemoved, oldVersions, 0L, 0L, 0L, 0L);
@@ -29,16 +29,16 @@ public class RemovalStats {
   public RemovalStats(
       long bytesRemoved,
       long oldVersions,
-      long removedDataFiles,
-      long removedTransactionFiles,
-      long removedIndexFiles,
-      long removedDeletionFiles) {
+      long dataFilesRemoved,
+      long transactionFilesRemoved,
+      long indexFilesRemoved,
+      long deletionFilesRemoved) {
     this.bytesRemoved = bytesRemoved;
     this.oldVersions = oldVersions;
-    this.removedDataFiles = removedDataFiles;
-    this.removedTransactionFiles = removedTransactionFiles;
-    this.removedIndexFiles = removedIndexFiles;
-    this.removedDeletionFiles = removedDeletionFiles;
+    this.dataFilesRemoved = dataFilesRemoved;
+    this.transactionFilesRemoved = transactionFilesRemoved;
+    this.indexFilesRemoved = indexFilesRemoved;
+    this.deletionFilesRemoved = deletionFilesRemoved;
   }
 
   public long getBytesRemoved() {
@@ -49,19 +49,19 @@ public class RemovalStats {
     return oldVersions;
   }
 
-  public long getRemovedDataFiles() {
-    return removedDataFiles;
+  public long getDataFilesRemoved() {
+    return dataFilesRemoved;
   }
 
-  public long getRemovedTransactionFiles() {
-    return removedTransactionFiles;
+  public long getTransactionFilesRemoved() {
+    return transactionFilesRemoved;
   }
 
-  public long getRemovedIndexFiles() {
-    return removedIndexFiles;
+  public long getIndexFilesRemoved() {
+    return indexFilesRemoved;
   }
 
-  public long getRemovedDeletionFiles() {
-    return removedDeletionFiles;
+  public long getDeletionFilesRemoved() {
+    return deletionFilesRemoved;
   }
 }

--- a/java/src/test/java/org/lance/CleanupTest.java
+++ b/java/src/test/java/org/lance/CleanupTest.java
@@ -42,10 +42,10 @@ public class CleanupTest {
         RemovalStats stats =
             dataset.cleanupWithPolicy(CleanupPolicy.builder().withBeforeVersion(3L).build());
         assertEquals(2L, stats.getOldVersions());
-        assertEquals(0L, stats.getRemovedDataFiles());
-        assertEquals(2L, stats.getRemovedTransactionFiles());
-        assertEquals(0L, stats.getRemovedIndexFiles());
-        assertEquals(0L, stats.getRemovedDeletionFiles());
+        assertEquals(0L, stats.getDataFilesRemoved());
+        assertEquals(2L, stats.getTransactionFilesRemoved());
+        assertEquals(0L, stats.getIndexFilesRemoved());
+        assertEquals(0L, stats.getDeletionFilesRemoved());
       }
     }
   }

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -86,10 +86,10 @@ from .trace import trace_to_chrome as trace_to_chrome
 class CleanupStats:
     bytes_removed: int
     old_versions: int
-    removed_data_files: int
-    removed_transaction_files: int
-    removed_index_files: int
-    removed_deletion_files: int
+    data_files_removed: int
+    transaction_files_removed: int
+    index_files_removed: int
+    deletion_files_removed: int
 
 class LanceFileWriter:
     def __init__(

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1388,10 +1388,10 @@ def test_cleanup_with_retain_versions(tmp_path: Path):
     assert len(ds.versions()) == 4
     stats = ds.cleanup_old_versions(retain_versions=3)
     assert stats.old_versions == 1
-    assert stats.removed_data_files == 1
-    assert stats.removed_transaction_files == 1
-    assert stats.removed_index_files == 0
-    assert stats.removed_deletion_files == 0
+    assert stats.data_files_removed == 1
+    assert stats.transaction_files_removed == 1
+    assert stats.index_files_removed == 0
+    assert stats.deletion_files_removed == 0
     assert len(ds.versions()) == 3
     assert ds.count_rows() == len(ds.to_table())
 

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1589,10 +1589,10 @@ impl Dataset {
         Ok(CleanupStats {
             bytes_removed: cleanup_stats.bytes_removed,
             old_versions: cleanup_stats.old_versions,
-            removed_data_files: cleanup_stats.removed_data_files,
-            removed_transaction_files: cleanup_stats.removed_transaction_files,
-            removed_index_files: cleanup_stats.removed_index_files,
-            removed_deletion_files: cleanup_stats.removed_deletion_files,
+            data_files_removed: cleanup_stats.data_files_removed,
+            transaction_files_removed: cleanup_stats.transaction_files_removed,
+            index_files_removed: cleanup_stats.index_files_removed,
+            deletion_files_removed: cleanup_stats.deletion_files_removed,
         })
     }
 

--- a/python/src/dataset/cleanup.rs
+++ b/python/src/dataset/cleanup.rs
@@ -19,10 +19,10 @@ use pyo3::{pyclass, pymethods};
 pub struct CleanupStats {
     pub bytes_removed: u64,
     pub old_versions: u64,
-    pub removed_data_files: u64,
-    pub removed_transaction_files: u64,
-    pub removed_index_files: u64,
-    pub removed_deletion_files: u64,
+    pub data_files_removed: u64,
+    pub transaction_files_removed: u64,
+    pub index_files_removed: u64,
+    pub deletion_files_removed: u64,
 }
 
 #[pymethods]

--- a/rust/lance-datafusion/src/planner.rs
+++ b/rust/lance-datafusion/src/planner.rs
@@ -55,7 +55,7 @@ use lance_core::{Error, Result};
 /// Encode a JSON string into a JSONB `LargeBinary` literal expression.
 fn encode_jsonb(json_str: &str) -> Result<Expr> {
     let bytes = lance_arrow::json::encode_json(json_str)
-        .map_err(|e| Error::invalid_input(format!("Failed to encode JSONB: {e}"), location!()))?;
+        .map_err(|e| Error::invalid_input(format!("Failed to encode JSONB: {e}")))?;
     Ok(Expr::Literal(ScalarValue::LargeBinary(Some(bytes)), None))
 }
 
@@ -669,7 +669,6 @@ impl Planner {
                 Value::SingleQuotedString(s) | Value::DoubleQuotedString(s) => encode_jsonb(s),
                 _ => Err(Error::invalid_input(
                     "Expected a string value for JSONB literal",
-                    location!(),
                 )),
             },
             // For example, DATE '2020-01-01'
@@ -758,7 +757,6 @@ impl Planner {
                 }) => encode_jsonb(s),
                 _ => Err(Error::invalid_input(
                     "CAST to JSONB only supports string literals",
-                    location!(),
                 )),
             },
             SQLExpr::Cast {

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -78,10 +78,10 @@ struct ReferencedFiles {
 pub struct RemovalStats {
     pub bytes_removed: u64,
     pub old_versions: u64,
-    pub removed_data_files: u64,
-    pub removed_transaction_files: u64,
-    pub removed_index_files: u64,
-    pub removed_deletion_files: u64,
+    pub data_files_removed: u64,
+    pub transaction_files_removed: u64,
+    pub index_files_removed: u64,
+    pub deletion_files_removed: u64,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -181,10 +181,10 @@ impl<'a> CleanupTask<'a> {
         let stats = self.delete_unreferenced_files(inspection).await?;
         final_stats.bytes_removed += stats.bytes_removed;
         final_stats.old_versions += stats.old_versions;
-        final_stats.removed_data_files += stats.removed_data_files;
-        final_stats.removed_transaction_files += stats.removed_transaction_files;
-        final_stats.removed_index_files += stats.removed_index_files;
-        final_stats.removed_deletion_files += stats.removed_deletion_files;
+        final_stats.data_files_removed += stats.data_files_removed;
+        final_stats.transaction_files_removed += stats.transaction_files_removed;
+        final_stats.index_files_removed += stats.index_files_removed;
+        final_stats.deletion_files_removed += stats.deletion_files_removed;
         Ok(final_stats)
     }
 
@@ -304,10 +304,10 @@ impl<'a> CleanupTask<'a> {
         fields(
             old_versions = inspection.old_manifests.len(),
             bytes_removed = tracing::field::Empty,
-            removed_data_files = tracing::field::Empty,
-            removed_transaction_files = tracing::field::Empty,
-            removed_index_files = tracing::field::Empty,
-            removed_deletion_files = tracing::field::Empty
+            data_files_removed = tracing::field::Empty,
+            transaction_files_removed = tracing::field::Empty,
+            index_files_removed = tracing::field::Empty,
+            deletion_files_removed = tracing::field::Empty
         )
     )]
     async fn delete_unreferenced_files(
@@ -360,12 +360,12 @@ impl<'a> CleanupTask<'a> {
                         stats.bytes_removed += obj_meta.size;
                         if let Some(file_type) = file_type {
                             match file_type {
-                                RemovedFileType::Data => stats.removed_data_files += 1,
+                                RemovedFileType::Data => stats.data_files_removed += 1,
                                 RemovedFileType::Transaction => {
-                                    stats.removed_transaction_files += 1
+                                    stats.transaction_files_removed += 1
                                 }
-                                RemovedFileType::Index => stats.removed_index_files += 1,
-                                RemovedFileType::Deletion => stats.removed_deletion_files += 1,
+                                RemovedFileType::Index => stats.index_files_removed += 1,
+                                RemovedFileType::Deletion => stats.deletion_files_removed += 1,
                             }
                         }
                     }
@@ -427,15 +427,15 @@ impl<'a> CleanupTask<'a> {
 
         let span = Span::current();
         span.record("bytes_removed", removal_stats.bytes_removed);
-        span.record("removed_data_files", removal_stats.removed_data_files);
+        span.record("data_files_removed", removal_stats.data_files_removed);
         span.record(
-            "removed_transaction_files",
-            removal_stats.removed_transaction_files,
+            "transaction_files_removed",
+            removal_stats.transaction_files_removed,
         );
-        span.record("removed_index_files", removal_stats.removed_index_files);
+        span.record("index_files_removed", removal_stats.index_files_removed);
         span.record(
-            "removed_deletion_files",
-            removal_stats.removed_deletion_files,
+            "deletion_files_removed",
+            removal_stats.deletion_files_removed,
         );
 
         Ok(removal_stats)
@@ -721,11 +721,11 @@ impl<'a> CleanupTask<'a> {
                             let mut stats_guard = final_stats.lock().unwrap();
                             stats_guard.bytes_removed += stats.bytes_removed;
                             stats_guard.old_versions += stats.old_versions;
-                            stats_guard.removed_data_files += stats.removed_data_files;
-                            stats_guard.removed_transaction_files +=
-                                stats.removed_transaction_files;
-                            stats_guard.removed_index_files += stats.removed_index_files;
-                            stats_guard.removed_deletion_files += stats.removed_deletion_files;
+                            stats_guard.data_files_removed += stats.data_files_removed;
+                            stats_guard.transaction_files_removed +=
+                                stats.transaction_files_removed;
+                            stats_guard.index_files_removed += stats.index_files_removed;
+                            stats_guard.deletion_files_removed += stats.deletion_files_removed;
                         }
                     }
                     Ok::<(), Error>(())
@@ -1117,7 +1117,7 @@ mod tests {
     };
     use lance_linalg::distance::MetricType;
     use lance_table::io::commit::RenameCommitHandler;
-    use lance_testing::datagen::{BatchGenerator, IncrementingInt32, some_batch, RandomVector};
+    use lance_testing::datagen::{BatchGenerator, IncrementingInt32, RandomVector, some_batch};
     use mock_instant::thread_local::MockClock;
 
     #[derive(Debug)]
@@ -1488,7 +1488,7 @@ mod tests {
 
         let after_count = fixture.count_files().await.unwrap();
         assert_eq!(removed.old_versions, 1);
-        assert_eq!(removed.removed_data_files, 1);
+        assert_eq!(removed.data_files_removed, 1);
         assert_eq!(
             removed.bytes_removed,
             before_count.num_bytes - after_count.num_bytes
@@ -2060,22 +2060,22 @@ mod tests {
             .unwrap();
         let after_count = fixture.count_files().await.unwrap();
 
-        let removed_data_files = (before_count.num_data_files - after_count.num_data_files) as u64;
-        let removed_transaction_files =
+        let data_files_removed = (before_count.num_data_files - after_count.num_data_files) as u64;
+        let transaction_files_removed =
             (before_count.num_tx_files - after_count.num_tx_files) as u64;
-        let removed_index_files =
+        let index_files_removed =
             (before_count.num_index_files - after_count.num_index_files) as u64;
-        let removed_deletion_files =
+        let deletion_files_removed =
             (before_count.num_delete_files - after_count.num_delete_files) as u64;
 
-        assert_eq!(removed.removed_data_files, removed_data_files);
-        assert_eq!(removed.removed_transaction_files, removed_transaction_files);
-        assert_eq!(removed.removed_index_files, removed_index_files);
-        assert_eq!(removed.removed_deletion_files, removed_deletion_files);
-        assert_gt!(removed.removed_data_files, 0);
-        assert_gt!(removed.removed_transaction_files, 0);
-        assert_gt!(removed.removed_index_files, 0);
-        assert_gt!(removed.removed_deletion_files, 0);
+        assert_eq!(removed.data_files_removed, data_files_removed);
+        assert_eq!(removed.transaction_files_removed, transaction_files_removed);
+        assert_eq!(removed.index_files_removed, index_files_removed);
+        assert_eq!(removed.deletion_files_removed, deletion_files_removed);
+        assert_gt!(removed.data_files_removed, 0);
+        assert_gt!(removed.transaction_files_removed, 0);
+        assert_gt!(removed.index_files_removed, 0);
+        assert_gt!(removed.deletion_files_removed, 0);
     }
 
     #[tokio::test]
@@ -2126,7 +2126,7 @@ mod tests {
 
         let after_count = fixture.count_files().await.unwrap();
         assert_eq!(removed.old_versions, 0);
-        assert_eq!(removed.removed_data_files, 1);
+        assert_eq!(removed.data_files_removed, 1);
         assert_eq!(
             removed.bytes_removed,
             before_count.num_bytes - after_count.num_bytes
@@ -2160,7 +2160,7 @@ mod tests {
 
         assert_eq!(removed.old_versions, 0);
         assert_eq!(removed.bytes_removed, 0);
-        assert_eq!(removed.removed_data_files, 0);
+        assert_eq!(removed.data_files_removed, 0);
 
         let after_count = fixture.count_files().await.unwrap();
         assert_eq!(before_count, after_count);


### PR DESCRIPTION
Add a new metric `removed_data_file_num` to the `RemovalStats` of the cleanup operation results, 

So that users can easily perceive how many lance data files have been deleted in the current cleanup operation and better evaluate the impact scope of the current cleanup.