### PR TITLE
perf: use ShardMergeReader for non-PQ index types

### DIFF
--- a/rust/lance-index/src/vector/distributed/index_merger.rs
+++ b/rust/lance-index/src/vector/distributed/index_merger.rs
@@ -13,7 +13,6 @@ use arrow_array::{Array, FixedSizeListArray, RecordBatch};
 use futures::StreamExt as _;
 use lance_arrow::{FixedSizeListArrayExt, RecordBatchExt};
 use lance_core::{Error, ROW_ID_FIELD, Result};
-use std::ops::Range;
 use std::sync::Arc;
 
 use crate::IndexMetadata as IndexMetaSchema;
@@ -281,29 +280,6 @@ pub async fn init_writer_for_sq(
     let meta_json = serde_json::to_string(sq_meta)?;
     init_writer_for_storage(&mut w, dt, &meta_json, SQ_METADATA_KEY)?;
     Ok(w)
-}
-
-/// Stream and write a range of rows from reader into writer.
-///
-/// The caller is responsible for ensuring that `range` corresponds to a
-/// contiguous row interval for a single IVF partition.
-pub async fn write_partition_rows(
-    reader: &V2Reader,
-    w: &mut FileWriter,
-    range: Range<usize>,
-) -> Result<()> {
-    let mut stream = reader.read_stream(
-        lance_io::ReadBatchParams::Range(range),
-        u32::MAX,
-        4,
-        lance_encoding::decoder::FilterExpression::no_filter(),
-    )?;
-    use futures::StreamExt as _;
-    while let Some(rb) = stream.next().await {
-        let rb = rb?;
-        w.write_batch(&rb).await?;
-    }
-    Ok(())
 }
 
 /// Transpose the PQ code column for a batch and write it to the unified writer.
@@ -602,16 +578,16 @@ async fn read_shard_window_partitions(
     Ok(per_partition_batches)
 }
 
-/// Merge the selected segment auxiliary files into `target_dir`.
+/// Merge the selected partial-shard auxiliary files into `target_dir`.
 ///
-/// This is the storage merge kernel for vector segment build. Callers choose
-/// which segments belong to one built segment and pass the
-/// corresponding auxiliary files here. The merge writes one unified
-/// `auxiliary.idx` into `target_dir`.
+/// This is the storage merge kernel for vector staged segment build. Callers
+/// choose which partial shards belong to one built segment and pass the corresponding
+/// auxiliary files here. The merge writes one unified `auxiliary.idx` into
+/// `target_dir`.
 ///
 /// Supports IVF_FLAT, IVF_PQ, IVF_SQ, IVF_HNSW_FLAT, IVF_HNSW_PQ, and
-/// IVF_HNSW_SQ storage types. For PQ and SQ, this assumes all selected source
-/// segments share the same quantizer/codebook and distance type; it reuses the
+/// IVF_HNSW_SQ storage types. For PQ and SQ, this assumes all selected partial
+/// shards share the same quantizer/codebook and distance type; it reuses the
 /// first encountered metadata.
 pub async fn merge_partial_vector_auxiliary_files(
     object_store: &lance_io::object_store::ObjectStore,
@@ -1243,16 +1219,36 @@ pub async fn merge_partial_vector_auxiliary_files(
             }
         }
         _ => {
-            for pid in 0..nlist {
-                for shard in shard_infos.iter() {
-                    let part_len = shard.lengths[pid] as usize;
-                    if part_len == 0 {
-                        continue;
-                    }
-                    let offset = shard.partition_offsets[pid];
-                    if let Some(w) = v2w_opt.as_mut() {
-                        write_partition_rows(shard.reader.as_ref(), w, offset..offset + part_len)
-                            .await?;
+            // Use the same windowed parallel I/O as PQ path for all non-PQ
+            // index types (IVF_FLAT, IVF_SQ, IVF_HNSW_FLAT, IVF_HNSW_SQ).
+            // This reduces I/O calls from nlist*shards serial reads to
+            // ceil(nlist/window)*shards parallel reads with prefetch.
+            let partition_window_size = *PARTITION_WINDOW_SIZE;
+            let prefetch_window_count = *PARTITION_PREFETCH_WINDOW_COUNT;
+            let mut shard_merge_reader = ShardMergeReader::new(
+                shard_infos,
+                nlist,
+                partition_window_size,
+                prefetch_window_count,
+            );
+
+            while let Some((pid, batches)) = shard_merge_reader.next_partition().await? {
+                if accumulated_lengths[pid] == 0 {
+                    continue;
+                }
+                if batches.is_empty() {
+                    return Err(Error::index(format!(
+                        "No merged batches found for non-empty partition {}",
+                        pid
+                    )));
+                }
+                if let Some(w) = v2w_opt.as_mut() {
+                    let schema = batches[0].schema();
+                    let merged = concat_batches(&schema, batches.iter())?;
+                    let batch_size: usize = 10_240;
+                    for offset in (0..merged.num_rows()).step_by(batch_size) {
+                        let len = std::cmp::min(batch_size, merged.num_rows() - offset);
+                        w.write_batch(&merged.slice(offset, len)).await?;
                     }
                 }
             }


### PR DESCRIPTION
## Problem Description
When processing the `merge_partial_vector_auxiliary_files` stage for the `ivf-sq` index on a dataset of 5 million records with 8 workers and 2236 partitions, the operation takes an excessively long time (**3780 seconds**), which significantly impacts the overall efficiency of vector index merging.(#6288 )

## Root Cause
The current implementation of merging partial vector auxiliary files lacks shard-based parallelism optimization, leading to serial processing bottlenecks when handling a large number of partitions and datasets.

## Proposed Solution
Use `ShardMergeReader` to leverage shard-level parallelism for merging partial vector auxiliary files. This optimization distributes the merge workload across multiple shards, reducing the overall processing time.

## Performance Metrics (Before/After)
| Scenario (8 workers / 2236 partitions / 5M dataset) | Before Optimization | After Optimization | Improvement |
|------------------------------------------------------|---------------------|--------------------|-------------|
| `merge_partial_vector_auxiliary_files` (ivf_sq index)| 3780 seconds        | 208 seconds        | ~18.1x faster |

## Additional Context
- Index type: `ivf_sq`
- Dataset size: 5 million records
- Worker count: 8
- Partition count: 2236
- Optimization core: `ShardMergeReader` (shard-based parallel merge logic)