### PR TITLE
fix: return errors for unsupported fixed-size-list child types

### DIFF
--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -123,6 +123,17 @@ fn timeunit_to_str(unit: &TimeUnit) -> &'static str {
     }
 }
 
+fn is_supported_fixed_size_list_child(data_type: &DataType, nested: bool) -> bool {
+    match data_type {
+        DataType::Struct(_) => !nested,
+        DataType::List(_) | DataType::LargeList(_) | DataType::Map(_, _) => false,
+        DataType::FixedSizeList(field, _) => {
+            is_supported_fixed_size_list_child(field.data_type(), true)
+        }
+        _ => true,
+    }
+}
+
 fn parse_timeunit(unit: &str) -> Result<TimeUnit> {
     match unit {
         "s" => Ok(TimeUnit::Second),
@@ -192,6 +203,8 @@ impl TryFrom<&DataType> for LogicalType {
                     // Don't want to directly use `bfloat16`, in case a built-in type is added
                     // that isn't identical to our extension type.
                     format!("fixed_size_list:lance.bfloat16:{}", *len)
+                } else if !is_supported_fixed_size_list_child(field.data_type(), false) {
+                    return Err(Error::schema(format!("Unsupported data type: {:?}", dt)));
                 } else {
                     format!(
                         "fixed_size_list:{}:{}",

--- a/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
@@ -617,6 +617,71 @@ mod tests {
         ])
     }
 
+    fn make_fsl_of_list() -> DataType {
+        DataType::FixedSizeList(
+            Arc::new(Field::new(
+                "item",
+                DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
+                true,
+            )),
+            2,
+        )
+    }
+
+    fn make_fsl_of_large_list() -> DataType {
+        DataType::FixedSizeList(
+            Arc::new(Field::new(
+                "item",
+                DataType::LargeList(Arc::new(Field::new("item", DataType::Int32, true))),
+                true,
+            )),
+            2,
+        )
+    }
+
+    fn make_fsl_of_map() -> DataType {
+        DataType::FixedSizeList(
+            Arc::new(Field::new(
+                "item",
+                DataType::Map(
+                    Arc::new(Field::new(
+                        "entries",
+                        DataType::Struct(Fields::from(vec![
+                            Field::new("key", DataType::Utf8, false),
+                            Field::new("value", DataType::Int32, true),
+                        ])),
+                        false,
+                    )),
+                    false,
+                ),
+                true,
+            )),
+            2,
+        )
+    }
+
+    fn make_fsl_of_nested_fsl_struct() -> DataType {
+        DataType::FixedSizeList(
+            Arc::new(Field::new(
+                "item",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new(
+                        "item",
+                        DataType::Struct(Fields::from(vec![Field::new(
+                            "x",
+                            DataType::Int32,
+                            true,
+                        )])),
+                        true,
+                    )),
+                    4,
+                ),
+                true,
+            )),
+            2,
+        )
+    }
+
     #[rstest]
     #[case::simple(simple_struct_fields(), 2, LanceFileVersion::V2_2)]
     #[case::nested_struct(nested_struct_fields(), 2, LanceFileVersion::V2_2)]
@@ -644,43 +709,15 @@ mod tests {
         check_specific_random(field, test_cases).await;
     }
 
-    // FSL<List> and FSL<Map> are not yet supported (blocked by repdef)
-    #[test]
-    #[should_panic(expected = "Unsupported logical type: list")]
-    fn test_fsl_list_rejected() {
-        let inner = Field::new(
-            "item",
-            DataType::List(Arc::new(Field::new("item", DataType::Int32, true))),
-            true,
-        );
-        let data_type = DataType::FixedSizeList(Arc::new(inner), 2);
+    #[rstest]
+    #[case::list(make_fsl_of_list())]
+    #[case::large_list(make_fsl_of_large_list())]
+    #[case::map(make_fsl_of_map())]
+    #[case::nested_fsl_struct(make_fsl_of_nested_fsl_struct())]
+    fn test_unsupported_fsl_child_types_return_error(#[case] data_type: DataType) {
         let arrow_field = Field::new("test", data_type, true);
-        let lance_field = lance_core::datatypes::Field::try_from(&arrow_field).unwrap();
-        let _ = lance_field.data_type();
-    }
-
-    #[test]
-    #[should_panic(expected = "Unsupported logical type: map")]
-    fn test_fsl_map_rejected() {
-        let inner = Field::new(
-            "item",
-            DataType::Map(
-                Arc::new(Field::new(
-                    "entries",
-                    DataType::Struct(Fields::from(vec![
-                        Field::new("key", DataType::Utf8, false),
-                        Field::new("value", DataType::Int32, true),
-                    ])),
-                    false,
-                )),
-                false,
-            ),
-            true,
-        );
-        let data_type = DataType::FixedSizeList(Arc::new(inner), 2);
-        let arrow_field = Field::new("test", data_type, true);
-        let lance_field = lance_core::datatypes::Field::try_from(&arrow_field).unwrap();
-        let _ = lance_field.data_type();
+        let err = lance_core::datatypes::Field::try_from(&arrow_field).unwrap_err();
+        assert!(err.to_string().contains("Unsupported data type"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject unsupported `FixedSizeList` child combinations during schema/type conversion
- return schema errors instead of letting these cases reach later panic paths
- replace the old panic-based tests with a small matrix of unsupported `FixedSizeList` child cases

## Implementation
This keeps the fix at the schema/type conversion boundary instead of deeper in the writer stack.

Unsupported `FixedSizeList` child types are now rejected while converting Arrow `DataType` into Lance `LogicalType`. Supported paths remain unchanged, including primitive nested FSL and the existing `FixedSizeList<Struct>` version gating.

## Testing
- cargo test -p lance-encoding unsupported_fsl_child_types -- --nocapture
- cargo test -p lance-encoding test_fixed_size_list_struct_requires_v2_2 -- --nocapture