### PR TITLE
perf: add SIMD-accelerated u8 dot product for SQ distance

### DIFF
--- a/rust/lance-linalg/benches/dot.rs
+++ b/rust/lance-linalg/benches/dot.rs
@@ -107,23 +107,39 @@ fn bench_distance(c: &mut Criterion) {
         });
     });
 
-    // u8 dot product benchmark (SQ distance path)
+    // u8 dot product benchmarks: scalar baseline vs SIMD dispatch
     {
-        const U8_DIMENSION: usize = 1024;
-        const U8_TOTAL: usize = 1024 * 1024;
-        let mut rng = rand::rng();
-        let key_u8: Vec<u8> = (0..U8_DIMENSION).map(|_| rng.random()).collect();
-        let target_u8: Vec<u8> = (0..U8_TOTAL * U8_DIMENSION).map(|_| rng.random()).collect();
-        c.bench_function("Dot(u8, dispatch)", |b| {
-            b.iter(|| {
-                black_box(
-                    target_u8
-                        .chunks(U8_DIMENSION)
-                        .map(|y| dot_distance(key_u8.as_slice(), y))
-                        .collect::<Vec<_>>(),
-                )
+        use lance_linalg::distance::dot_u8::{dot_u8, dot_u8_scalar};
+
+        for &dim in &[128, 256, 512, 1024] {
+            let num_vectors = 1024 * 1024 / dim; // ~1M elements total
+            let mut rng = rand::rng();
+            let key_u8: Vec<u8> = (0..dim).map(|_| rng.random()).collect();
+            let target_u8: Vec<u8> =
+                (0..num_vectors * dim).map(|_| rng.random()).collect();
+
+            c.bench_function(&format!("Dot(u8, scalar, dim={dim})"), |b| {
+                b.iter(|| {
+                    black_box(
+                        target_u8
+                            .chunks(dim)
+                            .map(|y| dot_u8_scalar(key_u8.as_slice(), y))
+                            .collect::<Vec<_>>(),
+                    )
+                });
             });
-        });
+
+            c.bench_function(&format!("Dot(u8, dispatch, dim={dim})"), |b| {
+                b.iter(|| {
+                    black_box(
+                        target_u8
+                            .chunks(dim)
+                            .map(|y| dot_u8(key_u8.as_slice(), y))
+                            .collect::<Vec<_>>(),
+                    )
+                });
+            });
+        }
     }
 
     run_bench::<Float32Type>(c);

--- a/rust/lance-linalg/benches/dot.rs
+++ b/rust/lance-linalg/benches/dot.rs
@@ -115,8 +115,7 @@ fn bench_distance(c: &mut Criterion) {
             let num_vectors = 1024 * 1024 / dim; // ~1M elements total
             let mut rng = rand::rng();
             let key_u8: Vec<u8> = (0..dim).map(|_| rng.random()).collect();
-            let target_u8: Vec<u8> =
-                (0..num_vectors * dim).map(|_| rng.random()).collect();
+            let target_u8: Vec<u8> = (0..num_vectors * dim).map(|_| rng.random()).collect();
 
             c.bench_function(&format!("Dot(u8, scalar, dim={dim})"), |b| {
                 b.iter(|| {

--- a/rust/lance-linalg/benches/dot.rs
+++ b/rust/lance-linalg/benches/dot.rs
@@ -107,6 +107,25 @@ fn bench_distance(c: &mut Criterion) {
         });
     });
 
+    // u8 dot product benchmark (SQ distance path)
+    {
+        const U8_DIMENSION: usize = 1024;
+        const U8_TOTAL: usize = 1024 * 1024;
+        let mut rng = rand::rng();
+        let key_u8: Vec<u8> = (0..U8_DIMENSION).map(|_| rng.random()).collect();
+        let target_u8: Vec<u8> = (0..U8_TOTAL * U8_DIMENSION).map(|_| rng.random()).collect();
+        c.bench_function("Dot(u8, dispatch)", |b| {
+            b.iter(|| {
+                black_box(
+                    target_u8
+                        .chunks(U8_DIMENSION)
+                        .map(|y| dot_distance(key_u8.as_slice(), y))
+                        .collect::<Vec<_>>(),
+                )
+            });
+        });
+    }
+
     run_bench::<Float32Type>(c);
     c.bench_function("Dot(f32, SIMD)", |b| {
         let key = generate_random_array_with_seed::<Float32Type>(DIMENSION, [0; 32]);

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -18,6 +18,7 @@ use arrow_schema::{ArrowError, DataType};
 
 pub mod cosine;
 pub mod dot;
+pub mod dot_u8;
 pub mod hamming;
 pub mod l2;
 pub mod norm_l2;

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -152,11 +152,7 @@ impl Dot for f64 {
 impl Dot for u8 {
     #[inline]
     fn dot(x: &[Self], y: &[Self]) -> f32 {
-        // TODO: this is not optimized for auto vectorization yet.
-        x.iter()
-            .zip(y.iter())
-            .map(|(&x_i, &y_i)| x_i as u32 * y_i as u32)
-            .sum::<u32>() as f32
+        super::dot_u8::dot_u8(x, y) as f32
     }
 }
 

--- a/rust/lance-linalg/src/distance/dot_u8.rs
+++ b/rust/lance-linalg/src/distance/dot_u8.rs
@@ -97,8 +97,8 @@ mod x86 {
         let mut i = 0usize;
 
         while i + 64 <= n {
-            let av = _mm512_loadu_si512(a.as_ptr().add(i) as *const i32);
-            let bv = _mm512_loadu_si512(b.as_ptr().add(i) as *const i32);
+            let av = _mm512_loadu_si512(a.as_ptr().add(i) as *const __m512i);
+            let bv = _mm512_loadu_si512(b.as_ptr().add(i) as *const __m512i);
             let b_biased = _mm512_xor_si512(bv, sign_flip);
             acc_dot = _mm512_dpbusd_epi32(acc_dot, av, b_biased);
             acc_suma = _mm512_add_epi64(acc_suma, _mm512_sad_epu8(av, zeros));
@@ -179,12 +179,7 @@ mod tests {
             }
         }
 
-        assert_eq!(
-            dot_u8(a, b),
-            reference,
-            "dispatch [{case}] n={}",
-            a.len()
-        );
+        assert_eq!(dot_u8(a, b), reference, "dispatch [{case}] n={}", a.len());
     }
 
     #[test]

--- a/rust/lance-linalg/src/distance/dot_u8.rs
+++ b/rust/lance-linalg/src/distance/dot_u8.rs
@@ -9,9 +9,10 @@
 //! dot product plus precomputed per-vector scalar terms.
 //!
 //! Backends (selected at runtime, best available wins):
-//!   1. scalar     — portable reference, also used for tails
-//!   2. avx2       — VPMADDWD on u16-widened halves, 32 elements/iter
-//!   3. avx512vnni — VPDPBUSD with XOR-0x80 bias trick, 64 elements/iter
+//!   1. scalar        — portable reference, also used for tails
+//!   2. neon_dotprod  — UDOT u8×u8→u32 (ARMv8.2-A+dotprod), 16 elements/iter
+//!   3. avx2          — VPMADDWD on u16-widened halves, 32 elements/iter
+//!   4. avx512vnni    — VPDPBUSD with XOR-0x80 bias trick, 64 elements/iter
 //!
 //! ## The VNNI bias trick
 //!
@@ -36,6 +37,81 @@ pub fn dot_u8_scalar(a: &[u8], b: &[u8]) -> u32 {
         .zip(b.iter())
         .map(|(&x, &y)| x as u32 * y as u32)
         .sum()
+}
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64 {
+    use std::arch::aarch64::*;
+    use std::arch::asm;
+
+    /// NEON dotprod path (ARMv8.2-A+: Apple M1+, Graviton2+, Cortex-A76+).
+    /// Uses inline asm for UDOT since `vdotq_u32` is not yet stable in Rust.
+    /// 16 elements per iteration.
+    pub unsafe fn dot_u8_neon_dotprod(a: &[u8], b: &[u8]) -> u32 {
+        debug_assert_eq!(a.len(), b.len());
+        let n = a.len();
+        let mut acc = vdupq_n_u32(0);
+        let mut i = 0usize;
+
+        while i + 16 <= n {
+            let av = vld1q_u8(a.as_ptr().add(i));
+            let bv = vld1q_u8(b.as_ptr().add(i));
+            // UDOT Vd.4S, Vn.16B, Vm.16B — native unsigned dot product.
+            asm!(
+                "udot {acc:v}.4s, {a:v}.16b, {b:v}.16b",
+                acc = inout(vreg) acc,
+                a = in(vreg) av,
+                b = in(vreg) bv,
+                options(pure, nomem, nostack),
+            );
+            i += 16;
+        }
+
+        let mut result = vaddvq_u32(acc);
+
+        // Scalar tail.
+        while i < n {
+            result += a[i] as u32 * b[i] as u32;
+            i += 1;
+        }
+
+        result
+    }
+
+    /// Base NEON path (all aarch64): widening multiply u8→u16 then
+    /// pairwise accumulate to u32. 16 elements per iteration.
+    /// Fallback when dotprod is not available.
+    pub unsafe fn dot_u8_neon(a: &[u8], b: &[u8]) -> u32 {
+        debug_assert_eq!(a.len(), b.len());
+        let n = a.len();
+        let mut acc = vdupq_n_u32(0);
+        let mut i = 0usize;
+
+        while i + 16 <= n {
+            let av = vld1q_u8(a.as_ptr().add(i));
+            let bv = vld1q_u8(b.as_ptr().add(i));
+
+            // vmull: u8×u8 → u16 (8 elements per half)
+            let prod_lo = vmull_u8(vget_low_u8(av), vget_low_u8(bv));
+            let prod_hi = vmull_u8(vget_high_u8(av), vget_high_u8(bv));
+
+            // vpadalq: pairwise add u16 → u32 and accumulate.
+            acc = vpadalq_u16(acc, prod_lo);
+            acc = vpadalq_u16(acc, prod_hi);
+
+            i += 16;
+        }
+
+        let mut result = vaddvq_u32(acc);
+
+        // Scalar tail.
+        while i < n {
+            result += a[i] as u32 * b[i] as u32;
+            i += 1;
+        }
+
+        result
+    }
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -156,6 +232,17 @@ fn select_backend() -> DotU8Fn {
         }
     }
 
+    #[cfg(target_arch = "aarch64")]
+    {
+        return if std::arch::is_aarch64_feature_detected!("dotprod") {
+            |a, b| unsafe { aarch64::dot_u8_neon_dotprod(a, b) }
+        } else {
+            // Base NEON is always available on aarch64.
+            |a, b| unsafe { aarch64::dot_u8_neon(a, b) }
+        };
+    }
+
+    #[allow(unreachable_code)]
     dot_u8_scalar
 }
 
@@ -186,6 +273,17 @@ mod tests {
     /// Run every available backend against the scalar reference.
     fn check_all_backends(a: &[u8], b: &[u8], case: &str) {
         let reference = dot_u8_scalar(a, b);
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            let got = unsafe { aarch64::dot_u8_neon(a, b) };
+            assert_eq!(got, reference, "neon [{case}] n={}", a.len());
+
+            if std::arch::is_aarch64_feature_detected!("dotprod") {
+                let got = unsafe { aarch64::dot_u8_neon_dotprod(a, b) };
+                assert_eq!(got, reference, "neon_dotprod [{case}] n={}", a.len());
+            }
+        }
 
         #[cfg(target_arch = "x86_64")]
         {

--- a/rust/lance-linalg/src/distance/dot_u8.rs
+++ b/rust/lance-linalg/src/distance/dot_u8.rs
@@ -9,10 +9,9 @@
 //! dot product plus precomputed per-vector scalar terms.
 //!
 //! Backends (selected at runtime, best available wins):
-//!   1. scalar        — portable reference, also used for tails
-//!   2. neon_dotprod  — UDOT u8×u8→u32 (ARMv8.2-A+dotprod), 16 elements/iter
-//!   3. avx2          — VPMADDWD on u16-widened halves, 32 elements/iter
-//!   4. avx512vnni    — VPDPBUSD with XOR-0x80 bias trick, 64 elements/iter
+//!   1. scalar     — portable reference, also used for tails
+//!   2. avx2       — VPMADDWD on u16-widened halves, 32 elements/iter
+//!   3. avx512vnni — VPDPBUSD with XOR-0x80 bias trick, 64 elements/iter
 //!
 //! ## The VNNI bias trick
 //!
@@ -37,67 +36,6 @@ pub fn dot_u8_scalar(a: &[u8], b: &[u8]) -> u32 {
         .zip(b.iter())
         .map(|(&x, &y)| x as u32 * y as u32)
         .sum()
-}
-
-#[cfg(target_arch = "aarch64")]
-mod aarch64 {
-    use std::arch::aarch64::*;
-    use std::arch::asm;
-
-    /// NEON dotprod path (Apple M1+, Graviton2+, Cortex-A76+).
-    /// Inline asm because `vdotq_u32` is not yet stable in std::arch.
-    pub unsafe fn dot_u8_neon_dotprod(a: &[u8], b: &[u8]) -> u32 {
-        debug_assert_eq!(a.len(), b.len());
-        let n = a.len();
-        let mut acc = vdupq_n_u32(0);
-        let mut i = 0usize;
-
-        while i + 16 <= n {
-            let av = vld1q_u8(a.as_ptr().add(i));
-            let bv = vld1q_u8(b.as_ptr().add(i));
-            asm!(
-                "udot {acc:v}.4s, {a:v}.16b, {b:v}.16b",
-                acc = inout(vreg) acc,
-                a = in(vreg) av,
-                b = in(vreg) bv,
-                options(pure, nomem, nostack),
-            );
-            i += 16;
-        }
-
-        let mut result = vaddvq_u32(acc);
-        while i < n {
-            result += a[i] as u32 * b[i] as u32;
-            i += 1;
-        }
-        result
-    }
-
-    /// Base NEON path: widening multiply u8→u16 then pairwise accumulate
-    /// to u32. Fallback when dotprod is not available.
-    pub unsafe fn dot_u8_neon(a: &[u8], b: &[u8]) -> u32 {
-        debug_assert_eq!(a.len(), b.len());
-        let n = a.len();
-        let mut acc = vdupq_n_u32(0);
-        let mut i = 0usize;
-
-        while i + 16 <= n {
-            let av = vld1q_u8(a.as_ptr().add(i));
-            let bv = vld1q_u8(b.as_ptr().add(i));
-            let prod_lo = vmull_u8(vget_low_u8(av), vget_low_u8(bv));
-            let prod_hi = vmull_u8(vget_high_u8(av), vget_high_u8(bv));
-            acc = vpadalq_u16(acc, prod_lo);
-            acc = vpadalq_u16(acc, prod_hi);
-            i += 16;
-        }
-
-        let mut result = vaddvq_u32(acc);
-        while i < n {
-            result += a[i] as u32 * b[i] as u32;
-            i += 1;
-        }
-        result
-    }
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -198,17 +136,6 @@ fn select_backend() -> DotU8Fn {
         }
     }
 
-    #[cfg(target_arch = "aarch64")]
-    {
-        return if std::arch::is_aarch64_feature_detected!("dotprod") {
-            |a, b| unsafe { aarch64::dot_u8_neon_dotprod(a, b) }
-        } else {
-            // Base NEON is always available on aarch64.
-            |a, b| unsafe { aarch64::dot_u8_neon(a, b) }
-        };
-    }
-
-    #[allow(unreachable_code)]
     dot_u8_scalar
 }
 
@@ -235,17 +162,6 @@ mod tests {
 
     fn check_all_backends(a: &[u8], b: &[u8], case: &str) {
         let reference = dot_u8_scalar(a, b);
-
-        #[cfg(target_arch = "aarch64")]
-        {
-            let got = unsafe { aarch64::dot_u8_neon(a, b) };
-            assert_eq!(got, reference, "neon [{case}] n={}", a.len());
-
-            if std::arch::is_aarch64_feature_detected!("dotprod") {
-                let got = unsafe { aarch64::dot_u8_neon_dotprod(a, b) };
-                assert_eq!(got, reference, "neon_dotprod [{case}] n={}", a.len());
-            }
-        }
 
         #[cfg(target_arch = "x86_64")]
         {

--- a/rust/lance-linalg/src/distance/dot_u8.rs
+++ b/rust/lance-linalg/src/distance/dot_u8.rs
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Unsigned int8 dot product with runtime-dispatched SIMD backends.
+//!
+//! Used by Scalar Quantization (SQ) distance computation. SQ stores each
+//! vector dimension as a u8 after linearly mapping [min, max] → [0, 255].
+//! Distance computation between SQ-encoded vectors reduces to a u8 × u8
+//! dot product plus precomputed per-vector scalar terms.
+//!
+//! Backends (selected at runtime, best available wins):
+//!   1. scalar     — portable reference, also used for tails
+//!   2. avx2       — VPMADDWD on u16-widened halves, 32 elements/iter
+//!   3. avx512vnni — VPDPBUSD with XOR-0x80 bias trick, 64 elements/iter
+//!
+//! ## The VNNI bias trick
+//!
+//! VPDPBUSD expects one unsigned and one signed operand, but SQ vectors
+//! are u8 × u8. We bias `b` into the signed domain via XOR 0x80 (equivalent
+//! to subtracting 128 when reinterpreted as i8), feed `a` directly as
+//! unsigned, and correct by adding 128·Σa at the end:
+//!
+//!   DPBUSD(a, b ⊕ 0x80) = Σ a·(b − 128) = Σ a·b − 128·Σa
+//!
+//! The Σa term uses VPSADBW, which dispatches to port 5 while VPDPBUSD
+//! runs on port 0 on Intel. The two instructions execute in parallel,
+//! making the correction effectively free.
+
+use std::sync::OnceLock;
+
+/// Portable scalar u8 dot product.
+#[inline]
+pub fn dot_u8_scalar(a: &[u8], b: &[u8]) -> u32 {
+    debug_assert_eq!(a.len(), b.len());
+    a.iter()
+        .zip(b.iter())
+        .map(|(&x, &y)| x as u32 * y as u32)
+        .sum()
+}
+
+#[cfg(target_arch = "x86_64")]
+mod x86 {
+    use std::arch::x86_64::*;
+
+    /// AVX2 path: zero-extend u8 → u16 via `_mm256_cvtepu8_epi16`, then
+    /// use `_mm256_madd_epi16` which treats inputs as i16 but produces
+    /// correct results for non-negative values. 32 elements per iteration.
+    #[target_feature(enable = "avx2")]
+    pub unsafe fn dot_u8_avx2(a: &[u8], b: &[u8]) -> u32 {
+        debug_assert_eq!(a.len(), b.len());
+        let n = a.len();
+        let mut acc = _mm256_setzero_si256();
+        let mut i = 0usize;
+
+        while i + 32 <= n {
+            let av = _mm256_loadu_si256(a.as_ptr().add(i) as *const __m256i);
+            let bv = _mm256_loadu_si256(b.as_ptr().add(i) as *const __m256i);
+
+            // Zero-extend low and high 128-bit halves to 16 × u16.
+            // Since all values are ≤ 255, they fit in i16 as positive,
+            // so VPMADDWD produces correct non-negative results.
+            let a_lo = _mm256_cvtepu8_epi16(_mm256_castsi256_si128(av));
+            let a_hi = _mm256_cvtepu8_epi16(_mm256_extracti128_si256(av, 1));
+            let b_lo = _mm256_cvtepu8_epi16(_mm256_castsi256_si128(bv));
+            let b_hi = _mm256_cvtepu8_epi16(_mm256_extracti128_si256(bv, 1));
+
+            // Each VPMADDWD produces 8 × i32 partial sums. All products
+            // are in [0, 255*255], so accumulation stays non-negative.
+            acc = _mm256_add_epi32(acc, _mm256_madd_epi16(a_lo, b_lo));
+            acc = _mm256_add_epi32(acc, _mm256_madd_epi16(a_hi, b_hi));
+
+            i += 32;
+        }
+
+        // Horizontal reduction of 8 × i32 → scalar.
+        let lo128 = _mm256_castsi256_si128(acc);
+        let hi128 = _mm256_extracti128_si256(acc, 1);
+        let mut sum128 = _mm_add_epi32(lo128, hi128);
+        sum128 = _mm_hadd_epi32(sum128, sum128);
+        sum128 = _mm_hadd_epi32(sum128, sum128);
+        let mut result = _mm_cvtsi128_si32(sum128) as u32;
+
+        // Scalar tail.
+        while i < n {
+            result += a[i] as u32 * b[i] as u32;
+            i += 1;
+        }
+
+        result
+    }
+
+    /// AVX-512 VNNI path (Ice Lake .. Emerald Rapids, Zen 4).
+    /// VPDPBUSD + XOR-0x80 bias trick, 64 elements per iteration.
+    #[target_feature(enable = "avx512f,avx512bw,avx512vnni")]
+    pub unsafe fn dot_u8_avx512_vnni(a: &[u8], b: &[u8]) -> u32 {
+        debug_assert_eq!(a.len(), b.len());
+        let n = a.len();
+
+        let mut acc_dot = _mm512_setzero_si512();
+        let mut acc_suma = _mm512_setzero_si512();
+        let sign_flip = _mm512_set1_epi8(0x80u8 as i8);
+        let zeros = _mm512_setzero_si512();
+
+        let mut i = 0usize;
+
+        while i + 64 <= n {
+            let av = _mm512_loadu_si512(a.as_ptr().add(i) as *const i32);
+            let bv = _mm512_loadu_si512(b.as_ptr().add(i) as *const i32);
+
+            // Bias b into the signed domain: b' = b ⊕ 0x80 = b - 128 (reinterpreted).
+            let b_biased = _mm512_xor_si512(bv, sign_flip);
+
+            // Port 0: VPDPBUSD(a unsigned, b_biased signed).
+            // Computes Σ a·(b − 128) = Σ a·b − 128·Σa per 4-byte group.
+            acc_dot = _mm512_dpbusd_epi32(acc_dot, av, b_biased);
+
+            // Port 5 (parallel): Σa via VPSADBW(a, 0) = sum of bytes.
+            acc_suma = _mm512_add_epi64(acc_suma, _mm512_sad_epu8(av, zeros));
+
+            i += 64;
+        }
+
+        // Horizontal reductions.
+        let biased_dot = _mm512_reduce_add_epi32(acc_dot);
+        let sum_a = _mm512_reduce_add_epi64(acc_suma);
+
+        // Correction: biased = Σ a·b − 128·Σa  ⟹  Σ a·b = biased + 128·Σa
+        let mut result = (biased_dot as i64 + 128 * sum_a) as u32;
+
+        // Scalar tail (< 64 elements remaining).
+        while i < n {
+            result += a[i] as u32 * b[i] as u32;
+            i += 1;
+        }
+
+        result
+    }
+}
+
+type DotU8Fn = fn(&[u8], &[u8]) -> u32;
+
+static DISPATCH: OnceLock<DotU8Fn> = OnceLock::new();
+
+fn select_backend() -> DotU8Fn {
+    #[cfg(target_arch = "x86_64")]
+    {
+        if is_x86_feature_detected!("avx512f")
+            && is_x86_feature_detected!("avx512bw")
+            && is_x86_feature_detected!("avx512vnni")
+        {
+            return |a, b| unsafe { x86::dot_u8_avx512_vnni(a, b) };
+        }
+
+        if is_x86_feature_detected!("avx2") {
+            return |a, b| unsafe { x86::dot_u8_avx2(a, b) };
+        }
+    }
+
+    dot_u8_scalar
+}
+
+/// Compute the dot product of two u8 slices, dispatching to the best
+/// available SIMD backend on the current CPU.
+#[inline]
+pub fn dot_u8(a: &[u8], b: &[u8]) -> u32 {
+    (DISPATCH.get_or_init(select_backend))(a, b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic PRNG for reproducible failures.
+    fn fill_random(buf: &mut [u8], seed: &mut u32) {
+        for slot in buf.iter_mut() {
+            *seed = seed.wrapping_mul(1103515245).wrapping_add(12345);
+            *slot = (*seed >> 16) as u8;
+        }
+    }
+
+    /// Sizes chosen to stress vector loop, scalar tail, and boundaries.
+    const SIZES: &[usize] = &[
+        0, 1, 7, 15, 16, 31, 32, 33, 63, 64, 65, 127, 128, 255, 256, 1024, 4096, 4097,
+    ];
+
+    /// Run every available backend against the scalar reference.
+    fn check_all_backends(a: &[u8], b: &[u8], case: &str) {
+        let reference = dot_u8_scalar(a, b);
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            if is_x86_feature_detected!("avx2") {
+                let got = unsafe { x86::dot_u8_avx2(a, b) };
+                assert_eq!(got, reference, "avx2 [{case}] n={}", a.len());
+            }
+
+            if is_x86_feature_detected!("avx512f")
+                && is_x86_feature_detected!("avx512bw")
+                && is_x86_feature_detected!("avx512vnni")
+            {
+                let got = unsafe { x86::dot_u8_avx512_vnni(a, b) };
+                assert_eq!(got, reference, "avx512_vnni [{case}] n={}", a.len());
+            }
+        }
+
+        assert_eq!(
+            dot_u8(a, b),
+            reference,
+            "dispatch [{case}] n={}",
+            a.len()
+        );
+    }
+
+    #[test]
+    fn random_inputs_across_sizes_and_seeds() {
+        let mut a = vec![0u8; 4097];
+        let mut b = vec![0u8; 4097];
+
+        for seed_idx in 0..4u32 {
+            let mut seed = 0xC0FFEE_u32.wrapping_add(seed_idx.wrapping_mul(7919));
+            for &n in SIZES {
+                fill_random(&mut a[..n], &mut seed);
+                fill_random(&mut b[..n], &mut seed);
+                check_all_backends(&a[..n], &b[..n], "random");
+            }
+        }
+    }
+
+    #[test]
+    fn boundary_values() {
+        let mut a = vec![0u8; 4097];
+        let mut b = vec![0u8; 4097];
+
+        for &n in SIZES {
+            a[..n].fill(u8::MAX);
+            b[..n].fill(u8::MAX);
+            check_all_backends(&a[..n], &b[..n], "max*max");
+
+            a[..n].fill(u8::MAX);
+            b[..n].fill(0);
+            check_all_backends(&a[..n], &b[..n], "max*0");
+
+            a[..n].fill(0);
+            b[..n].fill(u8::MAX);
+            check_all_backends(&a[..n], &b[..n], "0*max");
+
+            for i in 0..n {
+                a[i] = if i & 1 == 0 { 0 } else { u8::MAX };
+                b[i] = if i & 1 == 0 { u8::MAX } else { 0 };
+            }
+            check_all_backends(&a[..n], &b[..n], "alt 0/max");
+        }
+    }
+
+    #[test]
+    fn one_sided_zeros() {
+        let mut a = vec![0u8; 4097];
+        let mut b = vec![0u8; 4097];
+
+        for &n in SIZES {
+            let mut seed = 0xDEAD_BEEF_u32;
+            fill_random(&mut a[..n], &mut seed);
+            b[..n].fill(0);
+            check_all_backends(&a[..n], &b[..n], "b=0");
+
+            a[..n].fill(0);
+            fill_random(&mut b[..n], &mut seed);
+            check_all_backends(&a[..n], &b[..n], "a=0");
+        }
+    }
+
+    #[test]
+    fn all_ones_pattern() {
+        let mut a = vec![0u8; 4097];
+        let mut b = vec![0u8; 4097];
+
+        for &n in SIZES {
+            a[..n].fill(1);
+            b[..n].fill(1);
+            check_all_backends(&a[..n], &b[..n], "1*1");
+            assert_eq!(dot_u8_scalar(&a[..n], &b[..n]), n as u32);
+        }
+    }
+}

--- a/rust/lance-linalg/src/distance/dot_u8.rs
+++ b/rust/lance-linalg/src/distance/dot_u8.rs
@@ -29,7 +29,7 @@
 
 use std::sync::OnceLock;
 
-/// Portable scalar u8 dot product.
+/// Portable scalar u8 dot product, also used for SIMD tail elements.
 #[inline]
 pub fn dot_u8_scalar(a: &[u8], b: &[u8]) -> u32 {
     debug_assert_eq!(a.len(), b.len());
@@ -44,9 +44,8 @@ mod aarch64 {
     use std::arch::aarch64::*;
     use std::arch::asm;
 
-    /// NEON dotprod path (ARMv8.2-A+: Apple M1+, Graviton2+, Cortex-A76+).
-    /// Uses inline asm for UDOT since `vdotq_u32` is not yet stable in Rust.
-    /// 16 elements per iteration.
+    /// NEON dotprod path (Apple M1+, Graviton2+, Cortex-A76+).
+    /// Inline asm because `vdotq_u32` is not yet stable in std::arch.
     pub unsafe fn dot_u8_neon_dotprod(a: &[u8], b: &[u8]) -> u32 {
         debug_assert_eq!(a.len(), b.len());
         let n = a.len();
@@ -56,7 +55,6 @@ mod aarch64 {
         while i + 16 <= n {
             let av = vld1q_u8(a.as_ptr().add(i));
             let bv = vld1q_u8(b.as_ptr().add(i));
-            // UDOT Vd.4S, Vn.16B, Vm.16B — native unsigned dot product.
             asm!(
                 "udot {acc:v}.4s, {a:v}.16b, {b:v}.16b",
                 acc = inout(vreg) acc,
@@ -68,19 +66,15 @@ mod aarch64 {
         }
 
         let mut result = vaddvq_u32(acc);
-
-        // Scalar tail.
         while i < n {
             result += a[i] as u32 * b[i] as u32;
             i += 1;
         }
-
         result
     }
 
-    /// Base NEON path (all aarch64): widening multiply u8→u16 then
-    /// pairwise accumulate to u32. 16 elements per iteration.
-    /// Fallback when dotprod is not available.
+    /// Base NEON path: widening multiply u8→u16 then pairwise accumulate
+    /// to u32. Fallback when dotprod is not available.
     pub unsafe fn dot_u8_neon(a: &[u8], b: &[u8]) -> u32 {
         debug_assert_eq!(a.len(), b.len());
         let n = a.len();
@@ -90,26 +84,18 @@ mod aarch64 {
         while i + 16 <= n {
             let av = vld1q_u8(a.as_ptr().add(i));
             let bv = vld1q_u8(b.as_ptr().add(i));
-
-            // vmull: u8×u8 → u16 (8 elements per half)
             let prod_lo = vmull_u8(vget_low_u8(av), vget_low_u8(bv));
             let prod_hi = vmull_u8(vget_high_u8(av), vget_high_u8(bv));
-
-            // vpadalq: pairwise add u16 → u32 and accumulate.
             acc = vpadalq_u16(acc, prod_lo);
             acc = vpadalq_u16(acc, prod_hi);
-
             i += 16;
         }
 
         let mut result = vaddvq_u32(acc);
-
-        // Scalar tail.
         while i < n {
             result += a[i] as u32 * b[i] as u32;
             i += 1;
         }
-
         result
     }
 }
@@ -118,9 +104,7 @@ mod aarch64 {
 mod x86 {
     use std::arch::x86_64::*;
 
-    /// AVX2 path: zero-extend u8 → u16 via `_mm256_cvtepu8_epi16`, then
-    /// use `_mm256_madd_epi16` which treats inputs as i16 but produces
-    /// correct results for non-negative values. 32 elements per iteration.
+    /// AVX2 path: zero-extend u8→u16, then VPMADDWD. 32 elements/iter.
     #[target_feature(enable = "avx2")]
     pub unsafe fn dot_u8_avx2(a: &[u8], b: &[u8]) -> u32 {
         debug_assert_eq!(a.len(), b.len());
@@ -132,23 +116,18 @@ mod x86 {
             let av = _mm256_loadu_si256(a.as_ptr().add(i) as *const __m256i);
             let bv = _mm256_loadu_si256(b.as_ptr().add(i) as *const __m256i);
 
-            // Zero-extend low and high 128-bit halves to 16 × u16.
-            // Since all values are ≤ 255, they fit in i16 as positive,
-            // so VPMADDWD produces correct non-negative results.
+            // Zero-extend each 128-bit half to 16 × u16. Values ≤ 255 fit
+            // in i16 as positive, so VPMADDWD gives correct results.
             let a_lo = _mm256_cvtepu8_epi16(_mm256_castsi256_si128(av));
             let a_hi = _mm256_cvtepu8_epi16(_mm256_extracti128_si256(av, 1));
             let b_lo = _mm256_cvtepu8_epi16(_mm256_castsi256_si128(bv));
             let b_hi = _mm256_cvtepu8_epi16(_mm256_extracti128_si256(bv, 1));
 
-            // Each VPMADDWD produces 8 × i32 partial sums. All products
-            // are in [0, 255*255], so accumulation stays non-negative.
             acc = _mm256_add_epi32(acc, _mm256_madd_epi16(a_lo, b_lo));
             acc = _mm256_add_epi32(acc, _mm256_madd_epi16(a_hi, b_hi));
-
             i += 32;
         }
 
-        // Horizontal reduction of 8 × i32 → scalar.
         let lo128 = _mm256_castsi256_si128(acc);
         let hi128 = _mm256_extracti128_si256(acc, 1);
         let mut sum128 = _mm_add_epi32(lo128, hi128);
@@ -156,17 +135,18 @@ mod x86 {
         sum128 = _mm_hadd_epi32(sum128, sum128);
         let mut result = _mm_cvtsi128_si32(sum128) as u32;
 
-        // Scalar tail.
         while i < n {
             result += a[i] as u32 * b[i] as u32;
             i += 1;
         }
-
         result
     }
 
-    /// AVX-512 VNNI path (Ice Lake .. Emerald Rapids, Zen 4).
-    /// VPDPBUSD + XOR-0x80 bias trick, 64 elements per iteration.
+    /// AVX-512 VNNI path (Ice Lake+, Zen 4+). 64 elements/iter.
+    ///
+    /// VPDPBUSD expects (unsigned, signed) operands but SQ stores u8×u8.
+    /// We XOR b with 0x80 to map it to i8, then correct: result + 128·Σa.
+    /// The Σa term (VPSADBW, port 5) runs in parallel with VPDPBUSD (port 0).
     #[target_feature(enable = "avx512f,avx512bw,avx512vnni")]
     pub unsafe fn dot_u8_avx512_vnni(a: &[u8], b: &[u8]) -> u32 {
         debug_assert_eq!(a.len(), b.len());
@@ -176,39 +156,25 @@ mod x86 {
         let mut acc_suma = _mm512_setzero_si512();
         let sign_flip = _mm512_set1_epi8(0x80u8 as i8);
         let zeros = _mm512_setzero_si512();
-
         let mut i = 0usize;
 
         while i + 64 <= n {
             let av = _mm512_loadu_si512(a.as_ptr().add(i) as *const i32);
             let bv = _mm512_loadu_si512(b.as_ptr().add(i) as *const i32);
-
-            // Bias b into the signed domain: b' = b ⊕ 0x80 = b - 128 (reinterpreted).
             let b_biased = _mm512_xor_si512(bv, sign_flip);
-
-            // Port 0: VPDPBUSD(a unsigned, b_biased signed).
-            // Computes Σ a·(b − 128) = Σ a·b − 128·Σa per 4-byte group.
             acc_dot = _mm512_dpbusd_epi32(acc_dot, av, b_biased);
-
-            // Port 5 (parallel): Σa via VPSADBW(a, 0) = sum of bytes.
             acc_suma = _mm512_add_epi64(acc_suma, _mm512_sad_epu8(av, zeros));
-
             i += 64;
         }
 
-        // Horizontal reductions.
         let biased_dot = _mm512_reduce_add_epi32(acc_dot);
         let sum_a = _mm512_reduce_add_epi64(acc_suma);
-
-        // Correction: biased = Σ a·b − 128·Σa  ⟹  Σ a·b = biased + 128·Σa
         let mut result = (biased_dot as i64 + 128 * sum_a) as u32;
 
-        // Scalar tail (< 64 elements remaining).
         while i < n {
             result += a[i] as u32 * b[i] as u32;
             i += 1;
         }
-
         result
     }
 }
@@ -246,8 +212,7 @@ fn select_backend() -> DotU8Fn {
     dot_u8_scalar
 }
 
-/// Compute the dot product of two u8 slices, dispatching to the best
-/// available SIMD backend on the current CPU.
+/// Dispatched u8 dot product, selecting the best available SIMD backend.
 #[inline]
 pub fn dot_u8(a: &[u8], b: &[u8]) -> u32 {
     (DISPATCH.get_or_init(select_backend))(a, b)
@@ -257,7 +222,6 @@ pub fn dot_u8(a: &[u8], b: &[u8]) -> u32 {
 mod tests {
     use super::*;
 
-    /// Deterministic PRNG for reproducible failures.
     fn fill_random(buf: &mut [u8], seed: &mut u32) {
         for slot in buf.iter_mut() {
             *seed = seed.wrapping_mul(1103515245).wrapping_add(12345);
@@ -265,12 +229,10 @@ mod tests {
         }
     }
 
-    /// Sizes chosen to stress vector loop, scalar tail, and boundaries.
     const SIZES: &[usize] = &[
         0, 1, 7, 15, 16, 31, 32, 33, 63, 64, 65, 127, 128, 255, 256, 1024, 4096, 4097,
     ];
 
-    /// Run every available backend against the scalar reference.
     fn check_all_backends(a: &[u8], b: &[u8], case: &str) {
         let reference = dot_u8_scalar(a, b);
 


### PR DESCRIPTION
## Summary

- Add AVX-512 VNNI and AVX2 backends for unsigned int8 dot product with runtime CPU feature detection and automatic fallback to scalar
- Replace the unoptimized `Dot<u8>` impl (which had an explicit TODO) with dispatched SIMD kernel
- All existing callers including SQ distance computation benefit automatically with zero changes to lance-index

## Details

### New file: `rust/lance-linalg/src/distance/dot_u8.rs`

Three backends selected at runtime via `OnceLock` + `is_x86_feature_detected!`:

| Backend | Instruction | Elements/iter | CPU |
|---|---|---|---|
| AVX-512 VNNI | `VPDPBUSD` + XOR-0x80 bias trick | 64 | Ice Lake+ / Zen 4+ |
| AVX2 | `VPMADDWD` on zero-extended u16 | 32 | Haswell+ / Zen 1+ |
| Scalar | portable reference | - | any (including ARM) |

### The VNNI bias trick

`VPDPBUSD` expects one unsigned and one signed operand, but SQ vectors are u8×u8. We XOR one operand with 0x80 to map it to the signed domain, then correct by adding `128·Σa` at the end. The correction uses `VPSADBW` which runs on execution port 5 while `VPDPBUSD` runs on port 0 — they execute in parallel every cycle, making the correction effectively free.

### SQ integration (automatic)

`SQDistCalculator::distance()` already calls `dot_distance()` → `u8::dot()` for Dot distance type. Replacing the `Dot<u8>` body is the only change needed.

## Benchmarks

### Ryzen 4500 (AVX2, no VNNI)

1M total u8 elements, varying vector dimension. Scalar baseline vs AVX2-dispatched path:

| Dimension | Scalar | Dispatch (AVX2) | Speedup |
|-----------|--------|-----------------|---------|
| 128 | 51.02 µs | 58.25 µs | 0.88x (dispatch overhead dominates) |
| 256 | 44.96 µs | 38.62 µs | **1.16x** |
| 512 | 42.82 µs | 28.27 µs | **1.51x** |
| 1024 | 41.00 µs | 25.17 µs | **1.63x** |

AVX2 delivers up to 1.63x throughput at dim=1024. At dim=128 the `OnceLock` dispatch and AVX2 loop setup overhead exceeds the SIMD gains on short vectors. AVX-512 VNNI (Ice Lake+ / Zen 4+) is expected to show larger gains with 64 elements/iter.

### Apple M4 (ARM64, scalar fallback)

On ARM64 the dispatch falls back to scalar, so both paths perform identically (~13 µs at dim=1024). A follow-up ARM NEON `UDOT` path would bring SIMD gains to Apple Silicon.

### Out of scope (follow-up)
- L2/Cosine u8 SIMD optimization (different kernel: `Σ(a-b)²`)
- Native `VPDPBUUD` (unsigned×unsigned, Sierra Forest+) — too new for stable Rust
- ARM NEON `UDOT` path
- Precomputed norms for SQ L2/Cosine (requires storage format change)

## Test plan

- [x] Unit tests: random inputs across 18 vector sizes (0-4097), boundary values (all 0s, all 255s, alternating), one-sided zeros, all-ones patterns
- [x] Each backend tested independently against scalar reference (with `#[cfg]` guards for missing CPU features)
- [x] Existing `dot` tests continue to pass (9/9)
- [x] `cargo clippy -p lance-linalg --tests --benches -- -D warnings` clean
- [x] Benchmark on x86_64 with AVX2: `cargo bench --bench dot -p lance-linalg -- "Dot\(u8"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)