### PR TITLE
feat: per-index stable row ID tracking for compaction

### DIFF
--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -3469,6 +3469,7 @@ dependencies = [
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-schema",
  "arrow-select",

--- a/java/lance-jni/src/index.rs
+++ b/java/lance-jni/src/index.rs
@@ -128,10 +128,17 @@ impl IntoJava for &IndexMetadata {
         // Determine index type from index_details type_url
         let index_type = determine_index_type(env, &self.index_details)?;
 
+        // Convert stable_row_ids from Option<bool> to Boolean for Java
+        let stable_row_ids = if let Some(val) = self.stable_row_ids {
+            env.new_object("java/lang/Boolean", "(Z)V", &[JValue::Bool(val as u8)])?
+        } else {
+            JObject::null()
+        };
+
         // Create Index object
         Ok(env.new_object(
             "org/lance/index/Index",
-            "(Ljava/util/UUID;Ljava/util/List;Ljava/lang/String;JLjava/util/List;[BILjava/time/Instant;Ljava/lang/Integer;Lorg/lance/index/IndexType;)V",
+            "(Ljava/util/UUID;Ljava/util/List;Ljava/lang/String;JLjava/util/List;[BILjava/time/Instant;Ljava/lang/Integer;Lorg/lance/index/IndexType;Ljava/lang/Boolean;)V",
             &[
                 JValue::Object(&uuid),
                 JValue::Object(&fields),
@@ -143,6 +150,7 @@ impl IntoJava for &IndexMetadata {
                 JValue::Object(&created_at),
                 JValue::Object(&base_id),
                 JValue::Object(&index_type),
+                JValue::Object(&stable_row_ids),
             ],
         )?)
     }

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -203,6 +203,10 @@ impl FromJObjectWithEnv<IndexMetadata> for JObject<'_> {
                 Ok(DateTime::from_timestamp(seconds, nanos).unwrap())
             })?;
         let base_id = env.get_optional_u32_from_method(self, "baseId")?;
+        let stable_row_ids =
+            env.get_optional_from_method(self, "stableRowIds", |env, bool_obj| {
+                Ok(env.call_method(bool_obj, "booleanValue", "()Z", &[])?.z()?)
+            })?;
 
         Ok(IndexMetadata {
             uuid,
@@ -215,6 +219,7 @@ impl FromJObjectWithEnv<IndexMetadata> for JObject<'_> {
             created_at,
             base_id,
             files: None,
+            stable_row_ids,
         })
     }
 }

--- a/java/src/main/java/org/lance/index/Index.java
+++ b/java/src/main/java/org/lance/index/Index.java
@@ -37,6 +37,7 @@ public class Index {
   private final Instant createdAt;
   private final Integer baseId;
   private final IndexType indexType;
+  private final Boolean stableRowIds;
 
   private Index(
       UUID uuid,
@@ -48,7 +49,8 @@ public class Index {
       int indexVersion,
       Instant createdAt,
       Integer baseId,
-      IndexType indexType) {
+      IndexType indexType,
+      Boolean stableRowIds) {
     this.uuid = uuid;
     this.fields = fields;
     this.name = name;
@@ -59,6 +61,7 @@ public class Index {
     this.createdAt = createdAt;
     this.baseId = baseId;
     this.indexType = indexType;
+    this.stableRowIds = stableRowIds;
   }
 
   public UUID uuid() {
@@ -131,6 +134,17 @@ public class Index {
     return indexType;
   }
 
+  /**
+   * Whether this index references rows by stable row ID ({@code true}) or physical row address
+   * ({@code false}/{@code null}). When true, the index does not need remapping during compaction.
+   * Null means row-address-based (legacy/backward compat).
+   *
+   * @return the stable row IDs setting, or null if not set
+   */
+  public Optional<Boolean> stableRowIds() {
+    return Optional.ofNullable(stableRowIds);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
@@ -145,7 +159,8 @@ public class Index {
         && Arrays.equals(indexDetails, index.indexDetails)
         && Objects.equals(createdAt, index.createdAt)
         && Objects.equals(baseId, index.baseId)
-        && indexType == index.indexType;
+        && indexType == index.indexType
+        && Objects.equals(stableRowIds, index.stableRowIds);
   }
 
   @Override
@@ -160,7 +175,8 @@ public class Index {
             createdAt,
             baseId,
             fragments,
-            indexType);
+            indexType,
+            stableRowIds);
     result = 31 * result + Arrays.hashCode(indexDetails);
     return result;
   }
@@ -176,6 +192,7 @@ public class Index {
         .add("indexType", indexType)
         .add("createdAt", createdAt)
         .add("baseId", baseId)
+        .add("stableRowIds", stableRowIds)
         .toString();
   }
 
@@ -200,6 +217,7 @@ public class Index {
     private Instant createdAt;
     private Integer baseId;
     private IndexType indexType;
+    private Boolean stableRowIds;
 
     private Builder() {}
 
@@ -253,6 +271,11 @@ public class Index {
       return this;
     }
 
+    public Builder stableRowIds(Boolean stableRowIds) {
+      this.stableRowIds = stableRowIds;
+      return this;
+    }
+
     public Index build() {
       return new Index(
           uuid,
@@ -264,7 +287,8 @@ public class Index {
           indexVersion,
           createdAt,
           baseId,
-          indexType);
+          indexType,
+          stableRowIds);
     }
   }
 }

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -286,6 +286,12 @@ message IndexMetadata {
   // of index sizes without extra IO.
   // If this is empty, the index files sizes are unknown.
   repeated IndexFile files = 10;
+
+  // Whether this index references rows by stable row ID (true) or physical
+  // row address (false). When true, the index does not need remapping during
+  // compaction since stable row IDs survive fragment rewrites.
+  // If absent, the index is assumed to use row addresses (legacy behavior).
+  optional bool stable_row_ids = 11;
 }
 
 // Metadata about a single file within an index segment.

--- a/rust/lance-table/src/format/index.rs
+++ b/rust/lance-table/src/format/index.rs
@@ -85,6 +85,15 @@ pub struct IndexMetadata {
 }
 
 impl IndexMetadata {
+    /// Whether this index uses stable row IDs.
+    ///
+    /// If `stable_row_ids` is explicitly set, returns that value.
+    /// Otherwise falls back to the dataset-level setting for backward
+    /// compatibility with indexes created before this field existed.
+    pub fn uses_stable_row_ids(&self, dataset_uses_stable: bool) -> bool {
+        self.stable_row_ids.unwrap_or(dataset_uses_stable)
+    }
+
     pub fn effective_fragment_bitmap(
         &self,
         existing_fragments: &RoaringBitmap,

--- a/rust/lance-table/src/format/index.rs
+++ b/rust/lance-table/src/format/index.rs
@@ -76,6 +76,12 @@ pub struct IndexMetadata {
     /// This is None if the file sizes are unknown. This happens for indices created
     /// before this field was added.
     pub files: Option<Vec<IndexFile>>,
+
+    /// Whether this index references rows by stable row ID (`Some(true)`) or
+    /// physical row address (`Some(false)` / `None`).
+    /// When true, the index does not need remapping during compaction.
+    /// None means row-address-based (legacy/backward compat).
+    pub stable_row_ids: Option<bool>,
 }
 
 impl IndexMetadata {
@@ -132,6 +138,7 @@ impl DeepSizeOf for IndexMetadata {
                 .map(|fragment_bitmap| fragment_bitmap.serialized_size())
                 .unwrap_or(0)
             + self.files.deep_size_of_children(context)
+            + self.stable_row_ids.deep_size_of_children(context)
     }
 }
 
@@ -178,6 +185,7 @@ impl TryFrom<pb::IndexMetadata> for IndexMetadata {
             }),
             base_id: proto.base_id,
             files,
+            stable_row_ids: proto.stable_row_ids,
         })
     }
 }
@@ -222,6 +230,7 @@ impl From<&IndexMetadata> for pb::IndexMetadata {
             created_at: idx.created_at.map(|dt| dt.timestamp_millis() as u64),
             base_id: idx.base_id,
             files,
+            stable_row_ids: idx.stable_row_ids,
         }
     }
 }
@@ -319,6 +328,7 @@ mod tests {
                     path: "index.idx".to_string(),
                     size_bytes: 1024,
                 }]),
+                stable_row_ids: Some(true),
             },
             IndexMetadata {
                 uuid: Uuid::new_v4(),
@@ -331,6 +341,7 @@ mod tests {
                 created_at: None,
                 base_id: Some(7),
                 files: None,
+                stable_row_ids: None,
             },
         ];
 
@@ -363,6 +374,7 @@ mod tests {
             assert_eq!(orig.index_version, rec.index_version);
             assert_eq!(orig.base_id, rec.base_id);
             assert_eq!(orig.files, rec.files);
+            assert_eq!(orig.stable_row_ids, rec.stable_row_ids);
         }
     }
 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1442,6 +1442,24 @@ impl Dataset {
         TakeBuilder::try_new_from_ids(self.clone(), row_ids.to_vec(), projection.into())
     }
 
+    /// Take rows by their physical row addresses.
+    ///
+    /// Row addresses are `(fragment_id << 32) | row_offset` values. Unlike row
+    /// IDs, addresses may change after compaction.
+    pub async fn take_by_addresses(
+        &self,
+        addresses: &[u64],
+        projection: impl Into<ProjectionRequest>,
+    ) -> Result<RecordBatch> {
+        TakeBuilder::try_new_from_addresses_request(
+            Arc::new(self.clone()),
+            addresses.to_vec(),
+            projection.into(),
+        )?
+        .execute()
+        .await
+    }
+
     /// Take [BlobFile] by row IDs.
     pub async fn take_blobs(
         self: &Arc<Self>,

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -1582,6 +1582,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            stable_row_ids: None,
         }
     }
 

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -64,6 +64,7 @@ impl IndexRemapper for DatasetIndexRemapper {
         let mut remapped = Vec::with_capacity(indices.len());
         for index in indices.iter() {
             let needs_remapped = index.name != FRAG_REUSE_INDEX_NAME
+                && index.stable_row_ids != Some(true)
                 && match &index.fragment_bitmap {
                     None => true,
                     Some(fragment_bitmap) => fragment_bitmap

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -61,10 +61,11 @@ impl IndexRemapper for DatasetIndexRemapper {
     ) -> Result<Vec<RemappedIndex>> {
         let affected_frag_ids = HashSet::<u64>::from_iter(affected_fragment_ids.iter().copied());
         let indices = self.dataset.load_indices().await?;
+        let dataset_uses_stable = self.dataset.manifest.uses_stable_row_ids();
         let mut remapped = Vec::with_capacity(indices.len());
         for index in indices.iter() {
             let needs_remapped = index.name != FRAG_REUSE_INDEX_NAME
-                && index.stable_row_ids != Some(true)
+                && !index.uses_stable_row_ids(dataset_uses_stable)
                 && match &index.fragment_bitmap {
                     None => true,
                     Some(fragment_bitmap) => fragment_bitmap

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -477,6 +477,7 @@ impl MemTableFlusher {
                 created_at: None,
                 base_id: None,
                 files: None,
+                stable_row_ids: None,
             };
 
             // Commit the index to the dataset
@@ -721,6 +722,7 @@ impl MemTableFlusher {
             created_at: Some(chrono::Utc::now()),
             index_version: 1,
             files: None,
+            stable_row_ids: None,
         };
 
         Ok(index_meta)

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1152,13 +1152,18 @@ async fn rewrite_files(
         .iter()
         .map(|f| f.physical_rows.unwrap() as u64)
         .sum::<u64>();
-    // We need to track row addresses for remapping if any index uses row addresses.
-    // When stable_row_ids is None (legacy), fall back to the dataset-level flag.
+    // We need to track row addresses for index remapping.  Row addresses are
+    // needed whenever the dataset doesn't use stable row IDs (non-stable
+    // datasets default to address-based indices) OR when any existing index
+    // explicitly uses row addresses.  This covers deferred-remap scenarios
+    // where no indices exist yet but will be created later on a non-stable
+    // dataset.
     let indices = dataset.load_indices().await?;
     let dataset_uses_stable = dataset.manifest.uses_stable_row_ids();
-    let needs_remapping = indices
+    let any_address_based = indices
         .iter()
         .any(|idx| !idx.uses_stable_row_ids(dataset_uses_stable));
+    let needs_remapping = !dataset_uses_stable || any_address_based;
     let mut new_fragments: Vec<Fragment>;
     let task_id = uuid::Uuid::new_v4();
     log::info!(
@@ -1537,7 +1542,7 @@ pub async fn commit_compaction(
                 );
                 row_id_map.extend(transposed);
             }
-        } else if options.defer_index_remap {
+        } else if options.defer_index_remap && any_address_based {
             let changed_row_addrs = task.row_addrs.ok_or_else(|| {
                 Error::internal(
                     "defer_index_remap requires row_addrs but none were provided".to_string(),

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1152,8 +1152,10 @@ async fn rewrite_files(
         .iter()
         .map(|f| f.physical_rows.unwrap() as u64)
         .sum::<u64>();
-    // If we aren't using stable row ids, then we need to remap indices.
-    let needs_remapping = !dataset.manifest.uses_stable_row_ids();
+    // We need to track row addresses for remapping if any index uses row addresses
+    // (i.e. does not have stable_row_ids == Some(true)).
+    let indices = dataset.load_indices().await?;
+    let needs_remapping = indices.iter().any(|idx| idx.stable_row_ids != Some(true));
     let mut new_fragments: Vec<Fragment>;
     let task_id = uuid::Uuid::new_v4();
     log::info!(
@@ -1485,8 +1487,10 @@ pub async fn commit_compaction(
         return Ok(CompactionMetrics::default());
     }
 
-    // If we aren't using stable row ids, then we need to remap indices.
-    let needs_remapping = !dataset.manifest.uses_stable_row_ids() && !options.defer_index_remap;
+    // We need to remap indices that use row addresses (not stable row IDs).
+    let indices = dataset.load_indices().await?;
+    let any_address_based = indices.iter().any(|idx| idx.stable_row_ids != Some(true));
+    let needs_remapping = any_address_based && !options.defer_index_remap;
 
     let mut completed_tasks = completed_tasks;
 

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1152,10 +1152,13 @@ async fn rewrite_files(
         .iter()
         .map(|f| f.physical_rows.unwrap() as u64)
         .sum::<u64>();
-    // We need to track row addresses for remapping if any index uses row addresses
-    // (i.e. does not have stable_row_ids == Some(true)).
+    // We need to track row addresses for remapping if any index uses row addresses.
+    // When stable_row_ids is None (legacy), fall back to the dataset-level flag.
     let indices = dataset.load_indices().await?;
-    let needs_remapping = indices.iter().any(|idx| idx.stable_row_ids != Some(true));
+    let dataset_uses_stable = dataset.manifest.uses_stable_row_ids();
+    let needs_remapping = indices
+        .iter()
+        .any(|idx| !idx.uses_stable_row_ids(dataset_uses_stable));
     let mut new_fragments: Vec<Fragment>;
     let task_id = uuid::Uuid::new_v4();
     log::info!(
@@ -1488,8 +1491,12 @@ pub async fn commit_compaction(
     }
 
     // We need to remap indices that use row addresses (not stable row IDs).
+    // When stable_row_ids is None (legacy), fall back to the dataset-level flag.
     let indices = dataset.load_indices().await?;
-    let any_address_based = indices.iter().any(|idx| idx.stable_row_ids != Some(true));
+    let dataset_uses_stable = dataset.manifest.uses_stable_row_ids();
+    let any_address_based = indices
+        .iter()
+        .any(|idx| !idx.uses_stable_row_ids(dataset_uses_stable));
     let needs_remapping = any_address_based && !options.defer_index_remap;
 
     let mut completed_tasks = completed_tasks;

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -2470,6 +2470,74 @@ mod tests {
         assert_eq!(before_scalar_result, after_scalar_result);
     }
 
+    /// On a stable-row-ID dataset, compaction should NOT remap indices
+    /// (they default to stable_row_ids=true). On a non-stable dataset,
+    /// compaction MUST remap. This test verifies both behaviors and that
+    /// the per-index stable_row_ids field is set correctly by default.
+    #[rstest::rstest]
+    #[case(true)]
+    #[case(false)]
+    #[tokio::test]
+    async fn test_compaction_respects_per_index_stable_row_ids(#[case] use_stable: bool) {
+        let mut data_gen =
+            BatchGenerator::new().col(Box::new(IncrementingInt32::new().named("i".to_owned())));
+
+        let uri = format!("memory://test/per_index_stable_{use_stable}");
+        let mut dataset = Dataset::write(
+            data_gen.batch(500),
+            &uri,
+            Some(WriteParams {
+                enable_stable_row_ids: use_stable,
+                max_rows_per_file: 100,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        dataset
+            .create_index(
+                &["i"],
+                IndexType::Scalar,
+                Some("scalar".into()),
+                &ScalarIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+
+        let idx = dataset.load_index_by_name("scalar").await.unwrap().unwrap();
+        assert_eq!(idx.stable_row_ids, Some(use_stable));
+        let uuid_before = idx.uuid;
+
+        let options = CompactionOptions {
+            target_rows_per_fragment: 500,
+            ..Default::default()
+        };
+        compact_files(&mut dataset, options, None).await.unwrap();
+
+        let idx_after = dataset.load_index_by_name("scalar").await.unwrap().unwrap();
+        if use_stable {
+            // Stable indices should NOT be remapped
+            assert_eq!(uuid_before, idx_after.uuid);
+        } else {
+            // Address-based indices should be remapped
+            assert_ne!(uuid_before, idx_after.uuid);
+        }
+        // Setting is preserved after compaction
+        assert_eq!(idx_after.stable_row_ids, Some(use_stable));
+
+        // Query should work regardless
+        let result = dataset
+            .scan()
+            .filter("i = 42")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(result.num_rows(), 1);
+    }
+
     // Regression test for https://github.com/lancedb/lance/issues/6161
     // When FragReuseIndexDetails exceeds 204800 bytes it is written to an external
     // file. Previously the file was silently dropped (temp file deleted) because

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -286,6 +286,7 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                     created_at: curr_index_meta.created_at,
                     base_id: None,
                     files: curr_index_meta.files.clone(),
+                    stable_row_ids: curr_index_meta.stable_row_ids,
                 },
                 RemapResult::Remapped(remapped_index) => IndexMetadata {
                     uuid: remapped_index.new_id,
@@ -298,6 +299,7 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
                     created_at: curr_index_meta.created_at,
                     base_id: None,
                     files: remapped_index.files,
+                    stable_row_ids: curr_index_meta.stable_row_ids,
                 },
             };
 

--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -500,6 +500,16 @@ impl TakeBuilder {
         })
     }
 
+    /// Create a new `TakeBuilder` for taking by address from a [ProjectionRequest].
+    pub fn try_new_from_addresses_request(
+        dataset: Arc<Dataset>,
+        addresses: Vec<u64>,
+        projection: ProjectionRequest,
+    ) -> Result<Self> {
+        let plan = Arc::new(projection.into_projection_plan(dataset.clone())?);
+        Self::try_new_from_addresses(dataset, addresses, plan)
+    }
+
     /// Adds row addresses to the output
     pub fn with_row_address(mut self, with_row_address: bool) -> Self {
         self.with_row_address = with_row_address;

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -1916,17 +1916,20 @@ impl Transaction {
                     next_row_id.as_ref(),
                 )?;
 
-                if next_row_id.is_some() {
-                    // We can re-use indices, but need to rewrite the fragment bitmaps
-                    debug_assert!(rewritten_indices.is_empty());
-                    for index in final_indices.iter_mut() {
-                        if let Some(fragment_bitmap) = &mut index.fragment_bitmap {
-                            *fragment_bitmap =
-                                Self::recalculate_fragment_bitmap(fragment_bitmap, groups)?;
-                        }
+                // Handle remapped (address-based) indices
+                let rewritten_new_ids: HashSet<Uuid> =
+                    rewritten_indices.iter().map(|ri| ri.new_id).collect();
+                Self::handle_rewrite_indices(&mut final_indices, rewritten_indices, groups)?;
+
+                // Recalculate fragment bitmaps for non-remapped indices
+                // (stable-row-id indices and any others not touched by remapping)
+                for index in final_indices.iter_mut() {
+                    if !rewritten_new_ids.contains(&index.uuid)
+                        && let Some(fragment_bitmap) = &mut index.fragment_bitmap
+                    {
+                        *fragment_bitmap =
+                            Self::recalculate_fragment_bitmap(fragment_bitmap, groups)?;
                     }
-                } else {
-                    Self::handle_rewrite_indices(&mut final_indices, rewritten_indices, groups)?;
                 }
 
                 if let Some(frag_reuse_index) = frag_reuse_index {
@@ -3514,6 +3517,7 @@ mod tests {
             created_at: Some(Utc::now()),
             base_id: None,
             files: None,
+            stable_row_ids: None,
         }
     }
 
@@ -4021,6 +4025,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            stable_row_ids: None,
         }
     }
 
@@ -4043,6 +4048,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            stable_row_ids: None,
         }
     }
 

--- a/rust/lance/src/dataset/transaction.rs
+++ b/rust/lance/src/dataset/transaction.rs
@@ -1921,12 +1921,23 @@ impl Transaction {
                     rewritten_indices.iter().map(|ri| ri.new_id).collect();
                 Self::handle_rewrite_indices(&mut final_indices, rewritten_indices, groups)?;
 
-                // Recalculate fragment bitmaps for non-remapped indices
-                // (stable-row-id indices and any others not touched by remapping)
+                // Recalculate fragment bitmaps for indices that don't need
+                // remapping.  When deferring index remap (`frag_reuse_index` is
+                // set), only stable-row-ID indices have their bitmaps updated
+                // here — address-based indices keep their old bitmaps until the
+                // deferred remap runs.  When not deferring, all non-rewritten
+                // indices (i.e., stable-row-ID indices) get bitmap updates.
+                let is_deferring = frag_reuse_index.is_some();
                 for index in final_indices.iter_mut() {
-                    if !rewritten_new_ids.contains(&index.uuid)
-                        && let Some(fragment_bitmap) = &mut index.fragment_bitmap
-                    {
+                    if rewritten_new_ids.contains(&index.uuid) {
+                        continue;
+                    }
+                    // Skip address-based indices when deferring — their bitmaps
+                    // will be updated by the deferred remap.
+                    if is_deferring && !index.stable_row_ids.unwrap_or(next_row_id.is_some()) {
+                        continue;
+                    }
+                    if let Some(fragment_bitmap) = &mut index.fragment_bitmap {
                         *fragment_bitmap =
                             Self::recalculate_fragment_bitmap(fragment_bitmap, groups)?;
                     }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1065,6 +1065,7 @@ impl DatasetIndexExt for Dataset {
                 created_at: Some(chrono::Utc::now()),
                 base_id: None, // New merged index file locates in the cloned dataset.
                 files: res.files,
+                stable_row_ids: last_idx.stable_row_ids,
             };
             removed_indices.extend(res.removed_indices.iter().map(|&idx| idx.clone()));
             new_indices.push(new_idx);
@@ -2265,6 +2266,7 @@ mod tests {
                 path: INDEX_FILE_NAME.to_string(),
                 size_bytes: payload.len() as u64,
             }]),
+            stable_row_ids: None,
         }
     }
 

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -1686,4 +1686,78 @@ mod tests {
                     && idx.fragment_bitmap.as_ref().unwrap().len() == 1)
         );
     }
+
+    fn make_int_batch(n: usize) -> RecordBatch {
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "x",
+            DataType::Int32,
+            false,
+        )]));
+        RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int32Array::from_iter_values(0..n as i32))],
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_stable_row_ids_default_follows_dataset() {
+        // On a stable-row-ID dataset, default should be Some(true).
+        let batch = make_int_batch(100);
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema()),
+            "memory://test/stable_default",
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let idx = dataset
+            .create_index_builder(&["x"], IndexType::Scalar, &ScalarIndexParams::default())
+            .await
+            .unwrap();
+        assert_eq!(idx.stable_row_ids, Some(true));
+
+        // On a non-stable dataset, default should be Some(false).
+        let batch2 = make_int_batch(100);
+        let mut dataset2 = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch2.clone())], batch2.schema()),
+            "memory://test/nonstable_default",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let idx2 = dataset2
+            .create_index_builder(&["x"], IndexType::Scalar, &ScalarIndexParams::default())
+            .await
+            .unwrap();
+        assert_eq!(idx2.stable_row_ids, Some(false));
+    }
+
+    #[tokio::test]
+    async fn test_stable_row_ids_explicit_true_on_nonstable_errors() {
+        let batch = make_int_batch(100);
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema()),
+            "memory://test/stable_err",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let result = dataset
+            .create_index_builder(&["x"], IndexType::Scalar, &ScalarIndexParams::default())
+            .use_stable_row_ids(true)
+            .await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("stable row IDs"),
+            "Expected error about stable row IDs, got: {err_msg}"
+        );
+    }
 }

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -57,6 +57,8 @@ pub struct CreateIndexBuilder<'a> {
     progress: Arc<dyn IndexBuildProgress>,
     /// Transaction properties to store with this commit.
     transaction_properties: Option<Arc<HashMap<String, String>>>,
+    /// Whether the index should use stable row IDs instead of row addresses.
+    use_stable_row_ids: Option<bool>,
 }
 
 impl<'a> CreateIndexBuilder<'a> {
@@ -79,6 +81,7 @@ impl<'a> CreateIndexBuilder<'a> {
             preprocessed_data: None,
             progress: Arc::new(NoopIndexBuildProgress),
             transaction_properties: None,
+            use_stable_row_ids: None,
         }
     }
 
@@ -127,6 +130,14 @@ impl<'a> CreateIndexBuilder<'a> {
     /// (e.g., job_id for tracking completed index jobs).
     pub fn transaction_properties(mut self, properties: HashMap<String, String>) -> Self {
         self.transaction_properties = Some(Arc::new(properties));
+        self
+    }
+
+    /// Whether the index should reference rows by stable row ID (`true`) or
+    /// row address (`false`). If not set, defaults to `true` when the dataset
+    /// has stable row IDs enabled, `false` otherwise.
+    pub fn use_stable_row_ids(mut self, v: bool) -> Self {
+        self.use_stable_row_ids = Some(v);
         self
     }
 
@@ -455,6 +466,20 @@ impl<'a> CreateIndexBuilder<'a> {
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: created_index.files,
+            stable_row_ids: match self.use_stable_row_ids {
+                Some(true) => {
+                    if !self.dataset.manifest.uses_stable_row_ids() {
+                        return Err(Error::index(
+                            "Cannot create stable-row-ID index: dataset does not have \
+                             stable row IDs enabled"
+                                .to_string(),
+                        ));
+                    }
+                    Some(true)
+                }
+                Some(false) => Some(false),
+                None => Some(self.dataset.manifest.uses_stable_row_ids()),
+            },
         })
     }
 

--- a/rust/lance/src/index/frag_reuse.rs
+++ b/rust/lance/src/index/frag_reuse.rs
@@ -174,5 +174,6 @@ pub(crate) async fn build_frag_reuse_index_metadata(
         base_id: None,
         // Fragment reuse index is inline (no files)
         files: None,
+        stable_row_ids: None,
     })
 }

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -113,6 +113,7 @@ pub(crate) fn new_mem_wal_index_meta(
         base_id: None,
         // Memory WAL index is inline (no files)
         files: None,
+        stable_row_ids: None,
     })
 }
 

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -70,7 +70,10 @@ impl DatasetPreFilter {
                 fragments |= idx.fragment_bitmap.as_ref().unwrap();
             });
         }
-        let index_uses_stable = indices.iter().all(|idx| idx.stable_row_ids == Some(true));
+        let dataset_uses_stable = dataset.manifest.uses_stable_row_ids();
+        let index_uses_stable = indices
+            .iter()
+            .all(|idx| idx.uses_stable_row_ids(dataset_uses_stable));
         let deleted_ids = Self::create_deletion_mask(dataset, fragments, index_uses_stable)
             .map(SharedPrerequisite::spawn);
         let filtered_ids = filter

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -70,8 +70,9 @@ impl DatasetPreFilter {
                 fragments |= idx.fragment_bitmap.as_ref().unwrap();
             });
         }
-        let deleted_ids =
-            Self::create_deletion_mask(dataset, fragments).map(SharedPrerequisite::spawn);
+        let index_uses_stable = indices.iter().all(|idx| idx.stable_row_ids == Some(true));
+        let deleted_ids = Self::create_deletion_mask(dataset, fragments, index_uses_stable)
+            .map(SharedPrerequisite::spawn);
         let filtered_ids = filter
             .map(|filtered_ids| SharedPrerequisite::spawn(filtered_ids.load().in_current_span()));
         Self {
@@ -198,6 +199,7 @@ impl DatasetPreFilter {
     pub fn create_deletion_mask(
         dataset: Arc<Dataset>,
         fragments: RoaringBitmap,
+        index_uses_stable_row_ids: bool,
     ) -> Option<BoxFuture<'static, Result<Arc<RowAddrMask>>>> {
         let mut missing_frags = Vec::new();
         let mut frags_with_deletion_files = Vec::new();
@@ -220,7 +222,7 @@ impl DatasetPreFilter {
         }
         if missing_frags.is_empty() && frags_with_deletion_files.is_empty() {
             None
-        } else if dataset.manifest.uses_stable_row_ids() {
+        } else if index_uses_stable_row_ids {
             Some(Self::do_create_deletion_mask_row_id(dataset.clone()).boxed())
         } else {
             Some(
@@ -364,6 +366,7 @@ mod test {
         let mask = DatasetPreFilter::create_deletion_mask(
             datasets.no_deletions.clone(),
             RoaringBitmap::from_iter(0..3),
+            false,
         );
         assert!(mask.is_none());
 
@@ -371,6 +374,7 @@ mod test {
         let mask = DatasetPreFilter::create_deletion_mask(
             datasets.deletions_no_missing_frags.clone(),
             RoaringBitmap::from_iter(0..3),
+            false,
         );
         assert!(mask.is_some());
         let mask = mask.unwrap().await.unwrap();
@@ -380,6 +384,7 @@ mod test {
         let mask = DatasetPreFilter::create_deletion_mask(
             datasets.deletions_missing_frags.clone(),
             RoaringBitmap::from_iter(0..3),
+            false,
         );
         assert!(mask.is_some());
         let mask = mask.unwrap().await.unwrap();
@@ -391,6 +396,7 @@ mod test {
         let mask = DatasetPreFilter::create_deletion_mask(
             datasets.deletions_missing_frags.clone(),
             RoaringBitmap::from_iter(2..3),
+            false,
         );
         assert!(mask.is_some());
         let mask = mask.unwrap().await.unwrap();
@@ -400,6 +406,7 @@ mod test {
         let mask = DatasetPreFilter::create_deletion_mask(
             datasets.only_missing_frags.clone(),
             RoaringBitmap::from_iter(0..3),
+            false,
         );
         assert!(mask.is_some());
         let mask = mask.unwrap().await.unwrap();
@@ -418,6 +425,7 @@ mod test {
         let mask = DatasetPreFilter::create_deletion_mask(
             datasets.no_deletions.clone(),
             RoaringBitmap::from_iter(0..3),
+            true,
         );
         assert!(mask.is_none());
 
@@ -425,6 +433,7 @@ mod test {
         let mask = DatasetPreFilter::create_deletion_mask(
             datasets.deletions_no_missing_frags.clone(),
             RoaringBitmap::from_iter(0..3),
+            true,
         );
         assert!(mask.is_some());
         let mask = mask.unwrap().await.unwrap();
@@ -435,6 +444,7 @@ mod test {
         let mask = DatasetPreFilter::create_deletion_mask(
             datasets.deletions_missing_frags.clone(),
             RoaringBitmap::from_iter(0..2),
+            true,
         );
         assert!(mask.is_some());
         let mask = mask.unwrap().await.unwrap();
@@ -444,6 +454,7 @@ mod test {
         let mask = DatasetPreFilter::create_deletion_mask(
             datasets.only_missing_frags.clone(),
             RoaringBitmap::from_iter(0..3),
+            true,
         );
         assert!(mask.is_some());
         let mask = mask.unwrap().await.unwrap();

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -642,6 +642,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            stable_row_ids: None,
         }
     }
 

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -1795,6 +1795,7 @@ pub async fn initialize_vector_index(
         created_at: Some(chrono::Utc::now()),
         base_id: None,
         files: Some(files),
+        stable_row_ids: source_index.stable_row_ids,
     };
 
     let transaction = Transaction::new(

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -2852,6 +2852,7 @@ mod tests {
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: None,
+            stable_row_ids: None,
         };
 
         // We need to commit this index to the dataset so that it can be found
@@ -2891,6 +2892,7 @@ mod tests {
             created_at: None, // Test index, not setting timestamp
             base_id: None,
             files: None,
+            stable_row_ids: None,
         };
 
         let prefilter = Arc::new(DatasetPreFilter::new(dataset.clone(), &[index_meta], None));
@@ -2951,6 +2953,7 @@ mod tests {
             created_at: Some(chrono::Utc::now()),
             base_id: None,
             files: None,
+            stable_row_ids: None,
         };
 
         // We need to commit this new index to the dataset so it can be found

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -2176,6 +2176,7 @@ mod tests {
             created_at: None, // Test index, not setting timestamp
             base_id: None,
             files: None,
+            stable_row_ids: None,
         };
         let fragment0 = Fragment::new(0);
         let fragment1 = Fragment::new(1);
@@ -2676,6 +2677,7 @@ mod tests {
             created_at: None,
             base_id: None,
             files: None,
+            stable_row_ids: None,
         };
         let index1 = IndexMetadata {
             uuid: uuid::Uuid::new_v4(),
@@ -2742,6 +2744,7 @@ mod tests {
                         created_at: None,
                         base_id: None,
                         files: None,
+                        stable_row_ids: None,
                     }],
                     removed_indices: vec![],
                 },

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -314,8 +314,14 @@ static KNN_INDEX_ADDR_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 
 /// Returns the appropriate KNN output schema based on whether the indices
 /// use stable row IDs or row addresses.
-fn knn_output_schema(indices: &[IndexMetadata]) -> SchemaRef {
-    if indices.iter().all(|idx| idx.stable_row_ids == Some(true)) {
+///
+/// `dataset_uses_stable` is the dataset-level fallback when an index has
+/// `stable_row_ids: None` (backward compat with pre-existing indexes).
+fn knn_output_schema(indices: &[IndexMetadata], dataset_uses_stable: bool) -> SchemaRef {
+    if indices
+        .iter()
+        .all(|idx| idx.uses_stable_row_ids(dataset_uses_stable))
+    {
         KNN_INDEX_SCHEMA.clone()
     } else {
         KNN_INDEX_ADDR_SCHEMA.clone()
@@ -645,8 +651,11 @@ impl ANNIvfSubIndexExec {
                 PART_ID_COLUMN
             )));
         }
-        let is_address_based = !indices.iter().all(|idx| idx.stable_row_ids == Some(true));
-        let output_schema = knn_output_schema(&indices);
+        let dataset_uses_stable = dataset.manifest.uses_stable_row_ids();
+        let is_address_based = !indices
+            .iter()
+            .all(|idx| idx.uses_stable_row_ids(dataset_uses_stable));
+        let output_schema = knn_output_schema(&indices, dataset_uses_stable);
         let properties = PlanProperties::new(
             EquivalenceProperties::new(output_schema),
             Partitioning::RoundRobinBatch(1),

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -35,8 +35,8 @@ use datafusion_physical_expr::{Distribution, EquivalenceProperties};
 use datafusion_physical_plan::metrics::{BaselineMetrics, Count, Time};
 use futures::{Stream, StreamExt, TryFutureExt, TryStreamExt, future, stream};
 use itertools::Itertools;
+use lance_core::ROW_ID;
 use lance_core::utils::futures::FinallyStreamExt;
-use lance_core::{ROW_ADDR, ROW_ADDR_FIELD, ROW_ID};
 use lance_core::{ROW_ID_FIELD, utils::tokio::get_num_compute_intensive_cpus};
 use lance_datafusion::utils::{
     DELTAS_SEARCHED_METRIC, ExecutionPlanMetricsSetExt, FIND_PARTITIONS_ELAPSED_METRIC,
@@ -303,30 +303,6 @@ pub static KNN_INDEX_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
         ROW_ID_FIELD.clone(),
     ]))
 });
-
-/// Schema for index results that contain row addresses instead of row IDs.
-static KNN_INDEX_ADDR_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
-    Arc::new(Schema::new(vec![
-        Field::new(DIST_COL, DataType::Float32, true),
-        ROW_ADDR_FIELD.clone(),
-    ]))
-});
-
-/// Returns the appropriate KNN output schema based on whether the indices
-/// use stable row IDs or row addresses.
-///
-/// `dataset_uses_stable` is the dataset-level fallback when an index has
-/// `stable_row_ids: None` (backward compat with pre-existing indexes).
-fn knn_output_schema(indices: &[IndexMetadata], dataset_uses_stable: bool) -> SchemaRef {
-    if indices
-        .iter()
-        .all(|idx| idx.uses_stable_row_ids(dataset_uses_stable))
-    {
-        KNN_INDEX_SCHEMA.clone()
-    } else {
-        KNN_INDEX_ADDR_SCHEMA.clone()
-    }
-}
 
 pub static KNN_PARTITION_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     Arc::new(Schema::new(vec![
@@ -627,10 +603,6 @@ pub struct ANNIvfSubIndexExec {
     /// Prefiltering input
     prefilter_source: PreFilterSource,
 
-    /// Whether the indices use row addresses (not stable row IDs).
-    /// When true, output uses `_rowaddr` instead of `_rowid`.
-    is_address_based: bool,
-
     /// Datafusion Plan Properties
     properties: PlanProperties,
 
@@ -651,13 +623,8 @@ impl ANNIvfSubIndexExec {
                 PART_ID_COLUMN
             )));
         }
-        let dataset_uses_stable = dataset.manifest.uses_stable_row_ids();
-        let is_address_based = !indices
-            .iter()
-            .all(|idx| idx.uses_stable_row_ids(dataset_uses_stable));
-        let output_schema = knn_output_schema(&indices, dataset_uses_stable);
         let properties = PlanProperties::new(
-            EquivalenceProperties::new(output_schema),
+            EquivalenceProperties::new(KNN_INDEX_SCHEMA.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Final,
             Boundedness::Bounded,
@@ -668,7 +635,6 @@ impl ANNIvfSubIndexExec {
             indices,
             query,
             prefilter_source,
-            is_address_based,
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
         })
@@ -988,7 +954,6 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                 indices: self.indices.clone(),
                 query: self.query.clone(),
                 prefilter_source,
-                is_address_based: self.is_address_based,
                 properties: self.properties.clone(),
                 metrics: ExecutionPlanMetricsSet::new(),
             }
@@ -1071,8 +1036,6 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
         ));
 
         let state = Arc::new(ANNIvfEarlySearchResults::new(indices.len(), query.k));
-        let is_address_based = self.is_address_based;
-        let output_schema = schema.clone();
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             schema,
@@ -1116,17 +1079,6 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                 // Each delta stream is split into an early and late search.  The late search
                 // will not start until the early search is complete across all deltas.
                 .try_flatten_unordered(None)
-                .map(move |batch_result| {
-                    if is_address_based {
-                        // Rename _rowid → _rowaddr so TakeExec uses addresses directly
-                        batch_result.map(|batch| {
-                            RecordBatch::try_new(output_schema.clone(), batch.columns().to_vec())
-                                .expect("schema has same number of columns")
-                        })
-                    } else {
-                        batch_result
-                    }
-                })
                 .finally(move || {
                     metrics_clone
                         .baseline_metrics
@@ -1204,13 +1156,8 @@ pub struct MultivectorScoringExec {
 
 impl MultivectorScoringExec {
     pub fn try_new(inputs: Vec<Arc<dyn ExecutionPlan>>, query: Query) -> Result<Self> {
-        // Propagate schema from inputs: if inputs use _rowaddr, so do we
-        let output_schema = inputs
-            .first()
-            .map(|i| i.schema())
-            .unwrap_or_else(|| KNN_INDEX_SCHEMA.clone());
         let properties = PlanProperties::new(
-            EquivalenceProperties::new(output_schema),
+            EquivalenceProperties::new(KNN_INDEX_SCHEMA.clone()),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Final,
             Boundedness::Bounded,
@@ -1283,12 +1230,6 @@ impl ExecutionPlan for MultivectorScoringExec {
             .collect::<DataFusionResult<Vec<_>>>()?;
 
         let output_schema = self.schema();
-        // Determine the row column name from the schema (_rowid or _rowaddr)
-        let row_col = if output_schema.field_with_name(ROW_ADDR).is_ok() {
-            ROW_ADDR
-        } else {
-            ROW_ID
-        };
 
         // collect the top k results from each stream,
         // and max-reduce for each query,
@@ -1296,7 +1237,7 @@ impl ExecutionPlan for MultivectorScoringExec {
         let mut reduced_inputs = stream::select_all(inputs.into_iter().map(|stream| {
             stream.map(move |batch| {
                 let batch = batch?;
-                let row_ids = batch[row_col].as_primitive::<UInt64Type>();
+                let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
                 let dists = batch[DIST_COL].as_primitive::<Float32Type>();
                 debug_assert_eq!(dists.null_count(), 0);
 

--- a/rust/lance/src/io/exec/knn.rs
+++ b/rust/lance/src/io/exec/knn.rs
@@ -35,8 +35,8 @@ use datafusion_physical_expr::{Distribution, EquivalenceProperties};
 use datafusion_physical_plan::metrics::{BaselineMetrics, Count, Time};
 use futures::{Stream, StreamExt, TryFutureExt, TryStreamExt, future, stream};
 use itertools::Itertools;
-use lance_core::ROW_ID;
 use lance_core::utils::futures::FinallyStreamExt;
+use lance_core::{ROW_ADDR, ROW_ADDR_FIELD, ROW_ID};
 use lance_core::{ROW_ID_FIELD, utils::tokio::get_num_compute_intensive_cpus};
 use lance_datafusion::utils::{
     DELTAS_SEARCHED_METRIC, ExecutionPlanMetricsSetExt, FIND_PARTITIONS_ELAPSED_METRIC,
@@ -303,6 +303,24 @@ pub static KNN_INDEX_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
         ROW_ID_FIELD.clone(),
     ]))
 });
+
+/// Schema for index results that contain row addresses instead of row IDs.
+static KNN_INDEX_ADDR_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
+    Arc::new(Schema::new(vec![
+        Field::new(DIST_COL, DataType::Float32, true),
+        ROW_ADDR_FIELD.clone(),
+    ]))
+});
+
+/// Returns the appropriate KNN output schema based on whether the indices
+/// use stable row IDs or row addresses.
+fn knn_output_schema(indices: &[IndexMetadata]) -> SchemaRef {
+    if indices.iter().all(|idx| idx.stable_row_ids == Some(true)) {
+        KNN_INDEX_SCHEMA.clone()
+    } else {
+        KNN_INDEX_ADDR_SCHEMA.clone()
+    }
+}
 
 pub static KNN_PARTITION_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
     Arc::new(Schema::new(vec![
@@ -603,6 +621,10 @@ pub struct ANNIvfSubIndexExec {
     /// Prefiltering input
     prefilter_source: PreFilterSource,
 
+    /// Whether the indices use row addresses (not stable row IDs).
+    /// When true, output uses `_rowaddr` instead of `_rowid`.
+    is_address_based: bool,
+
     /// Datafusion Plan Properties
     properties: PlanProperties,
 
@@ -623,8 +645,10 @@ impl ANNIvfSubIndexExec {
                 PART_ID_COLUMN
             )));
         }
+        let is_address_based = !indices.iter().all(|idx| idx.stable_row_ids == Some(true));
+        let output_schema = knn_output_schema(&indices);
         let properties = PlanProperties::new(
-            EquivalenceProperties::new(KNN_INDEX_SCHEMA.clone()),
+            EquivalenceProperties::new(output_schema),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Final,
             Boundedness::Bounded,
@@ -635,6 +659,7 @@ impl ANNIvfSubIndexExec {
             indices,
             query,
             prefilter_source,
+            is_address_based,
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
         })
@@ -954,6 +979,7 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                 indices: self.indices.clone(),
                 query: self.query.clone(),
                 prefilter_source,
+                is_address_based: self.is_address_based,
                 properties: self.properties.clone(),
                 metrics: ExecutionPlanMetricsSet::new(),
             }
@@ -1036,6 +1062,8 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
         ));
 
         let state = Arc::new(ANNIvfEarlySearchResults::new(indices.len(), query.k));
+        let is_address_based = self.is_address_based;
+        let output_schema = schema.clone();
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             schema,
@@ -1079,6 +1107,17 @@ impl ExecutionPlan for ANNIvfSubIndexExec {
                 // Each delta stream is split into an early and late search.  The late search
                 // will not start until the early search is complete across all deltas.
                 .try_flatten_unordered(None)
+                .map(move |batch_result| {
+                    if is_address_based {
+                        // Rename _rowid → _rowaddr so TakeExec uses addresses directly
+                        batch_result.map(|batch| {
+                            RecordBatch::try_new(output_schema.clone(), batch.columns().to_vec())
+                                .expect("schema has same number of columns")
+                        })
+                    } else {
+                        batch_result
+                    }
+                })
                 .finally(move || {
                     metrics_clone
                         .baseline_metrics
@@ -1156,8 +1195,13 @@ pub struct MultivectorScoringExec {
 
 impl MultivectorScoringExec {
     pub fn try_new(inputs: Vec<Arc<dyn ExecutionPlan>>, query: Query) -> Result<Self> {
+        // Propagate schema from inputs: if inputs use _rowaddr, so do we
+        let output_schema = inputs
+            .first()
+            .map(|i| i.schema())
+            .unwrap_or_else(|| KNN_INDEX_SCHEMA.clone());
         let properties = PlanProperties::new(
-            EquivalenceProperties::new(KNN_INDEX_SCHEMA.clone()),
+            EquivalenceProperties::new(output_schema),
             Partitioning::RoundRobinBatch(1),
             EmissionType::Final,
             Boundedness::Bounded,
@@ -1229,13 +1273,21 @@ impl ExecutionPlan for MultivectorScoringExec {
             .map(|input| input.execute(partition, context.clone()))
             .collect::<DataFusionResult<Vec<_>>>()?;
 
+        let output_schema = self.schema();
+        // Determine the row column name from the schema (_rowid or _rowaddr)
+        let row_col = if output_schema.field_with_name(ROW_ADDR).is_ok() {
+            ROW_ADDR
+        } else {
+            ROW_ID
+        };
+
         // collect the top k results from each stream,
         // and max-reduce for each query,
         // records the minimum distance for each query as estimation.
         let mut reduced_inputs = stream::select_all(inputs.into_iter().map(|stream| {
-            stream.map(|batch| {
+            stream.map(move |batch| {
                 let batch = batch?;
-                let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
+                let row_ids = batch[row_col].as_primitive::<UInt64Type>();
                 let dists = batch[DIST_COL].as_primitive::<Float32Type>();
                 debug_assert_eq!(dists.null_count(), 0);
 
@@ -1262,12 +1314,7 @@ impl ExecutionPlan for MultivectorScoringExec {
                 let new_row_ids = UInt64Array::from(new_row_ids);
                 let new_dists = Float32Array::from(new_sims);
 
-                let batch = RecordBatch::try_new(
-                    KNN_INDEX_SCHEMA.clone(),
-                    vec![Arc::new(new_dists), Arc::new(new_row_ids)],
-                )?;
-
-                Ok::<_, DataFusionError>((min_sim, batch))
+                Ok::<_, DataFusionError>((min_sim, new_dists, new_row_ids))
             })
         }));
 
@@ -1278,10 +1325,7 @@ impl ExecutionPlan for MultivectorScoringExec {
             // at most, we will have k * refine_factor results for each query
             let mut results = HashMap::with_capacity(k * refactor);
             let mut missed_sim_sum = 0.0;
-            while let Some((min_sim, batch)) = reduced_inputs.try_next().await? {
-                let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
-                let sims = batch[DIST_COL].as_primitive::<Float32Type>();
-
+            while let Some((min_sim, sims, row_ids)) = reduced_inputs.try_next().await? {
                 let query_results = row_ids
                     .values()
                     .iter()
@@ -1316,7 +1360,7 @@ impl ExecutionPlan for MultivectorScoringExec {
             let row_ids = UInt64Array::from(row_ids);
             let dists = Float32Array::from(dists);
             let batch = RecordBatch::try_new(
-                KNN_INDEX_SCHEMA.clone(),
+                output_schema.clone(),
                 vec![Arc::new(dists), Arc::new(row_ids)],
             )?;
             Ok::<_, DataFusionError>(batch)

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -340,8 +340,11 @@ impl MapIndexExec {
             .load_scalar_index(IndexCriteria::default().with_name(&index_name))
             .await?
             .unwrap();
-        let deletion_mask_fut =
-            DatasetPreFilter::create_deletion_mask(dataset.clone(), index.fragment_bitmap.unwrap());
+        let deletion_mask_fut = DatasetPreFilter::create_deletion_mask(
+            dataset.clone(),
+            index.fragment_bitmap.unwrap(),
+            dataset.manifest.uses_stable_row_ids(),
+        );
         let deletion_mask = if let Some(deletion_mask_fut) = deletion_mask_fut {
             Some(deletion_mask_fut.await?)
         } else {
@@ -540,7 +543,11 @@ impl MaterializeIndexExec {
             // The user-requested `fragments` is guaranteed to be stricter than the index's fragment
             // bitmap.  This node only runs on indexed fragments and any fragments that were deleted
             // when the index was trained will still be deleted when the index is queried.
-            DatasetPreFilter::create_deletion_mask(dataset.clone(), fragment_bitmap)
+            DatasetPreFilter::create_deletion_mask(
+                dataset.clone(),
+                fragment_bitmap,
+                dataset.manifest.uses_stable_row_ids(),
+            )
         });
         let mask = if let Some(prefilter) = prefilter {
             let (expr_result, prefilter) = futures::try_join!(expr_result, prefilter)?;


### PR DESCRIPTION
## Summary
- Adds `optional bool stable_row_ids` field (proto field 11) to `IndexMetadata` so each index declares whether it references rows by stable row ID or physical row address
- Compaction now checks per-index instead of per-dataset, only remapping indexes that use row addresses — stable-row-id indexes skip the expensive remap entirely
- `CreateIndexBuilder::use_stable_row_ids()` lets users control the setting; defaults to stable when the dataset supports it
- `transaction.rs` handles the mixed state where both remapped (address-based) and non-remapped (stable) indexes coexist
- Adds `Dataset::take_by_addresses()` public API for taking rows by physical address

## Test plan
- [ ] Verify proto roundtrip with `stable_row_ids` field (lance-table codec test)
- [ ] Test index creation defaults (stable when dataset supports it, address otherwise)
- [ ] Test explicit `use_stable_row_ids(true)` on non-stable dataset returns error
- [ ] Test compaction with stable-row-id index skips remap but updates fragment bitmap
- [ ] Test compaction with address-based index remaps as before
- [ ] Test mixed index compaction (both types on same dataset)
- [ ] Test backward compat: legacy indexes (`stable_row_ids: None`) treated as address-based
- [ ] Test `take_by_addresses` returns correct rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)