### PR TITLE
feat: enable lance-io tencent feature in java/lance-jni for COS support

### DIFF
--- a/java/lance-jni/Cargo.toml
+++ b/java/lance-jni/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
+tencent = ["lance-io/tencent"]
 
 [dependencies]
 lance = { path = "../../rust/lance", features = ["substrait"] }


### PR DESCRIPTION
close https://github.com/lance-format/lance/issues/6111

- Enable the `tencent` feature flag for `lance-io` in `java/lance-jni/Cargo.toml` to add Tencent Cloud Object Storage (COS) support for the Java bindings.

## Test plan

- [x] Verify Java build succeeds with the tencent feature enabled
- [x] Confirm COS-backed object store operations work in integration tests