### PR TITLE
ci: fix pinned auth action ref in benchmarks workflow

### DIFF
--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
           lfs: true
       - name: Authenticate with GCS
-        uses: "google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2"
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: "${{ secrets.GCLOUD_BENCH_STORAGE_USER_KEY }}"
       - name: Install bencher


### PR DESCRIPTION
This PR fixes the regression benchmarks workflow failing to resolve the pinned `google-github-actions/auth` action. The workflow had quoted the entire `uses` value, which caused the trailing `# v2` comment to be parsed as part of the action ref.


