### PR TITLE
fix: filter out detached versions when scanning manifests

### DIFF
--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -115,6 +115,19 @@ impl ManifestNamingScheme {
         }
     }
 
+    /// Parse a detached version from a filename like `d123456.manifest`.
+    ///
+    /// Returns the full version number with the detached mask bit set.
+    pub fn parse_detached_version(filename: &str) -> Option<u64> {
+        if !filename.starts_with(DETACHED_VERSION_PREFIX) {
+            return None;
+        }
+        let without_prefix = &filename[DETACHED_VERSION_PREFIX.len()..];
+        without_prefix
+            .split_once('.')
+            .and_then(|(version_str, _)| version_str.parse::<u64>().ok())
+    }
+
     pub fn detect_scheme(filename: &str) -> Option<Self> {
         if filename.starts_with(DETACHED_VERSION_PREFIX) {
             // Currently, detached versions must imply V2
@@ -433,6 +446,38 @@ fn list_manifests<'a>(
         .boxed()
 }
 
+/// Convert object metadata to ManifestLocation for detached manifests.
+fn detached_manifest_location_from_meta(
+    meta: object_store::ObjectMeta,
+) -> Option<ManifestLocation> {
+    let filename = meta.location.filename()?;
+    let version = ManifestNamingScheme::parse_detached_version(filename)?;
+    Some(ManifestLocation {
+        version,
+        path: meta.location,
+        size: Some(meta.size),
+        naming_scheme: ManifestNamingScheme::V2,
+        e_tag: meta.e_tag,
+    })
+}
+
+/// List all detached manifest files in the versions directory.
+pub fn list_detached_manifests<'a>(
+    base_path: &Path,
+    object_store: &'a dyn OSObjectStore,
+) -> impl Stream<Item = Result<ManifestLocation>> + 'a {
+    object_store
+        .read_dir_all(&base_path.child(VERSIONS_DIR), None)
+        .filter_map(|obj_meta| {
+            futures::future::ready(
+                obj_meta
+                    .map(detached_manifest_location_from_meta)
+                    .transpose(),
+            )
+        })
+        .boxed()
+}
+
 fn make_staging_manifest_path(base: &Path) -> Result<Path> {
     let id = uuid::Uuid::new_v4().to_string();
     Path::parse(format!("{base}-{id}")).map_err(|e| Error::io_source(Box::new(e)))
@@ -467,6 +512,17 @@ pub trait CommitHandler: Debug + Send + Sync {
         object_store: &dyn OSObjectStore,
     ) -> Result<ManifestLocation> {
         default_resolve_version(base_path, version, object_store).await
+    }
+
+    /// List detached manifest locations.
+    ///
+    /// Returns a stream of detached manifest locations in arbitrary order.
+    fn list_detached_manifest_locations<'a>(
+        &self,
+        base_path: &Path,
+        object_store: &'a ObjectStore,
+    ) -> BoxStream<'a, Result<ManifestLocation>> {
+        list_detached_manifests(base_path, &object_store.inner).boxed()
     }
 
     /// If `sorted_descending` is `true`, the stream will yield manifests in descending
@@ -1220,5 +1276,78 @@ mod tests {
         assert_eq!(location.version, 11);
         assert_eq!(location.naming_scheme, naming_scheme);
         assert_eq!(location.path, naming_scheme.manifest_path(&base, 11));
+    }
+
+    #[test]
+    fn test_parse_detached_version() {
+        // Valid detached version filenames
+        assert_eq!(
+            ManifestNamingScheme::parse_detached_version("d12345.manifest"),
+            Some(12345)
+        );
+        assert_eq!(
+            ManifestNamingScheme::parse_detached_version("d9223372036854775808.manifest"),
+            Some(9223372036854775808)
+        );
+
+        // Invalid: not starting with 'd' prefix
+        assert_eq!(
+            ManifestNamingScheme::parse_detached_version("12345.manifest"),
+            None
+        );
+
+        // Invalid: regular V2 manifest
+        assert_eq!(
+            ManifestNamingScheme::parse_detached_version("18446744073709551615.manifest"),
+            None
+        );
+
+        // Invalid: no extension
+        assert_eq!(ManifestNamingScheme::parse_detached_version("d12345"), None);
+    }
+
+    #[tokio::test]
+    async fn test_list_detached_manifests() {
+        use crate::format::DETACHED_VERSION_MASK;
+        use futures::TryStreamExt;
+
+        let object_store = ObjectStore::memory();
+        let base = Path::from("base");
+        let versions_dir = base.child(VERSIONS_DIR);
+
+        // Create some regular manifests
+        for version in [1, 2, 3] {
+            let path = ManifestNamingScheme::V2.manifest_path(&base, version);
+            object_store.put(&path, b"".as_slice()).await.unwrap();
+        }
+
+        // Create some detached manifests
+        let detached_versions: Vec<u64> = vec![
+            100 | DETACHED_VERSION_MASK,
+            200 | DETACHED_VERSION_MASK,
+            300 | DETACHED_VERSION_MASK,
+        ];
+        for version in &detached_versions {
+            let path = versions_dir.child(format!("d{}.manifest", version));
+            object_store.put(&path, b"".as_slice()).await.unwrap();
+        }
+
+        // List detached manifests
+        let detached_locations: Vec<ManifestLocation> =
+            list_detached_manifests(&base, &object_store.inner)
+                .try_collect()
+                .await
+                .unwrap();
+
+        assert_eq!(detached_locations.len(), 3);
+        for loc in &detached_locations {
+            assert_eq!(loc.naming_scheme, ManifestNamingScheme::V2);
+        }
+
+        let mut found_versions: Vec<u64> = detached_locations.iter().map(|l| l.version).collect();
+        found_versions.sort();
+        let mut expected_versions = detached_versions.clone();
+        expected_versions.sort();
+        assert_eq!(found_versions, expected_versions);
     }
 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1776,6 +1776,27 @@ impl Dataset {
         Ok(versions)
     }
 
+    /// List all detached manifest locations.
+    ///
+    /// Detached manifests are versions that are not part of the main version history.
+    /// They are created by `commit_detached` and can be used for staging changes.
+    ///
+    /// To read transaction properties from a detached manifest:
+    /// ```ignore
+    /// let detached = dataset.list_detached_manifests().await?;
+    /// for location in detached {
+    ///     let ds = dataset.checkout_version(location.version).await?;
+    ///     let tx = ds.read_transaction().await?;
+    ///     // Access tx.transaction_properties
+    /// }
+    /// ```
+    pub async fn list_detached_manifests(&self) -> Result<Vec<ManifestLocation>> {
+        self.commit_handler
+            .list_detached_manifest_locations(&self.base, &self.object_store)
+            .try_collect()
+            .await
+    }
+
     /// Get the latest version of the dataset
     /// This is meant to be a fast path for checking if a dataset has changed. This is why
     /// we don't return the full version struct.

--- a/rust/lance/src/dataset/tests/dataset_transactions.rs
+++ b/rust/lance/src/dataset/tests/dataset_transactions.rs
@@ -377,3 +377,122 @@ async fn test_inline_transaction() {
     let read_tx = ds_new.read_transaction().await.unwrap().unwrap();
     assert_eq!(read_tx, tx);
 }
+
+#[tokio::test]
+async fn test_list_detached_manifests() {
+    let test_uri = TempStrDir::default();
+
+    // Create initial dataset
+    let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "id",
+        DataType::Int32,
+        false,
+    )]));
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+    )
+    .unwrap();
+
+    let dataset = Arc::new(
+        Dataset::write(
+            RecordBatchIterator::new([Ok(batch.clone())], schema.clone()),
+            &test_uri,
+            None,
+        )
+        .await
+        .unwrap(),
+    );
+
+    // Initially there should be no detached manifests
+    let detached = dataset.list_detached_manifests().await.unwrap();
+    assert!(detached.is_empty());
+
+    // Create a detached transaction with properties
+    let mut properties = HashMap::new();
+    properties.insert("detached_key".to_string(), "detached_value".to_string());
+
+    let batch2 = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![4, 5, 6]))],
+    )
+    .unwrap();
+
+    // Use execute_uncommitted + CommitBuilder with_detached(true)
+    let transaction = InsertBuilder::new(dataset.clone())
+        .with_params(&WriteParams {
+            mode: WriteMode::Append,
+            transaction_properties: Some(Arc::new(properties.clone())),
+            ..Default::default()
+        })
+        .execute_uncommitted(vec![batch2])
+        .await
+        .unwrap();
+
+    CommitBuilder::new(dataset.clone())
+        .with_detached(true)
+        .execute(transaction)
+        .await
+        .unwrap();
+
+    // Now there should be one detached manifest
+    let detached = dataset.list_detached_manifests().await.unwrap();
+    assert_eq!(detached.len(), 1);
+
+    // The detached version should have the high bit set
+    let detached_version = detached[0].version;
+    assert!(lance_table::format::is_detached_version(detached_version));
+
+    // We should be able to checkout the detached version and read transaction properties
+    let checked_out = dataset.checkout_version(detached_version).await.unwrap();
+    let tx = checked_out.read_transaction().await.unwrap().unwrap();
+    let tx_props = tx.transaction_properties.unwrap();
+    assert_eq!(
+        tx_props.get("detached_key"),
+        Some(&"detached_value".to_string())
+    );
+
+    // The detached dataset should have more rows
+    assert_eq!(checked_out.count_rows(None).await.unwrap(), 6);
+
+    // Create another detached transaction
+    let batch3 = RecordBatch::try_new(
+        schema.clone(),
+        vec![Arc::new(Int32Array::from(vec![7, 8, 9]))],
+    )
+    .unwrap();
+
+    let mut properties2 = HashMap::new();
+    properties2.insert("second_key".to_string(), "second_value".to_string());
+
+    let transaction2 = InsertBuilder::new(dataset.clone())
+        .with_params(&WriteParams {
+            mode: WriteMode::Append,
+            transaction_properties: Some(Arc::new(properties2)),
+            ..Default::default()
+        })
+        .execute_uncommitted(vec![batch3])
+        .await
+        .unwrap();
+
+    CommitBuilder::new(dataset.clone())
+        .with_detached(true)
+        .execute(transaction2)
+        .await
+        .unwrap();
+
+    // Now there should be two detached manifests
+    let detached = dataset.list_detached_manifests().await.unwrap();
+    assert_eq!(detached.len(), 2);
+
+    // Both should be detached versions
+    for loc in &detached {
+        assert!(lance_table::format::is_detached_version(loc.version));
+    }
+
+    // Regular versions() should not include detached manifests
+    let versions = dataset.versions().await.unwrap();
+    assert_eq!(versions.len(), 1);
+    assert_eq!(versions[0].version, 1);
+}


### PR DESCRIPTION
I am using detached manifests to do parallel data loading, and hit this bug that the finally committed table cannot be read because it cannot parse the detached manifest names. This is because we parse detached version as manifest scheme v2, and then try to parse version from it and fails. 

I think it's pending more discussion if we should treat detached manifests as a specific scheme, I tried to do that but it looks like the current code has some assumption that the file is either v1 or v2 scheme and detached is just a case within, so refactor gets pretty big and might not be worth it. This PR just do a quick fix so that we can at least open a dataset with detached manifests.

I also added the ability to list detached manifests, the functionality seems missing so far.