### PR TITLE
test: fix flaky distributed vector build results test

### DIFF
--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1775,6 +1775,7 @@ mod tests {
                     .unwrap()
                     .nearest("vector", q.as_ref(), K)
                     .unwrap()
+                    .minimum_nprobes(TWO_FRAG_NUM_PARTITIONS)
                     .try_into_batch()
                     .await
                     .unwrap();


### PR DESCRIPTION
## Summary
This fixes a flaky regression test added in #6220 (`b80fbb3231cf58dd50e5670f9c56d309999bbd73`).

The affected test is:
- `test_distributed_vector_build_commits_multiple_segments_and_preserves_query_results`

Recent failures showed up in both of these runs:
- https://github.com/lance-format/lance/actions/runs/23450834811
  `main` at `244c721504c6ef0b4c2f9700a342509976898d6e`
- https://github.com/lance-format/lance/actions/runs/23460892697
   #6263
  

In those failures, different platforms / index variants failed:
- `linux-arm / case_1_ivf_flat` on `main`
- `linux-build / case_2_ivf_pq` on #6263

That points to an existing flaky test.

## Root Cause
The test compared the exact Top-K `_rowid` results between:
- a single-segment index build, and
- a distributed multi-segment index build

However, the query path used by the test is ANN (`ANNIVFPartition`) under the default probing behavior. With partial probing, the candidate set can differ slightly between single-segment and multi-segment layouts, especially near the tail of Top-K. That makes exact `_rowid` equality too strict for this test and causes intermittent failures.

## Fix
Make the test probe all IVF partitions before comparing Top-K row ids:
- add `.minimum_nprobes(TWO_FRAG_NUM_PARTITIONS)` to the test query

This keeps the existing strong assertion (`ids_single == ids_split`) but removes the probing-related source of nondeterminism.

## Testing
Local verification:
- `export PROTOC=/opt/homebrew/opt/protobuf@3/bin/protoc`
- `cargo test -p lance test_distributed_vector_build_commits_multiple_segments_and_preserves_query_results -- --nocapture`

Observed result:
- `case_1_ivf_flat ... ok`
- `case_2_ivf_pq ... ok`
- `case_3_ivf_sq ... ok`

I also verified during debugging that with full probing enabled, repeated runs of the previously flaky `ivf_flat` / `ivf_pq` cases became stable.
