### PR TITLE
fix: use typed NamespaceError::TableNotFound in DirectoryNamespace instead of plain strings

### DIFF
--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -3789,6 +3789,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_deregister_nonexistent_table_v1() {
+        use lance_namespace::models::DeregisterTableRequest;
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(false)
+            .dir_listing_enabled(true)
+            .build()
+            .await
+            .unwrap();
+
+        let mut request = DeregisterTableRequest::new();
+        request.id = Some(vec!["nonexistent".to_string()]);
+        let err = namespace.deregister_table(request).await.unwrap_err();
+        assert_table_not_found(&err);
+        assert!(err.to_string().contains("Table not found"));
+    }
+
+    #[tokio::test]
     async fn test_deregister_table_v1_already_deregistered() {
         use lance_namespace::models::DeregisterTableRequest;
 

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -2834,6 +2834,29 @@ mod tests {
     #[case::with_optimization(true)]
     #[case::without_optimization(false)]
     #[tokio::test]
+    async fn test_deregister_nonexistent_table(#[case] inline_optimization: bool) {
+        use lance_namespace::models::DeregisterTableRequest;
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+
+        let dir_namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .inline_optimization_enabled(inline_optimization)
+            .build()
+            .await
+            .unwrap();
+
+        let mut request = DeregisterTableRequest::new();
+        request.id = Some(vec!["nonexistent".to_string()]);
+        let err = dir_namespace.deregister_table(request).await.unwrap_err();
+        assert_table_not_found(&err);
+        assert!(err.to_string().contains("Table not found"));
+    }
+
+    #[rstest]
+    #[case::with_optimization(true)]
+    #[case::without_optimization(false)]
+    #[tokio::test]
     async fn test_create_duplicate_table_fails(#[case] inline_optimization: bool) {
         let temp_dir = TempStdDir::default();
         let temp_path = temp_dir.to_str().unwrap();


### PR DESCRIPTION
## Summary

Replace `Error::namespace_source(String)` with `NamespaceError::TableNotFound` in `dir.rs` and `dir/manifest.rs` so that the JNI bridge can produce typed Java `TableNotFoundException` instead of raw `RuntimeException`.

## Problem

When a table doesn't exist, `dir.rs` and `dir/manifest.rs` construct errors like:

```rust
Error::namespace_source(format!("Table does not exist: {}", table_name).into())
```

This wraps a plain `String` as `Box<dyn Error>`. The JNI bridge ([`java/lance-jni/src/error.rs`](https://github.com/lance-format/lance/blob/244c721504c6ef0b4c2f9700a342509976898d6e/java/lance-jni/src/error.rs#L212-L215)) tries to downcast the source to `NamespaceError` to throw a typed `LanceNamespaceException(TABLE_NOT_FOUND)`, but the downcast fails on a `String` and falls back to `RuntimeException`.

The full typed error plumbing already exists — `NamespaceError::TableNotFound` → `lance_core::Error::Namespace` (preserves the `NamespaceError`) → JNI downcast → Java `TableNotFoundException`. Only the error construction at the call sites was missing it.

This causes issues in the Spark connector (lance-format/lance-spark#217) where Spark 4.0+ expects `NoSuchTableException` from `loadTable()` but gets `RuntimeException`, making `tableExists()` crash instead of returning `false`.

## Fix

- `dir.rs`: 3 occurrences — `"Table does not exist: {table_name}"` → `NamespaceError::TableNotFound { message: table_name }`
- `dir/manifest.rs`: 4 occurrences — `"Table '{name}' not found"` → `NamespaceError::TableNotFound { message: name }`
- Updated 2 test assertions in `dir.rs` to match the new display format (`"Table not found: ..."`)

## Test plan

- [x] `test_describe_nonexistent_table` — passes with updated assertion
- [x] `test_table_exists` — passes with updated assertion
- [x] `test_table_exists_fails_for_deregistered_v1` — passes (unchanged)
- [x] `test_convert_to_lance_error` in lance-namespace — confirms downcast chain works
- [x] `cargo check -p lance-namespace-impls` — compiles cleanly
