### PR TITLE
fix: remove legacy tempfile save of IVF centroids in GPU training path

### DIFF
--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -270,10 +270,6 @@ def train_ivf_centroids_on_accelerator(
         kmeans.centroids.cpu().numpy().astype(vector_value_type.to_pandas_dtype())
     )
 
-    with tempfile.NamedTemporaryFile(delete=False) as f:
-        np.save(f, centroids)
-    LOGGER.info("Saved centroids to %s", f.name)
-
     return centroids, kmeans
 
 


### PR DESCRIPTION
### Description

Removes the leftover `tempfile.NamedTemporaryFile` save in `train_ivf_centroids_on_accelerator`. 

This was a debugging/checkpoint artifact that is no longer needed — the `IvfModel.save()` API now provides explicit persistence to any URI (local or cloud). The temp file was created with `delete=False` and never cleaned up, leaking disk space over repeated runs.

The CPU training path (Rust `indices.train_ivf_model`) does not have this behavior, so this change also makes the two paths consistent.

### Changes

- **`python/python/lance/vector.py`**: Removed the `tempfile.NamedTemporaryFile` + `np.save` + log line from `train_ivf_centroids_on_accelerator` (3 lines deleted).

Closes #6395 