### PR TITLE
feat: add deterministic sampling with optional seed

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -1966,8 +1966,9 @@ pub extern "system" fn Java_org_lance_Dataset_nativeSample(
     n: jlong,
     columns_obj: JObject,       // List<String>
     fragment_ids_obj: JObject,   // Optional<List<Integer>>
+    seed_obj: JObject,           // Optional<Long>
 ) -> jbyteArray {
-    match inner_sample(&mut env, java_dataset, n, columns_obj, fragment_ids_obj) {
+    match inner_sample(&mut env, java_dataset, n, columns_obj, fragment_ids_obj, seed_obj) {
         Ok(byte_array) => byte_array,
         Err(e) => {
             let _ = env.throw_new("java/lang/RuntimeException", format!("{:?}", e));
@@ -1982,11 +1983,13 @@ fn inner_sample(
     n: jlong,
     columns_obj: JObject,       // List<String>
     fragment_ids_obj: JObject,   // Optional<List<Integer>>
+    seed_obj: JObject,           // Optional<Long>
 ) -> Result<jbyteArray> {
     let columns: Vec<String> = env.get_strings(&columns_obj)?;
     let fragment_ids: Option<Vec<i32>> = env.get_ints_opt(&fragment_ids_obj)?;
     let fragment_ids_u32: Option<Vec<u32>> =
         fragment_ids.map(|ids| ids.iter().map(|&id| id as u32).collect());
+    let seed: Option<u64> = env.get_u64_opt(&seed_obj)?;
 
     let result = {
         let dataset_guard =
@@ -2002,6 +2005,7 @@ fn inner_sample(
             n as usize,
             &projection,
             fragment_ids_u32.as_deref(),
+            seed,
         )) {
             Ok(res) => res,
             Err(e) => {

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -1960,6 +1960,68 @@ fn inner_take(
 }
 
 #[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_nativeSample(
+    mut env: JNIEnv,
+    java_dataset: JObject,
+    n: jlong,
+    columns_obj: JObject,       // List<String>
+    fragment_ids_obj: JObject,   // Optional<List<Integer>>
+) -> jbyteArray {
+    match inner_sample(&mut env, java_dataset, n, columns_obj, fragment_ids_obj) {
+        Ok(byte_array) => byte_array,
+        Err(e) => {
+            let _ = env.throw_new("java/lang/RuntimeException", format!("{:?}", e));
+            std::ptr::null_mut()
+        }
+    }
+}
+
+fn inner_sample(
+    env: &mut JNIEnv,
+    java_dataset: JObject,
+    n: jlong,
+    columns_obj: JObject,       // List<String>
+    fragment_ids_obj: JObject,   // Optional<List<Integer>>
+) -> Result<jbyteArray> {
+    let columns: Vec<String> = env.get_strings(&columns_obj)?;
+    let fragment_ids: Option<Vec<i32>> = env.get_ints_opt(&fragment_ids_obj)?;
+    let fragment_ids_u32: Option<Vec<u32>> =
+        fragment_ids.map(|ids| ids.iter().map(|&id| id as u32).collect());
+
+    let result = {
+        let dataset_guard =
+            unsafe { env.get_rust_field::<_, _, BlockingDataset>(java_dataset, NATIVE_DATASET) }?;
+        let dataset = &dataset_guard.inner;
+
+        let projection = dataset
+            .schema()
+            .project_preserve_system_columns(&columns)
+            .map_err(|e| Error::runtime_error(e.to_string()))?;
+
+        match RT.block_on(dataset.sample(
+            n as usize,
+            &projection,
+            fragment_ids_u32.as_deref(),
+        )) {
+            Ok(res) => res,
+            Err(e) => {
+                return Err(e.into());
+            }
+        }
+    };
+
+    let mut buffer = Vec::new();
+    {
+        let mut writer = StreamWriter::try_new(&mut buffer, &result.schema())?;
+        writer.write(&result)?;
+        writer.finish()?;
+    }
+
+    let byte_array = env.byte_array_from_slice(&buffer)?;
+    Ok(**byte_array)
+}
+
+#[unsafe(no_mangle)]
 pub extern "system" fn Java_org_lance_Dataset_nativeDelete(
     mut env: JNIEnv,
     java_dataset: JObject,

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -760,7 +760,7 @@ public class Dataset implements Closeable {
    * @throws IOException if an I/O error occurs
    */
   public ArrowReader sample(long n, List<String> columns) throws IOException {
-    return sample(n, columns, Optional.empty());
+    return sample(n, columns, Optional.empty(), Optional.empty());
   }
 
   /**
@@ -777,12 +777,35 @@ public class Dataset implements Closeable {
    */
   public ArrowReader sample(long n, List<String> columns, Optional<List<Integer>> fragmentIds)
       throws IOException {
+    return sample(n, columns, fragmentIds, Optional.empty());
+  }
+
+  /**
+   * Randomly sample n rows from specific fragments of the dataset with an optional seed for
+   * deterministic sampling.
+   *
+   * <p>The returned rows are in row-id order (not random order), which allows the underlying take
+   * operation to use an efficient sorted code path.
+   *
+   * <p>When a seed is provided, the same seed with the same dataset state will always produce the
+   * same result, which is useful for reproducible ML training/validation splits.
+   *
+   * @param n the number of rows to sample
+   * @param columns the columns to include in the result
+   * @param fragmentIds optional list of fragment IDs to restrict sampling to
+   * @param seed optional random seed for deterministic sampling
+   * @return an ArrowReader containing the sampled rows
+   * @throws IOException if an I/O error occurs
+   */
+  public ArrowReader sample(
+      long n, List<String> columns, Optional<List<Integer>> fragmentIds, Optional<Long> seed)
+      throws IOException {
     Preconditions.checkArgument(n > 0, "n must be greater than 0");
     Preconditions.checkNotNull(columns, "columns cannot be null");
     Preconditions.checkArgument(!columns.isEmpty(), "columns cannot be empty");
     Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
     try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
-      byte[] arrowData = nativeSample(n, columns, fragmentIds);
+      byte[] arrowData = nativeSample(n, columns, fragmentIds, seed);
       ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(arrowData);
       ReadableByteChannel readChannel = Channels.newChannel(byteArrayInputStream);
       return new ArrowStreamReader(readChannel, allocator) {
@@ -797,7 +820,7 @@ public class Dataset implements Closeable {
   }
 
   private native byte[] nativeSample(
-      long n, List<String> columns, Optional<List<Integer>> fragmentIds);
+      long n, List<String> columns, Optional<List<Integer>> fragmentIds, Optional<Long> seed);
 
   /**
    * Delete rows of data by predicate.

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -749,6 +749,57 @@ public class Dataset implements Closeable {
   private native byte[] nativeTake(List<Long> indices, List<String> columns);
 
   /**
+   * Randomly sample n rows from the dataset.
+   *
+   * <p>The returned rows are in row-id order (not random order), which allows the underlying take
+   * operation to use an efficient sorted code path.
+   *
+   * @param n the number of rows to sample
+   * @param columns the columns to include in the result
+   * @return an ArrowReader containing the sampled rows
+   * @throws IOException if an I/O error occurs
+   */
+  public ArrowReader sample(long n, List<String> columns) throws IOException {
+    return sample(n, columns, Optional.empty());
+  }
+
+  /**
+   * Randomly sample n rows from specific fragments of the dataset.
+   *
+   * <p>The returned rows are in row-id order (not random order), which allows the underlying take
+   * operation to use an efficient sorted code path.
+   *
+   * @param n the number of rows to sample
+   * @param columns the columns to include in the result
+   * @param fragmentIds optional list of fragment IDs to restrict sampling to
+   * @return an ArrowReader containing the sampled rows
+   * @throws IOException if an I/O error occurs
+   */
+  public ArrowReader sample(long n, List<String> columns, Optional<List<Integer>> fragmentIds)
+      throws IOException {
+    Preconditions.checkArgument(n > 0, "n must be greater than 0");
+    Preconditions.checkNotNull(columns, "columns cannot be null");
+    Preconditions.checkArgument(!columns.isEmpty(), "columns cannot be empty");
+    Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      byte[] arrowData = nativeSample(n, columns, fragmentIds);
+      ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(arrowData);
+      ReadableByteChannel readChannel = Channels.newChannel(byteArrayInputStream);
+      return new ArrowStreamReader(readChannel, allocator) {
+        @Override
+        public void close() throws IOException {
+          super.close();
+          readChannel.close();
+          byteArrayInputStream.close();
+        }
+      };
+    }
+  }
+
+  private native byte[] nativeSample(
+      long n, List<String> columns, Optional<List<Integer>> fragmentIds);
+
+  /**
    * Delete rows of data by predicate.
    *
    * @param predicate the predicate to delete

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -840,6 +840,49 @@ public class DatasetTest {
   }
 
   @Test
+  void testSample(@TempDir Path tempDir) throws IOException {
+    String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
+    String datasetPath = tempDir.resolve(testMethodName).toString();
+    try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+      TestUtils.SimpleTestDataset testDataset =
+          new TestUtils.SimpleTestDataset(allocator, datasetPath);
+      dataset = testDataset.createEmptyDataset();
+
+      try (Dataset dataset2 = testDataset.write(1, 20)) {
+        // Sample without fragment filter
+        List<String> columns = Arrays.asList("id", "name");
+        try (ArrowReader reader = dataset2.sample(5, columns)) {
+          assertTrue(reader.loadNextBatch());
+          VectorSchemaRoot result = reader.getVectorSchemaRoot();
+          assertNotNull(result);
+          assertEquals(5, result.getRowCount());
+          assertEquals(2, result.getSchema().getFields().size());
+        }
+
+        // Sample with fragment filter
+        List<Fragment> fragments = dataset2.getFragments();
+        assertFalse(fragments.isEmpty());
+        List<Integer> fragmentIds =
+            fragments.stream().map(f -> f.getId()).collect(Collectors.toList());
+        try (ArrowReader reader = dataset2.sample(3, columns, Optional.of(fragmentIds))) {
+          assertTrue(reader.loadNextBatch());
+          VectorSchemaRoot result = reader.getVectorSchemaRoot();
+          assertNotNull(result);
+          assertEquals(3, result.getRowCount());
+        }
+
+        // Sample more than available rows returns all rows
+        try (ArrowReader reader = dataset2.sample(100, columns)) {
+          assertTrue(reader.loadNextBatch());
+          VectorSchemaRoot result = reader.getVectorSchemaRoot();
+          assertNotNull(result);
+          assertEquals(20, result.getRowCount());
+        }
+      }
+    }
+  }
+
+  @Test
   void testCountRows(@TempDir Path tempDir) {
     String testMethodName = new Object() {}.getClass().getEnclosingMethod().getName();
     String datasetPath = tempDir.resolve(testMethodName).toString();

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -878,6 +878,32 @@ public class DatasetTest {
           assertNotNull(result);
           assertEquals(20, result.getRowCount());
         }
+
+        // Deterministic sampling with seed: same seed produces same results
+        long seed = 42L;
+        List<Integer> firstSampleIds;
+        try (ArrowReader reader =
+            dataset2.sample(5, columns, Optional.empty(), Optional.of(seed))) {
+          assertTrue(reader.loadNextBatch());
+          VectorSchemaRoot result = reader.getVectorSchemaRoot();
+          assertEquals(5, result.getRowCount());
+          firstSampleIds = new ArrayList<>();
+          for (int i = 0; i < result.getRowCount(); i++) {
+            firstSampleIds.add((Integer) result.getVector("id").getObject(i));
+          }
+        }
+        List<Integer> secondSampleIds;
+        try (ArrowReader reader =
+            dataset2.sample(5, columns, Optional.empty(), Optional.of(seed))) {
+          assertTrue(reader.loadNextBatch());
+          VectorSchemaRoot result = reader.getVectorSchemaRoot();
+          assertEquals(5, result.getRowCount());
+          secondSampleIds = new ArrayList<>();
+          for (int i = 0; i < result.getRowCount(); i++) {
+            secondSampleIds.add((Integer) result.getVector("id").getObject(i));
+          }
+        }
+        assertEquals(firstSampleIds, secondSampleIds);
       }
     }
   }

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::collections::HashMap;
 use std::num::NonZero;
 use std::sync::Arc;
 
@@ -233,33 +232,96 @@ impl TryFrom<pb::DataFile> for DataFile {
     }
 }
 
-/// Interns `fields` and `column_indices` slices so that `DataFile` instances
-/// with identical content share a single `Arc<[i32]>` allocation.
+/// Interns repeated data so that fragments with identical content share a
+/// single heap allocation via `Arc`.
 ///
 /// At 20M fragments the deduplication typically saves multiple GB of heap
-/// because every fragment in a homogeneous table carries the same field list.
+/// because every fragment in a homogeneous table carries the same field list,
+/// and post-compaction fragments share identical version metadata bytes.
+///
+/// Uses a small `Vec` of `Arc` entries instead of `HashMap` because the
+/// number of unique values is typically 1-3 (homogeneous tables). Linear
+/// scan over a few entries is faster than hashing every input slice.
 #[derive(Default)]
 pub struct DataFileFieldInterner {
-    fields: HashMap<Vec<i32>, Arc<[i32]>>,
-    column_indices: HashMap<Vec<i32>, Arc<[i32]>>,
+    fields: Vec<Arc<[i32]>>,
+    column_indices: Vec<Arc<[i32]>>,
+    inline_bytes: Vec<Arc<[u8]>>,
 }
 
 impl DataFileFieldInterner {
     /// Intern a `Vec<i32>`: if the same content was seen before, return a
     /// clone of the existing `Arc`; otherwise store and return a new one.
-    fn intern(cache: &mut HashMap<Vec<i32>, Arc<[i32]>>, v: Vec<i32>) -> Arc<[i32]> {
-        cache
-            .entry(v)
-            .or_insert_with_key(|k| Arc::from(k.as_slice()))
-            .clone()
+    fn intern_i32(cache: &mut Vec<Arc<[i32]>>, v: Vec<i32>) -> Arc<[i32]> {
+        for existing in cache.iter() {
+            if existing.as_ref() == v.as_slice() {
+                return existing.clone();
+            }
+        }
+        let arc: Arc<[i32]> = Arc::from(v);
+        cache.push(arc.clone());
+        arc
+    }
+
+    /// Intern a `Vec<u8>`: if the same content was seen before, return a
+    /// clone of the existing `Arc`; otherwise store and return a new one.
+    fn intern_u8(cache: &mut Vec<Arc<[u8]>>, v: Vec<u8>) -> Arc<[u8]> {
+        for existing in cache.iter() {
+            if existing.as_ref() == v.as_slice() {
+                return existing.clone();
+            }
+        }
+        let arc: Arc<[u8]> = Arc::from(v);
+        cache.push(arc.clone());
+        arc
+    }
+
+    /// Intern a `RowDatasetVersionMeta`, deduplicating inline byte payloads.
+    /// Accepts the protobuf oneof value directly to avoid an intermediate
+    /// `Arc<[u8]>` allocation that would need to be `.to_vec()`'d for the key lookup.
+    fn intern_last_updated_version_meta(
+        cache: &mut Vec<Arc<[u8]>>,
+        pb: pb::data_fragment::LastUpdatedAtVersionSequence,
+    ) -> Result<RowDatasetVersionMeta> {
+        match pb {
+            pb::data_fragment::LastUpdatedAtVersionSequence::InlineLastUpdatedAtVersions(data) => {
+                Ok(RowDatasetVersionMeta::Inline(Self::intern_u8(cache, data)))
+            }
+            pb::data_fragment::LastUpdatedAtVersionSequence::ExternalLastUpdatedAtVersions(
+                file,
+            ) => Ok(RowDatasetVersionMeta::External(ExternalFile {
+                path: file.path,
+                offset: file.offset,
+                size: file.size,
+            })),
+        }
+    }
+
+    /// Intern a `RowDatasetVersionMeta`, deduplicating inline byte payloads.
+    fn intern_created_version_meta(
+        cache: &mut Vec<Arc<[u8]>>,
+        pb: pb::data_fragment::CreatedAtVersionSequence,
+    ) -> Result<RowDatasetVersionMeta> {
+        match pb {
+            pb::data_fragment::CreatedAtVersionSequence::InlineCreatedAtVersions(data) => {
+                Ok(RowDatasetVersionMeta::Inline(Self::intern_u8(cache, data)))
+            }
+            pb::data_fragment::CreatedAtVersionSequence::ExternalCreatedAtVersions(file) => {
+                Ok(RowDatasetVersionMeta::External(ExternalFile {
+                    path: file.path,
+                    offset: file.offset,
+                    size: file.size,
+                }))
+            }
+        }
     }
 
     /// Convert a protobuf `DataFile`, interning `fields` and `column_indices`.
     pub fn intern_data_file(&mut self, proto: pb::DataFile) -> Result<DataFile> {
         Ok(DataFile {
             path: proto.path,
-            fields: Self::intern(&mut self.fields, proto.fields),
-            column_indices: Self::intern(&mut self.column_indices, proto.column_indices),
+            fields: Self::intern_i32(&mut self.fields, proto.fields),
+            column_indices: Self::intern_i32(&mut self.column_indices, proto.column_indices),
             file_major_version: proto.file_major_version,
             file_minor_version: proto.file_minor_version,
             file_size_bytes: CachedFileSize::new(proto.file_size_bytes),
@@ -267,13 +329,21 @@ impl DataFileFieldInterner {
         })
     }
 
-    /// Convert a protobuf `DataFragment`, interning fields within its data files.
+    /// Convert a protobuf `DataFragment`, interning fields and version metadata.
     pub fn intern_fragment(&mut self, p: pb::DataFragment) -> Result<Fragment> {
         let physical_rows = if p.physical_rows > 0 {
             Some(p.physical_rows as usize)
         } else {
             None
         };
+        let last_updated_at_version_meta = p
+            .last_updated_at_version_sequence
+            .map(|pb| Self::intern_last_updated_version_meta(&mut self.inline_bytes, pb))
+            .transpose()?;
+        let created_at_version_meta = p
+            .created_at_version_sequence
+            .map(|pb| Self::intern_created_version_meta(&mut self.inline_bytes, pb))
+            .transpose()?;
         Ok(Fragment {
             id: p.id,
             files: p
@@ -284,14 +354,8 @@ impl DataFileFieldInterner {
             deletion_file: p.deletion_file.map(DeletionFile::try_from).transpose()?,
             row_id_meta: p.row_id_sequence.map(RowIdMeta::try_from).transpose()?,
             physical_rows,
-            last_updated_at_version_meta: p
-                .last_updated_at_version_sequence
-                .map(RowDatasetVersionMeta::try_from)
-                .transpose()?,
-            created_at_version_meta: p
-                .created_at_version_sequence
-                .map(RowDatasetVersionMeta::try_from)
-                .transpose()?,
+            last_updated_at_version_meta,
+            created_at_version_meta,
         })
     }
 }

--- a/rust/lance/benches/take.rs
+++ b/rust/lance/benches/take.rs
@@ -376,7 +376,7 @@ fn bench_sample(c: &mut Criterion) {
                     let schema = schema.clone();
                     let dataset = dataset.clone();
                     async move {
-                        dataset.sample(sample_size, &schema, None).await.unwrap();
+                        dataset.sample(sample_size, &schema, None, None).await.unwrap();
                     }
                 })
             },

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1497,6 +1497,9 @@ impl Dataset {
     /// If `fragment_ids` is provided, sampling is limited to rows from those
     /// fragments in the current dataset version.
     ///
+    /// If `seed` is provided, the sampling is deterministic: the same seed
+    /// with the same dataset state will always produce the same result.
+    ///
     /// The returned rows are in row-id order (not random order), which allows
     /// the underlying take operation to use an efficient sorted code path.
     pub async fn sample(
@@ -1504,13 +1507,19 @@ impl Dataset {
         n: usize,
         projection: &Schema,
         fragment_ids: Option<&[u32]>,
+        seed: Option<u64>,
     ) -> Result<RecordBatch> {
         use rand::seq::IteratorRandom;
+        use rand::rngs::StdRng;
+        use rand::SeedableRng;
 
         match fragment_ids {
             None => {
                 let num_rows = self.count_rows(None).await?;
-                let mut ids = (0..num_rows as u64).choose_multiple(&mut rand::rng(), n);
+                let mut ids = match seed {
+                    Some(s) => (0..num_rows as u64).choose_multiple(&mut StdRng::seed_from_u64(s), n),
+                    None => (0..num_rows as u64).choose_multiple(&mut rand::rng(), n),
+                };
                 ids.sort_unstable();
                 self.take(&ids, projection.clone()).await
             }
@@ -1548,7 +1557,10 @@ impl Dataset {
                     .try_fold(0_u64, |acc, rows| async move { Ok(acc + rows as u64) })
                     .await?;
 
-                let mut offsets = (0..num_rows).choose_multiple(&mut rand::rng(), n);
+                let mut offsets = match seed {
+                    Some(s) => (0..num_rows).choose_multiple(&mut StdRng::seed_from_u64(s), n),
+                    None => (0..num_rows).choose_multiple(&mut rand::rng(), n),
+                };
                 offsets.sort_unstable();
 
                 let row_addrs = row_offsets_to_row_addresses(&selected_fragments, &offsets).await?;

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -1465,7 +1465,7 @@ async fn test_sample_with_fragment_ids(
 
     let projection = dataset.schema().project(&["i"]).unwrap();
     let sampled = dataset
-        .sample(8, &projection, Some(&[0, 0, 2]))
+        .sample(8, &projection, Some(&[0, 0, 2]), None)
         .await
         .unwrap();
     let sampled_values = sampled
@@ -1504,7 +1504,7 @@ async fn test_sample_with_empty_fragment_ids_rejected(
     .unwrap();
 
     let projection = dataset.schema().project(&["i"]).unwrap();
-    let err = dataset.sample(1, &projection, Some(&[])).await.unwrap_err();
+    let err = dataset.sample(1, &projection, Some(&[]), None).await.unwrap_err();
 
     assert!(matches!(err, Error::InvalidInput { .. }));
     assert!(
@@ -1538,7 +1538,7 @@ async fn test_sample_with_unknown_fragment_ids_rejected(
 
     let projection = dataset.schema().project(&["i"]).unwrap();
     let err = dataset
-        .sample(1, &projection, Some(&[0, 999]))
+        .sample(1, &projection, Some(&[0, 999]), None)
         .await
         .unwrap_err();
 
@@ -1548,6 +1548,51 @@ async fn test_sample_with_unknown_fragment_ids_rejected(
             .contains("not part of the current dataset version")
     );
     assert!(err.to_string().contains("999"));
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_sample_deterministic_with_seed(
+    #[values(LanceFileVersion::Legacy, LanceFileVersion::Stable)]
+    data_storage_version: LanceFileVersion,
+) {
+    let test_uri = TempStrDir::default();
+    let data = gen_batch()
+        .col("i", array::step::<Int32Type>())
+        .into_reader_rows(RowCount::from(100), BatchCount::from(1));
+    let dataset = Dataset::write(
+        data,
+        &test_uri,
+        Some(WriteParams {
+            max_rows_per_file: 50,
+            max_rows_per_group: 25,
+            data_storage_version: Some(data_storage_version),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    let projection = dataset.schema().project(&["i"]).unwrap();
+    let seed = 42u64;
+
+    let first = dataset
+        .sample(10, &projection, None, Some(seed))
+        .await
+        .unwrap();
+    let second = dataset
+        .sample(10, &projection, None, Some(seed))
+        .await
+        .unwrap();
+
+    assert_eq!(first, second);
+
+    // Different seed should (very likely) produce different results
+    let third = dataset
+        .sample(10, &projection, None, Some(123))
+        .await
+        .unwrap();
+    assert_ne!(first, third);
 }
 
 #[rstest]

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -3360,7 +3360,7 @@ mod tests {
 
         // Sample 2048 random indices and then paste on a column of 9999999's
         let some_indices = ds
-            .sample(2048, &(&just_index_col).try_into().unwrap(), None)
+            .sample(2048, &(&just_index_col).try_into().unwrap(), None, None)
             .await
             .unwrap();
         let some_indices = some_indices.column(0).clone();

--- a/rust/lance/src/index/vector/utils.rs
+++ b/rust/lance/src/index/vector/utils.rs
@@ -100,7 +100,7 @@ async fn estimate_multivector_vectors_per_row(
     let sample_batch_size = std::cmp::min(64, num_rows);
     for _ in 0..8 {
         let batch = dataset
-            .sample(sample_batch_size, &projection, fragments)
+            .sample(sample_batch_size, &projection, fragments, None)
             .await?;
         let array = get_column_from_batch(&batch, column)?;
         let list_array = array.as_list::<i32>();
@@ -438,7 +438,7 @@ async fn sample_training_data(
         if !is_nullable {
             let projection = dataset.schema().project(&[column])?;
             let batch = dataset
-                .sample(sample_size_hint, &projection, Some(fragment_ids))
+                .sample(sample_size_hint, &projection, Some(fragment_ids), None)
                 .await?;
             return vector_column_to_fsl(&batch, column);
         }


### PR DESCRIPTION
## Summary

- Add optional `seed: Option<u64>` parameter to Rust core `Dataset::sample()` for deterministic sampling
- When a seed is provided, uses `StdRng::seed_from_u64(seed)` for reproducible random index selection
- Without a seed, behavior is unchanged (uses `rand::rng()` with OS entropy)
- Expose through Java JNI with `Optional<Long> seed` parameter
- Useful for reproducible ML training/validation splits

## Changes

- **`rust/lance/src/dataset.rs`**: Add `seed` parameter; use `StdRng` when seeded, `rand::rng()` otherwise
- **`rust/lance/src/dataset/tests/dataset_io.rs`**: Add test verifying same seed = same result, different seed = different result
- **`rust/lance/src/index/vector/utils.rs`**, **`rust/lance/src/dataset/write/merge_insert.rs`**, **`rust/lance/benches/take.rs`**: Pass `None` for existing callers
- **`java/lance-jni/src/blocking_dataset.rs`**: Pass seed through JNI
- **`java/src/main/java/org/lance/Dataset.java`**: Add `sample(n, columns, fragmentIds, seed)` overload
- **`java/src/test/java/org/lance/DatasetTest.java`**: Test deterministic sampling via seed

## Test plan

- [ ] Rust test `test_sample_deterministic_with_seed` — verifies same seed produces identical results, different seed produces different results
- [ ] Java test `testSample` — verifies deterministic sampling with seed=42 produces identical results across two calls
- [ ] All existing `sample` callers pass `None` for backward compatibility

Builds on #6500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)