### PR TITLE
perf: share IVF partition search across deltas

### DIFF
--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -406,6 +406,8 @@ impl ANNIvfPartitionExec {
         })
     }
 
+    /// Determine whether one partition ranking can be safely reused across all
+    /// active delta indices for the query.
     fn can_share_partition_search<'a>(
         mut indices: impl Iterator<Item = &'a Arc<dyn VectorIndex>>,
     ) -> bool {
@@ -423,6 +425,9 @@ impl ANNIvfPartitionExec {
         })
     }
 
+    /// Materialize the shared partition id / centroid distance lists once so
+    /// they can be attached to multiple delta UUID batches without rebuilding
+    /// the Arrow list arrays each time.
     fn build_partition_columns(
         partitions: &UInt32Array,
         dist_q_c: &Float32Array,
@@ -443,6 +448,8 @@ impl ANNIvfPartitionExec {
         Ok((partition_col, dist_q_c_col))
     }
 
+    /// Attach a delta UUID to a partition-search result payload to match the
+    /// downstream `ANNIvfSubIndexExec` input contract.
     fn build_partition_batch(
         partition_col: ArrayRef,
         dist_q_c_col: ArrayRef,


### PR DESCRIPTION
This avoids re-ranking the same IVF centroids once per delta index during ANN search by sharing a single partition search across deltas when their metric and partition layout match.

When the active deltas disagree on metric type or partition count, the query falls back to the existing per-delta path so older inconsistent layouts continue to behave safely.

The `knn` test suite now covers the guard behavior and the updated partition-ranking metric semantics.

---

I believe this is the key reason why delta indexes perform so poorly for us.

I understand that `can_share_partition_search` is not an exact solution. If this approach does not work, we may need to add more metadata in our index proto to indicate that those segments can be searched together.

Also, I think @wjones127's https://github.com/lance-format/lance/discussions/6207 could be helpful.