### PR TITLE
feat: add write progress callback to InsertBuilder

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -130,7 +130,7 @@ pub use write::update::{UpdateBuilder, UpdateJob};
 #[allow(deprecated)]
 pub use write::{
     AutoCleanupParams, CommitBuilder, DeleteBuilder, DeleteResult, InsertBuilder, WriteDestination,
-    WriteMode, WriteParams, write_fragments,
+    WriteMode, WriteParams, WriteProgressFn, WriteStats, write_fragments,
 };
 
 pub(crate) const INDICES_DIR: &str = "_indices";

--- a/rust/lance/src/dataset/progress.rs
+++ b/rust/lance/src/dataset/progress.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use lance_table::format::Fragment;
 
@@ -24,6 +26,47 @@ pub trait WriteFragmentProgress: std::fmt::Debug + Sync + Send {
 
     /// Complete writing a [Fragment].
     async fn complete(&self, fragment: &Fragment) -> Result<()>;
+}
+
+/// Statistics reported to the write progress callback set via
+/// [`InsertBuilder::progress`](crate::dataset::InsertBuilder::progress) or
+/// [`WriteParams::write_progress`](crate::dataset::WriteParams::write_progress).
+#[derive(Debug, Clone, Default)]
+pub struct WriteStats {
+    /// Cumulative bytes handed to the writer so far.
+    ///
+    /// For local storage this closely tracks bytes flushed to disk. For cloud
+    /// object stores (S3, GCS, Azure) this reflects bytes handed to the
+    /// multipart-upload buffer; actual network I/O may lag slightly.
+    pub bytes_written: u64,
+    /// Cumulative rows written so far.
+    pub rows_written: u64,
+    /// Number of files (fragments) whose writes have completed so far.
+    pub files_written: u32,
+}
+
+/// An opaque wrapper around a write-progress closure.
+///
+/// Stored inside [`WriteParams::write_progress`](crate::dataset::WriteParams::write_progress).
+/// Construct via [`InsertBuilder::progress`](crate::dataset::InsertBuilder::progress) or
+/// directly with [`WriteProgressFn::new`].
+#[derive(Clone)]
+pub struct WriteProgressFn(Arc<dyn Fn(WriteStats) + Send + Sync>);
+
+impl WriteProgressFn {
+    pub fn new(f: impl Fn(WriteStats) + Send + Sync + 'static) -> Self {
+        Self(Arc::new(f))
+    }
+
+    pub(crate) fn call(&self, stats: WriteStats) {
+        (self.0)(stats);
+    }
+}
+
+impl std::fmt::Debug for WriteProgressFn {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WriteProgressFn").finish_non_exhaustive()
+    }
 }
 
 /// By default, Progress tracker is Noop.

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -52,6 +52,7 @@ pub mod merge_insert;
 mod retry;
 pub mod update;
 
+pub use super::progress::{WriteProgressFn, WriteStats};
 pub use commit::CommitBuilder;
 pub use delete::{DeleteBuilder, DeleteResult};
 pub use insert::InsertBuilder;
@@ -177,6 +178,13 @@ pub struct WriteParams {
 
     pub progress: Arc<dyn WriteFragmentProgress>,
 
+    /// Optional callback invoked after each batch is written.
+    ///
+    /// Receives cumulative [`WriteStats`] so callers can render a progress bar
+    /// or compute throughput. The callback must be cheap and non-blocking;
+    /// spawn a task if you need async work.
+    pub write_progress: Option<WriteProgressFn>,
+
     /// If present, dataset will use this to update the latest version
     ///
     /// If not set, the default will be based on the object store.  Generally this will
@@ -263,6 +271,7 @@ impl Default for WriteParams {
             mode: WriteMode::Create,
             store_params: None,
             progress: Arc::new(NoopFragmentWriteProgress::new()),
+            write_progress: None,
             commit_handler: None,
             data_storage_version: None,
             enable_stable_row_ids: false,
@@ -430,6 +439,9 @@ pub async fn do_write_fragments(
     let mut writer: Option<Box<dyn GenericWriter>> = None;
     let mut num_rows_in_current_file = 0;
     let mut fragments = Vec::new();
+    let mut bytes_completed: u64 = 0;
+    let mut rows_completed: u64 = 0;
+    let mut files_written: u32 = 0;
     while let Some(batch_chunk) = buffered_reader.next().await {
         let batch_chunk = batch_chunk?;
 
@@ -441,8 +453,17 @@ pub async fn do_write_fragments(
         }
 
         writer.as_mut().unwrap().write(&batch_chunk).await?;
-        for batch in batch_chunk {
+        for batch in &batch_chunk {
             num_rows_in_current_file += batch.num_rows() as u32;
+        }
+
+        if let Some(cb) = &params.write_progress {
+            let current_bytes = writer.as_mut().unwrap().tell().await?;
+            cb.call(WriteStats {
+                bytes_written: bytes_completed + current_bytes,
+                rows_written: rows_completed + num_rows_in_current_file as u64,
+                files_written,
+            });
         }
 
         if num_rows_in_current_file >= params.max_rows_per_file as u32
@@ -451,6 +472,9 @@ pub async fn do_write_fragments(
             let (num_rows, data_file) = writer.take().unwrap().finish().await?;
             info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_DATA, path = &data_file.path);
             debug_assert_eq!(num_rows, num_rows_in_current_file);
+            bytes_completed += data_file.file_size_bytes.get().map_or(0, |s| s.get());
+            rows_completed += num_rows as u64;
+            files_written += 1;
             params.progress.complete(fragments.last().unwrap()).await?;
             let last_fragment = fragments.last_mut().unwrap();
             last_fragment.physical_rows = Some(num_rows as usize);
@@ -463,6 +487,16 @@ pub async fn do_write_fragments(
     if let Some(mut writer) = writer.take() {
         let (num_rows, data_file) = writer.finish().await?;
         info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_DATA, path = &data_file.path);
+        bytes_completed += data_file.file_size_bytes.get().map_or(0, |s| s.get());
+        rows_completed += num_rows as u64;
+        files_written += 1;
+        if let Some(cb) = &params.write_progress {
+            cb.call(WriteStats {
+                bytes_written: bytes_completed,
+                rows_written: rows_completed,
+                files_written,
+            });
+        }
         let last_fragment = fragments.last_mut().unwrap();
         last_fragment.physical_rows = Some(num_rows as usize);
         last_fragment.files.push(data_file);

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -31,6 +31,8 @@ use super::WriteMode;
 use super::WriteParams;
 use super::commit::CommitBuilder;
 use super::resolve_commit_handler;
+use crate::dataset::progress::{WriteProgressFn, WriteStats};
+
 /// Insert or create a new dataset.
 ///
 /// There are different variants of `execute()` methods. Those with the `_stream`
@@ -46,6 +48,7 @@ pub struct InsertBuilder<'a> {
     dest: WriteDestination<'a>,
     // TODO: make these parameters a part of the builder, and add specific methods.
     params: Option<&'a WriteParams>,
+    write_progress: Option<WriteProgressFn>,
 }
 
 impl<'a> InsertBuilder<'a> {
@@ -53,11 +56,24 @@ impl<'a> InsertBuilder<'a> {
         Self {
             dest: dest.into(),
             params: None,
+            write_progress: None,
         }
     }
 
     pub fn with_params(mut self, params: &'a WriteParams) -> Self {
         self.params = Some(params);
+        self
+    }
+
+    /// Register a callback that is invoked after each batch of rows is written.
+    ///
+    /// The callback receives cumulative [`WriteStats`] and can be used to drive
+    /// a progress bar or compute throughput. It must be cheap and non-blocking;
+    /// spawn a task if you need async work.
+    ///
+    /// This overrides any `write_progress` set in [`WriteParams`].
+    pub fn progress(mut self, callback: impl Fn(WriteStats) + Send + Sync + 'static) -> Self {
+        self.write_progress = Some(WriteProgressFn::new(callback));
         self
     }
 
@@ -331,7 +347,10 @@ impl<'a> InsertBuilder<'a> {
     }
 
     async fn resolve_context(&self) -> Result<WriteContext<'a>> {
-        let params = self.params.cloned().unwrap_or_default();
+        let mut params = self.params.cloned().unwrap_or_default();
+        if let Some(cb) = self.write_progress.clone() {
+            params.write_progress = Some(cb);
+        }
         let (object_store, base_path, commit_handler) = match &self.dest {
             WriteDestination::Dataset(dataset) => (
                 dataset.object_store.clone(),
@@ -634,5 +653,59 @@ mod test {
                 Ok(_) => panic!("Expected error"),
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_write_progress_callback() {
+        use std::sync::Mutex;
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        // Three batches of 100 rows each.
+        let batches: Vec<_> = (0..3)
+            .map(|_| {
+                RecordBatch::try_new(
+                    schema.clone(),
+                    vec![Arc::new(Int32Array::from(vec![0i32; 100]))],
+                )
+                .unwrap()
+            })
+            .collect();
+
+        let stats_log: Arc<Mutex<Vec<crate::dataset::WriteStats>>> =
+            Arc::new(Mutex::new(Vec::new()));
+        let log_clone = stats_log.clone();
+
+        InsertBuilder::new("memory://test_write_progress")
+            .progress(move |stats| {
+                log_clone.lock().unwrap().push(stats);
+            })
+            .execute_stream(RecordBatchIterator::new(
+                batches.into_iter().map(Ok),
+                schema,
+            ))
+            .await
+            .unwrap();
+
+        let log = stats_log.lock().unwrap();
+        assert!(
+            !log.is_empty(),
+            "progress callback must be called at least once"
+        );
+        // bytes_written and rows_written must be monotonically non-decreasing.
+        for window in log.windows(2) {
+            assert!(
+                window[1].bytes_written >= window[0].bytes_written,
+                "bytes_written must not decrease: {:?} -> {:?}",
+                window[0].bytes_written,
+                window[1].bytes_written,
+            );
+            assert!(
+                window[1].rows_written >= window[0].rows_written,
+                "rows_written must not decrease",
+            );
+        }
+        let last = log.last().unwrap();
+        assert!(last.bytes_written > 0, "final bytes_written must be > 0");
+        assert_eq!(last.rows_written, 300, "all 300 rows must be reported");
+        assert_eq!(last.files_written, 1, "a single file should be written");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `InsertBuilder::progress(callback)` builder method that fires `WriteStats` after each batch is handed to the writer
- Adds `WriteParams::write_progress: Option<WriteProgressFn>` for lower-level callers using `do_write_fragments` directly
- `WriteStats` reports `bytes_written`, `rows_written`, and `files_written` (all cumulative)

## Usage

```rust
InsertBuilder::new(dataset)
    .with_params(&write_params)
    .progress(|stats| {
        // stats.bytes_written - cumulative bytes handed to the writer
        // stats.rows_written  - cumulative rows written
        // stats.files_written - completed fragment files so far
    })
    .execute_uncommitted_stream(input_stream)
    .await?;
```

The callback fires after each batch during the write and once more after the final file is closed (with exact totals). `bytes_written` uses `writer.tell()` for in-progress files and the final `DataFile.file_size_bytes` on completion.

Closes #6247