### PR TITLE
docs: require data_storage_version=2.2 in map type example

### DIFF
--- a/docs/src/guide/data_types.md
+++ b/docs/src/guide/data_types.md
@@ -283,6 +283,7 @@ ds = lance.write_dataset(table, "./with_metadata.lance")
 ### Map Types
 
 Store key-value pairs with dynamic keys:
+Map writes require Lance file format version 2.2 or later.
 
 ```python
 import lance
@@ -301,7 +302,7 @@ table = pa.Table.from_pydict({
     ],
 }, schema=schema)
 
-ds = lance.write_dataset(table, "./with_maps.lance")
+ds = lance.write_dataset(table, "./with_maps.lance", data_storage_version="2.2")
 ```
 
 ## Data Type Mapping for Integrations


### PR DESCRIPTION
## Summary
- update the Map type guide example to explicitly set `data_storage_version="2.2"`
- add a short note that Map writes require Lance file format version 2.2 or later

## Why
Map writes are only supported with file format 2.2+, and writing with 2.1 fails in tests. The previous example used default settings, which can be copied by users into a failing workflow.

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.3-codex`) and fully reviewed and edited by me. I take full responsibility for all changes.**