### PR TITLE
chore: clippy cleanups

### DIFF
--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -1113,8 +1113,14 @@ impl FileFragment {
     /// Fails if the fragment does not have the physical row count in the metadata.  This method should
     /// only be called in new workflows which are not run on old versions of Lance.
     pub fn fast_physical_rows(&self) -> Result<usize> {
-        if self.dataset.manifest.writer_version.is_some() && self.metadata.physical_rows.is_some() {
-            Ok(self.metadata.physical_rows.unwrap())
+        if self.dataset.manifest.writer_version.is_some() {
+            let Some(physical_rows) = self.metadata.physical_rows else {
+                return Err(Error::internal(format!(
+                    "The method fast_physical_rows was called on a fragment that does not have the physical row count in the metadata. Fragment id: {}",
+                    self.id()
+                )));
+            };
+            Ok(physical_rows)
         } else {
             Err(Error::internal(format!(
                 "The method fast_physical_rows was called on a fragment that does not have the physical row count in the metadata. Fragment id: {}",
@@ -1168,8 +1174,10 @@ impl FileFragment {
         // we should not used the cached value. On write, we update the values
         // in the manifest, fixing the issue for future reads.
         // See: https://github.com/lance-format/lance/issues/1531
-        if self.dataset.manifest.writer_version.is_some() && self.metadata.physical_rows.is_some() {
-            return Ok(self.metadata.physical_rows.unwrap());
+        if self.dataset.manifest.writer_version.is_some()
+            && let Some(physical_rows) = self.metadata.physical_rows
+        {
+            return Ok(physical_rows);
         }
 
         // Just open any file. All of them should have same size.

--- a/rust/lance/src/dataset/mem_wal/index/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/index/fts.rs
@@ -96,11 +96,11 @@ pub enum FtsQueryExpr {
     /// Boolean combination of queries.
     Boolean {
         /// All MUST clauses must match for a document to be included.
-        must: Vec<FtsQueryExpr>,
+        must: Vec<Self>,
         /// At least one SHOULD clause should match (adds to score).
-        should: Vec<FtsQueryExpr>,
+        should: Vec<Self>,
         /// No MUST_NOT clause may match (excludes documents).
-        must_not: Vec<FtsQueryExpr>,
+        must_not: Vec<Self>,
     },
     /// Boosting query with positive and optional negative components.
     ///
@@ -109,9 +109,9 @@ pub enum FtsQueryExpr {
     /// and negative have their scores reduced by `negative_boost`.
     Boost {
         /// The primary query (documents must match this).
-        positive: Box<FtsQueryExpr>,
+        positive: Box<Self>,
         /// Optional query to demote matching documents.
-        negative: Option<Box<FtsQueryExpr>>,
+        negative: Option<Box<Self>>,
         /// Boost factor for documents matching negative query (typically < 1.0).
         /// Score becomes: original_score * negative_boost for docs matching negative.
         negative_boost: f32,

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -193,9 +193,10 @@ impl<'a> CommitBuilder<'a> {
                 dataset.commit_handler.clone(),
             ),
             WriteDestination::Uri(uri) => {
-                let commit_handler = if self.commit_handler.is_some() && self.object_store.is_some()
+                let commit_handler = if let (Some(_), Some(commit_handler)) =
+                    (&self.object_store, &self.commit_handler)
                 {
-                    self.commit_handler.as_ref().unwrap().clone()
+                    commit_handler.clone()
                 } else {
                     resolve_commit_handler(uri, self.commit_handler.clone(), &self.store_params)
                         .await?

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -315,7 +315,7 @@ impl<'a> CreateIndexBuilder<'a> {
 
                 if train {
                     // Check if this is distributed indexing (fragment-level)
-                    if self.fragments.is_some() {
+                    if let Some(fragments) = &self.fragments {
                         // For distributed indexing, build only on specified fragments
                         // This creates temporary index metadata without committing
                         Box::pin(build_distributed_vector_index(
@@ -325,7 +325,7 @@ impl<'a> CreateIndexBuilder<'a> {
                             &index_id.to_string(),
                             vec_params,
                             fri,
-                            self.fragments.as_ref().unwrap(),
+                            fragments,
                             self.progress.clone(),
                         ))
                         .await?;

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -2300,28 +2300,19 @@ mod tests {
             }
         }
 
-        fn distance_between_points(&self) -> f32 {
-            (self.dim as f32).sqrt()
-        }
-
-        fn generate_centroids(&self) -> Float32Array {
+        fn generate_centroids(dim: u32, num_centroids: u32) -> Float32Array {
             const MAX_ATTEMPTS: u32 = 10;
-            let distance_needed =
-                self.distance_between_points() * Self::VALS_PER_CODE as f32 * 2_f32;
+            let distance_needed = (dim as f32).sqrt() * Self::VALS_PER_CODE as f32 * 2_f32;
             let mut attempts_remaining = MAX_ATTEMPTS;
-            let num_values = self.dim * self.num_centroids;
+            let num_values = dim * num_centroids;
             while attempts_remaining > 0 {
                 // Use some biggish numbers to ensure we get the distance we want but make them positive
                 // and not too big for easier debugging.
                 let centroids: Float32Array =
                     generate_scaled_random_array(num_values as usize, 0_f32, 1000_f32);
                 let mut broken = false;
-                for (index, centroid) in centroids
-                    .values()
-                    .chunks_exact(self.dim as usize)
-                    .enumerate()
-                {
-                    let offset = (index + 1) * self.dim as usize;
+                for (index, centroid) in centroids.values().chunks_exact(dim as usize).enumerate() {
+                    let offset = (index + 1) * dim as usize;
                     let length = centroids.len() - offset;
                     if length == 0 {
                         // This will be true for the last item since we ignore comparison with self
@@ -2330,7 +2321,7 @@ mod tests {
                     let distances = l2_distance_batch(
                         centroid,
                         &centroids.values()[offset..offset + length],
-                        self.dim as usize,
+                        dim as usize,
                     );
                     let min_distance = distances.min_by(|a, b| a.total_cmp(b)).unwrap();
                     // In theory we could just replace this one vector but, out of laziness, we just retry all of them
@@ -2351,11 +2342,10 @@ mod tests {
         }
 
         fn get_centroids(&mut self) -> &Float32Array {
-            if self.centroids.is_some() {
-                return self.centroids.as_ref().unwrap();
-            }
-            self.centroids = Some(self.generate_centroids());
-            self.centroids.as_ref().unwrap()
+            let dim = self.dim;
+            let num_centroids = self.num_centroids;
+            self.centroids
+                .get_or_insert_with(|| Self::generate_centroids(dim, num_centroids))
         }
 
         fn get_centroids_as_list_arr(&mut self) -> Arc<FixedSizeListArray> {
@@ -2368,10 +2358,12 @@ mod tests {
             )
         }
 
-        fn generate_vectors(&mut self) -> Float32Array {
-            let dim = self.dim as usize;
-            let num_centroids = self.num_centroids;
-            let centroids = self.get_centroids();
+        fn generate_vectors(
+            dim: u32,
+            num_centroids: u32,
+            centroids: &Float32Array,
+        ) -> Float32Array {
+            let dim = dim as usize;
             let mut vectors: Vec<f32> =
                 vec![0_f32; Self::VALS_PER_CODE as usize * dim * num_centroids as usize];
             for (centroid, dst_batch) in centroids
@@ -2389,11 +2381,11 @@ mod tests {
         }
 
         fn get_vectors(&mut self) -> &Float32Array {
-            if self.vectors.is_some() {
-                return self.vectors.as_ref().unwrap();
-            }
-            self.vectors = Some(self.generate_vectors());
-            self.vectors.as_ref().unwrap()
+            let dim = self.dim;
+            let num_centroids = self.num_centroids;
+            let centroids = self.get_centroids().clone();
+            self.vectors
+                .get_or_insert_with(|| Self::generate_vectors(dim, num_centroids, &centroids))
         }
 
         fn get_vector(&mut self, idx: u32) -> Float32Array {

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -1854,7 +1854,7 @@ impl ExecutionPlan for FilteredReadExec {
 
         let total_rows: u64 = fragments.iter().map(|f| f.num_rows().unwrap() as u64).sum();
 
-        if self.options.full_filter.is_none() {
+        let Some(filter) = self.options.full_filter.as_ref() else {
             // If there is no filter, we just return the total number of rows (sans any before-filter range)
             // divided by the number of partitions.
             let total_rows =
@@ -1876,83 +1876,81 @@ impl ExecutionPlan for FilteredReadExec {
                 total_rows
             };
 
-            Ok(Statistics {
+            return Ok(Statistics {
                 num_rows: Precision::Exact(total_rows as usize),
                 ..datafusion::physical_plan::Statistics::new_unknown(self.schema().as_ref())
-            })
-        } else {
-            // We could evaluate the indexed filter here but this is still during the planning
-            // phase so we want to avoid that.
-            //
-            // Instead, we create a mock input which is the filtered read (without the filter)
-            // and then use DF's FilterExec logic to calculate the statistics (which uses column
-            // stats and basic filter shape)
-            let filter = self.options.full_filter.as_ref().unwrap();
+            });
+        };
 
-            // Need to add in filter columns even though they aren't part of the projection
-            let filter_columns = Planner::column_names_in_expr(filter);
-            let read_projection = self
-                .options
-                .projection
-                .clone()
-                .union_columns(filter_columns, OnMissing::Error)?;
+        // We could evaluate the indexed filter here but this is still during the planning
+        // phase so we want to avoid that.
+        //
+        // Instead, we create a mock input which is the filtered read (without the filter)
+        // and then use DF's FilterExec logic to calculate the statistics (which uses column
+        // stats and basic filter shape)
 
-            let read_schema = Arc::new(read_projection.to_arrow_schema());
+        // Need to add in filter columns even though they aren't part of the projection
+        let filter_columns = Planner::column_names_in_expr(filter);
+        let read_projection = self
+            .options
+            .projection
+            .clone()
+            .union_columns(filter_columns, OnMissing::Error)?;
 
-            let planner = Arc::new(Planner::new(read_schema.clone()));
-            let physical_filter = planner.create_physical_expr(filter)?;
+        let read_schema = Arc::new(read_projection.to_arrow_schema());
 
-            let mock_input = Arc::new(Self::try_new(
-                self.dataset.clone(),
-                FilteredReadOptions {
-                    scan_range_after_filter: None,
-                    refine_filter: None,
-                    full_filter: None,
-                    projection: read_projection,
-                    ..self.options.clone()
-                },
-                None,
-            )?);
-            let df_filter_exec = FilterExec::try_new(physical_filter, mock_input)?;
-            let mut df_stats = df_filter_exec.partition_statistics(partition)?;
+        let planner = Arc::new(Planner::new(read_schema.clone()));
+        let physical_filter = planner.create_physical_expr(filter)?;
 
-            // If we have an after-filter range, we should apply it to the stats (the before-filter range
-            // is applied in the mock input)
-            let total_rows = if let Some(scan_range_after_filter) =
-                &self.options.scan_range_after_filter
-            {
+        let mock_input = Arc::new(Self::try_new(
+            self.dataset.clone(),
+            FilteredReadOptions {
+                scan_range_after_filter: None,
+                refine_filter: None,
+                full_filter: None,
+                projection: read_projection,
+                ..self.options.clone()
+            },
+            None,
+        )?);
+        let df_filter_exec = FilterExec::try_new(physical_filter, mock_input)?;
+        let mut df_stats = df_filter_exec.partition_statistics(partition)?;
+
+        // If we have an after-filter range, we should apply it to the stats (the before-filter range
+        // is applied in the mock input)
+        let total_rows =
+            if let Some(scan_range_after_filter) = &self.options.scan_range_after_filter {
                 df_stats.num_rows.min(&Precision::Exact(
                     scan_range_after_filter.end as usize - scan_range_after_filter.start as usize,
                 ))
             } else {
                 df_stats.num_rows
             };
-            df_stats.num_rows = total_rows;
+        df_stats.num_rows = total_rows;
 
-            let schema = self.schema();
+        let schema = self.schema();
 
-            // We might have added some columns to the schema so the filter compiles but we drop this
-            // columns during the filtered read and they aren't part of the output.  So we need to make
-            // sure and drop them from the column stats as well.
-            assert_eq!(read_schema.fields.len(), df_stats.column_statistics.len());
-            let mut proj_iter = schema.fields.iter().peekable();
-            let mut stats_iter = read_schema.fields.iter();
-            df_stats.column_statistics.retain(|_| {
-                let stats_field = stats_iter.next().unwrap();
-                if let Some(proj_field) = proj_iter.peek() {
-                    if proj_field.name() == stats_field.name() {
-                        proj_iter.next();
-                        true
-                    } else {
-                        false
-                    }
+        // We might have added some columns to the schema so the filter compiles but we drop this
+        // columns during the filtered read and they aren't part of the output.  So we need to make
+        // sure and drop them from the column stats as well.
+        assert_eq!(read_schema.fields.len(), df_stats.column_statistics.len());
+        let mut proj_iter = schema.fields.iter().peekable();
+        let mut stats_iter = read_schema.fields.iter();
+        df_stats.column_statistics.retain(|_| {
+            let stats_field = stats_iter.next().unwrap();
+            if let Some(proj_field) = proj_iter.peek() {
+                if proj_field.name() == stats_field.name() {
+                    proj_iter.next();
+                    true
                 } else {
                     false
                 }
-            });
+            } else {
+                false
+            }
+        });
 
-            Ok(df_stats)
-        }
+        Ok(df_stats)
     }
 
     fn with_new_children(


### PR DESCRIPTION
This PR moves a few unrelated clippy cleanups out of #6168 so the blob empty-range fix can stay focused on the regression it addresses. The changes here are all mechanical simplifications with no intended behavior change.
