### PR TITLE
fix: persist frag reuse index external file on local filesystem

### DIFF
--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -2291,6 +2291,71 @@ mod tests {
         assert_eq!(before_scalar_result, after_scalar_result);
     }
 
+    // Regression test for https://github.com/lancedb/lance/issues/6161
+    // When FragReuseIndexDetails exceeds 204800 bytes it is written to an external
+    // file. Previously the file was silently dropped (temp file deleted) because
+    // tokio::io::AsyncWriteExt::shutdown was called instead of
+    // lance_io::traits::Writer::shutdown, which persists the temp file.
+    #[tokio::test]
+    async fn test_defer_index_remap_large_external_file() {
+        let test_dir = TempStrDir::default();
+        let test_uri = &test_dir;
+
+        // Create ~150 fragments × 1000 rows to produce a FragReuseIndexDetails
+        // that exceeds the 204800-byte inline threshold (~302 KB serialized).
+        let num_fragments = 150usize;
+        let rows_per_fragment = 1000usize;
+        let total_rows = num_fragments * rows_per_fragment;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("i", DataType::Int32, false)]));
+
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(
+                vec![Ok(RecordBatch::try_new(
+                    schema.clone(),
+                    vec![Arc::new(Int32Array::from_iter_values(0..total_rows as i32)) as ArrayRef],
+                )
+                .unwrap())],
+                schema.clone(),
+            ),
+            test_uri,
+            Some(WriteParams {
+                max_rows_per_file: rows_per_fragment,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(dataset.get_fragments().len(), num_fragments);
+
+        // Delete a few rows from each fragment so compaction has something to do.
+        dataset.delete("i % 1000 = 0").await.unwrap();
+
+        compact_files(
+            &mut dataset,
+            CompactionOptions {
+                defer_index_remap: true,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+        // Loading the FragReuseIndex details must succeed even when the details
+        // were written to an external file.
+        let frag_reuse_meta = dataset
+            .load_index_by_name(FRAG_REUSE_INDEX_NAME)
+            .await
+            .unwrap()
+            .expect("fragment reuse index must exist after compaction");
+
+        load_frag_reuse_index_details(&dataset, &frag_reuse_meta)
+            .await
+            .expect("loading large frag reuse index details must not fail");
+    }
+
     #[tokio::test]
     async fn test_defer_index_remap() {
         let mut data_gen = BatchGenerator::new()

--- a/rust/lance/src/index/frag_reuse.rs
+++ b/rust/lance/src/index/frag_reuse.rs
@@ -9,6 +9,7 @@ use lance_index::frag_reuse::{
     FRAG_REUSE_DETAILS_FILE_NAME, FRAG_REUSE_INDEX_NAME, FragReuseGroup, FragReuseIndex,
     FragReuseIndexDetails, FragReuseVersion,
 };
+use lance_io::traits::Writer;
 use lance_table::format::IndexMetadata;
 use lance_table::format::pb::fragment_reuse_index_details::{Content, InlineContent};
 use lance_table::format::pb::{ExternalFile, FragmentReuseIndexDetails};
@@ -147,7 +148,7 @@ pub(crate) async fn build_frag_reuse_index_metadata(
         writer
             .write_all(new_index_details_proto.encode_to_vec().as_slice())
             .await?;
-        writer.shutdown().await?;
+        Writer::shutdown(writer.as_mut()).await?;
         let external_file = ExternalFile {
             path: FRAG_REUSE_DETAILS_FILE_NAME.to_owned(),
             offset: 0,


### PR DESCRIPTION
Previously, when `FragReuseIndexDetails` exceeded 204800 bytes (triggered by large compactions with many fragments), the code wrote the details to an external file (`details.binpb`). On local filesystems, `ObjectStore::create` returns a `LocalWriter` that atomically renames a temp file to the final path in `Writer::shutdown`. However, `frag_reuse.rs` imported `tokio::io::AsyncWriteExt` but not `lance_io::traits::Writer`, so `writer.shutdown()` resolved to `AsyncWriteExt::shutdown` (flush/close only) — the temp file was deleted on drop without being persisted. Any subsequent `load_indices` call would fail with `Not found: .../details.binpb`.

Fixed by using UFCS `Writer::shutdown(writer.as_mut()).await?` to explicitly call the lance trait method, matching the existing pattern in `ivf.rs` and `blob.rs`.

Fixes #6161