### PR TITLE
fix: use logical OR instead of bitwise OR in conflict resolver

### DIFF
--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1095,7 +1095,7 @@ impl<'a> TransactionRebase<'a> {
                         .transaction
                         .operation
                         .upsert_key_conflict(&other_transaction.operation)
-                        | self
+                        || self
                             .transaction
                             .operation
                             .modifies_same_metadata(&other_transaction.operation)


### PR DESCRIPTION
## Summary

Replace bitwise OR (`|`) with logical OR (`||`) in `check_update_config_txn` to enable short-circuit evaluation when checking for conflicting UpdateConfig transactions.

## Context

In `conflict_resolver.rs`, the condition checking whether two `UpdateConfig`  transactions conflict uses `|` (bitwise OR) instead of `||` (logical OR).  While both produce the same boolean result, `|` always evaluates both operands. 
Using `||` short-circuits on the first `true`, skipping the unnecessary call to `modifies_same_metadata` when `upsert_key_conflict` already determined a conflict.

## Test plan

- [X] Existing tests pass (`cargo test -p lance`)
