### PR TITLE
fix: allow same field name with different type in dataset overwrites

### DIFF
--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -1107,6 +1107,9 @@ fn convert_to_rust_operation(
                     to_rust_map(env, &config_upsert_values)
                 },
             )?;
+            // Pass None for dataset so that the new schema is not validated
+            // against the old schema. Overwrite replaces the entire dataset,
+            // so fields with the same name but different types are allowed.
             let schema = convert_schema_from_operation(
                 env,
                 java_operation,
@@ -1115,7 +1118,7 @@ fn convert_to_rust_operation(
                         "BufferAllocator is required for Overwrite operations".to_string(),
                     )
                 })?,
-                dataset,
+                None,
                 read_version,
             )?;
             Operation::Overwrite {

--- a/java/src/test/java/org/lance/operation/OverwriteTest.java
+++ b/java/src/test/java/org/lance/operation/OverwriteTest.java
@@ -19,15 +19,22 @@ import org.lance.Fragment;
 import org.lance.FragmentMetadata;
 import org.lance.TestUtils;
 import org.lance.Transaction;
+import org.lance.WriteParams;
 import org.lance.ipc.LanceScanner;
 
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -117,6 +124,69 @@ public class OverwriteTest extends OperationTestBase {
             assertEquals(testDataset.getSchema(), schemaRes);
           }
           assertEquals(retryTxn, dataset.readTransaction().orElse(null));
+        }
+      }
+    }
+  }
+
+  @Test
+  void testOverwriteWithDifferentFieldTypes(@TempDir Path tempDir) throws Exception {
+    String datasetPath = tempDir.resolve("testOverwriteFieldTypes").toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      // Create initial dataset with schema: id (int32), name (utf8)
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      dataset = testDataset.createEmptyDataset();
+      FragmentMetadata fragmentMeta = testDataset.createNewFragment(10);
+      try (Transaction txn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(
+                  Overwrite.builder()
+                      .fragments(Collections.singletonList(fragmentMeta))
+                      .schema(testDataset.getSchema())
+                      .build())
+              .build()) {
+        dataset = new CommitBuilder(this.dataset).execute(txn);
+      }
+      assertEquals(2, dataset.version());
+      assertEquals(10, dataset.countRows());
+
+      // Overwrite with a new schema where "id" changes from int32 to int64
+      // and "name" changes from utf8 to int64
+      Schema newSchema =
+          new Schema(
+              Arrays.asList(
+                  Field.nullable("id", new ArrowType.Int(64, true)),
+                  Field.nullable("name", new ArrowType.Int(64, true))));
+
+      int newRowCount = 5;
+      List<FragmentMetadata> newFragments;
+      try (VectorSchemaRoot root = VectorSchemaRoot.create(newSchema, allocator)) {
+        root.allocateNew();
+        BigIntVector idVector = (BigIntVector) root.getVector("id");
+        BigIntVector nameVector = (BigIntVector) root.getVector("name");
+        for (int i = 0; i < newRowCount; i++) {
+          idVector.setSafe(i, (long) i * 100);
+          nameVector.setSafe(i, (long) i * 200);
+        }
+        root.setRowCount(newRowCount);
+        newFragments =
+            Fragment.create(datasetPath, allocator, root, new WriteParams.Builder().build());
+      }
+
+      try (Transaction txn =
+          new Transaction.Builder()
+              .readVersion(dataset.version())
+              .operation(Overwrite.builder().fragments(newFragments).schema(newSchema).build())
+              .build()) {
+        try (Dataset overwritten = new CommitBuilder(this.dataset).execute(txn)) {
+          assertEquals(3, overwritten.version());
+          assertEquals(newRowCount, overwritten.countRows());
+
+          // Verify the schema has the new types
+          Schema resultSchema = overwritten.getSchema();
+          assertEquals(newSchema, resultSchema);
         }
       }
     }


### PR DESCRIPTION
[This PR](https://github.com/lance-format/lance/pull/5824) updated the dataset overwrite logic which caused a small regression that when overwriting a dataset we will error if there are identical field names with different types. Since this is an `OVERWRITE` operation, that should not cause a failure.