### PR TITLE
feat: support vector indices in describe_indices filtering

### DIFF
--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -461,21 +461,19 @@ pub fn index_matches_criteria(
         return Ok(true);
     };
 
-    if index_details.is_vector() {
-        // This method is only for finding matching scalar indexes today so reject any vector indexes
-        return Ok(false);
-    }
-
-    if criteria.must_support_fts && !index_details.supports_fts() {
-        return Ok(false);
-    }
-
-    // We should not use FTS / NGram indices for exact equality queries
-    // (i.e. merge insert with a join on the indexed column)
-    if criteria.must_support_exact_equality {
-        let plugin = index_details.get_plugin()?;
-        if !plugin.provides_exact_answer() {
+    // Only apply scalar-specific checks to scalar indices
+    if !index_details.is_vector() {
+        if criteria.must_support_fts && !index_details.supports_fts() {
             return Ok(false);
+        }
+
+        // We should not use FTS / NGram indices for exact equality queries
+        // (i.e. merge insert with a join on the indexed column)
+        if criteria.must_support_exact_equality {
+            let plugin = index_details.get_plugin()?;
+            if !plugin.provides_exact_answer() {
+                return Ok(false);
+            }
         }
     }
     Ok(true)
@@ -615,11 +613,12 @@ mod tests {
             fields: vec![field.clone()],
             metadata: Default::default(),
         };
+        // Vector indices should now match basic criteria
         let result = index_matches_criteria(&index1, &criteria, &[&field], true, &schema).unwrap();
-        assert!(!result);
+        assert!(result);
 
         let result = index_matches_criteria(&index1, &criteria, &[&field], false, &schema).unwrap();
-        assert!(!result);
+        assert!(result);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #6138

This PR extends `index_matches_criteria()` in `rust/lance/src/index/scalar.rs` to handle vector index types in addition to scalar indices.

## Problem

Previously, `index_matches_criteria()` contained an early return at lines 464-467 that rejected all non-scalar (vector) indices. This made it impossible to use `describe_indices` to filter for vector indices on a specific column.

## Solution

- Removed the early return that rejected all vector indices
- Refactored FTS and exact equality checks to only apply to scalar indices (these checks are not relevant for vector indices)
- Vector indices now pass through when matching basic criteria (name and column filters)

## Changes

- 1 file modified: `rust/lance/src/index/scalar.rs`
- 15 lines added, 16 lines removed
- Updated existing test `test_index_matches_criteria_vector_index()` to reflect the new expected behavior

## Testing

- Updated the existing unit test for vector index criteria matching
- The test now correctly expects vector indices to match basic criteria instead of being rejected

## AI Disclosure

This contribution was developed with the assistance of Claude (AI by Anthropic). The implementation approach, code, and PR description were AI-assisted. All changes are focused on resolving the specific issue described above.

Co-Authored-By: AI Assistant (Claude) <ai-assistant@contributor-bot.dev>