### PR TITLE
fix: handle DataType::Null in adjust_child_validity to prevent panic

### DIFF
--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -1565,7 +1565,7 @@ impl BufferExt for arrow_buffer::Buffer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{Float32Array, Int32Array, StructArray};
+    use arrow_array::{Float32Array, Int32Array, NullArray, StructArray};
     use arrow_array::{ListArray, StringArray, new_empty_array, new_null_array};
     use arrow_buffer::OffsetBuffer;
 
@@ -1997,8 +1997,6 @@ mod tests {
         // Reproduces ENT-990: panic in adjust_child_validity when a Null-typed column
         // exists on one side and the parent struct has null rows.
         // Arrow's Null type has no null bitmap, so passing one to ArrayData::try_new panics.
-        use arrow_array::NullArray;
-
         let left_struct = StructArray::new(
             Fields::from(vec![Field::new("a", DataType::Int32, true)]),
             vec![Arc::new(Int32Array::from(vec![Some(1), None])) as ArrayRef],

--- a/rust/lance/src/dataset/tests/dataset_schema_evolution.rs
+++ b/rust/lance/src/dataset/tests/dataset_schema_evolution.rs
@@ -563,10 +563,6 @@ async fn prepare_initial_dataset_with_list_struct_col(version: LanceFileVersion)
 /// — causing `ArrayData::try_new` to panic.
 #[tokio::test]
 async fn test_scan_with_null_typed_struct_subfield_across_fragments() {
-    use lance_core::utils::tempfile::TempStrDir;
-
-    let test_uri = TempStrDir::default();
-
     // Fragment 0: struct column with an `extra` sub-field of DataType::Null.
     // This simulates a user inserting rows from Python/pandas where `extra` is all None.
     let meta0 = StructArray::new(
@@ -593,9 +589,9 @@ async fn test_scan_with_null_typed_struct_subfield_across_fragments() {
     )
     .unwrap();
 
-    Dataset::write(
+    let mut ds = Dataset::write(
         RecordBatchIterator::new(vec![Ok(batch0)], schema0),
-        &test_uri,
+        "memory://",
         Some(WriteParams::default()),
     )
     .await
@@ -622,9 +618,8 @@ async fn test_scan_with_null_typed_struct_subfield_across_fragments() {
     )
     .unwrap();
 
-    Dataset::write(
+    ds.append(
         RecordBatchIterator::new(vec![Ok(batch1)], schema1),
-        &test_uri,
         Some(WriteParams {
             mode: WriteMode::Append,
             ..Default::default()
@@ -633,14 +628,12 @@ async fn test_scan_with_null_typed_struct_subfield_across_fragments() {
     .await
     .unwrap();
 
-    let dataset = Dataset::open(&test_uri).await.unwrap();
-
     // Scanning reads both fragments. Fragment 1 is missing `meta.extra: Null`, so Lance adds
     // a NullReader for it. MergeStream merges the real batch (with null struct rows) and the
     // NullReader batch (all-null `meta` struct). The recursive merge in `merge()` descends into
     // `meta`, where `right_validity` (from the all-null NullReader struct) has non-zero null
     // count and the child column has DataType::Null — previously panicked:
     // "Arrays of type Null cannot contain a null bitmask".
-    let result = dataset.scan().try_into_batch().await.unwrap();
+    let result = ds.scan().try_into_batch().await.unwrap();
     assert_eq!(result.num_rows(), 4);
 }


### PR DESCRIPTION
Previously, `adjust_child_validity` would call `ArrayData::try_new` with a null bitmap on a `DataType::Null` array, causing an `.unwrap()` panic with `InvalidArgumentError("Arrays of type Null cannot contain a null bitmask")`.

The trigger: when a user inserts rows where a struct sub-field has only null values, Arrow infers `DataType::Null` for that column. If a subsequent fragment omits that nullable sub-field, Lance inserts a `NullReader` to fill it in. `MergeStream` then merges the real batch (with null struct rows) and the `NullReader` batch (all-null struct), recursing into the struct where `adjust_child_validity` is called with the `Null`-typed child and a non-empty parent validity — triggering the panic.

Fix: skip the bitmask operation when `child.data_type() == DataType::Null`. A `Null` array is always entirely null by definition and needs no validity adjustment.

Closes https://github.com/lance-format/lance/issues/6159