### PR TITLE
fix: incorrect deletion masking in `DatasetPreFilter`

### DIFF
--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -1272,6 +1272,23 @@ def test_fts_deleted_rows(tmp_path):
     assert results.num_rows == 2
 
 
+def test_fts_deleted_rows_with_stable_row_ids(tmp_path):
+    # Regression test: stable-row-id prefiltering must not leak deleted rows.
+    data = pa.table(
+        {
+            "text": [f"dup_{i}" for i in range(200)],
+            "category": [["A", "B", "C", "D", "E"][i % 5] for i in range(200)],
+        }
+    )
+    ds = lance.write_dataset(data, tmp_path, enable_stable_row_ids=True)
+    ds.create_scalar_index("text", "INVERTED")
+
+    assert ds.to_table(full_text_query="dup", prefilter=True).num_rows == 200
+
+    ds.delete("category = 'A'")
+    assert ds.to_table(full_text_query="dup", prefilter=True).num_rows == 160
+
+
 def test_index_after_merge_insert(tmp_path):
     # This regresses a defect where a horizontal merge insert was not taking modified
     # fragments out of the index if the column is modified.

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -155,7 +155,7 @@ impl DatasetPreFilter {
                             |mut allow_list, (row_ids, deletion_vector)| {
                                 let seq = if let Some(deletion_vector) = deletion_vector {
                                     let mut row_ids = row_ids.as_ref().clone();
-                                    row_ids.mask(deletion_vector.iter()).unwrap();
+                                    row_ids.mask(deletion_vector.to_sorted_iter()).unwrap();
                                     Cow::<RowIdSequence>::Owned(row_ids)
                                 } else {
                                     Cow::<RowIdSequence>::Borrowed(row_ids.as_ref())


### PR DESCRIPTION
Resolves #5872 .

## Root Cause
  `RowIdSequence::mask` expects positions in monotonically increasing order, but `DeletionVector::iter()` is unordered for `Set(HashSet<u32>)`.
  This can produce a wrong allow-list and leak deleted rows into query results (observed in FTS + stable row id flow).