### PR TITLE
feat: support index build progress callbacks in Python bindings

### DIFF
--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -37,6 +37,7 @@ from .namespace import (
     DescribeTableRequest,
     LanceNamespace,
 )
+from .progress import IndexProgress
 from .schema import json_to_schema, schema_to_json
 from .util import sanitize_ts
 
@@ -81,6 +82,7 @@ __all__ = [
     "set_logger",
     "write_dataset",
     "FFILanceTableProvider",
+    "IndexProgress",
 ]
 
 

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -79,7 +79,7 @@ if TYPE_CHECKING:
 
     from .commit import CommitLock
     from .lance.indices import IndexDescription
-    from .progress import FragmentWriteProgress
+    from .progress import FragmentWriteProgress, IndexProgress
     from .types import ReaderLike
 
     QueryVectorLike = Union[
@@ -2512,6 +2512,7 @@ class LanceDataset(pa.dataset.Dataset):
         train: bool = True,
         fragment_ids: Optional[List[int]] = None,
         index_uuid: Optional[str] = None,
+        progress_callback: Optional[Callable[[IndexProgress], None]] = None,
         **kwargs,
     ):
         """Create a scalar index on a column.
@@ -2613,6 +2614,9 @@ class LanceDataset(pa.dataset.Dataset):
             A UUID to use for the segment written by this call.
             If not provided, a new UUID will be generated. This parameter is
             passed via kwargs internally.
+        progress_callback : callable, optional
+            A callback that receives :class:`lance.progress.IndexProgress` events while
+            the index is being built.
 
         with_position: bool, default False
             This is for the ``INVERTED`` index. If True, the index will store the
@@ -2796,6 +2800,8 @@ class LanceDataset(pa.dataset.Dataset):
             kwargs["fragment_ids"] = fragment_ids
         if index_uuid is not None:
             kwargs["index_uuid"] = index_uuid
+        if progress_callback is not None:
+            kwargs["progress_callback"] = progress_callback
 
         self._ds.create_index([column], index_type, name, replace, train, None, kwargs)
 
@@ -3200,6 +3206,7 @@ class LanceDataset(pa.dataset.Dataset):
         *,
         target_partition_size: Optional[int] = None,
         skip_transpose: bool = False,
+        progress_callback: Optional[Callable[[IndexProgress], None]] = None,
         **kwargs,
     ) -> LanceDataset:
         """Create index on column.
@@ -3279,6 +3286,9 @@ class LanceDataset(pa.dataset.Dataset):
         index_uuid : str, optional
             A UUID to use for the segment written by this call.
             If not provided, a new UUID will be generated.
+        progress_callback : callable, optional
+            A callback that receives :class:`lance.progress.IndexProgress` events while
+            the index is being built.
         target_partition_size: int, optional
             The target partition size. If set, the number of partitions will be computed
             based on the target partition size.
@@ -3380,6 +3390,8 @@ class LanceDataset(pa.dataset.Dataset):
           <https://hal.inria.fr/inria-00514462v2/document>`_
 
         """
+        if progress_callback is not None:
+            kwargs["progress_callback"] = progress_callback
         self._create_index_impl(
             column,
             index_type,
@@ -3526,6 +3538,7 @@ class LanceDataset(pa.dataset.Dataset):
         index_uuid: str,
         index_type: str,
         batch_readhead: Optional[int] = None,
+        progress_callback: Optional[Callable[[IndexProgress], None]] = None,
     ):
         """
         Merge distributed scalar index metadata.
@@ -3553,6 +3566,9 @@ class LanceDataset(pa.dataset.Dataset):
             supported by scalar distributed merge.
         batch_readhead: int, optional
             Prefetch concurrency used by BTREE merge reader. Default: 1.
+        progress_callback: callable, optional
+            A callback that receives :class:`lance.progress.IndexProgress` events while
+            metadata is being merged.
         """
         # Normalize type
         t = index_type.upper()
@@ -3564,7 +3580,7 @@ class LanceDataset(pa.dataset.Dataset):
             )
 
         # Merge physical index files at the index directory
-        self._ds.merge_index_metadata(index_uuid, t, batch_readhead)
+        self._ds.merge_index_metadata(index_uuid, t, batch_readhead, progress_callback)
         return None
 
     def merge_existing_index_segments(self, segments: List[Index]) -> Index:

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -48,6 +48,7 @@ from ..fragment import (
     FragmentMetadata,
 )
 from ..progress import FragmentWriteProgress as FragmentWriteProgress
+from ..progress import IndexProgress as IndexProgress
 from ..types import ReaderLike as ReaderLike
 from ..udf import BatchUDF as BatchUDF
 from .debug import format_fragment as format_fragment
@@ -362,7 +363,11 @@ class _Dataset:
     def drop_index(self, name: str): ...
     def prewarm_index(self, name: str): ...
     def merge_index_metadata(
-        self, index_uuid: str, index_type: str, batch_readhead: Optional[int] = None
+        self,
+        index_uuid: str,
+        index_type: str,
+        batch_readhead: Optional[int] = None,
+        progress_callback: Optional[Callable[[IndexProgress], None]] = None,
     ): ...
     def merge_existing_index_segments(self, segments: List[Index]) -> Index: ...
     def commit_existing_index_segments(

--- a/python/python/lance/progress.py
+++ b/python/python/lance/progress.py
@@ -8,11 +8,47 @@ from __future__ import annotations
 import json
 import os
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Dict, Optional
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, Literal, Optional
 
 if TYPE_CHECKING:
     # We don't import directly because of circular import
     from .fragment import FragmentMetadata
+
+
+@dataclass(frozen=True)
+class IndexProgress:
+    """Progress event emitted while creating or merging an index.
+
+    Parameters
+    ----------
+    event : str
+        The type of event. One of ``"start"``, ``"progress"``, or ``"complete"``.
+    stage : str
+        The stage name. Stage names are index-type-specific.
+    completed : int, optional
+        The amount of work completed so far, if known.
+    total : int, optional
+        The total amount of work for the stage, if known.
+    unit : str
+        The unit of work for ``completed`` / ``total``.
+    """
+
+    event: Literal["start", "progress", "complete"]
+    stage: str
+    completed: Optional[int] = None
+    total: Optional[int] = None
+    unit: str = ""
+
+    @property
+    def fraction(self) -> Optional[float]:
+        """Return fractional progress if both ``completed`` and ``total`` are known.
+
+        Returns ``None`` when ``total`` is ``None`` or ``0`` (treated as unknown).
+        """
+        if self.completed is None or self.total in (None, 0):
+            return None
+        return min(self.completed / self.total, 1.0)
 
 
 class FragmentWriteProgress(ABC):

--- a/python/python/tests/conftest.py
+++ b/python/python/tests/conftest.py
@@ -1,8 +1,44 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 import sys
+from typing import Optional
 
 import pytest
+
+
+class ProgressRecorder:
+    """Reusable progress callback recorder for index build tests."""
+
+    def __init__(
+        self,
+        fail_after: Optional[int] = None,
+        fail_on_tag: Optional[str] = None,
+    ):
+        self.events = []
+        self.fail_after = fail_after
+        self.fail_on_tag = fail_on_tag
+
+    def __call__(self, event):
+        self.events.append(event)
+        event_tag = f"{event.event}:{event.stage}"
+        if self.fail_on_tag is not None and event_tag == self.fail_on_tag:
+            raise RuntimeError("progress callback failure")
+        if self.fail_after is not None and len(self.events) >= self.fail_after:
+            raise RuntimeError("progress callback failure")
+
+
+def progress_event_tags(events):
+    return [f"{event.event}:{event.stage}" for event in events]
+
+
+def stage_progress_values(events, stage):
+    return [
+        event.completed
+        for event in events
+        if event.event == "progress"
+        and event.stage == stage
+        and event.completed is not None
+    ]
 
 
 @pytest.fixture(params=(True, False))

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -7,6 +7,7 @@ import random
 import re
 import shutil
 import string
+import uuid
 import zipfile
 from datetime import date, datetime, timedelta
 from pathlib import Path
@@ -15,6 +16,7 @@ import lance
 import numpy as np
 import pyarrow as pa
 import pytest
+from conftest import ProgressRecorder, progress_event_tags, stage_progress_values
 from lance.indices import IndexConfig
 from lance.query import (
     BooleanQuery,
@@ -260,6 +262,107 @@ def test_indexed_between(tmp_path):
 
     actual_data = scanner.to_table()
     assert actual_data.num_rows == 0
+
+
+def test_create_inverted_index_progress_callback(tmp_path):
+    ds = generate_multi_fragment_dataset(
+        tmp_path, num_fragments=2, rows_per_fragment=75
+    )
+    progress_recorder = ProgressRecorder()
+
+    ds.create_scalar_index(
+        column="text",
+        index_type="INVERTED",
+        remove_stop_words=False,
+        progress_callback=progress_recorder,
+    )
+
+    tags = progress_event_tags(progress_recorder.events)
+    expected_order = [
+        "start:load_data",
+        "complete:load_data",
+        "start:tokenize_docs",
+        "complete:tokenize_docs",
+        "start:copy_partitions",
+        "complete:copy_partitions",
+        "start:write_metadata",
+        "complete:write_metadata",
+    ]
+    positions = [tags.index(tag) for tag in expected_order]
+    assert positions == sorted(positions)
+
+    tokenize_progress = stage_progress_values(progress_recorder.events, "tokenize_docs")
+    assert tokenize_progress
+    assert tokenize_progress[-1] == ds.count_rows()
+
+    assert "progress:copy_partitions" in tags
+    assert "progress:write_metadata" in tags
+    assert "start:merge_partitions" not in tags
+
+
+def test_merge_index_metadata_inverted_index_progress_callback(tmp_path):
+    ds = generate_multi_fragment_dataset(
+        tmp_path, num_fragments=3, rows_per_fragment=60
+    )
+
+    inverted_index_id = str(uuid.uuid4())
+    for fragment in ds.get_fragments():
+        ds.create_scalar_index(
+            column="text",
+            index_type="INVERTED",
+            name="text_inverted_progress_idx",
+            replace=False,
+            index_uuid=inverted_index_id,
+            fragment_ids=[fragment.fragment_id],
+            remove_stop_words=False,
+        )
+
+    progress_recorder = ProgressRecorder()
+    ds.merge_index_metadata(
+        inverted_index_id,
+        index_type="INVERTED",
+        progress_callback=progress_recorder,
+    )
+
+    tags = progress_event_tags(progress_recorder.events)
+    expected_order = [
+        "start:read_partition_metadata",
+        "complete:read_partition_metadata",
+        "start:remap_partition_files",
+        "complete:remap_partition_files",
+        "start:write_merged_metadata",
+        "complete:write_merged_metadata",
+    ]
+    positions = [tags.index(tag) for tag in expected_order]
+    assert positions == sorted(positions)
+
+    metadata_progress = stage_progress_values(
+        progress_recorder.events, "read_partition_metadata"
+    )
+    assert metadata_progress
+    assert metadata_progress[-1] == len(ds.get_fragments())
+    assert "progress:remap_partition_files" in tags
+    assert "progress:write_merged_metadata" in tags
+
+
+def test_create_inverted_index_progress_callback_error_after_completion_is_ignored(
+    tmp_path,
+):
+    ds = generate_multi_fragment_dataset(
+        tmp_path, num_fragments=2, rows_per_fragment=75
+    )
+    progress_recorder = ProgressRecorder(fail_on_tag="complete:write_metadata")
+
+    ds.create_scalar_index(
+        column="text",
+        index_type="INVERTED",
+        remove_stop_words=False,
+        progress_callback=progress_recorder,
+    )
+
+    tags = progress_event_tags(progress_recorder.events)
+    assert tags[-1] == "complete:write_metadata"
+    assert any(idx.index_type == "Inverted" for idx in ds.describe_indices())
 
 
 def test_index_combination(tmp_path):

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -17,6 +17,7 @@ import numpy as np
 import pyarrow as pa
 import pyarrow.compute as pc
 import pytest
+from conftest import ProgressRecorder, progress_event_tags, stage_progress_values
 from lance import LanceDataset, LanceFragment
 from lance.dataset import VectorIndexReader
 from lance.indices import IndexFileVersion, IndicesBuilder
@@ -181,6 +182,61 @@ def test_flat(dataset):
 
 def test_ann(indexed_dataset):
     run(indexed_dataset)
+
+
+def test_create_index_progress_callback_vector(tmp_path):
+    ds = _make_sample_dataset_base(tmp_path, "vector_progress", 1500, 128)
+    recorder = ProgressRecorder()
+
+    ds.create_index(
+        column="vector",
+        index_type="IVF_PQ",
+        num_partitions=4,
+        num_sub_vectors=4,
+        progress_callback=recorder,
+    )
+
+    tags = progress_event_tags(recorder.events)
+    expected_order = [
+        "start:train_ivf",
+        "complete:train_ivf",
+        "start:train_quantizer",
+        "complete:train_quantizer",
+        "start:shuffle",
+        "complete:shuffle",
+        "start:merge_partitions",
+        "complete:merge_partitions",
+    ]
+    positions = [tags.index(tag) for tag in expected_order]
+    assert positions == sorted(positions)
+
+    shuffle_progress = stage_progress_values(recorder.events, "shuffle")
+    assert shuffle_progress
+    assert shuffle_progress[-1] == ds.count_rows()
+
+    merge_progress = stage_progress_values(recorder.events, "merge_partitions")
+    assert merge_progress
+    assert merge_progress[-1] == 4
+
+
+def test_create_index_progress_callback_error_after_completion_is_ignored(tmp_path):
+    ds = _make_sample_dataset_base(
+        tmp_path, "vector_progress_post_commit_error", 1500, 128
+    )
+    recorder = ProgressRecorder(fail_on_tag="complete:merge_partitions")
+
+    ds.create_index(
+        column="vector",
+        index_type="IVF_PQ",
+        num_partitions=4,
+        num_sub_vectors=4,
+        progress_callback=recorder,
+    )
+
+    tags = progress_event_tags(recorder.events)
+    assert tags[-1] == "complete:merge_partitions"
+    assert ds.has_index
+    assert ds.describe_indices()[0].field_names == ["vector"]
 
 
 def test_distributed_ivf_pq_partition_window_env_override(tmp_path, monkeypatch):

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -3,7 +3,8 @@
 
 use std::collections::HashMap;
 use std::str;
-use std::sync::Arc;
+use std::sync::mpsc::{self, Receiver, SyncSender, TrySendError};
+use std::sync::{Arc, Mutex};
 
 use arrow::array::AsArray;
 use arrow::datatypes::UInt8Type;
@@ -70,7 +71,7 @@ use lance_index::scalar::inverted::query::{
 use lance_index::{
     IndexParams, IndexType,
     optimize::OptimizeOptions,
-    progress::NoopIndexBuildProgress,
+    progress::{IndexBuildProgress, NoopIndexBuildProgress},
     scalar::{FullTextSearchQuery, InvertedIndexParams, ScalarIndexParams},
     vector::{
         Query as VectorQuery, hnsw::builder::HnswBuildParams, ivf::IvfBuildParams,
@@ -115,6 +116,7 @@ pub mod stats;
 
 const DEFAULT_NPROBES: usize = 1;
 const LANCE_COMMIT_MESSAGE_KEY: &str = "__lance_commit_message";
+const INDEX_PROGRESS_QUEUE_SIZE: usize = 1024;
 
 fn convert_reader(reader: &Bound<PyAny>) -> PyResult<Box<dyn RecordBatchReader + Send>> {
     let py = reader.py();
@@ -1986,6 +1988,7 @@ impl Dataset {
         let replace = replace.unwrap_or(true);
         let train = train.unwrap_or(true); // Default to true for backward compatibility
 
+        let mut progress_handler = Self::make_index_progress_handler_from_kwargs(kwargs)?;
         let mut new_self = self.ds.as_ref().clone();
         let mut builder = new_self
             .create_index_builder(&columns, idx_type, params.as_ref())
@@ -2022,6 +2025,9 @@ impl Dataset {
         if let Some(index_uuid) = index_uuid {
             builder = builder.index_uuid(index_uuid);
         }
+        if let Some(progress_handler) = progress_handler.as_ref() {
+            builder = builder.progress(progress_handler.progress.clone());
+        }
 
         use std::future::IntoFuture;
 
@@ -2029,11 +2035,13 @@ impl Dataset {
         let index_metadata = if has_fragment_ids {
             // For fragment-level indexing, use execute_uncommitted
             // Note: We don't update self.ds here as the index is not committed
-            rt().block_on(None, builder.execute_uncommitted())?
+            Self::run_index_future(builder.execute_uncommitted(), progress_handler.as_mut())?
                 .infer_error()?
         } else {
             // For regular indexing, use the standard execute path
-            let index_metadata = rt().block_on(None, builder.into_future())?.infer_error()?;
+            let index_metadata =
+                Self::run_index_future(builder.into_future(), progress_handler.as_mut())?
+                    .infer_error()?;
             self.ds = Arc::new(new_self);
             index_metadata
         };
@@ -2089,23 +2097,34 @@ impl Dataset {
             .infer_error()
     }
 
-    #[pyo3(signature = (index_uuid, index_type, batch_readhead=None))]
+    #[pyo3(signature = (index_uuid, index_type, batch_readhead=None, progress_callback=None))]
     fn merge_index_metadata(
         &self,
         index_uuid: &str,
         index_type: &str,
         batch_readhead: Option<usize>,
+        progress_callback: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<()> {
-        rt().block_on(None, async {
-            self.ds
-                .merge_index_metadata(
-                    index_uuid,
-                    IndexType::try_from(index_type)?,
-                    batch_readhead,
-                    Arc::new(NoopIndexBuildProgress),
-                )
-                .await
-        })?
+        let mut progress_handler =
+            Self::make_index_progress_handler_from_callback(progress_callback)?;
+        let progress: Arc<dyn IndexBuildProgress> = progress_handler
+            .as_ref()
+            .map(|handler| handler.progress.clone() as Arc<dyn IndexBuildProgress>)
+            .unwrap_or_else(|| Arc::new(NoopIndexBuildProgress));
+
+        Self::run_index_future(
+            async {
+                self.ds
+                    .merge_index_metadata(
+                        index_uuid,
+                        IndexType::try_from(index_type)?,
+                        batch_readhead,
+                        progress,
+                    )
+                    .await
+            },
+            progress_handler.as_mut(),
+        )?
         .map_err(|err| PyValueError::new_err(err.to_string()))
     }
 
@@ -2943,6 +2962,190 @@ impl PyWriteDest {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+enum IndexProgressEventType {
+    Start,
+    Progress,
+    Complete,
+}
+
+impl IndexProgressEventType {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Start => "start",
+            Self::Progress => "progress",
+            Self::Complete => "complete",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IndexProgressEvent {
+    event: IndexProgressEventType,
+    stage: String,
+    completed: Option<u64>,
+    total: Option<u64>,
+    unit: String,
+}
+
+#[derive(Debug, Default)]
+struct ActiveIndexProgressStage {
+    stage: Option<String>,
+    completed: Option<u64>,
+    total: Option<u64>,
+    unit: String,
+}
+
+#[derive(Debug)]
+struct PyIndexBuildProgress {
+    sender: SyncSender<IndexProgressEvent>,
+    active_stage: Mutex<ActiveIndexProgressStage>,
+}
+
+impl PyIndexBuildProgress {
+    fn new(sender: SyncSender<IndexProgressEvent>) -> Self {
+        Self {
+            sender,
+            active_stage: Mutex::new(ActiveIndexProgressStage::default()),
+        }
+    }
+
+    /// Send a lifecycle event (start/complete) with blocking semantics.
+    ///
+    /// These events are rare relative to the channel capacity
+    /// (`INDEX_PROGRESS_QUEUE_SIZE`), so blocking here will not stall
+    /// the tokio runtime in practice.  Progress events use the
+    /// non-blocking `try_send_progress_event` instead.
+    fn send_event(&self, event: IndexProgressEvent) -> lance::Result<()> {
+        self.sender.send(event).map_err(|_| {
+            Error::invalid_input("Index progress callback receiver disconnected".to_string())
+        })
+    }
+
+    fn try_send_progress_event(&self, event: IndexProgressEvent) -> lance::Result<()> {
+        match self.sender.try_send(event) {
+            Ok(()) | Err(TrySendError::Full(_)) => Ok(()),
+            Err(TrySendError::Disconnected(_)) => Err(Error::invalid_input(
+                "Index progress callback receiver disconnected".to_string(),
+            )),
+        }
+    }
+}
+
+#[async_trait]
+impl IndexBuildProgress for PyIndexBuildProgress {
+    async fn stage_start(&self, stage: &str, total: Option<u64>, unit: &str) -> lance::Result<()> {
+        {
+            let mut active_stage = self.active_stage.lock().unwrap();
+            *active_stage = ActiveIndexProgressStage {
+                stage: Some(stage.to_string()),
+                completed: Some(0),
+                total,
+                unit: unit.to_string(),
+            };
+        }
+
+        self.send_event(IndexProgressEvent {
+            event: IndexProgressEventType::Start,
+            stage: stage.to_string(),
+            completed: Some(0),
+            total,
+            unit: unit.to_string(),
+        })
+    }
+
+    async fn stage_progress(&self, stage: &str, completed: u64) -> lance::Result<()> {
+        let event = {
+            let mut active_stage = self.active_stage.lock().unwrap();
+            if active_stage.stage.is_none() {
+                active_stage.stage = Some(stage.to_string());
+            }
+            active_stage.completed = Some(completed);
+            IndexProgressEvent {
+                event: IndexProgressEventType::Progress,
+                stage: stage.to_string(),
+                completed: Some(completed),
+                total: active_stage.total,
+                unit: active_stage.unit.clone(),
+            }
+        };
+
+        self.try_send_progress_event(event)
+    }
+
+    async fn stage_complete(&self, stage: &str) -> lance::Result<()> {
+        let event = {
+            let mut active_stage = self.active_stage.lock().unwrap();
+            let completed = active_stage.completed.or(active_stage.total);
+            let total = active_stage.total;
+            let unit = active_stage.unit.clone();
+            *active_stage = ActiveIndexProgressStage::default();
+            IndexProgressEvent {
+                event: IndexProgressEventType::Complete,
+                stage: stage.to_string(),
+                completed,
+                total,
+                unit,
+            }
+        };
+
+        self.send_event(event)
+    }
+}
+
+struct IndexProgressDispatcher {
+    callback: Py<PyAny>,
+    index_progress_cls: Py<PyAny>,
+    receiver: Receiver<IndexProgressEvent>,
+}
+
+impl IndexProgressDispatcher {
+    fn new(
+        py: Python<'_>,
+        callback: Py<PyAny>,
+        receiver: Receiver<IndexProgressEvent>,
+    ) -> PyResult<Self> {
+        let index_progress_cls = py
+            .import("lance.progress")?
+            .getattr("IndexProgress")?
+            .unbind();
+        Ok(Self {
+            callback,
+            index_progress_cls,
+            receiver,
+        })
+    }
+
+    fn drain(&mut self) -> PyResult<()> {
+        while let Ok(event) = self.receiver.try_recv() {
+            self.dispatch(event)?;
+        }
+        Ok(())
+    }
+
+    fn dispatch(&self, event: IndexProgressEvent) -> PyResult<()> {
+        Python::attach(|py| {
+            let progress = self.index_progress_cls.call1(
+                py,
+                (
+                    event.event.as_str(),
+                    event.stage,
+                    event.completed,
+                    event.total,
+                    event.unit,
+                ),
+            )?;
+            self.callback.call1(py, (progress,))?;
+            Ok(())
+        })
+    }
+}
+
+struct IndexProgressHandler {
+    progress: Arc<PyIndexBuildProgress>,
+    dispatcher: IndexProgressDispatcher,
+}
+
 impl Dataset {
     fn transform_ref(&self, reference: Option<Bound<PyAny>>) -> PyResult<Ref> {
         if let Some(reference) = reference {
@@ -3034,6 +3237,62 @@ impl Dataset {
                 }
             });
         }))
+    }
+
+    fn make_index_progress_handler(
+        py: Python<'_>,
+        callback: Py<PyAny>,
+    ) -> PyResult<IndexProgressHandler> {
+        if !callback.bind(py).is_callable() {
+            return Err(PyValueError::new_err("Progress callback must be callable"));
+        }
+
+        let (sender, receiver) = mpsc::sync_channel(INDEX_PROGRESS_QUEUE_SIZE);
+        let progress = Arc::new(PyIndexBuildProgress::new(sender));
+        let dispatcher = IndexProgressDispatcher::new(py, callback, receiver)?;
+        Ok(IndexProgressHandler {
+            progress,
+            dispatcher,
+        })
+    }
+
+    fn make_index_progress_handler_from_kwargs(
+        kwargs: Option<&Bound<'_, PyDict>>,
+    ) -> PyResult<Option<IndexProgressHandler>> {
+        let Some(kwargs) = kwargs else {
+            return Ok(None);
+        };
+
+        let Some(callback) = get_dict_opt::<Py<PyAny>>(kwargs, "progress_callback")? else {
+            return Ok(None);
+        };
+
+        Self::make_index_progress_handler(kwargs.py(), callback).map(Some)
+    }
+
+    fn make_index_progress_handler_from_callback(
+        callback: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Option<IndexProgressHandler>> {
+        let Some(callback) = callback else {
+            return Ok(None);
+        };
+
+        Self::make_index_progress_handler(callback.py(), callback.clone().unbind()).map(Some)
+    }
+
+    fn run_index_future<F>(
+        future: F,
+        progress_handler: Option<&mut IndexProgressHandler>,
+    ) -> PyResult<F::Output>
+    where
+        F: std::future::Future + Send,
+        F::Output: Send,
+    {
+        if let Some(progress_handler) = progress_handler {
+            rt().block_on_pumping(None, future, || progress_handler.dispatcher.drain())
+        } else {
+            rt().block_on(None, future)
+        }
     }
 }
 

--- a/python/src/executor.rs
+++ b/python/src/executor.rs
@@ -173,6 +173,80 @@ impl BackgroundExecutor {
         }
     }
 
+    /// Block on a future, periodically draining a caller-provided pump.
+    ///
+    /// This is intended for progress callbacks where the future emits events from
+    /// background tasks and the caller needs to run Python code while waiting for
+    /// the future to complete.
+    ///
+    /// Unlike [`block_on`], this method does **not** wrap the future in
+    /// `result_or_interrupt`, so keyboard interrupts are only checked on the
+    /// main thread between poll intervals (`SIGNAL_CHECK_INTERVAL`).  This is
+    /// acceptable because index operations yield frequently to emit progress
+    /// events.
+    pub fn block_on_pumping<F, P>(
+        &self,
+        py: Option<Python<'_>>,
+        future: F,
+        mut pump: P,
+    ) -> PyResult<F::Output>
+    where
+        F: Future + Send,
+        F::Output: Send,
+        P: FnMut() -> PyResult<()>,
+    {
+        let mut future = std::pin::pin!(future);
+
+        loop {
+            pump()?;
+
+            let signal_check = match Python::try_attach(|py| py.check_signals()) {
+                Some(result) => result,
+                None => Ok(()),
+            };
+            signal_check?;
+
+            let maybe_output = if let Some(py) = py {
+                py.detach(|| {
+                    self.runtime.block_on(async {
+                        tokio::select! {
+                            result = &mut future => Some(result),
+                            _ = tokio::time::sleep(SIGNAL_CHECK_INTERVAL) => None,
+                        }
+                    })
+                })
+            } else if let Some(result) = Python::try_attach(|py| {
+                py.detach(|| {
+                    self.runtime.block_on(async {
+                        tokio::select! {
+                            result = &mut future => Some(result),
+                            _ = tokio::time::sleep(SIGNAL_CHECK_INTERVAL) => None,
+                        }
+                    })
+                })
+            }) {
+                result
+            } else {
+                self.runtime.block_on(async {
+                    tokio::select! {
+                        result = &mut future => Some(result),
+                        _ = tokio::time::sleep(SIGNAL_CHECK_INTERVAL) => None,
+                    }
+                })
+            };
+
+            if let Some(output) = maybe_output {
+                if let Err(err) = pump() {
+                    log::warn!(
+                        "Ignoring progress callback error after operation completed successfully: {}",
+                        err
+                    );
+                }
+                return Ok(output);
+            }
+        }
+    }
+
     async fn result_or_interrupt<F>(future: F) -> PyResult<F::Output>
     where
         F: Future + Send,

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1049,19 +1049,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.5.2"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/c6/aec0d7752e15536564b50cf9a8926f0e5d7780aa3ab8ce8bca46daa55659/lance_namespace-0.5.2.tar.gz", hash = "sha256:566cc33091b5631793ab411f095d46c66391db0a62343cd6b4470265bb04d577", size = 10274, upload-time = "2026-02-20T03:14:31.777Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/9f/7906ba4117df8d965510285eaf07264a77de2fd283b9d44ec7fc63a4a57a/lance_namespace-0.6.1.tar.gz", hash = "sha256:f0deea442bd3f1056a8e2fed056ae2778e3356517ec2e680db049058b824d131", size = 10666, upload-time = "2026-03-17T17:55:44.977Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/3d/737c008d8fb2861e7ce260e2ffab0d5058eae41556181f80f1a1c3b52ef5/lance_namespace-0.5.2-py3-none-any.whl", hash = "sha256:6ccaf5649bf6ee6aa92eed9c535a114b7b4eb08e89f40426f58bc1466cbcffa3", size = 12087, upload-time = "2026-02-20T03:14:35.261Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/91/aee1c0a04d17f2810173bd304bd444eb78332045df1b0c1b07cebd01f530/lance_namespace-0.6.1-py3-none-any.whl", hash = "sha256:9699c9e3f12236e5e08ea979cc4e036a8e3c67ed2f37ae6f25c5353ab908e1be", size = 12498, upload-time = "2026-03-17T17:55:44.062Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.5.2"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -1070,9 +1070,9 @@ dependencies = [
     { name = "urllib3", version = "1.26.20", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "urllib3", version = "2.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/64/51622c93ec8c164483c83b68764e5e76e52286c0137a8247bc6a7fac25f4/lance_namespace_urllib3_client-0.5.2.tar.gz", hash = "sha256:8a3a238006e6eabc01fc9d385ac3de22ba933aef0ae8987558f3c3199c9b3799", size = 172578, upload-time = "2026-02-20T03:14:33.031Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/a1/8706a2be25bd184acccc411e48f1a42a4cbf3b6556cba15b9fcf4c15cfcc/lance_namespace_urllib3_client-0.6.1.tar.gz", hash = "sha256:31fbd058ce1ea0bf49045cdeaa756360ece0bc61e9e10276f41af6d217debe87", size = 182567, upload-time = "2026-03-17T17:55:46.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/10/f86d994498b37f7f35d0b8c2f7626a16fe4cb1949b518c1e5d5052ecf95f/lance_namespace_urllib3_client-0.5.2-py3-none-any.whl", hash = "sha256:83cefb6fd6e5df0b99b5e866ee3d46300d375b75e8af32c27bc16fbf7c1a5978", size = 300351, upload-time = "2026-02-20T03:14:34.236Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c7/cb9580602dec25f0fdd6005c1c9ba1d4c8c0c3dc8d543107e5a9f248bba8/lance_namespace_urllib3_client-0.6.1-py3-none-any.whl", hash = "sha256:b9c103e1377ad46d2bd70eec894bfec0b1e2133dae0964d7e4de543c6e16293b", size = 317111, upload-time = "2026-03-17T17:55:45.546Z" },
 ]
 
 [[package]]
@@ -2594,7 +2594,7 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'tests'" },
     { name = "geoarrow-rust-core", marker = "extra == 'geo'" },
     { name = "geoarrow-rust-io", marker = "extra == 'geo'" },
-    { name = "lance-namespace", specifier = ">=0.5.2" },
+    { name = "lance-namespace", specifier = ">=0.6.1" },
     { name = "ml-dtypes", marker = "extra == 'tests'" },
     { name = "numpy", specifier = ">=1.22" },
     { name = "pandas", marker = "extra == 'tests'" },


### PR DESCRIPTION
Expose Python progress callbacks for index creation and segment merge.

Add the IndexProgress event type, pump Rust async progress events back into Python while waiting on index work