### PR TITLE
ci: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/approve-rc.yml
+++ b/.github/workflows/approve-rc.yml
@@ -13,6 +13,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   approve-rc:
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmark-comment-trigger.yml
+++ b/.github/workflows/benchmark-comment-trigger.yml
@@ -13,6 +13,10 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   forward-to-bench:
     # Only process comments on PRs that mention @bench-bot and contain 'benchmark'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,6 +3,9 @@ name: Run benchmarks
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   dataset:
     timeout-minutes: 30

--- a/.github/workflows/buf-publish.yml
+++ b/.github/workflows/buf-publish.yml
@@ -11,6 +11,9 @@ on:
         default: ''
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   push-module:
     runs-on: ubuntu-latest

--- a/.github/workflows/cargo-publish.yml
+++ b/.github/workflows/cargo-publish.yml
@@ -24,11 +24,15 @@ env:
   CARGO_INCREMENTAL: "0"
   RUSTFLAGS: "-C debuginfo=0"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # Needs additional disk space for the full build.
     runs-on: ubuntu-24.04-8x
     permissions:
+      contents: read
       id-token: write
     timeout-minutes: 60
     env:

--- a/.github/workflows/ci-benchmarks.yml
+++ b/.github/workflows/ci-benchmarks.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   bench_regress:
     timeout-minutes: 120

--- a/.github/workflows/create-rc.yml
+++ b/.github/workflows/create-rc.yml
@@ -13,6 +13,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   create-rc:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -14,6 +14,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   create-release-branch:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -13,6 +13,9 @@ on:
       - docs/**
       - .github/workflows/docs-check.yml
 
+permissions:
+  contents: read
+
 env:
   RUSTFLAGS: "-C debuginfo=0"
   # according to: https://matklad.github.io/2021/09/04/fast-rust-builds.html

--- a/.github/workflows/java-publish.yml
+++ b/.github/workflows/java-publish.yml
@@ -24,6 +24,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   linux-arm64:
     name: Build on Linux Arm64

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -20,6 +20,9 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: "1"
 
+permissions:
+  contents: read
+
 jobs:
   rust-clippy-fmt:
     runs-on: ubuntu-24.04

--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -12,6 +12,9 @@ on:
       - rust/**
       - python/**
       - protos/**
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -5,10 +5,15 @@ on:
     - cron: "0 0 * * *" # Runs every day at midnight UTC
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-24.04
     if: github.repository == 'lancedb/lance'
+    permissions:
+      actions: write
     steps:
       - name: Nightly Run File Verification Workflow
         uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1

--- a/.github/workflows/notebook.yml
+++ b/.github/workflows/notebook.yml
@@ -15,6 +15,9 @@ on:
       - protos/**
       - notebooks/**
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -14,6 +14,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   publish-beta:
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -26,6 +26,9 @@ on:
       - ".github/workflows/build_windows_wheel/**"
       - ".github/workflows/upload_wheel/**"
 
+permissions:
+  contents: read
+
 jobs:
   linux:
     timeout-minutes: 60

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,6 +19,9 @@ on:
       - .github/workflows/build_mac_wheel/**
       - .github/workflows/run_tests/**
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/recurring-tests.yml
+++ b/.github/workflows/recurring-tests.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 * * 0" # Runs at 00:00 UTC every Sunday
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   get-pylance-versions:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,9 @@ on:
       - Cargo.lock
       - deny.toml
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -53,6 +56,7 @@ jobs:
 
   clippy:
     permissions:
+      contents: read
       checks: write
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -5,6 +5,9 @@ on:
       - main
       - release/**
 
+permissions:
+  contents: read
+
 jobs:
   run:
     name: Spell Check with Typos


### PR DESCRIPTION
Most workflows lacked a `permissions` block, causing GitHub security warnings. Added `permissions: contents: read` at the top level for all affected workflows.

Special cases:
- `benchmark-comment-trigger`: also needs `pull-requests: read` to call the pulls REST API
- `nightly_run`: `run` job needs `actions: write` to dispatch `file_verification.yml`
- `rust`: `clippy` job-level permissions updated to include `contents: read` alongside `checks: write`
- `cargo-publish`: `build` job updated to include `contents: read` alongside `id-token: write`

Workflows already having correct permissions (`claude.yml`, `claude-code-review.yml`, `pr-title.yml`, `stale.yml`, `rust-benchmark.yml`, `docs-deploy.yml`, `codex-fix-ci.yml`, `codex-backport-pr.yml`, `file_verification.yml`, `cargo-publish.yml`) were left unchanged or minimally updated.