### PR TITLE
fix: missing bumpversion entry for lance-tokenizer

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -117,6 +117,11 @@ replace = 'lance-testing = {{ version = "={new_version}"'
 
 [[tool.bumpversion.files]]
 filename = "Cargo.toml"
+search = 'lance-tokenizer = {{ version = "={current_version}"'
+replace = 'lance-tokenizer = {{ version = "={new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "Cargo.toml"
 search = 'fsst = {{ version = "={current_version}"'
 replace = 'fsst = {{ version = "={new_version}"'
 
@@ -145,4 +150,3 @@ replace = 'version = "{new_version}"'
 filename = "java/pom.xml"
 search = "<version>{current_version}</version>"
 replace = "<version>{new_version}</version>"
-


### PR DESCRIPTION
This fixes the release bump configuration after `lance-tokenizer` was added to the workspace dependencies. `.bumpversion.toml` was missing the corresponding replacement rule, so version bumps could leave that internal dependency on the previous version. This is a targeted config-only fix to keep the release automation updating all workspace crates consistently.