### PR TITLE
fix: resolve Python lint failure on main

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -4564,6 +4564,7 @@ def test_file_reader_options(tmp_path: Path):
     # direct dataset read
     assert iops_scanner <= iops_without_cache
 
+
 def test_read_transaction_properties(tmp_path):
     """Test retrieving properties from transactions at different versions."""
     # Create schema and data for the dataset


### PR DESCRIPTION
This PR fixes the current Python CI failure on `main` by applying the formatter-required spacing in `python/python/tests/test_dataset.py`. 
