### PR TITLE
docs(python): prefer uv for local environment setup

### DIFF
--- a/python/AGENTS.md
+++ b/python/AGENTS.md
@@ -6,6 +6,7 @@ Also see [root AGENTS.md](../AGENTS.md) for cross-language standards.
 
 * Environment: prefer `uv` for local Python environment setup; start with `uv sync --extra tests --extra dev`, and add other extras such as `benchmarks`, `torch`, or `geo` only when needed.
 * Command execution: after initializing the environment with `uv`, either activate the environment or use `uv run ...`; keep `Makefile` targets and CI commands environment-manager agnostic unless CI has been migrated explicitly.
+* Build time expectations: `uv sync` and `uv run maturin develop` build the local `pylance` Rust extension as part of the environment workflow. This can be slow, especially on the first run or after Rust dependency changes; treat that as expected and do not switch to a different environment manager just because the build takes time.
 * Build: `maturin develop` (required after Rust changes)
 * Test: `make test`
 * Run single test: `pytest python/tests/<test_file>.py::<test_name>`

--- a/python/DEVELOPMENT.md
+++ b/python/DEVELOPMENT.md
@@ -8,6 +8,8 @@ uv sync --extra tests --extra dev
 
 Add extras such as `benchmarks`, `torch`, or `geo` only when you need them. After the environment is initialized, either activate it or use `uv run ...` for commands.
 
+`uv sync` is not just downloading Python packages here. It also builds the local `pylance` Rust extension as part of the editable environment, so the first run, cache misses, or Rust dependency changes can make it noticeably slow. This is expected; let the build finish instead of interrupting it and switching to a different environment setup.
+
 ## Building the project
 
 This project is built with [maturin](https://github.com/PyO3/maturin).
@@ -21,6 +23,8 @@ uv run maturin develop
 This builds the Rust native module in place. You will need to re-run this
 whenever you change the Rust code. But changing the Python code doesn't require
 re-building.
+
+As with `uv sync`, this may take a while because it is compiling Rust code for the local `pylance` extension. Slow builds are expected here, especially after dependency or toolchain changes.
 
 ## Running tests
 


### PR DESCRIPTION
This updates the Python contributor docs to prefer `uv` for local environment initialization and day-to-day command execution, while keeping the documented `Makefile` targets unchanged.

I intentionally did not migrate CI in this PR. We have already tried broader `uv` rollouts in #4221 and are still carrying a larger CI refactor in #5210; the current Python workflows still have materially different dependency shapes across lint, wheel-install test, benchmark, and optional Torch / TensorFlow / Ray paths, so I don't see a single environment definition we can switch to safely without a dedicated CI pass.

This keeps the local guidance moving in the right direction without pretending the CI environment has already been unified. No tests were run because this is a docs-only change.
