### PR TITLE
test: stabilize distributed IVF grouped build query test

### DIFF
--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1848,6 +1848,7 @@ mod tests {
                     .unwrap()
                     .nearest("vector", q.as_ref(), K)
                     .unwrap()
+                    .minimum_nprobes(TWO_FRAG_NUM_PARTITIONS)
                     .try_into_batch()
                     .await
                     .unwrap();
@@ -1984,6 +1985,7 @@ mod tests {
                     .unwrap()
                     .nearest("vector", q.as_ref(), K)
                     .unwrap()
+                    .minimum_nprobes(TWO_FRAG_NUM_PARTITIONS)
                     .try_into_batch()
                     .await
                     .unwrap();


### PR DESCRIPTION
Follow-up to #6268.

This applies the same stabilization to the grouped distributed IVF query test in `rust/lance/src/index/vector/ivf/v2.rs`.

Like the earlier flaky test, it was asserting exact Top-K `_rowid` equality while still using the default probing behavior. This change sets `minimum_nprobes(TWO_FRAG_NUM_PARTITIONS)` before making that exact row-id comparison.

Recent related CI failure:
https://github.com/lance-format/lance/actions/runs/23499541618/job/68390439921?pr=6263