### PR TITLE
fix: restore main CI by formatting take_blob imports

### DIFF
--- a/rust/lance/benches/take_blob.rs
+++ b/rust/lance/benches/take_blob.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use arrow_array::{LargeBinaryArray, RecordBatch, RecordBatchIterator, UInt64Array};
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use lance::blob::{blob_field, BlobArrayBuilder};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use lance::blob::{BlobArrayBuilder, blob_field};
 use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::{Dataset, ProjectionRequest, ReadParams, WriteParams};
 use lance_arrow::BLOB_META_KEY;


### PR DESCRIPTION
`origin/main` is currently red because `cargo fmt --check` reports import ordering in `rust/lance/benches/take_blob.rs`. This PR applies the formatter output to that file so the default branch CI can go green again.

Context:
- Failing workflow run on `main`: https://github.com/lance-format/lance/actions/runs/22605587818 (`format` job)
- Same formatting diff also breaks Python `lint` workflow: https://github.com/lance-format/lance/actions/runs/22605587780 (`lint` job)
