### PR TITLE
fix: avoid fts corruption when a fragment is deleted

### DIFF
--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -832,6 +832,14 @@ impl OldIndexDataFilter {
                 .collect(),
         }
     }
+
+    /// Check whether a single row ID passes the filter.
+    pub fn contains(&self, row_id: u64) -> bool {
+        match self {
+            Self::Fragments(valid_fragments) => valid_fragments.contains((row_id >> 32) as u32),
+            Self::RowIds(valid_row_ids) => valid_row_ids.contains(row_id),
+        }
+    }
 }
 
 impl UpdateCriteria {

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -66,7 +66,7 @@ impl InvertedIndexPlugin {
         let mut inverted_index =
             InvertedIndexBuilder::new_with_fragment_mask(params, fragment_mask)
                 .with_progress(progress);
-        inverted_index.update(data, index_store).await?;
+        inverted_index.update(data, index_store, None).await?;
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&details).unwrap(),
             index_version: INVERTED_INDEX_VERSION,

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -7,6 +7,7 @@ use super::{
     merger::{Merger, PartitionSource, SizeBasedMerger},
 };
 use crate::scalar::IndexStore;
+use crate::scalar::OldIndexDataFilter;
 use crate::scalar::inverted::json::JsonTextStream;
 use crate::scalar::inverted::lance_tokenizer::DocType;
 use crate::scalar::inverted::tokenizer::lance_tokenizer::LanceTokenizer;
@@ -140,6 +141,7 @@ impl InvertedIndexBuilder {
         &mut self,
         new_data: SendableRecordBatchStream,
         dest_store: &dyn IndexStore,
+        old_data_filter: Option<OldIndexDataFilter>,
     ) -> Result<()> {
         let schema = new_data.schema();
         let doc_col = schema.field(0).name();
@@ -159,7 +161,7 @@ impl InvertedIndexBuilder {
             .await?;
         self.update_index(new_data).await?;
         self.progress.stage_complete("tokenize_docs").await?;
-        self.write(dest_store).await?;
+        self.write(dest_store, old_data_filter).await?;
         Ok(())
     }
 
@@ -353,7 +355,11 @@ impl InvertedIndexBuilder {
         Ok(())
     }
 
-    async fn write(&self, dest_store: &dyn IndexStore) -> Result<()> {
+    async fn write(
+        &self,
+        dest_store: &dyn IndexStore,
+        old_data_filter: Option<OldIndexDataFilter>,
+    ) -> Result<()> {
         if self.params.skip_merge {
             let mut partitions =
                 Vec::with_capacity(self.partitions.len() + self.new_partitions.len());
@@ -409,11 +415,11 @@ impl InvertedIndexBuilder {
         let partitions = self
             .partitions
             .iter()
-            .map(|part| PartitionSource::new(self.src_store.clone(), *part))
+            .map(|part| PartitionSource::new(self.src_store.clone(), *part, true))
             .chain(
                 self.new_partitions
                     .iter()
-                    .map(|part| PartitionSource::new(self.local_store.clone(), *part)),
+                    .map(|part| PartitionSource::new(self.local_store.clone(), *part, false)),
             )
             .collect::<Vec<_>>();
         self.progress
@@ -429,6 +435,7 @@ impl InvertedIndexBuilder {
             *LANCE_FTS_TARGET_SIZE << 20,
             self.token_set_format,
             self.progress.clone(),
+            old_data_filter,
         );
         let partitions = merger.merge().await?;
         self.progress.stage_complete("merge_partitions").await?;
@@ -1478,7 +1485,7 @@ mod tests {
             token_set_format,
             None,
         );
-        builder.write(dest_store.as_ref()).await?;
+        builder.write(dest_store.as_ref(), None).await?;
 
         let metadata_reader = dest_store.open_index_file(METADATA_FILE).await?;
         let metadata = &metadata_reader.schema().metadata;
@@ -1526,7 +1533,7 @@ mod tests {
         .max_token_length(None);
 
         let mut builder = InvertedIndexBuilder::new(params);
-        builder.update(stream, store.as_ref()).await?;
+        builder.update(stream, store.as_ref(), None).await?;
 
         let index = InvertedIndex::load(store, None, &LanceCache::no_cache()).await?;
         assert_eq!(index.partitions.len(), 1);
@@ -1620,7 +1627,7 @@ mod tests {
         let mut builder =
             InvertedIndexBuilder::new(InvertedIndexParams::default().skip_merge(true))
                 .with_progress(progress.clone());
-        builder.update(stream, store.as_ref()).await?;
+        builder.update(stream, store.as_ref(), None).await?;
 
         let events = progress.events.lock().await.clone();
         let tags = events

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -634,9 +634,11 @@ impl ScalarIndex for InvertedIndex {
         &self,
         new_data: SendableRecordBatchStream,
         dest_store: &dyn IndexStore,
-        _old_data_filter: Option<crate::scalar::OldIndexDataFilter>,
+        old_data_filter: Option<crate::scalar::OldIndexDataFilter>,
     ) -> Result<CreatedIndex> {
-        self.to_builder().update(new_data, dest_store).await?;
+        self.to_builder()
+            .update(new_data, dest_store, old_data_filter)
+            .await?;
 
         let details = pbold::InvertedIndexDetails::try_from(&self.params)?;
 
@@ -819,17 +821,20 @@ impl InvertedPartition {
                     .posting_list(token_id, is_phrase_query, metrics)
                     .await?;
 
-                Result::Ok(PostingIterator::new(
-                    token,
-                    token_id,
-                    position as u32,
-                    posting,
-                    num_docs,
-                ))
+                Result::Ok((token, token_id, position as u32, posting))
             })
             .buffered(self.store.io_parallelism())
             .try_collect::<Vec<_>>()
             .await
+            .map(|items| {
+                items
+                    .into_iter()
+                    .filter(|(_, _, _, posting)| !posting.is_empty())
+                    .map(|(token, token_id, position, posting)| {
+                        PostingIterator::new(token, token_id, position, posting, num_docs)
+                    })
+                    .collect()
+            })
     }
 
     #[instrument(level = "debug", skip_all)]
@@ -1956,6 +1961,28 @@ impl PostingListBuilder {
         }
     }
 
+    fn build_empty_batch(self, schema: SchemaRef) -> Result<RecordBatch> {
+        let empty_compressed = LargeBinaryArray::from(Vec::<&[u8]>::new());
+        let offsets = OffsetBuffer::new(ScalarBuffer::from(vec![0_i32, 0]));
+        let mut columns = vec![
+            Arc::new(ListArray::try_new(
+                Arc::new(Field::new("item", datatypes::DataType::LargeBinary, true)),
+                offsets,
+                Arc::new(empty_compressed),
+                None,
+            )?) as ArrayRef,
+            Arc::new(Float32Array::from_iter_values(std::iter::once(0.0_f32))) as ArrayRef,
+            Arc::new(UInt32Array::from_iter_values(std::iter::once(0_u32))) as ArrayRef,
+        ];
+        if self.positions.is_some() {
+            let mut position_builder =
+                ListBuilder::new(ListBuilder::with_capacity(LargeBinaryBuilder::new(), 0));
+            position_builder.append(true);
+            columns.push(Arc::new(position_builder.finish()));
+        }
+        Ok(RecordBatch::try_new(schema, columns)?)
+    }
+
     fn build_batch(
         self,
         compressed: LargeBinaryArray,
@@ -2012,6 +2039,9 @@ impl PostingListBuilder {
 
     pub fn to_batch_with_docs(self, docs: &DocSet, schema: SchemaRef) -> Result<RecordBatch> {
         let length = self.len();
+        if length == 0 {
+            return self.build_empty_batch(schema);
+        }
         let avgdl = docs.average_length();
         let idf_scale = idf(length, docs.len()) * (K1 + 1.0);
         let (compressed, max_score) = compress_posting_list_with_scores(

--- a/rust/lance-index/src/scalar/inverted/merger.rs
+++ b/rust/lance-index/src/scalar/inverted/merger.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use crate::progress::IndexBuildProgress;
 use crate::scalar::IndexStore;
+use crate::scalar::OldIndexDataFilter;
 
 use super::{
     InvertedPartition, PostingListBuilder, TokenMap, TokenSetFormat,
@@ -26,11 +27,14 @@ pub trait Merger {
 pub(super) struct PartitionSource {
     store: std::sync::Arc<dyn IndexStore>,
     id: u64,
+    /// Whether this partition comes from the existing (old) index.
+    /// When true, `old_data_filter` in the merger will be applied.
+    is_old: bool,
 }
 
 impl PartitionSource {
-    pub(super) fn new(store: std::sync::Arc<dyn IndexStore>, id: u64) -> Self {
-        Self { store, id }
+    pub(super) fn new(store: std::sync::Arc<dyn IndexStore>, id: u64, is_old: bool) -> Self {
+        Self { store, id, is_old }
     }
 
     async fn load(
@@ -56,6 +60,8 @@ pub struct SizeBasedMerger<'a> {
     builder: Option<InnerBuilder>,
     next_id: u64,
     partitions: Vec<u64>,
+    /// Filter applied to old partitions to exclude stale row IDs.
+    old_data_filter: Option<OldIndexDataFilter>,
 }
 
 impl<'a> SizeBasedMerger<'a> {
@@ -69,6 +75,7 @@ impl<'a> SizeBasedMerger<'a> {
         target_size: u64,
         token_set_format: TokenSetFormat,
         progress: Arc<dyn IndexBuildProgress>,
+        old_data_filter: Option<OldIndexDataFilter>,
     ) -> Self {
         let max_id = input.iter().map(|p| p.id).max().unwrap_or(0);
 
@@ -82,6 +89,7 @@ impl<'a> SizeBasedMerger<'a> {
             builder: None,
             next_id: max_id + 1,
             partitions: Vec::new(),
+            old_data_filter,
         }
     }
 
@@ -142,6 +150,7 @@ impl<'a> SizeBasedMerger<'a> {
     async fn merge_partition(
         &mut self,
         part: InvertedPartition,
+        is_old: bool,
         estimated_size: &mut u64,
     ) -> Result<()> {
         self.ensure_builder(&part)?;
@@ -156,6 +165,14 @@ impl<'a> SizeBasedMerger<'a> {
                 self.ensure_builder(&part)?;
             }
         }
+
+        // Determine which filter (if any) to apply.
+        // Only old partitions are filtered; new partitions pass through unmodified.
+        let filter = if is_old {
+            self.old_data_filter.as_ref()
+        } else {
+            None
+        };
 
         let builder = self.builder.as_mut().expect("builder must exist");
         let mut token_id_map = vec![u32::MAX; part.tokens.len()];
@@ -180,10 +197,37 @@ impl<'a> SizeBasedMerger<'a> {
                 }
             }
         }
+
+        // Build doc_id mapping. When a filter is present, only docs whose
+        // row_id passes the filter are kept; others are skipped.
+        // old_doc_id_map[old_doc_id] = Some(new_doc_id) if kept, None if filtered.
         let doc_id_offset = builder.docs.len() as u32;
-        for (row_id, num_tokens) in part.docs.iter() {
-            builder.docs.append(*row_id, *num_tokens);
-        }
+        let old_doc_id_map: Vec<Option<u32>> = if let Some(filter) = filter {
+            let mut next_new = doc_id_offset;
+            part.docs
+                .iter()
+                .map(|(row_id, num_tokens)| {
+                    if filter.contains(*row_id) {
+                        builder.docs.append(*row_id, *num_tokens);
+                        let mapped = next_new;
+                        next_new += 1;
+                        Some(mapped)
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        } else {
+            part.docs
+                .iter()
+                .enumerate()
+                .map(|(i, (row_id, num_tokens))| {
+                    builder.docs.append(*row_id, *num_tokens);
+                    Some(doc_id_offset + i as u32)
+                })
+                .collect()
+        };
+
         builder.posting_lists.resize_with(builder.tokens.len(), || {
             PostingListBuilder::new(part.inverted_list.has_positions())
         });
@@ -201,12 +245,13 @@ impl<'a> SizeBasedMerger<'a> {
             let builder = &mut builder.posting_lists[new_token_id as usize];
             let old_size = builder.size();
             for (doc_id, freq, positions) in posting_list.iter() {
-                let new_doc_id = doc_id_offset + doc_id as u32;
-                let positions = match positions {
-                    Some(positions) => PositionRecorder::Position(positions.collect()),
-                    None => PositionRecorder::Count(freq),
-                };
-                builder.add(new_doc_id, positions);
+                if let Some(new_doc_id) = old_doc_id_map[doc_id as usize] {
+                    let positions = match positions {
+                        Some(positions) => PositionRecorder::Position(positions.collect()),
+                        None => PositionRecorder::Count(freq),
+                    };
+                    builder.add(new_doc_id, positions);
+                }
             }
             let new_size = builder.size();
             *estimated_size += new_size - old_size;
@@ -217,7 +262,7 @@ impl<'a> SizeBasedMerger<'a> {
 
 impl Merger for SizeBasedMerger<'_> {
     async fn merge(&mut self) -> Result<Vec<u64>> {
-        if self.input.len() <= 1 {
+        if self.input.len() <= 1 && self.old_data_filter.is_none() {
             let mut completed = 0;
             for part in self.input.iter() {
                 part.store
@@ -257,16 +302,21 @@ impl Merger for SizeBasedMerger<'_> {
         let cache = LanceCache::no_cache();
         let token_set_format = self.token_set_format;
         let mut stream = stream::iter(parts.into_iter().map(|part| {
+            let is_old = part.is_old;
             let cache = cache.clone();
-            tokio::task::spawn(async move { part.load(&cache, token_set_format).await })
+            tokio::task::spawn(async move {
+                let loaded = part.load(&cache, token_set_format).await?;
+                Ok::<_, lance_core::Error>((loaded, is_old))
+            })
         }))
         .buffered(buffer_size);
 
         let mut idx = 0;
-        while let Some(part) = stream.try_next().await? {
-            let part = part?;
+        while let Some(result) = stream.try_next().await? {
+            let (part, is_old) = result?;
             idx += 1;
-            self.merge_partition(part, &mut estimated_size).await?;
+            self.merge_partition(part, is_old, &mut estimated_size)
+                .await?;
             self.progress
                 .stage_progress("merge_partitions", idx as u64)
                 .await?;
@@ -335,12 +385,13 @@ mod tests {
         let mut merger = SizeBasedMerger::new(
             dest_store.as_ref(),
             vec![
-                PartitionSource::new(src_store.clone(), 0),
-                PartitionSource::new(src_store.clone(), 1),
+                PartitionSource::new(src_store.clone(), 0, false),
+                PartitionSource::new(src_store.clone(), 1, false),
             ],
             u64::MAX,
             token_set_format,
             crate::progress::noop_progress(),
+            None,
         );
         let merged_partitions = merger.merge().await?;
         assert_eq!(merged_partitions, vec![2]);
@@ -397,7 +448,7 @@ mod tests {
             let doc_id = builder.docs.append(id * 10, 1);
             builder.posting_lists[token_id as usize].add(doc_id, PositionRecorder::Count(1));
             builder.write(src_store.as_ref()).await?;
-            sources.push(PartitionSource::new(src_store.clone(), id));
+            sources.push(PartitionSource::new(src_store.clone(), id, false));
         }
 
         let mut merger = SizeBasedMerger::new(
@@ -406,6 +457,7 @@ mod tests {
             u64::MAX,
             token_set_format,
             crate::progress::noop_progress(),
+            None,
         );
         let merged_partitions = merger.merge().await?;
         assert_eq!(merged_partitions, vec![num_parts as u64]);

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -12,7 +12,8 @@ use crate::dataset::{AutoCleanupParams, MergeInsertBuilder, ProjectionRequest};
 use crate::{Dataset, Error};
 use lance_core::ROW_ADDR;
 use lance_index::optimize::OptimizeOptions;
-use lance_index::scalar::ScalarIndexParams;
+use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
+use lance_index::scalar::{FullTextSearchQuery, ScalarIndexParams};
 use lance_index::{DatasetIndexExt, IndexType};
 use mock_instant::thread_local::MockClock;
 
@@ -1704,4 +1705,184 @@ async fn test_data_replacement_invalidates_index_bitmap() {
         !effective.contains(0),
         "Fragment 0 should be removed from index bitmap after DataReplacement on indexed column"
     );
+}
+
+/// Regression test: inverted (FTS) index should not carry stale data after
+/// merge_insert + compact + optimize_indices.
+///
+/// This is the FTS equivalent of test_merge_insert_with_reordered_columns_and_index.
+/// The inverted index's update() ignores the valid_old_fragments filter, so stale
+/// posting list entries from pruned fragments survive the merge and cause errors
+/// when queries try to resolve the old row addresses.
+#[tokio::test]
+async fn test_fts_index_stale_data_after_merge_insert_compact_optimize() {
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", DataType::Int32, false),
+        ArrowField::new("text", DataType::Utf8, true),
+    ]));
+
+    // Step 1: Create dataset with 2 rows in separate fragments
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![0, 1])),
+            Arc::new(StringArray::from(vec![
+                "the quick brown fox",
+                "the lazy dog",
+            ])),
+        ],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+    let mut dataset = Dataset::write(
+        reader,
+        "memory://test_fts_stale",
+        Some(WriteParams {
+            max_rows_per_file: 1, // Force 2 fragments
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    // Step 2: Create FTS inverted index on 'text'
+    let params = InvertedIndexParams::default();
+    dataset
+        .create_index(&["text"], IndexType::Inverted, None, &params, true)
+        .await
+        .unwrap();
+
+    // Sanity check: searching "quick" should return 1 result
+    let results = dataset
+        .scan()
+        .full_text_search(FullTextSearchQuery::new("quick".to_owned()))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(results.num_rows(), 1);
+
+    // Step 3: merge_insert with reversed column order (text, id)
+    // This triggers the RewriteColumns/DataReplacement path, which prunes the
+    // index fragment bitmap for the 'text' column.
+    let reversed_schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("text", DataType::Utf8, true),
+        ArrowField::new("id", DataType::Int32, false),
+    ]));
+    let source_batch = RecordBatch::try_new(
+        reversed_schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec![
+                "updated fox text",
+                "new entry here",
+            ])),
+            Arc::new(Int32Array::from(vec![1, 2])),
+        ],
+    )
+    .unwrap();
+
+    let merge_job = MergeInsertBuilder::try_new(Arc::new(dataset.clone()), vec!["id".to_string()])
+        .unwrap()
+        .when_matched(WhenMatched::UpdateAll)
+        .when_not_matched(WhenNotMatched::InsertAll)
+        .try_build()
+        .unwrap();
+
+    let reader = Box::new(RecordBatchIterator::new(
+        vec![Ok(source_batch)],
+        reversed_schema.clone(),
+    ));
+    let (dataset, _stats) = merge_job.execute(reader_to_stream(reader)).await.unwrap();
+    let mut dataset = dataset.as_ref().clone();
+
+    // Step 4: compact_files — moves rows to new fragment(s)
+    compact_files(&mut dataset, CompactionOptions::default(), None)
+        .await
+        .unwrap();
+
+    // Step 5: optimize_indices — should rebuild the FTS index without stale data.
+    // With the current bug, the inverted index ignores valid_old_fragments and
+    // merges stale posting list entries pointing at now-deleted fragments.
+    dataset
+        .optimize_indices(&OptimizeOptions::default())
+        .await
+        .unwrap();
+
+    // Step 6: FTS search should not error and should return correct results.
+    // "quick" appeared in the original data for id=0 (never updated), so it
+    // should still be found.
+    let results = dataset
+        .scan()
+        .full_text_search(FullTextSearchQuery::new("quick".to_owned()))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(
+        results.num_rows(),
+        1,
+        "Expected 1 result for 'quick' after optimize, got {}",
+        results.num_rows()
+    );
+
+    // "lazy" was in the original text for id=1, but id=1 was updated to
+    // "updated fox text". The old posting for "lazy" should have been filtered
+    // out during the index update.
+    let results = dataset
+        .scan()
+        .full_text_search(FullTextSearchQuery::new("lazy".to_owned()))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(
+        results.num_rows(),
+        0,
+        "Expected 0 results for 'lazy' (stale data should be filtered), got {}",
+        results.num_rows()
+    );
+
+    // "updated" should be found (new text for id=1)
+    let results = dataset
+        .scan()
+        .full_text_search(FullTextSearchQuery::new("updated".to_owned()))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(results.num_rows(), 1);
+
+    // "entry" should be found (new row id=2)
+    let results = dataset
+        .scan()
+        .full_text_search(FullTextSearchQuery::new("entry".to_owned()))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(results.num_rows(), 1);
+
+    // Step 7: Another merge_insert should NOT error
+    let source_batch2 = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![1])),
+            Arc::new(StringArray::from(vec!["final text"])),
+        ],
+    )
+    .unwrap();
+
+    let merge_job2 = MergeInsertBuilder::try_new(Arc::new(dataset.clone()), vec!["id".to_string()])
+        .unwrap()
+        .when_matched(WhenMatched::UpdateAll)
+        .when_not_matched(WhenNotMatched::InsertAll)
+        .try_build()
+        .unwrap();
+
+    let reader2 = Box::new(RecordBatchIterator::new(
+        vec![Ok(source_batch2)],
+        schema.clone(),
+    ));
+    let (final_dataset, _) = merge_job2.execute(reader_to_stream(reader2)).await.unwrap();
+    final_dataset.validate().await.unwrap();
 }


### PR DESCRIPTION
This is basically the same problem encountered in https://github.com/lance-format/lance/pull/5929

If an entire fragment is deleted then, after an FTS update, the rows in that deleted fragment will still be indexed but shouldn't be.  This fix uses the `old_data_filter` to properly prune the old data during the update.

---

This PR was created with the help of Claude Opus 4.6.  I take responsibility for all code.