### PR TITLE
feat: add configurable blob v2 pack file size

### DIFF
--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3469,6 +3469,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "arrow-select",

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -632,6 +632,7 @@ fn create_dataset<'local>(
         &initial_bases,
         &target_bases,
         &JObject::null(), // allow_external_blob_outside_bases not used for Dataset.write()
+        &JObject::null(), // blob_max_pack_file_bytes not used for Dataset.write()
     )?;
 
     // Set up namespace commit handler and storage options provider if namespace is provided

--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -413,6 +413,8 @@ pub extern "system" fn Java_org_lance_Dataset_createWithFfiSchema<'local>(
     storage_options_obj: JObject,      // Map<String, String>
     initial_bases: JObject,
     target_bases: JObject,
+    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
+    blob_pack_file_size_threshold: JObject,     // Optional<Long>
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
@@ -430,6 +432,8 @@ pub extern "system" fn Java_org_lance_Dataset_createWithFfiSchema<'local>(
             storage_options_obj,
             initial_bases,
             target_bases,
+            allow_external_blob_outside_bases,
+            blob_pack_file_size_threshold,
         )
     )
 }
@@ -449,6 +453,8 @@ fn inner_create_with_ffi_schema<'local>(
     storage_options_obj: JObject,      // Map<String, String>
     initial_bases: JObject,
     target_bases: JObject,
+    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
+    blob_pack_file_size_threshold: JObject,     // Optional<Long>
 ) -> Result<JObject<'local>> {
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
     let c_schema = unsafe { FFI_ArrowSchema::from_raw(c_schema_ptr) };
@@ -468,6 +474,8 @@ fn inner_create_with_ffi_schema<'local>(
         storage_options_obj,
         initial_bases,
         target_bases,
+        allow_external_blob_outside_bases,
+        blob_pack_file_size_threshold,
         reader,
         None,  // No namespace for schema-only creation
         false, // No managed versioning for schema-only creation
@@ -523,6 +531,8 @@ pub extern "system" fn Java_org_lance_Dataset_createWithFfiStream<'local>(
     storage_options_obj: JObject,                  // Map<String, String>
     initial_bases: JObject,                        // Optional<List<BasePath>>
     target_bases: JObject,                         // Optional<List<String>>
+    allow_external_blob_outside_bases: JObject,    // Optional<Boolean>
+    blob_pack_file_size_threshold: JObject,        // Optional<Long>
     namespace_obj: JObject,                        // LanceNamespace (can be null)
     table_id_obj: JObject,                         // List<String> (can be null)
     namespace_client_managed_versioning: jboolean, // Whether namespace manages versioning
@@ -543,6 +553,8 @@ pub extern "system" fn Java_org_lance_Dataset_createWithFfiStream<'local>(
             storage_options_obj,
             initial_bases,
             target_bases,
+            allow_external_blob_outside_bases,
+            blob_pack_file_size_threshold,
             namespace_obj,
             table_id_obj,
             namespace_client_managed_versioning != 0,
@@ -555,19 +567,21 @@ fn inner_create_with_ffi_stream<'local>(
     env: &mut JNIEnv<'local>,
     arrow_array_stream_addr: jlong,
     path: JString,
-    max_rows_per_file: JObject,                // Optional<Integer>
-    max_rows_per_group: JObject,               // Optional<Integer>
-    max_bytes_per_file: JObject,               // Optional<Long>
-    mode: JObject,                             // Optional<String>
-    enable_stable_row_ids: JObject,            // Optional<Boolean>
-    data_storage_version: JObject,             // Optional<String>
-    enable_v2_manifest_paths: JObject,         // Optional<Boolean>
-    storage_options_obj: JObject,              // Map<String, String>
-    initial_bases: JObject,                    // Optional<List<BasePath>>
-    target_bases: JObject,                     // Optional<List<String>>
-    namespace_obj: JObject,                    // LanceNamespace (can be null)
-    table_id_obj: JObject,                     // List<String> (can be null)
-    namespace_client_managed_versioning: bool, // Whether namespace manages versioning
+    max_rows_per_file: JObject,                 // Optional<Integer>
+    max_rows_per_group: JObject,                // Optional<Integer>
+    max_bytes_per_file: JObject,                // Optional<Long>
+    mode: JObject,                              // Optional<String>
+    enable_stable_row_ids: JObject,             // Optional<Boolean>
+    data_storage_version: JObject,              // Optional<String>
+    enable_v2_manifest_paths: JObject,          // Optional<Boolean>
+    storage_options_obj: JObject,               // Map<String, String>
+    initial_bases: JObject,                     // Optional<List<BasePath>>
+    target_bases: JObject,                      // Optional<List<String>>
+    allow_external_blob_outside_bases: JObject, // Optional<Boolean>
+    blob_pack_file_size_threshold: JObject,     // Optional<Long>
+    namespace_obj: JObject,                     // LanceNamespace (can be null)
+    table_id_obj: JObject,                      // List<String> (can be null)
+    namespace_client_managed_versioning: bool,  // Whether namespace manages versioning
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
@@ -588,6 +602,8 @@ fn inner_create_with_ffi_stream<'local>(
         storage_options_obj,
         initial_bases,
         target_bases,
+        allow_external_blob_outside_bases,
+        blob_pack_file_size_threshold,
         reader,
         namespace_info,
         namespace_client_managed_versioning,
@@ -613,6 +629,8 @@ fn create_dataset<'local>(
     storage_options_obj: JObject,
     initial_bases: JObject,
     target_bases: JObject,
+    allow_external_blob_outside_bases: JObject,
+    blob_pack_file_size_threshold: JObject,
     reader: impl RecordBatchReader + Send + 'static,
     namespace_info: Option<(Arc<dyn LanceNamespace>, Vec<String>)>,
     namespace_client_managed_versioning: bool,
@@ -631,8 +649,8 @@ fn create_dataset<'local>(
         &storage_options_obj,
         &initial_bases,
         &target_bases,
-        &JObject::null(), // allow_external_blob_outside_bases not used for Dataset.write()
-        &JObject::null(), // blob_max_pack_file_bytes not used for Dataset.write()
+        &allow_external_blob_outside_bases,
+        &blob_pack_file_size_threshold,
     )?;
 
     // Set up namespace commit handler and storage options provider if namespace is provided

--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -99,7 +99,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiArray<'local>(
     namespace_obj: JObject,                     // LanceNamespace (can be null)
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_max_pack_file_bytes: JObject,          // Optional<Long>
+    blob_pack_file_size_threshold: JObject,     // Optional<Long>
 ) -> JObject<'local> {
     ok_or_throw_with_return!(
         env,
@@ -118,7 +118,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiArray<'local>(
             namespace_obj,
             table_id_obj,
             allow_external_blob_outside_bases,
-            blob_max_pack_file_bytes,
+            blob_pack_file_size_threshold,
         ),
         JObject::default()
     )
@@ -140,7 +140,7 @@ fn inner_create_with_ffi_array<'local>(
     namespace_obj: JObject,                     // LanceNamespace (can be null)
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_max_pack_file_bytes: JObject,          // Optional<Long>
+    blob_pack_file_size_threshold: JObject,     // Optional<Long>
 ) -> Result<JObject<'local>> {
     let c_array_ptr = arrow_array_addr as *mut FFI_ArrowArray;
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
@@ -168,7 +168,7 @@ fn inner_create_with_ffi_array<'local>(
         namespace_obj,
         table_id_obj,
         allow_external_blob_outside_bases,
-        blob_max_pack_file_bytes,
+        blob_pack_file_size_threshold,
         reader,
     )
 }
@@ -189,7 +189,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiStream<'a>(
     namespace_obj: JObject,                     // LanceNamespace (can be null)
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_max_pack_file_bytes: JObject,          // Optional<Long>
+    blob_pack_file_size_threshold: JObject,     // Optional<Long>
 ) -> JObject<'a> {
     ok_or_throw_with_return!(
         env,
@@ -207,7 +207,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiStream<'a>(
             namespace_obj,
             table_id_obj,
             allow_external_blob_outside_bases,
-            blob_max_pack_file_bytes,
+            blob_pack_file_size_threshold,
         ),
         JObject::null()
     )
@@ -228,7 +228,7 @@ fn inner_create_with_ffi_stream<'local>(
     namespace_obj: JObject,                     // LanceNamespace (can be null)
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_max_pack_file_bytes: JObject,          // Optional<Long>
+    blob_pack_file_size_threshold: JObject,     // Optional<Long>
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
@@ -246,7 +246,7 @@ fn inner_create_with_ffi_stream<'local>(
         namespace_obj,
         table_id_obj,
         allow_external_blob_outside_bases,
-        blob_max_pack_file_bytes,
+        blob_pack_file_size_threshold,
         reader,
     )
 }
@@ -265,7 +265,7 @@ fn create_fragment<'a>(
     namespace_obj: JObject,                     // LanceNamespace (can be null)
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
-    blob_max_pack_file_bytes: JObject,          // Optional<Long>
+    blob_pack_file_size_threshold: JObject,     // Optional<Long>
     source: impl StreamingWriteSource,
 ) -> Result<JObject<'a>> {
     let path_str = dataset_uri.extract(env)?;
@@ -283,7 +283,7 @@ fn create_fragment<'a>(
         &JObject::null(), // not used when creating fragments
         &JObject::null(), // not used when creating fragments
         &allow_external_blob_outside_bases,
-        &blob_max_pack_file_bytes,
+        &blob_pack_file_size_threshold,
     )?;
 
     // Set up storage options provider if namespace is provided

--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -99,6 +99,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiArray<'local>(
     namespace_obj: JObject,                     // LanceNamespace (can be null)
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
+    blob_max_pack_file_bytes: JObject,          // Optional<Long>
 ) -> JObject<'local> {
     ok_or_throw_with_return!(
         env,
@@ -117,6 +118,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiArray<'local>(
             namespace_obj,
             table_id_obj,
             allow_external_blob_outside_bases,
+            blob_max_pack_file_bytes,
         ),
         JObject::default()
     )
@@ -138,6 +140,7 @@ fn inner_create_with_ffi_array<'local>(
     namespace_obj: JObject,                     // LanceNamespace (can be null)
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
+    blob_max_pack_file_bytes: JObject,          // Optional<Long>
 ) -> Result<JObject<'local>> {
     let c_array_ptr = arrow_array_addr as *mut FFI_ArrowArray;
     let c_schema_ptr = arrow_schema_addr as *mut FFI_ArrowSchema;
@@ -165,6 +168,7 @@ fn inner_create_with_ffi_array<'local>(
         namespace_obj,
         table_id_obj,
         allow_external_blob_outside_bases,
+        blob_max_pack_file_bytes,
         reader,
     )
 }
@@ -185,6 +189,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiStream<'a>(
     namespace_obj: JObject,                     // LanceNamespace (can be null)
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
+    blob_max_pack_file_bytes: JObject,          // Optional<Long>
 ) -> JObject<'a> {
     ok_or_throw_with_return!(
         env,
@@ -202,6 +207,7 @@ pub extern "system" fn Java_org_lance_Fragment_createWithFfiStream<'a>(
             namespace_obj,
             table_id_obj,
             allow_external_blob_outside_bases,
+            blob_max_pack_file_bytes,
         ),
         JObject::null()
     )
@@ -222,6 +228,7 @@ fn inner_create_with_ffi_stream<'local>(
     namespace_obj: JObject,                     // LanceNamespace (can be null)
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
+    blob_max_pack_file_bytes: JObject,          // Optional<Long>
 ) -> Result<JObject<'local>> {
     let stream_ptr = arrow_array_stream_addr as *mut FFI_ArrowArrayStream;
     let reader = unsafe { ArrowArrayStreamReader::from_raw(stream_ptr) }?;
@@ -239,6 +246,7 @@ fn inner_create_with_ffi_stream<'local>(
         namespace_obj,
         table_id_obj,
         allow_external_blob_outside_bases,
+        blob_max_pack_file_bytes,
         reader,
     )
 }
@@ -257,6 +265,7 @@ fn create_fragment<'a>(
     namespace_obj: JObject,                     // LanceNamespace (can be null)
     table_id_obj: JObject,                      // List<String> (can be null)
     allow_external_blob_outside_bases: JObject, // Optional<Boolean>
+    blob_max_pack_file_bytes: JObject,          // Optional<Long>
     source: impl StreamingWriteSource,
 ) -> Result<JObject<'a>> {
     let path_str = dataset_uri.extract(env)?;
@@ -274,6 +283,7 @@ fn create_fragment<'a>(
         &JObject::null(), // not used when creating fragments
         &JObject::null(), // not used when creating fragments
         &allow_external_blob_outside_bases,
+        &blob_max_pack_file_bytes,
     )?;
 
     // Set up storage options provider if namespace is provided

--- a/java/lance-jni/src/utils.rs
+++ b/java/lance-jni/src/utils.rs
@@ -52,7 +52,7 @@ pub fn extract_write_params(
     initial_bases: &JObject,                     // Optional<BasePath>
     target_bases: &JObject,                      // Optional<String>
     allow_external_blob_outside_bases: &JObject, // Optional<Boolean>
-    blob_max_pack_file_bytes: &JObject,          // Optional<Long>
+    blob_pack_file_size_threshold: &JObject,     // Optional<Long>
 ) -> Result<WriteParams> {
     let mut write_params = WriteParams::default();
 
@@ -102,8 +102,8 @@ pub fn extract_write_params(
     if let Some(allow) = env.get_boolean_opt(allow_external_blob_outside_bases)? {
         write_params.allow_external_blob_outside_bases = allow;
     }
-    if let Some(max_bytes) = env.get_long_opt(blob_max_pack_file_bytes)? {
-        write_params.blob_max_pack_file_bytes = Some(max_bytes as usize);
+    if let Some(max_bytes) = env.get_long_opt(blob_pack_file_size_threshold)? {
+        write_params.blob_pack_file_size_threshold = Some(max_bytes as usize);
     }
 
     // Create storage options accessor from static storage_options

--- a/java/lance-jni/src/utils.rs
+++ b/java/lance-jni/src/utils.rs
@@ -52,6 +52,7 @@ pub fn extract_write_params(
     initial_bases: &JObject,                     // Optional<BasePath>
     target_bases: &JObject,                      // Optional<String>
     allow_external_blob_outside_bases: &JObject, // Optional<Boolean>
+    blob_max_pack_file_bytes: &JObject,          // Optional<Long>
 ) -> Result<WriteParams> {
     let mut write_params = WriteParams::default();
 
@@ -100,6 +101,9 @@ pub fn extract_write_params(
 
     if let Some(allow) = env.get_boolean_opt(allow_external_blob_outside_bases)? {
         write_params.allow_external_blob_outside_bases = allow;
+    }
+    if let Some(max_bytes) = env.get_long_opt(blob_max_pack_file_bytes)? {
+        write_params.blob_max_pack_file_bytes = Some(max_bytes as usize);
     }
 
     // Create storage options accessor from static storage_options

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -150,7 +150,9 @@ public class Dataset implements Closeable {
               params.getEnableV2ManifestPaths(),
               params.getStorageOptions(),
               params.getInitialBases(),
-              params.getTargetBases());
+              params.getTargetBases(),
+              params.getAllowExternalBlobOutsideBases(),
+              params.getBlobPackFileSizeThreshold());
       dataset.allocator = allocator;
       return dataset;
     }
@@ -196,7 +198,9 @@ public class Dataset implements Closeable {
       Optional<Boolean> enableV2ManifestPaths,
       Map<String, String> storageOptions,
       Optional<List<BasePath>> initialBases,
-      Optional<List<String>> targetBases);
+      Optional<List<String>> targetBases,
+      Optional<Boolean> allowExternalBlobOutsideBases,
+      Optional<Long> blobPackFileSizeThreshold);
 
   /**
    * Creates a dataset from an FFI arrow stream.
@@ -231,6 +235,8 @@ public class Dataset implements Closeable {
       Map<String, String> storageOptions,
       Optional<List<BasePath>> initialBases,
       Optional<List<String>> targetBases,
+      Optional<Boolean> allowExternalBlobOutsideBases,
+      Optional<Long> blobPackFileSizeThreshold,
       LanceNamespace namespaceClient,
       List<String> tableId,
       boolean namespaceClientManagedVersioning);
@@ -280,6 +286,8 @@ public class Dataset implements Closeable {
             params.getStorageOptions(),
             params.getInitialBases(),
             params.getTargetBases(),
+            params.getAllowExternalBlobOutsideBases(),
+            params.getBlobPackFileSizeThreshold(),
             namespaceClient,
             tableId,
             namespaceClientManagedVersioning);

--- a/java/src/main/java/org/lance/Fragment.java
+++ b/java/src/main/java/org/lance/Fragment.java
@@ -280,7 +280,8 @@ public class Fragment {
           params.getStorageOptions(),
           namespaceClient,
           tableId,
-          params.getAllowExternalBlobOutsideBases());
+          params.getAllowExternalBlobOutsideBases(),
+          params.getBlobMaxPackFileBytes());
     }
   }
 
@@ -306,7 +307,8 @@ public class Fragment {
         params.getStorageOptions(),
         namespaceClient,
         tableId,
-        params.getAllowExternalBlobOutsideBases());
+        params.getAllowExternalBlobOutsideBases(),
+        params.getBlobMaxPackFileBytes());
   }
 
   /** Create a fragment from the given arrow array and schema. */
@@ -323,7 +325,8 @@ public class Fragment {
       Map<String, String> storageOptions,
       LanceNamespace namespaceClient,
       List<String> tableId,
-      Optional<Boolean> allowExternalBlobOutsideBases);
+      Optional<Boolean> allowExternalBlobOutsideBases,
+      Optional<Long> blobMaxPackFileBytes);
 
   /** Create a fragment from the given arrow stream. */
   private static native List<FragmentMetadata> createWithFfiStream(
@@ -338,5 +341,6 @@ public class Fragment {
       Map<String, String> storageOptions,
       LanceNamespace namespaceClient,
       List<String> tableId,
-      Optional<Boolean> allowExternalBlobOutsideBases);
+      Optional<Boolean> allowExternalBlobOutsideBases,
+      Optional<Long> blobMaxPackFileBytes);
 }

--- a/java/src/main/java/org/lance/Fragment.java
+++ b/java/src/main/java/org/lance/Fragment.java
@@ -281,7 +281,7 @@ public class Fragment {
           namespaceClient,
           tableId,
           params.getAllowExternalBlobOutsideBases(),
-          params.getBlobMaxPackFileBytes());
+          params.getBlobPackFileSizeThreshold());
     }
   }
 
@@ -308,7 +308,7 @@ public class Fragment {
         namespaceClient,
         tableId,
         params.getAllowExternalBlobOutsideBases(),
-        params.getBlobMaxPackFileBytes());
+        params.getBlobPackFileSizeThreshold());
   }
 
   /** Create a fragment from the given arrow array and schema. */
@@ -326,7 +326,7 @@ public class Fragment {
       LanceNamespace namespaceClient,
       List<String> tableId,
       Optional<Boolean> allowExternalBlobOutsideBases,
-      Optional<Long> blobMaxPackFileBytes);
+      Optional<Long> blobPackFileSizeThreshold);
 
   /** Create a fragment from the given arrow stream. */
   private static native List<FragmentMetadata> createWithFfiStream(
@@ -342,5 +342,5 @@ public class Fragment {
       LanceNamespace namespaceClient,
       List<String> tableId,
       Optional<Boolean> allowExternalBlobOutsideBases,
-      Optional<Long> blobMaxPackFileBytes);
+      Optional<Long> blobPackFileSizeThreshold);
 }

--- a/java/src/main/java/org/lance/WriteDatasetBuilder.java
+++ b/java/src/main/java/org/lance/WriteDatasetBuilder.java
@@ -78,6 +78,8 @@ public class WriteDatasetBuilder {
   private Optional<String> dataStorageVersion = Optional.empty();
   private Optional<List<BasePath>> initialBases = Optional.empty();
   private Optional<List<String>> targetBases = Optional.empty();
+  private Optional<Boolean> allowExternalBlobOutsideBases = Optional.empty();
+  private Optional<Long> blobPackFileSizeThreshold = Optional.empty();
   private Session session;
 
   /** Creates a new builder instance. Package-private, use Dataset.write() instead. */
@@ -283,6 +285,30 @@ public class WriteDatasetBuilder {
   }
 
   /**
+   * Sets whether to allow external blob URIs outside registered base paths.
+   *
+   * @param allowExternalBlobOutsideBases Whether to allow external blob URIs outside bases
+   * @return this builder instance
+   */
+  public WriteDatasetBuilder allowExternalBlobOutsideBases(boolean allowExternalBlobOutsideBases) {
+    this.allowExternalBlobOutsideBases = Optional.of(allowExternalBlobOutsideBases);
+    return this;
+  }
+
+  /**
+   * Sets the maximum size in bytes for blob v2 pack (.blob) sidecar files.
+   *
+   * <p>When a pack file reaches this size, a new one is started. If not set, defaults to 1 GiB.
+   *
+   * @param blobPackFileSizeThreshold maximum pack file size in bytes
+   * @return this builder instance
+   */
+  public WriteDatasetBuilder blobPackFileSizeThreshold(long blobPackFileSizeThreshold) {
+    this.blobPackFileSizeThreshold = Optional.of(blobPackFileSizeThreshold);
+    return this;
+  }
+
+  /**
    * Sets the session to share caches with other datasets.
    *
    * <p>Note: For write operations, the session is currently not used during the write itself, but
@@ -414,6 +440,8 @@ public class WriteDatasetBuilder {
 
     initialBases.ifPresent(paramsBuilder::withInitialBases);
     targetBases.ifPresent(paramsBuilder::withTargetBases);
+    allowExternalBlobOutsideBases.ifPresent(paramsBuilder::withAllowExternalBlobOutsideBases);
+    blobPackFileSizeThreshold.ifPresent(paramsBuilder::withBlobPackFileSizeThreshold);
 
     WriteParams params = paramsBuilder.build();
 
@@ -446,6 +474,8 @@ public class WriteDatasetBuilder {
     dataStorageVersion.ifPresent(paramsBuilder::withDataStorageVersion);
     initialBases.ifPresent(paramsBuilder::withInitialBases);
     targetBases.ifPresent(paramsBuilder::withTargetBases);
+    allowExternalBlobOutsideBases.ifPresent(paramsBuilder::withAllowExternalBlobOutsideBases);
+    blobPackFileSizeThreshold.ifPresent(paramsBuilder::withBlobPackFileSizeThreshold);
 
     WriteParams params = paramsBuilder.build();
 

--- a/java/src/main/java/org/lance/WriteParams.java
+++ b/java/src/main/java/org/lance/WriteParams.java
@@ -41,7 +41,7 @@ public class WriteParams {
   private final Optional<List<BasePath>> initialBases;
   private final Optional<List<String>> targetBases;
   private final Optional<Boolean> allowExternalBlobOutsideBases;
-  private final Optional<Long> blobMaxPackFileBytes;
+  private final Optional<Long> blobPackFileSizeThreshold;
 
   private WriteParams(
       Optional<Integer> maxRowsPerFile,
@@ -55,7 +55,7 @@ public class WriteParams {
       Optional<List<BasePath>> initialBases,
       Optional<List<String>> targetBases,
       Optional<Boolean> allowExternalBlobOutsideBases,
-      Optional<Long> blobMaxPackFileBytes) {
+      Optional<Long> blobPackFileSizeThreshold) {
     this.maxRowsPerFile = maxRowsPerFile;
     this.maxRowsPerGroup = maxRowsPerGroup;
     this.maxBytesPerFile = maxBytesPerFile;
@@ -67,7 +67,7 @@ public class WriteParams {
     this.initialBases = initialBases;
     this.targetBases = targetBases;
     this.allowExternalBlobOutsideBases = allowExternalBlobOutsideBases;
-    this.blobMaxPackFileBytes = blobMaxPackFileBytes;
+    this.blobPackFileSizeThreshold = blobPackFileSizeThreshold;
   }
 
   public Optional<Integer> getMaxRowsPerFile() {
@@ -134,8 +134,8 @@ public class WriteParams {
    *
    * @return Optional containing the max pack file size in bytes, or empty if not set
    */
-  public Optional<Long> getBlobMaxPackFileBytes() {
-    return blobMaxPackFileBytes;
+  public Optional<Long> getBlobPackFileSizeThreshold() {
+    return blobPackFileSizeThreshold;
   }
 
   @Override
@@ -162,7 +162,7 @@ public class WriteParams {
     private Optional<List<BasePath>> initialBases = Optional.empty();
     private Optional<List<String>> targetBases = Optional.empty();
     private Optional<Boolean> allowExternalBlobOutsideBases = Optional.empty();
-    private Optional<Long> blobMaxPackFileBytes = Optional.empty();
+    private Optional<Long> blobPackFileSizeThreshold = Optional.empty();
 
     public Builder withMaxRowsPerFile(int maxRowsPerFile) {
       this.maxRowsPerFile = Optional.of(maxRowsPerFile);
@@ -237,8 +237,8 @@ public class WriteParams {
      * @param maxBytes maximum pack file size in bytes
      * @return this builder
      */
-    public Builder withBlobMaxPackFileBytes(long maxBytes) {
-      this.blobMaxPackFileBytes = Optional.of(maxBytes);
+    public Builder withBlobPackFileSizeThreshold(long maxBytes) {
+      this.blobPackFileSizeThreshold = Optional.of(maxBytes);
       return this;
     }
 
@@ -255,7 +255,7 @@ public class WriteParams {
           initialBases,
           targetBases,
           allowExternalBlobOutsideBases,
-          blobMaxPackFileBytes);
+          blobPackFileSizeThreshold);
     }
   }
 }

--- a/java/src/main/java/org/lance/WriteParams.java
+++ b/java/src/main/java/org/lance/WriteParams.java
@@ -41,6 +41,7 @@ public class WriteParams {
   private final Optional<List<BasePath>> initialBases;
   private final Optional<List<String>> targetBases;
   private final Optional<Boolean> allowExternalBlobOutsideBases;
+  private final Optional<Long> blobMaxPackFileBytes;
 
   private WriteParams(
       Optional<Integer> maxRowsPerFile,
@@ -53,7 +54,8 @@ public class WriteParams {
       Map<String, String> storageOptions,
       Optional<List<BasePath>> initialBases,
       Optional<List<String>> targetBases,
-      Optional<Boolean> allowExternalBlobOutsideBases) {
+      Optional<Boolean> allowExternalBlobOutsideBases,
+      Optional<Long> blobMaxPackFileBytes) {
     this.maxRowsPerFile = maxRowsPerFile;
     this.maxRowsPerGroup = maxRowsPerGroup;
     this.maxBytesPerFile = maxBytesPerFile;
@@ -65,6 +67,7 @@ public class WriteParams {
     this.initialBases = initialBases;
     this.targetBases = targetBases;
     this.allowExternalBlobOutsideBases = allowExternalBlobOutsideBases;
+    this.blobMaxPackFileBytes = blobMaxPackFileBytes;
   }
 
   public Optional<Integer> getMaxRowsPerFile() {
@@ -124,6 +127,17 @@ public class WriteParams {
     return allowExternalBlobOutsideBases;
   }
 
+  /**
+   * Get the maximum size in bytes for blob v2 pack (.blob) sidecar files.
+   *
+   * <p>When a pack file reaches this size, a new one is started. If not set, defaults to 1 GiB.
+   *
+   * @return Optional containing the max pack file size in bytes, or empty if not set
+   */
+  public Optional<Long> getBlobMaxPackFileBytes() {
+    return blobMaxPackFileBytes;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -148,6 +162,7 @@ public class WriteParams {
     private Optional<List<BasePath>> initialBases = Optional.empty();
     private Optional<List<String>> targetBases = Optional.empty();
     private Optional<Boolean> allowExternalBlobOutsideBases = Optional.empty();
+    private Optional<Long> blobMaxPackFileBytes = Optional.empty();
 
     public Builder withMaxRowsPerFile(int maxRowsPerFile) {
       this.maxRowsPerFile = Optional.of(maxRowsPerFile);
@@ -214,6 +229,19 @@ public class WriteParams {
       return this;
     }
 
+    /**
+     * Set the maximum size in bytes for blob v2 pack (.blob) sidecar files.
+     *
+     * <p>When a pack file reaches this size, a new one is started. If not set, defaults to 1 GiB.
+     *
+     * @param maxBytes maximum pack file size in bytes
+     * @return this builder
+     */
+    public Builder withBlobMaxPackFileBytes(long maxBytes) {
+      this.blobMaxPackFileBytes = Optional.of(maxBytes);
+      return this;
+    }
+
     public WriteParams build() {
       return new WriteParams(
           maxRowsPerFile,
@@ -226,7 +254,8 @@ public class WriteParams {
           storageOptions,
           initialBases,
           targetBases,
-          allowExternalBlobOutsideBases);
+          allowExternalBlobOutsideBases,
+          blobMaxPackFileBytes);
     }
   }
 }

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -5962,7 +5962,7 @@ def write_dataset(
     target_bases: Optional[List[str]] = None,
     external_blob_mode: Literal["reference", "ingest"] = "reference",
     allow_external_blob_outside_bases: bool = False,
-    blob_max_pack_file_bytes: Optional[int] = None,
+    blob_pack_file_size_threshold: Optional[int] = None,
     namespace_client: Optional[LanceNamespace] = None,
     table_id: Optional[List[str]] = None,
 ) -> LanceDataset:
@@ -6068,7 +6068,7 @@ def write_dataset(
         If False, external blob URIs must map to the dataset root or a registered
         base path. If True, external blob URIs outside registered bases are allowed.
         This option only applies when ``external_blob_mode="reference"``.
-    blob_max_pack_file_bytes: optional, int, default None
+    blob_pack_file_size_threshold: optional, int, default None
         Maximum size in bytes for blob v2 pack (.blob) sidecar files. When a pack
         file reaches this size, a new one is started. If not set, defaults to 1 GiB.
     namespace_client : optional, LanceNamespace
@@ -6199,7 +6199,7 @@ def write_dataset(
         "target_bases": target_bases,
         "external_blob_mode": external_blob_mode,
         "allow_external_blob_outside_bases": allow_external_blob_outside_bases,
-        "blob_max_pack_file_bytes": blob_max_pack_file_bytes,
+        "blob_pack_file_size_threshold": blob_pack_file_size_threshold,
     }
 
     # Add namespace_client and table_id for storage options provider and managed

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -5962,6 +5962,7 @@ def write_dataset(
     target_bases: Optional[List[str]] = None,
     external_blob_mode: Literal["reference", "ingest"] = "reference",
     allow_external_blob_outside_bases: bool = False,
+    blob_max_pack_file_bytes: Optional[int] = None,
     namespace_client: Optional[LanceNamespace] = None,
     table_id: Optional[List[str]] = None,
 ) -> LanceDataset:
@@ -6067,6 +6068,9 @@ def write_dataset(
         If False, external blob URIs must map to the dataset root or a registered
         base path. If True, external blob URIs outside registered bases are allowed.
         This option only applies when ``external_blob_mode="reference"``.
+    blob_max_pack_file_bytes: optional, int, default None
+        Maximum size in bytes for blob v2 pack (.blob) sidecar files. When a pack
+        file reaches this size, a new one is started. If not set, defaults to 1 GiB.
     namespace_client : optional, LanceNamespace
         A namespace client from which to fetch table location and storage options.
         Must be provided together with `table_id`. Cannot be used with `uri`.
@@ -6195,6 +6199,7 @@ def write_dataset(
         "target_bases": target_bases,
         "external_blob_mode": external_blob_mode,
         "allow_external_blob_outside_bases": allow_external_blob_outside_bases,
+        "blob_max_pack_file_bytes": blob_max_pack_file_bytes,
     }
 
     # Add namespace_client and table_id for storage options provider and managed

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -3500,6 +3500,9 @@ pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WritePar
                 ExternalBlobMode::try_from(external_blob_mode.as_str()).infer_error()?,
             );
         }
+        if let Some(max_bytes) = get_dict_opt::<usize>(options, "blob_max_pack_file_bytes")? {
+            p = p.with_blob_max_pack_file_bytes(max_bytes);
+        }
 
         // Handle properties
         if let Some(props) =

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -3500,8 +3500,8 @@ pub fn get_write_params(options: &Bound<'_, PyDict>) -> PyResult<Option<WritePar
                 ExternalBlobMode::try_from(external_blob_mode.as_str()).infer_error()?,
             );
         }
-        if let Some(max_bytes) = get_dict_opt::<usize>(options, "blob_max_pack_file_bytes")? {
-            p = p.with_blob_max_pack_file_bytes(max_bytes);
+        if let Some(max_bytes) = get_dict_opt::<usize>(options, "blob_pack_file_size_threshold")? {
+            p = p.with_blob_pack_file_size_threshold(max_bytes);
         }
 
         // Handle properties

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -308,12 +308,16 @@ impl BlobPreprocessor {
         external_blob_mode: ExternalBlobMode,
         source_store_registry: Arc<ObjectStoreRegistry>,
         source_store_params: ObjectStoreParams,
+        max_pack_file_bytes: Option<usize>,
     ) -> Self {
-        let pack_writer = PackWriter::new(
+        let mut pack_writer = PackWriter::new(
             object_store.clone(),
             data_dir.clone(),
             data_file_key.clone(),
         );
+        if let Some(max_bytes) = max_pack_file_bytes {
+            pack_writer.max_pack_size = max_bytes;
+        }
         let arrow_schema = arrow_schema::Schema::from(schema);
         let fields = arrow_schema.fields();
         let blob_v2_cols = fields.iter().map(|field| field.is_blob_v2()).collect();
@@ -2399,6 +2403,7 @@ mod tests {
             ExternalBlobMode::Reference,
             Arc::new(ObjectStoreRegistry::default()),
             ObjectStoreParams::default(),
+            None,
         );
 
         let mut blob_builder = BlobArrayBuilder::new(1);

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -308,14 +308,14 @@ impl BlobPreprocessor {
         external_blob_mode: ExternalBlobMode,
         source_store_registry: Arc<ObjectStoreRegistry>,
         source_store_params: ObjectStoreParams,
-        max_pack_file_bytes: Option<usize>,
+        pack_file_size_threshold: Option<usize>,
     ) -> Self {
         let mut pack_writer = PackWriter::new(
             object_store.clone(),
             data_dir.clone(),
             data_file_key.clone(),
         );
-        if let Some(max_bytes) = max_pack_file_bytes {
+        if let Some(max_bytes) = pack_file_size_threshold {
             pack_writer.max_pack_size = max_bytes;
         }
         let arrow_schema = arrow_schema::Schema::from(schema);

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -302,7 +302,7 @@ pub struct WriteParams {
     /// Maximum size in bytes for blob v2 pack (.blob) sidecar files.
     /// When a pack file reaches this size, a new one is started.
     /// If not set, defaults to 1 GiB.
-    pub blob_max_pack_file_bytes: Option<usize>,
+    pub blob_pack_file_size_threshold: Option<usize>,
 }
 
 impl Default for WriteParams {
@@ -330,7 +330,7 @@ impl Default for WriteParams {
             target_base_names_or_paths: None,
             allow_external_blob_outside_bases: false,
             external_blob_mode: ExternalBlobMode::Reference,
-            blob_max_pack_file_bytes: None,
+            blob_pack_file_size_threshold: None,
         }
     }
 }
@@ -427,9 +427,9 @@ impl WriteParams {
     }
 
     /// Set the maximum size in bytes for blob v2 pack (.blob) sidecar files.
-    pub fn with_blob_max_pack_file_bytes(self, max_bytes: usize) -> Self {
+    pub fn with_blob_pack_file_size_threshold(self, max_bytes: usize) -> Self {
         Self {
-            blob_max_pack_file_bytes: Some(max_bytes),
+            blob_pack_file_size_threshold: Some(max_bytes),
             ..self
         }
     }
@@ -505,7 +505,7 @@ pub async fn do_write_fragments(
         params.external_blob_mode,
         source_store_registry,
         source_store_params,
-        params.blob_max_pack_file_bytes,
+        params.blob_pack_file_size_threshold,
     );
     let mut writer: Option<Box<dyn GenericWriter>> = None;
     let mut num_rows_in_current_file = 0;
@@ -1014,7 +1014,7 @@ struct WriterOptions {
     external_blob_mode: ExternalBlobMode,
     source_store_registry: Arc<ObjectStoreRegistry>,
     source_store_params: ObjectStoreParams,
-    blob_max_pack_file_bytes: Option<usize>,
+    blob_pack_file_size_threshold: Option<usize>,
 }
 
 async fn open_writer_with_options(
@@ -1032,7 +1032,7 @@ async fn open_writer_with_options(
         external_blob_mode,
         source_store_registry,
         source_store_params,
-        blob_max_pack_file_bytes,
+        blob_pack_file_size_threshold,
     } = options;
 
     let data_file_key = generate_random_filename();
@@ -1080,7 +1080,7 @@ async fn open_writer_with_options(
                 external_blob_mode,
                 source_store_registry,
                 source_store_params,
-                blob_max_pack_file_bytes,
+                blob_pack_file_size_threshold,
             ))
         } else {
             None
@@ -1123,7 +1123,7 @@ struct WriterGenerator {
     external_blob_mode: ExternalBlobMode,
     source_store_registry: Arc<ObjectStoreRegistry>,
     source_store_params: ObjectStoreParams,
-    blob_max_pack_file_bytes: Option<usize>,
+    blob_pack_file_size_threshold: Option<usize>,
     /// Counter for round-robin selection
     next_base_index: AtomicUsize,
 }
@@ -1141,7 +1141,7 @@ impl WriterGenerator {
         external_blob_mode: ExternalBlobMode,
         source_store_registry: Arc<ObjectStoreRegistry>,
         source_store_params: ObjectStoreParams,
-        blob_max_pack_file_bytes: Option<usize>,
+        blob_pack_file_size_threshold: Option<usize>,
     ) -> Self {
         Self {
             object_store,
@@ -1154,7 +1154,7 @@ impl WriterGenerator {
             external_blob_mode,
             source_store_registry,
             source_store_params,
-            blob_max_pack_file_bytes,
+            blob_pack_file_size_threshold,
             next_base_index: AtomicUsize::new(0),
         }
     }
@@ -1188,7 +1188,7 @@ impl WriterGenerator {
                     external_blob_mode: self.external_blob_mode,
                     source_store_registry: self.source_store_registry.clone(),
                     source_store_params: self.source_store_params.clone(),
-                    blob_max_pack_file_bytes: self.blob_max_pack_file_bytes,
+                    blob_pack_file_size_threshold: self.blob_pack_file_size_threshold,
                 },
             )
             .await?
@@ -1206,7 +1206,7 @@ impl WriterGenerator {
                     external_blob_mode: self.external_blob_mode,
                     source_store_registry: self.source_store_registry.clone(),
                     source_store_params: self.source_store_params.clone(),
-                    blob_max_pack_file_bytes: self.blob_max_pack_file_bytes,
+                    blob_pack_file_size_threshold: self.blob_pack_file_size_threshold,
                 },
             )
             .await?

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -298,6 +298,11 @@ pub struct WriteParams {
 
     /// The strategy used when writing external blob URIs.
     pub external_blob_mode: ExternalBlobMode,
+
+    /// Maximum size in bytes for blob v2 pack (.blob) sidecar files.
+    /// When a pack file reaches this size, a new one is started.
+    /// If not set, defaults to 1 GiB.
+    pub blob_max_pack_file_bytes: Option<usize>,
 }
 
 impl Default for WriteParams {
@@ -325,6 +330,7 @@ impl Default for WriteParams {
             target_base_names_or_paths: None,
             allow_external_blob_outside_bases: false,
             external_blob_mode: ExternalBlobMode::Reference,
+            blob_max_pack_file_bytes: None,
         }
     }
 }
@@ -419,6 +425,14 @@ impl WriteParams {
             ..self
         }
     }
+
+    /// Set the maximum size in bytes for blob v2 pack (.blob) sidecar files.
+    pub fn with_blob_max_pack_file_bytes(self, max_bytes: usize) -> Self {
+        Self {
+            blob_max_pack_file_bytes: Some(max_bytes),
+            ..self
+        }
+    }
 }
 
 /// Writes the given data to the dataset and returns fragments.
@@ -491,6 +505,7 @@ pub async fn do_write_fragments(
         params.external_blob_mode,
         source_store_registry,
         source_store_params,
+        params.blob_max_pack_file_bytes,
     );
     let mut writer: Option<Box<dyn GenericWriter>> = None;
     let mut num_rows_in_current_file = 0;
@@ -999,6 +1014,7 @@ struct WriterOptions {
     external_blob_mode: ExternalBlobMode,
     source_store_registry: Arc<ObjectStoreRegistry>,
     source_store_params: ObjectStoreParams,
+    blob_max_pack_file_bytes: Option<usize>,
 }
 
 async fn open_writer_with_options(
@@ -1016,6 +1032,7 @@ async fn open_writer_with_options(
         external_blob_mode,
         source_store_registry,
         source_store_params,
+        blob_max_pack_file_bytes,
     } = options;
 
     let data_file_key = generate_random_filename();
@@ -1063,6 +1080,7 @@ async fn open_writer_with_options(
                 external_blob_mode,
                 source_store_registry,
                 source_store_params,
+                blob_max_pack_file_bytes,
             ))
         } else {
             None
@@ -1105,6 +1123,7 @@ struct WriterGenerator {
     external_blob_mode: ExternalBlobMode,
     source_store_registry: Arc<ObjectStoreRegistry>,
     source_store_params: ObjectStoreParams,
+    blob_max_pack_file_bytes: Option<usize>,
     /// Counter for round-robin selection
     next_base_index: AtomicUsize,
 }
@@ -1122,6 +1141,7 @@ impl WriterGenerator {
         external_blob_mode: ExternalBlobMode,
         source_store_registry: Arc<ObjectStoreRegistry>,
         source_store_params: ObjectStoreParams,
+        blob_max_pack_file_bytes: Option<usize>,
     ) -> Self {
         Self {
             object_store,
@@ -1134,6 +1154,7 @@ impl WriterGenerator {
             external_blob_mode,
             source_store_registry,
             source_store_params,
+            blob_max_pack_file_bytes,
             next_base_index: AtomicUsize::new(0),
         }
     }
@@ -1167,6 +1188,7 @@ impl WriterGenerator {
                     external_blob_mode: self.external_blob_mode,
                     source_store_registry: self.source_store_registry.clone(),
                     source_store_params: self.source_store_params.clone(),
+                    blob_max_pack_file_bytes: self.blob_max_pack_file_bytes,
                 },
             )
             .await?
@@ -1184,6 +1206,7 @@ impl WriterGenerator {
                     external_blob_mode: self.external_blob_mode,
                     source_store_registry: self.source_store_registry.clone(),
                     source_store_params: self.source_store_params.clone(),
+                    blob_max_pack_file_bytes: self.blob_max_pack_file_bytes,
                 },
             )
             .await?
@@ -1820,6 +1843,7 @@ mod tests {
             ExternalBlobMode::Reference,
             Arc::new(ObjectStoreRegistry::default()),
             ObjectStoreParams::default(),
+            None,
         );
 
         // Create a writer
@@ -1937,6 +1961,7 @@ mod tests {
             ExternalBlobMode::Reference,
             Arc::new(ObjectStoreRegistry::default()),
             ObjectStoreParams::default(),
+            None,
         );
 
         // Create test batch


### PR DESCRIPTION
## Summary
- Add `blob_max_pack_file_bytes` to `WriteParams`, allowing users to override the default 1 GiB maximum pack (`.blob`) sidecar file size
- Thread the configuration through the full write path: `WriteParams` -> `WriterGenerator` -> `WriterOptions` -> `BlobPreprocessor` -> `PackWriter`
- Expose the option in Python (`write_dataset`) and Java (`WriteParams.Builder`) bindings

## Test plan
- [x] All 37 existing blob tests pass (`cargo test -p lance blob`)
- [x] Clippy clean on `lance` and `lance-jni` crates
- [x] Verify Python binding works end-to-end with `blob_max_pack_file_bytes` kwarg
- [x] Verify Java binding compiles with `./mvnw compile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)