### PR TITLE
fix: warn and clamp LANCE_INITIAL_UPLOAD_SIZE instead of panicking

### DIFF
--- a/rust/lance-io/src/object_writer.rs
+++ b/rust/lance-io/src/object_writer.rs
@@ -92,7 +92,6 @@ pub struct ObjectWriter {
     cursor: usize,
     connection_resets: u16,
     buffer: Vec<u8>,
-    upload_size: usize,
     // TODO: use constant size to support R2
     use_constant_size_upload_parts: bool,
 }
@@ -171,32 +170,25 @@ impl UploadState {
 
 impl ObjectWriter {
     pub async fn new(object_store: &LanceObjectStore, path: &Path) -> Result<Self> {
-        let upload_size = initial_upload_size();
         Ok(Self {
             state: UploadState::Started(object_store.inner.clone()),
             cursor: 0,
             path: Arc::new(path.clone()),
             connection_resets: 0,
-            buffer: Vec::with_capacity(upload_size),
-            upload_size,
+            buffer: Vec::with_capacity(initial_upload_size()),
             use_constant_size_upload_parts: object_store.use_constant_size_upload_parts,
         })
     }
 
     /// Returns the contents of `buffer` as a `Bytes` object and resets `buffer`.
     /// The new capacity of `buffer` is determined by the current part index.
-    fn next_part_buffer(
-        buffer: &mut Vec<u8>,
-        part_idx: u16,
-        constant_upload_size: bool,
-        upload_size: usize,
-    ) -> Bytes {
+    fn next_part_buffer(buffer: &mut Vec<u8>, part_idx: u16, constant_upload_size: bool) -> Bytes {
         let new_capacity = if constant_upload_size {
             // The store does not support variable part sizes, so use the initial size.
-            upload_size
+            initial_upload_size()
         } else {
             // Increase the upload size every 100 parts. This gives maximum part size of 2.5TB.
-            upload_size.max(((part_idx / 100) as usize + 1) * INITIAL_UPLOAD_STEP)
+            initial_upload_size().max(((part_idx / 100) as usize + 1) * INITIAL_UPLOAD_STEP)
         };
         let new_buffer = Vec::with_capacity(new_capacity);
         let part = std::mem::replace(buffer, new_buffer);
@@ -243,7 +235,6 @@ impl ObjectWriter {
                             &mut mut_self.buffer,
                             0,
                             mut_self.use_constant_size_upload_parts,
-                            mut_self.upload_size,
                         );
                         futures.spawn(Self::put_part(upload.as_mut(), data, 0, None));
 
@@ -408,7 +399,6 @@ impl AsyncWrite for ObjectWriter {
                             &mut mut_self.buffer,
                             *part_idx,
                             mut_self.use_constant_size_upload_parts,
-                            mut_self.upload_size,
                         );
                         futures.spawn(
                             Self::put_part(upload.as_mut(), data, *part_idx, None)


### PR DESCRIPTION
## Summary

- Replace `panic!()` in `initial_upload_size()` with a warn-and-clamp fallback when `LANCE_INITIAL_UPLOAD_SIZE` is set outside the valid `[5MB, 5GB]` range, so misconfiguration can't crash the process
- Extract `MAX_UPLOAD_PART_SIZE` constant for the 5GB upper bound
- Extract `clamp_initial_upload_size` as a pure helper and add boundary unit tests

## Motivation

Setting `LANCE_INITIAL_UPLOAD_SIZE` to a value outside the valid range previously crashed the entire process via `panic!()` — a disproportionate response to a perf-tuning env var misconfiguration. Per review feedback (#6389 (comment)), a crash (or even a propagated `Result`) forces every caller to handle a purely operator-side mistake. Clamping to the valid range and emitting a single warning lets the workload proceed and surfaces the misconfiguration to operators. This also matches the silent-fallback behavior of the sibling env vars `LANCE_UPLOAD_CONCURRENCY` and `LANCE_CONN_RESET_RETRIES`.

## What Changed

**`initial_upload_size()`**: Return type stays `usize`. Out-of-range values are clamped into `[5MB, 5GB]` and a single `tracing::warn!` is emitted with `requested` and `clamped` fields. The existing `OnceLock` cache guarantees the warning fires at most once per process, so no separate rate-limiting logic is needed. Non-numeric and unset values continue to fall back silently to the 5MB default.

**`clamp_initial_upload_size(raw) -> (usize, bool)`**: Pure helper extracted for testability. Returns the clamped value and whether clamping occurred.

**`MAX_UPLOAD_PART_SIZE`**: New constant for the 5GB upper bound.

## Behavioral Equivalence

| Input | Before | After |
|-------|--------|-------|
| Env not set | 5MB default | 5MB default |
| Non-numeric (e.g. `"abc"`) | 5MB default | 5MB default |
| Valid integer in `[5MB, 5GB]` | Returns the value | Returns the value |
| Integer `< 5MB` | **`panic!()`** | Clamped to 5MB + `warn!` (once) |
| Integer `> 5GB` | **`panic!()`** | Clamped to 5GB + `warn!` (once) |

No API changes — `ObjectWriter::new()` signature is unchanged.

## Test plan

- [x] New boundary unit tests: below min, min boundary, in-range, max boundary, above max, `usize::MAX`
- [x] `cargo test -p lance-io --lib object_writer` — 7 tests pass
- [x] `cargo clippy -p lance-io --tests -- -D warnings` — clean
- [x] `cargo fmt -p lance-io -- --check` — clean
- [x] `cargo check --workspace --tests` — full workspace compiles