### PR TITLE
chore(deps): bump arrow 58, datafusion 53, object_store 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,19 +206,40 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4754a624e5ae42081f464514be454b39711daae0458906dacde5f4c632f33a8"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-csv",
- "arrow-data",
- "arrow-ipc",
- "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-arith 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-csv 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-ipc 57.3.0",
+ "arrow-json 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-row 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "arrow-string 57.3.0",
+]
+
+[[package]]
+name = "arrow"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d441fdda254b65f3e9025910eb2c2066b6295d9c8ed409522b8d2ace1ff8574c"
+dependencies = [
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-csv 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-json 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-row 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+ "arrow-string 58.1.0",
 ]
 
 [[package]]
@@ -227,10 +248,24 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b3141e0ec5145a22d8694ea8b6d6f69305971c4fa1c1a13ef0195aef2d678b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced5406f8b720cc0bc3aa9cf5758f93e8593cda5490677aa194e4b4b383f9a59"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
  "chrono",
  "num-traits",
 ]
@@ -242,9 +277,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8955af33b25f3b175ee10af580577280b4bd01f7e823d94c7cdef7cf8c9aef"
 dependencies = [
  "ahash",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "chrono",
+ "chrono-tz",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772bd34cacdda8baec9418d80d23d0fb4d50ef0735685bd45158b83dfeb6e62d"
+dependencies = [
+ "ahash",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
  "chrono",
  "chrono-tz",
  "half",
@@ -267,17 +321,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-buffer"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "898f4cf1e9598fdb77f356fdf2134feedfd0ee8d5a4e0a5f573e7d0aec16baa4"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
 name = "arrow-cast"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "646bbb821e86fd57189c10b4fcdaa941deaf4181924917b0daa92735baa6ada5"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0127816c96533d20fc938729f48c52d3e48f99717e7a0b5ade77d742510736d"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "atoi",
  "base64 0.22.1",
  "chrono",
@@ -294,9 +382,24 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da746f4180004e3ce7b83c977daf6394d768332349d3d913998b10a120b790a"
 dependencies = [
- "arrow-array",
- "arrow-cast",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-schema 57.3.0",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca025bd0f38eeecb57c2153c0123b960494138e6a957bbda10da2b25415209fe"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-schema 58.1.0",
  "chrono",
  "csv",
  "csv-core",
@@ -309,8 +412,21 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fdd994a9d28e6365aa78e15da3f3950c0fdcea6b963a12fa1c391afb637b304"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 57.3.0",
+ "arrow-schema 57.3.0",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d10beeab2b1c3bb0b53a00f7c944a178b622173a5c7bcabc3cb45d90238df4"
+dependencies = [
+ "arrow-buffer 58.1.0",
+ "arrow-schema 58.1.0",
  "half",
  "num-integer",
  "num-traits",
@@ -322,13 +438,28 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abf7df950701ab528bf7c0cf7eeadc0445d03ef5d6ffc151eaae6b38a58feff1"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
  "flatbuffers",
  "lz4_flex 0.12.1",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "609a441080e338147a84e8e6904b6da482cefb957c5cdc0f3398872f69a315d0"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
+ "flatbuffers",
+ "lz4_flex 0.13.0",
  "zstd",
 ]
 
@@ -338,11 +469,35 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ff8357658bedc49792b13e2e862b80df908171275f8e6e075c460da5ee4bf86"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "chrono",
+ "half",
+ "indexmap",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-json"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ead0914e4861a531be48fe05858265cf854a4880b9ed12618b1d08cba9bebc8"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
  "chrono",
  "half",
  "indexmap",
@@ -362,11 +517,24 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d8f1870e03d4cbed632959498bcc84083b5a24bded52905ae1695bd29da45b"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a7ba279b20b52dad300e68cfc37c17efa65e68623169076855b3a9e941ca5"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
 ]
 
 [[package]]
@@ -375,10 +543,23 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18228633bad92bff92a95746bbeb16e5fc318e8382b75619dec26db79e4de4c0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "half",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14fe367802f16d7668163ff647830258e6e0aeea9a4d79aaedf273af3bdcd3e"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
  "half",
 ]
 
@@ -387,6 +568,16 @@ name = "arrow-schema"
 version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c872d36b7bf2a6a6a2b40de9156265f0242910791db366a2c17476ba8330d68"
+dependencies = [
+ "serde_core",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
 dependencies = [
  "bitflags 2.11.0",
  "serde_core",
@@ -400,10 +591,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68bf3e3efbd1278f770d67e5dc410257300b161b93baedb3aae836144edcaf4b"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-select"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78694888660a9e8ac949853db393af2a8b8fc82c19ce333132dfa2e72cc1a7fe"
+dependencies = [
+ "ahash",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
  "num-traits",
 ]
 
@@ -413,11 +618,28 @@ version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e968097061b3c0e9fe3079cf2e703e487890700546b5b0647f60fca1b5a8d8"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e04a01f8bb73ce54437514c5fd3ee2aa3e8abe4c777ee5cc55853b1652f79e"
+dependencies = [
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "memchr",
  "num-traits",
  "regex",
@@ -1533,6 +1755,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,42 +2333,88 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c18ba387f9c05ac1f3be32a73f8f3cc6c1cfc43e5d4b7a8e5b0d3a5eb48dc7"
 dependencies = [
- "arrow",
- "arrow-schema",
+ "arrow 57.3.0",
+ "arrow-schema 57.3.0",
  "async-trait",
  "bytes",
  "chrono",
- "datafusion-catalog",
- "datafusion-catalog-listing",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-datasource-arrow",
- "datafusion-datasource-csv",
- "datafusion-datasource-json",
+ "datafusion-catalog 52.4.0",
+ "datafusion-catalog-listing 52.4.0",
+ "datafusion-common 52.4.0",
+ "datafusion-common-runtime 52.4.0",
+ "datafusion-datasource 52.4.0",
+ "datafusion-datasource-arrow 52.4.0",
+ "datafusion-datasource-csv 52.4.0",
+ "datafusion-datasource-json 52.4.0",
+ "datafusion-execution 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-expr-common 52.4.0",
+ "datafusion-functions 52.4.0",
+ "datafusion-functions-aggregate 52.4.0",
+ "datafusion-functions-table 52.4.0",
+ "datafusion-functions-window 52.4.0",
+ "datafusion-optimizer 52.4.0",
+ "datafusion-physical-expr 52.4.0",
+ "datafusion-physical-expr-adapter 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+ "datafusion-physical-optimizer 52.4.0",
+ "datafusion-physical-plan 52.4.0",
+ "datafusion-session 52.4.0",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.12.5",
+ "parking_lot",
+ "rand 0.9.2",
+ "regex",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de9f8117889ba9503440f1dd79ebab32ba52ccf1720bb83cd718a29d4edc0d16"
+dependencies = [
+ "arrow 58.1.0",
+ "arrow-schema 58.1.0",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion-catalog 53.0.0",
+ "datafusion-catalog-listing 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-datasource-arrow 53.0.0",
+ "datafusion-datasource-csv 53.0.0",
+ "datafusion-datasource-json 53.0.0",
  "datafusion-datasource-parquet",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-functions",
- "datafusion-functions-aggregate",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-functions-aggregate 53.0.0",
  "datafusion-functions-nested",
- "datafusion-functions-table",
- "datafusion-functions-window",
- "datafusion-optimizer",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-optimizer",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-functions-table 53.0.0",
+ "datafusion-functions-window 53.0.0",
+ "datafusion-optimizer 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-adapter 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-optimizer 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
  "datafusion-sql",
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot",
- "parquet",
+ "parquet 58.1.0",
  "rand 0.9.2",
  "regex",
  "sqlparser",
@@ -2151,21 +2430,46 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c75a4ce672b27fb8423810efb92a3600027717a1664d06a2c307eeeabcec694"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "dashmap",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 52.4.0",
+ "datafusion-common-runtime 52.4.0",
+ "datafusion-datasource 52.4.0",
+ "datafusion-execution 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-physical-expr 52.4.0",
+ "datafusion-physical-plan 52.4.0",
+ "datafusion-session 52.4.0",
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.5",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-catalog"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be893b73a13671f310ffcc8da2c546b81efcc54c22e0382c0a28aa3537017137"
+dependencies = [
+ "arrow 58.1.0",
+ "async-trait",
+ "dashmap",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
  "parking_lot",
  "tokio",
 ]
@@ -2176,21 +2480,44 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c8b9a3795ffb46bf4957a34c67d89a67558b311ae455c8d4295ff2115eeea50"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
- "datafusion-catalog",
- "datafusion-common",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
+ "datafusion-catalog 52.4.0",
+ "datafusion-common 52.4.0",
+ "datafusion-datasource 52.4.0",
+ "datafusion-execution 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-physical-expr 52.4.0",
+ "datafusion-physical-expr-adapter 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+ "datafusion-physical-plan 52.4.0",
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.5",
+]
+
+[[package]]
+name = "datafusion-catalog-listing"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830487b51ed83807d6b32d6325f349c3144ae0c9bf772cf2a712db180c31d5e6"
+dependencies = [
+ "arrow 58.1.0",
+ "async-trait",
+ "datafusion-catalog 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-adapter 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
 ]
 
 [[package]]
@@ -2200,16 +2527,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "205dc1e20441973f470e6b7ef87626a3b9187970e5106058fef1b713047f770c"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-ipc",
+ "arrow 57.3.0",
+ "arrow-ipc 57.3.0",
  "chrono",
  "half",
  "hashbrown 0.16.1",
  "indexmap",
  "libc",
  "log",
- "object_store",
- "parquet",
+ "object_store 0.12.5",
+ "paste",
+ "tokio",
+ "web-time",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d7663f3af955292f8004e74bcaf8f7ea3d66cc38438749615bb84815b61a293"
+dependencies = [
+ "ahash",
+ "arrow 58.1.0",
+ "arrow-ipc 58.1.0",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "object_store 0.13.2",
+ "parquet 58.1.0",
  "paste",
  "sqlparser",
  "tokio",
@@ -2228,29 +2577,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-common-runtime"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f590205c7e32fe1fea48dd53ffb406e56ae0e7a062213a3ac848db8771641bd"
+dependencies = [
+ "futures",
+ "log",
+ "tokio",
+]
+
+[[package]]
 name = "datafusion-datasource"
 version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc614d6e709450e29b7b032a42c1bdb705f166a6b2edef7bed7c7897eb905499"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "bytes",
  "chrono",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 52.4.0",
+ "datafusion-common-runtime 52.4.0",
+ "datafusion-execution 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-physical-expr 52.4.0",
+ "datafusion-physical-expr-adapter 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+ "datafusion-physical-plan 52.4.0",
+ "datafusion-session 52.4.0",
  "futures",
  "glob",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.12.5",
+ "rand 0.9.2",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "datafusion-datasource"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde1e030a9dc87b743c806fbd631f5ecfa2ccaa4ffb61fa19144a07fea406b79"
+dependencies = [
+ "arrow 58.1.0",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-adapter 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
+ "futures",
+ "glob",
+ "itertools 0.14.0",
+ "log",
+ "object_store 0.13.2",
  "rand 0.9.2",
  "tokio",
  "url",
@@ -2262,21 +2651,45 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e497d5fc48dac7ce86f6b4fb09a3a494385774af301ff20ec91aebfae9b05b4"
 dependencies = [
- "arrow",
- "arrow-ipc",
+ "arrow 57.3.0",
+ "arrow-ipc 57.3.0",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 52.4.0",
+ "datafusion-common-runtime 52.4.0",
+ "datafusion-datasource 52.4.0",
+ "datafusion-execution 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+ "datafusion-physical-plan 52.4.0",
+ "datafusion-session 52.4.0",
  "futures",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.12.5",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-arrow"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331ebae7055dc108f9b54994b93dff91f3a17445539efe5b74e89264f7b36e15"
+dependencies = [
+ "arrow 58.1.0",
+ "arrow-ipc 58.1.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
+ "futures",
+ "itertools 0.14.0",
+ "object_store 0.13.2",
  "tokio",
 ]
 
@@ -2286,19 +2699,42 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dfc250cad940d0327ca2e9109dc98830892d17a3d6b2ca11d68570e872cf379"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 52.4.0",
+ "datafusion-common-runtime 52.4.0",
+ "datafusion-datasource 52.4.0",
+ "datafusion-execution 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+ "datafusion-physical-plan 52.4.0",
+ "datafusion-session 52.4.0",
  "futures",
- "object_store",
+ "object_store 0.12.5",
+ "regex",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e0d475088325e2986876aa27bb30d0574f72a22955a527d202f454681d55c5c"
+dependencies = [
+ "arrow 58.1.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
+ "futures",
+ "object_store 0.13.2",
  "regex",
  "tokio",
 ]
@@ -2309,49 +2745,73 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c91e9677ed62833b0e8129dec0d1a8f3c9bb7590bd6dd714a43e4c3b663e4aa0"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-session",
+ "datafusion-common 52.4.0",
+ "datafusion-common-runtime 52.4.0",
+ "datafusion-datasource 52.4.0",
+ "datafusion-execution 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+ "datafusion-physical-plan 52.4.0",
+ "datafusion-session 52.4.0",
  "futures",
- "object_store",
+ "object_store 0.12.5",
  "tokio",
 ]
 
 [[package]]
-name = "datafusion-datasource-parquet"
-version = "52.4.0"
+name = "datafusion-datasource-json"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23798383465e0c569bd442d1453b50691261f8ad6511d840c48457b3bf51ae21"
+checksum = "ea1520d81f31770f3ad6ee98b391e75e87a68a5bb90de70064ace5e0a7182fe8"
 dependencies = [
- "arrow",
+ "arrow 58.1.0",
  "async-trait",
  "bytes",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-datasource",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions-aggregate-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-adapter",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-pruning",
- "datafusion-session",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-session 53.0.0",
+ "futures",
+ "object_store 0.13.2",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "datafusion-datasource-parquet"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95be805d0742ab129720f4c51ad9242cd872599cdb076098b03f061fcdc7f946"
+dependencies = [
+ "arrow 58.1.0",
+ "async-trait",
+ "bytes",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-adapter 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-pruning 53.0.0",
+ "datafusion-session 53.0.0",
  "futures",
  "itertools 0.14.0",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "parking_lot",
- "parquet",
+ "parquet 58.1.0",
  "tokio",
 ]
 
@@ -2362,20 +2822,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e13e5fe3447baa0584b61ee8644086e007e1ef6e58f4be48bc8a72417854729"
 
 [[package]]
+name = "datafusion-doc"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c93ad9e37730d2c7196e68616f3f2dd3b04c892e03acd3a8eeca6e177f3c06a"
+
+[[package]]
 name = "datafusion-execution"
 version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48a6cc03e34899a54546b229235f7b192634c8e832f78a267f0989b18216c56d"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "chrono",
  "dashmap",
- "datafusion-common",
- "datafusion-expr",
+ "datafusion-common 52.4.0",
+ "datafusion-expr 52.4.0",
  "futures",
  "log",
- "object_store",
+ "object_store 0.12.5",
+ "parking_lot",
+ "rand 0.9.2",
+ "tempfile",
+ "url",
+]
+
+[[package]]
+name = "datafusion-execution"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9437d3cd5d363f9319f8122182d4d233427de79c7eb748f23054c9aaa0fdd8df"
+dependencies = [
+ "arrow 58.1.0",
+ "arrow-buffer 58.1.0",
+ "async-trait",
+ "chrono",
+ "dashmap",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "futures",
+ "log",
+ "object_store 0.13.2",
  "parking_lot",
  "rand 0.9.2",
  "tempfile",
@@ -2388,15 +2877,36 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee3315d87eca7a7df58e52a1fb43b4c4171b545fd30ffc3102945c162a9f6ddb"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
  "chrono",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-expr-common",
- "datafusion-functions-aggregate-common",
- "datafusion-functions-window-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 52.4.0",
+ "datafusion-doc 52.4.0",
+ "datafusion-expr-common 52.4.0",
+ "datafusion-functions-aggregate-common 52.4.0",
+ "datafusion-functions-window-common 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+ "indexmap",
+ "itertools 0.14.0",
+ "paste",
+ "serde_json",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67164333342b86521d6d93fa54081ee39839894fb10f7a700c099af96d7552cf"
+dependencies = [
+ "arrow 58.1.0",
+ "async-trait",
+ "chrono",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-functions-window-common 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "indexmap",
  "itertools 0.14.0",
  "paste",
@@ -2410,8 +2920,21 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c6d83feae0753799f933a2c47dfd15980c6947960cb95ed60f5c1f885548b3"
 dependencies = [
- "arrow",
- "datafusion-common",
+ "arrow 57.3.0",
+ "datafusion-common 52.4.0",
+ "indexmap",
+ "itertools 0.14.0",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-expr-common"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab05fdd00e05d5a6ee362882546d29d6d3df43a6c55355164a7fbee12d163bc9"
+dependencies = [
+ "arrow 58.1.0",
+ "datafusion-common 53.0.0",
  "indexmap",
  "itertools 0.14.0",
  "paste",
@@ -2423,23 +2946,51 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b82962015cc3db4d7662459c9f7fcda0591b5edacb8af1cf3bc3031f274800"
 dependencies = [
- "arrow",
- "arrow-buffer",
+ "arrow 57.3.0",
+ "arrow-buffer 57.3.0",
+ "base64 0.22.1",
+ "chrono",
+ "chrono-tz",
+ "datafusion-common 52.4.0",
+ "datafusion-doc 52.4.0",
+ "datafusion-execution 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-expr-common 52.4.0",
+ "datafusion-macros 52.4.0",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "num-traits",
+ "rand 0.9.2",
+ "regex",
+ "unicode-segmentation",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04fb863482d987cf938db2079e07ab0d3bb64595f28907a6c2f8671ad71cca7e"
+dependencies = [
+ "arrow 58.1.0",
+ "arrow-buffer 58.1.0",
  "base64 0.22.1",
  "blake2",
  "blake3",
  "chrono",
  "chrono-tz",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-macros",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-macros 53.0.0",
  "hex",
  "itertools 0.14.0",
  "log",
  "md-5",
+ "memchr",
  "num-traits",
  "rand 0.9.2",
  "regex",
@@ -2455,17 +3006,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e42c227d9e55a6c8041785d4a8a117e4de531033d480aae10984247ac62e27e"
 dependencies = [
  "ahash",
- "arrow",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions-aggregate-common",
- "datafusion-macros",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "arrow 57.3.0",
+ "datafusion-common 52.4.0",
+ "datafusion-doc 52.4.0",
+ "datafusion-execution 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-functions-aggregate-common 52.4.0",
+ "datafusion-macros 52.4.0",
+ "datafusion-physical-expr 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
  "half",
  "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829856f4e14275fb376c104f27cbf3c3b57a9cfe24885d98677525f5e43ce8d6"
+dependencies = [
+ "ahash",
+ "arrow 58.1.0",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-macros 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "half",
+ "log",
+ "num-traits",
  "paste",
 ]
 
@@ -2476,31 +3049,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cead3cfed825b0b688700f4338d281cd7857e4907775a5b9554c083edd5f3f95"
 dependencies = [
  "ahash",
- "arrow",
- "datafusion-common",
- "datafusion-expr-common",
- "datafusion-physical-expr-common",
+ "arrow 57.3.0",
+ "datafusion-common 52.4.0",
+ "datafusion-expr-common 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate-common"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08af79cc3d2aa874a362fb97decfcbd73d687190cb096f16a6c85a7780cce311"
+dependencies = [
+ "ahash",
+ "arrow 58.1.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
 ]
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "52.4.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ea99612970aebab8cf864d02eb3d296bbab7f4881e1023d282b57fe431b201"
+checksum = "465ae3368146d49c2eda3e2c0ef114424c87e8a6b509ab34c1026ace6497e790"
 dependencies = [
- "arrow",
- "arrow-ord",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-functions",
- "datafusion-functions-aggregate",
- "datafusion-functions-aggregate-common",
- "datafusion-macros",
- "datafusion-physical-expr-common",
+ "arrow 58.1.0",
+ "arrow-ord 58.1.0",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-functions-aggregate 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-macros 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "hashbrown 0.16.1",
  "itertools 0.14.0",
+ "itoa",
  "log",
  "paste",
 ]
@@ -2511,12 +3099,28 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d83dbf3ab8b9af6f209b068825a7adbd3b88bf276f2a1ec14ba09567b97f5674"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "async-trait",
- "datafusion-catalog",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-physical-plan",
+ "datafusion-catalog 52.4.0",
+ "datafusion-common 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-physical-plan 52.4.0",
+ "parking_lot",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-table"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6156e6b22fcf1784112fc0173f3ae6e78c8fdb4d3ed0eace9543873b437e2af6"
+dependencies = [
+ "arrow 58.1.0",
+ "async-trait",
+ "datafusion-catalog 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-plan 53.0.0",
  "parking_lot",
  "paste",
 ]
@@ -2527,14 +3131,32 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "732edabe07496e2fc5a1e57a284d7a36edcea445a2821119770a0dea624b472c"
 dependencies = [
- "arrow",
- "datafusion-common",
- "datafusion-doc",
- "datafusion-expr",
- "datafusion-functions-window-common",
- "datafusion-macros",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "arrow 57.3.0",
+ "datafusion-common 52.4.0",
+ "datafusion-doc 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-functions-window-common 52.4.0",
+ "datafusion-macros 52.4.0",
+ "datafusion-physical-expr 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+ "log",
+ "paste",
+]
+
+[[package]]
+name = "datafusion-functions-window"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca7baec14f866729012efb89011a6973f3a346dc8090c567bfcd328deff551c1"
+dependencies = [
+ "arrow 58.1.0",
+ "datafusion-common 53.0.0",
+ "datafusion-doc 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions-window-common 53.0.0",
+ "datafusion-macros 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "log",
  "paste",
 ]
@@ -2545,8 +3167,18 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c6e30e09700799bd52adce8c377ab03dda96e73a623e4803a31ad94fe7ce14"
 dependencies = [
- "datafusion-common",
- "datafusion-physical-expr-common",
+ "datafusion-common 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+]
+
+[[package]]
+name = "datafusion-functions-window-common"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "159228c3280d342658466bb556dc24de30047fe1d7e559dc5d16ccc5324166f9"
+dependencies = [
+ "datafusion-common 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
 ]
 
 [[package]]
@@ -2555,7 +3187,18 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402f2a8ed70fb99a18f71580a1fe338604222a3d32ddeac6e72c5b34feea2d4d"
 dependencies = [
- "datafusion-doc",
+ "datafusion-doc 52.4.0",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "datafusion-macros"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5427e5da5edca4d21ea1c7f50e1c9421775fe33d7d5726e5641a833566e7578"
+dependencies = [
+ "datafusion-doc 53.0.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -2566,12 +3209,31 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99f32edb8ba12f08138f86c09b80fae3d4a320551262fa06b91d8a8cb3065a5b"
 dependencies = [
- "arrow",
+ "arrow 57.3.0",
  "chrono",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-physical-expr",
+ "datafusion-common 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-expr-common 52.4.0",
+ "datafusion-physical-expr 52.4.0",
+ "indexmap",
+ "itertools 0.14.0",
+ "log",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89099eefcd5b223ec685c36a41d35c69239236310d71d339f2af0fa4383f3f46"
+dependencies = [
+ "arrow 58.1.0",
+ "chrono",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
  "indexmap",
  "itertools 0.14.0",
  "log",
@@ -2586,12 +3248,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "987c5e29e96186589301b42e25aa7d11bbe319a73eb02ef8d755edc55b5b89fc"
 dependencies = [
  "ahash",
- "arrow",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-functions-aggregate-common",
- "datafusion-physical-expr-common",
+ "arrow 57.3.0",
+ "datafusion-common 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-expr-common 52.4.0",
+ "datafusion-functions-aggregate-common 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "parking_lot",
+ "paste",
+ "petgraph",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-physical-expr"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f222df5195d605d79098ef37bdd5323bff0131c9d877a24da6ec98dfca9fe36"
+dependencies = [
+ "ahash",
+ "arrow 58.1.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "half",
  "hashbrown 0.16.1",
  "indexmap",
@@ -2608,12 +3293,27 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de89d0afa08b6686697bd8a6bac4ba2cd44c7003356e1bce6114d5a93f94b5c"
 dependencies = [
- "arrow",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "arrow 57.3.0",
+ "datafusion-common 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-functions 52.4.0",
+ "datafusion-physical-expr 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr-adapter"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40838625d63d9c12549d81979db3dd675d159055eb9135009ba272ab0e8d0f64"
+dependencies = [
+ "arrow 58.1.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
  "itertools 0.14.0",
 ]
 
@@ -2624,10 +3324,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602d1970c0fe87f1c3a36665d131fbfe1c4379d35f8fc5ec43a362229ad2954d"
 dependencies = [
  "ahash",
- "arrow",
+ "arrow 57.3.0",
  "chrono",
- "datafusion-common",
- "datafusion-expr-common",
+ "datafusion-common 52.4.0",
+ "datafusion-expr-common 52.4.0",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-physical-expr-common"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eacbcc4cfd502558184ed58fa3c72e775ec65bf077eef5fd2b3453db676f893c"
+dependencies = [
+ "ahash",
+ "arrow 58.1.0",
+ "chrono",
+ "datafusion-common 53.0.0",
+ "datafusion-expr-common 53.0.0",
  "hashbrown 0.16.1",
  "indexmap",
  "itertools 0.14.0",
@@ -2640,15 +3357,33 @@ version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b24d704b6385ebe27c756a12e5ba15684576d3b47aeca79cc9fb09480236dc32"
 dependencies = [
- "arrow",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-expr-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "datafusion-pruning",
+ "arrow 57.3.0",
+ "datafusion-common 52.4.0",
+ "datafusion-execution 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-expr-common 52.4.0",
+ "datafusion-physical-expr 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+ "datafusion-physical-plan 52.4.0",
+ "datafusion-pruning 52.4.0",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-optimizer"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d501d0e1d0910f015677121601ac177ec59272ef5c9324d1147b394988f40941"
+dependencies = [
+ "arrow 58.1.0",
+ "datafusion-common 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
+ "datafusion-pruning 53.0.0",
  "itertools 0.14.0",
 ]
 
@@ -2659,19 +3394,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c21d94141ea5043e98793f170798e9c1887095813b8291c5260599341e383a38"
 dependencies = [
  "ahash",
- "arrow",
- "arrow-ord",
- "arrow-schema",
+ "arrow 57.3.0",
+ "arrow-ord 57.3.0",
+ "arrow-schema 57.3.0",
  "async-trait",
- "datafusion-common",
- "datafusion-common-runtime",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-functions-aggregate-common",
- "datafusion-functions-window-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
+ "datafusion-common 52.4.0",
+ "datafusion-common-runtime 52.4.0",
+ "datafusion-execution 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-functions 52.4.0",
+ "datafusion-functions-aggregate-common 52.4.0",
+ "datafusion-functions-window-common 52.4.0",
+ "datafusion-physical-expr 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
  "futures",
  "half",
  "hashbrown 0.16.1",
@@ -2684,18 +3419,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-physical-plan"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "463c88ad6f1ecab1810f4c9f046898bee035b370137eb79b2b2db925e270631d"
+dependencies = [
+ "ahash",
+ "arrow 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
+ "async-trait",
+ "datafusion-common 53.0.0",
+ "datafusion-common-runtime 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-functions-aggregate-common 53.0.0",
+ "datafusion-functions-window-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "futures",
+ "half",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "log",
+ "num-traits",
+ "parking_lot",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "datafusion-pruning"
 version = "52.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a68cce43d18c0dfac95cacd74e70565f7e2fb12b9ed41e2d312f0fa837626b1"
 dependencies = [
- "arrow",
- "datafusion-common",
- "datafusion-datasource",
- "datafusion-expr-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
+ "arrow 57.3.0",
+ "datafusion-common 52.4.0",
+ "datafusion-datasource 52.4.0",
+ "datafusion-expr-common 52.4.0",
+ "datafusion-physical-expr 52.4.0",
+ "datafusion-physical-expr-common 52.4.0",
+ "datafusion-physical-plan 52.4.0",
+ "itertools 0.14.0",
+ "log",
+]
+
+[[package]]
+name = "datafusion-pruning"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857618a0ecbd8cd0cf29826889edd3a25774ec26b2995fc3862095c95d88fc6"
+dependencies = [
+ "arrow 58.1.0",
+ "datafusion-common 53.0.0",
+ "datafusion-datasource 53.0.0",
+ "datafusion-expr-common 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-expr-common 53.0.0",
+ "datafusion-physical-plan 53.0.0",
  "itertools 0.14.0",
  "log",
 ]
@@ -2707,24 +3491,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4e1c40a0b1896aed4a4504145c2eb7fa9b9da13c2d04b40a4767a09f076199"
 dependencies = [
  "async-trait",
- "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-plan",
+ "datafusion-common 52.4.0",
+ "datafusion-execution 52.4.0",
+ "datafusion-expr 52.4.0",
+ "datafusion-physical-plan 52.4.0",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-session"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef8637e35022c5c775003b3ab1debc6b4a8f0eb41b069bdd5475dd3aa93f6eba"
+dependencies = [
+ "async-trait",
+ "datafusion-common 53.0.0",
+ "datafusion-execution 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-plan 53.0.0",
  "parking_lot",
 ]
 
 [[package]]
 name = "datafusion-sql"
-version = "52.4.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f1891e5b106d1d73c7fe403bd8a265d19c3977edc17f60808daf26c2fe65ffb"
+checksum = "12d9e9f16a1692a11c94bcc418191fa15fd2b4d72a0c1a0c607db93c0b84dd81"
 dependencies = [
- "arrow",
+ "arrow 58.1.0",
  "bigdecimal",
  "chrono",
- "datafusion-common",
- "datafusion-expr",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions-nested",
  "indexmap",
  "log",
  "regex",
@@ -2733,17 +3532,17 @@ dependencies = [
 
 [[package]]
 name = "datafusion-substrait"
-version = "52.4.0"
+version = "53.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2379388ecab67079eeb1185c953fb9c5ed4b283fa3cb81417538378a30545957"
+checksum = "d5e5656a7e63d51dd3e5af3dbd347ea83bbe993a77c66b854b74961570d16490"
 dependencies = [
  "async-recursion",
  "async-trait",
  "chrono",
- "datafusion",
+ "datafusion 53.0.0",
  "half",
  "itertools 0.14.0",
- "object_store",
+ "object_store 0.13.2",
  "pbjson-types",
  "prost",
  "substrait",
@@ -3350,7 +4149,7 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 name = "fsst"
 version = "5.0.0-beta.5"
 dependencies = [
- "arrow-array",
+ "arrow-array 58.1.0",
  "lance-datagen",
  "rand 0.9.2",
  "rand_xoshiro",
@@ -3566,9 +4365,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1cc4106ac0a0a512c398961ce95d8150475c84a84e17c4511c3643fa120a17"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-schema 57.3.0",
  "geo-traits",
  "geoarrow-schema",
  "num-traits",
@@ -3582,8 +4381,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa84300361ce57fb875bcaa6e32b95b0aff5c6b1af692b936bdd58ff343f4394"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
  "geo",
  "geo-traits",
  "geoarrow-array",
@@ -3596,7 +4395,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e97be4e9f523f92bd6a0e0458323f4b783d073d011664decd8dbf05651704f34"
 dependencies = [
- "arrow-schema",
+ "arrow-schema 57.3.0",
  "geo-traits",
  "serde",
  "serde_json",
@@ -3609,10 +4408,10 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cb8faa9b3bf4ae9f49b1f023b82d20626826f6448a7055498376146c10c4ead"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-schema",
- "datafusion",
+ "arrow-arith 57.3.0",
+ "arrow-array 57.3.0",
+ "arrow-schema 57.3.0",
+ "datafusion 52.4.0",
  "geo",
  "geo-traits",
  "geoarrow-array",
@@ -3689,6 +4488,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -4584,15 +5384,15 @@ version = "5.0.0-beta.5"
 dependencies = [
  "all_asserts",
  "approx",
- "arrow",
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-ipc",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
+ "arrow 58.1.0",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-row 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-recursion",
  "async-trait",
  "async_cell",
@@ -4607,11 +5407,11 @@ dependencies = [
  "criterion",
  "crossbeam-skiplist",
  "dashmap",
- "datafusion",
- "datafusion-expr",
- "datafusion-functions",
- "datafusion-physical-expr",
- "datafusion-physical-plan",
+ "datafusion 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-physical-expr 53.0.0",
+ "datafusion-physical-plan 53.0.0",
  "datafusion-substrait",
  "deepsize",
  "dirs 5.0.1",
@@ -4644,7 +5444,7 @@ dependencies = [
  "lzma-sys",
  "mock_instant",
  "moka",
- "object_store",
+ "object_store 0.13.2",
  "paste",
  "permutation",
  "pin-project",
@@ -4678,13 +5478,13 @@ dependencies = [
 name = "lance-arrow"
 version = "5.0.0-beta.5"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "bytes",
  "futures",
  "getrandom 0.2.17",
@@ -4696,15 +5496,15 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow-scalar"
-version = "57.0.0"
+version = "58.0.0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-row 58.1.0",
+ "arrow-schema 58.1.0",
  "half",
  "proptest",
  "rstest",
@@ -4712,11 +5512,11 @@ dependencies = [
 
 [[package]]
 name = "lance-arrow-stats"
-version = "57.0.0"
+version = "58.0.0"
 dependencies = [
- "arrow-array",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "half",
  "lance-arrow-scalar",
  "proptest",
@@ -4736,14 +5536,14 @@ dependencies = [
 name = "lance-core"
 version = "5.0.0-beta.5"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-schema 58.1.0",
  "async-trait",
  "byteorder",
  "bytes",
  "chrono",
- "datafusion-common",
+ "datafusion-common 53.0.0",
  "datafusion-sql",
  "deepsize",
  "futures",
@@ -4755,7 +5555,7 @@ dependencies = [
  "mock_instant",
  "moka",
  "num_cpus",
- "object_store",
+ "object_store 0.13.2",
  "pin-project",
  "proptest",
  "prost",
@@ -4776,18 +5576,18 @@ dependencies = [
 name = "lance-datafusion"
 version = "5.0.0-beta.5"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-trait",
  "chrono",
- "datafusion",
- "datafusion-common",
- "datafusion-functions",
- "datafusion-physical-expr",
+ "datafusion 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-functions 53.0.0",
+ "datafusion-physical-expr 53.0.0",
  "datafusion-substrait",
  "futures",
  "jsonb",
@@ -4810,10 +5610,10 @@ dependencies = [
 name = "lance-datagen"
 version = "5.0.0-beta.5"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-cast",
- "arrow-schema",
+ "arrow 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-schema 58.1.0",
  "chrono",
  "criterion",
  "futures",
@@ -4830,14 +5630,14 @@ dependencies = [
 name = "lance-encoding"
 version = "5.0.0-beta.5"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "bytemuck",
  "byteorder",
  "bytes",
@@ -4879,9 +5679,9 @@ name = "lance-examples"
 version = "5.0.0-beta.5"
 dependencies = [
  "all_asserts",
- "arrow",
- "arrow-schema",
- "arrow-select",
+ "arrow 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "clap",
  "env_logger",
  "futures",
@@ -4892,8 +5692,8 @@ dependencies = [
  "lance-datagen",
  "lance-index",
  "lance-linalg",
- "object_store",
- "parquet",
+ "object_store 0.13.2",
+ "parquet 57.3.0",
  "rand 0.9.2",
  "tempfile",
  "tokenizers",
@@ -4904,18 +5704,18 @@ dependencies = [
 name = "lance-file"
 version = "5.0.0-beta.5"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-recursion",
  "async-trait",
  "byteorder",
  "bytes",
  "criterion",
- "datafusion-common",
+ "datafusion-common 53.0.0",
  "deepsize",
  "futures",
  "lance-arrow",
@@ -4927,7 +5727,7 @@ dependencies = [
  "libc",
  "log",
  "num-traits",
- "object_store",
+ "object_store 0.13.2",
  "pprof",
  "pretty_assertions",
  "proptest",
@@ -4947,7 +5747,7 @@ dependencies = [
 name = "lance-geo"
 version = "5.0.0-beta.5"
 dependencies = [
- "datafusion",
+ "datafusion 53.0.0",
  "geo-traits",
  "geo-types",
  "geoarrow-array",
@@ -4962,12 +5762,12 @@ name = "lance-index"
 version = "5.0.0-beta.5"
 dependencies = [
  "approx",
- "arrow",
- "arrow-arith",
- "arrow-array",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow 58.1.0",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-ord 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-channel 2.5.0",
  "async-recursion",
  "async-trait",
@@ -4977,10 +5777,10 @@ dependencies = [
  "chrono",
  "criterion",
  "crossbeam-queue",
- "datafusion",
- "datafusion-common",
- "datafusion-expr",
- "datafusion-physical-expr",
+ "datafusion 53.0.0",
+ "datafusion-common 53.0.0",
+ "datafusion-expr 53.0.0",
+ "datafusion-physical-expr 53.0.0",
  "datafusion-sql",
  "deepsize",
  "dirs 6.0.0",
@@ -5013,7 +5813,7 @@ dependencies = [
  "log",
  "ndarray",
  "num-traits",
- "object_store",
+ "object_store 0.13.2",
  "pprof",
  "prost",
  "prost-build",
@@ -5042,14 +5842,14 @@ dependencies = [
 name = "lance-io"
 version = "5.0.0-beta.5"
 dependencies = [
- "arrow",
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow 58.1.0",
+ "arrow-arith 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-cast 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "async-recursion",
  "async-trait",
  "aws-config",
@@ -5070,7 +5870,7 @@ dependencies = [
  "mock_instant",
  "mockall",
  "moka",
- "object_store",
+ "object_store 0.13.2",
  "object_store_opendal",
  "opendal",
  "path_abs",
@@ -5094,9 +5894,9 @@ name = "lance-linalg"
 version = "5.0.0-beta.5"
 dependencies = [
  "approx",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-schema 58.1.0",
  "cc",
  "criterion",
  "deepsize",
@@ -5114,7 +5914,7 @@ dependencies = [
 name = "lance-namespace"
 version = "5.0.0-beta.5"
 dependencies = [
- "arrow",
+ "arrow 58.1.0",
  "async-trait",
  "bytes",
  "lance-core",
@@ -5129,12 +5929,12 @@ dependencies = [
 name = "lance-namespace-datafusion"
 version = "5.0.0-beta.5"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-schema",
+ "arrow 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-schema 58.1.0",
  "async-trait",
  "dashmap",
- "datafusion",
+ "datafusion 53.0.0",
  "datafusion-sql",
  "lance",
  "lance-namespace",
@@ -5147,9 +5947,9 @@ dependencies = [
 name = "lance-namespace-impls"
 version = "5.0.0-beta.5"
 dependencies = [
- "arrow",
- "arrow-ipc",
- "arrow-schema",
+ "arrow 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
  "async-trait",
  "aws-config",
  "aws-credential-types",
@@ -5172,7 +5972,7 @@ dependencies = [
  "lance-namespace",
  "lance-table",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "rand 0.9.2",
  "reqwest",
  "rstest",
@@ -5206,11 +6006,11 @@ dependencies = [
 name = "lance-table"
 version = "5.0.0-beta.5"
 dependencies = [
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ipc",
- "arrow-schema",
+ "arrow 58.1.0",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
  "async-trait",
  "aws-credential-types",
  "aws-sdk-dynamodb",
@@ -5226,7 +6026,7 @@ dependencies = [
  "lance-file",
  "lance-io",
  "log",
- "object_store",
+ "object_store 0.13.2",
  "pprof",
  "pretty_assertions",
  "proptest",
@@ -5261,8 +6061,8 @@ dependencies = [
 name = "lance-testing"
 version = "5.0.0-beta.5"
 dependencies = [
- "arrow-array",
- "arrow-schema",
+ "arrow-array 58.1.0",
+ "arrow-schema 58.1.0",
  "lance-arrow",
  "num-traits",
  "rand 0.9.2",
@@ -5276,7 +6076,7 @@ dependencies = [
  "lance-core",
  "lance-file",
  "lance-io",
- "object_store",
+ "object_store 0.13.2",
  "snafu",
  "tokio",
  "url",
@@ -5663,6 +6463,15 @@ name = "lz4_flex"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98c23545df7ecf1b16c303910a69b079e8e251d60f7dd2cc9b4177f2afaf1746"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db9a0d582c2874f68138a16ce1867e0ffde6c0bb0a0df85e1f36d04146db488a"
 dependencies = [
  "twox-hash",
 ]
@@ -6125,11 +6934,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
 dependencies = [
  "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "http 1.4.0",
+ "humantime",
+ "itertools 0.14.0",
+ "parking_lot",
+ "percent-encoding",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body-util",
  "httparse",
@@ -6139,11 +6974,11 @@ dependencies = [
  "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml 0.38.4",
- "rand 0.9.2",
+ "quick-xml 0.39.2",
+ "rand 0.10.0",
  "reqwest",
  "ring",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6166,7 +7001,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "object_store",
+ "object_store 0.12.5",
  "opendal",
  "pin-project",
  "tokio",
@@ -6377,13 +7212,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
 dependencies = [
  "ahash",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-data",
- "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 57.3.0",
+ "arrow-buffer 57.3.0",
+ "arrow-cast 57.3.0",
+ "arrow-data 57.3.0",
+ "arrow-ipc 57.3.0",
+ "arrow-schema 57.3.0",
+ "arrow-select 57.3.0",
+ "base64 0.22.1",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown 0.16.1",
+ "lz4_flex 0.12.1",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "parquet"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+dependencies = [
+ "ahash",
+ "arrow-array 58.1.0",
+ "arrow-buffer 58.1.0",
+ "arrow-data 58.1.0",
+ "arrow-ipc 58.1.0",
+ "arrow-schema 58.1.0",
+ "arrow-select 58.1.0",
  "base64 0.22.1",
  "brotli",
  "bytes",
@@ -6392,11 +7260,11 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.16.1",
- "lz4_flex 0.12.1",
+ "lz4_flex 0.13.0",
  "num-bigint",
  "num-integer",
  "num-traits",
- "object_store",
+ "object_store 0.13.2",
  "paste",
  "seq-macro",
  "simdutf8",
@@ -6980,6 +7848,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7096,6 +7974,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7151,6 +8040,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_distr"
@@ -8169,9 +9064,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.59.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4591acadbcf52f0af60eafbb2c003232b2b4cd8de5f0e9437cb8b1b59046cc0f"
+checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -8179,9 +9074,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8831,6 +9726,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,19 +73,19 @@ lance-test-macros = { version = "=5.0.0-beta.5", path = "./rust/lance-test-macro
 lance-testing = { version = "=5.0.0-beta.5", path = "./rust/lance-testing" }
 approx = "0.5.1"
 # Note that this one does not include pyarrow
-arrow = { version = "57.0.0", optional = false, features = ["prettyprint"] }
-lance-arrow-scalar = { version = "=57.0.0", path = "./rust/arrow-scalar" }
-lance-arrow-stats = { version = "=57.0.0", path = "./rust/arrow-stats" }
-arrow-arith = "57.0.0"
-arrow-array = "57.0.0"
-arrow-buffer = "57.0.0"
-arrow-cast = "57.0.0"
-arrow-data = "57.0.0"
-arrow-ipc = { version = "57.0.0", features = ["zstd"] }
-arrow-ord = "57.0.0"
-arrow-row = "57.0.0"
-arrow-schema = "57.0.0"
-arrow-select = "57.0.0"
+arrow = { version = "58.0.0", optional = false, features = ["prettyprint"] }
+lance-arrow-scalar = { version = "=58.0.0", path = "./rust/arrow-scalar" }
+lance-arrow-stats = { version = "=58.0.0", path = "./rust/arrow-stats" }
+arrow-arith = "58.0.0"
+arrow-array = "58.0.0"
+arrow-buffer = "58.0.0"
+arrow-cast = "58.0.0"
+arrow-data = "58.0.0"
+arrow-ipc = { version = "58.0.0", features = ["zstd"] }
+arrow-ord = "58.0.0"
+arrow-row = "58.0.0"
+arrow-schema = "58.0.0"
+arrow-select = "58.0.0"
 async-recursion = "1.0"
 async-trait = "0.1"
 axum = "0.7"
@@ -114,7 +114,7 @@ criterion = { version = "0.5", features = [
 ] }
 crossbeam-queue = "0.3"
 crossbeam-skiplist = "0.1"
-datafusion = { version = "52.1.0", default-features = false, features = [
+datafusion = { version = "53.0.0", default-features = false, features = [
     "crypto_expressions",
     "datetime_expressions",
     "encoding_expressions",
@@ -124,16 +124,16 @@ datafusion = { version = "52.1.0", default-features = false, features = [
     "string_expressions",
     "unicode_expressions",
 ] }
-datafusion-common = "52.1.0"
-datafusion-functions = { version = "52.1.0", features = ["regex_expressions"] }
-datafusion-sql = "52.1.0"
-datafusion-expr = "52.1.0"
-datafusion-ffi = "52.1.0"
-datafusion-execution = "52.1.0"
-datafusion-optimizer = "52.1.0"
-datafusion-physical-expr = "52.1.0"
-datafusion-physical-plan = "52.1.0"
-datafusion-substrait = "52.1.0"
+datafusion-common = "53.0.0"
+datafusion-functions = { version = "53.0.0", features = ["regex_expressions"] }
+datafusion-sql = "53.0.0"
+datafusion-expr = "53.0.0"
+datafusion-ffi = "53.0.0"
+datafusion-execution = "53.0.0"
+datafusion-optimizer = "53.0.0"
+datafusion-physical-expr = "53.0.0"
+datafusion-physical-plan = "53.0.0"
+datafusion-substrait = "53.0.0"
 deepsize = "0.2.0"
 dirs = "6.0.0"
 either = "1.0"
@@ -159,7 +159,7 @@ mock_instant = { version = "0.6.0" }
 moka = { version = "0.12", features = ["future", "sync"] }
 ndarray = { version = "0.16.1", features = ["matrixmultiply-threading"] }
 num-traits = "0.2"
-object_store = { version = "0.12.3" }
+object_store = { version = "0.13" }
 opendal = { version = "0.55" }
 object_store_opendal = { version = "0.55" }
 pin-project = "1.0"

--- a/rust/arrow-scalar/Cargo.toml
+++ b/rust/arrow-scalar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lance-arrow-scalar"
-version = "57.0.0"
+version = "58.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/rust/arrow-stats/Cargo.toml
+++ b/rust/arrow-stats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lance-arrow-stats"
-version = "57.0.0"
+version = "58.0.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/rust/lance-core/src/utils/testing.rs
+++ b/rust/lance-core/src/utils/testing.rs
@@ -10,8 +10,8 @@ use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
 use object_store::{
-    Error as OSError, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as OSResult,
+    CopyOptions, Error as OSError, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as OSResult,
 };
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -147,25 +147,9 @@ impl ObjectStore for ProxyObjectStore {
         self.target.get_opts(location, options).await
     }
 
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> OSResult<Bytes> {
-        self.before_method("get_range", location)?;
-        self.target.get_range(location, range).await
-    }
-
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
         self.before_method("get_ranges", location)?;
         self.target.get_ranges(location, ranges).await
-    }
-
-    async fn head(&self, location: &Path) -> OSResult<ObjectMeta> {
-        self.before_method("head", location)?;
-        let meta = self.target.head(location).await?;
-        self.transform_meta("head", meta)
-    }
-
-    async fn delete(&self, location: &Path) -> OSResult<()> {
-        self.before_method("delete", location)?;
-        self.target.delete(location).await
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
@@ -189,18 +173,15 @@ impl ObjectStore for ProxyObjectStore {
         self.target.list_with_delimiter(prefix).await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> OSResult<()> {
+    async fn copy_opts(&self, from: &Path, to: &Path, opts: CopyOptions) -> OSResult<()> {
         self.before_method("copy", from)?;
-        self.target.copy(from, to).await
+        self.target.copy_opts(from, to, opts).await
     }
 
-    async fn rename(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.before_method("rename", from)?;
-        self.target.rename(from, to).await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.before_method("copy_if_not_exists", from)?;
-        self.target.copy_if_not_exists(from, to).await
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, OSResult<Path>>,
+    ) -> BoxStream<'static, OSResult<Path>> {
+        self.target.delete_stream(locations)
     }
 }

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -71,7 +71,7 @@ pub struct OneShotExec {
     // We save off a copy of the schema to speed up formatting and so ExecutionPlan::schema & display_as
     // can still function after exhausted
     schema: Arc<ArrowSchema>,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
 }
 
 impl OneShotExec {
@@ -81,12 +81,12 @@ impl OneShotExec {
         Self {
             stream: Mutex::new(Some(stream)),
             schema: schema.clone(),
-            properties: PlanProperties::new(
+            properties: Arc::new(PlanProperties::new(
                 EquivalenceProperties::new(schema),
                 Partitioning::RoundRobinBatch(1),
                 EmissionType::Incremental,
                 Boundedness::Bounded,
-            ),
+            )),
         }
     }
 
@@ -195,18 +195,14 @@ impl ExecutionPlan for OneShotExec {
         }
     }
 
-    fn statistics(&self) -> datafusion_common::Result<datafusion_common::Statistics> {
-        Ok(Statistics::new_unknown(&self.schema))
-    }
-
-    fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 }
 
 struct TracedExec {
     input: Arc<dyn ExecutionPlan>,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     span: Span,
 }
 
@@ -250,7 +246,7 @@ impl ExecutionPlan for TracedExec {
         self
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 
@@ -892,7 +888,7 @@ impl ExecutionPlan for StrictBatchSizeExec {
         self
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         self.input.properties()
     }
 

--- a/rust/lance-datafusion/src/planner.rs
+++ b/rust/lance-datafusion/src/planner.rs
@@ -39,7 +39,6 @@ use datafusion::sql::sqlparser::ast::{
 use datafusion::{
     common::Column,
     logical_expr::{Between, BinaryExpr, Like, Operator},
-    physical_expr::execution_props::ExecutionProps,
     physical_plan::PhysicalExpr,
     prelude::Expr,
     scalar::ScalarValue,
@@ -49,7 +48,6 @@ use lance_arrow::cast::cast_with_options;
 use lance_core::datatypes::Schema;
 use lance_core::error::LanceOptionExt;
 
-use chrono::Utc;
 use lance_core::{Error, Result};
 
 /// Encode a JSON string into a JSONB `LargeBinary` literal expression.
@@ -340,7 +338,7 @@ impl Planner {
 
     fn unary_expr(&self, op: &UnaryOperator, expr: &SQLExpr) -> Result<Expr> {
         Ok(match op {
-            UnaryOperator::Not | UnaryOperator::PGBitwiseNot => {
+            UnaryOperator::Not | UnaryOperator::BitwiseNot => {
                 Expr::Not(Box::new(self.parse_sql_expr(expr)?))
             }
 
@@ -920,8 +918,7 @@ impl Planner {
 
         // DataFusion needs the simplify and coerce passes to be applied before
         // expressions can be handled by the physical planner.
-        let props = ExecutionProps::new().with_query_execution_start_time(Utc::now());
-        let simplify_context = SimplifyContext::new(&props).with_schema(df_schema.clone());
+        let simplify_context = SimplifyContext::default().with_schema(df_schema.clone());
         let simplifier =
             datafusion::optimizer::simplify_expressions::ExprSimplifier::new(simplify_context);
 

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -587,6 +587,9 @@ impl Ord for OrderableScalarValue {
             (Union(_, _, _), _) => todo!("Support for union scalars"),
             (Null, Null) => Ordering::Equal,
             (Null, _) => todo!(),
+            (RunEndEncoded(_, _, _), _) => {
+                todo!("Support for RunEndEncoded scalars")
+            }
         }
     }
 }

--- a/rust/lance-io/src/object_reader.rs
+++ b/rust/lance-io/src/object_reader.rs
@@ -18,7 +18,7 @@ use futures::{
     stream::{self, StreamExt},
 };
 use lance_core::{Error, Result, error::CloneableError};
-use object_store::{GetOptions, GetResult, ObjectStore, Result as OSResult, path::Path};
+use object_store::{GetOptions, GetResult, ObjectStore, ObjectStoreExt as _, Result as OSResult, path::Path};
 use tokio::sync::OnceCell;
 use tracing::instrument;
 
@@ -176,7 +176,7 @@ impl Reader for CloudObjectReader {
         Box::pin(async move {
             self.size
                 .get_or_try_init(|| async move {
-                    let meta = do_with_retry(|| self.object_store.head(&self.path)).await?;
+                    let meta = do_with_retry(|| Box::pin(self.object_store.head(&self.path))).await?;
                     Ok(meta.size as usize)
                 })
                 .await

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -25,7 +25,7 @@ use object_store::Error as ObjectStoreError;
 use object_store::aws::AwsCredentialProvider;
 #[cfg(any(feature = "aws", feature = "azure", feature = "gcp"))]
 use object_store::{ClientOptions, HeaderMap, HeaderValue};
-use object_store::{ObjectMeta, ObjectStore as OSObjectStore, path::Path};
+use object_store::{ObjectMeta, ObjectStore as OSObjectStore, ObjectStoreExt as _, path::Path};
 use providers::local::FileStoreProvider;
 use providers::memory::MemoryStoreProvider;
 use tokio::io::AsyncWriteExt;
@@ -827,10 +827,10 @@ impl ObjectStore {
         Ok(())
     }
 
-    pub fn remove_stream<'a>(
-        &'a self,
-        locations: BoxStream<'a, Result<Path>>,
-    ) -> BoxStream<'a, Result<Path>> {
+    pub fn remove_stream(
+        &self,
+        locations: BoxStream<'static, Result<Path>>,
+    ) -> BoxStream<'static, Result<Path>> {
         self.inner
             .delete_stream(locations.err_into::<ObjectStoreError>().boxed())
             .err_into::<Error>()

--- a/rust/lance-io/src/object_store/list_retry.rs
+++ b/rust/lance-io/src/object_store/list_retry.rs
@@ -43,7 +43,7 @@ impl ListRetryStream {
             object_store::Error::NotFound { .. }
                 | object_store::Error::InvalidPath { .. }
                 | object_store::Error::NotSupported { .. }
-                | object_store::Error::NotImplemented
+                | object_store::Error::NotImplemented { .. }
         )
     }
 }

--- a/rust/lance-io/src/object_store/throttle.rs
+++ b/rust/lance-io/src/object_store/throttle.rs
@@ -32,7 +32,7 @@ use futures::stream::BoxStream;
 use lance_core::utils::aimd::{AimdConfig, AimdController, RequestOutcome};
 use object_store::path::Path;
 use object_store::{
-    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
     PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as OSResult, UploadPart,
 };
 use rand::Rng;
@@ -615,12 +615,6 @@ impl AimdThrottledStore {
 #[async_trait]
 #[deny(clippy::missing_trait_methods)]
 impl ObjectStore for AimdThrottledStore {
-    async fn put(&self, location: &Path, bytes: PutPayload) -> OSResult<PutResult> {
-        self.write
-            .throttled(|| self.target.put(location, bytes.clone()))
-            .await
-    }
-
     async fn put_opts(
         &self,
         location: &Path,
@@ -630,17 +624,6 @@ impl ObjectStore for AimdThrottledStore {
         self.write
             .throttled(|| self.target.put_opts(location, bytes.clone(), opts.clone()))
             .await
-    }
-
-    async fn put_multipart(&self, location: &Path) -> OSResult<Box<dyn MultipartUpload>> {
-        let target = self
-            .write
-            .throttled(|| self.target.put_multipart(location))
-            .await?;
-        Ok(Box::new(ThrottledMultipartUpload {
-            target,
-            write: Arc::clone(&self.write),
-        }))
     }
 
     async fn put_multipart_opts(
@@ -658,19 +641,9 @@ impl ObjectStore for AimdThrottledStore {
         }))
     }
 
-    async fn get(&self, location: &Path) -> OSResult<GetResult> {
-        self.read.throttled(|| self.target.get(location)).await
-    }
-
     async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
         self.read
             .throttled(|| self.target.get_opts(location, options.clone()))
-            .await
-    }
-
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> OSResult<Bytes> {
-        self.read
-            .throttled(|| self.target.get_range(location, range.clone()))
             .await
     }
 
@@ -680,25 +653,24 @@ impl ObjectStore for AimdThrottledStore {
             .await
     }
 
-    async fn head(&self, location: &Path) -> OSResult<ObjectMeta> {
-        self.read.throttled(|| self.target.head(location)).await
-    }
-
-    async fn delete(&self, location: &Path) -> OSResult<()> {
-        self.delete.throttled(|| self.target.delete(location)).await
-    }
-
-    fn delete_stream<'a>(
-        &'a self,
-        locations: BoxStream<'a, OSResult<Path>>,
-    ) -> BoxStream<'a, OSResult<Path>> {
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, OSResult<Path>>,
+    ) -> BoxStream<'static, OSResult<Path>> {
+        let throttle = Arc::clone(&self.delete);
         self.target
             .delete_stream(locations)
-            .map(|item| {
-                self.delete.observe_outcome(&item);
+            .map(move |item| {
+                throttle.observe_outcome(&item);
                 item
             })
             .boxed()
+    }
+
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> OSResult<()> {
+        self.write
+            .throttled(|| self.target.copy_opts(from, to, options.clone()))
+            .await
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
@@ -733,30 +705,12 @@ impl ObjectStore for AimdThrottledStore {
             .await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.write.throttled(|| self.target.copy(from, to)).await
-    }
-
-    async fn rename(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.write.throttled(|| self.target.rename(from, to)).await
-    }
-
-    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.write
-            .throttled(|| self.target.rename_if_not_exists(from, to))
-            .await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.write
-            .throttled(|| self.target.copy_if_not_exists(from, to))
-            .await
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use object_store::ObjectStoreExt as _;
     use object_store::memory::InMemory;
     use rstest::rstest;
     use std::collections::VecDeque;
@@ -966,9 +920,6 @@ mod tests {
 
     #[async_trait]
     impl ObjectStore for ThrottlingListMockStore {
-        async fn put(&self, location: &Path, bytes: PutPayload) -> OSResult<PutResult> {
-            self.inner.put(location, bytes).await
-        }
         async fn put_opts(
             &self,
             location: &Path,
@@ -977,9 +928,6 @@ mod tests {
         ) -> OSResult<PutResult> {
             self.inner.put_opts(location, bytes, opts).await
         }
-        async fn put_multipart(&self, location: &Path) -> OSResult<Box<dyn MultipartUpload>> {
-            self.inner.put_multipart(location).await
-        }
         async fn put_multipart_opts(
             &self,
             location: &Path,
@@ -987,29 +935,20 @@ mod tests {
         ) -> OSResult<Box<dyn MultipartUpload>> {
             self.inner.put_multipart_opts(location, opts).await
         }
-        async fn get(&self, location: &Path) -> OSResult<GetResult> {
-            self.inner.get(location).await
-        }
         async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
             self.inner.get_opts(location, options).await
-        }
-        async fn get_range(&self, location: &Path, range: Range<u64>) -> OSResult<Bytes> {
-            self.inner.get_range(location, range).await
         }
         async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
             self.inner.get_ranges(location, ranges).await
         }
-        async fn head(&self, location: &Path) -> OSResult<ObjectMeta> {
-            self.inner.head(location).await
-        }
-        async fn delete(&self, location: &Path) -> OSResult<()> {
-            self.inner.delete(location).await
-        }
-        fn delete_stream<'a>(
-            &'a self,
-            locations: BoxStream<'a, OSResult<Path>>,
-        ) -> BoxStream<'a, OSResult<Path>> {
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, OSResult<Path>>,
+        ) -> BoxStream<'static, OSResult<Path>> {
             self.inner.delete_stream(locations)
+        }
+        async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> OSResult<()> {
+            self.inner.copy_opts(from, to, options).await
         }
         fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
             let n = self.throttle_count;
@@ -1032,18 +971,6 @@ mod tests {
         }
         async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
             self.inner.list_with_delimiter(prefix).await
-        }
-        async fn copy(&self, from: &Path, to: &Path) -> OSResult<()> {
-            self.inner.copy(from, to).await
-        }
-        async fn rename(&self, from: &Path, to: &Path) -> OSResult<()> {
-            self.inner.rename(from, to).await
-        }
-        async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-            self.inner.rename_if_not_exists(from, to).await
-        }
-        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-            self.inner.copy_if_not_exists(from, to).await
         }
     }
 
@@ -1216,10 +1143,6 @@ mod tests {
 
     #[async_trait]
     impl ObjectStore for RateLimitingMockStore {
-        async fn put(&self, location: &Path, bytes: PutPayload) -> OSResult<PutResult> {
-            self.inner.put(location, bytes).await
-        }
-
         async fn put_opts(
             &self,
             location: &Path,
@@ -1227,10 +1150,6 @@ mod tests {
             opts: PutOptions,
         ) -> OSResult<PutResult> {
             self.inner.put_opts(location, bytes, opts).await
-        }
-
-        async fn put_multipart(&self, location: &Path) -> OSResult<Box<dyn MultipartUpload>> {
-            self.inner.put_multipart(location).await
         }
 
         async fn put_multipart_opts(
@@ -1241,25 +1160,9 @@ mod tests {
             self.inner.put_multipart_opts(location, opts).await
         }
 
-        async fn get(&self, location: &Path) -> OSResult<GetResult> {
-            if self.check_rate() {
-                self.inner.get(location).await
-            } else {
-                Err(Self::throttle_error())
-            }
-        }
-
         async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
             if self.check_rate() {
                 self.inner.get_opts(location, options).await
-            } else {
-                Err(Self::throttle_error())
-            }
-        }
-
-        async fn get_range(&self, location: &Path, range: Range<u64>) -> OSResult<Bytes> {
-            if self.check_rate() {
-                self.inner.get_range(location, range).await
             } else {
                 Err(Self::throttle_error())
             }
@@ -1273,23 +1176,15 @@ mod tests {
             }
         }
 
-        async fn head(&self, location: &Path) -> OSResult<ObjectMeta> {
-            if self.check_rate() {
-                self.inner.head(location).await
-            } else {
-                Err(Self::throttle_error())
-            }
-        }
-
-        async fn delete(&self, location: &Path) -> OSResult<()> {
-            self.inner.delete(location).await
-        }
-
-        fn delete_stream<'a>(
-            &'a self,
-            locations: BoxStream<'a, OSResult<Path>>,
-        ) -> BoxStream<'a, OSResult<Path>> {
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, OSResult<Path>>,
+        ) -> BoxStream<'static, OSResult<Path>> {
             self.inner.delete_stream(locations)
+        }
+
+        async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> OSResult<()> {
+            self.inner.copy_opts(from, to, options).await
         }
 
         fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
@@ -1306,22 +1201,6 @@ mod tests {
 
         async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
             self.inner.list_with_delimiter(prefix).await
-        }
-
-        async fn copy(&self, from: &Path, to: &Path) -> OSResult<()> {
-            self.inner.copy(from, to).await
-        }
-
-        async fn rename(&self, from: &Path, to: &Path) -> OSResult<()> {
-            self.inner.rename(from, to).await
-        }
-
-        async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-            self.inner.rename_if_not_exists(from, to).await
-        }
-
-        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-            self.inner.copy_if_not_exists(from, to).await
         }
     }
 
@@ -1460,9 +1339,6 @@ mod tests {
 
     #[async_trait]
     impl ObjectStore for RetryTestMockStore {
-        async fn put(&self, location: &Path, bytes: PutPayload) -> OSResult<PutResult> {
-            self.inner.put(location, bytes).await
-        }
         async fn put_opts(
             &self,
             location: &Path,
@@ -1471,9 +1347,6 @@ mod tests {
         ) -> OSResult<PutResult> {
             self.inner.put_opts(location, bytes, opts).await
         }
-        async fn put_multipart(&self, location: &Path) -> OSResult<Box<dyn MultipartUpload>> {
-            self.inner.put_multipart(location).await
-        }
         async fn put_multipart_opts(
             &self,
             location: &Path,
@@ -1481,7 +1354,7 @@ mod tests {
         ) -> OSResult<Box<dyn MultipartUpload>> {
             self.inner.put_multipart_opts(location, opts).await
         }
-        async fn get(&self, location: &Path) -> OSResult<GetResult> {
+        async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
             self.get_call_count.fetch_add(1, Ordering::Relaxed);
             let should_error = {
                 let mut remaining = self.errors_remaining.lock().unwrap();
@@ -1499,29 +1372,20 @@ mod tests {
                         .into(),
                 })
             } else {
-                self.inner.get(location).await
+                self.inner.get_opts(location, options).await
             }
-        }
-        async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
-            self.inner.get_opts(location, options).await
-        }
-        async fn get_range(&self, location: &Path, range: Range<u64>) -> OSResult<Bytes> {
-            self.inner.get_range(location, range).await
         }
         async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
             self.inner.get_ranges(location, ranges).await
         }
-        async fn head(&self, location: &Path) -> OSResult<ObjectMeta> {
-            self.inner.head(location).await
-        }
-        async fn delete(&self, location: &Path) -> OSResult<()> {
-            self.inner.delete(location).await
-        }
-        fn delete_stream<'a>(
-            &'a self,
-            locations: BoxStream<'a, OSResult<Path>>,
-        ) -> BoxStream<'a, OSResult<Path>> {
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, OSResult<Path>>,
+        ) -> BoxStream<'static, OSResult<Path>> {
             self.inner.delete_stream(locations)
+        }
+        async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> OSResult<()> {
+            self.inner.copy_opts(from, to, options).await
         }
         fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
             self.inner.list(prefix)
@@ -1535,18 +1399,6 @@ mod tests {
         }
         async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
             self.inner.list_with_delimiter(prefix).await
-        }
-        async fn copy(&self, from: &Path, to: &Path) -> OSResult<()> {
-            self.inner.copy(from, to).await
-        }
-        async fn rename(&self, from: &Path, to: &Path) -> OSResult<()> {
-            self.inner.rename(from, to).await
-        }
-        async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-            self.inner.rename_if_not_exists(from, to).await
-        }
-        async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-            self.inner.copy_if_not_exists(from, to).await
         }
     }
 

--- a/rust/lance-io/src/object_store/tracing.rs
+++ b/rust/lance-io/src/object_store/tracing.rs
@@ -12,8 +12,8 @@ use futures::stream::BoxStream;
 use lance_core::utils::tracing::StreamTracingExt;
 use object_store::path::Path;
 use object_store::{
-    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, PutMultipartOptions,
-    PutOptions, PutPayload, PutResult, Result as OSResult, UploadPart,
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as OSResult, UploadPart,
 };
 use tracing::{Instrument, Span, instrument};
 
@@ -61,11 +61,6 @@ impl std::fmt::Display for TracedObjectStore {
 #[deny(clippy::missing_trait_methods)]
 impl object_store::ObjectStore for TracedObjectStore {
     #[instrument(level = "debug", skip(self, bytes, location), fields(path = location.as_ref(), size = bytes.content_length()))]
-    async fn put(&self, location: &Path, bytes: PutPayload) -> OSResult<PutResult> {
-        self.target.put(location, bytes).await
-    }
-
-    #[instrument(level = "debug", skip(self, bytes, location), fields(path = location.as_ref(), size = bytes.content_length()))]
     async fn put_opts(
         &self,
         location: &Path,
@@ -73,19 +68,6 @@ impl object_store::ObjectStore for TracedObjectStore {
         opts: PutOptions,
     ) -> OSResult<PutResult> {
         self.target.put_opts(location, bytes, opts).await
-    }
-
-    #[instrument(level = "debug", skip(self, location), fields(path = location.as_ref(), size = tracing::field::Empty))]
-    async fn put_multipart(
-        &self,
-        location: &Path,
-    ) -> OSResult<Box<dyn object_store::MultipartUpload>> {
-        let upload = self.target.put_multipart(location).await?;
-        Ok(Box::new(TracedMultipartUpload {
-            target: upload,
-            write_span: tracing::Span::current(),
-            write_size: 0,
-        }))
     }
 
     #[instrument(level = "debug", skip(self, location), fields(path = location.as_ref(), size = tracing::field::Empty))]
@@ -102,16 +84,6 @@ impl object_store::ObjectStore for TracedObjectStore {
         }))
     }
 
-    #[instrument(level = "debug", skip(self, location), fields(path = location.as_ref(), size = tracing::field::Empty))]
-    async fn get(&self, location: &Path) -> OSResult<GetResult> {
-        let res = self.target.get(location).await?;
-
-        let span = tracing::Span::current();
-        span.record("size", res.meta.size);
-
-        Ok(res)
-    }
-
     #[instrument(level = "debug", skip(self, options, location), fields(path = location.as_ref(), size = tracing::field::Empty))]
     async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
         let res = self.target.get_opts(location, options).await?;
@@ -122,35 +94,25 @@ impl object_store::ObjectStore for TracedObjectStore {
         Ok(res)
     }
 
-    #[instrument(level = "debug", skip(self, location), fields(path = location.as_ref(), size = range.end - range.start))]
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> OSResult<Bytes> {
-        self.target.get_range(location, range).await
-    }
-
     #[instrument(level = "debug", skip(self, location), fields(path = location.as_ref(), size = ranges.iter().map(|r| r.end - r.start).sum::<u64>()))]
     async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
         self.target.get_ranges(location, ranges).await
     }
 
-    #[instrument(level = "debug", skip(self, location), fields(path = location.as_ref()))]
-    async fn head(&self, location: &Path) -> OSResult<ObjectMeta> {
-        self.target.head(location).await
-    }
-
-    #[instrument(level = "debug", skip(self, location), fields(path = location.as_ref()))]
-    async fn delete(&self, location: &Path) -> OSResult<()> {
-        self.target.delete(location).await
-    }
-
     #[instrument(level = "debug", skip_all)]
-    fn delete_stream<'a>(
-        &'a self,
-        locations: BoxStream<'a, OSResult<Path>>,
-    ) -> BoxStream<'a, OSResult<Path>> {
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, OSResult<Path>>,
+    ) -> BoxStream<'static, OSResult<Path>> {
         self.target
             .delete_stream(locations)
             .stream_in_current_span()
             .boxed()
+    }
+
+    #[instrument(level = "debug", skip(self, from, to), fields(from = from.as_ref(), to = to.as_ref()))]
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> OSResult<()> {
+        self.target.copy_opts(from, to, options).await
     }
 
     #[instrument(level = "debug", skip(self, prefix), fields(prefix = prefix.map(|p| p.as_ref())))]
@@ -175,25 +137,6 @@ impl object_store::ObjectStore for TracedObjectStore {
         self.target.list_with_delimiter(prefix).await
     }
 
-    #[instrument(level = "debug", skip(self, from, to), fields(from = from.as_ref(), to = to.as_ref()))]
-    async fn copy(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.target.copy(from, to).await
-    }
-
-    #[instrument(level = "debug", skip(self, from, to), fields(from = from.as_ref(), to = to.as_ref()))]
-    async fn rename(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.target.rename(from, to).await
-    }
-
-    #[instrument(level = "debug", skip(self, from, to), fields(from = from.as_ref(), to = to.as_ref()))]
-    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.target.rename_if_not_exists(from, to).await
-    }
-
-    #[instrument(level = "debug", skip(self, from, to), fields(from = from.as_ref(), to = to.as_ref()))]
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-        self.target.copy_if_not_exists(from, to).await
-    }
 }
 
 pub trait ObjectStoreTracingExt {
@@ -217,6 +160,7 @@ mod tests {
     use super::*;
 
     use bytes::Bytes;
+    use object_store::ObjectStoreExt as _;
     use object_store::PutPayload;
     use object_store::memory::InMemory;
     use object_store::path::Path;

--- a/rust/lance-io/src/object_writer.rs
+++ b/rust/lance-io/src/object_writer.rs
@@ -12,7 +12,7 @@ use bytes::Bytes;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use object_store::MultipartUpload;
-use object_store::{Error as OSError, ObjectStore, Result as OSResult, path::Path};
+use object_store::{Error as OSError, ObjectStore, ObjectStoreExt as _, Result as OSResult, path::Path};
 use rand::Rng;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::task::JoinSet;

--- a/rust/lance-io/src/utils/tracking_store.rs
+++ b/rust/lance-io/src/utils/tracking_store.rs
@@ -18,8 +18,9 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use object_store::path::Path;
 use object_store::{
-    GetOptions, GetRange, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
-    PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as OSResult, UploadPart,
+    CopyOptions, GetOptions, GetRange, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as OSResult,
+    UploadPart,
 };
 
 use crate::object_store::WrappingObjectStore;
@@ -294,12 +295,6 @@ impl IoTrackingStore {
 #[async_trait::async_trait]
 #[deny(clippy::missing_trait_methods)]
 impl ObjectStore for IoTrackingStore {
-    async fn put(&self, location: &Path, bytes: PutPayload) -> OSResult<PutResult> {
-        let _guard = self.stage_guard();
-        self.record_write("put", location.to_owned(), bytes.content_length() as u64);
-        self.target.put(location, bytes).await
-    }
-
     async fn put_opts(
         &self,
         location: &Path,
@@ -313,19 +308,6 @@ impl ObjectStore for IoTrackingStore {
             bytes.content_length() as u64,
         );
         self.target.put_opts(location, bytes, opts).await
-    }
-
-    async fn put_multipart(&self, location: &Path) -> OSResult<Box<dyn MultipartUpload>> {
-        let _guard = self.stage_guard();
-        let target = self.target.put_multipart(location).await?;
-        Ok(Box::new(IoTrackingMultipartUpload {
-            target,
-            stats: self.stats.clone(),
-            #[cfg(feature = "test-util")]
-            path: location.to_owned(),
-            #[cfg(feature = "test-util")]
-            _guard,
-        }))
     }
 
     async fn put_multipart_opts(
@@ -345,16 +327,6 @@ impl ObjectStore for IoTrackingStore {
         }))
     }
 
-    async fn get(&self, location: &Path) -> OSResult<GetResult> {
-        let _guard = self.stage_guard();
-        let result = self.target.get(location).await;
-        if let Ok(result) = &result {
-            let num_bytes = result.range.end - result.range.start;
-            self.record_read("get", location.to_owned(), num_bytes, None);
-        }
-        result
-    }
-
     async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
         let _guard = self.stage_guard();
         let range = match &options.range {
@@ -366,20 +338,6 @@ impl ObjectStore for IoTrackingStore {
             let num_bytes = result.range.end - result.range.start;
 
             self.record_read("get_opts", location.to_owned(), num_bytes, range);
-        }
-        result
-    }
-
-    async fn get_range(&self, location: &Path, range: Range<u64>) -> OSResult<Bytes> {
-        let _guard = self.stage_guard();
-        let result = self.target.get_range(location, range.clone()).await;
-        if let Ok(result) = &result {
-            self.record_read(
-                "get_range",
-                location.to_owned(),
-                result.len() as u64,
-                Some(range),
-            );
         }
         result
     }
@@ -398,23 +356,17 @@ impl ObjectStore for IoTrackingStore {
         result
     }
 
-    async fn head(&self, location: &Path) -> OSResult<ObjectMeta> {
-        let _guard = self.stage_guard();
-        self.record_read("head", location.to_owned(), 0, None);
-        self.target.head(location).await
-    }
-
-    async fn delete(&self, location: &Path) -> OSResult<()> {
-        let _guard = self.stage_guard();
-        self.record_write("delete", location.to_owned(), 0);
-        self.target.delete(location).await
-    }
-
-    fn delete_stream<'a>(
-        &'a self,
-        locations: BoxStream<'a, OSResult<Path>>,
-    ) -> BoxStream<'a, OSResult<Path>> {
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, OSResult<Path>>,
+    ) -> BoxStream<'static, OSResult<Path>> {
         self.target.delete_stream(locations)
+    }
+
+    async fn copy_opts(&self, from: &Path, to: &Path, options: CopyOptions) -> OSResult<()> {
+        let _guard = self.stage_guard();
+        self.record_write("copy_opts", from.to_owned(), 0);
+        self.target.copy_opts(from, to, options).await
     }
 
     fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
@@ -448,29 +400,6 @@ impl ObjectStore for IoTrackingStore {
         self.target.list_with_delimiter(prefix).await
     }
 
-    async fn copy(&self, from: &Path, to: &Path) -> OSResult<()> {
-        let _guard = self.stage_guard();
-        self.record_write("copy", from.to_owned(), 0);
-        self.target.copy(from, to).await
-    }
-
-    async fn rename(&self, from: &Path, to: &Path) -> OSResult<()> {
-        let _guard = self.stage_guard();
-        self.record_write("rename", from.to_owned(), 0);
-        self.target.rename(from, to).await
-    }
-
-    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-        let _guard = self.stage_guard();
-        self.record_write("rename_if_not_exists", from.to_owned(), 0);
-        self.target.rename_if_not_exists(from, to).await
-    }
-
-    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> OSResult<()> {
-        let _guard = self.stage_guard();
-        self.record_write("copy_if_not_exists", from.to_owned(), 0);
-        self.target.copy_if_not_exists(from, to).await
-    }
 }
 
 #[derive(Debug)]

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -31,7 +31,10 @@ use lance_io::object_store::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry
 use lance_linalg::distance::MetricType;
 use lance_table::io::commit::ManifestNamingScheme;
 use object_store::path::Path;
-use object_store::{Error as ObjectStoreError, ObjectStore as OSObjectStore, PutMode, PutOptions};
+use object_store::{
+    Error as ObjectStoreError, ObjectStore as OSObjectStore, ObjectStoreExt as _, PutMode,
+    PutOptions,
+};
 use std::collections::HashMap;
 use std::io::Cursor;
 use std::sync::{Arc, Mutex};

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -40,7 +40,10 @@ use lance_file::format::{MAGIC, MAJOR_VERSION, MINOR_VERSION};
 use lance_io::object_writer::{ObjectWriter, WriteResult, get_etag};
 use log::warn;
 use object_store::PutOptions;
-use object_store::{Error as ObjectStoreError, ObjectStore as OSObjectStore, path::Path};
+use object_store::{
+    Error as ObjectStoreError, ObjectStore as OSObjectStore, ObjectStoreExt as _,
+    RenameOptions, RenameTargetMode, path::Path,
+};
 use tracing::info;
 use url::Url;
 
@@ -1011,7 +1014,7 @@ impl CommitHandler for RenameCommitHandler {
         naming_scheme: ManifestNamingScheme,
         transaction: Option<Transaction>,
     ) -> std::result::Result<ManifestLocation, CommitError> {
-        // Create a temporary object, then use `rename_if_not_exists` to commit.
+        // Create a temporary object, then use `rename_opts` to commit.
         // If failed, clean up the temporary object.
 
         let path = naming_scheme.manifest_path(base_path, manifest.version);
@@ -1021,7 +1024,14 @@ impl CommitHandler for RenameCommitHandler {
 
         match object_store
             .inner
-            .rename_if_not_exists(&tmp_path, &path)
+            .rename_opts(
+                &tmp_path,
+                &path,
+                RenameOptions {
+                    target_mode: RenameTargetMode::Create,
+                    ..Default::default()
+                },
+            )
             .await
         {
             Ok(_) => {

--- a/rust/lance-table/src/io/commit/external_manifest.rs
+++ b/rust/lance-table/src/io/commit/external_manifest.rs
@@ -15,7 +15,9 @@ use lance_core::{Error, Result};
 use lance_io::object_store::ObjectStore;
 use log::warn;
 use object_store::ObjectMeta;
-use object_store::{Error as ObjectStoreError, ObjectStore as OSObjectStore, path::Path};
+use object_store::{
+    Error as ObjectStoreError, ObjectStore as OSObjectStore, ObjectStoreExt as _, path::Path,
+};
 use tracing::info;
 
 use super::{

--- a/rust/lance-table/src/io/manifest.rs
+++ b/rust/lance-table/src/io/manifest.rs
@@ -8,6 +8,7 @@ use lance_arrow::DataTypeExt;
 use lance_file::{
     previous::writer::ManifestProvider as PreviousManifestProvider, version::LanceFileVersion,
 };
+use object_store::ObjectStoreExt as _;
 use object_store::path::Path;
 use prost::Message;
 use std::collections::HashMap;

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -49,6 +49,7 @@ use lance_table::io::commit::{
 
 use crate::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
 use lance_table::io::manifest::{read_manifest, read_manifest_indexes};
+use object_store::ObjectStoreExt as _;
 use object_store::path::Path;
 use prost::Message;
 use roaring::RoaringBitmap;

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -63,7 +63,7 @@ use std::fmt::Debug;
 use std::{
     collections::{HashMap, HashSet},
     future,
-    sync::{Mutex, MutexGuard},
+    sync::{Arc, Mutex, MutexGuard},
     time::Duration,
 };
 use tokio::time::{MissedTickBehavior, interval};
@@ -131,6 +131,208 @@ struct CleanupInspection {
 const UNVERIFIED_THRESHOLD_DAYS: i64 = 7;
 const S3_DELETE_STREAM_BATCH_SIZE: u64 = 1_000;
 const AZURE_DELETE_STREAM_BATCH_SIZE: u64 = 256;
+
+fn is_not_found_err(e: &Error) -> bool {
+    matches!(
+        e,
+        Error::IO { source,.. }
+            if source
+              .downcast_ref::<ObjectStoreError>()
+              .map(|os_err| matches!(os_err, ObjectStoreError::NotFound {.. }))
+              .unwrap_or(false)
+    )
+}
+
+fn path_if_not_referenced(
+    base: &Path,
+    path: Path,
+    maybe_in_progress: bool,
+    inspection: &CleanupInspection,
+) -> Result<Option<Path>> {
+    let relative_path = remove_prefix(&path, base);
+    if relative_path.as_ref().starts_with("_versions/.tmp") {
+        // This is a temporary manifest file.
+        //
+        // If the file is old (or the user has verified there are no writes in progress) then
+        // it must be leftover from a failed tx.
+        if maybe_in_progress {
+            return Ok(None);
+        } else {
+            return Ok(Some(path));
+        }
+    }
+    if relative_path.as_ref().starts_with("_indices") {
+        // Indices are referenced by UUID so we need to examine the UUID
+        // portion of the path.
+        if let Some(uuid) = relative_path.parts().nth(1) {
+            if inspection
+                .referenced_files
+                .index_uuids
+                .contains(uuid.as_ref())
+            {
+                return Ok(None);
+            } else if !maybe_in_progress {
+                info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE_UNVERIFIED, r#type=AUDIT_TYPE_INDEX, path = path.to_string());
+                return Ok(Some(path));
+            } else if inspection
+                .verified_files
+                .index_uuids
+                .contains(uuid.as_ref())
+            {
+                info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE, r#type=AUDIT_TYPE_INDEX, path = path.to_string());
+                return Ok(Some(path));
+            }
+        } else {
+            return Ok(None);
+        }
+    }
+    match path.extension() {
+        Some("lance") => {
+            if relative_path.as_ref().starts_with("data") {
+                if inspection
+                    .referenced_files
+                    .data_paths
+                    .contains(&relative_path)
+                {
+                    Ok(None)
+                } else if !maybe_in_progress {
+                    info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE_UNVERIFIED, r#type=AUDIT_TYPE_DATA, path = path.to_string());
+                    Ok(Some(path))
+                } else if inspection
+                    .verified_files
+                    .data_paths
+                    .contains(&relative_path)
+                {
+                    info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE, r#type=AUDIT_TYPE_DATA, path = path.to_string());
+                    Ok(Some(path))
+                } else {
+                    Ok(None)
+                }
+            } else {
+                // If a .lance file isn't in the data directory we err on the side of leaving it alone
+                Ok(None)
+            }
+        }
+        Some("blob") => {
+            // Blob v2 sidecar files are keyed by the data file stem:
+            //   data/{data_file_key}/{obfuscated_blob_id:032b}.blob
+            //
+            // These files are not referenced directly by the manifest.  Instead, treat them
+            // as referenced if their parent data file is referenced.
+            if !relative_path.as_ref().starts_with("data") {
+                debug!(
+                    path = relative_path.as_ref(),
+                    "Will not garbage collect blob file because it does not follow convention"
+                );
+                return Ok(None);
+            }
+
+            let mut parts = relative_path.parts();
+            let data_dir = parts.next();
+            let data_file_key = parts.next();
+            let blob_file = parts.next();
+            // Be conservative: only handle the expected 3-part layout.
+            if !matches!(data_dir, Some(dir) if dir.as_ref() == "data")
+                || data_file_key.is_none()
+                || blob_file.is_none()
+            {
+                debug!(
+                    path = relative_path.as_ref(),
+                    "Will not garbage collect blob file because it does not follow convention"
+                );
+                return Ok(None);
+            }
+            if parts.next().is_some() {
+                debug!(
+                    path = relative_path.as_ref(),
+                    "Will not garbage collect blob file because it does not follow convention"
+                );
+                return Ok(None);
+            }
+
+            let data_file_key = data_file_key.expect("checked is_some");
+            let Ok(parent_data_path) =
+                Path::parse(format!("data/{}.lance", data_file_key.as_ref()))
+            else {
+                debug!(
+                    path = relative_path.as_ref(),
+                    derived_parent = format!("data/{}.lance", data_file_key.as_ref()),
+                    "Will not garbage collect blob file because derived parent data file path is invalid"
+                );
+                return Ok(None);
+            };
+
+            if inspection
+                .referenced_files
+                .data_paths
+                .contains(&parent_data_path)
+            {
+                Ok(None)
+            } else if !maybe_in_progress {
+                info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE_UNVERIFIED, r#type=AUDIT_TYPE_DATA, path = path.to_string());
+                Ok(Some(path))
+            } else if inspection
+                .verified_files
+                .data_paths
+                .contains(&parent_data_path)
+            {
+                info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE, r#type=AUDIT_TYPE_DATA, path = path.to_string());
+                Ok(Some(path))
+            } else {
+                Ok(None)
+            }
+        }
+        Some("manifest") => {
+            // We already scanned the manifest files
+            Ok(None)
+        }
+        Some("arrow") | Some("bin") => {
+            if relative_path.as_ref().starts_with("_deletions") {
+                if inspection
+                    .referenced_files
+                    .delete_paths
+                    .contains(&relative_path)
+                {
+                    Ok(None)
+                } else if !maybe_in_progress {
+                    info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE_UNVERIFIED, r#type=AUDIT_TYPE_DELETION, path = path.to_string());
+                    Ok(Some(path))
+                } else if inspection
+                    .verified_files
+                    .delete_paths
+                    .contains(&relative_path)
+                {
+                    info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE, r#type=AUDIT_TYPE_DELETION, path = path.to_string());
+                    Ok(Some(path))
+                } else {
+                    Ok(None)
+                }
+            } else {
+                Ok(None)
+            }
+        }
+        Some("txn") => {
+            if relative_path.as_ref().starts_with(TRANSACTIONS_DIR) {
+                if inspection
+                    .referenced_files
+                    .tx_paths
+                    .contains(&relative_path)
+                {
+                    Ok(None)
+                } else if !maybe_in_progress
+                    || inspection.verified_files.tx_paths.contains(&relative_path)
+                {
+                    Ok(Some(path))
+                } else {
+                    Ok(None)
+                }
+            } else {
+                Ok(None)
+            }
+        }
+        _ => Ok(None),
+    }
+}
 
 impl<'a> CleanupTask<'a> {
     fn new(dataset: &'a Dataset, policy: CleanupPolicy) -> Self {
@@ -320,27 +522,54 @@ impl<'a> CleanupTask<'a> {
         &self,
         inspection: CleanupInspection,
     ) -> Result<RemovalStats> {
-        let removal_stats = Mutex::new(RemovalStats::default());
+        let removal_stats = self.delete_unreferenced_files_inner(inspection).await?;
+
+        let span = Span::current();
+        span.record("bytes_removed", removal_stats.bytes_removed);
+        span.record("data_files_removed", removal_stats.data_files_removed);
+        span.record(
+            "transaction_files_removed",
+            removal_stats.transaction_files_removed,
+        );
+        span.record("index_files_removed", removal_stats.index_files_removed);
+        span.record(
+            "deletion_files_removed",
+            removal_stats.deletion_files_removed,
+        );
+
+        Ok(removal_stats)
+    }
+
+    async fn delete_unreferenced_files_inner(
+        &self,
+        inspection: CleanupInspection,
+    ) -> Result<RemovalStats> {
+        let removal_stats = Arc::new(Mutex::new(RemovalStats::default()));
         let verification_threshold = utc_now()
             - TimeDelta::try_days(UNVERIFIED_THRESHOLD_DAYS).expect("TimeDelta::try_days");
 
-        let is_not_found_err = |e: &Error| {
-            matches!(
-                e,
-                Error::IO { source,.. }
-                    if source
-                      .downcast_ref::<ObjectStoreError>()
-                      .map(|os_err| matches!(os_err, ObjectStoreError::NotFound {.. }))
-                      .unwrap_or(false)
-            )
-        };
+        let inspection = Arc::new(inspection);
+        let delete_unverified = self.policy.delete_unverified;
+        let base = self.dataset.base.clone();
+        let inner_store = self.dataset.object_store.inner.clone();
+
         // Build stream for a managed subtree
         let build_listing_stream = |dir: Path, file_type: Option<RemovedFileType>| {
-            let inspection_ref = &inspection;
-            let removal_stats_ref = &removal_stats;
-            self.dataset
-                .object_store
-                .read_dir_all(&dir, inspection.earliest_retained_manifest_time)
+            let inspection_ref = inspection.clone();
+            let removal_stats_ref = removal_stats.clone();
+            let base_ref = base.clone();
+            let earliest = inspection_ref.earliest_retained_manifest_time;
+            let listing = inner_store
+                .list(Some(&dir))
+                .map_err(|e| lance_core::Error::from(e));
+            let listing: BoxStream<'static, Result<ObjectMeta>> = if let Some(unmodified_since) = earliest {
+                listing
+                    .try_filter(move |file| future::ready(file.last_modified <= unmodified_since))
+                    .boxed()
+            } else {
+                listing.boxed()
+            };
+            listing
                 .map_ok(|obj| stream::once(future::ready(Ok(obj))).boxed())
                 .or_else(|e| {
                     // If the directory doesn't exist then we can just return an empty stream.
@@ -354,12 +583,13 @@ impl<'a> CleanupTask<'a> {
                 .try_filter_map(move |obj_meta| {
                     // If a file is new-ish then it might be part of an ongoing operation and so we only
                     // delete it if we can verify it is part of an old version.
-                    let maybe_in_progress = !self.policy.delete_unverified
+                    let maybe_in_progress = !delete_unverified
                         && obj_meta.last_modified >= verification_threshold;
-                    let path_to_remove = self.path_if_not_referenced(
+                    let path_to_remove = path_if_not_referenced(
+                        &base_ref,
                         obj_meta.location,
                         maybe_in_progress,
-                        inspection_ref,
+                        &inspection_ref,
                     );
                     if matches!(path_to_remove, Ok(Some(..))) {
                         let mut stats = removal_stats_ref.lock().unwrap();
@@ -441,22 +671,12 @@ impl<'a> CleanupTask<'a> {
 
         delete_fut.await?;
 
-        let mut removal_stats = removal_stats.into_inner().unwrap();
+        let mut removal_stats = Arc::try_unwrap(removal_stats)
+            .expect("all streams should be consumed")
+            .into_inner()
+            .unwrap();
         removal_stats.old_versions = num_old_manifests as u64;
         removal_stats.bytes_removed += manifest_bytes_removed?;
-
-        let span = Span::current();
-        span.record("bytes_removed", removal_stats.bytes_removed);
-        span.record("data_files_removed", removal_stats.data_files_removed);
-        span.record(
-            "transaction_files_removed",
-            removal_stats.transaction_files_removed,
-        );
-        span.record("index_files_removed", removal_stats.index_files_removed);
-        span.record(
-            "deletion_files_removed",
-            removal_stats.deletion_files_removed,
-        );
 
         Ok(removal_stats)
     }
@@ -467,189 +687,7 @@ impl<'a> CleanupTask<'a> {
         maybe_in_progress: bool,
         inspection: &CleanupInspection,
     ) -> Result<Option<Path>> {
-        let relative_path = remove_prefix(&path, &self.dataset.base);
-        if relative_path.as_ref().starts_with("_versions/.tmp") {
-            // This is a temporary manifest file.
-            //
-            // If the file is old (or the user has verified there are no writes in progress) then
-            // it must be leftover from a failed tx.
-            if maybe_in_progress {
-                return Ok(None);
-            } else {
-                return Ok(Some(path));
-            }
-        }
-        if relative_path.as_ref().starts_with("_indices") {
-            // Indices are referenced by UUID so we need to examine the UUID
-            // portion of the path.
-            if let Some(uuid) = relative_path.parts().nth(1) {
-                if inspection
-                    .referenced_files
-                    .index_uuids
-                    .contains(uuid.as_ref())
-                {
-                    return Ok(None);
-                } else if !maybe_in_progress {
-                    info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE_UNVERIFIED, r#type=AUDIT_TYPE_INDEX, path = path.to_string());
-                    return Ok(Some(path));
-                } else if inspection
-                    .verified_files
-                    .index_uuids
-                    .contains(uuid.as_ref())
-                {
-                    info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE, r#type=AUDIT_TYPE_INDEX, path = path.to_string());
-                    return Ok(Some(path));
-                }
-            } else {
-                return Ok(None);
-            }
-        }
-        match path.extension() {
-            Some("lance") => {
-                if relative_path.as_ref().starts_with("data") {
-                    if inspection
-                        .referenced_files
-                        .data_paths
-                        .contains(&relative_path)
-                    {
-                        Ok(None)
-                    } else if !maybe_in_progress {
-                        info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE_UNVERIFIED, r#type=AUDIT_TYPE_DATA, path = path.to_string());
-                        Ok(Some(path))
-                    } else if inspection
-                        .verified_files
-                        .data_paths
-                        .contains(&relative_path)
-                    {
-                        info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE, r#type=AUDIT_TYPE_DATA, path = path.to_string());
-                        Ok(Some(path))
-                    } else {
-                        Ok(None)
-                    }
-                } else {
-                    // If a .lance file isn't in the data directory we err on the side of leaving it alone
-                    Ok(None)
-                }
-            }
-            Some("blob") => {
-                // Blob v2 sidecar files are keyed by the data file stem:
-                //   data/{data_file_key}/{obfuscated_blob_id:032b}.blob
-                //
-                // These files are not referenced directly by the manifest.  Instead, treat them
-                // as referenced if their parent data file is referenced.
-                if !relative_path.as_ref().starts_with("data") {
-                    debug!(
-                        path = relative_path.as_ref(),
-                        "Will not garbage collect blob file because it does not follow convention"
-                    );
-                    return Ok(None);
-                }
-
-                let mut parts = relative_path.parts();
-                let data_dir = parts.next();
-                let data_file_key = parts.next();
-                let blob_file = parts.next();
-                // Be conservative: only handle the expected 3-part layout.
-                if !matches!(data_dir, Some(dir) if dir.as_ref() == "data")
-                    || data_file_key.is_none()
-                    || blob_file.is_none()
-                {
-                    debug!(
-                        path = relative_path.as_ref(),
-                        "Will not garbage collect blob file because it does not follow convention"
-                    );
-                    return Ok(None);
-                }
-                if parts.next().is_some() {
-                    debug!(
-                        path = relative_path.as_ref(),
-                        "Will not garbage collect blob file because it does not follow convention"
-                    );
-                    return Ok(None);
-                }
-
-                let data_file_key = data_file_key.expect("checked is_some");
-                let Ok(parent_data_path) =
-                    Path::parse(format!("data/{}.lance", data_file_key.as_ref()))
-                else {
-                    debug!(
-                        path = relative_path.as_ref(),
-                        derived_parent = format!("data/{}.lance", data_file_key.as_ref()),
-                        "Will not garbage collect blob file because derived parent data file path is invalid"
-                    );
-                    return Ok(None);
-                };
-
-                if inspection
-                    .referenced_files
-                    .data_paths
-                    .contains(&parent_data_path)
-                {
-                    Ok(None)
-                } else if !maybe_in_progress {
-                    info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE_UNVERIFIED, r#type=AUDIT_TYPE_DATA, path = path.to_string());
-                    Ok(Some(path))
-                } else if inspection
-                    .verified_files
-                    .data_paths
-                    .contains(&parent_data_path)
-                {
-                    info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE, r#type=AUDIT_TYPE_DATA, path = path.to_string());
-                    Ok(Some(path))
-                } else {
-                    Ok(None)
-                }
-            }
-            Some("manifest") => {
-                // We already scanned the manifest files
-                Ok(None)
-            }
-            Some("arrow") | Some("bin") => {
-                if relative_path.as_ref().starts_with("_deletions") {
-                    if inspection
-                        .referenced_files
-                        .delete_paths
-                        .contains(&relative_path)
-                    {
-                        Ok(None)
-                    } else if !maybe_in_progress {
-                        info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE_UNVERIFIED, r#type=AUDIT_TYPE_DELETION, path = path.to_string());
-                        Ok(Some(path))
-                    } else if inspection
-                        .verified_files
-                        .delete_paths
-                        .contains(&relative_path)
-                    {
-                        info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_DELETE, r#type=AUDIT_TYPE_DELETION, path = path.to_string());
-                        Ok(Some(path))
-                    } else {
-                        Ok(None)
-                    }
-                } else {
-                    Ok(None)
-                }
-            }
-            Some("txn") => {
-                if relative_path.as_ref().starts_with(TRANSACTIONS_DIR) {
-                    if inspection
-                        .referenced_files
-                        .tx_paths
-                        .contains(&relative_path)
-                    {
-                        Ok(None)
-                    } else if !maybe_in_progress
-                        || inspection.verified_files.tx_paths.contains(&relative_path)
-                    {
-                        Ok(Some(path))
-                    } else {
-                        Ok(None)
-                    }
-                } else {
-                    Ok(None)
-                }
-            }
-            _ => Ok(None),
-        }
+        path_if_not_referenced(&self.dataset.base, path, maybe_in_progress, inspection)
     }
 
     async fn find_referenced_branches(&self) -> Result<Vec<(String, u64)>> {

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -37,9 +37,11 @@ use lance_index::mem_wal::ShardManifest;
 use lance_io::object_store::ObjectStore;
 use lance_table::format::pb;
 use log::{info, warn};
+use object_store::ObjectStoreExt as _;
 use object_store::PutMode;
 use object_store::PutOptions;
 use object_store::path::Path;
+use object_store::{RenameOptions, RenameTargetMode};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -158,7 +160,7 @@ impl ShardManifestStore {
             match self
                 .object_store
                 .inner
-                .rename_if_not_exists(&temp_path, &path)
+                .rename_opts(&temp_path, &path, RenameOptions { target_mode: RenameTargetMode::Create, ..Default::default() })
                 .await
             {
                 Ok(()) => {}

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -14,6 +14,7 @@ use lance_index::scalar::{IndexStore, ScalarIndexParams};
 use lance_io::object_store::ObjectStore;
 use lance_table::format::IndexMetadata;
 use log::info;
+use object_store::ObjectStoreExt as _;
 use object_store::path::Path;
 use uuid::Uuid;
 

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/btree.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/btree.rs
@@ -34,7 +34,7 @@ pub struct BTreeIndexExec {
     max_visible_batch_position: usize,
     projection: Option<Vec<usize>>,
     output_schema: SchemaRef,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
     /// Column name of the indexed field.
     column: String,
@@ -92,12 +92,12 @@ impl BTreeIndexExec {
             )));
         }
 
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(output_schema.clone()),
             Partitioning::UnknownPartitioning(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
 
         Ok(Self {
             batch_store,
@@ -371,7 +371,7 @@ impl ExecutionPlan for BTreeIndexExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
@@ -46,7 +46,7 @@ pub struct FtsIndexExec {
     max_visible_batch_position: usize,
     projection: Option<Vec<usize>>,
     output_schema: SchemaRef,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
     /// Pre-computed batch ranges for O(log n) lookup.
     batch_ranges: Vec<BatchRange>,
@@ -112,12 +112,12 @@ impl FtsIndexExec {
         }
         let output_schema = Arc::new(Schema::new(fields));
 
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(output_schema.clone()),
             Partitioning::UnknownPartitioning(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
 
         // Pre-compute batch ranges for O(log n) lookup and max visible row
         let mut batch_ranges = Vec::new();
@@ -408,7 +408,7 @@ impl ExecutionPlan for FtsIndexExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/scan.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/scan.rs
@@ -41,7 +41,7 @@ pub struct MemTableScanExec {
     output_schema: SchemaRef,
     /// Schema of the source data (before projection), used for filter evaluation.
     source_schema: SchemaRef,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
     /// Whether to include _rowid column (row position) in output.
     with_row_id: bool,
@@ -123,12 +123,12 @@ impl MemTableScanExec {
         filter_predicate: Option<PhysicalExprRef>,
         filter_expr: Option<Expr>,
     ) -> Self {
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(output_schema.clone()),
             Partitioning::UnknownPartitioning(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
 
         Self {
             batch_store,
@@ -353,7 +353,7 @@ impl ExecutionPlan for MemTableScanExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/vector.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/vector.rs
@@ -38,7 +38,7 @@ pub struct VectorIndexExec {
     max_visible_batch_position: usize,
     projection: Option<Vec<usize>>,
     output_schema: SchemaRef,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
     /// Whether to include _rowid column (row position) in output.
     with_row_id: bool,
@@ -114,12 +114,12 @@ impl VectorIndexExec {
         }
         let output_schema = Arc::new(Schema::new(fields));
 
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(output_schema.clone()),
             Partitioning::UnknownPartitioning(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
 
         Ok(Self {
             batch_store,
@@ -504,7 +504,7 @@ impl ExecutionPlan for VectorIndexExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/dataset/mem_wal/scanner/exec/bloom_guard.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec/bloom_guard.rs
@@ -60,7 +60,7 @@ pub struct BloomFilterGuardExec {
     /// Output schema.
     schema: SchemaRef,
     /// Plan properties.
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
 }
 
 impl BloomFilterGuardExec {
@@ -80,12 +80,12 @@ impl BloomFilterGuardExec {
     ) -> Self {
         let schema = input.schema();
 
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(schema.clone()),
             Partitioning::UnknownPartitioning(1),
             input.pipeline_behavior(),
             input.boundedness(),
-        );
+        ));
 
         Self {
             input,
@@ -142,7 +142,7 @@ impl ExecutionPlan for BloomFilterGuardExec {
         self.schema.clone()
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/dataset/mem_wal/scanner/exec/coalesce_first.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec/coalesce_first.rs
@@ -48,7 +48,7 @@ pub struct CoalesceFirstExec {
     /// Output schema (must be same for all inputs).
     schema: SchemaRef,
     /// Plan properties.
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
 }
 
 impl CoalesceFirstExec {
@@ -79,12 +79,12 @@ impl CoalesceFirstExec {
             );
         }
 
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(schema.clone()),
             Partitioning::UnknownPartitioning(1),
             inputs[0].pipeline_behavior(),
             inputs[0].boundedness(),
-        );
+        ));
 
         Self {
             inputs,
@@ -119,7 +119,7 @@ impl ExecutionPlan for CoalesceFirstExec {
         self.schema.clone()
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/dataset/mem_wal/scanner/exec/deduplicate.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec/deduplicate.rs
@@ -67,7 +67,7 @@ pub struct DeduplicateExec {
     /// Whether the input is already sorted by (pk, _memtable_gen DESC, _rowaddr DESC).
     input_sorted: bool,
     /// Plan properties.
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
 }
 
 impl DeduplicateExec {
@@ -155,12 +155,12 @@ impl DeduplicateExec {
         let schema = Arc::new(Schema::new(output_fields));
 
         // Output is single partition after sort + dedup
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(schema.clone()),
             Partitioning::UnknownPartitioning(1),
             input.pipeline_behavior(),
             input.boundedness(),
-        );
+        ));
 
         Ok(Self {
             input,
@@ -237,12 +237,12 @@ impl DeduplicateExec {
         let schema = Arc::new(Schema::new(output_fields));
 
         // Output is single partition after dedup
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(schema.clone()),
             Partitioning::UnknownPartitioning(1),
             input.pipeline_behavior(),
             input.boundedness(),
-        );
+        ));
 
         Ok(Self {
             input,
@@ -381,7 +381,7 @@ impl ExecutionPlan for DeduplicateExec {
         self.schema.clone()
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/dataset/mem_wal/scanner/exec/filter_stale.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec/filter_stale.rs
@@ -82,7 +82,7 @@ pub struct FilterStaleExec {
     /// Output schema.
     schema: SchemaRef,
     /// Plan properties.
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
 }
 
 impl FilterStaleExec {
@@ -104,12 +104,12 @@ impl FilterStaleExec {
         let mut bloom_filters = bloom_filters;
         bloom_filters.sort_by(|a, b| b.generation.cmp(&a.generation));
 
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(schema.clone()),
             Partitioning::UnknownPartitioning(1),
             input.pipeline_behavior(),
             input.boundedness(),
-        );
+        ));
 
         Self {
             input,
@@ -166,7 +166,7 @@ impl ExecutionPlan for FilterStaleExec {
         self.schema.clone()
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/dataset/mem_wal/scanner/exec/generation_tag.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec/generation_tag.rs
@@ -44,7 +44,7 @@ pub struct MemtableGenTagExec {
     /// Output schema (input schema + _gen column).
     schema: SchemaRef,
     /// Plan properties.
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
 }
 
 impl MemtableGenTagExec {
@@ -62,12 +62,12 @@ impl MemtableGenTagExec {
         let schema = Arc::new(Schema::new(fields));
 
         // Preserve input properties
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(schema.clone()),
             input.output_partitioning().clone(),
             input.pipeline_behavior(),
             input.boundedness(),
-        );
+        ));
 
         Self {
             input,
@@ -108,7 +108,7 @@ impl ExecutionPlan for MemtableGenTagExec {
         self.schema.clone()
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/dataset/mem_wal/wal.rs
+++ b/rust/lance/src/dataset/mem_wal/wal.rs
@@ -18,6 +18,7 @@ use arrow_schema::Schema as ArrowSchema;
 use bytes::Bytes;
 use lance_core::{Error, Result};
 use lance_io::object_store::ObjectStore;
+use object_store::ObjectStoreExt as _;
 use object_store::path::Path;
 use tokio::sync::{mpsc, watch};
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -3201,6 +3201,7 @@ impl Scanner {
                             None,
                             datafusion_physical_plan::joins::PartitionMode::CollectLeft,
                             NullEquality::NullEqualsNothing,
+                            false,
                         )?) as _);
                     } else {
                         must = Some(plan);
@@ -4159,6 +4160,7 @@ impl Scanner {
                     None,
                     PartitionMode::CollectLeft,
                     NullEquality::NullEqualsNull,
+                    false,
                 )?;
 
                 let schema = join.schema();

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -737,6 +737,7 @@ impl MergeInsertJob {
                 None,
                 PartitionMode::CollectLeft,
                 NullEquality::NullEqualsNull,
+                false,
             )
             .unwrap(),
         );

--- a/rust/lance/src/dataset/write/merge_insert/exec/delete.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/delete.rs
@@ -41,7 +41,7 @@ pub struct DeleteOnlyMergeInsertExec {
     input: Arc<dyn ExecutionPlan>,
     dataset: Arc<Dataset>,
     params: MergeInsertParams,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
     merge_stats: Arc<Mutex<Option<MergeStats>>>,
     transaction: Arc<Mutex<Option<Transaction>>>,
@@ -55,12 +55,12 @@ impl DeleteOnlyMergeInsertExec {
         params: MergeInsertParams,
     ) -> DFResult<Self> {
         let empty_schema = Arc::new(arrow_schema::Schema::empty());
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(empty_schema),
             Partitioning::UnknownPartitioning(1),
             EmissionType::Final,
             Boundedness::Bounded,
-        );
+        ));
 
         Ok(Self {
             input,
@@ -231,7 +231,7 @@ impl ExecutionPlan for DeleteOnlyMergeInsertExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/dataset/write/merge_insert/exec/write.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/write.rs
@@ -181,7 +181,7 @@ pub struct FullSchemaMergeInsertExec {
     input: Arc<dyn ExecutionPlan>,
     dataset: Arc<Dataset>,
     params: MergeInsertParams,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
     merge_stats: Arc<Mutex<Option<MergeStats>>>,
     transaction: Arc<Mutex<Option<Transaction>>>,
@@ -199,12 +199,12 @@ impl FullSchemaMergeInsertExec {
         params: MergeInsertParams,
     ) -> DFResult<Self> {
         let empty_schema = Arc::new(arrow_schema::Schema::empty());
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(empty_schema),
             Partitioning::UnknownPartitioning(1),
             EmissionType::Final,
             Boundedness::Bounded,
-        );
+        ));
 
         // Check if ON columns match the schema's unenforced primary key
         let field_ids: Vec<i32> = params
@@ -790,7 +790,7 @@ impl ExecutionPlan for FullSchemaMergeInsertExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -60,6 +60,7 @@ use lance_core::{Error, Result};
 use lance_index::is_system_index;
 use lance_io::object_store::ObjectStoreRegistry;
 use log;
+use object_store::ObjectStoreExt as _;
 use object_store::path::Path;
 use prost::Message;
 

--- a/rust/lance/src/io/exec/filter.rs
+++ b/rust/lance/src/io/exec/filter.rs
@@ -52,7 +52,7 @@ impl ExecutionPlan for LanceFilterExec {
         self
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         self.filter.properties()
     }
 

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -1453,7 +1453,7 @@ impl FilteredReadOptions {
 pub struct FilteredReadExec {
     dataset: Arc<Dataset>,
     options: FilteredReadOptions,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
     index_input: Option<Arc<dyn ExecutionPlan>>,
     // Precomputed internal plan
@@ -1552,12 +1552,12 @@ impl FilteredReadExec {
             FilteredReadThreadingMode::MultiplePartitions(n) => n,
         };
 
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(output_schema),
             Partitioning::RoundRobinBatch(num_partitions),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
 
         let metrics = ExecutionPlanMetricsSet::new();
 
@@ -1820,7 +1820,7 @@ impl ExecutionPlan for FilteredReadExec {
         self
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -83,7 +83,7 @@ pub struct MatchQueryExec {
     params: FtsSearchParams,
     prefilter_source: PreFilterSource,
 
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
 
@@ -117,12 +117,12 @@ impl MatchQueryExec {
         params: FtsSearchParams,
         prefilter_source: PreFilterSource,
     ) -> Self {
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(FTS_SCHEMA.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Final,
             Boundedness::Bounded,
-        );
+        ));
         Self {
             dataset,
             query,
@@ -322,15 +322,11 @@ impl ExecutionPlan for MatchQueryExec {
         )))
     }
 
-    fn statistics(&self) -> DataFusionResult<datafusion::physical_plan::Statistics> {
-        Ok(Statistics::new_unknown(&FTS_SCHEMA))
-    }
-
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 
@@ -541,11 +537,6 @@ impl ExecutionPlan for FlatMatchFilterExec {
         )))
     }
 
-    fn statistics(&self) -> DataFusionResult<datafusion::physical_plan::Statistics> {
-        #[allow(deprecated)]
-        self.input.statistics()
-    }
-
     fn partition_statistics(&self, partition: Option<usize>) -> DataFusionResult<Statistics> {
         self.input.partition_statistics(partition)
     }
@@ -554,7 +545,7 @@ impl ExecutionPlan for FlatMatchFilterExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         self.input.properties()
     }
 
@@ -571,7 +562,7 @@ pub struct FlatMatchQueryExec {
     params: FtsSearchParams,
     unindexed_input: Arc<dyn ExecutionPlan>,
 
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
 
@@ -605,12 +596,12 @@ impl FlatMatchQueryExec {
         params: FtsSearchParams,
         unindexed_input: Arc<dyn ExecutionPlan>,
     ) -> Self {
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(FTS_SCHEMA.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
         Self {
             dataset,
             query,
@@ -718,15 +709,11 @@ impl ExecutionPlan for FlatMatchQueryExec {
         )))
     }
 
-    fn statistics(&self) -> DataFusionResult<datafusion::physical_plan::Statistics> {
-        Ok(Statistics::new_unknown(&FTS_SCHEMA))
-    }
-
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 
@@ -741,7 +728,7 @@ pub struct PhraseQueryExec {
     query: PhraseQuery,
     params: FtsSearchParams,
     prefilter_source: PreFilterSource,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
 
@@ -775,12 +762,12 @@ impl PhraseQueryExec {
         mut params: FtsSearchParams,
         prefilter_source: PreFilterSource,
     ) -> Self {
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(FTS_SCHEMA.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Final,
             Boundedness::Bounded,
-        );
+        ));
         params = params.with_phrase_slop(Some(query.slop));
 
         Self {
@@ -951,15 +938,11 @@ impl ExecutionPlan for PhraseQueryExec {
         )))
     }
 
-    fn statistics(&self) -> DataFusionResult<datafusion::physical_plan::Statistics> {
-        Ok(Statistics::new_unknown(&FTS_SCHEMA))
-    }
-
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 
@@ -975,7 +958,7 @@ pub struct BoostQueryExec {
     positive: Arc<dyn ExecutionPlan>,
     negative: Arc<dyn ExecutionPlan>,
 
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
 
@@ -1007,12 +990,12 @@ impl BoostQueryExec {
         positive: Arc<dyn ExecutionPlan>,
         negative: Arc<dyn ExecutionPlan>,
     ) -> Self {
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(FTS_SCHEMA.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Final,
             Boundedness::Bounded,
-        );
+        ));
         Self {
             query,
             params,
@@ -1126,15 +1109,11 @@ impl ExecutionPlan for BoostQueryExec {
         )))
     }
 
-    fn statistics(&self) -> DataFusionResult<datafusion::physical_plan::Statistics> {
-        Ok(Statistics::new_unknown(&FTS_SCHEMA))
-    }
-
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 
@@ -1151,7 +1130,7 @@ pub struct BooleanQueryExec {
     must: Option<Arc<dyn ExecutionPlan>>,
     must_not: Arc<dyn ExecutionPlan>,
 
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
 
@@ -1190,12 +1169,12 @@ impl BooleanQueryExec {
         must: Option<Arc<dyn ExecutionPlan>>,
         must_not: Arc<dyn ExecutionPlan>,
     ) -> Self {
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(FTS_SCHEMA.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Final,
             Boundedness::Bounded,
-        );
+        ));
         Self {
             query,
             params,
@@ -1381,15 +1360,11 @@ impl ExecutionPlan for BooleanQueryExec {
         )))
     }
 
-    fn statistics(&self) -> DataFusionResult<datafusion::physical_plan::Statistics> {
-        Ok(Statistics::new_unknown(&FTS_SCHEMA))
-    }
-
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 }

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -118,7 +118,7 @@ pub struct KNNVectorDistanceExec {
     pub distance_type: DistanceType,
 
     output_schema: SchemaRef,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
 
     metrics: ExecutionPlanMetricsSet,
 }
@@ -164,10 +164,10 @@ impl KNNVectorDistanceExec {
 
         // This node has the same partitioning & boundedness as the input node
         // but it destroys any ordering.
-        let properties = input
+        let properties = Arc::new(Arc::unwrap_or_clone(input
             .properties()
-            .clone()
-            .with_eq_properties(EquivalenceProperties::new(output_schema.clone()));
+            .clone())
+            .with_eq_properties(EquivalenceProperties::new(output_schema.clone())));
 
         Ok(Self {
             input,
@@ -288,7 +288,7 @@ impl ExecutionPlan for KNNVectorDistanceExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 
@@ -376,7 +376,7 @@ pub struct ANNIvfPartitionExec {
     /// The UUIDs of the indices to search.
     pub index_uuids: Vec<String>,
 
-    pub properties: PlanProperties,
+    pub properties: Arc<PlanProperties>,
 
     pub metrics: ExecutionPlanMetricsSet,
 }
@@ -392,12 +392,12 @@ impl ANNIvfPartitionExec {
         }
 
         let schema = KNN_PARTITION_SCHEMA.clone();
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(schema),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
 
         Ok(Self {
             dataset,
@@ -449,14 +449,7 @@ impl ExecutionPlan for ANNIvfPartitionExec {
         KNN_PARTITION_SCHEMA.clone()
     }
 
-    fn statistics(&self) -> DataFusionResult<Statistics> {
-        Ok(Statistics {
-            num_rows: Precision::Exact(self.query.minimum_nprobes),
-            ..Statistics::new_unknown(self.schema().as_ref())
-        })
-    }
-
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 
@@ -604,7 +597,7 @@ pub struct ANNIvfSubIndexExec {
     prefilter_source: PreFilterSource,
 
     /// Datafusion Plan Properties
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
 
     metrics: ExecutionPlanMetricsSet,
 }
@@ -623,12 +616,12 @@ impl ANNIvfSubIndexExec {
                 PART_ID_COLUMN
             )));
         }
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(KNN_INDEX_SCHEMA.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Final,
             Boundedness::Bounded,
-        );
+        ));
         Ok(Self {
             input,
             dataset,
@@ -1113,7 +1106,7 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 
@@ -1151,17 +1144,17 @@ pub struct MultivectorScoringExec {
     // the inputs are sorted ANN search results
     inputs: Vec<Arc<dyn ExecutionPlan>>,
     query: Query,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
 }
 
 impl MultivectorScoringExec {
     pub fn try_new(inputs: Vec<Arc<dyn ExecutionPlan>>, query: Query) -> Result<Self> {
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(KNN_INDEX_SCHEMA.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Final,
             Boundedness::Bounded,
-        );
+        ));
 
         Ok(Self {
             inputs,
@@ -1327,16 +1320,7 @@ impl ExecutionPlan for MultivectorScoringExec {
         )))
     }
 
-    fn statistics(&self) -> DataFusionResult<Statistics> {
-        Ok(Statistics {
-            num_rows: Precision::Inexact(
-                self.query.k * self.query.refine_factor.unwrap_or(1) as usize,
-            ),
-            ..Statistics::new_unknown(self.schema().as_ref())
-        })
-    }
-
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -9,12 +9,10 @@ use arrow_array::types::{Int64Type, UInt64Type};
 use arrow_array::{Array, BooleanArray, Int64Array, PrimitiveArray, RecordBatch, UInt32Array};
 use arrow_schema::{DataType, Schema as ArrowSchema, SchemaRef};
 use arrow_select::filter::filter_record_batch;
-use datafusion::common::Statistics;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::col;
 use datafusion::logical_expr::interval_arithmetic::{Interval, NullableInterval};
 use datafusion::optimizer::simplify_expressions::{ExprSimplifier, SimplifyContext};
-use datafusion::physical_expr::execution_props::ExecutionProps;
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::{ColumnarValue, PlanProperties};
@@ -97,7 +95,7 @@ pub struct LancePushdownScanExec {
     predicate: Expr,
     config: ScanConfig,
     output_schema: Arc<ArrowSchema>,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
 
@@ -134,12 +132,12 @@ impl LancePushdownScanExec {
         }
         let output_schema = Arc::new(output_schema);
 
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(output_schema.clone()),
             Partitioning::UnknownPartitioning(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
 
         Ok(Self {
             dataset,
@@ -183,10 +181,6 @@ impl ExecutionPlan for LancePushdownScanExec {
         } else {
             Ok(self)
         }
-    }
-
-    fn statistics(&self) -> datafusion::error::Result<datafusion::physical_plan::Statistics> {
-        Ok(Statistics::new_unknown(self.output_schema.as_ref()))
     }
 
     fn metrics(&self) -> Option<MetricsSet> {
@@ -239,7 +233,7 @@ impl ExecutionPlan for LancePushdownScanExec {
         )))
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 }
@@ -677,8 +671,7 @@ impl FragmentScanner {
                 .collect();
             let schema =
                 Arc::new(ArrowSchema::from(self.predicate_projection.as_ref()).try_into()?);
-            let props = ExecutionProps::new();
-            let context = SimplifyContext::new(&props).with_schema(schema);
+            let context = SimplifyContext::default().with_schema(schema);
             let mut simplifier = ExprSimplifier::new(context);
 
             let mut predicates = Vec::with_capacity(num_batches);

--- a/rust/lance/src/io/exec/rowids.rs
+++ b/rust/lance/src/io/exec/rowids.rs
@@ -47,7 +47,7 @@ pub struct AddRowAddrExec {
     /// Position in the output schema where to insert the row address
     rowaddr_pos: usize,
     output_schema: SchemaRef,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
 
     metrics: ExecutionPlanMetricsSet,
 }
@@ -106,10 +106,10 @@ impl AddRowAddrExec {
 
         // Is just a simple projections, so it inherits the partitioning and
         // execution mode from parent.
-        let properties = input
+        let properties = Arc::new(Arc::unwrap_or_clone(input
             .properties()
-            .clone()
-            .with_eq_properties(EquivalenceProperties::new(output_schema.clone()));
+            .clone())
+            .with_eq_properties(EquivalenceProperties::new(output_schema.clone())));
 
         Ok(Self {
             input,
@@ -326,7 +326,7 @@ impl ExecutionPlan for AddRowAddrExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 }
@@ -347,7 +347,7 @@ pub struct AddRowOffsetExec {
     input: Arc<dyn ExecutionPlan>,
     row_addr_pos: usize,
     frag_id_to_offset: Arc<HashMap<u32, FragInfo>>,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
 }
 
 impl AddRowOffsetExec {
@@ -376,7 +376,7 @@ impl AddRowOffsetExec {
 
         let new_eq_props =
             EquivalenceProperties::new(schema).extend(input.properties().eq_properties.clone())?;
-        let properties = input.properties().clone().with_eq_properties(new_eq_props);
+        let properties = Arc::new(Arc::unwrap_or_clone(input.properties().clone()).with_eq_properties(new_eq_props));
 
         Ok(Self {
             input,
@@ -496,7 +496,7 @@ impl ExecutionPlan for AddRowOffsetExec {
         self
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -14,7 +14,6 @@ use arrow_schema::{Schema, SchemaRef};
 use async_recursion::async_recursion;
 use async_trait::async_trait;
 use datafusion::{
-    common::{Statistics, stats::Precision},
     physical_plan::{
         DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
         execution_plan::{Boundedness, EmissionType},
@@ -82,7 +81,7 @@ impl ScalarIndexLoader for Dataset {
 pub struct ScalarIndexExec {
     dataset: Arc<Dataset>,
     expr: ScalarIndexExpr,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
 
@@ -101,12 +100,12 @@ impl DisplayAs for ScalarIndexExec {
 
 impl ScalarIndexExec {
     pub fn new(dataset: Arc<Dataset>, expr: ScalarIndexExpr) -> Self {
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(INDEX_EXPR_RESULT_SCHEMA.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
         Self {
             dataset,
             expr,
@@ -217,18 +216,11 @@ impl ExecutionPlan for ScalarIndexExec {
         )))
     }
 
-    fn statistics(&self) -> datafusion::error::Result<datafusion::physical_plan::Statistics> {
-        Ok(Statistics {
-            num_rows: Precision::Exact(2),
-            ..Statistics::new_unknown(&INDEX_EXPR_RESULT_SCHEMA)
-        })
-    }
-
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 
@@ -249,7 +241,7 @@ pub struct MapIndexExec {
     column_name: String,
     index_name: String,
     input: Arc<dyn ExecutionPlan>,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
 
@@ -272,12 +264,12 @@ impl MapIndexExec {
         index_name: String,
         input: Arc<dyn ExecutionPlan>,
     ) -> Self {
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(INDEX_LOOKUP_SCHEMA.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
         Self {
             dataset,
             column_name,
@@ -426,7 +418,7 @@ impl ExecutionPlan for MapIndexExec {
         )))
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 
@@ -448,7 +440,7 @@ pub struct MaterializeIndexExec {
     dataset: Arc<Dataset>,
     expr: ScalarIndexExpr,
     fragments: Arc<Vec<Fragment>>,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
 
@@ -510,12 +502,12 @@ impl MaterializeIndexExec {
         expr: ScalarIndexExpr,
         fragments: Arc<Vec<Fragment>>,
     ) -> Self {
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(MATERIALIZE_INDEX_SCHEMA.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
         Self {
             dataset,
             expr,
@@ -712,15 +704,11 @@ impl ExecutionPlan for MaterializeIndexExec {
         )))
     }
 
-    fn statistics(&self) -> datafusion::error::Result<datafusion::physical_plan::Statistics> {
-        Ok(Statistics::new_unknown(&MATERIALIZE_INDEX_SCHEMA))
-    }
-
     fn metrics(&self) -> Option<MetricsSet> {
         Some(self.metrics.clone_inner())
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -9,14 +9,13 @@ use std::task::{Context, Poll};
 
 use arrow_array::RecordBatch;
 use arrow_schema::{Schema as ArrowSchema, SchemaRef};
-use datafusion::common::stats::Precision;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet, MetricsSet};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties, RecordBatchStream,
-    SendableRecordBatchStream, Statistics,
+    SendableRecordBatchStream,
 };
 use datafusion_physical_expr::EquivalenceProperties;
 use futures::future::BoxFuture;
@@ -528,7 +527,7 @@ pub struct LanceScanExec {
     range: Option<Range<u64>>,
     projection: Arc<Schema>,
     output_schema: Arc<ArrowSchema>,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     config: LanceScanConfig,
     metrics: ExecutionPlanMetricsSet,
 }
@@ -602,12 +601,12 @@ impl LanceScanExec {
         }
         let output_schema = Arc::new(output_schema);
 
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(output_schema.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
         Self {
             dataset,
             fragments,
@@ -705,30 +704,7 @@ impl ExecutionPlan for LanceScanExec {
         Some(self.metrics.clone_inner())
     }
 
-    fn statistics(&self) -> datafusion::error::Result<Statistics> {
-        // Some fragments from older datasets might have the row count stats missing.
-        let (row_count, is_exact) =
-            self.fragments
-                .iter()
-                .fold(
-                    (0, true),
-                    |(row_count, is_exact), fragment| match fragment.num_rows() {
-                        Some(num_rows) => (row_count + num_rows, is_exact),
-                        None => (row_count, false),
-                    },
-                );
-        let num_rows = match is_exact {
-            true => Precision::Exact(row_count),
-            false => Precision::Absent,
-        };
-
-        Ok(Statistics {
-            num_rows,
-            ..datafusion::physical_plan::Statistics::new_unknown(self.schema().as_ref())
-        })
-    }
-
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -397,7 +397,7 @@ pub struct TakeExec {
     // The schema of the output
     output_schema: SchemaRef,
     input: Arc<dyn ExecutionPlan>,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
 
@@ -477,10 +477,10 @@ impl TakeExec {
             &projection,
         ));
         let output_arrow = Arc::new(ArrowSchema::from(output_schema.as_ref()));
-        let properties = input
+        let properties = Arc::new(Arc::unwrap_or_clone(input
             .properties()
-            .clone()
-            .with_eq_properties(EquivalenceProperties::new(output_arrow.clone()));
+            .clone())
+            .with_eq_properties(EquivalenceProperties::new(output_arrow.clone())));
 
         Ok(Some(Self {
             dataset,
@@ -651,7 +651,7 @@ impl ExecutionPlan for TakeExec {
         })
     }
 
-    fn properties(&self) -> &PlanProperties {
+    fn properties(&self) -> &Arc<PlanProperties> {
         &self.properties
     }
 

--- a/rust/lance/src/io/exec/testing.rs
+++ b/rust/lance/src/io/exec/testing.rs
@@ -23,17 +23,17 @@ use futures::StreamExt;
 #[derive(Debug)]
 pub struct TestingExec {
     pub(crate) batches: Vec<RecordBatch>,
-    properties: PlanProperties,
+    properties: Arc<PlanProperties>,
 }
 
 impl TestingExec {
     pub(crate) fn new(batches: Vec<RecordBatch>) -> Self {
-        let properties = PlanProperties::new(
+        let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(batches[0].schema()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
-        );
+        ));
         Self {
             batches,
             properties,
@@ -81,11 +81,7 @@ impl ExecutionPlan for TestingExec {
         Ok(Box::pin(stream))
     }
 
-    fn statistics(&self) -> datafusion::error::Result<datafusion::physical_plan::Statistics> {
-        Ok(Statistics::new_unknown(self.schema().as_ref()))
-    }
-
-    fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
+    fn properties(&self) -> &Arc<datafusion::physical_plan::PlanProperties> {
         &self.properties
     }
 }

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -353,7 +353,7 @@ impl ExecutionPlan for ReplayExec {
         }
     }
 
-    fn properties(&self) -> &datafusion::physical_plan::PlanProperties {
+    fn properties(&self) -> &Arc<datafusion::physical_plan::PlanProperties> {
         self.input.properties()
     }
 }


### PR DESCRIPTION
## Summary

Upgrade core dependencies to align with the latest Apache DataFusion ecosystem:
- **arrow** 57.0.0 → 58.0.0
- **datafusion** 52.1.0 → 53.0.0
- **object_store** 0.12.3 → 0.13

## Key API changes addressed

### object_store 0.12 → 0.13
- Methods (`get`, `put`, `head`, `delete`, `copy`, `rename`, etc.) moved from `ObjectStore` trait to `ObjectStoreExt` extension trait
- Added new required trait methods: `delete_stream`, `copy_opts`
- `rename_if_not_exists` replaced with `rename_opts` + `RenameTargetMode::Create`

### datafusion 52 → 53
- `ExecutionPlan::statistics()` removed (now has default impl)
- `ExecutionPlan::properties()` returns `&Arc<PlanProperties>` instead of `&PlanProperties`
- `SimplifyContext::new(&props)` → `SimplifyContext::default()`
- `UnaryOperator::PGBitwiseNot` → `UnaryOperator::BitwiseNot`
- `HashJoinExec::try_new` added `null_aware` parameter

### arrow 57 → 58
- No breaking changes for lance's usage

## Known issue

`object_store_opendal 0.55` does not yet support `object_store 0.13`. Cloud storage features (`aws`, `gcp`, `azure`, `oss`, `tencent`, `huggingface`) will need an opendal update once released. The fix is already merged upstream: apache/opendal#7243

## Test plan

- [x] `cargo check` passes for all core crates with `--no-default-features`
- [ ] CI tests (pending opendal update for cloud features)

🤖 Generated with [Claude Code](https://claude.com/claude-code)