### PR TITLE
feat(java): add Dataset.readIndexFile() for raw index data access

### DIFF
--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3469,6 +3469,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "arrow-select",

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -3072,3 +3072,75 @@ fn inner_get_session_handle(env: &mut JNIEnv, java_dataset: JObject) -> Result<j
     let session = dataset_guard.inner.session();
     Ok(handle_from_session(session))
 }
+
+/////////////////////////////////
+// Index File Read Methods     //
+/////////////////////////////////
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_nativeReadIndexFile(
+    mut env: JNIEnv,
+    java_dataset: JObject,
+    jindex_name: JString,
+    jfile_name: JString,
+    stream_addr: jlong,
+) {
+    ok_or_throw_without_return!(
+        env,
+        inner_read_index_file(&mut env, java_dataset, jindex_name, jfile_name, stream_addr)
+    );
+}
+
+fn inner_read_index_file(
+    env: &mut JNIEnv,
+    java_dataset: JObject,
+    jindex_name: JString,
+    jfile_name: JString,
+    stream_addr: jlong,
+) -> Result<()> {
+    use lance::dataset::index::LanceIndexStoreExt;
+    use lance_index::scalar::IndexStore;
+    use lance_index::scalar::lance_format::LanceIndexStore;
+
+    let index_name: String = jindex_name.extract(env)?;
+    let file_name: String = jfile_name.extract(env)?;
+
+    let dataset = {
+        let dataset_guard =
+            unsafe { env.get_rust_field::<_, _, BlockingDataset>(java_dataset, NATIVE_DATASET) }?;
+        dataset_guard.inner.clone()
+    };
+
+    let record_batch = RT.block_on(async {
+        let indices = dataset.load_indices().await.map_err(Error::from)?;
+        let index_meta = indices
+            .iter()
+            .find(|idx| idx.name == index_name)
+            .ok_or_else(|| {
+                Error::input_error(format!("Index '{}' not found in dataset", index_name))
+            })?;
+
+        let index_store = Arc::new(
+            LanceIndexStore::from_dataset_for_existing(&dataset, index_meta)
+                .map_err(Error::from)?,
+        );
+
+        let index_file = index_store
+            .open_index_file(&file_name)
+            .await
+            .map_err(Error::from)?;
+
+        let batch = index_file
+            .read_range(0..index_file.num_rows(), None)
+            .await
+            .map_err(Error::from)?;
+
+        Ok::<_, Error>(batch)
+    })?;
+
+    let schema = Arc::new(record_batch.schema().as_ref().clone());
+    let reader = RecordBatchIterator::new(std::iter::once(Ok(record_batch)), schema);
+    let ffi_stream = FFI_ArrowArrayStream::new(Box::new(reader));
+    unsafe { std::ptr::write_unaligned(stream_addr as *mut FFI_ArrowArrayStream, ffi_stream) }
+    Ok(())
+}

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -1317,6 +1317,50 @@ public class Dataset implements Closeable {
   private native List<IndexDescription> nativeDescribeIndices(Optional<IndexCriteria> criteria);
 
   /**
+   * Read a file from an index as an Arrow stream.
+   *
+   * <p>This is a low-level API that reads the raw contents of a file within an index directory.
+   * The caller is responsible for interpreting the returned schema and columns.
+   *
+   * <p>Example: reading zonemap statistics for a column:
+   *
+   * <pre>{@code
+   * // Find the zonemap index name via describeIndices()
+   * String indexName = ...;
+   * try (ArrowReader reader = dataset.readIndexFile(indexName, "zonemap.lance")) {
+   *   while (reader.loadNextBatch()) {
+   *     VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+   *     // columns: fragment_id, zone_start, zone_length, min, max, null_count
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param indexName the logical index name (from {@link IndexDescription#getName()})
+   * @param fileName the file within the index directory (e.g. "zonemap.lance")
+   * @return an ArrowReader over the file contents; caller must close it
+   * @throws IllegalArgumentException if indexName or fileName is null/empty, or if the index is
+   *     not found
+   * @throws RuntimeException if the file does not exist within the index
+   */
+  public ArrowReader readIndexFile(String indexName, String fileName) {
+    Preconditions.checkArgument(
+        indexName != null && !indexName.isEmpty(), "indexName cannot be null or empty");
+    Preconditions.checkArgument(
+        fileName != null && !fileName.isEmpty(), "fileName cannot be null or empty");
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+      try (ArrowArrayStream stream = ArrowArrayStream.allocateNew(allocator)) {
+        nativeReadIndexFile(indexName, fileName, stream.memoryAddress());
+        return Data.importArrayStream(allocator, stream);
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to read index file: " + e.getMessage(), e);
+      }
+    }
+  }
+
+  private native void nativeReadIndexFile(String indexName, String fileName, long streamAddress);
+
+  /**
    * Get the table config of the dataset.
    *
    * @return the table config

--- a/java/src/test/java/org/lance/index/ReadIndexFileTest.java
+++ b/java/src/test/java/org/lance/index/ReadIndexFileTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.index;
+
+import org.lance.Dataset;
+import org.lance.Fragment;
+import org.lance.FragmentMetadata;
+import org.lance.FragmentOperation;
+import org.lance.WriteParams;
+import org.lance.index.scalar.ScalarIndexParams;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Tests for {@link Dataset#readIndexFile(String, String)}. */
+public class ReadIndexFileTest {
+
+  private static Schema intSchema() {
+    return new Schema(
+        Arrays.asList(
+            Field.nullable("id", new ArrowType.Int(32, true)),
+            Field.nullable("value", new ArrowType.Int(32, true))),
+        null);
+  }
+
+  private Dataset writeIntFragment(
+      BufferAllocator allocator, String path, long version, int startValue, int rowCount) {
+    Schema schema = intSchema();
+    List<FragmentMetadata> metas;
+    try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+      root.allocateNew();
+      IntVector idVec = (IntVector) root.getVector("id");
+      IntVector valVec = (IntVector) root.getVector("value");
+      for (int i = 0; i < rowCount; i++) {
+        idVec.setSafe(i, startValue + i);
+        valVec.setSafe(i, (startValue + i) * 10);
+      }
+      root.setRowCount(rowCount);
+      metas = Fragment.create(path, allocator, root, new WriteParams.Builder().build());
+    }
+    FragmentOperation.Append appendOp = new FragmentOperation.Append(metas);
+    return Dataset.commit(allocator, path, appendOp, Optional.of(version));
+  }
+
+  @Test
+  public void testReadZonemapIndexFile(@TempDir Path tempDir) throws Exception {
+    String path = tempDir.resolve("zonemap_read").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      // Create empty dataset then append a fragment
+      try (Dataset ds =
+          Dataset.create(allocator, path, intSchema(), new WriteParams.Builder().build())) {
+        // empty
+      }
+      Dataset ds2 = writeIntFragment(allocator, path, 1, 0, 100);
+      ds2.close();
+
+      try (Dataset dataset = Dataset.open(path, allocator)) {
+        // Create zonemap index on "value" column
+        ScalarIndexParams params = ScalarIndexParams.create("zonemap", "{}");
+        IndexParams indexParams = IndexParams.builder().setScalarIndexParams(params).build();
+        dataset.createIndex(
+            Collections.singletonList("value"),
+            IndexType.ZONEMAP,
+            Optional.of("value_zm"),
+            indexParams,
+            true);
+
+        // Read the zonemap file via the new API
+        try (ArrowReader reader = dataset.readIndexFile("value_zm", "zonemap.lance")) {
+          assertTrue(reader.loadNextBatch());
+          VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+
+          // Verify expected columns exist
+          assertNotNull(batch.getVector("fragment_id"));
+          assertNotNull(batch.getVector("zone_start"));
+          assertNotNull(batch.getVector("zone_length"));
+          assertNotNull(batch.getVector("min"));
+          assertNotNull(batch.getVector("max"));
+          assertNotNull(batch.getVector("null_count"));
+
+          assertTrue(batch.getRowCount() > 0, "Expected at least one zone row");
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testReadZonemapMultiFragment(@TempDir Path tempDir) throws Exception {
+    String path = tempDir.resolve("multi_frag").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      try (Dataset ds =
+          Dataset.create(allocator, path, intSchema(), new WriteParams.Builder().build())) {
+        // empty
+      }
+      Dataset ds2 = writeIntFragment(allocator, path, 1, 0, 50);
+      ds2.close();
+      Dataset ds3 = writeIntFragment(allocator, path, 2, 50, 50);
+      ds3.close();
+
+      try (Dataset dataset = Dataset.open(path, allocator)) {
+        assertEquals(2, dataset.getFragments().size());
+
+        ScalarIndexParams params = ScalarIndexParams.create("zonemap", "{}");
+        IndexParams indexParams = IndexParams.builder().setScalarIndexParams(params).build();
+        dataset.createIndex(
+            Collections.singletonList("value"),
+            IndexType.ZONEMAP,
+            Optional.of("value_zm"),
+            indexParams,
+            true);
+
+        try (ArrowReader reader = dataset.readIndexFile("value_zm", "zonemap.lance")) {
+          assertTrue(reader.loadNextBatch());
+          VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+          assertTrue(batch.getRowCount() > 0);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testReadIndexFileNotFound(@TempDir Path tempDir) {
+    String path = tempDir.resolve("not_found").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      try (Dataset dataset =
+          Dataset.create(allocator, path, intSchema(), new WriteParams.Builder().build())) {
+        // No index exists — should throw
+        assertThrows(RuntimeException.class, () -> dataset.readIndexFile("no_such_index", "foo.lance"));
+      }
+    }
+  }
+
+  @Test
+  public void testReadIndexFileNullArgs(@TempDir Path tempDir) {
+    String path = tempDir.resolve("null_args").toString();
+    try (BufferAllocator allocator = new RootAllocator()) {
+      try (Dataset dataset =
+          Dataset.create(allocator, path, intSchema(), new WriteParams.Builder().build())) {
+        assertThrows(IllegalArgumentException.class, () -> dataset.readIndexFile(null, "foo.lance"));
+        assertThrows(IllegalArgumentException.class, () -> dataset.readIndexFile("idx", null));
+        assertThrows(IllegalArgumentException.class, () -> dataset.readIndexFile("", "foo.lance"));
+        assertThrows(IllegalArgumentException.class, () -> dataset.readIndexFile("idx", ""));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `Dataset.readIndexFile(String indexName, String fileName)` which returns an `ArrowReader` over the raw contents of a file within an index directory
- This is a generic, low-level API that enables consumers (e.g. lance-spark) to read zonemap statistics and other index data as Arrow RecordBatches without requiring index-type-specific methods in the SDK
- Alternative to #6421 — instead of exposing a zonemap-specific `getZonemapStats()` method with manual JNI column-by-column conversion, this returns the data via Arrow FFI, keeping the SDK generic and the Rust JNI layer simple

## Motivation
The lance-spark connector needs to read zonemap index statistics for fragment pruning and partition detection. Rather than adding a `ZoneStats` POJO and zonemap-specific logic to the SDK, this exposes the underlying index file read capability so consumers can interpret the Arrow schema themselves.

## Example usage
```java
// Find the zonemap index via describeIndices()
String indexName = ...;
try (ArrowReader reader = dataset.readIndexFile(indexName, "zonemap.lance")) {
  while (reader.loadNextBatch()) {
    VectorSchemaRoot batch = reader.getVectorSchemaRoot();
    // columns: fragment_id, zone_start, zone_length, min, max, null_count
  }
}
```

## Test plan
- [ ] `ReadIndexFileTest.testReadZonemapIndexFile` — creates dataset with zonemap index, reads via new API, verifies expected columns
- [ ] `ReadIndexFileTest.testReadZonemapMultiFragment` — multi-fragment dataset
- [ ] `ReadIndexFileTest.testReadIndexFileNotFound` — missing index throws
- [ ] `ReadIndexFileTest.testReadIndexFileNullArgs` — null/empty arg validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)