### PR TITLE
feat(index): support float16 and float64 in IVF_FLAT

### DIFF
--- a/rust/lance-index/src/vector/distributed/index_merger.rs
+++ b/rust/lance-index/src/vector/distributed/index_merger.rs
@@ -176,6 +176,7 @@ pub async fn init_writer_for_flat(
     object_store: &lance_io::object_store::ObjectStore,
     aux_out: &object_store::path::Path,
     d0: usize,
+    item_type: &DataType,
     dt: DistanceType,
     format_version: LanceFileVersion,
 ) -> Result<FileWriter> {
@@ -184,7 +185,7 @@ pub async fn init_writer_for_flat(
         Field::new(
             crate::vector::flat::storage::FLAT_COLUMN,
             DataType::FixedSizeList(
-                Arc::new(Field::new("item", DataType::Float32, true)),
+                Arc::new(Field::new("item", item_type.clone(), true)),
                 d0 as i32,
             ),
             true,
@@ -1129,64 +1130,11 @@ pub async fn merge_partial_vector_auxiliary_files(
                     .iter()
                     .find(|f| f.name() == crate::vector::flat::storage::FLAT_COLUMN)
                     .ok_or_else(|| Error::index("FLAT column missing".to_string()))?;
-                let d0 = match flat_field.data_type() {
-                    DataType::FixedSizeList(_, sz) => *sz as usize,
-                    _ => 0,
-                };
-                dim.get_or_insert(d0);
-                if let Some(dprev) = dim
-                    && dprev != d0
-                {
-                    return Err(Error::index("Dimension mismatch across shards".to_string()));
-                }
-                if v2w_opt.is_none() {
-                    let w = init_writer_for_flat(object_store, &aux_out, d0, dt, fv).await?;
-                    v2w_opt = Some(w);
-                }
-            }
-            SupportedIvfIndexType::IvfHnswFlat => {
-                // Treat HNSW_FLAT storage the same as FLAT: create schema with ROW_ID + flat vectors
-                // Determine dimension from shard schema (flat column) or fallback to STORAGE_METADATA_KEY
-                let schema_arrow: ArrowSchema = reader.schema().as_ref().into();
-                // Try to find flat column and derive dim
-                let d0 = if let Some(flat_field) = schema_arrow
-                    .fields
-                    .iter()
-                    .find(|f| f.name() == crate::vector::flat::storage::FLAT_COLUMN)
-                {
-                    match flat_field.data_type() {
-                        DataType::FixedSizeList(_, sz) => *sz as usize,
-                        _ => 0,
-                    }
-                } else {
-                    // Fallback to STORAGE_METADATA_KEY FlatMetadata
-                    if let Some(storage_meta_json) = reader
-                        .metadata()
-                        .file_schema
-                        .metadata
-                        .get(STORAGE_METADATA_KEY)
-                    {
-                        let storage_metadata_vec: Vec<String> =
-                            serde_json::from_str(storage_meta_json).map_err(|e| {
-                                Error::index(format!("Failed to parse storage metadata: {}", e))
-                            })?;
-                        if let Some(first_meta) = storage_metadata_vec.first() {
-                            if let Ok(flat_meta) = serde_json::from_str::<FlatMetadata>(first_meta)
-                            {
-                                flat_meta.dim
-                            } else {
-                                return Err(Error::index(
-                                    "FLAT metadata missing in storage metadata".to_string(),
-                                ));
-                            }
-                        } else {
-                            return Err(Error::index(
-                                "FLAT metadata missing in storage metadata".to_string(),
-                            ));
-                        }
-                    } else {
+                let (d0, item_type) = match flat_field.data_type() {
+                    DataType::FixedSizeList(item, sz) => (*sz as usize, item.data_type().clone()),
+                    _ => {
                         return Err(Error::index(
-                            "FLAT column missing and no storage metadata".to_string(),
+                            "FLAT column is not a FixedSizeList in shard schema".to_string(),
                         ));
                     }
                 };
@@ -1197,7 +1145,41 @@ pub async fn merge_partial_vector_auxiliary_files(
                     return Err(Error::index("Dimension mismatch across shards".to_string()));
                 }
                 if v2w_opt.is_none() {
-                    let w = init_writer_for_flat(object_store, &aux_out, d0, dt, fv).await?;
+                    let w = init_writer_for_flat(object_store, &aux_out, d0, &item_type, dt, fv)
+                        .await?;
+                    v2w_opt = Some(w);
+                }
+            }
+            SupportedIvfIndexType::IvfHnswFlat => {
+                // Treat HNSW_FLAT storage the same as FLAT and preserve the actual flat item dtype.
+                let schema_arrow: ArrowSchema = reader.schema().as_ref().into();
+                let Some(flat_field) = schema_arrow
+                    .fields
+                    .iter()
+                    .find(|f| f.name() == crate::vector::flat::storage::FLAT_COLUMN)
+                else {
+                    return Err(Error::index(
+                        "FLAT column missing from IVF_HNSW_FLAT shard schema".to_string(),
+                    ));
+                };
+                let (d0, item_type) = match flat_field.data_type() {
+                    DataType::FixedSizeList(item, sz) => (*sz as usize, item.data_type().clone()),
+                    _ => {
+                        return Err(Error::index(
+                            "FLAT column is not a FixedSizeList in IVF_HNSW_FLAT shard schema"
+                                .to_string(),
+                        ));
+                    }
+                };
+                dim.get_or_insert(d0);
+                if let Some(dprev) = dim
+                    && dprev != d0
+                {
+                    return Err(Error::index("Dimension mismatch across shards".to_string()));
+                }
+                if v2w_opt.is_none() {
+                    let w = init_writer_for_flat(object_store, &aux_out, d0, &item_type, dt, fv)
+                        .await?;
                     v2w_opt = Some(w);
                 }
             }
@@ -1523,7 +1505,9 @@ pub async fn merge_partial_vector_auxiliary_files(
 mod tests {
     use super::*;
 
-    use arrow_array::{FixedSizeListArray, Float32Array, RecordBatch, UInt8Array, UInt64Array};
+    use arrow_array::{
+        FixedSizeListArray, Float32Array, Float64Array, RecordBatch, UInt8Array, UInt64Array,
+    };
     use arrow_schema::Field;
     use bytes::Bytes;
     use futures::StreamExt;
@@ -1602,6 +1586,71 @@ mod tests {
 
         let row_id_arr = UInt64Array::from(row_ids);
         let value_arr = Float32Array::from(values);
+        let fsl = FixedSizeListArray::try_new_from_values(value_arr, dim).unwrap();
+        let batch = RecordBatch::try_new(
+            Arc::new(arrow_schema),
+            vec![Arc::new(row_id_arr), Arc::new(fsl)],
+        )
+        .unwrap();
+
+        v2w.write_batch(&batch).await?;
+        v2w.finish().await?;
+        Ok(total_rows)
+    }
+
+    async fn write_flat_partial_aux_f64(
+        store: &ObjectStore,
+        aux_path: &Path,
+        dim: i32,
+        lengths: &[u32],
+        base_row_id: u64,
+        distance_type: DistanceType,
+    ) -> Result<usize> {
+        let arrow_schema = ArrowSchema::new(vec![
+            (*ROW_ID_FIELD).clone(),
+            Field::new(
+                crate::vector::flat::storage::FLAT_COLUMN,
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float64, true)), dim),
+                true,
+            ),
+        ]);
+
+        let writer = store.create(aux_path).await?;
+        let mut v2w = V2Writer::try_new(
+            writer,
+            lance_core::datatypes::Schema::try_from(&arrow_schema)?,
+            V2WriterOptions::default(),
+        )?;
+        v2w.add_schema_metadata(DISTANCE_TYPE_KEY, distance_type.to_string());
+
+        let ivf_meta = pb::Ivf {
+            centroids: Vec::new(),
+            offsets: Vec::new(),
+            lengths: lengths.to_vec(),
+            centroids_tensor: None,
+            loss: None,
+        };
+        let buf = Bytes::from(ivf_meta.encode_to_vec());
+        let pos = v2w.add_global_buffer(buf).await?;
+        v2w.add_schema_metadata(IVF_METADATA_KEY, pos.to_string());
+
+        let total_rows: usize = lengths.iter().map(|v| *v as usize).sum();
+        let mut row_ids = Vec::with_capacity(total_rows);
+        let mut values = Vec::with_capacity(total_rows * dim as usize);
+
+        let mut current_row_id = base_row_id;
+        for (pid, len) in lengths.iter().enumerate() {
+            for _ in 0..*len {
+                row_ids.push(current_row_id);
+                current_row_id += 1;
+                for d in 0..dim {
+                    values.push(pid as f64 + d as f64 * 0.01);
+                }
+            }
+        }
+
+        let row_id_arr = UInt64Array::from(row_ids);
+        let value_arr = Float64Array::from(values);
         let fsl = FixedSizeListArray::try_new_from_values(value_arr, dim).unwrap();
         let batch = RecordBatch::try_new(
             Arc::new(arrow_schema),
@@ -1829,6 +1878,64 @@ mod tests {
                 other
             ),
         }
+    }
+
+    #[tokio::test]
+    async fn test_merge_ivf_flat_preserves_float64_schema() {
+        let object_store = ObjectStore::memory();
+        let index_dir = Path::from("index/float64_uuid");
+
+        let partial0 = index_dir.child("partial_0");
+        let partial1 = index_dir.child("partial_1");
+        let aux0 = partial0.child(INDEX_AUXILIARY_FILE_NAME);
+        let aux1 = partial1.child(INDEX_AUXILIARY_FILE_NAME);
+
+        let lengths = vec![2_u32, 2_u32];
+        let dim = 3_i32;
+
+        write_flat_partial_aux_f64(&object_store, &aux0, dim, &lengths, 0, DistanceType::L2)
+            .await
+            .unwrap();
+        write_flat_partial_aux_f64(&object_store, &aux1, dim, &lengths, 100, DistanceType::L2)
+            .await
+            .unwrap();
+
+        merge_partial_vector_auxiliary_files(
+            &object_store,
+            &[aux0.clone(), aux1.clone()],
+            &index_dir,
+            Arc::new(RecordingProgress::default()),
+        )
+        .await
+        .unwrap();
+
+        let aux_out = index_dir.child(INDEX_AUXILIARY_FILE_NAME);
+        let sched = ScanScheduler::new(
+            Arc::new(object_store.clone()),
+            SchedulerConfig::max_bandwidth(&object_store),
+        );
+        let fh = sched
+            .open_file(&aux_out, &CachedFileSize::unknown())
+            .await
+            .unwrap();
+        let reader = V2Reader::try_open(
+            fh,
+            None,
+            Arc::default(),
+            &lance_core::cache::LanceCache::no_cache(),
+            V2ReaderOptions::default(),
+        )
+        .await
+        .unwrap();
+
+        let flat_field = reader
+            .schema()
+            .field(crate::vector::flat::storage::FLAT_COLUMN)
+            .unwrap();
+        let DataType::FixedSizeList(item, _) = flat_field.data_type() else {
+            panic!("flat column should be a fixed size list");
+        };
+        assert_eq!(item.data_type(), &DataType::Float64);
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -10,18 +10,18 @@ use crate::vector::storage::{DistCalculator, VectorStore};
 use crate::vector::utils::do_prefetch;
 use arrow::array::AsArray;
 use arrow::compute::concat_batches;
-use arrow::datatypes::UInt8Type;
+use arrow::datatypes::{Float16Type, Float64Type, UInt8Type};
 use arrow_array::ArrowPrimitiveType;
 use arrow_array::{
     Array, ArrayRef, FixedSizeListArray, RecordBatch, UInt64Array,
     types::{Float32Type, UInt64Type},
 };
-use arrow_schema::SchemaRef;
+use arrow_schema::{DataType, SchemaRef};
 use deepsize::DeepSizeOf;
 use lance_core::{Error, ROW_ID, Result};
 use lance_file::previous::reader::FileReader as PreviousFileReader;
-use lance_linalg::distance::DistanceType;
 use lance_linalg::distance::hamming::hamming;
+use lance_linalg::distance::{Cosine, DistanceType, Dot, L2};
 
 pub const FLAT_COLUMN: &str = "flat";
 
@@ -126,7 +126,7 @@ impl FlatFloatStorage {
 }
 
 impl VectorStore for FlatFloatStorage {
-    type DistanceCalculator<'a> = FlatDistanceCal<'a, Float32Type>;
+    type DistanceCalculator<'a> = FlatFloatDistanceCalc<'a>;
 
     fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch>> {
         Ok([self.batch.clone()].into_iter())
@@ -136,6 +136,20 @@ impl VectorStore for FlatFloatStorage {
         // TODO: use chunked storage
         let new_batch = concat_batches(&batch.schema(), vec![&self.batch, &batch].into_iter())?;
         let mut storage = self.clone();
+        storage.row_ids = Arc::new(
+            new_batch
+                .column_by_name(ROW_ID)
+                .ok_or(Error::schema(format!("column {} not found", ROW_ID)))?
+                .as_primitive::<UInt64Type>()
+                .clone(),
+        );
+        storage.vectors = Arc::new(
+            new_batch
+                .column_by_name(FLAT_COLUMN)
+                .ok_or(Error::schema("column flat not found".to_string()))?
+                .as_fixed_size_list()
+                .clone(),
+        );
         storage.batch = new_batch;
         Ok(storage)
     }
@@ -288,6 +302,20 @@ impl VectorStore for FlatBinStorage {
         // TODO: use chunked storage
         let new_batch = concat_batches(&batch.schema(), vec![&self.batch, &batch].into_iter())?;
         let mut storage = self.clone();
+        storage.row_ids = Arc::new(
+            new_batch
+                .column_by_name(ROW_ID)
+                .ok_or(Error::schema(format!("column {} not found", ROW_ID)))?
+                .as_primitive::<UInt64Type>()
+                .clone(),
+        );
+        storage.vectors = Arc::new(
+            new_batch
+                .column_by_name(FLAT_COLUMN)
+                .ok_or(Error::schema("column flat not found".to_string()))?
+                .as_fixed_size_list()
+                .clone(),
+        );
         storage.batch = new_batch;
         Ok(storage)
     }
@@ -317,11 +345,11 @@ impl VectorStore for FlatBinStorage {
     }
 
     fn dist_calculator(&self, query: ArrayRef, _dist_q_c: f32) -> Self::DistanceCalculator<'_> {
-        Self::DistanceCalculator::new(self.vectors.as_ref(), query, self.distance_type)
+        Self::DistanceCalculator::new_binary(self.vectors.as_ref(), query, self.distance_type)
     }
 
     fn dist_calculator_from_id(&self, id: u32) -> Self::DistanceCalculator<'_> {
-        Self::DistanceCalculator::new(
+        Self::DistanceCalculator::new_binary(
             self.vectors.as_ref(),
             self.vectors.value(id as usize),
             self.distance_type,
@@ -337,15 +365,18 @@ pub struct FlatDistanceCal<'a, T: ArrowPrimitiveType> {
     distance_fn: fn(&[T::Native], &[T::Native]) -> f32,
 }
 
-impl<'a> FlatDistanceCal<'a, Float32Type> {
+impl<'a, T> FlatDistanceCal<'a, T>
+where
+    T: ArrowPrimitiveType,
+    T::Native: L2 + Cosine + Dot,
+{
     fn new(vectors: &'a FixedSizeListArray, query: ArrayRef, distance_type: DistanceType) -> Self {
         // Gained significant performance improvement by using strong typed primitive slice.
-        // TODO: to support other data types other than `f32`, make FlatDistanceCal a generic struct.
-        let flat_array = vectors.values().as_primitive::<Float32Type>();
+        let flat_array = vectors.values().as_primitive::<T>();
         let dimension = vectors.value_length() as usize;
         Self {
             vectors: flat_array.values(),
-            query: query.as_primitive::<Float32Type>().values().to_vec(),
+            query: query.as_primitive::<T>().values().to_vec(),
             dimension,
             distance_fn: distance_type.func(),
         }
@@ -353,7 +384,11 @@ impl<'a> FlatDistanceCal<'a, Float32Type> {
 }
 
 impl<'a> FlatDistanceCal<'a, UInt8Type> {
-    fn new(vectors: &'a FixedSizeListArray, query: ArrayRef, _distance_type: DistanceType) -> Self {
+    fn new_binary(
+        vectors: &'a FixedSizeListArray,
+        query: ArrayRef,
+        _distance_type: DistanceType,
+    ) -> Self {
         // Gained significant performance improvement by using strong typed primitive slice.
         // TODO: to support other data types other than `f32`, make FlatDistanceCal a generic struct.
         let flat_array = vectors.values().as_primitive::<UInt8Type>();
@@ -393,5 +428,115 @@ impl<T: ArrowPrimitiveType> DistCalculator for FlatDistanceCal<'_, T> {
     fn prefetch(&self, id: u32) {
         let vector = self.get_vector(id);
         do_prefetch(vector.as_ptr_range())
+    }
+}
+
+pub enum FlatFloatDistanceCalc<'a> {
+    Float16(FlatDistanceCal<'a, Float16Type>),
+    Float32(FlatDistanceCal<'a, Float32Type>),
+    Float64(FlatDistanceCal<'a, Float64Type>),
+}
+
+impl<'a> FlatFloatDistanceCalc<'a> {
+    fn new(vectors: &'a FixedSizeListArray, query: ArrayRef, distance_type: DistanceType) -> Self {
+        match vectors.value_type() {
+            DataType::Float16 => Self::Float16(FlatDistanceCal::<Float16Type>::new(
+                vectors,
+                query,
+                distance_type,
+            )),
+            DataType::Float32 => Self::Float32(FlatDistanceCal::<Float32Type>::new(
+                vectors,
+                query,
+                distance_type,
+            )),
+            DataType::Float64 => Self::Float64(FlatDistanceCal::<Float64Type>::new(
+                vectors,
+                query,
+                distance_type,
+            )),
+            dt => panic!("flat float storage does not support data type {dt}"),
+        }
+    }
+}
+
+impl DistCalculator for FlatFloatDistanceCalc<'_> {
+    fn distance(&self, id: u32) -> f32 {
+        match self {
+            Self::Float16(calc) => calc.distance(id),
+            Self::Float32(calc) => calc.distance(id),
+            Self::Float64(calc) => calc.distance(id),
+        }
+    }
+
+    fn distance_all(&self, k_hint: usize) -> Vec<f32> {
+        match self {
+            Self::Float16(calc) => calc.distance_all(k_hint),
+            Self::Float32(calc) => calc.distance_all(k_hint),
+            Self::Float64(calc) => calc.distance_all(k_hint),
+        }
+    }
+
+    fn prefetch(&self, id: u32) {
+        match self {
+            Self::Float16(calc) => calc.prefetch(id),
+            Self::Float32(calc) => calc.prefetch(id),
+            Self::Float64(calc) => calc.prefetch(id),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use arrow_array::{Float16Array, Float64Array};
+    use half::f16;
+    use lance_arrow::FixedSizeListArrayExt;
+
+    fn make_f16_storage() -> FlatFloatStorage {
+        let values = Float16Array::from(vec![
+            f16::from_f32(1.0),
+            f16::from_f32(2.0),
+            f16::from_f32(4.0),
+            f16::from_f32(6.0),
+        ]);
+        let vectors = FixedSizeListArray::try_new_from_values(values, 2).unwrap();
+        FlatFloatStorage::new(vectors, DistanceType::L2)
+    }
+
+    fn make_f64_storage() -> FlatFloatStorage {
+        let values = Float64Array::from(vec![1.0, 2.0, 4.0, 6.0]);
+        let vectors = FixedSizeListArray::try_new_from_values(values, 2).unwrap();
+        FlatFloatStorage::new(vectors, DistanceType::L2)
+    }
+
+    #[test]
+    fn test_flat_float_storage_distance_f16() {
+        let storage = make_f16_storage();
+        let query: ArrayRef = Arc::new(Float16Array::from(vec![
+            f16::from_f32(1.0),
+            f16::from_f32(2.0),
+        ]));
+
+        let calc = storage.dist_calculator(query, 0.0);
+        let distances = calc.distance_all(2);
+
+        assert_eq!(distances.len(), 2);
+        assert_eq!(distances[0], 0.0);
+        assert!((distances[1] - 25.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn test_flat_float_storage_distance_f64() {
+        let storage = make_f64_storage();
+        let query: ArrayRef = Arc::new(Float64Array::from(vec![1.0, 2.0]));
+
+        let calc = storage.dist_calculator(query, 0.0);
+        let distances = calc.distance_all(2);
+
+        assert_eq!(distances.len(), 2);
+        assert_eq!(distances[0], 0.0);
+        assert!((distances[1] - 25.0).abs() < 1e-6);
     }
 }

--- a/rust/lance-index/src/vector/utils.rs
+++ b/rust/lance-index/src/vector/utils.rs
@@ -90,10 +90,8 @@ impl SimpleIndex {
         }
 
         let store = match (centroids.data_type(), distance_type) {
-            (DataType::Float16 | DataType::Float32, _) => {
-                let f32_centroids = cast(&centroids, &DataType::Float32)
-                    .map_err(|e| Error::index(e.to_string()))?;
-                let fsl = FixedSizeListArray::try_new_from_values(f32_centroids, dimension as i32)?;
+            (DataType::Float16 | DataType::Float32 | DataType::Float64, _) => {
+                let fsl = FixedSizeListArray::try_new_from_values(centroids, dimension as i32)?;
                 SimpleStore::Float(FlatFloatStorage::new(fsl, distance_type))
             }
             (DataType::UInt8, DistanceType::Hamming) => {
@@ -113,11 +111,7 @@ impl SimpleIndex {
             dist_q_c: 0.0,
         };
         let res = match &self.store {
-            SimpleStore::Float(store) => {
-                let query =
-                    cast(&query, &DataType::Float32).map_err(|e| Error::index(e.to_string()))?;
-                self.index.search_basic(query, 1, &params, None, store)?
-            }
+            SimpleStore::Float(store) => self.index.search_basic(query, 1, &params, None, store)?,
             SimpleStore::Binary(store) => {
                 let query = if query.data_type() == &DataType::UInt8 {
                     query

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -1176,7 +1176,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     DataType::FixedSizeList(
                         Arc::new(arrow_schema::Field::new(
                             "item",
-                            centroids.value_type().clone(),
+                            centroids.value_type(),
                             true,
                         )),
                         centroids.value_length(),

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -1024,29 +1024,35 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             ));
         };
 
-        let is_pq = Q::quantization_type() == QuantizationType::Product;
-        let is_rq = Q::quantization_type() == QuantizationType::Rabit;
+        let quantization_type = Q::quantization_type();
+        let is_pq = quantization_type == QuantizationType::Product;
+        let is_rq = quantization_type == QuantizationType::Rabit;
+        let is_flat = quantization_type == QuantizationType::Flat;
 
         // prepare the final writers
         let storage_path = self.index_dir.child(INDEX_AUXILIARY_FILE_NAME);
         let index_path = self.index_dir.child(INDEX_FILE_NAME);
 
-        let mut fields = vec![ROW_ID_FIELD.clone(), quantizer.field()];
-        fields.extend(quantizer.extra_fields());
-        let storage_schema: Schema = (&arrow_schema::Schema::new(fields)).try_into()?;
         let writer_options = FileWriterOptions {
             format_version: Some(self.format_version),
             ..Default::default()
         };
-        let mut storage_writer = FileWriter::try_new(
-            self.store.create(&storage_path).await?,
-            storage_schema.clone(),
-            writer_options.clone(),
-        )?;
+        let mut storage_writer = if is_flat {
+            None
+        } else {
+            let mut fields = vec![ROW_ID_FIELD.clone(), quantizer.field()];
+            fields.extend(quantizer.extra_fields());
+            let storage_schema: Schema = (&arrow_schema::Schema::new(fields)).try_into()?;
+            Some(FileWriter::try_new(
+                self.store.create(&storage_path).await?,
+                storage_schema,
+                writer_options.clone(),
+            )?)
+        };
         let mut index_writer = FileWriter::try_new(
             self.store.create(&index_path).await?,
             S::schema().as_ref().try_into()?,
-            writer_options,
+            writer_options.clone(),
         )?;
 
         // maintain the IVF partitions
@@ -1109,7 +1115,19 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                         batch = batch.replace_column_by_name(RABIT_CODE_COLUMN, unpacked)?;
                     }
 
-                    storage_writer.write_batch(&batch).await?;
+                    if storage_writer.is_none() {
+                        let storage_schema: Schema = batch.schema_ref().as_ref().try_into()?;
+                        storage_writer = Some(FileWriter::try_new(
+                            self.store.create(&storage_path).await?,
+                            storage_schema,
+                            writer_options.clone(),
+                        )?);
+                    }
+                    storage_writer
+                        .as_mut()
+                        .expect("storage writer must be initialized before write")
+                        .write_batch(&batch)
+                        .await?;
                     storage_ivf.add_partition(batch.num_rows() as u32);
                 }
             }
@@ -1145,14 +1163,45 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
         }
 
+        if storage_writer.is_none() {
+            let Some(centroids) = ivf.centroids.as_ref() else {
+                return Err(Error::invalid_input(
+                    "flat storage writer could not infer schema from empty partitions without IVF centroids",
+                ));
+            };
+            let flat_schema = arrow_schema::Schema::new(vec![
+                ROW_ID_FIELD.as_ref().clone(),
+                arrow_schema::Field::new(
+                    lance_index::vector::flat::storage::FLAT_COLUMN,
+                    DataType::FixedSizeList(
+                        Arc::new(arrow_schema::Field::new(
+                            "item",
+                            centroids.value_type().clone(),
+                            true,
+                        )),
+                        centroids.value_length(),
+                    ),
+                    true,
+                ),
+            ]);
+            let storage_schema: Schema = (&flat_schema).try_into()?;
+            storage_writer = Some(FileWriter::try_new(
+                self.store.create(&storage_path).await?,
+                storage_schema,
+                writer_options.clone(),
+            )?);
+        }
+
+        let storage_writer = storage_writer
+            .as_mut()
+            .expect("storage writer must be initialized before final metadata write");
         let storage_ivf_pb = pb::Ivf::try_from(&storage_ivf)?;
         storage_writer.add_schema_metadata(DISTANCE_TYPE_KEY, self.distance_type.to_string());
         let ivf_buffer_pos = storage_writer
             .add_global_buffer(storage_ivf_pb.encode_to_vec().into())
             .await?;
         storage_writer.add_schema_metadata(IVF_METADATA_KEY, ivf_buffer_pos.to_string());
-        let quant_type = Q::quantization_type();
-        let transposed = match quant_type {
+        let transposed = match quantization_type {
             QuantizationType::Product | QuantizationType::Rabit => self.transpose_codes,
             _ => false,
         };

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -2438,11 +2438,12 @@ mod tests {
 
     use arrow_array::types::UInt64Type;
     use arrow_array::{
-        FixedSizeListArray, Float32Array, RecordBatch, RecordBatchIterator, RecordBatchReader,
-        UInt64Array, make_array,
+        FixedSizeListArray, Float16Array, Float32Array, RecordBatch, RecordBatchIterator,
+        RecordBatchReader, UInt64Array, make_array,
     };
     use arrow_buffer::{BooleanBuffer, NullBuffer};
     use arrow_schema::{DataType, Field, Schema};
+    use half::f16;
     use itertools::Itertools;
     use lance_core::ROW_ID;
     use lance_core::utils::address::RowAddress;
@@ -3524,6 +3525,106 @@ mod tests {
                 Field::new("_distance", DataType::Float32, true)
             ]))
         );
+    }
+
+    #[tokio::test]
+    async fn test_create_ivf_flat_f16() {
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        const DIM: usize = 32;
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float16, true)),
+                DIM as i32,
+            ),
+            true,
+        )]));
+
+        let arr = generate_random_array_with_seed::<Float16Type>(1000 * DIM, [22; 32]);
+        let fsl = FixedSizeListArray::try_new_from_values(arr, DIM as i32).unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(fsl)]).unwrap();
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
+        let mut dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+
+        let params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+
+        let query = Float16Array::from_iter_values(repeat_n(f16::from_f32(0.5), DIM));
+        let results = dataset
+            .scan()
+            .nearest("vector", &query, 5)
+            .unwrap()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].num_rows(), 5);
+        let schema = results[0].schema();
+        let field = schema.field(0);
+        let DataType::FixedSizeList(item, _) = field.data_type() else {
+            panic!("vector column should remain fixed size list");
+        };
+        assert_eq!(item.data_type(), &DataType::Float16);
+    }
+
+    #[tokio::test]
+    async fn test_create_ivf_hnsw_flat_f16() {
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        const DIM: usize = 32;
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float16, true)),
+                DIM as i32,
+            ),
+            true,
+        )]));
+
+        let arr = generate_random_array_with_seed::<Float16Type>(1000 * DIM, [22; 32]);
+        let fsl = FixedSizeListArray::try_new_from_values(arr, DIM as i32).unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(fsl)]).unwrap();
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
+        let mut dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+
+        let params = VectorIndexParams::ivf_hnsw(
+            MetricType::L2,
+            IvfBuildParams::new(2),
+            HnswBuildParams::default(),
+        );
+        dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+
+        let query = Float16Array::from_iter_values(repeat_n(f16::from_f32(0.5), DIM));
+        let results = dataset
+            .scan()
+            .nearest("vector", &query, 5)
+            .unwrap()
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].num_rows(), 5);
+        let schema = results[0].schema();
+        let field = schema.field(0);
+        let DataType::FixedSizeList(item, _) = field.data_type() else {
+            panic!("vector column should remain fixed size list");
+        };
+        assert_eq!(item.data_type(), &DataType::Float16);
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector/ivf/partition_serde.rs
+++ b/rust/lance/src/index/vector/ivf/partition_serde.rs
@@ -530,10 +530,11 @@ mod tests {
 
     use arrow_array::cast::AsArray;
     use arrow_array::{
-        Float32Array, UInt8Array, UInt64Array,
+        Float16Array, Float32Array, Float64Array, UInt8Array, UInt64Array,
         types::{Float32Type, UInt8Type},
     };
     use arrow_schema::{DataType, Field, Schema};
+    use half::f16;
     use lance_arrow::FixedSizeListArrayExt;
     use lance_index::vector::bq::storage::RABIT_CODE_COLUMN;
     use lance_index::vector::bq::transform::{ADD_FACTORS_COLUMN, SCALE_FACTORS_COLUMN};
@@ -721,6 +722,22 @@ mod tests {
         FlatFloatStorage::new(vectors, DistanceType::L2)
     }
 
+    fn make_flat_storage_f16(num_rows: usize, dim: usize) -> FlatFloatStorage {
+        let values: Vec<f16> = (0..num_rows * dim)
+            .map(|i| f16::from_f32(i as f32 * 0.01))
+            .collect();
+        let values_array = Float16Array::from(values);
+        let vectors = FixedSizeListArray::try_new_from_values(values_array, dim as i32).unwrap();
+        FlatFloatStorage::new(vectors, DistanceType::L2)
+    }
+
+    fn make_flat_storage_f64(num_rows: usize, dim: usize) -> FlatFloatStorage {
+        let values: Vec<f64> = (0..num_rows * dim).map(|i| i as f64 * 0.01).collect();
+        let values_array = Float64Array::from(values);
+        let vectors = FixedSizeListArray::try_new_from_values(values_array, dim as i32).unwrap();
+        FlatFloatStorage::new(vectors, DistanceType::L2)
+    }
+
     // ----- Flat tests -------------------------------------------------------
 
     #[test]
@@ -768,6 +785,56 @@ mod tests {
                     .unwrap();
             assert_eq!(restored.storage.distance_type(), dt);
         }
+    }
+
+    #[test]
+    fn test_roundtrip_flat_flat_f16() {
+        let storage = make_flat_storage_f16(8, 16);
+        let entry = PartitionEntry::<FlatIndex, FlatQuantizer> {
+            index: FlatIndex::default(),
+            storage,
+        };
+
+        let mut bytes = Vec::new();
+        entry.serialize(&mut bytes).unwrap();
+        let restored =
+            PartitionEntry::<FlatIndex, FlatQuantizer>::deserialize(&bytes::Bytes::from(bytes))
+                .unwrap();
+
+        let restored_batch = restored.storage.to_batches().unwrap().next().unwrap();
+        let schema = restored_batch.schema();
+        let field = schema
+            .field_with_name(lance_index::vector::flat::storage::FLAT_COLUMN)
+            .unwrap();
+        let DataType::FixedSizeList(item, _) = field.data_type() else {
+            panic!("flat column should be fixed size list");
+        };
+        assert_eq!(item.data_type(), &DataType::Float16);
+    }
+
+    #[test]
+    fn test_roundtrip_flat_flat_f64() {
+        let storage = make_flat_storage_f64(8, 16);
+        let entry = PartitionEntry::<FlatIndex, FlatQuantizer> {
+            index: FlatIndex::default(),
+            storage,
+        };
+
+        let mut bytes = Vec::new();
+        entry.serialize(&mut bytes).unwrap();
+        let restored =
+            PartitionEntry::<FlatIndex, FlatQuantizer>::deserialize(&bytes::Bytes::from(bytes))
+                .unwrap();
+
+        let restored_batch = restored.storage.to_batches().unwrap().next().unwrap();
+        let schema = restored_batch.schema();
+        let field = schema
+            .field_with_name(lance_index::vector::flat::storage::FLAT_COLUMN)
+            .unwrap();
+        let DataType::FixedSizeList(item, _) = field.data_type() else {
+            panic!("flat column should be fixed size list");
+        };
+        assert_eq!(item.data_type(), &DataType::Float64);
     }
 
     // ----- SQ helpers -------------------------------------------------------

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -3021,13 +3021,7 @@ mod tests {
                 )
                 .await;
 
-                let index_type = params.index_type();
-                // *_FLAT doesn't support float16/float64
-                if !(index_type == IndexType::IvfFlat
-                    || (index_type == IndexType::IvfHnswFlat && params.stages.len() == 2)) // IVF_HNSW_FLAT
-                    && dataset.is_none()
-                // if dataset is provided, it has been created, so the data type is already determined, no need to test float64
-                {
+                if dataset.is_none() {
                     test_index_impl::<Float64Type>(
                         params,
                         nlist,
@@ -3106,13 +3100,23 @@ mod tests {
                 .await;
             }
             _ => {
+                let index_type = params.index_type();
                 Box::pin(test_remap_impl::<Float32Type>(
-                    params,
+                    params.clone(),
                     nlist,
                     recall_requirement,
                     0.0..1.0,
                 ))
                 .await;
+                if matches!(index_type, IndexType::IvfFlat | IndexType::IvfHnswFlat) {
+                    Box::pin(test_remap_impl::<Float64Type>(
+                        params,
+                        nlist,
+                        recall_requirement,
+                        0.0..1.0,
+                    ))
+                    .await;
+                }
             }
         }
     }


### PR DESCRIPTION
## Feature

### What is the new feature?
This PR adds native `float16` and `float64` support for `IVF_FLAT` and `IVF_HNSW_FLAT`.

### Why do we need this feature?
Flat IVF indexing previously only worked end to end for `float32`. That meant users could not build, merge, reload, and query flat IVF indexes on `float16` or `float64` vectors without running into `Float32`-specific assumptions in flat storage, writer initialization, and merge/query paths.

### How does it work?
The implementation makes flat IVF paths dispatch on the actual Arrow element type from stored flat data instead of assuming `Float32`.

- `FlatFloatStorage` now dispatches distance calculators for `float16`, `float32`, and `float64`.
- Query/training helpers that previously special-cased `Float32` now accept the native float dtype where needed.
- Tests now cover flat storage distance, partition serde roundtrip, IVF create/query/remap, and distributed merge behavior for `float16` / `float64`.

## Validation

- `cargo fmt --all`
- `cargo check -p lance-index --lib`
- `cargo check -p lance --lib`
- `cargo test -p lance-index test_flat_float_storage_distance_f16 -- --nocapture`
- `cargo test -p lance-index test_merge_ivf_flat_preserves_float64_schema -- --nocapture`
- `cargo test -p lance test_build_ivf_flat -- --nocapture`
- `cargo test -p lance test_create_ivf_hnsw_flat -- --nocapture`
- `cargo test -p lance test_create_ivf_flat_f16 -- --nocapture`

## Benchmark Note

I also benchmarked float32 `IVF_FLAT` before vs after, no obvious performance diffs