### PR TITLE
refactor!: refactor java access to file format version

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -1617,6 +1617,38 @@ fn inner_get_config<'local>(
 }
 
 #[no_mangle]
+pub extern "system" fn Java_org_lance_Dataset_nativeGetLanceFileFormatVersion<'local>(
+    mut env: JNIEnv<'local>,
+    java_dataset: JObject,
+) -> JString<'local> {
+    ok_or_throw_with_return!(
+        env,
+        inner_get_lance_file_format_version(&mut env, java_dataset),
+        JObject::null().into()
+    )
+}
+
+fn inner_get_lance_file_format_version<'local>(
+    env: &mut JNIEnv<'local>,
+    java_dataset: JObject,
+) -> Result<JString<'local>> {
+    let version_string = {
+        let dataset_guard =
+            unsafe { env.get_rust_field::<_, _, BlockingDataset>(java_dataset, NATIVE_DATASET) }?;
+        let version = dataset_guard
+            .inner
+            .manifest()
+            .data_storage_format
+            .lance_file_version()?;
+        version.to_string()
+    };
+
+    Ok(env
+        .new_string(&version_string)
+        .expect("Failed to create Java String"))
+}
+
+#[no_mangle]
 pub extern "system" fn Java_org_lance_Dataset_nativeTake(
     mut env: JNIEnv,
     java_dataset: JObject,

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -1209,6 +1209,22 @@ public class Dataset implements Closeable {
   private native Map<String, String> nativeGetConfig();
 
   /**
+   * Get the Lance file format version of this dataset.
+   *
+   * <p>The returned string will be one of: "0.1" (legacy), "2.0", "2.1", or "2.2".
+   *
+   * @return the Lance file format version string
+   */
+  public String getLanceFileFormatVersion() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+      return nativeGetLanceFileFormatVersion();
+    }
+  }
+
+  private native String nativeGetLanceFileFormatVersion();
+
+  /**
    * Compact the dataset to improve performance.
    *
    * <p>This operation performs several optimizations:

--- a/java/src/main/java/org/lance/LanceConstants.java
+++ b/java/src/main/java/org/lance/LanceConstants.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance;
+
+/** Constants for the Lance SDK. */
+public final class LanceConstants {
+
+  private LanceConstants() {}
+
+  /** Legacy file format version (0.1). */
+  public static final String FILE_FORMAT_VERSION_LEGACY = "legacy";
+
+  /** Stable file format version (resolves to latest stable). */
+  public static final String FILE_FORMAT_VERSION_STABLE = "stable";
+
+  /** Next file format version (resolves to latest). */
+  public static final String FILE_FORMAT_VERSION_NEXT = "next";
+
+  /** File format version 0.1. */
+  public static final String FILE_FORMAT_VERSION_0_1 = "0.1";
+
+  /** File format version 2.0. */
+  public static final String FILE_FORMAT_VERSION_2_0 = "2.0";
+
+  /** File format version 2.1. */
+  public static final String FILE_FORMAT_VERSION_2_1 = "2.1";
+
+  /** File format version 2.2. */
+  public static final String FILE_FORMAT_VERSION_2_2 = "2.2";
+}

--- a/java/src/main/java/org/lance/WriteDatasetBuilder.java
+++ b/java/src/main/java/org/lance/WriteDatasetBuilder.java
@@ -79,7 +79,7 @@ public class WriteDatasetBuilder {
   private Optional<Integer> maxRowsPerGroup = Optional.empty();
   private Optional<Long> maxBytesPerFile = Optional.empty();
   private Optional<Boolean> enableStableRowIds = Optional.empty();
-  private Optional<WriteParams.LanceFileVersion> dataStorageVersion = Optional.empty();
+  private Optional<String> dataStorageVersion = Optional.empty();
   private Optional<List<BasePath>> initialBases = Optional.empty();
   private Optional<List<String>> targetBases = Optional.empty();
   private Session session;
@@ -268,10 +268,10 @@ public class WriteDatasetBuilder {
   /**
    * Sets the data storage version.
    *
-   * @param dataStorageVersion The Lance file version to use
+   * @param dataStorageVersion The Lance file version to use (e.g., "legacy", "stable", "2.0")
    * @return this builder instance
    */
-  public WriteDatasetBuilder dataStorageVersion(WriteParams.LanceFileVersion dataStorageVersion) {
+  public WriteDatasetBuilder dataStorageVersion(String dataStorageVersion) {
     this.dataStorageVersion = Optional.of(dataStorageVersion);
     return this;
   }

--- a/java/src/main/java/org/lance/WriteFragmentBuilder.java
+++ b/java/src/main/java/org/lance/WriteFragmentBuilder.java
@@ -196,10 +196,10 @@ public class WriteFragmentBuilder {
   /**
    * Set the data storage version.
    *
-   * @param version the data storage version
+   * @param version the data storage version (e.g., "legacy", "stable", "2.0")
    * @return this builder
    */
-  public WriteFragmentBuilder dataStorageVersion(WriteParams.LanceFileVersion version) {
+  public WriteFragmentBuilder dataStorageVersion(String version) {
     ensureWriteParamsBuilder();
     this.writeParamsBuilder.withDataStorageVersion(version);
     return this;

--- a/java/src/main/java/org/lance/WriteParams.java
+++ b/java/src/main/java/org/lance/WriteParams.java
@@ -30,32 +30,12 @@ public class WriteParams {
     OVERWRITE
   }
 
-  public enum LanceFileVersion {
-    LEGACY("legacy"),
-    V0_1("0.1"),
-    V2_0("2.0"),
-    STABLE("stable"),
-    V2_1("2.1"),
-    NEXT("next"),
-    V2_2("2.2");
-
-    private final String versionString;
-
-    LanceFileVersion(String versionString) {
-      this.versionString = versionString;
-    }
-
-    public String getVersionString() {
-      return versionString;
-    }
-  }
-
   private final Optional<Integer> maxRowsPerFile;
   private final Optional<Integer> maxRowsPerGroup;
   private final Optional<Long> maxBytesPerFile;
   private final Optional<WriteMode> mode;
   private final Optional<Boolean> enableStableRowIds;
-  private final Optional<LanceFileVersion> dataStorageVersion;
+  private final Optional<String> dataStorageVersion;
   private final Optional<Boolean> enableV2ManifestPaths;
   private Map<String, String> storageOptions = new HashMap<>();
   private final Optional<List<BasePath>> initialBases;
@@ -67,7 +47,7 @@ public class WriteParams {
       Optional<Long> maxBytesPerFile,
       Optional<WriteMode> mode,
       Optional<Boolean> enableStableRowIds,
-      Optional<LanceFileVersion> dataStorageVersion,
+      Optional<String> dataStorageVersion,
       Optional<Boolean> enableV2ManifestPaths,
       Map<String, String> storageOptions,
       Optional<List<BasePath>> initialBases,
@@ -110,7 +90,7 @@ public class WriteParams {
   }
 
   public Optional<String> getDataStorageVersion() {
-    return dataStorageVersion.map(LanceFileVersion::getVersionString);
+    return dataStorageVersion;
   }
 
   public Optional<Boolean> getEnableV2ManifestPaths() {
@@ -147,7 +127,7 @@ public class WriteParams {
     private Optional<Long> maxBytesPerFile = Optional.empty();
     private Optional<WriteMode> mode = Optional.empty();
     private Optional<Boolean> enableStableRowIds = Optional.empty();
-    private Optional<LanceFileVersion> dataStorageVersion = Optional.empty();
+    private Optional<String> dataStorageVersion = Optional.empty();
     private Optional<Boolean> enableV2ManifestPaths;
     private Map<String, String> storageOptions = new HashMap<>();
     private Optional<List<BasePath>> initialBases = Optional.empty();
@@ -173,7 +153,7 @@ public class WriteParams {
       return this;
     }
 
-    public Builder withDataStorageVersion(LanceFileVersion dataStorageVersion) {
+    public Builder withDataStorageVersion(String dataStorageVersion) {
       this.dataStorageVersion = Optional.of(dataStorageVersion);
       return this;
     }

--- a/java/src/main/java/org/lance/file/LanceFileWriter.java
+++ b/java/src/main/java/org/lance/file/LanceFileWriter.java
@@ -14,7 +14,6 @@
 package org.lance.file;
 
 import org.lance.JniLoader;
-import org.lance.WriteParams;
 
 import org.apache.arrow.c.ArrowArray;
 import org.apache.arrow.c.ArrowSchema;
@@ -87,19 +86,18 @@ public class LanceFileWriter implements AutoCloseable {
    * @param path the URI of the file to write to
    * @param allocator the BufferAllocator to use for the writer
    * @param dictionaryProvider the DictionaryProvider to use for the writer
-   * @param dataStorageVersion the version of the data storage format to use
+   * @param dataStorageVersion the version of the data storage format to use (e.g., "legacy",
+   *     "stable", "2.0")
    * @return a new LanceFileWriter
    */
   public static LanceFileWriter open(
       String path,
       BufferAllocator allocator,
       DictionaryProvider dictionaryProvider,
-      Optional<WriteParams.LanceFileVersion> dataStorageVersion,
+      Optional<String> dataStorageVersion,
       Map<String, String> storageOptions)
       throws IOException {
-    Optional<String> dataStorageVersionStr =
-        dataStorageVersion.map(WriteParams.LanceFileVersion::getVersionString);
-    LanceFileWriter writer = openNative(path, dataStorageVersionStr, storageOptions);
+    LanceFileWriter writer = openNative(path, dataStorageVersion, storageOptions);
     writer.allocator = allocator;
     writer.dictionaryProvider = dictionaryProvider;
     return writer;

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -118,6 +118,33 @@ public class DatasetTest {
   }
 
   @Test
+  void testGetLanceFileFormatVersion(@TempDir Path tempDir) {
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      // Test default version (V2_0)
+      String defaultPath = tempDir.resolve("default_version").toString();
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, defaultPath);
+      try (Dataset dataset = testDataset.createEmptyDataset()) {
+        assertEquals(LanceConstants.FILE_FORMAT_VERSION_2_0, dataset.getLanceFileFormatVersion());
+      }
+
+      // Test LEGACY version
+      String legacyPath = tempDir.resolve("legacy_version").toString();
+      try (Dataset legacyDataset =
+          Dataset.write()
+              .allocator(allocator)
+              .uri(legacyPath)
+              .schema(testDataset.getSchema())
+              .mode(WriteParams.WriteMode.CREATE)
+              .dataStorageVersion(LanceConstants.FILE_FORMAT_VERSION_LEGACY)
+              .execute()) {
+        assertEquals(
+            LanceConstants.FILE_FORMAT_VERSION_0_1, legacyDataset.getLanceFileFormatVersion());
+      }
+    }
+  }
+
+  @Test
   void testCreateDirNotExist(@TempDir Path tempDir) throws IOException, URISyntaxException {
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     String datasetPath = tempDir.resolve(testMethodName).toString();


### PR DESCRIPTION
- Add `Dataset.getLanceFileFormatVersion()` to read file format version from existing dataset
- Remove `LanceFileVersion` enum, use plain strings for forward compatibility
- Add `LanceConstants` with version constants:
    - `FILE_FORMAT_VERSION_LEGACY`, `FILE_FORMAT_VERSION_STABLE`, `FILE_FORMAT_VERSION_NEXT`
    - `FILE_FORMAT_VERSION_0_1`, `FILE_FORMAT_VERSION_2_0`, `FILE_FORMAT_VERSION_2_1`, `FILE_FORMAT_VERSION_2_2`