### PR TITLE
feat(java): add Dataset.getZonemapStats() API

### DIFF
--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3778,10 +3778,12 @@ name = "lance-jni"
 version = "5.0.0-beta.5"
 dependencies = [
  "arrow",
+ "arrow-array",
  "arrow-schema",
  "async-trait",
  "bytes",
  "chrono",
+ "datafusion-common",
  "env_logger",
  "jni",
  "lance",

--- a/java/lance-jni/Cargo.toml
+++ b/java/lance-jni/Cargo.toml
@@ -28,7 +28,9 @@ lance-core = { path = "../../rust/lance-core" }
 lance-file = { path = "../../rust/lance-file" }
 lance-table = { path = "../../rust/lance-table" }
 arrow = { version = "57.1", features = ["ffi"] }
+arrow-array = "57.1"
 arrow-schema = "57.1"
+datafusion-common = "52.1.0"
 object_store = { version = "0.12.2" }
 tokio = { version = "1.23", features = [
     "rt-multi-thread",

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -3072,3 +3072,196 @@ fn inner_get_session_handle(env: &mut JNIEnv, java_dataset: JObject) -> Result<j
     let session = dataset_guard.inner.session();
     Ok(handle_from_session(session))
 }
+
+/////////////////////////////////
+// Zonemap Stats Methods       //
+/////////////////////////////////
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_nativeGetZonemapStats<'local>(
+    mut env: JNIEnv<'local>,
+    java_dataset: JObject,
+    jcolumn_name: JString,
+) -> JObject<'local> {
+    ok_or_throw!(
+        env,
+        inner_get_zonemap_stats(&mut env, java_dataset, jcolumn_name)
+    )
+}
+
+fn inner_get_zonemap_stats<'local>(
+    env: &mut JNIEnv<'local>,
+    java_dataset: JObject,
+    jcolumn_name: JString,
+) -> Result<JObject<'local>> {
+    use arrow_array::Array;
+    use datafusion_common::ScalarValue;
+    use lance::dataset::index::LanceIndexStoreExt;
+    use lance::index::DatasetIndexExt;
+    use lance_index::scalar::IndexStore;
+    use lance_index::scalar::lance_format::LanceIndexStore;
+
+    let column_name: String = jcolumn_name.extract(env)?;
+
+    // 1. Get the dataset and find the zonemap index for this column
+    let zonemap_data = {
+        let dataset = {
+            let dataset_guard = unsafe {
+                env.get_rust_field::<_, _, BlockingDataset>(java_dataset, NATIVE_DATASET)
+            }?;
+            dataset_guard.inner.clone()
+        };
+        // Guard is dropped here — dataset is owned
+
+        // Find the field for the requested column (validates it exists)
+        dataset.schema().field(&column_name).ok_or_else(|| {
+            Error::input_error(format!(
+                "Column '{}' not found in dataset schema",
+                column_name
+            ))
+        })?;
+
+        // Do all async work in a single block_on call to avoid nested runtime issues
+        RT.block_on(async {
+            // Find the zonemap index for this column using describe_indices
+            let descriptions = dataset
+                .describe_indices(Some(lance_index::IndexCriteria {
+                    for_column: Some(&column_name),
+                    has_name: None,
+                    must_support_fts: false,
+                    must_support_exact_equality: false,
+                }))
+                .await
+                .map_err(Error::from)?;
+
+            let zonemap_desc = descriptions
+                .iter()
+                .find(|desc| desc.index_type().to_lowercase().contains("zonemap"));
+
+            match zonemap_desc {
+                Some(desc) => {
+                    let indices = dataset.load_indices().await.map_err(Error::from)?;
+                    let index_meta = indices.iter().find(|idx| idx.name == desc.name());
+                    match index_meta {
+                        Some(index) => {
+                            let index_store = Arc::new(
+                                LanceIndexStore::from_dataset_for_existing(&dataset, index)
+                                    .map_err(Error::from)?,
+                            );
+                            let index_file = index_store
+                                .open_index_file("zonemap.lance")
+                                .await
+                                .map_err(Error::from)?;
+                            let record_batch = index_file
+                                .read_range(0..index_file.num_rows(), None)
+                                .await
+                                .map_err(Error::from)?;
+                            Ok::<_, Error>(Some(record_batch))
+                        }
+                        None => Ok(None),
+                    }
+                }
+                None => Ok(None),
+            }
+        })?
+    };
+
+    // 3. Convert the RecordBatch to a Java ArrayList<ZoneStats>
+    let array_list = env.new_object("java/util/ArrayList", "()V", &[])?;
+
+    let record_batch = match zonemap_data {
+        Some(batch) => batch,
+        None => return Ok(array_list), // empty list if no zonemap index
+    };
+
+    if record_batch.num_rows() == 0 {
+        return Ok(array_list);
+    }
+
+    let min_col = record_batch
+        .column_by_name("min")
+        .ok_or_else(|| Error::input_error("ZoneMap index file missing 'min' column".to_string()))?;
+    let max_col = record_batch
+        .column_by_name("max")
+        .ok_or_else(|| Error::input_error("ZoneMap index file missing 'max' column".to_string()))?;
+    let null_count_col = record_batch
+        .column_by_name("null_count")
+        .ok_or_else(|| {
+            Error::input_error("ZoneMap index file missing 'null_count' column".to_string())
+        })?
+        .as_any()
+        .downcast_ref::<arrow_array::UInt32Array>()
+        .ok_or_else(|| {
+            Error::input_error("ZoneMap 'null_count' column is not UInt32".to_string())
+        })?;
+    let fragment_id_col = record_batch
+        .column_by_name("fragment_id")
+        .ok_or_else(|| {
+            Error::input_error("ZoneMap index file missing 'fragment_id' column".to_string())
+        })?
+        .as_any()
+        .downcast_ref::<arrow_array::UInt64Array>()
+        .ok_or_else(|| {
+            Error::input_error("ZoneMap 'fragment_id' column is not UInt64".to_string())
+        })?;
+    let zone_start_col = record_batch
+        .column_by_name("zone_start")
+        .ok_or_else(|| {
+            Error::input_error("ZoneMap index file missing 'zone_start' column".to_string())
+        })?
+        .as_any()
+        .downcast_ref::<arrow_array::UInt64Array>()
+        .ok_or_else(|| {
+            Error::input_error("ZoneMap 'zone_start' column is not UInt64".to_string())
+        })?;
+    let zone_length_col = record_batch
+        .column_by_name("zone_length")
+        .ok_or_else(|| {
+            Error::input_error("ZoneMap index file missing 'zone_length' column".to_string())
+        })?
+        .as_any()
+        .downcast_ref::<arrow_array::UInt64Array>()
+        .ok_or_else(|| {
+            Error::input_error("ZoneMap 'zone_length' column is not UInt64".to_string())
+        })?;
+
+    for i in 0..record_batch.num_rows() {
+        let fragment_id = fragment_id_col.value(i) as i32;
+        let zone_start = zone_start_col.value(i) as i64;
+        let zone_length = zone_length_col.value(i) as i64;
+        let null_count = null_count_col.value(i) as i64;
+
+        // Convert min/max ScalarValues to Java Comparable objects
+        let min_scalar = ScalarValue::try_from_array(min_col, i).map_err(|e| {
+            Error::input_error(format!("Failed to read min value at row {}: {}", i, e))
+        })?;
+        let max_scalar = ScalarValue::try_from_array(max_col, i).map_err(|e| {
+            Error::input_error(format!("Failed to read max value at row {}: {}", i, e))
+        })?;
+
+        let j_min = crate::utils::scalar_value_to_java(env, &min_scalar)?;
+        let j_max = crate::utils::scalar_value_to_java(env, &max_scalar)?;
+
+        let zone_stats = env.new_object(
+            "org/lance/index/scalar/ZoneStats",
+            "(IJJLjava/lang/Comparable;Ljava/lang/Comparable;J)V",
+            &[
+                JValue::Int(fragment_id),
+                JValue::Long(zone_start),
+                JValue::Long(zone_length),
+                JValue::Object(&j_min),
+                JValue::Object(&j_max),
+                JValue::Long(null_count),
+            ],
+        )?;
+
+        env.call_method(
+            &array_list,
+            "add",
+            "(Ljava/lang/Object;)Z",
+            &[JValue::Object(&zone_stats)],
+        )?;
+    }
+
+    Ok(array_list)
+}

--- a/java/lance-jni/src/utils.rs
+++ b/java/lance-jni/src/utils.rs
@@ -570,3 +570,85 @@ pub fn to_java_float_obj<'local>(
         None => Ok(JObject::null()),
     }
 }
+
+pub fn to_java_double_obj<'local>(
+    env: &mut JNIEnv<'local>,
+    value: Option<f64>,
+) -> Result<JObject<'local>> {
+    match value {
+        Some(v) => Ok(env.new_object("java/lang/Double", "(D)V", &[JValue::Double(v)])?),
+        None => Ok(JObject::null()),
+    }
+}
+
+pub fn to_java_string_obj<'local>(
+    env: &mut JNIEnv<'local>,
+    value: Option<&str>,
+) -> Result<JObject<'local>> {
+    match value {
+        Some(v) => {
+            let jstr = env.new_string(v)?;
+            Ok(jstr.into())
+        }
+        None => Ok(JObject::null()),
+    }
+}
+
+/// Convert a DataFusion ScalarValue to a Java Comparable object.
+///
+/// Maps numeric types to their boxed Java equivalents (Long, Double)
+/// and string types to Java String. Null ScalarValues produce JObject::null().
+///
+/// This is useful for exposing index statistics (e.g., zonemap min/max)
+/// to Java clients in a type-safe, Comparable-compatible way.
+pub fn scalar_value_to_java<'a>(
+    env: &mut JNIEnv<'a>,
+    value: &datafusion_common::ScalarValue,
+) -> Result<JObject<'a>> {
+    use datafusion_common::ScalarValue;
+
+    match value {
+        ScalarValue::Null => Ok(JObject::null()),
+
+        ScalarValue::Boolean(v) => to_java_boolean_obj(env, *v),
+
+        // Integer types → Java Long
+        ScalarValue::Int8(v) => to_java_long_obj(env, v.map(|x| x as i64)),
+        ScalarValue::Int16(v) => to_java_long_obj(env, v.map(|x| x as i64)),
+        ScalarValue::Int32(v) => to_java_long_obj(env, v.map(|x| x as i64)),
+        ScalarValue::Int64(v) => to_java_long_obj(env, *v),
+        ScalarValue::UInt8(v) => to_java_long_obj(env, v.map(|x| x as i64)),
+        ScalarValue::UInt16(v) => to_java_long_obj(env, v.map(|x| x as i64)),
+        ScalarValue::UInt32(v) => to_java_long_obj(env, v.map(|x| x as i64)),
+        // UInt64 may overflow i64, but for min/max stats this is acceptable
+        ScalarValue::UInt64(v) => to_java_long_obj(env, v.map(|x| x as i64)),
+
+        // Float types → Java Double
+        ScalarValue::Float16(v) => to_java_double_obj(env, v.map(|x| f64::from(x.to_f32()))),
+        ScalarValue::Float32(v) => to_java_double_obj(env, v.map(|x| x as f64)),
+        ScalarValue::Float64(v) => to_java_double_obj(env, *v),
+
+        // String types → Java String
+        ScalarValue::Utf8(v) => to_java_string_obj(env, v.as_deref()),
+        ScalarValue::LargeUtf8(v) => to_java_string_obj(env, v.as_deref()),
+
+        // Date types → Java Long
+        ScalarValue::Date32(v) => to_java_long_obj(env, v.map(|x| x as i64)),
+        ScalarValue::Date64(v) => to_java_long_obj(env, *v),
+
+        // Timestamp types → Java Long
+        ScalarValue::TimestampSecond(v, _) => to_java_long_obj(env, *v),
+        ScalarValue::TimestampMillisecond(v, _) => to_java_long_obj(env, *v),
+        ScalarValue::TimestampMicrosecond(v, _) => to_java_long_obj(env, *v),
+        ScalarValue::TimestampNanosecond(v, _) => to_java_long_obj(env, *v),
+
+        // For any unsupported type, return null (conservative: caller will skip)
+        _ => {
+            log::warn!(
+                "Unsupported ScalarValue type for Java conversion: {:?}",
+                value.data_type()
+            );
+            Ok(JObject::null())
+        }
+    }
+}

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -24,6 +24,7 @@ import org.lance.index.IndexOptions;
 import org.lance.index.IndexParams;
 import org.lance.index.IndexType;
 import org.lance.index.OptimizeOptions;
+import org.lance.index.scalar.ZoneStats;
 import org.lance.ipc.DataStatistics;
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
@@ -1315,6 +1316,29 @@ public class Dataset implements Closeable {
   }
 
   private native List<IndexDescription> nativeDescribeIndices(Optional<IndexCriteria> criteria);
+
+  /**
+   * Read zonemap statistics for a column.
+   *
+   * <p>Returns per-zone min/max/null_count statistics for the given column, if a zonemap index
+   * exists. Returns an empty list if no zonemap index exists for the column.
+   *
+   * <p>The zonemap index file is typically small (one row per zone), so this is a lightweight
+   * metadata-only operation suitable for calling on the driver during scan planning.
+   *
+   * @param columnName the column name
+   * @return list of per-zone statistics, ordered by (fragment_id, zone_start)
+   */
+  public List<ZoneStats> getZonemapStats(String columnName) {
+    Preconditions.checkArgument(
+        columnName != null && !columnName.isEmpty(), "columnName cannot be null or empty");
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+      return nativeGetZonemapStats(columnName);
+    }
+  }
+
+  private native List<ZoneStats> nativeGetZonemapStats(String columnName);
 
   /**
    * Get the table config of the dataset.

--- a/java/src/main/java/org/lance/index/scalar/ZoneStats.java
+++ b/java/src/main/java/org/lance/index/scalar/ZoneStats.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.index.scalar;
+
+import java.io.Serializable;
+
+/**
+ * Per-zone statistics from a zonemap index.
+ *
+ * <p>Each zone covers a contiguous range of row offsets within a single fragment. The min/max
+ * values are represented as {@link Comparable} objects (Long, Double, String, etc.) matching the
+ * column's data type.
+ *
+ * <p>A zone never spans fragment boundaries: if a fragment has more rows than the zone size,
+ * multiple zones are created within that fragment.
+ *
+ * <p>This class is populated from the Rust {@code ZoneMapStatistics} via JNI. See {@code
+ * lance-index/src/scalar/zonemap.rs} for the on-disk format.
+ */
+public class ZoneStats implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private final int fragmentId;
+  private final long zoneStart;
+  private final long zoneLength;
+  private final Comparable<?> min;
+  private final Comparable<?> max;
+  private final long nullCount;
+
+  /**
+   * Constructs a new ZoneStats instance.
+   *
+   * @param fragmentId the fragment this zone belongs to
+   * @param zoneStart the starting row offset within the fragment
+   * @param zoneLength the span of row offsets (last_offset - first_offset + 1); may differ from
+   *     physical row count if rows have been deleted
+   * @param min the minimum value in the zone, or null if all values are null
+   * @param max the maximum value in the zone, or null if all values are null
+   * @param nullCount the number of null values in the zone
+   */
+  public ZoneStats(
+      int fragmentId,
+      long zoneStart,
+      long zoneLength,
+      Comparable<?> min,
+      Comparable<?> max,
+      long nullCount) {
+    this.fragmentId = fragmentId;
+    this.zoneStart = zoneStart;
+    this.zoneLength = zoneLength;
+    this.min = min;
+    this.max = max;
+    this.nullCount = nullCount;
+  }
+
+  /** Returns the fragment ID this zone belongs to. */
+  public int getFragmentId() {
+    return fragmentId;
+  }
+
+  /** Returns the starting row offset within the fragment. */
+  public long getZoneStart() {
+    return zoneStart;
+  }
+
+  /**
+   * Returns the span of row offsets covered by this zone.
+   *
+   * <p>This is (last_row_offset - first_row_offset + 1), not the count of physical rows. Deletions
+   * may create gaps within the span.
+   */
+  public long getZoneLength() {
+    return zoneLength;
+  }
+
+  /**
+   * Returns the minimum value in the zone.
+   *
+   * @return the min value, or null if all values in the zone are null
+   */
+  public Comparable<?> getMin() {
+    return min;
+  }
+
+  /**
+   * Returns the maximum value in the zone.
+   *
+   * @return the max value, or null if all values in the zone are null
+   */
+  public Comparable<?> getMax() {
+    return max;
+  }
+
+  /** Returns the number of null values in the zone. */
+  public long getNullCount() {
+    return nullCount;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "ZoneStats{fragmentId=%d, zoneStart=%d, zoneLength=%d," + " min=%s, max=%s, nullCount=%d}",
+        fragmentId, zoneStart, zoneLength, min, max, nullCount);
+  }
+}

--- a/java/src/test/java/org/lance/index/ZonemapStatsTest.java
+++ b/java/src/test/java/org/lance/index/ZonemapStatsTest.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.index;
+
+import org.lance.Dataset;
+import org.lance.Fragment;
+import org.lance.FragmentMetadata;
+import org.lance.FragmentOperation;
+import org.lance.WriteParams;
+import org.lance.index.scalar.ScalarIndexParams;
+import org.lance.index.scalar.ZoneStats;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Tests for {@link Dataset#getZonemapStats(String)} and the {@link ZoneStats} data class. */
+public class ZonemapStatsTest {
+
+  private static Schema intSchema() {
+    return new Schema(
+        Arrays.asList(
+            Field.nullable("id", new ArrowType.Int(32, true)),
+            Field.nullable("value", new ArrowType.Int(32, true))),
+        null);
+  }
+
+  /** Write a single fragment with sequential integer values. */
+  private Dataset writeIntFragment(
+      BufferAllocator allocator, String path, long version, int startValue, int rowCount) {
+    Schema schema = intSchema();
+    List<FragmentMetadata> metas;
+    try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+      root.allocateNew();
+      IntVector idVec = (IntVector) root.getVector("id");
+      IntVector valVec = (IntVector) root.getVector("value");
+      for (int i = 0; i < rowCount; i++) {
+        idVec.setSafe(i, startValue + i);
+        valVec.setSafe(i, (startValue + i) * 10);
+      }
+      root.setRowCount(rowCount);
+      metas = Fragment.create(path, allocator, root, new WriteParams.Builder().build());
+    }
+    FragmentOperation.Append appendOp = new FragmentOperation.Append(metas);
+    return Dataset.commit(allocator, path, appendOp, Optional.of(version));
+  }
+
+  // -------------------------------------------------------
+  // ZoneStats data class tests
+  // -------------------------------------------------------
+
+  @Test
+  public void testZoneStatsGetters() {
+    ZoneStats stats = new ZoneStats(3, 100, 50, 10L, 99L, 5);
+    assertEquals(3, stats.getFragmentId());
+    assertEquals(100, stats.getZoneStart());
+    assertEquals(50, stats.getZoneLength());
+    assertEquals(10L, stats.getMin());
+    assertEquals(99L, stats.getMax());
+    assertEquals(5, stats.getNullCount());
+  }
+
+  @Test
+  public void testZoneStatsNullMinMax() {
+    ZoneStats stats = new ZoneStats(0, 0, 10, null, null, 10);
+    assertNull(stats.getMin());
+    assertNull(stats.getMax());
+    assertEquals(10, stats.getNullCount());
+  }
+
+  @Test
+  public void testZoneStatsToString() {
+    ZoneStats stats = new ZoneStats(1, 0, 100, 0L, 99L, 0);
+    String str = stats.toString();
+    assertTrue(str.contains("fragmentId=1"));
+    assertTrue(str.contains("min=0"));
+    assertTrue(str.contains("max=99"));
+  }
+
+  // -------------------------------------------------------
+  // getZonemapStats integration tests
+  // -------------------------------------------------------
+
+  @Test
+  public void testGetZonemapStatsNoIndex(@TempDir Path tempDir) {
+    String path = tempDir.resolve("no_index").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      try (Dataset dataset =
+          Dataset.create(allocator, path, intSchema(), new WriteParams.Builder().build())) {
+        List<ZoneStats> stats = dataset.getZonemapStats("id");
+        assertNotNull(stats);
+        assertTrue(stats.isEmpty());
+      }
+    }
+  }
+
+  @Test
+  public void testGetZonemapStatsNonexistentColumn(@TempDir Path tempDir) {
+    String path = tempDir.resolve("bad_col").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      try (Dataset dataset =
+          Dataset.create(allocator, path, intSchema(), new WriteParams.Builder().build())) {
+        assertThrows(IllegalArgumentException.class, () -> dataset.getZonemapStats("nonexistent"));
+      }
+    }
+  }
+
+  @Test
+  public void testGetZonemapStatsWithData(@TempDir Path tempDir) throws Exception {
+    String path = tempDir.resolve("with_data").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      try (Dataset ds =
+          Dataset.create(allocator, path, intSchema(), new WriteParams.Builder().build())) {
+        // empty
+      }
+      Dataset ds2 = writeIntFragment(allocator, path, 1, 0, 100);
+      ds2.close();
+
+      try (Dataset dataset = Dataset.open(path, allocator)) {
+        ScalarIndexParams params = ScalarIndexParams.create("zonemap", "{}");
+        IndexParams indexParams = IndexParams.builder().setScalarIndexParams(params).build();
+        dataset.createIndex(
+            Collections.singletonList("value"),
+            IndexType.ZONEMAP,
+            Optional.of("value_zm"),
+            indexParams,
+            true);
+
+        List<ZoneStats> stats = dataset.getZonemapStats("value");
+        assertNotNull(stats);
+        assertFalse(stats.isEmpty());
+
+        for (ZoneStats z : stats) {
+          assertEquals(0, z.getFragmentId());
+          assertNotNull(z.getMin());
+          assertNotNull(z.getMax());
+          assertTrue(z.getZoneLength() > 0);
+        }
+
+        ZoneStats first = stats.get(0);
+        assertTrue(
+            ((Number) first.getMin()).longValue() <= 0,
+            "First zone min should be <= 0, got: " + first.getMin());
+
+        ZoneStats last = stats.get(stats.size() - 1);
+        assertTrue(
+            ((Number) last.getMax()).longValue() >= 990,
+            "Last zone max should be >= 990, got: " + last.getMax());
+      }
+    }
+  }
+
+  @Test
+  public void testGetZonemapStatsMultiFragment(@TempDir Path tempDir) throws Exception {
+    String path = tempDir.resolve("multi_frag").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      try (Dataset ds =
+          Dataset.create(allocator, path, intSchema(), new WriteParams.Builder().build())) {
+        // empty
+      }
+      Dataset ds2 = writeIntFragment(allocator, path, 1, 0, 50);
+      ds2.close();
+      Dataset ds3 = writeIntFragment(allocator, path, 2, 50, 50);
+      ds3.close();
+
+      try (Dataset dataset = Dataset.open(path, allocator)) {
+        assertEquals(2, dataset.getFragments().size());
+
+        ScalarIndexParams params = ScalarIndexParams.create("zonemap", "{}");
+        IndexParams indexParams = IndexParams.builder().setScalarIndexParams(params).build();
+        dataset.createIndex(
+            Collections.singletonList("value"),
+            IndexType.ZONEMAP,
+            Optional.of("value_zm"),
+            indexParams,
+            true);
+
+        List<ZoneStats> stats = dataset.getZonemapStats("value");
+        assertNotNull(stats);
+        assertFalse(stats.isEmpty());
+
+        Set<Integer> fragmentIds = new HashSet<>();
+        for (ZoneStats z : stats) {
+          fragmentIds.add(z.getFragmentId());
+        }
+        assertEquals(2, fragmentIds.size(), "Expected zones from 2 fragments, got: " + fragmentIds);
+      }
+    }
+  }
+
+  @Test
+  public void testGetZonemapStatsWrongColumnReturnsEmpty(@TempDir Path tempDir) throws Exception {
+    String path = tempDir.resolve("wrong_col").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      try (Dataset ds =
+          Dataset.create(allocator, path, intSchema(), new WriteParams.Builder().build())) {
+        // empty
+      }
+      Dataset ds2 = writeIntFragment(allocator, path, 1, 0, 100);
+      ds2.close();
+
+      try (Dataset dataset = Dataset.open(path, allocator)) {
+        ScalarIndexParams params = ScalarIndexParams.create("zonemap", "{}");
+        IndexParams indexParams = IndexParams.builder().setScalarIndexParams(params).build();
+        dataset.createIndex(
+            Collections.singletonList("value"),
+            IndexType.ZONEMAP,
+            Optional.of("value_zm"),
+            indexParams,
+            true);
+
+        List<ZoneStats> stats = dataset.getZonemapStats("id");
+        assertNotNull(stats);
+        assertTrue(stats.isEmpty(), "Expected empty for non-indexed column");
+      }
+    }
+  }
+
+  @Test
+  public void testGetZonemapStatsNullArgument(@TempDir Path tempDir) {
+    String path = tempDir.resolve("null_arg").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      try (Dataset dataset =
+          Dataset.create(allocator, path, intSchema(), new WriteParams.Builder().build())) {
+        assertThrows(IllegalArgumentException.class, () -> dataset.getZonemapStats(null));
+      }
+    }
+  }
+
+  @Test
+  public void testGetZonemapStatsEmptyArgument(@TempDir Path tempDir) {
+    String path = tempDir.resolve("empty_arg").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      try (Dataset dataset =
+          Dataset.create(allocator, path, intSchema(), new WriteParams.Builder().build())) {
+        assertThrows(IllegalArgumentException.class, () -> dataset.getZonemapStats(""));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `Dataset.getZonemapStats(columnName)` Java API to read per-zone min/max/null_count statistics from zonemap indexes
- Add `ZoneStats` data class representing per-zone statistics (fragment_id, zone_start, zone_length, min, max, null_count)
- Add Rust JNI implementation that reads the `zonemap.lance` index file and converts `ScalarValue` to Java `Comparable` objects (Long, Double, String, Boolean)
- This enables Spark connectors to perform fragment-level pruning at scan planning time using zonemap statistics — analogous to partition pruning in Hive/Iceberg

## Motivation
The lance-spark connector currently only prunes fragments based on `_rowaddr` filters. With this API, it can also prune fragments based on arbitrary user-column predicates (e.g., `WHERE date = '2026-01-15'`) by consulting zonemap min/max statistics — skipping fragments whose zones provably cannot contain matching values.

## Changes
### New files
- `java/src/main/java/org/lance/index/scalar/ZoneStats.java` — Serializable data class for per-zone statistics
- `java/src/test/java/org/lance/index/ZonemapStatsTest.java` — 10 tests (data class unit tests + JNI integration tests)

### Modified files
- `java/src/main/java/org/lance/Dataset.java` — Added `getZonemapStats()` method + native declaration
- `java/lance-jni/src/blocking_dataset.rs` — JNI implementation:
  - `nativeGetZonemapStats`: finds zonemap index via `describe_indices`, reads `zonemap.lance` file, converts RecordBatch rows to Java `ZoneStats` objects
  - `scalar_value_to_java`: converts DataFusion `ScalarValue` to boxed Java types (Long, Double, String, Boolean)
- `java/lance-jni/Cargo.toml` — Added `arrow-array` and `datafusion-common` dependencies

## Test plan
- [x] `ZonemapStatsTest#testZoneStatsGetters` — data class getters
- [x] `ZonemapStatsTest#testZoneStatsNullMinMax` — null min/max handling
- [x] `ZonemapStatsTest#testZoneStatsToString` — toString format
- [x] `ZonemapStatsTest#testGetZonemapStatsNoIndex` — empty dataset, no index → empty list
- [x] `ZonemapStatsTest#testGetZonemapStatsNonexistentColumn` — bad column → exception
- [x] `ZonemapStatsTest#testGetZonemapStatsWithData` — full JNI round-trip with real data
- [x] `ZonemapStatsTest#testGetZonemapStatsMultiFragment` — 2 fragments → stats from both
- [x] `ZonemapStatsTest#testGetZonemapStatsWrongColumnReturnsEmpty` — zonemap on col A, query col B → empty
- [x] `ZonemapStatsTest#testGetZonemapStatsNullArgument` — null → exception
- [x] `ZonemapStatsTest#testGetZonemapStatsEmptyArgument` — empty → exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)