### PR TITLE
refactor: rename arrow-scalar to lance-arrow-scalar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,22 +407,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-scalar"
-version = "57.0.0"
-dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "half",
- "proptest",
- "rstest",
-]
-
-[[package]]
 name = "arrow-schema"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4870,6 +4854,22 @@ dependencies = [
  "jsonb",
  "num-traits",
  "rand 0.9.2",
+]
+
+[[package]]
+name = "lance-arrow-scalar"
+version = "57.0.0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "half",
+ "proptest",
+ "rstest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ lance-testing = { version = "=4.0.0-beta.10", path = "./rust/lance-testing" }
 approx = "0.5.1"
 # Note that this one does not include pyarrow
 arrow = { version = "57.0.0", optional = false, features = ["prettyprint"] }
-arrow-scalar = { version = "=57.0.0", path = "./rust/arrow-scalar" }
+lance-arrow-scalar = { version = "=57.0.0", path = "./rust/arrow-scalar" }
 arrow-arith = "57.0.0"
 arrow-array = "57.0.0"
 arrow-buffer = "57.0.0"

--- a/rust/arrow-scalar/Cargo.toml
+++ b/rust/arrow-scalar/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "arrow-scalar"
+name = "lance-arrow-scalar"
 version = "57.0.0"
 edition.workspace = true
 authors.workspace = true

--- a/rust/arrow-scalar/README.md
+++ b/rust/arrow-scalar/README.md
@@ -1,0 +1,57 @@
+# lance-arrow-scalar
+
+A scalar type backed by Apache Arrow arrays with `Ord`, `Hash`, and `Eq` support.
+
+## Overview
+
+`ArrowScalar` wraps a single-element Arrow array and provides comparison and hashing operations by leveraging Apache Arrow's `OwnedRow` representation. This ensures:
+
+- **Correct total ordering** for all Arrow types
+- **Proper NaN handling** for floating-point values
+- **Consistent null ordering**
+- **O(1) comparisons** via cached row bytes
+
+## Features
+
+- `Eq`, `Ord`, and `Hash` traits for Arrow scalar values
+- Support for all Arrow data types
+- Serde serialization/deserialization support
+- Zero-copy conversion from Arrow arrays
+
+## Usage
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+lance-arrow-scalar = "57.0.0"
+```
+
+Then use in your code:
+
+```rust
+use lance_arrow_scalar::ArrowScalar;
+
+// Create from primitive types
+let a = ArrowScalar::from(42i32);
+let b = ArrowScalar::from(100i32);
+assert!(a < b);
+
+// Create from strings
+let s1 = ArrowScalar::from("hello");
+let s2 = ArrowScalar::from("world");
+assert!(s1 < s2);
+
+// Use in collections
+use std::collections::HashMap;
+let mut map = HashMap::new();
+map.insert(ArrowScalar::from("key"), ArrowScalar::from(123));
+```
+
+## Cross-Type Comparison
+
+Comparing scalars of different data types produces an arbitrary but consistent ordering based on the underlying row bytes. This allows scalars to be used as keys in sorted collections regardless of type, though the ordering across types is not semantically meaningful.
+
+## Implementation Details
+
+Comparisons and hashing are delegated to [`arrow_row::OwnedRow`], which provides efficient byte-level operations. The row representation is cached at construction time, making all comparison and hashing operations O(1).

--- a/rust/arrow-scalar/src/lib.rs
+++ b/rust/arrow-scalar/src/lib.rs
@@ -40,7 +40,7 @@ type Result<T> = std::result::Result<T, ArrowError>;
 /// # Examples
 ///
 /// ```
-/// use arrow_scalar::ArrowScalar;
+/// use lance_arrow_scalar::ArrowScalar;
 ///
 /// let a = ArrowScalar::from(1i32);
 /// let b = ArrowScalar::from(2i32);


### PR DESCRIPTION
In retrospect the old name was somewhat presumptuous.  It would probably be good to get the Arrow project's permission before taking up cargo real estate.  This also adds a README which was preventing the publish.