### PR TITLE
feat(python): add storage_options to IvfModel and PqModel save/load

### DIFF
--- a/python/python/lance/indices/ivf.py
+++ b/python/python/lance/indices/ivf.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
+from typing import Dict, Optional
+
 import pyarrow as pa
 
 from lance.file import LanceFileReader, LanceFileWriter
@@ -24,7 +26,7 @@ class IvfModel:
         """
         return len(self.centroids)
 
-    def save(self, uri: str):
+    def save(self, uri: str, *, storage_options: Optional[Dict[str, str]] = None):
         """
         Save the IVF model to a lance file.
 
@@ -34,6 +36,8 @@ class IvfModel:
         uri: str
             The URI to save the model to.  The URI can be a local file path or a
             cloud storage path.
+        storage_options : optional, dict
+            Extra options for the storage backend (e.g. S3 credentials).
         """
         with LanceFileWriter(
             uri,
@@ -41,12 +45,13 @@ class IvfModel:
                 [pa.field("centroids", self.centroids.type)],
                 metadata={b"distance_type": self.distance_type.encode()},
             ),
+            storage_options=storage_options,
         ) as writer:
             batch = pa.table([self.centroids], names=["centroids"])
             writer.write_batch(batch)
 
     @classmethod
-    def load(cls, uri: str):
+    def load(cls, uri: str, *, storage_options: Optional[Dict[str, str]] = None):
         """
         Load an IVF model from a lance file.
 
@@ -56,8 +61,10 @@ class IvfModel:
         uri: str
             The URI to load the model from.  The URI can be a local file path or a
             cloud storage path.
+        storage_options : optional, dict
+            Extra options for the storage backend (e.g. S3 credentials).
         """
-        reader = LanceFileReader(uri)
+        reader = LanceFileReader(uri, storage_options=storage_options)
         num_rows = reader.metadata().num_rows
         metadata = reader.metadata().schema.metadata
         distance_type = metadata[b"distance_type"].decode()

--- a/python/python/lance/indices/pq.py
+++ b/python/python/lance/indices/pq.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
+from typing import Dict, Optional
+
 import pyarrow as pa
 
 from lance.file import LanceFileReader, LanceFileWriter
@@ -23,7 +25,7 @@ class PqModel:
         """The dimension of the vectors this model was trained on"""
         return self.codebook.type.list_size
 
-    def save(self, uri: str):
+    def save(self, uri: str, *, storage_options: Optional[Dict[str, str]] = None):
         """
         Save the PQ model to a lance file.
 
@@ -33,6 +35,8 @@ class PqModel:
         uri: str
             The URI to save the model to.  The URI can be a local file path or a
             cloud storage path.
+        storage_options : optional, dict
+            Extra options for the storage backend (e.g. S3 credentials).
         """
         with LanceFileWriter(
             uri,
@@ -40,12 +44,13 @@ class PqModel:
                 [pa.field("codebook", self.codebook.type)],
                 metadata={b"num_subvectors": str(self.num_subvectors).encode()},
             ),
+            storage_options=storage_options,
         ) as writer:
             batch = pa.table([self.codebook], names=["codebook"])
             writer.write_batch(batch)
 
     @classmethod
-    def load(cls, uri: str):
+    def load(cls, uri: str, *, storage_options: Optional[Dict[str, str]] = None):
         """
         Load a PQ model from a lance file.
 
@@ -55,8 +60,10 @@ class PqModel:
         uri: str
             The URI to load the model from.  The URI can be a local file path or a
             cloud storage path.
+        storage_options : optional, dict
+            Extra options for the storage backend (e.g. S3 credentials).
         """
-        reader = LanceFileReader(uri)
+        reader = LanceFileReader(uri, storage_options=storage_options)
         num_rows = reader.metadata().num_rows
         metadata = reader.metadata().schema.metadata
         num_subvectors = int(metadata[b"num_subvectors"].decode())


### PR DESCRIPTION
Closes #6311 

## What

Add an optional `storage_options` keyword argument to `IvfModel.save()`, `IvfModel.load()`, `PqModel.save()`, and `PqModel.load()`, and forward it to the underlying `LanceFileWriter` / `LanceFileReader`.

## Why

These methods accept cloud storage URIs (e.g. `s3://`, `gs://`) but previously had no way to pass credentials or backend-specific configuration. Users were forced to rely on environment variables for authentication, which breaks down when dealing with multiple storage backends that require different credentials.

Both `LanceFileWriter` and `LanceFileReader` already support `storage_options` — this change simply threads the parameter through.

## Change Summary

- **`python/python/lance/indices/ivf.py`**: Add `storage_options` parameter to `IvfModel.save()` and `IvfModel.load()`, forward to `LanceFileWriter` / `LanceFileReader`.
- **`python/python/lance/indices/pq.py`**: Same change for `PqModel.save()` and `PqModel.load()`.

## Usage

```python
from lance.indices.ivf import IvfModel
from lance.indices.pq import PqModel

opts = {"aws_access_key_id": "...", "aws_secret_access_key": "...", "region": "us-east-1"}

# Save
ivf_model.save("s3://bucket/ivf.lance", storage_options=opts)
pq_model.save("s3://bucket/pq.lance", storage_options=opts)

# Load
ivf_model = IvfModel.load("s3://bucket/ivf.lance", storage_options=opts)
pq_model = PqModel.load("s3://bucket/pq.lance", storage_options=opts)
