### PR TITLE
fix(btree): include null pages in non-IsNull queries for correct thre…

### DIFF
--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -4,7 +4,7 @@
 use std::{
     any::Any,
     cmp::Ordering,
-    collections::{BTreeMap, BinaryHeap, HashMap},
+    collections::{BTreeMap, BinaryHeap, HashMap, HashSet},
     fmt::{Debug, Display},
     ops::Bound,
     sync::Arc,
@@ -1492,7 +1492,7 @@ impl ScalarIndex for BTreeIndex {
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<SargableQuery>().unwrap();
-        let pages = match query {
+        let mut pages = match query {
             SargableQuery::Equals(val) => self
                 .page_lookup
                 .pages_eq(&OrderableScalarValue(val.clone())),
@@ -1508,6 +1508,29 @@ impl ScalarIndex for BTreeIndex {
             )),
             SargableQuery::IsNull() => self.page_lookup.pages_null(),
         };
+
+        // For non-IsNull queries, also include null pages so that null row IDs
+        // are tracked in the result. Any comparison with NULL yields NULL, and
+        // we need this information for correct three-valued logic (e.g. NOT,
+        // OR). Without this, a query like `NOT(x = 0)` on data where 0 doesn't
+        // exist would incorrectly include NULL rows.
+        //
+        // We add them as Matches::Some (not Matches::All) so that
+        // FlatIndex::search() evaluates the predicate and correctly marks
+        // the rows as NULL rather than TRUE.
+        if !matches!(query, SargableQuery::IsNull()) {
+            let existing: HashSet<u32> = pages.iter().map(|m| m.page_id()).collect();
+            for &page_id in self
+                .page_lookup
+                .null_pages
+                .iter()
+                .chain(self.page_lookup.all_null_pages.iter())
+            {
+                if !existing.contains(&page_id) {
+                    pages.push(Matches::Some(page_id));
+                }
+            }
+        }
 
         let lazy_index_reader =
             LazyIndexReader::new(self.store.clone(), self.ranges_to_files.clone());
@@ -4188,6 +4211,111 @@ mod tests {
                     panic!("Btree search result should always be Exact.");
                 }
             }
+        }
+    }
+
+    /// Regression test: BTree search must track null row IDs for non-IsNull
+    /// queries, even when no pages match the queried value.
+    ///
+    /// Without this, `NOT(x = val)` when `val` is absent from the data would
+    /// produce an empty null set, causing NULL rows to incorrectly pass.
+    #[tokio::test]
+    async fn test_search_tracks_nulls_for_absent_value() {
+        use arrow_array::{Int32Array, UInt64Array};
+
+        let tmpdir = TempObjDir::default();
+        let test_store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+
+        // Create data with 80% nulls so that training produces separate
+        // all-null pages (which are not in the BTree map). Non-null values
+        // are all in [100, 5099], so value 0 never appears.
+        let num_rows = 5000u64;
+        let values: Int32Array = (0..num_rows)
+            .map(|i| {
+                if i % 5 != 0 {
+                    None // 80% null
+                } else {
+                    Some(100 + i as i32) // non-null values in [100, 5099]
+                }
+            })
+            .collect();
+        let row_ids = UInt64Array::from_iter_values(0..num_rows);
+        let data = arrow_array::RecordBatch::try_from_iter(vec![
+            ("value", Arc::new(values) as arrow_array::ArrayRef),
+            ("_rowid", Arc::new(row_ids) as arrow_array::ArrayRef),
+        ])
+        .unwrap();
+
+        let schema = data.schema();
+        let stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::iter(vec![Ok(data)]),
+        ));
+        train_btree_index(stream, test_store.as_ref(), num_rows, None, None)
+            .await
+            .unwrap();
+
+        let index = BTreeIndex::load(test_store.clone(), None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+
+        // Verify we have all-null pages (the bug depends on this)
+        assert!(
+            !index.page_lookup.all_null_pages.is_empty(),
+            "Test setup requires all-null pages; got null_pages={}, all_null_pages={}",
+            index.page_lookup.null_pages.len(),
+            index.page_lookup.all_null_pages.len(),
+        );
+
+        let metrics = NoOpMetricsCollector;
+
+        // Search for Equals(0) — value 0 doesn't exist in any page
+        let result = index
+            .search(
+                &SargableQuery::Equals(ScalarValue::Int32(Some(0))),
+                &metrics,
+            )
+            .await
+            .unwrap();
+
+        match result {
+            SearchResult::Exact(set) => {
+                // No rows should be TRUE (value 0 doesn't exist)
+                assert!(set.true_rows().is_empty(), "No rows should match Equals(0)");
+                // NULL rows MUST be tracked as null
+                assert!(
+                    !set.null_rows().is_empty(),
+                    "Null rows must be tracked even when no pages match the value"
+                );
+            }
+            _ => panic!("BTree search should return Exact"),
+        }
+
+        // Also verify Range query tracks nulls when no values match
+        let result = index
+            .search(
+                &SargableQuery::Range(
+                    std::ops::Bound::Unbounded,
+                    std::ops::Bound::Excluded(ScalarValue::Int32(Some(50))),
+                ),
+                &metrics,
+            )
+            .await
+            .unwrap();
+
+        match result {
+            SearchResult::Exact(set) => {
+                assert!(set.true_rows().is_empty(), "No rows should be < 50");
+                assert!(
+                    !set.null_rows().is_empty(),
+                    "Null rows must be tracked for range queries too"
+                );
+            }
+            _ => panic!("BTree search should return Exact"),
         }
     }
 }

--- a/rust/lance/tests/query/primitives.rs
+++ b/rust/lance/tests/query/primitives.rs
@@ -97,6 +97,42 @@ async fn test_query_integer(#[case] data_type: DataType) {
         .await
 }
 
+/// Regression test: BTree OR on nullable column with value not in index.
+///
+/// When all non-null values are far from the equality value (e.g. all > 100,
+/// query `!= 0`), the BTree's page lookup finds no pages containing that value.
+/// Previously, null pages were not consulted for non-IsNull queries, so the
+/// null set was empty and `NOT(x = 0)` would incorrectly pass all rows
+/// (including NULLs). See also test_search_tracks_nulls_for_absent_value in
+/// lance-index for a direct unit test of the BTree fix.
+#[tokio::test]
+async fn test_btree_nullable_or_with_absent_value() {
+    // All non-null values are in [100..160], so value 0 never appears in the index.
+    // ~33% of rows are NULL (every 3rd row).
+    let value_array: Int32Array = (0..60)
+        .map(|i| if i % 3 == 0 { None } else { Some(100 + i) })
+        .collect();
+    let id_array = Int32Array::from((0..60).collect::<Vec<i32>>());
+
+    let batch = RecordBatch::try_from_iter(vec![
+        ("id", Arc::new(id_array) as ArrayRef),
+        ("value", Arc::new(value_array) as ArrayRef),
+    ])
+    .unwrap();
+
+    DatasetTestCases::from_data(batch)
+        .with_index_types("value", [Some(IndexType::BTree)])
+        .run(|ds: Dataset, original: RecordBatch| async move {
+            test_filter(&original, &ds, "(value != 0) OR (value < 5)").await;
+            test_filter(&original, &ds, "NOT ((value != 0) OR (value < 5))").await;
+            test_filter(&original, &ds, "value != 0").await;
+            test_filter(&original, &ds, "NOT (value = 0)").await;
+            test_filter(&original, &ds, "value is null").await;
+            test_filter(&original, &ds, "value is not null").await;
+        })
+        .await;
+}
+
 #[tokio::test]
 #[rstest::rstest]
 #[case::float32(DataType::Float32)]


### PR DESCRIPTION
…e-valued logic

BTree index search only consulted pages whose value range matched the query. When a queried value (e.g. 0) didn't exist in any page, no pages were searched and the null row set was empty. This caused `NOT(x = 0)` to produce a BlockList with no nulls tracked, incorrectly allowing NULL rows to pass the filter.

The fix adds null pages (both partially-null and all-null) to every non-IsNull query's page list as Matches::Some, so FlatIndex::search() evaluates the predicate and correctly marks those rows as NULL. This preserves three-valued logic for compound expressions like `(x != 0) OR (x < 5)`.