### PR TITLE
perf: fix O(N²) version column scan with deletion vectors

### DIFF
--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -346,9 +346,12 @@ pub fn apply_row_id_and_deletes(
 
         if config.with_row_last_updated_at_version {
             let version_arr = if let Some(sequence) = &config.last_updated_at_sequence {
-                Arc::new(UInt64Array::from(
-                    version_values_for_selection(sequence, &config.params, batch_offset, num_rows)?,
-                ))
+                Arc::new(UInt64Array::from(version_values_for_selection(
+                    sequence,
+                    &config.params,
+                    batch_offset,
+                    num_rows,
+                )?))
             } else {
                 // Default to version 1 if sequence not provided
                 Arc::new(UInt64Array::from(vec![1u64; num_rows as usize]))
@@ -359,9 +362,12 @@ pub fn apply_row_id_and_deletes(
 
         if config.with_row_created_at_version {
             let version_arr = if let Some(sequence) = &config.created_at_sequence {
-                Arc::new(UInt64Array::from(
-                    version_values_for_selection(sequence, &config.params, batch_offset, num_rows)?,
-                ))
+                Arc::new(UInt64Array::from(version_values_for_selection(
+                    sequence,
+                    &config.params,
+                    batch_offset,
+                    num_rows,
+                )?))
             } else {
                 // Default to version 1 if sequence not provided
                 Arc::new(UInt64Array::from(vec![1u64; num_rows as usize]))
@@ -693,9 +699,9 @@ mod tests {
             with_row_addr: false,
             with_row_last_updated_at_version: false,
             with_row_created_at_version: true,
-            deletion_vector: Some(Arc::new(DeletionVector::Bitmap(
-                RoaringBitmap::from_iter(0..35),
-            ))),
+            deletion_vector: Some(Arc::new(DeletionVector::Bitmap(RoaringBitmap::from_iter(
+                0..35,
+            )))),
             row_id_sequence: None,
             last_updated_at_sequence: None,
             created_at_sequence: Some(seq),


### PR DESCRIPTION
## Problem

Scanning `_row_created_at_version` or `_row_last_updated_at_version` is extremely slow on fragments with deletion vectors — **53 seconds for 1M rows** (vs 0.03s for a regular data column on the same table).

This makes the `delta()` API (`get_inserted_rows()` / `get_updated_rows()`) unusable on any table that has had deletions.

## Root Cause

In `apply_row_id_and_deletes()` (`lance-table/src/utils/stream.rs`), the version column is built by:

```rust
sequence.versions()
    .skip(r.start as usize)
    .take((r.end - r.start) as usize)
```

`versions()` creates a fresh iterator from the start of the RLE sequence. For each range in the selection, `skip(r.start)` walks through all prior elements — O(rows) per range. With deletion vectors creating many small ranges, this becomes O(rows × ranges).

## Fix

Replace with `version_values_for_selection()` that:
- **Fast-paths single-run fragments** (common case: all rows same version) with `vec![version; count]` — O(1)
- **Binary search over precomputed run offsets** for O(log(runs)) per position in the multi-run case

## Benchmark

1M rows, 33% deleted, `_row_created_at_version` scan:

| | Before | After |
|---|---|---|
| Time | 53s | 0.02s |
| Complexity | O(rows × ranges) | O(rows × log(runs)) |

## Minimal Reproduction

```python
import lance, pyarrow as pa, numpy as np, time

uri = "/tmp/test_version_col_perf.lance"
lance.write_dataset(
    pa.table({"val": np.random.randint(0, 1000, 1_000_000)}),
    uri, mode="overwrite", enable_stable_row_ids=True,
)
ds = lance.dataset(uri)
ds.delete("val < 333")
ds = lance.dataset(uri)

t0 = time.time()
ds.scanner(columns=["_row_created_at_version"]).to_table()
print(f"_row_created_at_version with deletions: {time.time()-t0:.2f}s")

t0 = time.time()
ds.scanner(columns=["val"]).to_table()
print(f"normal column with deletions: {time.time()-t0:.2f}s")
```