### PR TITLE
ci: allow Claude review workflow for external contributors

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.pull_request.author_association == 'CONTRIBUTOR'
+    if: github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
This PR updates the `Claude Code Review` workflow to allow non-write contributors to run the review job. It addresses failures where `anthropics/claude-code-action` exits early because PR authors from forks only have `read` permission.

Context: this was observed on PR #6068, where `claude-review` was triggered but failed with `Actor does not have write permissions to the repository`. We intentionally keep all other workflow behavior unchanged.
