### PR TITLE
fix: return error instead of OOM on corrupt binary page offsets

### DIFF
--- a/rust/lance-encoding/src/previous/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/previous/encodings/physical/binary.rs
@@ -57,11 +57,7 @@ impl IndicesNormalizer {
         }
     }
 
-    fn extend(
-        &mut self,
-        new_indices: &PrimitiveArray<UInt64Type>,
-        is_start: bool,
-    ) -> Result<()> {
+    fn extend(&mut self, new_indices: &PrimitiveArray<UInt64Type>, is_start: bool) -> Result<()> {
         let mut last = *self.indices.last().unwrap();
         if is_start {
             let (is_valid, val) = self.normalize(new_indices.value(0));
@@ -75,14 +71,12 @@ impl IndicesNormalizer {
             let next = match val.checked_sub(prev) {
                 Some(delta) => delta + last,
                 None => {
-                    return Err(lance_core::Error::invalid_input(
-                        format!(
-                            "corrupt binary page: normalized offset {} is less than previous offset {} \
+                    return Err(lance_core::Error::invalid_input(format!(
+                        "corrupt binary page: normalized offset {} is less than previous offset {} \
                              at index {}, null_adjustment={}, raw values were [{}, {}]. \
                              This usually indicates the file data has been corrupted.",
-                            val, prev, i, self.null_adjustment, w[0], w[1]
-                        ),
-                    ));
+                        val, prev, i, self.null_adjustment, w[0], w[1]
+                    )));
                 }
             };
             self.indices.push(next);


### PR DESCRIPTION
## Summary

- When reading a corrupt lance file where binary page offsets are non-monotonic (e.g. due to multipart upload part reordering), the subtraction `val - prev` in `IndicesNormalizer::extend` would underflow, producing a huge value used as a byte-range length, triggering an OOM allocation that kills the process.
- Use `checked_sub` to detect the underflow and return a descriptive error message instead, indicating the file data has been corrupted.

## Context

This was discovered investigating a real-world corruption where two adjacent 5MB multipart upload parts were swapped when writing to an S3 Express directory bucket. The swapped parts caused the binary (string) column's cumulative offset indices to be non-monotonic at the part boundary, leading to the underflow.

## Test plan

- [x] Verified the fix compiles cleanly (`cargo check -p lance-encoding`)
- [x] Verified against a real corrupt lance file: returns a clear error instead of OOM
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)