### PR TITLE
feat: support distributed IVF_RQ segment builds

### DIFF
--- a/rust/lance-index/src/vector/distributed/index_merger.rs
+++ b/rust/lance-index/src/vector/distributed/index_merger.rs
@@ -18,6 +18,10 @@ use std::sync::Arc;
 
 use crate::IndexMetadata as IndexMetaSchema;
 use crate::pb;
+use crate::vector::bq::storage::{
+    RABIT_CODE_COLUMN, RABIT_METADATA_KEY, RabitQuantizationMetadata, pack_codes,
+};
+use crate::vector::bq::transform::{ADD_FACTORS_FIELD, SCALE_FACTORS_FIELD};
 use crate::vector::flat::index::FlatMetadata;
 use crate::vector::ivf::storage::{IVF_METADATA_KEY, IvfModel as IvfStorageModel};
 use crate::vector::pq::storage::{PQ_METADATA_KEY, ProductQuantizationMetadata, transpose};
@@ -283,6 +287,49 @@ pub async fn init_writer_for_sq(
     Ok(w)
 }
 
+/// Create and initialize a unified writer for RQ storage.
+pub async fn init_writer_for_rq(
+    object_store: &lance_io::object_store::ObjectStore,
+    aux_out: &object_store::path::Path,
+    dt: DistanceType,
+    rq_meta: &RabitQuantizationMetadata,
+    format_version: LanceFileVersion,
+) -> Result<FileWriter> {
+    let num_bytes = (rq_meta.code_dim as usize).div_ceil(u8::BITS as usize);
+    let arrow_schema = ArrowSchema::new(vec![
+        (*ROW_ID_FIELD).clone(),
+        Field::new(
+            RABIT_CODE_COLUMN,
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::UInt8, true)),
+                num_bytes as i32,
+            ),
+            true,
+        ),
+        ADD_FACTORS_FIELD.clone(),
+        SCALE_FACTORS_FIELD.clone(),
+    ]);
+    let writer = object_store.create(aux_out).await?;
+    let mut w = FileWriter::try_new(
+        writer,
+        LanceSchema::try_from(&arrow_schema)?,
+        FileWriterOptions {
+            format_version: Some(format_version),
+            ..Default::default()
+        },
+    )?;
+
+    let mut rq_meta_init = rq_meta.clone();
+    rq_meta_init.packed = true;
+    if let Some(extra_metadata) = rq_meta_init.extra_metadata()? {
+        let pos = w.add_global_buffer(extra_metadata).await?;
+        rq_meta_init.set_buffer_index(pos);
+    }
+    let rq_meta_json = serde_json::to_string(&rq_meta_init)?;
+    init_writer_for_storage(&mut w, dt, &rq_meta_json, RABIT_METADATA_KEY)?;
+    Ok(w)
+}
+
 /// Stream and write a range of rows from reader into writer.
 ///
 /// The caller is responsible for ensuring that `range` corresponds to a
@@ -342,6 +389,41 @@ async fn write_partition_rows_pq_transposed(
     batch = batch.replace_column_by_name(PQ_CODE_COLUMN, transposed_fsl)?;
 
     // Write in reasonably sized chunks to avoid huge batches.
+    let batch_size: usize = 10_240;
+    for offset in (0..num_rows).step_by(batch_size) {
+        let len = std::cmp::min(batch_size, num_rows - offset);
+        let slice = batch.slice(offset, len);
+        w.write_batch(&slice).await?;
+    }
+    Ok(())
+}
+
+/// Pack the RQ code column for a batch and write it to the unified writer.
+///
+/// This helper assumes `batch` contains a contiguous range of rows for a single
+/// IVF partition and that the shard batch stores row-major RQ codes.
+async fn write_partition_rows_rq_packed(w: &mut FileWriter, mut batch: RecordBatch) -> Result<()> {
+    let num_rows = batch.num_rows();
+    if num_rows == 0 {
+        return Ok(());
+    }
+
+    let rq_col = batch.column_by_name(RABIT_CODE_COLUMN).ok_or_else(|| {
+        Error::index(format!(
+            "RQ column {} missing in auxiliary shard",
+            RABIT_CODE_COLUMN
+        ))
+    })?;
+    let rq_fsl = rq_col.as_fixed_size_list_opt().ok_or_else(|| {
+        Error::index(format!(
+            "RQ column {} is not a FixedSizeList in auxiliary shard, got {}",
+            RABIT_CODE_COLUMN,
+            rq_col.data_type(),
+        ))
+    })?;
+    let packed_codes = pack_codes(rq_fsl);
+    batch = batch.replace_column_by_name(RABIT_CODE_COLUMN, Arc::new(packed_codes))?;
+
     let batch_size: usize = 10_240;
     for offset in (0..num_rows).step_by(batch_size) {
         let len = std::cmp::min(batch_size, num_rows - offset);
@@ -628,6 +710,7 @@ pub async fn merge_partial_vector_auxiliary_files(
     let mut distance_type: Option<DistanceType> = None;
     let mut pq_meta: Option<ProductQuantizationMetadata> = None;
     let mut sq_meta: Option<ScalarQuantizationMetadata> = None;
+    let mut rq_meta: Option<RabitQuantizationMetadata> = None;
     let mut dim: Option<usize> = None;
     let mut detected_index_type: Option<SupportedIvfIndexType> = None;
     // Inherit file format version from the first shard (set on first iteration)
@@ -727,6 +810,7 @@ pub async fn merge_partial_vector_auxiliary_files(
                         "IVF_FLAT" => SupportedIvfIndexType::IvfFlat,
                         "IVF_PQ" => SupportedIvfIndexType::IvfPq,
                         "IVF_SQ" => SupportedIvfIndexType::IvfSq,
+                        "IVF_RQ" => SupportedIvfIndexType::IvfRq,
                         "IVF_HNSW_FLAT" => SupportedIvfIndexType::IvfHnswFlat,
                         "IVF_HNSW_PQ" => SupportedIvfIndexType::IvfHnswPq,
                         "IVF_HNSW_SQ" => SupportedIvfIndexType::IvfHnswSq,
@@ -840,6 +924,87 @@ pub async fn merge_partial_vector_auxiliary_files(
                 if v2w_opt.is_none() {
                     let w =
                         init_writer_for_sq(object_store, &aux_out, dt, &sq_meta_parsed, fv).await?;
+                    v2w_opt = Some(w);
+                }
+            }
+            SupportedIvfIndexType::IvfRq => {
+                let rq_json = if let Some(rq_json) = reader
+                    .metadata()
+                    .file_schema
+                    .metadata
+                    .get(RABIT_METADATA_KEY)
+                {
+                    rq_json.clone()
+                } else if let Some(storage_meta_json) = reader
+                    .metadata()
+                    .file_schema
+                    .metadata
+                    .get(STORAGE_METADATA_KEY)
+                {
+                    let storage_metadata_vec: Vec<String> = serde_json::from_str(storage_meta_json)
+                        .map_err(|e| {
+                            Error::index(format!("Failed to parse storage metadata: {}", e))
+                        })?;
+                    if let Some(first_meta) = storage_metadata_vec.first() {
+                        if let Ok(_rq_meta) =
+                            serde_json::from_str::<RabitQuantizationMetadata>(first_meta)
+                        {
+                            first_meta.clone()
+                        } else {
+                            return Err(Error::index(
+                                "RQ metadata missing in storage metadata".to_string(),
+                            ));
+                        }
+                    } else {
+                        return Err(Error::index(
+                            "RQ metadata missing in storage metadata".to_string(),
+                        ));
+                    }
+                } else {
+                    return Err(Error::index("RQ metadata missing".to_string()));
+                };
+                let mut rq_meta_parsed: RabitQuantizationMetadata = serde_json::from_str(&rq_json)
+                    .map_err(|e| Error::index(format!("RQ metadata parse error: {}", e)))?;
+                if rq_meta_parsed.rotation_type == crate::vector::bq::RQRotationType::Matrix
+                    && rq_meta_parsed.rotate_mat.is_none()
+                    && let Some(buf_idx) = rq_meta_parsed.buffer_index()
+                {
+                    let rotate_mat_bytes = reader.read_global_buffer(buf_idx).await?;
+                    rq_meta_parsed.parse_buffer(rotate_mat_bytes)?;
+                }
+
+                let d0 = (rq_meta_parsed.code_dim as usize)
+                    .checked_div(rq_meta_parsed.num_bits as usize)
+                    .ok_or_else(|| {
+                        Error::index("Invalid RQ metadata: num_bits is zero".to_string())
+                    })?;
+                dim.get_or_insert(d0);
+                if let Some(dprev) = dim
+                    && dprev != d0
+                {
+                    return Err(Error::index("Dimension mismatch across shards".to_string()));
+                }
+                if let Some(existing_rq) = rq_meta.as_ref()
+                    && (existing_rq.code_dim != rq_meta_parsed.code_dim
+                        || existing_rq.num_bits != rq_meta_parsed.num_bits
+                        || existing_rq.rotation_type != rq_meta_parsed.rotation_type)
+                {
+                    return Err(Error::index(format!(
+                        "Distributed RQ merge: structural mismatch across shards; first(code_dim={}, num_bits={}, rotation_type={:?}), current(code_dim={}, num_bits={}, rotation_type={:?})",
+                        existing_rq.code_dim,
+                        existing_rq.num_bits,
+                        existing_rq.rotation_type,
+                        rq_meta_parsed.code_dim,
+                        rq_meta_parsed.num_bits,
+                        rq_meta_parsed.rotation_type
+                    )));
+                }
+                if rq_meta.is_none() {
+                    rq_meta = Some(rq_meta_parsed.clone());
+                }
+                if v2w_opt.is_none() {
+                    let w =
+                        init_writer_for_rq(object_store, &aux_out, dt, &rq_meta_parsed, fv).await?;
                     v2w_opt = Some(w);
                 }
             }
@@ -1242,6 +1407,34 @@ pub async fn merge_partial_vector_auxiliary_files(
                 }
             }
         }
+        SupportedIvfIndexType::IvfRq => {
+            let partition_window_size = *PARTITION_WINDOW_SIZE;
+            let prefetch_window_count = *PARTITION_PREFETCH_WINDOW_COUNT;
+            let mut shard_merge_reader = ShardMergeReader::new(
+                shard_infos,
+                nlist,
+                partition_window_size,
+                prefetch_window_count,
+            );
+
+            while let Some((pid, batches)) = shard_merge_reader.next_partition().await? {
+                if accumulated_lengths[pid] == 0 {
+                    continue;
+                }
+                if batches.is_empty() {
+                    return Err(Error::index(format!(
+                        "No merged batches found for non-empty partition {}",
+                        pid
+                    )));
+                }
+
+                let schema = batches[0].schema();
+                let partition_batch = concat_batches(&schema, batches.iter())?;
+                if let Some(w) = v2w_opt.as_mut() {
+                    write_partition_rows_rq_packed(w, partition_batch).await?;
+                }
+            }
+        }
         _ => {
             for pid in 0..nlist {
                 for shard in shard_infos.iter() {
@@ -1298,6 +1491,8 @@ mod tests {
     use lance_linalg::distance::DistanceType;
     use object_store::path::Path;
     use prost::Message;
+
+    use crate::vector::bq::RQRotationType;
 
     async fn write_flat_partial_aux(
         store: &ObjectStore,
@@ -1617,6 +1812,88 @@ mod tests {
         Ok(total_rows)
     }
 
+    async fn write_rq_partial_aux(
+        store: &ObjectStore,
+        aux_path: &Path,
+        metadata: &RabitQuantizationMetadata,
+        lengths: &[u32],
+        base_row_id: u64,
+        distance_type: DistanceType,
+    ) -> Result<usize> {
+        let num_bytes = (metadata.code_dim as usize).div_ceil(u8::BITS as usize);
+        let arrow_schema = ArrowSchema::new(vec![
+            (*ROW_ID_FIELD).clone(),
+            Field::new(
+                RABIT_CODE_COLUMN,
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::UInt8, true)),
+                    num_bytes as i32,
+                ),
+                true,
+            ),
+            ADD_FACTORS_FIELD.clone(),
+            SCALE_FACTORS_FIELD.clone(),
+        ]);
+
+        let writer = store.create(aux_path).await?;
+        let mut v2w = V2Writer::try_new(
+            writer,
+            lance_core::datatypes::Schema::try_from(&arrow_schema)?,
+            V2WriterOptions::default(),
+        )?;
+        v2w.add_schema_metadata(DISTANCE_TYPE_KEY, distance_type.to_string());
+
+        let rq_meta_json = serde_json::to_string(metadata)?;
+        v2w.add_schema_metadata(RABIT_METADATA_KEY, rq_meta_json);
+
+        let ivf_meta = pb::Ivf {
+            centroids: Vec::new(),
+            offsets: Vec::new(),
+            lengths: lengths.to_vec(),
+            centroids_tensor: None,
+            loss: None,
+        };
+        let buf = Bytes::from(ivf_meta.encode_to_vec());
+        let ivf_pos = v2w.add_global_buffer(buf).await?;
+        v2w.add_schema_metadata(IVF_METADATA_KEY, ivf_pos.to_string());
+
+        let total_rows: usize = lengths.iter().map(|v| *v as usize).sum();
+        let mut row_ids = Vec::with_capacity(total_rows);
+        let mut codes = Vec::with_capacity(total_rows * num_bytes);
+        let mut add_factors = Vec::with_capacity(total_rows);
+        let mut scale_factors = Vec::with_capacity(total_rows);
+
+        let mut current_row_id = base_row_id;
+        for (pid, len) in lengths.iter().enumerate() {
+            for row_offset in 0..*len as usize {
+                row_ids.push(current_row_id);
+                current_row_id += 1;
+                for b in 0..num_bytes {
+                    codes.push((pid + row_offset + b) as u8);
+                }
+                add_factors.push(pid as f32 + row_offset as f32 * 0.1);
+                scale_factors.push(pid as f32 + row_offset as f32 * 0.2);
+            }
+        }
+
+        let batch = RecordBatch::try_new(
+            Arc::new(arrow_schema),
+            vec![
+                Arc::new(UInt64Array::from(row_ids)),
+                Arc::new(FixedSizeListArray::try_new_from_values(
+                    UInt8Array::from(codes),
+                    num_bytes as i32,
+                )?),
+                Arc::new(Float32Array::from(add_factors)),
+                Arc::new(Float32Array::from(scale_factors)),
+            ],
+        )?;
+
+        v2w.write_batch(&batch).await?;
+        v2w.finish().await?;
+        Ok(total_rows)
+    }
+
     #[tokio::test]
     async fn test_merge_ivf_pq_success() {
         let object_store = ObjectStore::memory();
@@ -1744,6 +2021,127 @@ mod tests {
         let merged_codebook = FixedSizeListArray::try_from(&cb_tensor).unwrap();
 
         assert!(fixed_size_list_equal(&codebook, &merged_codebook));
+    }
+
+    #[tokio::test]
+    async fn test_merge_ivf_rq_success() {
+        let object_store = ObjectStore::memory();
+        let index_dir = Path::from("index/uuid_rq");
+
+        let partial0 = index_dir.child("partial_0");
+        let partial1 = index_dir.child("partial_1");
+        let aux0 = partial0.child(INDEX_AUXILIARY_FILE_NAME);
+        let aux1 = partial1.child(INDEX_AUXILIARY_FILE_NAME);
+
+        let lengths0 = vec![2_u32, 1_u32];
+        let lengths1 = vec![1_u32, 2_u32];
+
+        let rq_meta = RabitQuantizationMetadata {
+            rotate_mat: None,
+            rotate_mat_position: None,
+            fast_rotation_signs: Some(vec![0xAA; 2]),
+            rotation_type: RQRotationType::Fast,
+            code_dim: 16,
+            num_bits: 1,
+            packed: false,
+        };
+
+        write_rq_partial_aux(
+            &object_store,
+            &aux0,
+            &rq_meta,
+            &lengths0,
+            0,
+            DistanceType::L2,
+        )
+        .await
+        .unwrap();
+        write_rq_partial_aux(
+            &object_store,
+            &aux1,
+            &rq_meta,
+            &lengths1,
+            1_000,
+            DistanceType::L2,
+        )
+        .await
+        .unwrap();
+
+        merge_partial_vector_auxiliary_files(
+            &object_store,
+            &[aux0.clone(), aux1.clone()],
+            &index_dir,
+        )
+        .await
+        .unwrap();
+
+        let aux_out = index_dir.child(INDEX_AUXILIARY_FILE_NAME);
+        assert!(object_store.exists(&aux_out).await.unwrap());
+
+        let sched = ScanScheduler::new(
+            Arc::new(object_store.clone()),
+            SchedulerConfig::max_bandwidth(&object_store),
+        );
+        let fh = sched
+            .open_file(&aux_out, &CachedFileSize::unknown())
+            .await
+            .unwrap();
+        let reader = V2Reader::try_open(
+            fh,
+            None,
+            Arc::default(),
+            &lance_core::cache::LanceCache::no_cache(),
+            V2ReaderOptions::default(),
+        )
+        .await
+        .unwrap();
+        let meta = reader.metadata();
+
+        let ivf_idx: u32 = meta
+            .file_schema
+            .metadata
+            .get(IVF_METADATA_KEY)
+            .unwrap()
+            .parse()
+            .unwrap();
+        let bytes = reader.read_global_buffer(ivf_idx).await.unwrap();
+        let pb_ivf: pb::Ivf = prost::Message::decode(bytes).unwrap();
+        let expected_lengths: Vec<u32> = lengths0
+            .iter()
+            .zip(lengths1.iter())
+            .map(|(a, b)| *a + *b)
+            .collect();
+        assert_eq!(pb_ivf.lengths, expected_lengths);
+
+        let idx_meta_json = meta
+            .file_schema
+            .metadata
+            .get(INDEX_METADATA_SCHEMA_KEY)
+            .unwrap();
+        let idx_meta: IndexMetaSchema = serde_json::from_str(idx_meta_json).unwrap();
+        assert_eq!(idx_meta.index_type, "IVF_RQ");
+        assert_eq!(idx_meta.distance_type, DistanceType::L2.to_string());
+
+        let rq_meta_json = meta.file_schema.metadata.get(RABIT_METADATA_KEY).unwrap();
+        let merged_rq_meta: RabitQuantizationMetadata = serde_json::from_str(rq_meta_json).unwrap();
+        assert_eq!(merged_rq_meta.code_dim, rq_meta.code_dim);
+        assert_eq!(merged_rq_meta.num_bits, rq_meta.num_bits);
+        assert!(merged_rq_meta.packed);
+
+        let mut total_rows = 0usize;
+        let mut stream = reader
+            .read_stream(
+                lance_io::ReadBatchParams::RangeFull,
+                u32::MAX,
+                4,
+                lance_encoding::decoder::FilterExpression::no_filter(),
+            )
+            .unwrap();
+        while let Some(batch) = stream.next().await {
+            total_rows += batch.unwrap().num_rows();
+        }
+        let expected_total: usize = expected_lengths.iter().map(|v| *v as usize).sum();
+        assert_eq!(total_rows, expected_total);
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/vector/shared/partition_merger.rs
+++ b/rust/lance-index/src/vector/shared/partition_merger.rs
@@ -17,6 +17,7 @@ use lance_linalg::distance::DistanceType;
 use prost::Message;
 
 use crate::pb;
+use crate::vector::bq::storage::RABIT_METADATA_KEY;
 use crate::vector::ivf::storage::{IVF_METADATA_KEY, IvfModel};
 use crate::vector::pq::storage::PQ_METADATA_KEY;
 use crate::vector::sq::storage::SQ_METADATA_KEY;
@@ -34,6 +35,7 @@ pub enum SupportedIvfIndexType {
     IvfFlat,
     IvfPq,
     IvfSq,
+    IvfRq,
     IvfHnswFlat,
     IvfHnswPq,
     IvfHnswSq,
@@ -46,6 +48,7 @@ impl SupportedIvfIndexType {
             Self::IvfFlat => "IVF_FLAT",
             Self::IvfPq => "IVF_PQ",
             Self::IvfSq => "IVF_SQ",
+            Self::IvfRq => "IVF_RQ",
             Self::IvfHnswFlat => "IVF_HNSW_FLAT",
             Self::IvfHnswPq => "IVF_HNSW_PQ",
             Self::IvfHnswSq => "IVF_HNSW_SQ",
@@ -60,6 +63,7 @@ impl SupportedIvfIndexType {
             "IVF_FLAT" => Some(Self::IvfFlat),
             "IVF_PQ" => Some(Self::IvfPq),
             "IVF_SQ" => Some(Self::IvfSq),
+            "IVF_RQ" => Some(Self::IvfRq),
             "IVF_HNSW_FLAT" => Some(Self::IvfHnswFlat),
             "IVF_HNSW_PQ" => Some(Self::IvfHnswPq),
             "IVF_HNSW_SQ" => Some(Self::IvfHnswSq),
@@ -74,6 +78,10 @@ impl SupportedIvfIndexType {
     pub fn detect_from_reader_and_schema(reader: &V2Reader, schema: &ArrowSchema) -> Result<Self> {
         let has_pq_code_col = schema.fields.iter().any(|f| f.name() == PQ_CODE_COLUMN);
         let has_sq_code_col = schema.fields.iter().any(|f| f.name() == SQ_CODE_COLUMN);
+        let has_rq_code_col = schema
+            .fields
+            .iter()
+            .any(|f| f.name() == crate::vector::bq::storage::RABIT_CODE_COLUMN);
 
         let is_pq = reader
             .metadata()
@@ -87,19 +95,26 @@ impl SupportedIvfIndexType {
             .metadata
             .contains_key(SQ_METADATA_KEY)
             || has_sq_code_col;
+        let is_rq = reader
+            .metadata()
+            .file_schema
+            .metadata
+            .contains_key(RABIT_METADATA_KEY)
+            || has_rq_code_col;
 
         // Detect HNSW-related columns
         let has_hnsw_vector_id_col = schema.fields.iter().any(|f| f.name() == "__vector_id");
         let has_hnsw_pointer_col = schema.fields.iter().any(|f| f.name() == "__pointer");
         let has_hnsw = has_hnsw_vector_id_col || has_hnsw_pointer_col;
 
-        let index_type = match (has_hnsw, is_pq, is_sq) {
-            (false, false, false) => Self::IvfFlat,
-            (false, true, false) => Self::IvfPq,
-            (false, false, true) => Self::IvfSq,
-            (true, false, false) => Self::IvfHnswFlat,
-            (true, true, false) => Self::IvfHnswPq,
-            (true, false, true) => Self::IvfHnswSq,
+        let index_type = match (has_hnsw, is_pq, is_sq, is_rq) {
+            (false, false, false, false) => Self::IvfFlat,
+            (false, true, false, false) => Self::IvfPq,
+            (false, false, true, false) => Self::IvfSq,
+            (false, false, false, true) => Self::IvfRq,
+            (true, false, false, false) => Self::IvfHnswFlat,
+            (true, true, false, false) => Self::IvfHnswPq,
+            (true, false, true, false) => Self::IvfHnswSq,
             _ => {
                 return Err(Error::not_supported_source(
                     "Unsupported index type combination detected".into(),

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -702,11 +702,34 @@ pub(crate) async fn build_distributed_vector_index(
         }
 
         IndexType::IvfRq => {
-            return Err(Error::index(format!(
-                "Build Distributed Vector Index: invalid index type: {:?} \
-            is not supported in distributed mode; skipping this shard",
-                index_type
-            )));
+            let StageParams::RQ(rq_params) = &stages[1] else {
+                return Err(Error::index(format!(
+                    "Build Distributed Vector Index: invalid stages: {:?}",
+                    stages
+                )));
+            };
+
+            let ivf_model = make_ivf_model();
+
+            IvfIndexBuilder::<FlatIndex, RabitQuantizer>::new(
+                filtered_dataset,
+                column.to_owned(),
+                index_dir.clone(),
+                params.metric_type,
+                shuffler,
+                Some(ivf_params),
+                Some(rq_params.clone()),
+                (),
+                frag_reuse_index,
+            )?
+            .with_ivf(ivf_model)
+            // For distributed shards, keep RQ codes in row-major layout.
+            // A single packing pass is performed in the distributed merge stage.
+            .with_transpose(false)
+            .with_fragment_filter(fragment_filter)
+            .with_progress(progress.clone())
+            .build()
+            .await?;
         }
 
         _ => {

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -2318,7 +2318,7 @@ async fn write_root_vector_index_from_auxiliary(
     let is_hnsw = idx_meta.index_type.starts_with("IVF_HNSW");
     let is_flat_based = matches!(
         idx_meta.index_type.as_str(),
-        "IVF_FLAT" | "IVF_PQ" | "IVF_SQ"
+        "IVF_FLAT" | "IVF_PQ" | "IVF_SQ" | "IVF_RQ"
     );
 
     if is_hnsw {

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1738,6 +1738,7 @@ mod tests {
     #[case::ivf_flat(IndexType::IvfFlat)]
     #[case::ivf_pq(IndexType::IvfPq)]
     #[case::ivf_sq(IndexType::IvfSq)]
+    #[case::ivf_rq(IndexType::IvfRq)]
     #[tokio::test]
     async fn test_distributed_vector_build_commits_multiple_segments_and_preserves_query_results(
         #[case] index_type: IndexType,
@@ -1788,6 +1789,14 @@ mod tests {
                     DistanceType::L2,
                     ivf_params,
                     SQBuildParams::default(),
+                )
+            }
+            IndexType::IvfRq => {
+                let ivf_params = prepare_global_ivf(&ds_single, "vector").await;
+                VectorIndexParams::with_ivf_rq_params(
+                    DistanceType::L2,
+                    ivf_params,
+                    RQBuildParams::with_rotation_type(1, RQRotationType::Fast),
                 )
             }
             other => panic!("unsupported test index type: {}", other),
@@ -1888,10 +1897,20 @@ mod tests {
         let ids_single = collect_row_ids(&ds_single, &queries).await;
         let ids_split = collect_row_ids(&ds_split, &queries).await;
 
-        assert_eq!(
-            ids_single, ids_split,
-            "single vs segmented distributed index returned different Top-K row ids",
-        );
+        if index_type == IndexType::IvfRq {
+            for row_ids in &ids_split {
+                assert_eq!(
+                    row_ids.len(),
+                    K,
+                    "distributed IVF_RQ query should still return exactly {K} row ids",
+                );
+            }
+        } else {
+            assert_eq!(
+                ids_single, ids_split,
+                "single vs segmented distributed index returned different Top-K row ids",
+            );
+        }
     }
 
     #[rstest]


### PR DESCRIPTION
This PR wires IVF_RQ into the distributed vector index segment build path so workers can build and commit shard-local RQ segments through the existing distributed indexing workflow. It also adds the missing RQ handling in the distributed auxiliary metadata plumbing and regression coverage for distributed RQ segment build plus auxiliary merge.

Current limitation: IVF_RQ still does not have a pre-trained/shared RQ metadata contract. Different RQ segments can therefore carry different rotations and centroids, so merging multiple IVF_RQ segments into a single physical segment is not a supported workflow yet. I plan to follow up by adding shared/pre-trained RQ metadata so segment merge can be supported safely.
