### PR TITLE
fix: use StorageOptions::new() in cloud providers to pick up env vars

### DIFF
--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -131,7 +131,7 @@ impl ObjectStoreProvider for AwsStoreProvider {
     ) -> Result<ObjectStore> {
         let block_size = params.block_size.unwrap_or(DEFAULT_CLOUD_BLOCK_SIZE);
         let mut storage_options =
-            StorageOptions(params.storage_options().cloned().unwrap_or_default());
+            StorageOptions::new(params.storage_options().cloned().unwrap_or_default());
         storage_options.with_env_s3();
         let download_retry_count = storage_options.download_retry_count();
 

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -146,7 +146,7 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
 
         let block_size = params.block_size.unwrap_or(DEFAULT_CLOUD_BLOCK_SIZE);
         let mut storage_options =
-            StorageOptions(params.storage_options().cloned().unwrap_or_default());
+            StorageOptions::new(params.storage_options().cloned().unwrap_or_default());
         storage_options.with_env_azure();
         let download_retry_count = storage_options.download_retry_count();
 

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -91,7 +91,7 @@ impl ObjectStoreProvider for GcsStoreProvider {
     async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore> {
         let block_size = params.block_size.unwrap_or(DEFAULT_CLOUD_BLOCK_SIZE);
         let mut storage_options =
-            StorageOptions(params.storage_options().cloned().unwrap_or_default());
+            StorageOptions::new(params.storage_options().cloned().unwrap_or_default());
         storage_options.with_env_gcs();
         let download_retry_count = storage_options.download_retry_count();
 


### PR DESCRIPTION
## Summary
- Cloud providers (AWS, Azure, GCP) constructed `StorageOptions` using the raw tuple struct constructor, bypassing `StorageOptions::new()` which reads `OBJECT_STORE_CLIENT_MAX_RETRIES` and `OBJECT_STORE_CLIENT_RETRY_TIMEOUT` from environment variables
- This meant those env vars were silently ignored — the default (10) was always used regardless of what was set in the environment

## Test plan
- [ ] Set `OBJECT_STORE_CLIENT_MAX_RETRIES=1` and verify the object store client respects it
- [ ] Verify `OBJECT_STORE_CLIENT_RETRY_TIMEOUT` is also picked up

🤖 Generated with [Claude Code](https://claude.com/claude-code)