### PR TITLE
feat(blob): distribute blob sidecar keys with reversed binary ids

### DIFF
--- a/rust/lance-core/src/utils/blob.rs
+++ b/rust/lance-core/src/utils/blob.rs
@@ -5,12 +5,12 @@ use object_store::path::Path;
 
 /// Format a blob sidecar path for a data file.
 ///
-/// Layout: `<base>/<data_file_key>/<blob_id>.blob`
+/// Layout: `<base>/<data_file_key>/<obfuscated_blob_id>.blob`
 /// - `base` is typically the dataset's data directory.
 /// - `data_file_key` is the stem of the data file (without extension).
-/// - `blob_id` is the hex-encoded identifier assigned during write.
+/// - `blob_id` is transformed via `reverse_bits()` before binary formatting.
 pub fn blob_path(base: &Path, data_file_key: &str, blob_id: u32) -> Path {
-    let file_name = format!("{:08x}.blob", blob_id);
+    let file_name = format!("{:032b}.blob", blob_id.reverse_bits());
     base.child(data_file_key).child(file_name.as_str())
 }
 
@@ -22,6 +22,25 @@ mod tests {
     fn test_blob_path_formatting() {
         let base = Path::from("base");
         let path = blob_path(&base, "deadbeef", 2);
-        assert_eq!(path.to_string(), "base/deadbeef/00000002.blob");
+        assert_eq!(
+            path.to_string(),
+            "base/deadbeef/01000000000000000000000000000000.blob"
+        );
+    }
+
+    #[test]
+    fn test_blob_path_scattered_prefixes_for_sequential_ids() {
+        let base = Path::from("base");
+        let p1 = blob_path(&base, "deadbeef", 1);
+        let p2 = blob_path(&base, "deadbeef", 2);
+        assert_ne!(p1.to_string(), p2.to_string());
+        assert_eq!(
+            p1.to_string(),
+            "base/deadbeef/10000000000000000000000000000000.blob"
+        );
+        assert_eq!(
+            p2.to_string(),
+            "base/deadbeef/01000000000000000000000000000000.blob"
+        );
     }
 }

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -29,7 +29,7 @@ const DEDICATED_THRESHOLD: usize = 4 * 1024 * 1024; // 4MB dedicated cutoff
 const PACK_FILE_MAX_SIZE: usize = 1024 * 1024 * 1024; // 1GiB per .pack sidecar
 
 // Maintains rolling `.blob` sidecar files for packed blobs.
-// Layout: data/{data_file_key}/{blob_id:08x}.blob where each file is an
+// Layout: data/{data_file_key}/{obfuscated_blob_id:032b}.blob where each file is an
 // unframed concatenation of blob payloads; descriptors store (blob_id,
 // position, size) to locate each slice. A dedicated struct keeps path state
 // and rolling size separate from the per-batch preprocessor logic, so we can

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -457,7 +457,7 @@ impl<'a> CleanupTask<'a> {
             }
             Some("blob") => {
                 // Blob v2 sidecar files are keyed by the data file stem:
-                //   data/{data_file_key}/{blob_id:08x}.blob
+                //   data/{data_file_key}/{obfuscated_blob_id:032b}.blob
                 //
                 // These files are not referenced directly by the manifest.  Instead, treat them
                 // as referenced if their parent data file is referenced.
@@ -474,7 +474,10 @@ impl<'a> CleanupTask<'a> {
                 let data_file_key = parts.next();
                 let blob_file = parts.next();
                 // Be conservative: only handle the expected 3-part layout.
-                if data_dir.is_none() || data_file_key.is_none() || blob_file.is_none() {
+                if !matches!(data_dir, Some(dir) if dir.as_ref() == "data")
+                    || data_file_key.is_none()
+                    || blob_file.is_none()
+                {
                     debug!(
                         path = relative_path.as_ref(),
                         "Will not garbage collect blob file because it does not follow convention"


### PR DESCRIPTION
This PR accepts suggestion from @jackye1995.

`data_file_key` already randomizes distribution across data files, but sidecars under a single data file still used sequential-looking names. Reversed-bit binary names improve prefix fan-out for this local sequence without introducing compatibility constraints (this version is unreleased).

- change blob v2 sidecar file naming from hex (`{:08x}`) to binary (`{:032b}`)
- derive the file name from `blob_id.reverse_bits()` so early sequential IDs spread quickly across object-store key prefixes

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.3-codex`) and fully reviewed and edited by me. I take full responsibility for all changes.**
