### PR TITLE
feat(namespace): add directory namespace index operations and align REST index APIs

### DIFF
--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -6,6 +6,7 @@
 //! This module provides a directory-based implementation of the Lance namespace
 //! that stores tables as Lance datasets in a filesystem directory structure.
 
+mod indexes;
 pub mod manifest;
 
 use arrow::record_batch::RecordBatchIterator;
@@ -16,6 +17,7 @@ use futures::TryStreamExt;
 use lance::dataset::builder::DatasetBuilder;
 use lance::dataset::{Dataset, WriteParams};
 use lance::session::Session;
+use lance_index::DatasetIndexExt;
 use lance_io::object_store::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
 use lance_table::io::commit::ManifestNamingScheme;
 use object_store::path::Path;
@@ -27,12 +29,15 @@ use std::sync::Arc;
 use crate::context::DynamicContextProvider;
 use lance_namespace::models::{
     BatchDeleteTableVersionsRequest, BatchDeleteTableVersionsResponse, CreateNamespaceRequest,
-    CreateNamespaceResponse, CreateTableRequest, CreateTableResponse, CreateTableVersionRequest,
+    CreateNamespaceResponse, CreateTableIndexRequest, CreateTableIndexResponse, CreateTableRequest,
+    CreateTableResponse, CreateTableScalarIndexResponse, CreateTableVersionRequest,
     CreateTableVersionResponse, DeclareTableRequest, DeclareTableResponse,
-    DescribeNamespaceRequest, DescribeNamespaceResponse, DescribeTableRequest,
-    DescribeTableResponse, DescribeTableVersionRequest, DescribeTableVersionResponse,
-    DropNamespaceRequest, DropNamespaceResponse, DropTableRequest, DropTableResponse, Identity,
-    ListNamespacesRequest, ListNamespacesResponse, ListTableVersionsRequest,
+    DescribeNamespaceRequest, DescribeNamespaceResponse, DescribeTableIndexStatsRequest,
+    DescribeTableIndexStatsResponse, DescribeTableRequest, DescribeTableResponse,
+    DescribeTableVersionRequest, DescribeTableVersionResponse, DropNamespaceRequest,
+    DropNamespaceResponse, DropTableIndexRequest, DropTableIndexResponse, DropTableRequest,
+    DropTableResponse, Identity, ListNamespacesRequest, ListNamespacesResponse,
+    ListTableIndicesRequest, ListTableIndicesResponse, ListTableVersionsRequest,
     ListTableVersionsResponse, ListTablesRequest, ListTablesResponse, NamespaceExistsRequest,
     TableExistsRequest, TableVersion,
 };
@@ -693,6 +698,46 @@ impl DirectoryNamespace {
         }
 
         Ok(id[0].clone())
+    }
+
+    async fn load_dataset_at_version(
+        &self,
+        table_uri: &str,
+        version: Option<i64>,
+    ) -> Result<Dataset> {
+        // Always construct through DatasetBuilder so storage/session context is preserved
+        // for local and object-store-backed URIs.
+        let mut builder = DatasetBuilder::from_uri(table_uri);
+        if let Some(opts) = &self.storage_options {
+            builder = builder.with_storage_options(opts.clone());
+        }
+        if let Some(sess) = &self.session {
+            builder = builder.with_session(sess.clone());
+        }
+        let mut dataset = builder.load().await.map_err(|e| {
+            Error::namespace_source(
+                format!("Failed to load table at '{}': {}", table_uri, e).into(),
+            )
+        })?;
+
+        if let Some(v) = version {
+            if v < 0 {
+                return Err(Error::invalid_input_source(
+                    format!("Version must be non-negative, got {}", v).into(),
+                ));
+            }
+            // Version checkout is explicit to keep callers from reading latest implicitly.
+            dataset = dataset.checkout_version(v as u64).await.map_err(|e| {
+                Error::namespace_source(
+                    format!(
+                        "Failed to checkout version {} for table at '{}': {}",
+                        v, table_uri, e
+                    )
+                    .into(),
+                )
+            })?;
+        }
+        Ok(dataset)
     }
 
     async fn resolve_table_location(&self, id: &Option<Vec<String>>) -> Result<String> {
@@ -1518,6 +1563,67 @@ impl LanceNamespace for DirectoryNamespace {
         })
     }
 
+    async fn create_table_index(
+        &self,
+        request: CreateTableIndexRequest,
+    ) -> Result<CreateTableIndexResponse> {
+        let table_uri = self.resolve_table_location(&request.id).await?;
+        let mut dataset = self.load_dataset_at_version(&table_uri, None).await?;
+        indexes::create_table_index(&mut dataset, &request).await?;
+
+        Ok(CreateTableIndexResponse::new())
+    }
+
+    async fn create_table_scalar_index(
+        &self,
+        request: CreateTableIndexRequest,
+    ) -> Result<CreateTableScalarIndexResponse> {
+        indexes::validate_scalar_index_type(&request.index_type)?;
+        self.create_table_index(request).await?;
+        Ok(CreateTableScalarIndexResponse::new())
+    }
+
+    async fn list_table_indices(
+        &self,
+        request: ListTableIndicesRequest,
+    ) -> Result<ListTableIndicesResponse> {
+        let table_uri = self.resolve_table_location(&request.id).await?;
+        let dataset = self
+            .load_dataset_at_version(&table_uri, request.version)
+            .await?;
+        indexes::list_table_indices(&dataset, &request).await
+    }
+
+    async fn describe_table_index_stats(
+        &self,
+        request: DescribeTableIndexStatsRequest,
+    ) -> Result<DescribeTableIndexStatsResponse> {
+        // Validate required fields before any table lookup so error shape is deterministic.
+        if request.index_name.is_none() {
+            return Err(Error::invalid_input_source(
+                "index_name is required".to_string().into(),
+            ));
+        }
+        let table_uri = self.resolve_table_location(&request.id).await?;
+        let dataset = self
+            .load_dataset_at_version(&table_uri, request.version)
+            .await?;
+        indexes::describe_table_index_stats(&dataset, &request).await
+    }
+
+    async fn drop_table_index(
+        &self,
+        request: DropTableIndexRequest,
+    ) -> Result<DropTableIndexResponse> {
+        let index_name = request.index_name.as_ref().ok_or_else(|| {
+            Error::invalid_input_source("index_name is required".to_string().into())
+        })?;
+        let table_uri = self.resolve_table_location(&request.id).await?;
+        let mut dataset = self.load_dataset_at_version(&table_uri, None).await?;
+        dataset.drop_index(index_name).await?;
+        Ok(DropTableIndexResponse::new())
+    }
+
     async fn list_table_versions(
         &self,
         request: ListTableVersionsRequest,
@@ -1817,13 +1923,19 @@ impl LanceNamespace for DirectoryNamespace {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow::array::{Int32Array, StringArray};
+    use arrow::ipc::writer::StreamWriter;
     use arrow_ipc::reader::StreamReader;
     use lance::dataset::Dataset;
     use lance_core::utils::tempfile::{TempStdDir, TempStrDir};
+    use lance_index::IndexType;
     use lance_namespace::models::{
-        CreateTableRequest, JsonArrowDataType, JsonArrowField, JsonArrowSchema, ListTablesRequest,
+        CreateTableIndexRequest, CreateTableRequest, DescribeTableIndexStatsRequest,
+        DropTableIndexRequest, JsonArrowDataType, JsonArrowField, JsonArrowSchema,
+        ListTableIndicesRequest, ListTablesRequest,
     };
     use lance_namespace::schema::convert_json_arrow_schema;
+    use serde_json::Value as JsonValue;
     use std::io::Cursor;
     use std::sync::Arc;
 
@@ -1840,11 +1952,32 @@ mod tests {
 
     /// Helper to create test IPC data from a schema
     fn create_test_ipc_data(schema: &JsonArrowSchema) -> Vec<u8> {
-        use arrow::ipc::writer::StreamWriter;
-
         let arrow_schema = convert_json_arrow_schema(schema).unwrap();
         let arrow_schema = Arc::new(arrow_schema);
         let batch = arrow::record_batch::RecordBatch::new_empty(arrow_schema.clone());
+        let mut buffer = Vec::new();
+        {
+            let mut writer = StreamWriter::try_new(&mut buffer, &arrow_schema).unwrap();
+            writer.write(&batch).unwrap();
+            writer.finish().unwrap();
+        }
+        buffer
+    }
+
+    /// Helper to create test IPC data with rows matching the default test schema.
+    fn create_test_ipc_data_with_rows(schema: &JsonArrowSchema, ids: &[i32]) -> Vec<u8> {
+        let arrow_schema = Arc::new(convert_json_arrow_schema(schema).unwrap());
+        let id_array = Int32Array::from(ids.to_vec());
+        let name_values: Vec<Option<String>> =
+            ids.iter().map(|id| Some(format!("name-{}", id))).collect();
+        let name_array = StringArray::from(name_values);
+
+        let batch = arrow::record_batch::RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![Arc::new(id_array), Arc::new(name_array)],
+        )
+        .unwrap();
+
         let mut buffer = Vec::new();
         {
             let mut writer = StreamWriter::try_new(&mut buffer, &arrow_schema).unwrap();
@@ -1877,6 +2010,278 @@ mod tests {
             fields: vec![id_field, name_field],
             metadata: None,
         }
+    }
+
+    #[test]
+    fn test_normalize_index_type_aliases() {
+        assert_eq!(indexes::normalize_index_type("fts"), "INVERTED");
+        assert_eq!(indexes::normalize_index_type("label_list"), "LABELLIST");
+        assert_eq!(indexes::normalize_index_type("BLOOMFILTER"), "BLOOMFILTER");
+        assert_eq!(indexes::normalize_index_type("BLOOM_FILTER"), "BLOOMFILTER");
+        assert_eq!(indexes::normalize_index_type("BTREE"), "BTREE");
+    }
+
+    #[test]
+    fn test_parse_index_type_aliases_and_invalid() {
+        assert_eq!(
+            indexes::parse_index_type("FTS").unwrap(),
+            IndexType::Inverted
+        );
+        assert_eq!(
+            indexes::parse_index_type("label_list").unwrap(),
+            IndexType::LabelList
+        );
+        assert_eq!(
+            indexes::parse_index_type("bloom_filter").unwrap(),
+            IndexType::BloomFilter
+        );
+
+        let err = indexes::parse_index_type("not_a_real_type").unwrap_err();
+        assert!(err.to_string().contains("Invalid index_type"));
+    }
+
+    #[test]
+    fn test_as_i64_handles_signed_unsigned_and_invalid() {
+        let signed = JsonValue::from(-11);
+        assert_eq!(indexes::as_i64(Some(&signed)), Some(-11));
+
+        let unsigned = JsonValue::from(42_u64);
+        assert_eq!(indexes::as_i64(Some(&unsigned)), Some(42));
+
+        let too_large_unsigned = JsonValue::from(u64::MAX);
+        assert_eq!(indexes::as_i64(Some(&too_large_unsigned)), None);
+
+        let non_numeric = JsonValue::from("not-a-number");
+        assert_eq!(indexes::as_i64(Some(&non_numeric)), None);
+        assert_eq!(indexes::as_i64(None), None);
+    }
+
+    #[tokio::test]
+    async fn test_load_dataset_at_version_selects_version_and_validates_input() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data_with_rows(&schema, &[1, 2]);
+
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(vec!["versioned_table".to_string()]);
+        namespace
+            .create_table(create_request, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let table_uri = namespace.table_full_uri("versioned_table");
+        let mut dataset = Dataset::open(&table_uri).await.unwrap();
+
+        let append_schema = Arc::new(convert_json_arrow_schema(&schema).unwrap());
+        let append_batch = arrow::record_batch::RecordBatch::try_new(
+            append_schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![3])),
+                Arc::new(StringArray::from(vec![Some("name-3")])),
+            ],
+        )
+        .unwrap();
+        let append_reader = RecordBatchIterator::new(vec![Ok(append_batch)], append_schema);
+        dataset.append(append_reader, None).await.unwrap();
+
+        let latest = namespace
+            .load_dataset_at_version(&table_uri, None)
+            .await
+            .unwrap();
+        assert_eq!(latest.version().version, 2);
+        assert_eq!(latest.count_rows(None).await.unwrap(), 3);
+
+        let version_1 = namespace
+            .load_dataset_at_version(&table_uri, Some(1))
+            .await
+            .unwrap();
+        assert_eq!(version_1.version().version, 1);
+        assert_eq!(version_1.count_rows(None).await.unwrap(), 2);
+
+        let err = namespace
+            .load_dataset_at_version(&table_uri, Some(-1))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("Version must be non-negative"));
+    }
+
+    #[tokio::test]
+    async fn test_create_table_scalar_index_lifecycle() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data_with_rows(&schema, &[1, 2, 3, 4]);
+
+        let mut create_table_req = CreateTableRequest::new();
+        create_table_req.id = Some(vec!["indexed_table".to_string()]);
+        namespace
+            .create_table(create_table_req, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let mut create_index_req =
+            CreateTableIndexRequest::new("id".to_string(), "BTREE".to_string());
+        create_index_req.id = Some(vec!["indexed_table".to_string()]);
+        create_index_req.name = Some("id_btree_idx".to_string());
+        namespace
+            .create_table_scalar_index(create_index_req)
+            .await
+            .unwrap();
+
+        let mut list_req = ListTableIndicesRequest::new();
+        list_req.id = Some(vec!["indexed_table".to_string()]);
+        let list_resp = namespace.list_table_indices(list_req).await.unwrap();
+        assert_eq!(list_resp.indexes.len(), 1);
+        assert_eq!(list_resp.indexes[0].index_name, "id_btree_idx");
+        assert_eq!(list_resp.indexes[0].columns, vec!["id".to_string()]);
+        assert_eq!(list_resp.indexes[0].status, "done");
+
+        let mut describe_req = DescribeTableIndexStatsRequest::new();
+        describe_req.id = Some(vec!["indexed_table".to_string()]);
+        describe_req.index_name = Some("id_btree_idx".to_string());
+        let stats = namespace
+            .describe_table_index_stats(describe_req)
+            .await
+            .unwrap();
+        let index_type = stats.index_type.unwrap_or_default().to_ascii_uppercase();
+        assert!(
+            index_type.contains("BTREE"),
+            "Expected BTREE stats, got: {}",
+            index_type
+        );
+
+        let mut drop_req = DropTableIndexRequest::new();
+        drop_req.id = Some(vec!["indexed_table".to_string()]);
+        drop_req.index_name = Some("id_btree_idx".to_string());
+        namespace.drop_table_index(drop_req).await.unwrap();
+
+        let mut list_req = ListTableIndicesRequest::new();
+        list_req.id = Some(vec!["indexed_table".to_string()]);
+        let list_resp = namespace.list_table_indices(list_req).await.unwrap();
+        assert_eq!(list_resp.indexes.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_create_table_scalar_index_rejects_vector_index_types() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data_with_rows(&schema, &[1, 2, 3, 4]);
+
+        let mut create_table_req = CreateTableRequest::new();
+        create_table_req.id = Some(vec!["indexed_table".to_string()]);
+        namespace
+            .create_table(create_table_req, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        for index_type in ["IVF_FLAT", "IVF_PQ"] {
+            let mut create_index_req =
+                CreateTableIndexRequest::new("id".to_string(), index_type.to_string());
+            create_index_req.id = Some(vec!["indexed_table".to_string()]);
+            create_index_req.name = Some(format!("{}_idx", index_type.to_ascii_lowercase()));
+
+            let err = namespace
+                .create_table_scalar_index(create_index_req)
+                .await
+                .unwrap_err();
+            assert!(
+                err.to_string()
+                    .contains("create_table_scalar_index only supports scalar index types"),
+                "Expected scalar-only validation error for index type {}, got: {}",
+                index_type,
+                err
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list_table_indices_pagination() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data_with_rows(&schema, &[10, 20, 30, 40]);
+
+        let mut create_table_req = CreateTableRequest::new();
+        create_table_req.id = Some(vec!["paged_table".to_string()]);
+        namespace
+            .create_table(create_table_req, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let mut idx_a = CreateTableIndexRequest::new("id".to_string(), "BTREE".to_string());
+        idx_a.id = Some(vec!["paged_table".to_string()]);
+        idx_a.name = Some("a_index".to_string());
+        namespace.create_table_index(idx_a).await.unwrap();
+
+        let mut idx_b = CreateTableIndexRequest::new("id".to_string(), "BITMAP".to_string());
+        idx_b.id = Some(vec!["paged_table".to_string()]);
+        idx_b.name = Some("b_index".to_string());
+        namespace.create_table_index(idx_b).await.unwrap();
+
+        let mut page1_req = ListTableIndicesRequest::new();
+        page1_req.id = Some(vec!["paged_table".to_string()]);
+        page1_req.limit = Some(1);
+        let page1 = namespace.list_table_indices(page1_req).await.unwrap();
+        assert_eq!(page1.indexes.len(), 1);
+        assert_eq!(page1.page_token.as_deref(), Some("a_index"));
+
+        let mut page2_req = ListTableIndicesRequest::new();
+        page2_req.id = Some(vec!["paged_table".to_string()]);
+        page2_req.limit = Some(1);
+        page2_req.page_token = page1.page_token.clone();
+        let page2 = namespace.list_table_indices(page2_req).await.unwrap();
+        assert_eq!(page2.indexes.len(), 1);
+        assert_ne!(page1.indexes[0].index_name, page2.indexes[0].index_name);
+        assert_eq!(page2.page_token, None);
+    }
+
+    #[tokio::test]
+    async fn test_list_table_indices_rejects_non_positive_limit() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data_with_rows(&schema, &[10, 20, 30, 40]);
+
+        let mut create_table_req = CreateTableRequest::new();
+        create_table_req.id = Some(vec!["limit_table".to_string()]);
+        namespace
+            .create_table(create_table_req, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        for limit in [0, -1] {
+            let mut req = ListTableIndicesRequest::new();
+            req.id = Some(vec!["limit_table".to_string()]);
+            req.limit = Some(limit);
+
+            let err = namespace.list_table_indices(req).await.unwrap_err();
+            assert!(
+                err.to_string().contains("limit must be positive"),
+                "Expected non-positive limit error for limit={}, got: {}",
+                limit,
+                err
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_describe_table_index_stats_requires_index_name() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        let mut request = DescribeTableIndexStatsRequest::new();
+        request.id = Some(vec!["table".to_string()]);
+
+        let err = namespace
+            .describe_table_index_stats(request)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("index_name is required"));
+    }
+
+    #[tokio::test]
+    async fn test_drop_table_index_requires_index_name() {
+        let (namespace, _temp_dir) = create_test_namespace().await;
+        let mut request = DropTableIndexRequest::new();
+        request.id = Some(vec!["table".to_string()]);
+
+        let err = namespace.drop_table_index(request).await.unwrap_err();
+        assert!(err.to_string().contains("index_name is required"));
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir/indexes.rs
+++ b/rust/lance-namespace-impls/src/dir/indexes.rs
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::collections::HashMap;
+
+use lance::dataset::Dataset;
+use lance::index::vector::VectorIndexParams;
+use lance_core::{Error, Result};
+use lance_index::scalar::{BuiltinIndexType, InvertedIndexParams, ScalarIndexParams};
+use lance_index::vector::bq::RQBuildParams;
+use lance_index::vector::hnsw::builder::HnswBuildParams;
+use lance_index::vector::ivf::IvfBuildParams;
+use lance_index::vector::pq::PQBuildParams;
+use lance_index::vector::sq::builder::SQBuildParams;
+use lance_index::{DatasetIndexExt, IndexType};
+use lance_namespace::models::{
+    CreateTableIndexRequest, DescribeTableIndexStatsRequest, DescribeTableIndexStatsResponse,
+    IndexContent, ListTableIndicesRequest, ListTableIndicesResponse,
+};
+
+pub(super) fn normalize_index_type(index_type: &str) -> String {
+    // Accept common aliases used by upstream clients and examples.
+    match index_type.trim().to_ascii_uppercase().as_str() {
+        "FTS" => "INVERTED".to_string(),
+        "LABEL_LIST" => "LABELLIST".to_string(),
+        "BLOOM_FILTER" => "BLOOMFILTER".to_string(),
+        other => other.to_string(),
+    }
+}
+
+pub(super) fn parse_index_type(index_type: &str) -> Result<IndexType> {
+    let normalized = normalize_index_type(index_type);
+    // BloomFilter has a spelling difference between wire value and enum variant.
+    if normalized == "BLOOMFILTER" {
+        return Ok(IndexType::BloomFilter);
+    }
+    IndexType::try_from(normalized.as_str()).map_err(|e| {
+        Error::invalid_input_source(format!("Invalid index_type '{}': {}", index_type, e).into())
+    })
+}
+
+pub(super) fn validate_scalar_index_type(index_type: &str) -> Result<()> {
+    let parsed = parse_index_type(index_type)?;
+    if parsed.is_vector() {
+        return Err(Error::invalid_input_source(
+            format!(
+                "create_table_scalar_index only supports scalar index types, got '{}'",
+                index_type
+            )
+            .into(),
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn as_i64(value: Option<&serde_json::Value>) -> Option<i64> {
+    value.and_then(|v| {
+        if let Some(x) = v.as_i64() {
+            Some(x)
+        } else {
+            v.as_u64().and_then(|x| i64::try_from(x).ok())
+        }
+    })
+}
+
+pub(super) async fn create_table_index(
+    dataset: &mut Dataset,
+    request: &CreateTableIndexRequest,
+) -> Result<()> {
+    let index_type = parse_index_type(&request.index_type)?;
+    let index_name = request.name.clone();
+    let column = request.column.as_str();
+
+    if index_type.is_vector() {
+        // Vector index families share distance metric semantics and IVF partitioning.
+        let metric = request.distance_type.as_deref().unwrap_or("l2");
+        let ivf = IvfBuildParams::with_target_partition_size(index_type.target_partition_size());
+
+        match index_type {
+            IndexType::IvfFlat => {
+                let params = VectorIndexParams::with_ivf_flat_params(
+                    metric.try_into().map_err(|e| {
+                        Error::invalid_input_source(
+                            format!("Invalid distance_type '{}': {}", metric, e).into(),
+                        )
+                    })?,
+                    ivf,
+                );
+                dataset
+                    .create_index(&[column], index_type, index_name, &params, false)
+                    .await?;
+            }
+            IndexType::IvfSq => {
+                let params = VectorIndexParams::with_ivf_sq_params(
+                    metric.try_into().map_err(|e| {
+                        Error::invalid_input_source(
+                            format!("Invalid distance_type '{}': {}", metric, e).into(),
+                        )
+                    })?,
+                    ivf,
+                    SQBuildParams::default(),
+                );
+                dataset
+                    .create_index(&[column], index_type, index_name, &params, false)
+                    .await?;
+            }
+            IndexType::IvfRq => {
+                let params = VectorIndexParams::with_ivf_rq_params(
+                    metric.try_into().map_err(|e| {
+                        Error::invalid_input_source(
+                            format!("Invalid distance_type '{}': {}", metric, e).into(),
+                        )
+                    })?,
+                    ivf,
+                    RQBuildParams::default(),
+                );
+                dataset
+                    .create_index(&[column], index_type, index_name, &params, false)
+                    .await?;
+            }
+            IndexType::IvfHnswFlat => {
+                let params = VectorIndexParams::ivf_hnsw(
+                    metric.try_into().map_err(|e| {
+                        Error::invalid_input_source(
+                            format!("Invalid distance_type '{}': {}", metric, e).into(),
+                        )
+                    })?,
+                    ivf,
+                    HnswBuildParams::default(),
+                );
+                dataset
+                    .create_index(&[column], index_type, index_name, &params, false)
+                    .await?;
+            }
+            IndexType::IvfHnswSq => {
+                let params = VectorIndexParams::with_ivf_hnsw_sq_params(
+                    metric.try_into().map_err(|e| {
+                        Error::invalid_input_source(
+                            format!("Invalid distance_type '{}': {}", metric, e).into(),
+                        )
+                    })?,
+                    ivf,
+                    HnswBuildParams::default(),
+                    SQBuildParams::default(),
+                );
+                dataset
+                    .create_index(&[column], index_type, index_name, &params, false)
+                    .await?;
+            }
+            IndexType::IvfHnswPq => {
+                let params = VectorIndexParams::with_ivf_hnsw_pq_params(
+                    metric.try_into().map_err(|e| {
+                        Error::invalid_input_source(
+                            format!("Invalid distance_type '{}': {}", metric, e).into(),
+                        )
+                    })?,
+                    ivf,
+                    HnswBuildParams::default(),
+                    PQBuildParams::default(),
+                );
+                dataset
+                    .create_index(&[column], index_type, index_name, &params, false)
+                    .await?;
+            }
+            IndexType::Vector | IndexType::IvfPq => {
+                let params = VectorIndexParams::with_ivf_pq_params(
+                    metric.try_into().map_err(|e| {
+                        Error::invalid_input_source(
+                            format!("Invalid distance_type '{}': {}", metric, e).into(),
+                        )
+                    })?,
+                    ivf,
+                    PQBuildParams::default(),
+                );
+                dataset
+                    .create_index(&[column], index_type, index_name, &params, false)
+                    .await?;
+            }
+            _ => {
+                return Err(Error::invalid_input_source(
+                    format!("Unsupported vector index_type '{}'", request.index_type).into(),
+                ));
+            }
+        }
+    } else if matches!(
+        index_type,
+        IndexType::BTree
+            | IndexType::Bitmap
+            | IndexType::LabelList
+            | IndexType::NGram
+            | IndexType::ZoneMap
+            | IndexType::BloomFilter
+    ) {
+        // Scalar built-ins map directly to one builtin descriptor each.
+        let builtin = match index_type {
+            IndexType::BTree => BuiltinIndexType::BTree,
+            IndexType::Bitmap => BuiltinIndexType::Bitmap,
+            IndexType::LabelList => BuiltinIndexType::LabelList,
+            IndexType::NGram => BuiltinIndexType::NGram,
+            IndexType::ZoneMap => BuiltinIndexType::ZoneMap,
+            IndexType::BloomFilter => BuiltinIndexType::BloomFilter,
+            _ => unreachable!(),
+        };
+        let params = ScalarIndexParams::for_builtin(builtin);
+        dataset
+            .create_index(&[column], index_type, index_name, &params, false)
+            .await?;
+    } else if index_type == IndexType::Inverted {
+        // Inverted index exposes several optional tokenizer/normalization knobs.
+        let mut params = InvertedIndexParams::default();
+        if let Some(with_position) = request.with_position {
+            params = params.with_position(with_position);
+        }
+        if let Some(base_tokenizer) = request.base_tokenizer.clone() {
+            params = params.base_tokenizer(base_tokenizer);
+        }
+        if let Some(language) = request.language.clone() {
+            params = params.language(language.as_str()).map_err(|e| {
+                Error::invalid_input_source(
+                    format!("Invalid language '{}': {}", language, e).into(),
+                )
+            })?;
+        }
+        if let Some(max_token_length) = request.max_token_length {
+            if max_token_length < 0 {
+                return Err(Error::invalid_input_source(
+                    format!(
+                        "max_token_length must be non-negative, got {}",
+                        max_token_length
+                    )
+                    .into(),
+                ));
+            }
+            params = params.max_token_length(Some(max_token_length as usize));
+        }
+        if let Some(lower_case) = request.lower_case {
+            params = params.lower_case(lower_case);
+        }
+        if let Some(stem) = request.stem {
+            params = params.stem(stem);
+        }
+        if let Some(remove_stop_words) = request.remove_stop_words {
+            params = params.remove_stop_words(remove_stop_words);
+        }
+        if let Some(ascii_folding) = request.ascii_folding {
+            params = params.ascii_folding(ascii_folding);
+        }
+
+        dataset
+            .create_index(&[column], index_type, index_name, &params, false)
+            .await?;
+    } else {
+        return Err(Error::invalid_input_source(
+            format!("Unsupported index_type '{}'", request.index_type).into(),
+        ));
+    }
+
+    Ok(())
+}
+
+pub(super) async fn list_table_indices(
+    dataset: &Dataset,
+    request: &ListTableIndicesRequest,
+) -> Result<ListTableIndicesResponse> {
+    let schema = dataset.schema();
+    let indices = dataset.load_indices().await?;
+
+    // A dataset may keep multiple metadata versions per logical index name.
+    // Surface only the latest metadata entry per name.
+    let mut latest_by_name: HashMap<String, lance_table::format::IndexMetadata> = HashMap::new();
+    for idx in indices.iter() {
+        match latest_by_name.get(&idx.name) {
+            Some(existing) => {
+                let should_replace = idx.dataset_version > existing.dataset_version
+                    || (idx.dataset_version == existing.dataset_version
+                        && idx.created_at > existing.created_at);
+                if should_replace {
+                    latest_by_name.insert(idx.name.clone(), idx.clone());
+                }
+            }
+            None => {
+                latest_by_name.insert(idx.name.clone(), idx.clone());
+            }
+        }
+    }
+
+    let mut index_contents: Vec<IndexContent> = latest_by_name
+        .into_values()
+        .map(|idx| {
+            // Convert field ids to current schema names; silently skip unknown ids.
+            let columns = idx
+                .fields
+                .iter()
+                .filter_map(|field_id| schema.field_by_id(*field_id).map(|f| f.name.clone()))
+                .collect::<Vec<_>>();
+            IndexContent {
+                index_name: idx.name,
+                index_uuid: idx.uuid.to_string(),
+                columns,
+                status: "done".to_string(),
+            }
+        })
+        .collect();
+
+    index_contents.sort_by(|a, b| a.index_name.cmp(&b.index_name));
+
+    if let Some(start_after) = request.page_token.as_ref() {
+        // Tokens use "start_after index_name" semantics to match list_* APIs.
+        if let Some(index) = index_contents
+            .iter()
+            .position(|item| item.index_name.as_str() > start_after.as_str())
+        {
+            index_contents.drain(0..index);
+        } else {
+            index_contents.clear();
+        }
+    }
+
+    let mut next_page_token = None;
+    if let Some(limit) = request.limit {
+        if limit <= 0 {
+            return Err(Error::invalid_input_source(
+                format!("limit must be positive, got {}", limit).into(),
+            ));
+        }
+        let limit = limit as usize;
+        if index_contents.len() > limit {
+            // Return the last emitted name as continuation token.
+            next_page_token = limit
+                .checked_sub(1)
+                .and_then(|idx| index_contents.get(idx))
+                .map(|item| item.index_name.clone());
+            index_contents.truncate(limit);
+        }
+    }
+
+    Ok(ListTableIndicesResponse {
+        indexes: index_contents,
+        page_token: next_page_token,
+    })
+}
+
+pub(super) async fn describe_table_index_stats(
+    dataset: &Dataset,
+    request: &DescribeTableIndexStatsRequest,
+) -> Result<DescribeTableIndexStatsResponse> {
+    let index_name = request
+        .index_name
+        .as_ref()
+        .ok_or_else(|| Error::invalid_input_source("index_name is required".to_string().into()))?;
+
+    let stats_str = dataset.index_statistics(index_name).await?;
+    // Convert backend JSON stats payload into stable typed response fields.
+    let stats_json: serde_json::Value = serde_json::from_str(&stats_str).map_err(|e| {
+        Error::namespace_source(
+            format!(
+                "Failed to parse index statistics for '{}': {}",
+                index_name, e
+            )
+            .into(),
+        )
+    })?;
+
+    let num_indices = as_i64(stats_json.get("num_indices")).and_then(|v| i32::try_from(v).ok());
+    Ok(DescribeTableIndexStatsResponse {
+        distance_type: stats_json
+            .get("distance_type")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        index_type: stats_json
+            .get("index_type")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        num_indexed_rows: as_i64(stats_json.get("num_indexed_rows")),
+        num_unindexed_rows: as_i64(stats_json.get("num_unindexed_rows")),
+        num_indices,
+    })
+}

--- a/rust/lance-namespace-impls/src/rest.rs
+++ b/rust/lance-namespace-impls/src/rest.rs
@@ -1010,8 +1010,25 @@ impl LanceNamespace for RestNamespace {
         let id = object_id_str(&request.id, &self.delimiter)?;
         let encoded_id = urlencode(&id);
         let path = format!("/v1/table/{}/index/list", encoded_id);
-        let query = [("delimiter", self.delimiter.as_str())];
-        self.post_json(&path, &query, &request, "list_table_indices", &id)
+        // The REST spec models list/read operations as GET + query parameters.
+        // Keep request shaping here so clients interoperate with non-adapter servers.
+        let mut query = vec![("delimiter", self.delimiter.as_str())];
+        let version_str;
+        if let Some(version) = request.version {
+            version_str = version.to_string();
+            query.push(("version", version_str.as_str()));
+        }
+        let page_token_str;
+        if let Some(ref page_token) = request.page_token {
+            page_token_str = page_token.clone();
+            query.push(("page_token", page_token_str.as_str()));
+        }
+        let limit_str;
+        if let Some(limit) = request.limit {
+            limit_str = limit.to_string();
+            query.push(("limit", limit_str.as_str()));
+        }
+        self.get_json(&path, &query, "list_table_indices", &id)
             .await
     }
 
@@ -1021,14 +1038,27 @@ impl LanceNamespace for RestNamespace {
     ) -> Result<DescribeTableIndexStatsResponse> {
         let id = object_id_str(&request.id, &self.delimiter)?;
         let encoded_id = urlencode(&id);
-        let index_name = request.index_name.as_deref().unwrap_or("");
+        let index_name = request.index_name.as_deref().ok_or_else(|| {
+            Error::invalid_input_source("index_name is required".to_string().into())
+        })?;
+        if index_name.is_empty() {
+            return Err(Error::invalid_input_source(
+                "index_name must not be empty".to_string().into(),
+            ));
+        }
         let path = format!(
             "/v1/table/{}/index/{}/stats",
             encoded_id,
             urlencode(index_name)
         );
-        let query = [("delimiter", self.delimiter.as_str())];
-        self.post_json(&path, &query, &request, "describe_table_index_stats", &id)
+        // Version is optional and lets callers request stats from historical snapshots.
+        let mut query = vec![("delimiter", self.delimiter.as_str())];
+        let version_str;
+        if let Some(version) = request.version {
+            version_str = version.to_string();
+            query.push(("version", version_str.as_str()));
+        }
+        self.get_json(&path, &query, "describe_table_index_stats", &id)
             .await
     }
 
@@ -1074,7 +1104,14 @@ impl LanceNamespace for RestNamespace {
     ) -> Result<DropTableIndexResponse> {
         let id = object_id_str(&request.id, &self.delimiter)?;
         let encoded_id = urlencode(&id);
-        let index_name = request.index_name.as_deref().unwrap_or("");
+        let index_name = request.index_name.as_deref().ok_or_else(|| {
+            Error::invalid_input_source("index_name is required".to_string().into())
+        })?;
+        if index_name.is_empty() {
+            return Err(Error::invalid_input_source(
+                "index_name must not be empty".to_string().into(),
+            ));
+        }
         let path = format!(
             "/v1/table/{}/index/{}/drop",
             encoded_id,
@@ -1348,7 +1385,7 @@ impl LanceNamespace for RestNamespace {
 mod tests {
     use super::*;
     use bytes::Bytes;
-    use wiremock::matchers::{method, path};
+    use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
@@ -1695,6 +1732,119 @@ mod tests {
         assert!(result.is_ok());
         let response = result.unwrap();
         assert_eq!(response.transaction_id, Some("txn-123".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_list_table_indices_uses_get_with_query_params() {
+        let mock_server = MockServer::start().await;
+        let path_str = "/v1/table/test$namespace$table/index/list".replace("$", "%24");
+
+        Mock::given(method("GET"))
+            .and(path(path_str.as_str()))
+            .and(query_param("delimiter", "$"))
+            .and(query_param("version", "7"))
+            .and(query_param("page_token", "a_index"))
+            .and(query_param("limit", "10"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "indexes": [],
+                "page_token": "next_page"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let namespace = RestNamespaceBuilder::new(mock_server.uri()).build();
+        let request = ListTableIndicesRequest {
+            id: Some(vec![
+                "test".to_string(),
+                "namespace".to_string(),
+                "table".to_string(),
+            ]),
+            version: Some(7),
+            page_token: Some("a_index".to_string()),
+            limit: Some(10),
+            ..Default::default()
+        };
+
+        let result = namespace.list_table_indices(request).await;
+        assert!(result.is_ok(), "Failed: {:?}", result.err());
+        let response = result.unwrap();
+        assert_eq!(response.page_token.as_deref(), Some("next_page"));
+    }
+
+    #[tokio::test]
+    async fn test_describe_table_index_stats_uses_get_with_version_query() {
+        let mock_server = MockServer::start().await;
+        let path_str =
+            "/v1/table/test$namespace$table/index/id_btree_idx/stats".replace("$", "%24");
+
+        Mock::given(method("GET"))
+            .and(path(path_str.as_str()))
+            .and(query_param("delimiter", "$"))
+            .and(query_param("version", "3"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "distance_type": null,
+                "index_type": "BTREE",
+                "num_indexed_rows": 3,
+                "num_unindexed_rows": 0,
+                "num_indices": 1
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let namespace = RestNamespaceBuilder::new(mock_server.uri()).build();
+        let request = DescribeTableIndexStatsRequest {
+            id: Some(vec![
+                "test".to_string(),
+                "namespace".to_string(),
+                "table".to_string(),
+            ]),
+            version: Some(3),
+            index_name: Some("id_btree_idx".to_string()),
+            ..Default::default()
+        };
+
+        let result = namespace.describe_table_index_stats(request).await;
+        assert!(result.is_ok(), "Failed: {:?}", result.err());
+        let stats = result.unwrap();
+        assert_eq!(stats.index_type.as_deref(), Some("BTREE"));
+        assert_eq!(stats.num_indexed_rows, Some(3));
+    }
+
+    #[tokio::test]
+    async fn test_describe_table_index_stats_requires_index_name() {
+        let namespace = RestNamespaceBuilder::new("http://127.0.0.1:9").build();
+        let request = DescribeTableIndexStatsRequest {
+            id: Some(vec![
+                "test".to_string(),
+                "namespace".to_string(),
+                "table".to_string(),
+            ]),
+            index_name: None,
+            ..Default::default()
+        };
+
+        let err = namespace
+            .describe_table_index_stats(request)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("index_name is required"));
+    }
+
+    #[tokio::test]
+    async fn test_drop_table_index_requires_index_name() {
+        let namespace = RestNamespaceBuilder::new("http://127.0.0.1:9").build();
+        let request = DropTableIndexRequest {
+            id: Some(vec![
+                "test".to_string(),
+                "namespace".to_string(),
+                "table".to_string(),
+            ]),
+            index_name: None,
+            ..Default::default()
+        };
+
+        let err = namespace.drop_table_index(request).await.unwrap_err();
+        assert!(err.to_string().contains("index_name is required"));
     }
 
     // Integration tests for DynamicContextProvider

--- a/rust/lance-namespace-impls/src/rest_adapter.rs
+++ b/rust/lance-namespace-impls/src/rest_adapter.rs
@@ -236,9 +236,17 @@ struct DelimiterQuery {
 #[derive(Debug, Deserialize)]
 struct PaginationQuery {
     delimiter: Option<String>,
+    // Optional snapshot selection for APIs that support historical reads.
+    version: Option<i64>,
     page_token: Option<String>,
     limit: Option<i32>,
     descending: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VersionQuery {
+    delimiter: Option<String>,
+    version: Option<i64>,
 }
 
 // ============================================================================
@@ -860,13 +868,14 @@ async fn list_table_indices(
     State(backend): State<Arc<dyn LanceNamespace>>,
     headers: HeaderMap,
     Path(id): Path<String>,
-    Query(params): Query<DelimiterQuery>,
+    Query(params): Query<PaginationQuery>,
 ) -> Response {
+    // Keep HTTP query params as a thin mapping to namespace request fields.
     let request = ListTableIndicesRequest {
         id: Some(parse_id(&id, params.delimiter.as_deref())),
-        version: None,
-        page_token: None,
-        limit: None,
+        version: params.version,
+        page_token: params.page_token,
+        limit: params.limit,
         identity: extract_identity(&headers),
         ..Default::default()
     };
@@ -887,11 +896,12 @@ async fn describe_table_index_stats(
     State(backend): State<Arc<dyn LanceNamespace>>,
     headers: HeaderMap,
     Path(params): Path<IndexPathParams>,
-    Query(query): Query<DelimiterQuery>,
+    Query(query): Query<VersionQuery>,
 ) -> Response {
+    // Stats endpoint takes index name from path and optional snapshot version from query.
     let request = DescribeTableIndexStatsRequest {
         id: Some(parse_id(&params.id, query.delimiter.as_deref())),
-        version: None,
+        version: query.version,
         index_name: Some(params.index_name),
         identity: extract_identity(&headers),
         ..Default::default()
@@ -2948,6 +2958,132 @@ mod tests {
                 result.is_ok(),
                 "Failed to list table versions with ascending: {:?}",
                 result
+            );
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_list_table_indices_with_query_pagination() {
+            let fixture = RestServerFixture::new().await;
+            let table_data = create_test_arrow_data();
+
+            let create_ns_req = CreateNamespaceRequest {
+                id: Some(vec!["index_test_ns".to_string()]),
+                ..Default::default()
+            };
+            fixture
+                .namespace
+                .create_namespace(create_ns_req)
+                .await
+                .unwrap();
+
+            let create_table_req = CreateTableRequest {
+                id: Some(vec!["index_test_ns".to_string(), "index_table".to_string()]),
+                mode: Some("create".to_string()),
+                ..Default::default()
+            };
+            fixture
+                .namespace
+                .create_table(create_table_req, table_data)
+                .await
+                .unwrap();
+
+            let mut create_idx_a =
+                CreateTableIndexRequest::new("id".to_string(), "BTREE".to_string());
+            create_idx_a.id = Some(vec!["index_test_ns".to_string(), "index_table".to_string()]);
+            create_idx_a.name = Some("a_index".to_string());
+            fixture
+                .namespace
+                .create_table_index(create_idx_a)
+                .await
+                .unwrap();
+
+            let mut create_idx_b =
+                CreateTableIndexRequest::new("id".to_string(), "BITMAP".to_string());
+            create_idx_b.id = Some(vec!["index_test_ns".to_string(), "index_table".to_string()]);
+            create_idx_b.name = Some("b_index".to_string());
+            fixture
+                .namespace
+                .create_table_index(create_idx_b)
+                .await
+                .unwrap();
+
+            let mut page1_req = ListTableIndicesRequest::new();
+            page1_req.id = Some(vec!["index_test_ns".to_string(), "index_table".to_string()]);
+            page1_req.limit = Some(1);
+            let page1 = fixture
+                .namespace
+                .list_table_indices(page1_req)
+                .await
+                .unwrap();
+            assert_eq!(page1.indexes.len(), 1);
+            assert_eq!(page1.page_token.as_deref(), Some("a_index"));
+
+            let mut page2_req = ListTableIndicesRequest::new();
+            page2_req.id = Some(vec!["index_test_ns".to_string(), "index_table".to_string()]);
+            page2_req.limit = Some(1);
+            page2_req.page_token = page1.page_token.clone();
+            let page2 = fixture
+                .namespace
+                .list_table_indices(page2_req)
+                .await
+                .unwrap();
+            assert_eq!(page2.indexes.len(), 1);
+            assert_eq!(page2.indexes[0].index_name, "b_index".to_string());
+            assert_eq!(page2.page_token, None);
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_describe_table_index_stats_propagates_version_query() {
+            let fixture = RestServerFixture::new().await;
+            let table_data = create_test_arrow_data();
+
+            let create_ns_req = CreateNamespaceRequest {
+                id: Some(vec!["stats_test_ns".to_string()]),
+                ..Default::default()
+            };
+            fixture
+                .namespace
+                .create_namespace(create_ns_req)
+                .await
+                .unwrap();
+
+            let create_table_req = CreateTableRequest {
+                id: Some(vec!["stats_test_ns".to_string(), "stats_table".to_string()]),
+                mode: Some("create".to_string()),
+                ..Default::default()
+            };
+            fixture
+                .namespace
+                .create_table(create_table_req, table_data)
+                .await
+                .unwrap();
+
+            let mut create_idx_req =
+                CreateTableIndexRequest::new("id".to_string(), "BTREE".to_string());
+            create_idx_req.id = Some(vec!["stats_test_ns".to_string(), "stats_table".to_string()]);
+            create_idx_req.name = Some("id_btree_idx".to_string());
+            fixture
+                .namespace
+                .create_table_index(create_idx_req)
+                .await
+                .unwrap();
+
+            let stats_req = DescribeTableIndexStatsRequest {
+                id: Some(vec!["stats_test_ns".to_string(), "stats_table".to_string()]),
+                version: Some(-1),
+                index_name: Some("id_btree_idx".to_string()),
+                ..Default::default()
+            };
+
+            let err = fixture
+                .namespace
+                .describe_table_index_stats(stats_req)
+                .await
+                .unwrap_err();
+            assert!(
+                err.to_string().contains("Version must be non-negative"),
+                "Expected version validation error, got: {}",
+                err
             );
         }
 


### PR DESCRIPTION
Implement directory namespace index APIs and align REST index interoperability for metadata/catalog tooling.

Motivation:
Directory-backed namespace implementations need first-class index metadata operations. This change completes that surface and removes REST client/server mismatches that made index APIs unreliable across implementations.

Changes:
- Implement directory namespace index operations in `lance-namespace-impls`:
  - `create_table_index`
  - `create_table_scalar_index` (strict scalar-only validation)
  - `list_table_indices` (token pagination + continuation token)
  - `describe_table_index_stats`
  - `drop_table_index`
- Extract index logic from `dir.rs` into `dir/indexes.rs`.
- Add shared dataset loading helper with optional version checkout and negative-version validation.
- Harden index pagination semantics:
  - reject non-positive `limit`
  - emit continuation token when additional pages exist.
- Align REST index read/list behavior:
  - `RestNamespace` uses GET + query params for `list_table_indices` and `describe_table_index_stats`
  - `RestAdapter` accepts and propagates pagination/version query params
  - client-side validation for missing/empty `index_name` on stats/drop endpoints.

Non-trivial decisions:
- Keep `create_table_scalar_index` strict and reject vector index types explicitly.
- Use name-based continuation tokens to keep client paging behavior simple and stable.
- Collapse multiple metadata entries per index name to latest entry when listing.
- Model index read/list operations as GET to preserve compatibility with REST servers beyond this adapter.

Usage:
This enables catalog and metadata applications to create/manage indexes, page through large index lists, and inspect index stats for current or historical table versions with consistent REST semantics.

Validation:
- `cargo fmt --all`
- `cargo clippy -p lance-namespace-impls --tests --features "rest rest-adapter" -- -D warnings`
- `cargo test -p lance-namespace-impls --tests --no-fail-fast`
- `cargo test -p lance-namespace-impls --features "rest rest-adapter" --tests --no-fail-fast`

All pass.
