### PR TITLE
docs: remove legacy preview index note

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,6 @@ To install a preview release:
 pip install --pre --extra-index-url https://pypi.fury.io/lance-format/pylance
 ```
 
-> [!NOTE]
-> For versions prior to 1.0.0-beta.4, you can find them at https://pypi.fury.io/lancedb/pylance
-
 > [!TIP]
 > Preview releases are released more often than full releases and contain the
 > latest features and bug fixes. They receive the same level of testing as full releases.

--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -25,8 +25,6 @@ pip install --pre --extra-index-url https://pypi.fury.io/lance-format/pylance
 
 > Note: Preview releases receive the same level of testing as regular releases.
 
-> Note: For versions prior to 1.0.0-beta.4, you can find them at https://pypi.fury.io/lancedb/pylance
-
 ## Set Up Your Environment
 
 First, let's import the necessary libraries:


### PR DESCRIPTION
This removes the outdated note that pointed users to the legacy `lancedb/pylance` preview index from our main installation docs.

The transition period is over, so keeping that note in the README and quickstart now adds confusion to the current install path.
