### PR TITLE
fix(lance-linalg): fix missing return value in u8x16::bit_and for non-x86_64/aarch64 targets

### DIFF
--- a/rust/lance-linalg/src/simd/u8.rs
+++ b/rust/lance-linalg/src/simd/u8.rs
@@ -42,9 +42,11 @@ impl u8x16 {
         }
         #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
         {
+            let mut result = self.0;
             for i in 0..16 {
-                self.0[i] &= mask;
+                result[i] &= mask;
             }
+            Self(result)
         }
     }
 


### PR DESCRIPTION
## Summary

Fix a compilation error in `u8x16::bit_and` on non-x86_64/aarch64 architectures (e.g. loongarch64).

## Problem

The fallback implementation of `u8x16::bit_and` for non-x86_64/aarch64 targets was incorrectly modifying `self.0` in-place via a `for` loop, which evaluates to `()` (unit type). This caused a type mismatch error since the function is expected to return `Self` (`u8x16`).

```rust
// Before (broken): for loop returns (), not u8x16
#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
{
    for i in 0..16 {
        self.0[i] &= mask;
    }
}
```

This results in the following compile error on loongarch64:

```
error[E0308]: mismatched types
   --> rust/lance-linalg/src/simd/u8.rs:45:13
    |
34  |     pub fn bit_and(self, mask: u8) -> Self {
    |                                       ---- expected `u8x16` because of return type
...
45  | /             for i in 0..16 {
46  | |                 self.0[i] &= mask;
47  | |             }
    | |_____________^ expected `u8x16`, found `()`
```

## Fix

Copy `self.0` into a mutable local variable `result`, apply the mask, and return `Self(result)` — consistent with the approach already used in `right_shift`:

```rust
// After (fixed): copy, mutate, and return
#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
{
    let mut result = self.0;
    for i in 0..16 {
        result[i] &= mask;
    }
    Self(result)
}
```

## Affected Targets

Any architecture other than `x86_64` and `aarch64`, including:
- `loongarch64`
- `riscv64`
- `mips64`
- etc.

## Testing

Verified compilation on `loongarch64-unknown-linux-gnu`.